### PR TITLE
Introducing Mya, a MemorY Analyzer, and libJavaScriptCoreTools.

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1617,6 +1617,26 @@ if (USE_INSPECTOR_SOCKET_SERVER)
     )
 endif ()
 
+# The corpse memory-analysis support is built on Mach task and corpse APIs, so
+# its headers have no content off Darwin and there is nothing to build or export.
+if (APPLE)
+    list(APPEND JavaScriptCore_PRIVATE_INCLUDE_DIRECTORIES
+        "${JAVASCRIPTCORE_DIR}/corpse"
+    )
+    list(APPEND JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
+        corpse/CorpseAddress.h
+        corpse/CorpseByteParser.h
+        corpse/CorpseClient.h
+        corpse/CorpseError.h
+        corpse/CorpseExportsTrie.h
+        corpse/CorpseProcess.h
+        corpse/CorpseRegion.h
+        corpse/CorpseSnapshot.h
+        corpse/CorpseSymbol.h
+        corpse/CorpseThread.h
+    )
+endif ()
+
 # GENERATOR 1-B: particular LUT creator (for 1 file only)
 GENERATE_HASH_LUT(${CMAKE_CURRENT_SOURCE_DIR}/parser/Keywords.table ${JavaScriptCore_DERIVED_SOURCES_DIR}/Lexer.lut.h)
 
@@ -1869,6 +1889,14 @@ endif ()
 add_custom_target(JavaScriptCoreSharedScripts DEPENDS ${JavaScriptCore_SCRIPTS})
 add_dependencies(JavaScriptCore JavaScriptCoreSharedScripts ${JavaScriptCore_EXTRA_DEPENDENCIES})
 add_dependencies(JavaScriptCoreSharedScripts JSCBuiltins)
+
+# The corpse code is part of JavaScriptCoreTools, which ships as a static library used
+# only by tools for assisting in the development of JavaScriptCore and WebKit. This code
+# is not needed for JavaScriptCore and WebKit functionality as a browser engine. The
+# corpse code rely on Mach APIs which are only available on Apple platforms.
+if (APPLE)
+  add_subdirectory(corpse)
+endif ()
 
 if (ENABLE_JAVASCRIPT_SHELL)
   add_subdirectory(shell)

--- a/Source/JavaScriptCore/Configurations/Mya.xcconfig
+++ b/Source/JavaScriptCore/Configurations/Mya.xcconfig
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "JSC.xcconfig"
+
+PRODUCT_NAME = mya;
+
+INSTALL_PATH = /usr/local/bin;
+
+// Simulator platforms are deliberately omitted.
+SUPPORTED_PLATFORMS = macosx iphoneos appletvos watchos xros;
+
+OTHER_CODE_SIGN_FLAGS[sdk=iphone*] = -i com.apple.jsc.mya --entitlements ${WK_PROCESSED_XCENT_FILE};

--- a/Source/JavaScriptCore/Configurations/TestLibJSCTools.xcconfig
+++ b/Source/JavaScriptCore/Configurations/TestLibJSCTools.xcconfig
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "TestExecutable.xcconfig"
+
+// Simulator platforms are deliberately omitted; libJavaScriptCoreTools, which this links,
+// is not built for them.
+SUPPORTED_PLATFORMS = macosx iphoneos appletvos watchos xros;

--- a/Source/JavaScriptCore/Configurations/libJavaScriptCoreTools.xcconfig
+++ b/Source/JavaScriptCore/Configurations/libJavaScriptCoreTools.xcconfig
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// JavaScriptCoreTools is a tools library that is for implementing tools to assist
+// in JavaScriptCore and WebKit development. It builds on JavaScriptCore, but does
+// not contain any functionality that is part of core JSC, and it is not needed for
+// implementing browser engines.
+//
+// JavaScriptCoreTools is packaged as a static library, and meant only to be linked
+// by tools that need it. Its headers are included as private headers of JavaScriptCore.
+// This allows JavaScriptCore and JavaScriptCoreTools to be revision locked, and
+// built in tandem to prevent bit rot from creeping in.
+#include "BaseTarget.xcconfig"
+
+PRODUCT_NAME = JavaScriptCoreTools;
+
+// Simulator platforms are deliberately omitted.
+SUPPORTED_PLATFORMS = macosx iphoneos appletvos watchos xros;
+
+// Installed to /usr/local/lib, alongside libWTF.a and libbmalloc.a.
+INSTALL_PATH = $(WK_LIBRARY_INSTALL_PATH);
+SKIP_INSTALL = NO;
+STRIP_INSTALLED_PRODUCT = NO;
+
+// The sources include "config.h" and their own headers from the source tree,
+// plus JavaScriptCore's generated and private headers.
+HEADER_SEARCH_PATHS = $(SRCROOT) $(SRCROOT)/corpse "$(JAVASCRIPTCORE_FRAMEWORKS_DIR)/JavaScriptCore.framework/PrivateHeaders" $(inherited);

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 			dependencies = (
 				932F5BE70822A1C700736975 /* PBXTargetDependency */,
 				5D69E912152BE5470028D720 /* PBXTargetDependency */,
+				D3934A4385F631C04057F7E7 /* PBXTargetDependency */,
+				5F40739EF054554602787C41 /* PBXTargetDependency */,
 				5D6B2A57152B9E2E005231DE /* PBXTargetDependency */,
 			);
 			name = All;
@@ -1527,6 +1529,9 @@
 		92B4EF902D71C3650068CB55 /* LLVMProfiling.h in Headers */ = {isa = PBXBuildFile; fileRef = 92B4EF8F2D71C3650068CB55 /* LLVMProfiling.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93052C350FB792190048FDC3 /* ParserArena.h in Headers */ = {isa = PBXBuildFile; fileRef = 93052C330FB792190048FDC3 /* ParserArena.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		932F5BDD0822A1C700736975 /* jsc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45E12D8806A49B0F00E9DF84 /* jsc.cpp */; };
+		6DCC8B386903B87B8A4E5A26 /* mya.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 806620AA0612E27A5093C379 /* mya.cpp */; };
+		ACB50B356C9AA8E90AA3DF50 /* JavaScriptCore.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 932F5BD90822A1C700736975 /* JavaScriptCore.framework */; };
+		D9BBE216687E30084BD44207 /* libedit.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D5D8AD00E0D0EBE00F9C692 /* libedit.dylib */; };
 		933040040E6A749400786E6A /* SmallStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = 93303FEA0E6A72C000786E6A /* SmallStrings.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93BFC6D929B344C90030D7BE /* GlobalObjectMethodTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BFC6D829B344C80030D7BE /* GlobalObjectMethodTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		95CA6AD328809E010062D5EC /* ImplementationVisibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 95CA6AD228809E010062D5EC /* ImplementationVisibility.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1828,6 +1833,35 @@
 		BC11667B0E199C05008066DD /* InternalFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = BC11667A0E199C05008066DD /* InternalFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC1167DA0E19BCC9008066DD /* JSCell.h in Headers */ = {isa = PBXBuildFile; fileRef = BC1167D80E19BCC9008066DD /* JSCell.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC18C3E50E16F5CD00B34460 /* APICast.h in Headers */ = {isa = PBXBuildFile; fileRef = 1482B78A0A4305AB00517CFC /* APICast.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0D9C2E68ACFF010D91916993 /* CorpseProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 55D0F2DD9CA70132D5104B34 /* CorpseProcess.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3A7C1E5D9B0F4A2681C34D07 /* CorpseRegion.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F41D6082A3E4B57C0768DB1 /* CorpseRegion.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		725D045D67B3017EAC56561C /* CorpseAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C6EB9C72F84ED87DF23277A /* CorpseAddress.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		80B96670131FB9EBB9AD49CC /* CorpseClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CBE14E70FB474FCFCD6A8B9 /* CorpseClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C2EB941F3198AE0BD86A2324 /* CorpseClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 422D2FE4AA2401EA8C3F2D8F /* CorpseClient.cpp */; };
+		85428E7BE0B3557DD2988043 /* CorpseError.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DDA7A78AD90B64B97AE329C /* CorpseError.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		121D90BB8171A66F1922D548 /* CorpseError.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC15166B6F71CD338DD8D6F /* CorpseError.cpp */; };
+		7E83C43817D785F3003DC41B /* CorpseExportsTrie.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C43617D785F3003DC41B /* CorpseExportsTrie.cpp */; };
+		7E83C42417D785F3003DC41B /* CorpseByteParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C42317D785F3003DC41B /* CorpseByteParser.cpp */; };
+		7E83C42817D785F3003DC41B /* CorpseByteParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E83C42217D785F3003DC41B /* CorpseByteParser.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7E83C42717D785F3003DC41B /* CorpseByteParserTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C42617D785F3003DC41B /* CorpseByteParserTest.cpp */; };
+		7E83C42B17D785F3003DC41B /* CorpseAddressTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C42917D785F3003DC41B /* CorpseAddressTest.cpp */; };
+		7E83C42E17D785F3003DC41B /* CorpseProcessTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C42C17D785F3003DC41B /* CorpseProcessTest.cpp */; };
+		7E83C43117D785F3003DC41B /* CorpseRegionTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C42F17D785F3003DC41B /* CorpseRegionTest.cpp */; };
+		7E83C43417D785F3003DC41B /* CorpseThreadTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C43217D785F3003DC41B /* CorpseThreadTest.cpp */; };
+		7E83C40B17D785F3003DC41B /* CorpseExportsTrieTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C40217D785F3003DC41B /* CorpseExportsTrieTest.cpp */; };
+		7E83C41017D785F3003DC41B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF0F569B2E334C90002A232A /* Foundation.framework */; };
+		7E83C40F17D785F3003DC41B /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932F5BD90822A1C700736975 /* JavaScriptCore.framework */; };
+		7E83C40C17D785F3003DC41B /* LibJSCToolsTestUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C40417D785F3003DC41B /* LibJSCToolsTestUtilities.cpp */; };
+		7E83C41117D785F3003DC41B /* libJavaScriptCoreTools.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 76A3C1425B4D63FC23BD2344 /* libJavaScriptCoreTools.a */; };
+		7E83C40D17D785F3003DC41B /* CorpseSnapshotTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C40617D785F3003DC41B /* CorpseSnapshotTest.cpp */; };
+		7E83C40E17D785F3003DC41B /* CorpseSymbolTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C40817D785F3003DC41B /* CorpseSymbolTest.cpp */; };
+		7E83C40A17D785F3003DC41B /* testLibJSCTools.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E83C40017D785F3003DC41B /* testLibJSCTools.cpp */; };
+		7E83C43717D785F3003DC41B /* CorpseExportsTrie.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E83C43517D785F3003DC41B /* CorpseExportsTrie.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		56C6C2B7EBDCC63B6ECEA9AD /* CorpseThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 211E3D6CA97F31CEB385A75A /* CorpseThread.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EF648B9EEAF54C44048B416A /* CorpseThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 960BD2B783EAEBE3233F91BF /* CorpseThread.cpp */; };
+		CA47D093D003440A28D15924 /* CorpseSnapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 94711688984F16F71D615DE5 /* CorpseSnapshot.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5601486802533982ACC870BE /* CorpseSymbol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F1FA0900D09DF06EE63F7D2 /* CorpseSymbol.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		377C8C2416AE3DF90650C0E9 /* CorpseSymbol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8D1735B28066A3B1D756ECC /* CorpseSymbol.cpp */; };
 		BC18C3E60E16F5CD00B34460 /* ArrayConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC7952070E15E8A800A898AB /* ArrayConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC18C3E70E16F5CD00B34460 /* ArrayPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A84E0255597D01FF60F7 /* ArrayPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC18C3EC0E16F5CD00B34460 /* BooleanObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 704FD35305697E6D003DBED9 /* BooleanObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2131,6 +2165,10 @@
 		E392E6F924D25FA900B20767 /* B3BottomTupleValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E392E6F724D25FA600B20767 /* B3BottomTupleValue.h */; };
 		E393ADD81FE702D00022D681 /* WeakMapImplInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E393ADD71FE702CC0022D681 /* WeakMapImplInlines.h */; };
 		E39440542F276A4A0055F0DB /* Binja.c in Sources */ = {isa = PBXBuildFile; fileRef = E3380F572F271A400097D76C /* Binja.c */; };
+		B7459796495B7F9AFCA962C1 /* libJavaScriptCoreTools.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 76A3C1425B4D63FC23BD2344 /* libJavaScriptCoreTools.a */; };
+		C366EA5039A3B51405995EA6 /* CorpseProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68BBF9CBD85C8635B2B8385F /* CorpseProcess.cpp */; };
+		5E2B94A17C6D40F3B85219CE /* CorpseRegion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8503B7E641A29DF5B0E3742 /* CorpseRegion.cpp */; };
+		0946712DEC51E0E86C4A49E3 /* CorpseSnapshot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E906BE4CC29012A83A8F299 /* CorpseSnapshot.cpp */; };
 		E3952C182F1DDF5700F5BEE8 /* B3WasmStructGetValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E3952C122F1DDF5700F5BEE8 /* B3WasmStructGetValue.h */; };
 		E3952C192F1DDF5700F5BEE8 /* B3WasmStructNewValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E3952C142F1DDF5700F5BEE8 /* B3WasmStructNewValue.h */; };
 		E3952C1A2F1DDF5700F5BEE8 /* B3WasmStructFieldValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E3952C102F1DDF5700F5BEE8 /* B3WasmStructFieldValue.h */; };
@@ -2527,6 +2565,48 @@
 /* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
+		6044D4B120B01FBCA9BCFBE5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 49D9C56EC7911960C24239F3;
+			remoteInfo = JavaScriptCoreTools;
+		};
+		A1B2C3000AE5B4A700C0FFEE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65FB3F6609D11E9100F49DEB;
+			remoteInfo = "Derived Sources";
+		};
+		A1B2C30004E5B4A700C0FFEE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 49D9C56EC7911960C24239F3;
+			remoteInfo = JavaScriptCoreTools;
+		};
+		A1B2C30006E5B4A700C0FFEE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6B03652E1F50D87F0DEC6B42;
+			remoteInfo = mya;
+		};
+		A1B2C30008E5B4A700C0FFEE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E83C41317D785F3003DC41B;
+			remoteInfo = testLibJSCTools;
+		};
+		291A8D565940996D3CA021C1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 49D9C56EC7911960C24239F3;
+			remoteInfo = JavaScriptCoreTools;
+		};
 		074D7E092E3D3B6800CD38C6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
@@ -2646,6 +2726,20 @@
 			remoteGlobalIDString = 65FB3F6609D11E9100F49DEB;
 			remoteInfo = "Derived Sources";
 		};
+		B70B8C003BC4F51DF41C2D65 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65FB3F6609D11E9100F49DEB;
+			remoteInfo = "Derived Sources";
+		};
+		A269FDF04AF38423A3A5DE9A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6B03652E1F50D87F0DEC6B42;
+			remoteInfo = mya;
+		};
 		44F93E102AE7200100FFA37C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
@@ -2758,6 +2852,27 @@
 			remoteGlobalIDString = FE533CA11F217DB30016A1FE;
 			remoteInfo = testmasm;
 		};
+		7E83C41C17D785F3003DC41B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65FB3F6609D11E9100F49DEB;
+			remoteInfo = "Derived Sources";
+		};
+		7E83C41E17D785F3003DC41B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E1AC2E2720F7B94C00B0897D;
+			remoteInfo = "Unlock Keychain";
+		};
+		7E83C42017D785F3003DC41B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E83C41317D785F3003DC41B;
+			remoteInfo = testLibJSCTools;
+		};
 		FF0F56882E33437C002A232A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
@@ -2811,6 +2926,17 @@
 			dstSubfolderSpec = 16;
 			files = (
 				4469970B2AFEF6CF008B930C /* JavaScriptCore.framework in Product Dependencies */,
+			);
+			name = "Product Dependencies";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		184CD487A9C6C6DCE0BA2ADA /* Product Dependencies */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 16;
+			files = (
+				ACB50B356C9AA8E90AA3DF50 /* JavaScriptCore.framework in Product Dependencies */,
 			);
 			name = "Product Dependencies";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3951,6 +4077,23 @@
 		1482B74B0A43032800517CFC /* JSStringRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringRef.h; sourceTree = "<group>"; };
 		1482B74C0A43032800517CFC /* JSStringRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSStringRef.cpp; sourceTree = "<group>"; };
 		1482B78A0A4305AB00517CFC /* APICast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APICast.h; sourceTree = "<group>"; };
+		55D0F2DD9CA70132D5104B34 /* CorpseProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseProcess.h; sourceTree = "<group>"; };
+		9F41D6082A3E4B57C0768DB1 /* CorpseRegion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseRegion.h; sourceTree = "<group>"; };
+		94711688984F16F71D615DE5 /* CorpseSnapshot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseSnapshot.h; sourceTree = "<group>"; };
+		8F1FA0900D09DF06EE63F7D2 /* CorpseSymbol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseSymbol.h; sourceTree = "<group>"; };
+		E8D1735B28066A3B1D756ECC /* CorpseSymbol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseSymbol.cpp; sourceTree = "<group>"; };
+		68BBF9CBD85C8635B2B8385F /* CorpseProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseProcess.cpp; sourceTree = "<group>"; };
+		C8503B7E641A29DF5B0E3742 /* CorpseRegion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseRegion.cpp; sourceTree = "<group>"; };
+		5E906BE4CC29012A83A8F299 /* CorpseSnapshot.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseSnapshot.cpp; sourceTree = "<group>"; };
+		2C6EB9C72F84ED87DF23277A /* CorpseAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseAddress.h; sourceTree = "<group>"; };
+		9CBE14E70FB474FCFCD6A8B9 /* CorpseClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseClient.h; sourceTree = "<group>"; };
+		422D2FE4AA2401EA8C3F2D8F /* CorpseClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseClient.cpp; sourceTree = "<group>"; };
+		8DDA7A78AD90B64B97AE329C /* CorpseError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseError.h; sourceTree = "<group>"; };
+		2AC15166B6F71CD338DD8D6F /* CorpseError.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseError.cpp; sourceTree = "<group>"; };
+		7E83C43617D785F3003DC41B /* CorpseExportsTrie.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseExportsTrie.cpp; sourceTree = "<group>"; };
+		7E83C43517D785F3003DC41B /* CorpseExportsTrie.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseExportsTrie.h; sourceTree = "<group>"; };
+		211E3D6CA97F31CEB385A75A /* CorpseThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseThread.h; sourceTree = "<group>"; };
+		960BD2B783EAEBE3233F91BF /* CorpseThread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseThread.cpp; sourceTree = "<group>"; };
 		1482B7E10A43076000517CFC /* JSObjectRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSObjectRef.h; sourceTree = "<group>"; };
 		1482B7E20A43076000517CFC /* JSObjectRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSObjectRef.cpp; sourceTree = "<group>"; };
 		148521D526EAEBDF00CC1D1A /* WasmHandlerInfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmHandlerInfo.cpp; sourceTree = "<group>"; };
@@ -4347,9 +4490,35 @@
 		4487DB822AF825C800AFECAE /* Fuzzilli.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Fuzzilli.h; sourceTree = "<group>"; };
 		44F93DFD2AE71EBD00FFA37C /* libJavaScriptCore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = libJavaScriptCore.xcconfig; sourceTree = "<group>"; };
 		44F93E022AE71F5400FFA37C /* libJavaScriptCore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libJavaScriptCore.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CCFE0660BE540320EF4777 /* libJavaScriptCoreTools.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = libJavaScriptCoreTools.xcconfig; sourceTree = "<group>"; };
+		A1B2C30001E5B4A700C0FFEE /* TestLibJSCTools.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TestLibJSCTools.xcconfig; sourceTree = "<group>"; };
+		76A3C1425B4D63FC23BD2344 /* libJavaScriptCoreTools.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libJavaScriptCoreTools.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		7E83C42317D785F3003DC41B /* CorpseByteParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseByteParser.cpp; sourceTree = "<group>"; };
+		7E83C42217D785F3003DC41B /* CorpseByteParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseByteParser.h; sourceTree = "<group>"; };
+		7E83C42617D785F3003DC41B /* CorpseByteParserTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseByteParserTest.cpp; sourceTree = "<group>"; };
+		7E83C42917D785F3003DC41B /* CorpseAddressTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseAddressTest.cpp; sourceTree = "<group>"; };
+		7E83C42A17D785F3003DC41B /* CorpseAddressTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseAddressTest.h; sourceTree = "<group>"; };
+		7E83C42C17D785F3003DC41B /* CorpseProcessTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseProcessTest.cpp; sourceTree = "<group>"; };
+		7E83C42D17D785F3003DC41B /* CorpseProcessTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseProcessTest.h; sourceTree = "<group>"; };
+		7E83C42F17D785F3003DC41B /* CorpseRegionTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseRegionTest.cpp; sourceTree = "<group>"; };
+		7E83C43017D785F3003DC41B /* CorpseRegionTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseRegionTest.h; sourceTree = "<group>"; };
+		7E83C43217D785F3003DC41B /* CorpseThreadTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseThreadTest.cpp; sourceTree = "<group>"; };
+		7E83C43317D785F3003DC41B /* CorpseThreadTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseThreadTest.h; sourceTree = "<group>"; };
+		7E83C42517D785F3003DC41B /* CorpseByteParserTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseByteParserTest.h; sourceTree = "<group>"; };
+		7E83C40217D785F3003DC41B /* CorpseExportsTrieTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseExportsTrieTest.cpp; sourceTree = "<group>"; };
+		7E83C40117D785F3003DC41B /* CorpseExportsTrieTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseExportsTrieTest.h; sourceTree = "<group>"; };
+		7E83C40417D785F3003DC41B /* LibJSCToolsTestUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LibJSCToolsTestUtilities.cpp; sourceTree = "<group>"; };
+		7E83C40317D785F3003DC41B /* LibJSCToolsTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibJSCToolsTestUtilities.h; sourceTree = "<group>"; };
+		7E83C40617D785F3003DC41B /* CorpseSnapshotTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseSnapshotTest.cpp; sourceTree = "<group>"; };
+		7E83C40517D785F3003DC41B /* CorpseSnapshotTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseSnapshotTest.h; sourceTree = "<group>"; };
+		7E83C40817D785F3003DC41B /* CorpseSymbolTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CorpseSymbolTest.cpp; sourceTree = "<group>"; };
+		7E83C40717D785F3003DC41B /* CorpseSymbolTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorpseSymbolTest.h; sourceTree = "<group>"; };
+		7E83C40017D785F3003DC41B /* testLibJSCTools.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = testLibJSCTools.cpp; sourceTree = "<group>"; };
+		7E83C40917D785F3003DC41B /* testLibJSCTools */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = testLibJSCTools; sourceTree = BUILT_PRODUCTS_DIR; };
 		44F93E0D2AE71F9F00FFA37C /* JavaScriptCoreFramework.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JavaScriptCoreFramework.cpp; sourceTree = "<group>"; };
 		451539B812DC994500EF7AC4 /* Yarr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Yarr.h; path = yarr/Yarr.h; sourceTree = "<group>"; };
 		45E12D8806A49B0F00E9DF84 /* jsc.cpp */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsc.cpp; sourceTree = "<group>"; tabWidth = 4; };
+		806620AA0612E27A5093C379 /* mya.cpp */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mya.cpp; path = mya/mya.cpp; sourceTree = "<group>"; tabWidth = 4; };
 		4615E4662B5833FB001D4D53 /* WasmBBQJIT64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmBBQJIT64.h; sourceTree = "<group>"; };
 		4615E4682B5833FB001D4D53 /* WasmBBQJIT64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmBBQJIT64.cpp; sourceTree = "<group>"; };
 		4B78E098294427D2003C6682 /* B3SIMDValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3SIMDValue.cpp; path = b3/B3SIMDValue.cpp; sourceTree = "<group>"; };
@@ -4752,6 +4921,7 @@
 		5C7E1A152DA1B0E100A4C005 /* JSTypedArrayViewPrototypeInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSTypedArrayViewPrototypeInternal.h; sourceTree = "<group>"; };
 		5D5D8AD00E0D0EBE00F9C692 /* libedit.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libedit.dylib; path = /usr/lib/libedit.dylib; sourceTree = "<absolute>"; };
 		5DAFD6CB146B686300FBEFB4 /* JSC.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = JSC.xcconfig; sourceTree = "<group>"; };
+		3E812A1EEBE0D5AEA7D3C74B /* Mya.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Mya.xcconfig; sourceTree = "<group>"; };
 		5DE3D0F40DD8DDFB00468714 /* WebKitAvailability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitAvailability.h; sourceTree = "<group>"; };
 		623A37EB1B87A7BD00754209 /* RegisterMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegisterMap.h; sourceTree = "<group>"; };
 		627673211B680C1E00FD9F2E /* CallMode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CallMode.cpp; sourceTree = "<group>"; };
@@ -5183,6 +5353,7 @@
 		932F5BD80822A1C700736975 /* Info.plist */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; tabWidth = 8; usesTabs = 1; };
 		932F5BD90822A1C700736975 /* JavaScriptCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JavaScriptCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		932F5BE10822A1C700736975 /* jsc */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = jsc; sourceTree = BUILT_PRODUCTS_DIR; };
+		B2D6E3DABD6662589CD25896 /* mya */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = mya; sourceTree = BUILT_PRODUCTS_DIR; };
 		93303FE80E6A72B500786E6A /* SmallStrings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SmallStrings.cpp; sourceTree = "<group>"; };
 		93303FEA0E6A72C000786E6A /* SmallStrings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmallStrings.h; sourceTree = "<group>"; };
 		933A349A038AE7C6008635CE /* Identifier.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = Identifier.h; sourceTree = "<group>"; tabWidth = 8; };
@@ -6726,12 +6897,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		97663BCF9AB10EBDF8B13940 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D9BBE216687E30084BD44207 /* libedit.dylib in Frameworks */,
+				B7459796495B7F9AFCA962C1 /* libJavaScriptCoreTools.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FE533CA41F217DB30016A1FE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				FE533CA51F217DB30016A1FE /* Foundation.framework in Frameworks */,
 				FE533CA61F217DB30016A1FE /* JavaScriptCore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7E83C41A17D785F3003DC41B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7E83C41017D785F3003DC41B /* Foundation.framework in Frameworks */,
+				7E83C40F17D785F3003DC41B /* JavaScriptCore.framework in Frameworks */,
+				7E83C41117D785F3003DC41B /* libJavaScriptCoreTools.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6747,11 +6937,65 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7E83C41217D785F3003DC41B /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				7E83C42917D785F3003DC41B /* CorpseAddressTest.cpp */,
+				7E83C42A17D785F3003DC41B /* CorpseAddressTest.h */,
+				7E83C42617D785F3003DC41B /* CorpseByteParserTest.cpp */,
+				7E83C42517D785F3003DC41B /* CorpseByteParserTest.h */,
+				7E83C40217D785F3003DC41B /* CorpseExportsTrieTest.cpp */,
+				7E83C40117D785F3003DC41B /* CorpseExportsTrieTest.h */,
+				7E83C42C17D785F3003DC41B /* CorpseProcessTest.cpp */,
+				7E83C42D17D785F3003DC41B /* CorpseProcessTest.h */,
+				7E83C42F17D785F3003DC41B /* CorpseRegionTest.cpp */,
+				7E83C43017D785F3003DC41B /* CorpseRegionTest.h */,
+				7E83C40617D785F3003DC41B /* CorpseSnapshotTest.cpp */,
+				7E83C40517D785F3003DC41B /* CorpseSnapshotTest.h */,
+				7E83C40817D785F3003DC41B /* CorpseSymbolTest.cpp */,
+				7E83C40717D785F3003DC41B /* CorpseSymbolTest.h */,
+				7E83C43217D785F3003DC41B /* CorpseThreadTest.cpp */,
+				7E83C43317D785F3003DC41B /* CorpseThreadTest.h */,
+				7E83C40417D785F3003DC41B /* LibJSCToolsTestUtilities.cpp */,
+				7E83C40317D785F3003DC41B /* LibJSCToolsTestUtilities.h */,
+			);
+			path = tests;
+			sourceTree = "<group>";
+		};
+		65036098A29083DFB9FCF27C /* corpse */ = {
+			isa = PBXGroup;
+			children = (
+				7E83C41217D785F3003DC41B /* tests */,
+				2C6EB9C72F84ED87DF23277A /* CorpseAddress.h */,
+				7E83C42317D785F3003DC41B /* CorpseByteParser.cpp */,
+				7E83C42217D785F3003DC41B /* CorpseByteParser.h */,
+				422D2FE4AA2401EA8C3F2D8F /* CorpseClient.cpp */,
+				9CBE14E70FB474FCFCD6A8B9 /* CorpseClient.h */,
+				2AC15166B6F71CD338DD8D6F /* CorpseError.cpp */,
+				8DDA7A78AD90B64B97AE329C /* CorpseError.h */,
+				7E83C43617D785F3003DC41B /* CorpseExportsTrie.cpp */,
+				7E83C43517D785F3003DC41B /* CorpseExportsTrie.h */,
+				68BBF9CBD85C8635B2B8385F /* CorpseProcess.cpp */,
+				55D0F2DD9CA70132D5104B34 /* CorpseProcess.h */,
+				C8503B7E641A29DF5B0E3742 /* CorpseRegion.cpp */,
+				9F41D6082A3E4B57C0768DB1 /* CorpseRegion.h */,
+				5E906BE4CC29012A83A8F299 /* CorpseSnapshot.cpp */,
+				94711688984F16F71D615DE5 /* CorpseSnapshot.h */,
+				E8D1735B28066A3B1D756ECC /* CorpseSymbol.cpp */,
+				8F1FA0900D09DF06EE63F7D2 /* CorpseSymbol.h */,
+				960BD2B783EAEBE3233F91BF /* CorpseThread.cpp */,
+				211E3D6CA97F31CEB385A75A /* CorpseThread.h */,
+				7E83C40017D785F3003DC41B /* testLibJSCTools.cpp */,
+			);
+			path = corpse;
+			sourceTree = "<group>";
+		};
 		034768DFFF38A50411DB9C8B /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				0F9327591C20BCBA00CF6564 /* dynbench */,
 				932F5BE10822A1C700736975 /* jsc */,
+				B2D6E3DABD6662589CD25896 /* mya */,
 				0FF922CF14F46B130041A24E /* JSCLLIntOffsetsExtractor */,
 				14BD688E215191310050DAFF /* JSCLLIntSettingsExtractor */,
 				141211200A48793C00480255 /* minidom */,
@@ -6761,9 +7005,11 @@
 				52CD0F642242F569004A18A5 /* testdfg */,
 				FE533CAC1F217DB40016A1FE /* testmasm */,
 				79281BDC20B62B3E002E2A60 /* testmem */,
+				7E83C40917D785F3003DC41B /* testLibJSCTools */,
 				6511230514046A4C002B101D /* testRegExp */,
 				932F5BD90822A1C700736975 /* JavaScriptCore.framework */,
 				44F93E022AE71F5400FFA37C /* libJavaScriptCore.a */,
+				76A3C1425B4D63FC23BD2344 /* libJavaScriptCoreTools.a */,
 				FF0F56942E33437C002A232A /* testwasmdebugger */,
 			);
 			name = Products;
@@ -6795,6 +7041,7 @@
 				44F93E0D2AE71F9F00FFA37C /* JavaScriptCoreFramework.cpp */,
 				F5C290E60284F98E018635CA /* JavaScriptCorePrefix.h */,
 				45E12D8806A49B0F00E9DF84 /* jsc.cpp */,
+				806620AA0612E27A5093C379 /* mya.cpp */,
 				A7C225CC139981F100FF1662 /* KeywordLookupGenerator.py */,
 				79D7B0E121152FD200FE7C64 /* entitlements.plist */,
 				53ADF4742F0D7A2000A05CDD /* lol */,
@@ -6804,6 +7051,7 @@
 				A7D8019F1880D66E0026C39B /* builtins */,
 				969A078F0ED1D3AE00F1F681 /* bytecode */,
 				7E39D81D0EC38EFA003AF11A /* bytecompiler */,
+				65036098A29083DFB9FCF27C /* corpse */,
 				1C90513E0BA9E8830081E9D0 /* Configurations */,
 				1480DB9A0DDC2231003CFDF2 /* debugger */,
 				650FDF8D09D0FCA700769E54 /* Derived Sources */,
@@ -7952,8 +8200,11 @@
 				1C9051430BA9E8A70081E9D0 /* JavaScriptCore.xcconfig */,
 				5DAFD6CB146B686300FBEFB4 /* JSC.xcconfig */,
 				44F93DFD2AE71EBD00FFA37C /* libJavaScriptCore.xcconfig */,
+				33CCFE0660BE540320EF4777 /* libJavaScriptCoreTools.xcconfig */,
 				DD8A31502F17A00000000001 /* LLIntExtractor.xcconfig */,
+				3E812A1EEBE0D5AEA7D3C74B /* Mya.xcconfig */,
 				FEE0A12229FE250400CED5E4 /* TestExecutable.xcconfig */,
+				A1B2C30001E5B4A700C0FFEE /* TestLibJSCTools.xcconfig */,
 				BC021BF2136900C300FC5467 /* ToolExecutable.xcconfig */,
 			);
 			path = Configurations;
@@ -11438,6 +11689,16 @@
 				E3FCCB642310A90D00238E72 /* ConstructorKind.h in Headers */,
 				A57D23F21891B5B40031C7FA /* ContentSearchUtilities.h in Headers */,
 				52678F911A04177C006A306D /* ControlFlowProfiler.h in Headers */,
+				725D045D67B3017EAC56561C /* CorpseAddress.h in Headers */,
+				7E83C42817D785F3003DC41B /* CorpseByteParser.h in Headers */,
+				80B96670131FB9EBB9AD49CC /* CorpseClient.h in Headers */,
+				85428E7BE0B3557DD2988043 /* CorpseError.h in Headers */,
+				7E83C43717D785F3003DC41B /* CorpseExportsTrie.h in Headers */,
+				0D9C2E68ACFF010D91916993 /* CorpseProcess.h in Headers */,
+				3A7C1E5D9B0F4A2681C34D07 /* CorpseRegion.h in Headers */,
+				CA47D093D003440A28D15924 /* CorpseSnapshot.h in Headers */,
+				5601486802533982ACC870BE /* CorpseSymbol.h in Headers */,
+				56C6C2B7EBDCC63B6ECEA9AD /* CorpseThread.h in Headers */,
 				C4F4B6F41A05C944005CAB76 /* cpp_generator.py in Headers */,
 				C4F4B6F31A05C944005CAB76 /* cpp_generator_templates.py in Headers */,
 				0F30D7C01D95D6320053089D /* CPU.h in Headers */,
@@ -13005,6 +13266,22 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		49D9C56EC7911960C24239F3 /* JavaScriptCoreTools */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CDAB8A13AA6F0C8A7D95A0DD /* Build configuration list for PBXNativeTarget "JavaScriptCoreTools" */;
+			buildPhases = (
+				0F73B81D27D8B848DDFD4BA2 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A1B2C3000BE5B4A700C0FFEE /* PBXTargetDependency */,
+			);
+			name = JavaScriptCoreTools;
+			productName = JavaScriptCoreTools;
+			productReference = 76A3C1425B4D63FC23BD2344 /* libJavaScriptCoreTools.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		0F6183381C45F62A0072450B /* testair */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0F61833E1C45F62A0072450B /* Build configuration list for PBXNativeTarget "testair" */;
@@ -13261,12 +13538,36 @@
 			buildRules = (
 			);
 			dependencies = (
+				A1B2C30005E5B4A700C0FFEE /* PBXTargetDependency */,
+				A1B2C30007E5B4A700C0FFEE /* PBXTargetDependency */,
+				A1B2C30009E5B4A700C0FFEE /* PBXTargetDependency */,
 				14D9D9DA218462B5009126C2 /* PBXTargetDependency */,
 			);
 			name = jsc;
 			productInstallPath = /usr/local/bin;
 			productName = jsc;
 			productReference = 932F5BE10822A1C700736975 /* jsc */;
+			productType = "com.apple.product-type.tool";
+		};
+		6B03652E1F50D87F0DEC6B42 /* mya */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1564F766F55B0B045D183322 /* Build configuration list for PBXNativeTarget "mya" */;
+			buildPhases = (
+				184CD487A9C6C6DCE0BA2ADA /* Product Dependencies */,
+				FE35E0580C774FF6AC63188E /* Generate Entitlements */,
+				4ECC923BDB875C54F15ECFB7 /* Sources */,
+				97663BCF9AB10EBDF8B13940 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D3934A4385F631C04057F7E7 /* PBXTargetDependency */,
+				87B6EB7D11A4B965B9269538 /* PBXTargetDependency */,
+			);
+			name = mya;
+			productInstallPath = /usr/local/bin;
+			productName = mya;
+			productReference = B2D6E3DABD6662589CD25896 /* mya */;
 			productType = "com.apple.product-type.tool";
 		};
 		FE533CA11F217DB30016A1FE /* testmasm */ = {
@@ -13285,6 +13586,27 @@
 			name = testmasm;
 			productName = testapi;
 			productReference = FE533CAC1F217DB40016A1FE /* testmasm */;
+			productType = "com.apple.product-type.tool";
+		};
+		7E83C41317D785F3003DC41B /* testLibJSCTools */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7E83C41417D785F3003DC41B /* Build configuration list for PBXNativeTarget "testLibJSCTools" */;
+			buildPhases = (
+				7E83C42117D785F3003DC41B /* Generate Entitlements */,
+				7E83C41917D785F3003DC41B /* Sources */,
+				7E83C41A17D785F3003DC41B /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F7DDEC2D6CAFD2ACDD19D991 /* PBXTargetDependency */,
+				7E83C41B17D785F3003DC41B /* PBXTargetDependency */,
+				7E83C41D17D785F3003DC41B /* PBXTargetDependency */,
+			);
+			name = testLibJSCTools;
+			productInstallPath = /usr/local/bin;
+			productName = testLibJSCTools;
+			productReference = 7E83C40917D785F3003DC41B /* testLibJSCTools */;
 			productType = "com.apple.product-type.tool";
 		};
 		FF0F56862E33437C002A232A /* testwasmdebugger */ = {
@@ -13354,6 +13676,8 @@
 				1412111F0A48793C00480255 /* minidom */,
 				14BD59BE0A3E8F9000BAF59C /* testapi */,
 				932F5BDA0822A1C700736975 /* jsc */,
+				49D9C56EC7911960C24239F3 /* JavaScriptCoreTools */,
+				6B03652E1F50D87F0DEC6B42 /* mya */,
 				651122F714046A4C002B101D /* testRegExp */,
 				0FEC85941BDB5CF10080FF74 /* testb3 */,
 				5D6B2A47152B9E17005231DE /* Test Tools */,
@@ -13364,6 +13688,7 @@
 				5325BDBF21DFF2B100A0DEE1 /* Apply Configuration to XCFileLists */,
 				52CD0F592242F569004A18A5 /* testdfg */,
 				FF0F56862E33437C002A232A /* testwasmdebugger */,
+				7E83C41317D785F3003DC41B /* testLibJSCTools */,
 			);
 		};
 /* End PBXProject section */
@@ -13772,6 +14097,26 @@
 			shellPath = /bin/sh;
 			shellScript = "Scripts/process-entitlements.sh\n";
 		};
+		FE35E0580C774FF6AC63188E /* Generate Entitlements */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Scripts/process-entitlements.sh",
+			);
+			name = "Generate Entitlements";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(WK_PROCESSED_XCENT_FILE)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "Scripts/process-entitlements.sh\n";
+		};
 		E3D6F6EE25D78CF600C20EB4 /* Generate Entitlements */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -13976,6 +14321,26 @@
 			shellPath = /bin/sh;
 			shellScript = "Scripts/process-entitlements.sh\n";
 		};
+		7E83C42117D785F3003DC41B /* Generate Entitlements */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Scripts/process-entitlements.sh",
+			);
+			name = "Generate Entitlements";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(WK_PROCESSED_XCENT_FILE)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "Scripts/process-entitlements.sh\n";
+		};
 		FF0F56892E33437C002A232A /* Generate Entitlements */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -13999,6 +14364,22 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0F73B81D27D8B848DDFD4BA2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7E83C42417D785F3003DC41B /* CorpseByteParser.cpp in Sources */,
+				C2EB941F3198AE0BD86A2324 /* CorpseClient.cpp in Sources */,
+				121D90BB8171A66F1922D548 /* CorpseError.cpp in Sources */,
+				7E83C43817D785F3003DC41B /* CorpseExportsTrie.cpp in Sources */,
+				C366EA5039A3B51405995EA6 /* CorpseProcess.cpp in Sources */,
+				5E2B94A17C6D40F3B85219CE /* CorpseRegion.cpp in Sources */,
+				0946712DEC51E0E86C4A49E3 /* CorpseSnapshot.cpp in Sources */,
+				377C8C2416AE3DF90650C0E9 /* CorpseSymbol.cpp in Sources */,
+				EF648B9EEAF54C44048B416A /* CorpseThread.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		0F6183391C45F62A0072450B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -14345,11 +14726,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4ECC923BDB875C54F15ECFB7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6DCC8B386903B87B8A4E5A26 /* mya.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FE533CA21F217DB30016A1FE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				FE533CAD1F217EA50016A1FE /* testmasm.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7E83C41917D785F3003DC41B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7E83C42B17D785F3003DC41B /* CorpseAddressTest.cpp in Sources */,
+				7E83C42717D785F3003DC41B /* CorpseByteParserTest.cpp in Sources */,
+				7E83C40B17D785F3003DC41B /* CorpseExportsTrieTest.cpp in Sources */,
+				7E83C42E17D785F3003DC41B /* CorpseProcessTest.cpp in Sources */,
+				7E83C43117D785F3003DC41B /* CorpseRegionTest.cpp in Sources */,
+				7E83C40D17D785F3003DC41B /* CorpseSnapshotTest.cpp in Sources */,
+				7E83C40E17D785F3003DC41B /* CorpseSymbolTest.cpp in Sources */,
+				7E83C43417D785F3003DC41B /* CorpseThreadTest.cpp in Sources */,
+				7E83C40C17D785F3003DC41B /* LibJSCToolsTestUtilities.cpp in Sources */,
+				7E83C40A17D785F3003DC41B /* testLibJSCTools.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14377,6 +14783,31 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		D3934A4385F631C04057F7E7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 49D9C56EC7911960C24239F3 /* JavaScriptCoreTools */;
+			targetProxy = 6044D4B120B01FBCA9BCFBE5 /* PBXContainerItemProxy */;
+		};
+		A1B2C30005E5B4A700C0FFEE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 49D9C56EC7911960C24239F3 /* JavaScriptCoreTools */;
+			targetProxy = A1B2C30004E5B4A700C0FFEE /* PBXContainerItemProxy */;
+		};
+		A1B2C30007E5B4A700C0FFEE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6B03652E1F50D87F0DEC6B42 /* mya */;
+			targetProxy = A1B2C30006E5B4A700C0FFEE /* PBXContainerItemProxy */;
+		};
+		A1B2C30009E5B4A700C0FFEE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7E83C41317D785F3003DC41B /* testLibJSCTools */;
+			targetProxy = A1B2C30008E5B4A700C0FFEE /* PBXContainerItemProxy */;
+		};
+		F7DDEC2D6CAFD2ACDD19D991 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 49D9C56EC7911960C24239F3 /* JavaScriptCoreTools */;
+			targetProxy = 291A8D565940996D3CA021C1 /* PBXContainerItemProxy */;
+		};
 		074D7E0A2E3D3B6800CD38C6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 65FB3F6609D11E9100F49DEB /* Derived Sources */;
@@ -14462,6 +14893,21 @@
 			target = 65FB3F6609D11E9100F49DEB /* Derived Sources */;
 			targetProxy = 14D9D9D9218462B5009126C2 /* PBXContainerItemProxy */;
 		};
+		87B6EB7D11A4B965B9269538 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65FB3F6609D11E9100F49DEB /* Derived Sources */;
+			targetProxy = B70B8C003BC4F51DF41C2D65 /* PBXContainerItemProxy */;
+		};
+		A1B2C3000BE5B4A700C0FFEE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65FB3F6609D11E9100F49DEB /* Derived Sources */;
+			targetProxy = A1B2C3000AE5B4A700C0FFEE /* PBXContainerItemProxy */;
+		};
+		5F40739EF054554602787C41 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6B03652E1F50D87F0DEC6B42 /* mya */;
+			targetProxy = A269FDF04AF38423A3A5DE9A /* PBXContainerItemProxy */;
+		};
 		44F93E112AE7200100FFA37C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 44F93E012AE71F5300FFA37C /* libJavaScriptCore */;
@@ -14542,6 +14988,21 @@
 			target = FE533CA11F217DB30016A1FE /* testmasm */;
 			targetProxy = FE533CAE1F217EC60016A1FE /* PBXContainerItemProxy */;
 		};
+		7E83C41B17D785F3003DC41B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65FB3F6609D11E9100F49DEB /* Derived Sources */;
+			targetProxy = 7E83C41C17D785F3003DC41B /* PBXContainerItemProxy */;
+		};
+		7E83C41D17D785F3003DC41B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E1AC2E2720F7B94C00B0897D /* Unlock Keychain */;
+			targetProxy = 7E83C41E17D785F3003DC41B /* PBXContainerItemProxy */;
+		};
+		7E83C41F17D785F3003DC41B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7E83C41317D785F3003DC41B /* testLibJSCTools */;
+			targetProxy = 7E83C42017D785F3003DC41B /* PBXContainerItemProxy */;
+		};
 		FF0F56872E33437C002A232A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = E1AC2E2720F7B94C00B0897D /* Unlock Keychain */;
@@ -14555,6 +15016,34 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		0496C9FAB31F908B0425279C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 33CCFE0660BE540320EF4777 /* libJavaScriptCoreTools.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		CF17CD764111B2A78C3D8F10 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 33CCFE0660BE540320EF4777 /* libJavaScriptCoreTools.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		1738026904B5B9E1BA357B8F /* Profiling */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 33CCFE0660BE540320EF4777 /* libJavaScriptCoreTools.xcconfig */;
+			buildSettings = {
+			};
+			name = Profiling;
+		};
+		1A9B847BE318F847F08771D9 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 33CCFE0660BE540320EF4777 /* libJavaScriptCoreTools.xcconfig */;
+			buildSettings = {
+			};
+			name = Production;
+		};
 		0F61833F1C45F62A0072450B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FEE0A12229FE250400CED5E4 /* TestExecutable.xcconfig */;
@@ -14727,6 +15216,34 @@
 		149C276B08902AFE008A9EFC /* Production */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5DAFD6CB146B686300FBEFB4 /* JSC.xcconfig */;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		0D9FBE8C4B6D65ED3E83AB12 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3E812A1EEBE0D5AEA7D3C74B /* Mya.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		39672BABA758BF6EC3C9BDE6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3E812A1EEBE0D5AEA7D3C74B /* Mya.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		D433E29BE1849C8E3DEEF0BB /* Profiling */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3E812A1EEBE0D5AEA7D3C74B /* Mya.xcconfig */;
+			buildSettings = {
+			};
+			name = Profiling;
+		};
+		9FAFBEC1CDCCB2F48A335C3E /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3E812A1EEBE0D5AEA7D3C74B /* Mya.xcconfig */;
 			buildSettings = {
 			};
 			name = Production;
@@ -15183,6 +15700,38 @@
 			};
 			name = Production;
 		};
+		7E83C41517D785F3003DC41B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1B2C30001E5B4A700C0FFEE /* TestLibJSCTools.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		7E83C41617D785F3003DC41B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1B2C30001E5B4A700C0FFEE /* TestLibJSCTools.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		7E83C41717D785F3003DC41B /* Profiling */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1B2C30001E5B4A700C0FFEE /* TestLibJSCTools.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Profiling;
+		};
+		7E83C41817D785F3003DC41B /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1B2C30001E5B4A700C0FFEE /* TestLibJSCTools.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
 		FF0F56902E33437C002A232A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FEE0A12229FE250400CED5E4 /* TestExecutable.xcconfig */;
@@ -15218,6 +15767,17 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		CDAB8A13AA6F0C8A7D95A0DD /* Build configuration list for PBXNativeTarget "JavaScriptCoreTools" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0496C9FAB31F908B0425279C /* Debug */,
+				CF17CD764111B2A78C3D8F10 /* Release */,
+				1738026904B5B9E1BA357B8F /* Profiling */,
+				1A9B847BE318F847F08771D9 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
 		0F61833E1C45F62A0072450B /* Build configuration list for PBXNativeTarget "testair" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -15291,6 +15851,17 @@
 				149C276908902AFE008A9EFC /* Release */,
 				A76148430E6402F700E357FA /* Profiling */,
 				149C276B08902AFE008A9EFC /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		1564F766F55B0B045D183322 /* Build configuration list for PBXNativeTarget "mya" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0D9FBE8C4B6D65ED3E83AB12 /* Debug */,
+				39672BABA758BF6EC3C9BDE6 /* Release */,
+				D433E29BE1849C8E3DEEF0BB /* Profiling */,
+				9FAFBEC1CDCCB2F48A335C3E /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
@@ -15445,6 +16016,17 @@
 				FE533CA91F217DB30016A1FE /* Release */,
 				FE533CAA1F217DB30016A1FE /* Profiling */,
 				FE533CAB1F217DB30016A1FE /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		7E83C41417D785F3003DC41B /* Build configuration list for PBXNativeTarget "testLibJSCTools" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7E83C41517D785F3003DC41B /* Debug */,
+				7E83C41617D785F3003DC41B /* Release */,
+				7E83C41717D785F3003DC41B /* Profiling */,
+				7E83C41817D785F3003DC41B /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;

--- a/Source/JavaScriptCore/Scripts/process-entitlements.sh
+++ b/Source/JavaScriptCore/Scripts/process-entitlements.sh
@@ -69,6 +69,23 @@ function mac_process_testapi_entitlements()
     fi
 }
 
+function mac_process_mya_entitlements()
+{
+    if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
+    then
+        plistbuddy Add :com.apple.private.cs.debugger bool YES
+
+        if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
+        then
+            plistbuddy Add :com.apple.private.pac.exception bool YES
+        fi
+
+        plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+
+        plistbuddy Add :com.apple.developer.hardened-process bool YES
+    fi
+}
+
 # ========================================
 # macCatalyst entitlements
 # ========================================
@@ -133,6 +150,23 @@ function maccatalyst_process_testapi_entitlements()
     fi
 }
 
+function maccatalyst_process_mya_entitlements()
+{
+    if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
+    then
+        plistbuddy Add :com.apple.private.cs.debugger bool YES
+
+        if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
+        then
+            plistbuddy Add :com.apple.private.pac.exception bool YES
+        fi
+
+        plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+
+        plistbuddy Add :com.apple.developer.hardened-process bool YES
+    fi
+}
+
 # ========================================
 # iOS Family entitlements
 # ========================================
@@ -165,6 +199,22 @@ function ios_family_process_jsc_entitlements()
     plistbuddy Add :com.apple.developer.hardened-process bool YES
 }
 
+function ios_family_process_mya_entitlements()
+{
+    if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
+    then
+        plistbuddy Add :com.apple.private.cs.debugger bool YES
+    fi
+
+    if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
+    then
+        plistbuddy Add :com.apple.private.pac.exception bool YES
+    fi
+
+    plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+    plistbuddy Add :com.apple.developer.hardened-process bool YES
+}
+
 rm -f "${WK_PROCESSED_XCENT_FILE}"
 plistbuddy Clear dict
 
@@ -185,6 +235,9 @@ then
           "${PRODUCT_NAME}" == testmem ||
           "${PRODUCT_NAME}" == testRegExp ]]; then mac_process_jsc_entitlements
     elif [[ "${PRODUCT_NAME}" == testapi ]]; then mac_process_testapi_entitlements
+    elif [[ "${PRODUCT_NAME}" == mya ]]; then mac_process_mya_entitlements
+    # testLibJSCTools only ever snapshots its own process, which needs no entitlement.
+    elif [[ "${PRODUCT_NAME}" == testLibJSCTools ]]; then true
     else echo "Unsupported/unknown product: ${PRODUCT_NAME}"
     fi
 elif [[ "${WK_PLATFORM_NAME}" == maccatalyst || "${WK_PLATFORM_NAME}" == iosmac ]]
@@ -201,6 +254,9 @@ then
           "${PRODUCT_NAME}" == testmem ||
           "${PRODUCT_NAME}" == testRegExp ]]; then maccatalyst_process_jsc_entitlements
     elif [[ "${PRODUCT_NAME}" == testapi ]]; then maccatalyst_process_testapi_entitlements
+    elif [[ "${PRODUCT_NAME}" == mya ]]; then maccatalyst_process_mya_entitlements
+    # testLibJSCTools only ever snapshots its own process, which needs no entitlement.
+    elif [[ "${PRODUCT_NAME}" == testLibJSCTools ]]; then true
     else echo "Unsupported/unknown product: ${PRODUCT_NAME}"
     fi
 elif [[ "${WK_PLATFORM_NAME}" == iphoneos ||
@@ -218,6 +274,9 @@ then
           "${PRODUCT_NAME}" == testmasm ||
           "${PRODUCT_NAME}" == testmem ||
           "${PRODUCT_NAME}" == testRegExp ]]; then ios_family_process_jsc_entitlements
+    elif [[ "${PRODUCT_NAME}" == mya ]]; then ios_family_process_mya_entitlements
+    # testLibJSCTools only ever snapshots its own process, which needs no entitlement.
+    elif [[ "${PRODUCT_NAME}" == testLibJSCTools ]]; then true
     else echo "Unsupported/unknown product: ${PRODUCT_NAME}"
     fi
 else

--- a/Source/JavaScriptCore/corpse/CMakeLists.txt
+++ b/Source/JavaScriptCore/corpse/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(JavaScriptCoreTools_LIBRARY_TYPE STATIC)
+
+set(JavaScriptCoreTools_SOURCES
+    CorpseByteParser.cpp
+    CorpseClient.cpp
+    CorpseError.cpp
+    CorpseExportsTrie.cpp
+    CorpseProcess.cpp
+    CorpseRegion.cpp
+    CorpseSnapshot.cpp
+    CorpseSymbol.cpp
+    CorpseThread.cpp
+)
+
+set(JavaScriptCoreTools_PRIVATE_INCLUDE_DIRECTORIES
+    $<TARGET_PROPERTY:JavaScriptCore,INCLUDE_DIRECTORIES>
+)
+
+set(JavaScriptCoreTools_FRAMEWORKS
+    JavaScriptCore
+    WTF
+    bmalloc
+)
+
+WEBKIT_LIBRARY_DECLARE(JavaScriptCoreTools)
+
+WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
+
+WEBKIT_LIBRARY(JavaScriptCoreTools)
+
+# The corpse sources use JavaScriptCore's generated headers.
+add_dependencies(JavaScriptCoreTools JavaScriptCore)

--- a/Source/JavaScriptCore/corpse/CorpseAddress.h
+++ b/Source/JavaScriptCore/corpse/CorpseAddress.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <bit>
+#include <compare>
+#include <cstddef>
+#include <mach/mach.h>
+#include <stdint.h>
+
+#if CPU(ARM64E)
+#include <ptrauth.h>
+#endif
+
+namespace JSC {
+namespace Corpse {
+
+// An address in the target corpse process. A corpse address can never be dereferenced
+// by accident.
+class Address {
+public:
+    Address() = default;
+    explicit Address(mach_vm_address_t value)
+        : m_value(value)
+    {
+    }
+    explicit Address(const void* pointer)
+        : m_value(reinterpret_cast<mach_vm_address_t>(pointer))
+    {
+    }
+
+    mach_vm_address_t toMachVMAddress() const { return m_value; }
+    explicit operator bool() const { return m_value; }
+    template<typename T> explicit operator T() const = delete;
+
+    Address stripped() const
+    {
+#if CPU(ARM64E)
+        // We don't know if this is a code or data pointer. The 2 have different number of
+        // bits. But we know that code pointers have more PAC bits. So, we'll conservatively
+        // use XPACI to strip the max number of PAC bits.
+        auto stripped = ptrauth_strip(reinterpret_cast<void*>(m_value), ptrauth_key_process_dependent_code);
+
+        // While XPACI may have already stripped the MTE tag in data pointers as well,
+        // we don't want to assume that code pointer PAC bits will always cover the MTE
+        // nibble or non-zero data pointer top-bytes due to TBI (Top Byte Ignore). So,
+        // let's explicitly clear the top byte to be sure.
+        constexpr uintptr_t topByte = 0xffull << 56;
+        uintptr_t strippedInt = std::bit_cast<uintptr_t>(stripped);
+        strippedInt &= ~topByte;
+
+        return Address(std::bit_cast<void*>(strippedInt));
+#else
+        return *this;
+#endif
+    }
+
+    friend bool operator==(Address, Address) = default;
+    friend auto operator<=>(Address, Address) = default;
+
+    friend bool operator==(Address address, std::nullptr_t) { return !address.m_value; }
+
+    Address operator+(uint64_t offset) const { return Address(m_value + offset); }
+    Address operator-(uint64_t offset) const { return Address(m_value - offset); }
+
+    uint64_t operator-(Address other) const { return m_value - other.m_value; }
+
+private:
+    mach_vm_address_t m_value { 0 };
+};
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseByteParser.cpp
+++ b/Source/JavaScriptCore/corpse/CorpseByteParser.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseByteParser.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <wtf/LEBDecoder.h>
+#include <wtf/StdLibExtras.h>
+
+namespace JSC {
+namespace Corpse {
+
+std::optional<uint8_t> ByteParser::consumeByte()
+{
+    if (m_position >= m_data.size())
+        return std::nullopt;
+    return m_data[m_position++];
+}
+
+std::optional<uint64_t> ByteParser::consumeULEB128()
+{
+    size_t start = m_position;
+    uint64_t result = 0;
+    if (WTF::LEBDecoder::decodeUInt64(m_data, m_position, result))
+        return result;
+    m_position = start;
+    return std::nullopt;
+}
+
+std::optional<std::string_view> ByteParser::consumeCString()
+{
+    size_t start = m_position;
+    while (m_position < m_data.size() && m_data[m_position])
+        ++m_position;
+    if (m_position >= m_data.size()) {
+        m_position = start;
+        return std::nullopt;
+    }
+    std::string_view result(spanReinterpretCast<const char>(m_data.subspan(start, m_position - start)));
+    ++m_position; // Consume the null terminator.
+    return result;
+}
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseByteParser.h
+++ b/Source/JavaScriptCore/corpse/CorpseByteParser.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <optional>
+#include <span>
+#include <stdint.h>
+#include <string_view>
+
+namespace JSC {
+namespace Corpse {
+
+// A forward byte parser over a local buffer. Every read reports whether it got
+// what it asked for, and a read that fails consumes nothing.
+class ByteParser {
+public:
+    ByteParser(std::span<const uint8_t> data, size_t position = 0)
+        : m_data(data)
+        , m_position(position)
+    {
+    }
+
+    size_t position() const { return m_position; }
+
+    std::optional<uint8_t> consumeByte();
+
+    // Decodes the ULEB128 at the cursor. Returns nullopt if the buffer ends
+    // before the encoding does, or if the value will not fit in 64 bits.
+    // Untrusted data can hold either, and silently truncating one would yield a
+    // plausible wrong value instead of a detected failure.
+    std::optional<uint64_t> consumeULEB128();
+
+    // Returns the null-terminated string at the cursor. Returns nullopt if the
+    // buffer ends before the terminator does: without that the trailing bytes of
+    // a truncated buffer read back as a complete string.
+    std::optional<std::string_view> consumeCString();
+
+private:
+    std::span<const uint8_t> m_data;
+    size_t m_position;
+};
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseClient.cpp
+++ b/Source/JavaScriptCore/corpse/CorpseClient.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseClient.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+namespace JSC {
+namespace Corpse {
+
+ASCIILiteral Client::s_clientName = "JSC::Corpse"_s; // Default if not set.
+
+void Client::setName(ASCIILiteral name)
+{
+    if (!name.isEmpty())
+        s_clientName = name;
+}
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseClient.h
+++ b/Source/JavaScriptCore/corpse/CorpseClient.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <wtf/text/ASCIILiteral.h>
+
+namespace JSC {
+namespace Corpse {
+
+// Currently, this is only to allow the client application to set the client name
+// during initialization so that error messages identify with the client instead
+// of the corpse library.
+
+class Client {
+public:
+    static void setName(ASCIILiteral);
+    static ASCIILiteral name() { return s_clientName; }
+
+private:
+    static ASCIILiteral s_clientName;
+};
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseError.cpp
+++ b/Source/JavaScriptCore/corpse/CorpseError.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseError.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "CorpseClient.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC {
+namespace Corpse {
+
+void Error::report(const char* format, ...)
+{
+    fprintf(stderr, "%s: ", Client::name().characters());
+
+    va_list args;
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
+
+    fputc('\n', stderr);
+}
+
+} // namespace Corpse
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseError.h
+++ b/Source/JavaScriptCore/corpse/CorpseError.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <wtf/Assertions.h>
+
+namespace JSC {
+namespace Corpse {
+
+// Reports the library's diagnostics. Messages are prefixed with the name the
+// client set via Corpse::Client, so they read as the client's own output.
+class Error {
+public:
+    static void report(const char* format, ...) WTF_ATTRIBUTE_PRINTF(1, 2);
+};
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseExportsTrie.cpp
+++ b/Source/JavaScriptCore/corpse/CorpseExportsTrie.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseExportsTrie.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <mach-o/loader.h>
+#include <optional>
+
+namespace JSC {
+namespace Corpse {
+
+// The bits that Mach-O defines in an exports trie terminal's flags.
+constexpr uint64_t knownExportFlagBits = EXPORT_SYMBOL_FLAGS_KIND_MASK
+    | EXPORT_SYMBOL_FLAGS_WEAK_DEFINITION
+    | EXPORT_SYMBOL_FLAGS_REEXPORT
+    | EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER
+    | EXPORT_SYMBOL_FLAGS_STATIC_RESOLVER;
+
+Expected<ExportsTrie::Export, ExportsTrie::Failure> ExportsTrie::lookUp(std::span<const uint8_t> trie, std::string_view name)
+{
+    size_t nodeOffset = 0;
+    std::string_view remaining = name;
+
+    // The only way around this loop is by matching an edge, which consumes at least
+    // one character of the `remaining` name we're searching for. Because empty edges
+    // are rejected below, the walk is bounded by the length of the name no matter
+    // what the trie's child offsets say, and cannot be made to revisit a node forever.
+    while (nodeOffset < trie.size()) {
+        ByteParser node(trie, nodeOffset);
+
+        // A terminal node in a dyld exports trie is: a length, then flags, then some
+        // ULEB128s whose meaning depends on the flags. See mach-o/loader.h around lines
+        // 1488–1499 for details.
+        auto terminalLength = node.consumeULEB128();
+        if (!terminalLength)
+            return makeUnexpected(Failure::Malformed);
+
+        // terminalLength is a full 64-bit value out of the trie, so it is compared
+        // against what is left of the trie rather than by forming position + terminalLength,
+        // which could wrap and pass a direct comparison. The subtraction is safe because
+        // consumeULEB128 stops at the end of the trie, so the position cannot have passed it.
+        if (*terminalLength > trie.size() - node.position())
+            return makeUnexpected(Failure::Malformed);
+        size_t childrenPosition = node.position() + *terminalLength;
+
+        if (remaining.empty() && *terminalLength) {
+            // The payload is read through a parser bounded to the terminal, so that a
+            // terminal declaring less than the flags and offset it needs cannot be made
+            // to take the bytes that follow it as its own.
+            ByteParser terminal(trie.subspan(node.position(), *terminalLength));
+            auto flags = terminal.consumeULEB128();
+            if (!flags)
+                return makeUnexpected(Failure::Malformed);
+            if (*flags & ~knownExportFlagBits)
+                return makeUnexpected(Failure::Malformed);
+            if (*flags & EXPORT_SYMBOL_FLAGS_REEXPORT)
+                return makeUnexpected(Failure::ReExport);
+
+            Export::Kind kind;
+            switch (*flags & EXPORT_SYMBOL_FLAGS_KIND_MASK) {
+            case EXPORT_SYMBOL_FLAGS_KIND_REGULAR:
+                kind = Export::Kind::Regular;
+                break;
+            case EXPORT_SYMBOL_FLAGS_KIND_ABSOLUTE:
+                kind = Export::Kind::Absolute; // the value is the address itself.
+                break;
+            default:
+                // Thread-local, or a kind postdating this code. A thread-local's value
+                // is the offset of its TLV descriptor, not of the variable, and the
+                // variable's address differs per thread, so there is no one answer to
+                // report. Saying nothing beats reporting the descriptor as if it were
+                // the variable.
+                return makeUnexpected(Failure::UnsupportedKind);
+            }
+
+            auto value = terminal.consumeULEB128();
+            if (!value)
+                return makeUnexpected(Failure::Malformed);
+            return Export { kind, *value };
+        }
+
+        ByteParser children(trie, childrenPosition);
+        auto childCount = children.consumeByte();
+        if (!childCount)
+            return makeUnexpected(Failure::Malformed);
+
+        std::optional<uint64_t> nextNodeOffset;
+        for (uint8_t i = 0; i < *childCount; ++i) {
+            auto edge = children.consumeCString();
+            if (!edge)
+                return makeUnexpected(Failure::Malformed);
+            // An edge carries the characters that tell a node's children apart,
+            // so an empty one is malformed. It would also match anything, and
+            // descending on it would consume none of the name.
+            if (edge->empty())
+                return makeUnexpected(Failure::Malformed);
+            auto childOffset = children.consumeULEB128();
+            if (!childOffset)
+                return makeUnexpected(Failure::Malformed);
+            if (remaining.starts_with(*edge)) {
+                remaining.remove_prefix(edge->size());
+                nextNodeOffset = childOffset;
+                break;
+            }
+        }
+        // No edge matched what is left of the name, so nothing below this node
+        // can hold it. A node with no children ends the walk the same way.
+        if (!nextNodeOffset)
+            return makeUnexpected(Failure::Absent);
+        nodeOffset = *nextNodeOffset;
+    }
+    // A child offset led to or past the end of the trie.
+    return makeUnexpected(Failure::Malformed);
+}
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseExportsTrie.h
+++ b/Source/JavaScriptCore/corpse/CorpseExportsTrie.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <JavaScriptCore/CorpseByteParser.h>
+#include <span>
+#include <stdint.h>
+#include <string_view>
+#include <wtf/Expected.h>
+
+namespace JSC {
+namespace Corpse {
+
+// The dyld exports trie of one Mach-O image: a prefix tree over exported symbol
+// names, whose terminals say how to compute each symbol's address.
+//
+// A trie read out of a corpse is untrusted input, so the walk is bounded and a
+// malformed encoding is reported rather than guessed at.
+class ExportsTrie {
+public:
+    // A matched terminal, and how to turn it into an address.
+    struct Export {
+        enum class Kind : uint8_t {
+            Regular, // An offset from the image's base address.
+            Absolute, // Already an address, not relative to the image.
+        };
+        Kind kind { Kind::Regular };
+        uint64_t value { 0 };
+    };
+
+    enum class Failure : uint8_t {
+        Absent,
+        Malformed, // An encoding did not decode, or an offset led outside the trie.
+        ReExport, // Matched, but the symbol is defined in another image.
+        UnsupportedKind, // Matched, but the kind has no one address, such as a thread-local.
+    };
+
+    static Expected<Export, Failure> lookUp(std::span<const uint8_t> trie, std::string_view name);
+};
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseProcess.cpp
+++ b/Source/JavaScriptCore/corpse/CorpseProcess.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseProcess.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "CorpseError.h"
+
+#include <errno.h>
+#include <mach/mach.h>
+#include <mach/mach_error.h>
+#include <mach/mach_traps.h>
+#include <signal.h>
+#include <sys/proc.h>
+#include <sys/sysctl.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC {
+namespace Corpse {
+
+// A task port name outlives the task it named: when the target exits, the right we
+// hold becomes a dead name while the name itself is unchanged. MACH_PORT_VALID only
+// looks at the name, so it keeps reporting the port as good. Asking the kernel which
+// pid the port names is what tells a still-attached process apart from one that has
+// since exited -- and, because the answer is compared against m_pid, from a later
+// process that inherited the same pid.
+bool Process::holdsLiveTask() const
+{
+    if (!MACH_PORT_VALID(m_taskPort))
+        return false;
+    int pid = -1;
+    return pid_for_task(m_taskPort, &pid) == KERN_SUCCESS && pid == m_pid;
+}
+
+bool Process::isTranslated() const
+{
+    struct kinfo_proc info;
+    size_t length = sizeof info;
+    int selector[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, m_pid };
+    // A pid that no longer exists is not an error here: sysctl succeeds and reports
+    // that it wrote nothing, so the size has to be checked rather than the result.
+    if (sysctl(selector, 4, &info, &length, nullptr, 0) || length < sizeof info)
+        return false;
+    return info.kp_proc.p_flag & P_TRANSLATED;
+}
+
+bool Process::attach()
+{
+    if (isAttached()) {
+        if (holdsLiveTask())
+            return true;
+        // The target exited while we held its port.
+        detach();
+    }
+
+    mach_port_t taskPort = MACH_PORT_NULL;
+    kern_return_t kr = task_for_pid(mach_task_self(), m_pid, &taskPort);
+    if (kr == KERN_SUCCESS) {
+        m_taskPort = taskPort;
+        return true;
+    }
+
+    if (kill(m_pid, 0) && errno == ESRCH)
+        Error::report("No process with PID %d", static_cast<int>(m_pid));
+    else {
+        Error::report("Could not attach to PID %u: %s (0x%x) -- may need to run as root "
+            "or add the appropriate debugger entitlement",
+            static_cast<unsigned>(m_pid), mach_error_string(kr), kr);
+    }
+    return false;
+}
+
+void Process::detach()
+{
+    if (MACH_PORT_VALID(m_taskPort))
+        mach_port_deallocate(mach_task_self(), m_taskPort);
+    m_taskPort = MACH_PORT_NULL;
+}
+
+} // namespace Corpse
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseProcess.h
+++ b/Source/JavaScriptCore/corpse/CorpseProcess.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <mach/mach.h>
+#include <sys/types.h>
+#include <wtf/Assertions.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+
+namespace JSC {
+namespace Corpse {
+
+// Represents a target corpse process identified by PID. It manages the Mach task
+// port for that process: attach() acquires it, detach() releases it (but keeps the
+// PID so the same Process can be reattached later).
+class Process final : public RefCounted<Process> {
+public:
+    static Ref<Process> create(pid_t pid) { return adoptRef(*new Process(pid)); }
+
+    ~Process() { detach(); }
+
+    bool attach();
+    void detach();
+
+    pid_t pid() const { return m_pid; }
+    mach_port_t taskPort() const { return m_taskPort; }
+
+    bool isAttached() const { return MACH_PORT_VALID(m_taskPort); }
+
+    // The target process may have terminated while we still hold the port.
+    bool holdsLiveTask() const;
+
+    // True if the target runs under Rosetta translation. Such a process executes as
+    // arm64 whatever its own architecture is, so its thread state describes the
+    // translator rather than the program, and cannot be read as the program's.
+    bool isTranslated() const;
+
+private:
+    explicit Process(pid_t pid)
+        : m_pid(pid)
+    {
+        RELEASE_ASSERT(pid > 0);
+    }
+
+    pid_t m_pid;
+    mach_port_t m_taskPort { MACH_PORT_NULL };
+};
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseRegion.cpp
+++ b/Source/JavaScriptCore/corpse/CorpseRegion.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseRegion.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <mach/mach_vm.h>
+
+namespace JSC {
+namespace Corpse {
+
+uint64_t Region::pageCount() const
+{
+    return vm_kernel_page_size ? m_size / vm_kernel_page_size : 0;
+}
+
+std::optional<Region> Region::findContaining(mach_port_t task, Address address)
+{
+    // mach_vm_region_recurse reports the region at or above the address it is given,
+    // so the result only describes `address` if it turns out to contain it.
+    mach_vm_address_t regionAddress = 0;
+    mach_vm_size_t regionSize = 0;
+    vm_region_submap_info_data_64_t info;
+    for (natural_t depth = 0; ; ++depth) {
+        regionAddress = address.toMachVMAddress();
+        regionSize = 0;
+        natural_t depthLimit = depth; // We tell the kernel how deep we want to go. Kernel tells us how deep it can go.
+        mach_msg_type_number_t infoCount = VM_REGION_SUBMAP_INFO_COUNT_64;
+        kern_return_t kr = mach_vm_region_recurse(task, &regionAddress, &regionSize,
+            &depthLimit, reinterpret_cast<vm_region_recurse_info_t>(&info), &infoCount);
+        if (kr != KERN_SUCCESS)
+            return std::nullopt;
+        if (!info.is_submap)
+            break;
+    }
+
+    Region region;
+    region.m_base = Address(regionAddress);
+    region.m_size = static_cast<size_t>(regionSize);
+    if (!region.contains(address))
+        return std::nullopt;
+
+    region.m_residentPageCount = info.pages_resident;
+    region.m_dirtyPageCount = info.pages_dirtied;
+    return region;
+}
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseRegion.h
+++ b/Source/JavaScriptCore/corpse/CorpseRegion.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <JavaScriptCore/CorpseAddress.h>
+#include <mach/mach.h>
+#include <optional>
+#include <stdint.h>
+
+namespace JSC {
+namespace Corpse {
+
+// One mapped region of a task's address space, as the kernel describes it.
+class Region {
+public:
+    // The region containing `address`, or nullopt if not found in any region.
+    static std::optional<Region> findContaining(mach_port_t task, Address);
+
+    Address base() const { return m_base; }
+    size_t size() const { return m_size; }
+    Address end() const { return m_base + m_size; }
+    bool contains(Address address) const { return address >= m_base && address < end(); }
+
+    uint64_t pageCount() const;
+    uint64_t residentPageCount() const { return m_residentPageCount; }
+    uint64_t dirtyPageCount() const { return m_dirtyPageCount; }
+
+private:
+    Address m_base;
+    size_t m_size { 0 };
+    uint64_t m_residentPageCount { 0 };
+    uint64_t m_dirtyPageCount { 0 };
+};
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseSnapshot.cpp
+++ b/Source/JavaScriptCore/corpse/CorpseSnapshot.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseSnapshot.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "CorpseError.h"
+
+#include <mach/mach.h>
+#include <mach/mach_error.h>
+#include <wtf/TZoneMallocInlines.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC {
+namespace Corpse {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Snapshot);
+
+unsigned Snapshot::s_nextId = 1;
+
+Snapshot::Snapshot(RefPtr<Process> process)
+    : m_process(WTF::move(process))
+    , m_id(s_nextId++)
+{
+    if (!m_process || !m_process->isAttached())
+        return;
+
+    // Snapshot the target into a corpse; only a read port is required from here
+    // on, and the corpse is independent of the live target.
+    kern_return_t kr = task_generate_corpse(m_process->taskPort(), &m_corpsePort);
+    if (kr != KERN_SUCCESS) {
+        m_corpsePort = MACH_PORT_NULL;
+        if (!m_process->holdsLiveTask()) {
+            Error::report("Could not snapshot PID %d: the process has terminated",
+                static_cast<int>(m_process->pid()));
+        } else {
+            Error::report("Could not snapshot PID %d: %s (0x%x)",
+                static_cast<int>(m_process->pid()), mach_error_string(kr), kr);
+        }
+    }
+}
+
+Snapshot::~Snapshot()
+{
+    if (isValid())
+        mach_port_deallocate(mach_task_self(), m_corpsePort);
+}
+
+const Vector<Thread>& Snapshot::threads()
+{
+    if (!m_threads)
+        m_threads = Thread::collect(*this);
+    return *m_threads;
+}
+
+Address Snapshot::symbol(const char* name)
+{
+    if (!name || !*name)
+        return { };
+
+    auto entry = m_symbols.ensure<StringViewHashTranslator>(StringView::fromLatin1(name), [&] {
+        return WTF::makeUnique<Symbol>(*this, name);
+    });
+
+    return entry.iterator->value->address();
+}
+
+} // namespace Corpse
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseSnapshot.h
+++ b/Source/JavaScriptCore/corpse/CorpseSnapshot.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <JavaScriptCore/CorpseAddress.h>
+#include <JavaScriptCore/CorpseProcess.h>
+#include <JavaScriptCore/CorpseSymbol.h>
+#include <JavaScriptCore/CorpseThread.h>
+#include <mach/mach.h>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <wtf/DoublyLinkedList.h>
+#include <wtf/HashMap.h>
+#include <wtf/RefPtr.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+#include <wtf/text/StringHash.h>
+#include <wtf/text/StringView.h>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+namespace Corpse {
+
+// Owns a corpse (a read-only Mach snapshot of a process)
+// Check isValid() to see whether acquisition succeeded.
+//
+// Snapshots are linked into a DoublyLinkedList by their owner. The list is
+// intrusive and does not own its nodes: whoever appends a Snapshot must remove
+// it from the list before destroying it.
+class Snapshot : public DoublyLinkedListNode<Snapshot> {
+    WTF_MAKE_TZONE_ALLOCATED(Snapshot);
+public:
+    explicit Snapshot(RefPtr<Process>);
+    ~Snapshot();
+
+    Snapshot(const Snapshot&) = delete;
+    Snapshot& operator=(const Snapshot&) = delete;
+    Snapshot(Snapshot&& other) = delete;
+
+    bool isValid() const { return MACH_PORT_VALID(m_corpsePort); }
+
+    // A monotonically increasing identifier assigned at construction. IDs are
+    // never reused, so they stay stable as snapshots are added and removed.
+    unsigned id() const { return m_id; }
+
+    Process* process() const { return m_process.get(); }
+    mach_port_t corpsePort() const { return m_corpsePort; }
+
+    // The threads captured in this corpse, read and cached on the first call.
+    const Vector<Thread>& threads();
+
+    // The address of `name` in this corpse, null if it is not there.
+    Address symbol(const char* name);
+
+private:
+    static unsigned s_nextId;
+
+    RefPtr<Process> m_process;
+    mach_port_t m_corpsePort { MACH_PORT_NULL };
+    unsigned m_id;
+
+    std::optional<Vector<Thread>> m_threads;
+    HashMap<String, std::unique_ptr<Symbol>> m_symbols;
+
+    Snapshot* m_prev { nullptr }; // Required by DoublyLinkedListNode.
+    Snapshot* m_next { nullptr }; // Required by DoublyLinkedListNode.
+
+    friend class WTF::DoublyLinkedListNode<Snapshot>;
+};
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseSymbol.cpp
+++ b/Source/JavaScriptCore/corpse/CorpseSymbol.cpp
@@ -1,0 +1,481 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseSymbol.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "CorpseError.h"
+#include "CorpseExportsTrie.h"
+#include "CorpseSnapshot.h"
+
+#include <mach-o/dyld_images.h>
+#include <mach-o/loader.h>
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <mach/task_info.h>
+#include <optional>
+#include <span>
+#include <string.h>
+#include <string_view>
+#include <type_traits>
+#include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/Vector.h>
+#include <wtf/text/StringCommon.h>
+
+#if CORPSE_SYMBOL_LOOKUP_DIAGNOSTICS
+#define CORPSE_DIAGNOSTIC_DO(statement) statement
+#else
+#define CORPSE_DIAGNOSTIC_DO(statement) ((void)0)
+#endif
+
+namespace JSC {
+namespace Corpse {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Symbol);
+
+// It is assumed that this corpse analysis library is built with the same SDK targeting
+// the same OS that the corpse binary is built for. While the corpse gives us the data
+// to inspect, it does not provide the format. Hence, we need to rely on the invariant
+// that this analysis library is built with the same understanding of the same data
+// format used in the corpse. This is how we can walk and interpret the corpse's
+// dyld exports trie and get addresses of symbols.
+
+namespace {
+
+// Sizes and counts read out of a corpse are used to bound loops and to size
+// allocations, so they are checked against these limits first. Each one is a
+// sanity check on a single value: it says the struct we read was not what we
+// thought it was, in which case the addresses in it are not worth chasing. They
+// are not a bound on the work a lookup can do, because the per-image limits
+// multiply by the image count. maxTotalBytesRead below is that bound.
+//
+// The values sit above what was empirically measured: across every Mach-O image
+// installed on a sample system the largest load commands were 7.4 KB and the
+// largest exports trie 2.1 MB, and a process that dlopens every framework on the
+// system reaches about 2,800 images.
+constexpr size_t maxLoadCommandsSize = 128 * KB; // About 17× the measured maximum.
+constexpr size_t maxExportsTrieSize = 16 * MB; // About 8× the measured maximum.
+constexpr uint32_t maxImageCount = 16 * 1024; // About 6× the measured maximum.
+
+// A lookup that finds nothing will read every image's load commands and exports
+// trie, which measured 101 MB for the ~2,800 image process above and 0.4 MB for
+// a small one. This caps the total for one lookup, so a corpse claiming many
+// large images cannot turn a single symbol lookup into unbounded copying.
+constexpr size_t maxTotalBytesRead = 256 * MB; // About 2.5× the measured maximum.
+
+// Copies data from a corpse task's virtual address space.
+// FIXME: This is a temporary "get things to work solution", and will be replaced with
+// a more efficient memory access from a page manager later that eliminates copying.
+class TaskMemory {
+public:
+    explicit TaskMemory(mach_port_t task)
+        : m_task(task)
+    {
+    }
+
+    template<typename T>
+    std::optional<T> read(Address address) const
+    {
+        static_assert(std::is_trivially_copyable_v<T>);
+        T out;
+        if (!readRaw(address, &out, sizeof out))
+            return std::nullopt;
+        return out;
+    }
+
+    std::optional<Vector<uint8_t>> readBytes(Address address, size_t length) const
+    {
+        Vector<uint8_t> buffer;
+        // Callers derive `length` from the corpse, so failing to allocate is a
+        // potential outcome here due to potential corruption.
+        if (!buffer.tryGrow(length))
+            return std::nullopt;
+        if (!readRaw(address, buffer.mutableSpan().data(), length))
+            return std::nullopt;
+        return buffer;
+    }
+
+private:
+    bool readRaw(Address address, void* destination, size_t length) const
+    {
+        mach_vm_size_t got = 0;
+        kern_return_t kr = mach_vm_read_overwrite(m_task, address.toMachVMAddress(), length,
+            reinterpret_cast<mach_vm_address_t>(destination), &got);
+        return kr == KERN_SUCCESS && got == length;
+    }
+
+    mach_port_t m_task;
+};
+
+template<typename T>
+std::optional<T> readCommand(std::span<const uint8_t> commands, size_t offset)
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+    // Compared against what is left of the buffer rather than by forming
+    // offset + sizeof(T), which could wrap and pass a direct comparison. The
+    // first clause is what makes the subtraction safe.
+    if (offset > commands.size() || commands.size() - offset < sizeof(T))
+        return std::nullopt;
+
+    T value;
+    memcpySpan(asMutableByteSpan(value), commands.subspan(offset, sizeof(T)));
+    return value;
+}
+
+bool segmentNameIs(const char (&name)[16], std::string_view expected)
+{
+    // A segment name fills the whole array when it is exactly 16 characters, in
+    // which case it has no terminator.
+    std::span<const char> span { name };
+    return std::string_view(span.first(strlenSpan(span))) == expected;
+}
+
+} // anonymous namespace
+
+bool Symbol::hasReadBudget(size_t length)
+{
+    if (length > m_readBudget) {
+        CORPSE_DIAGNOSTIC_DO(++m_diagnostics.readBudgetExhausted);
+        return false;
+    }
+    m_readBudget -= length;
+    return true;
+}
+
+// Resolves `name` in the one image loaded at `imageAddress`, via its exports
+// trie. Returns a null address if this image does not export it.
+Address Symbol::resolveInImage(mach_port_t task, Address imageAddress, std::string_view name)
+{
+    TaskMemory memory(task);
+
+    auto header = memory.read<mach_header_64>(imageAddress);
+    if (!header || header->magic != MH_MAGIC_64) {
+        CORPSE_DIAGNOSTIC_DO(++m_diagnostics.unreadableHeader);
+        return { };
+    }
+    CORPSE_DIAGNOSTIC_DO(++m_diagnostics.examined);
+    if (header->flags & MH_DYLIB_IN_CACHE)
+        CORPSE_DIAGNOSTIC_DO(++m_diagnostics.inSharedCache);
+
+    if (header->sizeofcmds > maxLoadCommandsSize) {
+        CORPSE_DIAGNOSTIC_DO(++m_diagnostics.implausibleCommandsSize);
+        return { };
+    }
+    if (!hasReadBudget(header->sizeofcmds))
+        return { };
+    auto commandsBuffer = memory.readBytes(imageAddress + sizeof(mach_header_64), header->sizeofcmds);
+    if (!commandsBuffer) {
+        CORPSE_DIAGNOSTIC_DO(++m_diagnostics.unreadableCommands);
+        return { };
+    }
+    std::span<const uint8_t> commands = commandsBuffer->span();
+
+    std::optional<uint64_t> textVMAddress;
+    std::optional<uint64_t> linkeditVMAddress;
+    std::optional<uint64_t> linkeditFileOffset;
+    std::optional<uint64_t> linkeditFileSize;
+    uint32_t exportOffset = 0;
+    uint32_t exportSize = 0;
+
+    size_t offset = 0;
+    for (uint32_t i = 0; i < header->ncmds; ++i) {
+        auto command = readCommand<load_command>(commands, offset);
+        // cmdsize is compared against what is left of the blob rather than by
+        // forming offset + cmdsize, which could wrap and pass a direct
+        // comparison. The subtraction is safe only because a successful
+        // readCommand has already established that offset is within the blob,
+        // so the clauses have to stay in this order.
+        if (!command || command->cmdsize < sizeof(load_command) || command->cmdsize > commands.size() - offset)
+            break;
+
+        // Each case below re-reads `offset` as the larger struct the command
+        // claims to be. cmdsize has to cover that struct too: a command that
+        // declares itself smaller is malformed, and reading it anyway would take
+        // the fields that follow it as its own.
+        switch (command->cmd) {
+        case LC_SEGMENT_64: {
+            if (command->cmdsize < sizeof(segment_command_64))
+                break;
+            auto segment = readCommand<segment_command_64>(commands, offset);
+            if (!segment)
+                break;
+            if (segmentNameIs(segment->segname, SEG_TEXT))
+                textVMAddress = segment->vmaddr;
+            else if (segmentNameIs(segment->segname, SEG_LINKEDIT)) {
+                linkeditVMAddress = segment->vmaddr;
+                linkeditFileOffset = segment->fileoff;
+                linkeditFileSize = segment->filesize;
+            }
+            break;
+        }
+        case LC_DYLD_INFO:
+        case LC_DYLD_INFO_ONLY: {
+            if (command->cmdsize < sizeof(dyld_info_command))
+                break;
+            auto info = readCommand<dyld_info_command>(commands, offset);
+            if (!info)
+                break;
+            exportOffset = info->export_off;
+            exportSize = info->export_size;
+            break;
+        }
+        case LC_DYLD_EXPORTS_TRIE: {
+            if (command->cmdsize < sizeof(linkedit_data_command))
+                break;
+            auto data = readCommand<linkedit_data_command>(commands, offset);
+            if (!data)
+                break;
+            exportOffset = data->dataoff;
+            exportSize = data->datasize;
+            break;
+        }
+        default:
+            break;
+        }
+        offset += command->cmdsize;
+    }
+
+    if (!textVMAddress || !linkeditVMAddress || !linkeditFileOffset || !linkeditFileSize || !exportSize) {
+        CORPSE_DIAGNOSTIC_DO(++m_diagnostics.withoutTrie);
+        return { };
+    }
+    if (exportSize > maxExportsTrieSize) {
+        CORPSE_DIAGNOSTIC_DO(++m_diagnostics.implausibleTrieSize);
+        return { };
+    }
+
+    // The trie is file-backed data living inside __LINKEDIT. So, exportOffset cannot
+    // be less than the start of __LINKEDIT, cannot exceed the end of __LINKEDIT, and
+    // the whole trie must fit inside it.
+    if (exportOffset < *linkeditFileOffset) {
+        CORPSE_DIAGNOSTIC_DO(++m_diagnostics.trieOutsideLinkedit);
+        return { };
+    }
+    uint64_t trieSegmentOffset = exportOffset - *linkeditFileOffset;
+    if (trieSegmentOffset > *linkeditFileSize || exportSize > *linkeditFileSize - trieSegmentOffset) {
+        CORPSE_DIAGNOSTIC_DO(++m_diagnostics.trieOutsideLinkedit);
+        return { };
+    }
+
+    // __TEXT's link-time address against where the image actually landed. The
+    // load commands give link-time addresses, so everything read out of them
+    // needs this added to reach the corpse.
+    uint64_t slide = imageAddress - Address(*textVMAddress);
+    Address trieAddress = Address(*linkeditVMAddress) + slide + trieSegmentOffset;
+
+    if (!hasReadBudget(exportSize))
+        return { };
+    auto trieBuffer = memory.readBytes(trieAddress, exportSize);
+    if (!trieBuffer) {
+        CORPSE_DIAGNOSTIC_DO(++m_diagnostics.unreadableTrie);
+        return { };
+    }
+    CORPSE_DIAGNOSTIC_DO(++m_diagnostics.searched);
+
+    auto found = ExportsTrie::lookUp(trieBuffer->span(), name);
+    if (!found) {
+#if CORPSE_SYMBOL_LOOKUP_DIAGNOSTICS
+        if (found.error() == ExportsTrie::Failure::ReExport)
+            ++m_diagnostics.reExports;
+        else if (found.error() == ExportsTrie::Failure::UnsupportedKind)
+            ++m_diagnostics.unsupportedKind;
+#endif
+        return { };
+    }
+    if (found->kind == ExportsTrie::Export::Kind::Absolute)
+        return Address(found->value);
+    return imageAddress + found->value;
+}
+
+Address Symbol::lookUpName(const Snapshot& snapshot)
+{
+    if (!snapshot.isValid() || m_name.empty())
+        return { };
+
+    m_readBudget = maxTotalBytesRead;
+
+    auto doLookUp = [&] () -> Address {
+        std::string name = "_" + m_name; // Use Mach-O symbol name for look up.
+
+        mach_port_t task = snapshot.corpsePort();
+        TaskMemory memory(task);
+
+        // dyld publishes the list of loaded images; search each one in turn.
+        task_dyld_info_data_t dyldInfo;
+        mach_msg_type_number_t count = TASK_DYLD_INFO_COUNT;
+        if (task_info(task, TASK_DYLD_INFO, reinterpret_cast<task_info_t>(&dyldInfo), &count) != KERN_SUCCESS)
+            return { };
+        CORPSE_DIAGNOSTIC_DO(m_diagnostics.readDyldInfo = true);
+
+        Address allImageInfosAddress { dyldInfo.all_image_info_addr };
+        CORPSE_DIAGNOSTIC_DO(m_diagnostics.allImageInfosAddress = allImageInfosAddress);
+        if (!allImageInfosAddress)
+            return { };
+
+        auto allImages = memory.read<dyld_all_image_infos>(allImageInfosAddress);
+        if (!allImages)
+            return { };
+        CORPSE_DIAGNOSTIC_DO(m_diagnostics.readAllImageInfos = true);
+        CORPSE_DIAGNOSTIC_DO(m_diagnostics.version = allImages->version);
+
+        Address rawArrayAddress { allImages->infoArray };
+        Address arrayAddress = rawArrayAddress.stripped();
+        uint32_t imageCount = allImages->infoArrayCount;
+        CORPSE_DIAGNOSTIC_DO(m_diagnostics.rawImageArrayAddress = rawArrayAddress);
+        CORPSE_DIAGNOSTIC_DO(m_diagnostics.imageArrayAddress = arrayAddress);
+        CORPSE_DIAGNOSTIC_DO(m_diagnostics.images = imageCount);
+        if (!arrayAddress || !imageCount)
+            return { };
+        // Each image below costs a Mach round-trip and two buffer reads, so an
+        // implausible count is a lot of work to be talked into doing.
+        if (imageCount > maxImageCount) {
+            CORPSE_DIAGNOSTIC_DO(m_diagnostics.implausibleImageCount = true);
+            return { };
+        }
+
+        for (uint32_t i = 0; i < imageCount; ++i) {
+            auto info = memory.read<dyld_image_info>(arrayAddress + static_cast<uint64_t>(i) * sizeof(dyld_image_info));
+            if (!info) {
+                CORPSE_DIAGNOSTIC_DO(++m_diagnostics.unreadableInfo);
+                continue;
+            }
+            auto imageAddress = Address(info->imageLoadAddress).stripped();
+            auto symbolAddress = resolveInImage(task, imageAddress, name);
+            if (symbolAddress)
+                return symbolAddress;
+        }
+
+        return { };
+    };
+
+    Address address = doLookUp();
+#if CORPSE_SYMBOL_LOOKUP_DIAGNOSTICS
+    if (!address)
+        reportFailure(snapshot);
+#endif
+    return address;
+}
+
+#if CORPSE_SYMBOL_LOOKUP_DIAGNOSTICS
+
+// Says how a failed search went, so a caller can tell "the symbol is not
+// exported" from "the corpse could not be read".
+void Symbol::reportFailure(const Snapshot& snapshot) const
+{
+    const Diagnostics& d = m_diagnostics;
+
+    Error::report("No symbol '_%s' in pid %d", m_name.c_str(),
+        static_cast<int>(snapshot.process()->pid()));
+
+    if (!d.readDyldInfo) {
+        Error::report("  could not read dyld information (task_info TASK_DYLD_INFO failed)");
+        return;
+    }
+    if (!d.allImageInfosAddress) {
+        Error::report("  dyld reports no image list (all_image_info_addr is 0)");
+        return;
+    }
+    if (!d.readAllImageInfos) {
+        Error::report("  could not read dyld_all_image_infos at 0x%llx",
+            d.allImageInfosAddress.toMachVMAddress());
+        return;
+    }
+
+    // A sane version says the struct read probably landed on real data, which is what
+    // makes the image count and array address below worth printing.
+    Error::report("  dyld_all_image_infos v%u at 0x%llx lists %u images at 0x%llx",
+        d.version, d.allImageInfosAddress.toMachVMAddress(),
+        d.images, d.imageArrayAddress.toMachVMAddress());
+    if (d.rawImageArrayAddress != d.imageArrayAddress) {
+        Error::report("  that address was ptrauth-signed as 0x%llx; the signature was stripped",
+            d.rawImageArrayAddress.toMachVMAddress());
+    }
+    if (!d.imageArrayAddress || !d.images) {
+        Error::report("  that list is empty, so there was nothing to search");
+        return;
+    }
+    if (d.implausibleImageCount) {
+        Error::report("  that count is too large to be a real image list, so the struct read"
+            " was not dyld_all_image_infos and was not searched");
+        return;
+    }
+
+    Error::report("  read %u of %u image headers (%u in the shared cache), walked %u exports tries",
+        d.examined, d.images, d.inSharedCache, d.searched);
+    if (d.unreadableInfo)
+        Error::report("  %u image list entries were unreadable", d.unreadableInfo);
+    if (d.unreadableHeader)
+        Error::report("  %u image headers were unreadable or not 64-bit Mach-O", d.unreadableHeader);
+    if (d.implausibleCommandsSize)
+        Error::report("  %u images had implausible load command sizes", d.implausibleCommandsSize);
+    if (d.unreadableCommands)
+        Error::report("  %u images had unreadable load commands", d.unreadableCommands);
+    if (d.withoutTrie)
+        Error::report("  %u images had no exports trie", d.withoutTrie);
+    if (d.implausibleTrieSize)
+        Error::report("  %u images had implausible exports trie sizes", d.implausibleTrieSize);
+    if (d.trieOutsideLinkedit)
+        Error::report("  %u images placed their exports trie outside __LINKEDIT", d.trieOutsideLinkedit);
+    if (d.unreadableTrie)
+        Error::report("  %u exports tries were not readable", d.unreadableTrie);
+    if (d.readBudgetExhausted) {
+        Error::report("  gave up after reading %u MB from the corpse; %u images were skipped",
+            static_cast<unsigned>(maxTotalBytesRead / MB), d.readBudgetExhausted);
+    }
+    if (d.reExports)
+        Error::report("  %u images re-export the name from elsewhere, which is not followed", d.reExports);
+    if (d.unsupportedKind)
+        Error::report("  %u images export the name in a form that has no single address, such as a thread-local", d.unsupportedKind);
+
+    if (d.searched) {
+        Error::report(
+            "  only exported symbols appear in an exports trie: a symbol hidden"
+            " by the linker is invisible here even though lldb can still find"
+            " it in the symbol table");
+    } else {
+        Error::report(
+            "  no trie was searched, so this is a memory-access problem rather"
+            " than the symbol being absent");
+    }
+}
+
+#endif // CORPSE_SYMBOL_LOOKUP_DIAGNOSTICS
+
+Symbol::Symbol(const Snapshot& snapshot, const char* name)
+    : m_name(name ? name : "")
+{
+    if (!m_name.empty())
+        m_address = lookUpName(snapshot);
+}
+
+} // namespace Corpse
+} // namespace JSC
+
+#undef CORPSE_DIAGNOSTIC_DO
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseSymbol.h
+++ b/Source/JavaScriptCore/corpse/CorpseSymbol.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <JavaScriptCore/CorpseAddress.h>
+#include <mach/mach.h>
+#include <stdint.h>
+#include <string>
+#include <string_view>
+#include <wtf/TZoneMalloc.h>
+
+// Enable for more detailed error messages on what may have caused a symbol lookup failure.
+#define CORPSE_SYMBOL_LOOKUP_DIAGNOSTICS 0
+
+namespace JSC {
+namespace Corpse {
+
+class Snapshot;
+
+// A symbol looked up in a corpse by name. The lookup happens on construction.
+//
+// Only regular and absolute exports are read out of an image's trie. A re-export is
+// skipped rather than followed, so a name that one image re-exports resolves in the
+// image that defines it, as long as that image is loaded in the corpse. A
+// thread-local is not found at all.
+//
+// A re-export may also rename, and then no image exports the name at all: memcpy
+// exists only as libsystem_c's re-export of __platform_memmove from
+// libsystem_platform, so a lookup of memcpy finds nothing while a lookup of
+// __platform_memmove succeeds.
+class Symbol {
+    WTF_MAKE_TZONE_ALLOCATED(Symbol);
+public:
+    Symbol(const Snapshot&, const char* name);
+
+    const std::string& name() const { return m_name; }
+
+    Address address() const { return m_address; } // Null means not found.
+    bool isValid() const { return static_cast<bool>(m_address); }
+
+private:
+    Address lookUpName(const Snapshot&);
+    Address resolveInImage(mach_port_t, Address loadAddress, std::string_view name);
+    bool hasReadBudget(size_t length);
+
+#if CORPSE_SYMBOL_LOOKUP_DIAGNOSTICS
+    // How far a search got, so a failure can name the stage that fell short.
+    struct Diagnostics {
+        bool readDyldInfo { false };
+        Address allImageInfosAddress;
+        bool readAllImageInfos { false };
+        uint32_t version { 0 };                 // dyld_all_image_infos::version.
+        Address rawImageArrayAddress;           // As stored, possibly signed.
+        Address imageArrayAddress;              // ...with any signature stripped.
+        unsigned images { 0 };                  // Images dyld reported.
+        bool implausibleImageCount { false };   // ...but too many to be believed.
+        unsigned examined { 0 };                // ...whose Mach header we read.
+        unsigned inSharedCache { 0 };           // ...of those, in the shared cache.
+        unsigned unreadableInfo { 0 };          // dyld_image_info unreadable.
+        unsigned unreadableHeader { 0 };        // Header missing or not 64-bit.
+        unsigned implausibleCommandsSize { 0 }; // sizeofcmds too large to believe.
+        unsigned unreadableCommands { 0 };      // Load commands unreadable.
+        unsigned withoutTrie { 0 };             // No trie, or no __TEXT/__LINKEDIT.
+        unsigned implausibleTrieSize { 0 };     // Trie size too large to believe.
+        unsigned trieOutsideLinkedit { 0 };     // Trie not within __LINKEDIT.
+        unsigned unreadableTrie { 0 };          // Trie located but not readable.
+        unsigned readBudgetExhausted { 0 };     // Gave up: the lookup hit its read budget.
+        unsigned searched { 0 };                // Tries actually walked.
+        unsigned reExports { 0 };               // Matched, but re-exported.
+        unsigned unsupportedKind { 0 };         // Matched, but not an export kind with one address.
+    };
+
+    void reportFailure(const Snapshot&) const;
+
+    Diagnostics m_diagnostics;
+#endif
+
+    std::string m_name;
+    Address m_address;
+
+    // What this lookup may still copy out of the corpse. Set when the search starts.
+    size_t m_readBudget { 0 };
+};
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseThread.cpp
+++ b/Source/JavaScriptCore/corpse/CorpseThread.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseThread.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "CorpseError.h"
+#include "CorpseProcess.h"
+#include "CorpseRegion.h"
+#include "CorpseSnapshot.h"
+
+#include <mach/mach.h>
+#include <mach/mach_error.h>
+#include <mach/mach_vm.h>
+#include <mach/thread_act.h>
+#include <mach/thread_info.h>
+#include <mach/thread_status.h>
+#include <optional>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC {
+namespace Corpse {
+
+static std::optional<Address> readStackPointer(thread_act_t thread)
+{
+#if CPU(ARM64)
+    arm_thread_state64_t state = { };
+    mach_msg_type_number_t count = ARM_THREAD_STATE64_COUNT;
+    if (thread_get_state(thread, ARM_THREAD_STATE64, reinterpret_cast<thread_state_t>(&state), &count) != KERN_SUCCESS)
+        return std::nullopt; // May fail e.g. for Rosetta.
+    // The target's pc/lr/sp/fp arrive signed for its own ptrauth context. On an
+    // arm64e build the accessors would try to authenticate them against ours and
+    // trap (EXC_BAD_ACCESS / EXC_ARM_PAC_FAIL), so strip the signatures first.
+    // Stripping also marks the state as unsigned, so the accessor reads it raw.
+    arm_thread_state64_ptrauth_strip(state);
+    return Address(arm_thread_state64_get_sp(state));
+#elif CPU(X86_64)
+    x86_thread_state64_t state = { };
+    mach_msg_type_number_t count = x86_THREAD_STATE64_COUNT;
+    if (thread_get_state(thread, x86_THREAD_STATE64, reinterpret_cast<thread_state_t>(&state), &count) != KERN_SUCCESS)
+        return std::nullopt;
+    return Address(state.__rsp);
+#else
+    UNUSED_PARAM(thread);
+    return std::nullopt;
+#endif
+}
+
+const char* Thread::runStateDescription() const
+{
+    switch (m_runState) {
+    case TH_STATE_RUNNING:
+        return "running";
+    case TH_STATE_STOPPED:
+        return "stopped";
+    case TH_STATE_WAITING:
+        return "waiting";
+    case TH_STATE_UNINTERRUPTIBLE:
+        return "uninterruptible";
+    case TH_STATE_HALTED:
+        return "halted";
+    default:
+        return "unknown";
+    }
+}
+
+Vector<Thread> Thread::collect(const Snapshot& snapshot)
+{
+    Vector<Thread> result;
+
+    if (!snapshot.isValid()) {
+        Error::report("Cannot read threads from an invalid snapshot");
+        return result;
+    }
+    mach_port_t task = snapshot.corpsePort();
+
+    thread_act_array_t threads = nullptr;
+    mach_msg_type_number_t threadCount = 0;
+    kern_return_t kr = task_threads(task, &threads, &threadCount);
+    if (kr != KERN_SUCCESS) {
+        pid_t pid = snapshot.process()->pid();
+        Error::report("Could not read the thread list for pid %d: %s (0x%x)",
+            static_cast<int>(pid), mach_error_string(kr), kr);
+        return result;
+    }
+
+    result.reserveCapacity(threadCount);
+
+    // A translated target executes as arm64 whatever its own architecture is, so its
+    // threads' stack pointers belong to Rosetta's runtime rather than to the program.
+    // Those addresses do land in real mappings, so reporting the region around one
+    // would name a plausible but wrong stack; report no stack instead.
+    Process* process = snapshot.process();
+    bool isTranslated = process->isTranslated();
+    if (isTranslated) {
+        Error::report("Thread stacks for pid %d are not available: the process runs"
+            " under Rosetta translation, whose thread state does not describe the program",
+            static_cast<int>(process->pid()));
+    }
+
+    unsigned unreadableStates = 0;
+    for (mach_msg_type_number_t i = 0; i < threadCount; ++i) {
+        Thread thread;
+
+        thread_identifier_info_data_t identifierInfo;
+        mach_msg_type_number_t count = THREAD_IDENTIFIER_INFO_COUNT;
+        if (thread_info(threads[i], THREAD_IDENTIFIER_INFO, reinterpret_cast<thread_info_t>(&identifierInfo), &count) == KERN_SUCCESS)
+            thread.m_id = identifierInfo.thread_id;
+
+        thread_basic_info_data_t basicInfo;
+        count = THREAD_BASIC_INFO_COUNT;
+        if (thread_info(threads[i], THREAD_BASIC_INFO, reinterpret_cast<thread_info_t>(&basicInfo), &count) == KERN_SUCCESS) {
+            thread.m_runState = basicInfo.run_state;
+            thread.m_suspendCount = basicInfo.suspend_count;
+            thread.m_userTimeUsec = static_cast<uint64_t>(basicInfo.user_time.seconds) * 1000000
+                + basicInfo.user_time.microseconds;
+            thread.m_systemTimeUsec = static_cast<uint64_t>(basicInfo.system_time.seconds) * 1000000
+                + basicInfo.system_time.microseconds;
+        }
+
+        // Extended info is the only flavor that reports the pthread name.
+        thread_extended_info_data_t extendedInfo;
+        count = THREAD_EXTENDED_INFO_COUNT;
+        if (thread_info(threads[i], THREAD_EXTENDED_INFO, reinterpret_cast<thread_info_t>(&extendedInfo), &count) == KERN_SUCCESS) {
+            extendedInfo.pth_name[sizeof(extendedInfo.pth_name) - 1] = '\0';
+            thread.m_name = extendedInfo.pth_name;
+        }
+
+        // The stack is the region the stack pointer points into.
+        if (!isTranslated) {
+            if (auto stackPointer = readStackPointer(threads[i])) {
+                thread.m_stackPointer = *stackPointer;
+                if (auto region = Region::findContaining(task, thread.m_stackPointer))
+                    thread.m_stackRegion = *region;
+            } else
+                ++unreadableStates;
+        }
+
+        result.append(thread);
+    }
+
+    // Failing to read the thread state leaves a thread with no stack, which on its
+    // own looks the same as a thread that has none. Say which it was.
+    if (unreadableStates) {
+        Error::report("Could not read the thread state of %u of %u threads in pid %d:"
+            " this build cannot read the target's architecture",
+            unreadableStates, static_cast<unsigned>(threadCount),
+            static_cast<int>(process->pid()));
+    }
+
+    // task_threads hands us a right to each thread plus the array itself.
+    for (mach_msg_type_number_t i = 0; i < threadCount; ++i)
+        mach_port_deallocate(mach_task_self(), threads[i]);
+    mach_vm_size_t threadsSize = threadCount * sizeof(thread_act_t);
+    mach_vm_deallocate(mach_task_self(), reinterpret_cast<mach_vm_address_t>(threads), threadsSize);
+
+    return result;
+}
+} // namespace Corpse
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/CorpseThread.h
+++ b/Source/JavaScriptCore/corpse/CorpseThread.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <JavaScriptCore/CorpseAddress.h>
+#include <JavaScriptCore/CorpseRegion.h>
+#include <mach/mach.h>
+#include <stdint.h>
+#include <string>
+#include <wtf/Vector.h>
+
+namespace JSC {
+namespace Corpse {
+
+class Snapshot;
+
+// A snapshot of thread values read out of a corpse.
+class Thread {
+public:
+    // The kernel's system-wide unique 64-bit thread id, as reported by lldb and
+    // spindump. This is an identifier, not an address.
+    uint64_t id() const { return m_id; }
+
+    // The pthread name, empty if the thread was never named.
+    const std::string& name() const { return m_name; }
+
+    int runState() const { return m_runState; }
+    int suspendCount() const { return m_suspendCount; }
+    uint64_t userTimeUsec() const { return m_userTimeUsec; }
+    uint64_t systemTimeUsec() const { return m_systemTimeUsec; }
+
+    Address stackPointer() const { return m_stackPointer; }
+
+    const Region& stackRegion() const { return m_stackRegion; }
+    bool hasStack() const { return m_stackRegion.size(); }
+
+    const char* runStateDescription() const;
+
+private:
+    static Vector<Thread> collect(const Snapshot&);
+
+    uint64_t m_id { 0 };
+    std::string m_name;
+    int m_runState { 0 };
+    int m_suspendCount { 0 };
+    uint64_t m_userTimeUsec { 0 };
+    uint64_t m_systemTimeUsec { 0 };
+    Address m_stackPointer;
+    Region m_stackRegion;
+
+    friend class Snapshot;
+};
+
+} // namespace Corpse
+} // namespace JSC
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/testLibJSCTools.cpp
+++ b/Source/JavaScriptCore/corpse/testLibJSCTools.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <wtf/DataLog.h>
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "tests/CorpseAddressTest.h"
+#include "tests/CorpseByteParserTest.h"
+#include "tests/CorpseExportsTrieTest.h"
+#include "tests/CorpseProcessTest.h"
+#include "tests/CorpseRegionTest.h"
+#include "tests/CorpseSnapshotTest.h"
+#include "tests/CorpseSymbolTest.h"
+#include "tests/CorpseThreadTest.h"
+#include "tests/LibJSCToolsTestUtilities.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <string_view>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/StringToIntegerConversion.h>
+#include <wtf/text/StringView.h>
+
+namespace {
+
+// A default that runs in well under a second, so that every run exercises the
+// decoder on inputs nobody wrote. A longer hunt is a matter of passing a bigger
+// count and a different seed.
+constexpr uint64_t defaultFuzzSeed = 0x5eed1234;
+constexpr unsigned defaultFuzzIterations = 20000;
+
+void printUsage()
+{
+    dataLogLn("Usage: testLibJSCTools [<suite filter>]");
+    dataLogLn("       testLibJSCTools --fuzz-trie [<seed> [<iterations>]]");
+    dataLogLn("");
+    dataLogLn("  Runs the tests for libJavaScriptCoreTools. With a filter, only the");
+    dataLogLn("  suites whose name contains it run.");
+}
+
+bool parseUint64(std::string_view text, uint64_t& out)
+{
+    uint8_t base = text.starts_with("0x") || text.starts_with("0X") ? 16 : 10;
+    if (base == 16)
+        text = text.substr(2);
+    auto parsed = WTF::parseInteger<uint64_t>(StringView::fromLatin1(std::string(text).c_str()), base);
+    if (!parsed)
+        return false;
+    out = *parsed;
+    return true;
+}
+
+} // anonymous namespace
+
+int main(int argc, char** argv)
+{
+    uint64_t fuzzSeed = defaultFuzzSeed;
+    uint64_t fuzzIterations = defaultFuzzIterations;
+    bool fuzzOnly = false;
+
+    // argv is wrapped in a span so that nothing here walks off the end of it.
+    auto arguments = unsafeMakeSpan(argv, static_cast<size_t>(argc));
+    for (size_t index = 1; index < arguments.size(); ++index) {
+        std::string_view argument = arguments[index];
+        if (argument == "--help" || argument == "-h") {
+            printUsage();
+            return 0;
+        }
+        if (argument == "--fuzz-trie") {
+            fuzzOnly = true;
+            if (index + 1 < arguments.size() && parseUint64(arguments[index + 1], fuzzSeed)) {
+                ++index;
+                if (index + 1 < arguments.size() && parseUint64(arguments[index + 1], fuzzIterations))
+                    ++index;
+            }
+            continue;
+        }
+        if (argument.starts_with("-")) {
+            dataLogLn("Unknown option '", arguments[index], "'");
+            printUsage();
+            return 1;
+        }
+        JSCToolsTest::suiteFilter = arguments[index];
+    }
+
+    dataLogLn("Starting libJavaScriptCoreTools tests");
+
+    if (fuzzOnly)
+        JSCToolsTest::fuzzExportsTrie(fuzzSeed, static_cast<unsigned>(fuzzIterations));
+    else {
+        JSCToolsTest::testByteParser();
+        JSCToolsTest::testExportsTrie();
+        JSCToolsTest::fuzzExportsTrie(fuzzSeed, static_cast<unsigned>(fuzzIterations));
+        JSCToolsTest::testAddress();
+        JSCToolsTest::testProcess();
+        JSCToolsTest::testSnapshot();
+        JSCToolsTest::testRegion();
+        JSCToolsTest::testThreads();
+        JSCToolsTest::testSymbol();
+    }
+
+    dataLogLn("Ran ", JSCToolsTest::assertionsRun, " assertions, ",
+        JSCToolsTest::assertionsFailed, " failed, ",
+        JSCToolsTest::suitesSkipped, " suites skipped");
+
+    if (JSCToolsTest::assertionsFailed) {
+        dataLogLn("Some libJavaScriptCoreTools tests FAILED!");
+        return 1;
+    }
+    if (!JSCToolsTest::assertionsRun) {
+        dataLogLn("No tests ran!");
+        return 1;
+    }
+
+    dataLogLn("All libJavaScriptCoreTools tests PASSED!");
+    return 0;
+}
+
+#else // !(OS(MACOS) || USE(APPLE_INTERNAL_SDK))
+
+int main(int argc, char** argv)
+{
+    UNUSED_PARAM(argc);
+    UNUSED_PARAM(argv);
+
+    // The corpse support is built on Mach task APIs, so there is nothing to test
+    // on other platforms. Report success so that a run here is not a failure.
+    dataLogLn("libJavaScriptCoreTools tests are disabled (Mach task APIs are not available)");
+    return 0;
+}
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseAddressTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseAddressTest.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseAddressTest.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "LibJSCToolsTestUtilities.h"
+
+#include <JavaScriptCore/CorpseAddress.h>
+#include <mach/mach.h>
+#include <type_traits>
+
+#if CPU(ARM64E)
+#include <ptrauth.h>
+#endif
+
+namespace JSCToolsTest {
+
+using JSC::Corpse::Address;
+
+void testAddress()
+{
+    if (!beginSuite("Address"))
+        return;
+
+    {
+        Address none;
+        TEST_ASSERT(!none, "a default Address is null");
+        TEST_ASSERT(none == nullptr, "a default Address compares equal to nullptr");
+        TEST_ASSERT_HEX_EQ(none.toMachVMAddress(), 0, "a default Address holds zero");
+    }
+    {
+        Address address(static_cast<mach_vm_address_t>(0x1000));
+        TEST_ASSERT(static_cast<bool>(address), "a non-zero Address is not null");
+        TEST_ASSERT(!(address == nullptr), "a non-zero Address does not compare equal to nullptr");
+        TEST_ASSERT_HEX_EQ(address.toMachVMAddress(), 0x1000, "an Address holds what it was given");
+    }
+    {
+        int local = 0;
+        Address address(&local);
+        TEST_ASSERT_HEX_EQ(address.toMachVMAddress(), reinterpret_cast<uintptr_t>(&local),
+            "an Address built from a pointer holds that pointer");
+    }
+    {
+        // The whole point of the type: a corpse address must not be usable as a
+        // local one by accident, so there is no conversion out of it.
+        TEST_ASSERT(!(std::is_convertible_v<Address, uint64_t>),
+            "an Address does not convert to an integer");
+        TEST_ASSERT(!(std::is_convertible_v<Address, void*>),
+            "an Address does not convert to a pointer");
+    }
+    {
+        Address low(static_cast<mach_vm_address_t>(0x1000));
+        Address high(static_cast<mach_vm_address_t>(0x2000));
+        TEST_ASSERT(low < high, "Addresses order by value");
+        TEST_ASSERT(high > low, "Addresses order by value the other way");
+        TEST_ASSERT(low <= low && low >= low, "an Address is not less or greater than itself");
+        TEST_ASSERT(low == Address(static_cast<mach_vm_address_t>(0x1000)), "equal values compare equal");
+        TEST_ASSERT(low != high, "different values do not compare equal");
+    }
+    {
+        Address base(static_cast<mach_vm_address_t>(0x1000));
+        TEST_ASSERT_HEX_EQ((base + 0x20).toMachVMAddress(), 0x1020, "adding an offset moves forward");
+        TEST_ASSERT_HEX_EQ((base - 0x20).toMachVMAddress(), 0x0fe0, "subtracting an offset moves back");
+        TEST_ASSERT_HEX_EQ(Address(static_cast<mach_vm_address_t>(0x1030)) - base, 0x30,
+            "subtracting two Addresses gives the distance between them");
+    }
+    {
+        // A plain address has nothing to strip, whatever the platform.
+        Address plain(static_cast<mach_vm_address_t>(0x0000000100002000));
+        TEST_ASSERT_HEX_EQ(plain.stripped().toMachVMAddress(), 0x0000000100002000,
+            "stripping an unsigned address changes nothing");
+    }
+#if CPU(ARM64E)
+    {
+        // A pointer read out of a corpse arrives signed for the target's context,
+        // and must be reduced to the address it names before it is used as one.
+        void* raw = reinterpret_cast<void*>(static_cast<uintptr_t>(0x0000000100002000));
+        void* signedPointer;
+        unsigned count = 0;
+        constexpr unsigned maxRetryCount = 10;
+        do {
+            signedPointer = ptrauth_sign_unauthenticated(raw, ptrauth_key_process_dependent_code, 0);
+        } while (signedPointer == raw && ++count <= maxRetryCount);
+        TEST_ASSERT(count <= maxRetryCount, "unable to generate PAC signed pointer for test");
+        TEST_ASSERT_HEX_EQ(Address(signedPointer).stripped().toMachVMAddress(),
+            reinterpret_cast<uintptr_t>(raw), "stripping recovers the address a signed pointer names");
+    }
+    {
+        // Top-byte-ignore and memory tagging both leave data in the top byte, which
+        // is not part of the address either.
+        Address tagged(static_cast<mach_vm_address_t>(0x4200000100002000));
+        TEST_ASSERT_HEX_EQ(tagged.stripped().toMachVMAddress(), 0x0000000100002000,
+            "stripping clears a tagged top byte");
+    }
+#endif
+}
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseAddressTest.h
+++ b/Source/JavaScriptCore/corpse/tests/CorpseAddressTest.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+namespace JSCToolsTest {
+
+void testAddress();
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseByteParserTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseByteParserTest.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseByteParserTest.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "LibJSCToolsTestUtilities.h"
+
+#include <JavaScriptCore/CorpseByteParser.h>
+#include <limits>
+
+namespace JSCToolsTest {
+
+using JSC::Corpse::ByteParser;
+
+void testByteParser()
+{
+    if (!beginSuite("ByteParser"))
+        return;
+
+    {
+        Vector<uint8_t> empty;
+        ByteParser parser(empty.span());
+        TEST_ASSERT(!parser.consumeByte(), "consumeByte on an empty buffer yields nothing");
+        TEST_ASSERT(!parser.consumeULEB128(), "consumeULEB128 on an empty buffer yields nothing");
+        TEST_ASSERT(!parser.consumeCString(), "consumeCString on an empty buffer yields nothing");
+        TEST_ASSERT_EQ(parser.position(), static_cast<size_t>(0), "a failed read does not advance");
+    }
+    {
+        Vector<uint8_t> data { 0x11, 0x22 };
+        ByteParser parser(data.span());
+        auto first = parser.consumeByte();
+        TEST_ASSERT(first && *first == 0x11, "consumeByte yields the first byte");
+        TEST_ASSERT_EQ(parser.position(), static_cast<size_t>(1), "consumeByte advances by one");
+        auto second = parser.consumeByte();
+        TEST_ASSERT(second && *second == 0x22, "consumeByte yields the next byte");
+        TEST_ASSERT_EQ(parser.position(), static_cast<size_t>(2), "consumeByte advances past the last byte");
+        TEST_ASSERT(!parser.consumeByte(), "consumeByte stops at the end");
+    }
+    {
+        // A parser may start part way in, which is how a node is read out of a trie.
+        Vector<uint8_t> data { 0x11, 0x22, 0x33 };
+        ByteParser parser(data.span(), 2);
+        auto value = parser.consumeByte();
+        TEST_ASSERT(value && *value == 0x33, "a parser starts at the position it is given");
+        TEST_ASSERT_EQ(parser.position(), static_cast<size_t>(3), "a read advances from the given position");
+    }
+    {
+        // A trie node's fields are ULEB128s read through a parser bounded to the whole
+        // trie but starting at the node, so decoding has to begin at that position and
+        // leave the cursor on the field that follows.
+        Vector<uint8_t> data { 0x11, 0x22, 0xe5, 0x8e, 0x26, 0x33 };
+        ByteParser parser(data.span(), 2);
+        auto value = parser.consumeULEB128();
+        TEST_ASSERT(value && *value == 624485, "consumeULEB128 decodes from the position it is given");
+        TEST_ASSERT_EQ(parser.position(), static_cast<size_t>(5), "consumeULEB128 stops after the value it decoded");
+        auto next = parser.consumeByte();
+        TEST_ASSERT(next && *next == 0x33, "the byte after a decoded value is left for the next read");
+    }
+    {
+        // A failed read rewinds to where the cursor was, which is not necessarily the
+        // start of the buffer.
+        Vector<uint8_t> data { 0x11, 0x22, 0x80 };
+        ByteParser parser(data.span(), 2);
+        TEST_ASSERT(!parser.consumeULEB128(), "a truncated ULEB128 is rejected wherever it starts");
+        TEST_ASSERT_EQ(parser.position(), static_cast<size_t>(2), "a failed read rewinds to the given position");
+    }
+
+    struct ULEBCase {
+        Vector<uint8_t> bytes;
+        bool decodes;
+        uint64_t value;
+        const char* description;
+    };
+    Vector<ULEBCase> ulebCases;
+    ulebCases.append({ { 0x00 }, true, 0, "zero" });
+    ulebCases.append({ { 0x01 }, true, 1, "one" });
+    ulebCases.append({ { 0x7f }, true, 127, "the largest one-byte value" });
+    ulebCases.append({ { 0x80, 0x01 }, true, 128, "the smallest two-byte value" });
+    ulebCases.append({ { 0xe5, 0x8e, 0x26 }, true, 624485, "a three-byte value" });
+    ulebCases.append({ { 0x80, 0x80, 0x80, 0x00 }, true, 0, "zero padded with continuations" });
+    ulebCases.append({ { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01 }, true,
+        std::numeric_limits<uint64_t>::max(), "the largest 64-bit value" });
+    // Rejected: the top group carries bits that do not fit in 64.
+    ulebCases.append({ { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02 }, false, 0,
+        "a value one bit too wide for 64 bits" });
+    // Rejected: the shift would reach 64, which is undefined rather than merely large.
+    ulebCases.append({ { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01 }, false, 0,
+        "an encoding longer than 64 bits can hold" });
+    ulebCases.append({ { 0x80 }, false, 0, "a value whose continuation runs off the end" });
+    ulebCases.append({ { 0xff, 0xff }, false, 0, "a truncated multi-byte value" });
+
+    for (const ULEBCase& testCase : ulebCases) {
+        ByteParser parser(testCase.bytes.span());
+        auto decoded = parser.consumeULEB128();
+        if (!testCase.decodes) {
+            TEST_ASSERT(!decoded, testCase.description);
+            TEST_ASSERT_EQ(parser.position(), static_cast<size_t>(0), testCase.description);
+            continue;
+        }
+        if (!decoded) {
+            TEST_ASSERT(decoded, testCase.description);
+            continue;
+        }
+        TEST_ASSERT_HEX_EQ(*decoded, testCase.value, testCase.description);
+        TEST_ASSERT_EQ(parser.position(), testCase.bytes.size(), testCase.description);
+    }
+
+    {
+        Vector<uint8_t> data { 'a', 'b', 0, 'c', 0 };
+        ByteParser parser(data.span());
+        auto first = parser.consumeCString();
+        TEST_ASSERT(first && *first == "ab", "consumeCString yields the string");
+        TEST_ASSERT_EQ(parser.position(), static_cast<size_t>(3), "consumeCString consumes the terminator");
+        auto second = parser.consumeCString();
+        TEST_ASSERT(second && *second == "c", "consumeCString yields the following string");
+        TEST_ASSERT_EQ(parser.position(), static_cast<size_t>(5), "consumeCString consumes the second terminator");
+        TEST_ASSERT(!parser.consumeCString(), "consumeCString stops at the end");
+    }
+    {
+        Vector<uint8_t> data { 0 };
+        ByteParser parser(data.span());
+        auto empty = parser.consumeCString();
+        TEST_ASSERT(empty && empty->empty(), "an empty string is a string");
+        TEST_ASSERT_EQ(parser.position(), static_cast<size_t>(1), "an empty string still consumes its terminator");
+    }
+    {
+        // A read that fails consumes nothing.
+        Vector<uint8_t> unterminated { 'a', 'b' };
+        ByteParser cstring(unterminated.span());
+        TEST_ASSERT(!cstring.consumeCString(), "an unterminated string is rejected");
+        TEST_ASSERT_EQ(cstring.position(), static_cast<size_t>(0),
+            "a failed string read leaves the cursor where it was");
+
+        Vector<uint8_t> truncated { 0x80, 0x80 };
+        ByteParser uleb(truncated.span());
+        TEST_ASSERT(!uleb.consumeULEB128(), "a truncated ULEB128 is rejected");
+        TEST_ASSERT_EQ(uleb.position(), static_cast<size_t>(0),
+            "a failed ULEB128 read leaves the cursor where it was");
+
+        // The failed read should not advance the cursor. Therefore, the 2nd read should succeed.
+        Vector<uint8_t> lone { 0x80 };
+        ByteParser retry(lone.span());
+        TEST_ASSERT(!retry.consumeULEB128(), "a lone continuation byte is not a value");
+        auto byte = retry.consumeByte();
+        TEST_ASSERT(byte && *byte == 0x80, "a failed read leaves its bytes for another reader");
+    }
+    {
+        Vector<uint8_t> data { 0x11, 'a', 0 };
+        for (size_t position : { data.size(), data.size() + 1, std::numeric_limits<size_t>::max() }) {
+            ByteParser parser(data.span(), position);
+            TEST_ASSERT(!parser.consumeByte(), "consumeByte from beyond the end yields nothing");
+            TEST_ASSERT(!parser.consumeULEB128(), "consumeULEB128 from beyond the end yields nothing");
+            TEST_ASSERT(!parser.consumeCString(), "consumeCString from beyond the end yields nothing");
+            TEST_ASSERT_EQ(parser.position(), position, "a failed read beyond the end does not move the cursor");
+        }
+    }
+}
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseByteParserTest.h
+++ b/Source/JavaScriptCore/corpse/tests/CorpseByteParserTest.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+namespace JSCToolsTest {
+
+void testByteParser();
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseExportsTrieTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseExportsTrieTest.cpp
@@ -1,0 +1,811 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseExportsTrieTest.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "LibJSCToolsTestUtilities.h"
+
+#include <JavaScriptCore/CorpseExportsTrie.h>
+#include <array>
+#include <limits>
+#include <mach-o/loader.h>
+#include <pthread.h>
+#include <string>
+#include <unistd.h>
+#include <wtf/Atomics.h>
+
+namespace JSCToolsTest {
+
+using JSC::Corpse::ExportsTrie;
+
+namespace {
+
+// Builds the bytes of a dyld exports trie, or of something that is not quite one.
+// Emitting bytes rather than describing exports is deliberate: most of what is
+// worth testing here is malformed, and could not be described any other way.
+class TrieBytes {
+public:
+    void byte(uint8_t value) { m_bytes.append(value); }
+    void bytes(std::span<const uint8_t>);
+    void uleb128(uint64_t);
+
+    // A ULEB128 padded to a fixed width so that a forward reference can be
+    // patched once its target is known. Non-canonical but well formed: the
+    // padding bytes carry a continuation bit and no payload.
+    static constexpr unsigned fixedWidth = 3;
+    size_t uleb128Fixed(uint64_t);
+    void patchUleb128Fixed(size_t position, uint64_t);
+
+    void cString(std::string_view); // With its terminator.
+    void string(std::string_view); // Without.
+
+    size_t position() const { return m_bytes.size(); }
+    std::span<const uint8_t> span() const { return m_bytes.span(); }
+    Vector<uint8_t> take() { return WTF::move(m_bytes); }
+
+private:
+    Vector<uint8_t> m_bytes;
+};
+
+// The flags and payload of one terminal, as a trie encodes them.
+struct TerminalSpec {
+    uint64_t flags { 0 };
+    // The ULEB128s that follow the flags. What they mean depends on the flags:
+    // one offset for an ordinary export, a stub offset then a resolver offset
+    // for a stub-and-resolver, an ordinal for a re-export.
+    Vector<uint64_t> values;
+    // Appended after the values, for a re-export's imported name.
+    std::string_view trailingString;
+    bool hasTrailingString { false };
+};
+
+// A trie holding one export named "", so that a look up of "" reaches the
+// terminal without walking any edge. Isolates terminal decoding from the walk.
+Vector<uint8_t> terminalOnlyTrie(const TerminalSpec&);
+
+// A trie whose root has one edge, `name`, leading to a terminal.
+Vector<uint8_t> singleExportTrie(std::string_view name, const TerminalSpec&);
+
+// A trie spelling one export across several edges, so a look up has to walk.
+Vector<uint8_t> chainedExportTrie(std::span<const std::string_view> edges, const TerminalSpec&);
+
+// An ordinary export at `offset` from the image's base.
+TerminalSpec regularExport(uint64_t offset);
+
+void TrieBytes::bytes(std::span<const uint8_t> data)
+{
+    m_bytes.append(data);
+}
+
+void TrieBytes::uleb128(uint64_t value)
+{
+    do {
+        uint8_t group = value & 0x7f;
+        value >>= 7;
+        if (value)
+            group |= 0x80;
+        m_bytes.append(group);
+    } while (value);
+}
+
+size_t TrieBytes::uleb128Fixed(uint64_t value)
+{
+    size_t start = m_bytes.size();
+    for (unsigned i = 0; i < fixedWidth; ++i) {
+        uint8_t group = (value >> (7 * i)) & 0x7f;
+        if (i + 1 < fixedWidth)
+            group |= 0x80;
+        m_bytes.append(group);
+    }
+    return start;
+}
+
+void TrieBytes::patchUleb128Fixed(size_t position, uint64_t value)
+{
+    for (unsigned i = 0; i < fixedWidth; ++i) {
+        uint8_t group = (value >> (7 * i)) & 0x7f;
+        if (i + 1 < fixedWidth)
+            group |= 0x80;
+        m_bytes[position + i] = group;
+    }
+}
+
+void TrieBytes::cString(std::string_view text)
+{
+    string(text);
+    m_bytes.append(0);
+}
+
+void TrieBytes::string(std::string_view text)
+{
+    for (char character : text)
+        m_bytes.append(static_cast<uint8_t>(character));
+}
+
+TerminalSpec regularExport(uint64_t offset)
+{
+    TerminalSpec spec;
+    spec.values.append(offset);
+    return spec;
+}
+
+// The bytes a terminal node holds after its length: the flags, then whatever
+// ULEB128s and string the flags call for.
+static Vector<uint8_t> terminalPayload(const TerminalSpec& spec)
+{
+    TrieBytes payload;
+    payload.uleb128(spec.flags);
+    for (uint64_t value : spec.values)
+        payload.uleb128(value);
+    if (spec.hasTrailingString)
+        payload.cString(spec.trailingString);
+    return payload.take();
+}
+
+// A node with a terminal and no children.
+static void appendTerminalNode(TrieBytes& trie, const TerminalSpec& spec)
+{
+    Vector<uint8_t> payload = terminalPayload(spec);
+    trie.uleb128(payload.size());
+    trie.bytes(payload.span());
+    trie.byte(0); // No children.
+}
+
+Vector<uint8_t> terminalOnlyTrie(const TerminalSpec& spec)
+{
+    TrieBytes trie;
+    appendTerminalNode(trie, spec);
+    return trie.take();
+}
+
+Vector<uint8_t> chainedExportTrie(std::span<const std::string_view> edges, const TerminalSpec& spec)
+{
+    TrieBytes trie;
+
+    // Every node but the last points at the one after it, whose position is not
+    // known until it has been emitted, so each reference is patched from behind.
+    Vector<size_t> patchPositions;
+    for (std::string_view edge : edges) {
+        if (!patchPositions.isEmpty()) {
+            trie.patchUleb128Fixed(patchPositions.last(), trie.position());
+            patchPositions.removeLast();
+        }
+        trie.uleb128(0); // No terminal on the way down.
+        trie.byte(1); // One edge.
+        trie.cString(edge);
+        patchPositions.append(trie.uleb128Fixed(0));
+    }
+    if (!patchPositions.isEmpty())
+        trie.patchUleb128Fixed(patchPositions.last(), trie.position());
+    appendTerminalNode(trie, spec);
+    return trie.take();
+}
+
+Vector<uint8_t> singleExportTrie(std::string_view name, const TerminalSpec& spec)
+{
+    std::array<std::string_view, 1> edges { name };
+    return chainedExportTrie(std::span<const std::string_view>(edges), spec);
+}
+
+// A node's children count is one byte, so 255 edges is as wide as a node can be.
+static constexpr unsigned maximumEdgeCount = 255;
+
+// The name of the `index`th edge of a fan-out trie. Two characters wide so that no
+// edge is a prefix of another, which leaves exactly one of them matching a name.
+static std::string fanOutEdgeName(unsigned index)
+{
+    return { static_cast<char>('a' + index / 16), static_cast<char>('a' + index % 16) };
+}
+
+// Distinct per edge, so that a walk landing on the wrong child is caught.
+static constexpr uint64_t fanOutExportOffset(unsigned index)
+{
+    return 0x1000 + index;
+}
+
+// A root with `edgeCount` edges, each leading to a terminal of its own.
+static Vector<uint8_t> fanOutTrie(unsigned edgeCount)
+{
+    TrieBytes trie;
+    trie.uleb128(0); // The root itself exports nothing.
+    trie.byte(static_cast<uint8_t>(edgeCount));
+
+    // Each edge points at a node that has not been emitted yet, so the references
+    // are patched once their targets are laid down below.
+    Vector<size_t> patchPositions;
+    for (unsigned index = 0; index < edgeCount; ++index) {
+        trie.cString(fanOutEdgeName(index));
+        patchPositions.append(trie.uleb128Fixed(0));
+    }
+    for (unsigned index = 0; index < edgeCount; ++index) {
+        trie.patchUleb128Fixed(patchPositions[index], trie.position());
+        appendTerminalNode(trie, regularExport(fanOutExportOffset(index)));
+    }
+    return trie.take();
+}
+
+using Failure = ExportsTrie::Failure;
+using Kind = ExportsTrie::Export::Kind;
+
+} // anonymous namespace
+
+// A node carrying both a terminal and one edge, which is how a trie holds an
+// export whose name is a prefix of another export's name.
+static Vector<uint8_t> prefixAndChildTrie(std::string_view rootEdge, const TerminalSpec& atRootEdge,
+    std::string_view childEdge, const TerminalSpec& atChild)
+{
+    TrieBytes trie;
+    trie.uleb128(0); // The root itself exports nothing.
+    trie.byte(1);
+    trie.cString(rootEdge);
+    size_t rootEdgePatch = trie.uleb128Fixed(0);
+
+    trie.patchUleb128Fixed(rootEdgePatch, trie.position());
+    TrieBytes payload;
+    payload.uleb128(atRootEdge.flags);
+    for (uint64_t value : atRootEdge.values)
+        payload.uleb128(value);
+    Vector<uint8_t> payloadBytes = payload.take();
+    trie.uleb128(payloadBytes.size());
+    trie.bytes(payloadBytes.span());
+    trie.byte(1);
+    trie.cString(childEdge);
+    size_t childPatch = trie.uleb128Fixed(0);
+
+    trie.patchUleb128Fixed(childPatch, trie.position());
+    TrieBytes childPayload;
+    childPayload.uleb128(atChild.flags);
+    for (uint64_t value : atChild.values)
+        childPayload.uleb128(value);
+    Vector<uint8_t> childPayloadBytes = childPayload.take();
+    trie.uleb128(childPayloadBytes.size());
+    trie.bytes(childPayloadBytes.span());
+    trie.byte(0);
+
+    return trie.take();
+}
+
+static void testFoundExports()
+{
+    {
+        Vector<uint8_t> trie = singleExportTrie("_foo", regularExport(0x1234));
+        auto found = ExportsTrie::lookUp(trie.span(), "_foo");
+        TEST_ASSERT(found, "an exported name is found");
+        if (found) {
+            TEST_ASSERT(found->kind == Kind::Regular, "an ordinary export is Regular");
+            TEST_ASSERT_HEX_EQ(found->value, 0x1234, "an ordinary export yields its offset");
+        }
+    }
+    {
+        TerminalSpec spec;
+        spec.flags = EXPORT_SYMBOL_FLAGS_KIND_ABSOLUTE;
+        spec.values.append(0xdeadbeef);
+        Vector<uint8_t> trie = singleExportTrie("_absolute", spec);
+        auto found = ExportsTrie::lookUp(trie.span(), "_absolute");
+        TEST_ASSERT(found, "an absolute export is found");
+        if (found) {
+            TEST_ASSERT(found->kind == Kind::Absolute, "an absolute export is Absolute");
+            TEST_ASSERT_HEX_EQ(found->value, 0xdeadbeef, "an absolute export yields the address itself");
+        }
+    }
+    {
+        // A weak definition is still an ordinary export; the flag sits outside the
+        // kind mask and must not disturb it.
+        TerminalSpec spec;
+        spec.flags = EXPORT_SYMBOL_FLAGS_WEAK_DEFINITION | EXPORT_SYMBOL_FLAGS_KIND_REGULAR;
+        spec.values.append(0x40);
+        Vector<uint8_t> trie = singleExportTrie("_weak", spec);
+        auto found = ExportsTrie::lookUp(trie.span(), "_weak");
+        TEST_ASSERT(found, "a weak definition is found");
+        if (found) {
+            TEST_ASSERT(found->kind == Kind::Regular, "a weak definition is Regular");
+            TEST_ASSERT_HEX_EQ(found->value, 0x40, "a weak definition yields its offset");
+        }
+    }
+    {
+        // Per <mach-o/loader.h>, a stub-and-resolver terminal holds two ULEB128s:
+        // the stub offset and then the resolver offset. The stub is the address
+        // the symbol resolves to; the resolver is only how a lazy binding finds it.
+        TerminalSpec spec;
+        spec.flags = EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER | EXPORT_SYMBOL_FLAGS_KIND_REGULAR;
+        spec.values.append(0x1000); // Stub offset.
+        spec.values.append(0x2000); // Resolver offset.
+        Vector<uint8_t> trie = singleExportTrie("_resolved", spec);
+        auto found = ExportsTrie::lookUp(trie.span(), "_resolved");
+        TEST_ASSERT(found, "a stub-and-resolver export is found");
+        if (found) {
+            TEST_ASSERT(found->kind == Kind::Regular, "a stub-and-resolver export is Regular");
+            TEST_ASSERT_HEX_EQ(found->value, 0x1000, "a stub-and-resolver export yields the stub offset");
+        }
+    }
+    {
+        // The highest defined flag bit. It carries no payload of its own, so a
+        // terminal that sets it still decodes; nothing in dyld, ld or cctools reads
+        // it, which is why it must not be mistaken for an unknown bit.
+        TerminalSpec spec;
+        spec.flags = EXPORT_SYMBOL_FLAGS_STATIC_RESOLVER | EXPORT_SYMBOL_FLAGS_KIND_REGULAR;
+        spec.values.append(0x50);
+        Vector<uint8_t> trie = singleExportTrie("_staticResolver", spec);
+        auto found = ExportsTrie::lookUp(trie.span(), "_staticResolver");
+        TEST_ASSERT(found, "an export with the highest defined flag bit is found");
+        if (found) {
+            TEST_ASSERT(found->kind == Kind::Regular, "a static-resolver export is Regular");
+            TEST_ASSERT_HEX_EQ(found->value, 0x50, "a static-resolver export yields its offset");
+        }
+    }
+    {
+        // A terminal may declare more room than its flags and offset need. The spare
+        // room is not part of the offset, and the export still resolves.
+        TrieBytes builder;
+        builder.uleb128(4); // Two bytes more than the payload below uses.
+        builder.uleb128(0); // Flags: an ordinary export.
+        builder.uleb128(0x7f); // Offset.
+        builder.byte(0); // Spare terminal byte.
+        builder.byte(0); // Spare terminal byte.
+        builder.byte(0); // No children.
+        Vector<uint8_t> trie = builder.take();
+        auto found = ExportsTrie::lookUp(trie.span(), "");
+        TEST_ASSERT(found, "a terminal with room to spare still resolves");
+        if (found)
+            TEST_ASSERT_HEX_EQ(found->value, 0x7f, "spare terminal room is not read as the offset");
+    }
+    {
+        // A look up of "" reaches the root's own terminal without walking an edge.
+        Vector<uint8_t> trie = terminalOnlyTrie(regularExport(0x99));
+        auto found = ExportsTrie::lookUp(trie.span(), "");
+        TEST_ASSERT(found, "a terminal at the root is found");
+        if (found)
+            TEST_ASSERT_HEX_EQ(found->value, 0x99, "a terminal at the root yields its offset");
+    }
+    {
+        // Real tries spread a name over several edges, so the walk has to cross
+        // more than one node to reach the terminal.
+        std::array<std::string_view, 3> edges { "_f", "oo", "bar" };
+        Vector<uint8_t> trie = chainedExportTrie(std::span<const std::string_view>(edges), regularExport(0x77));
+        auto found = ExportsTrie::lookUp(trie.span(), "_foobar");
+        TEST_ASSERT(found, "a name spread over several edges is found");
+        if (found)
+            TEST_ASSERT_HEX_EQ(found->value, 0x77, "a multi-edge name yields its offset");
+
+        auto prefix = ExportsTrie::lookUp(trie.span(), "_foo");
+        TEST_ASSERT(!prefix && prefix.error() == Failure::Absent,
+            "a prefix of a multi-edge name is absent");
+        auto extension = ExportsTrie::lookUp(trie.span(), "_foobarbaz");
+        TEST_ASSERT(!extension && extension.error() == Failure::Absent,
+            "an extension of a multi-edge name is absent");
+    }
+    {
+        // "_foo" and "_foobar" both exported: the shorter one lives on a node that
+        // also has children, so a terminal must not end the walk when name is left.
+        Vector<uint8_t> trie = prefixAndChildTrie("_foo", regularExport(0x10), "bar", regularExport(0x20));
+        auto shorter = ExportsTrie::lookUp(trie.span(), "_foo");
+        TEST_ASSERT(shorter, "the shorter of two nested names is found");
+        if (shorter)
+            TEST_ASSERT_HEX_EQ(shorter->value, 0x10, "the shorter name yields its own offset");
+        auto longer = ExportsTrie::lookUp(trie.span(), "_foobar");
+        TEST_ASSERT(longer, "the longer of two nested names is found");
+        if (longer)
+            TEST_ASSERT_HEX_EQ(longer->value, 0x20, "the longer name yields its own offset");
+        TEST_ASSERT(!ExportsTrie::lookUp(trie.span(), "_foobaz"), "a name that diverges is not found");
+    }
+    {
+        // A node's children count is a byte rather than a ULEB128. Decoded as one, a
+        // count of 255 carries a continuation bit, so it would swallow the first
+        // character of the edge behind it: the count comes out far too large and that
+        // edge is read from the wrong byte. 255 edges is the widest a node can be, and
+        // reaching the last of them needs the walk to scan past every edge ahead of it.
+        Vector<uint8_t> trie = fanOutTrie(maximumEdgeCount);
+        for (unsigned index : { 0u, maximumEdgeCount / 2, maximumEdgeCount - 1 }) {
+            auto found = ExportsTrie::lookUp(trie.span(), fanOutEdgeName(index));
+            TEST_ASSERT(found, "an export is found among 255 edges");
+            if (found) {
+                TEST_ASSERT_HEX_EQ(found->value, fanOutExportOffset(index),
+                    "each of 255 edges leads to its own export");
+            }
+        }
+
+        // Nothing matches, so the walk has to scan all 255 edges and end.
+        auto absent = ExportsTrie::lookUp(trie.span(), "zz");
+        TEST_ASSERT(!absent && absent.error() == Failure::Absent,
+            "a name matching none of 255 edges is Absent");
+    }
+}
+
+static void testClassifiedFailures()
+{
+    {
+        TerminalSpec spec;
+        spec.flags = EXPORT_SYMBOL_FLAGS_REEXPORT | EXPORT_SYMBOL_FLAGS_KIND_REGULAR;
+        spec.values.append(1); // Library ordinal.
+        spec.trailingString = "_other";
+        spec.hasTrailingString = true;
+        Vector<uint8_t> trie = singleExportTrie("_reexported", spec);
+        auto result = ExportsTrie::lookUp(trie.span(), "_reexported");
+        TEST_ASSERT(!result && result.error() == Failure::ReExport,
+            "a re-exported name reports ReExport rather than being absent");
+    }
+    {
+        TerminalSpec spec;
+        spec.flags = EXPORT_SYMBOL_FLAGS_KIND_THREAD_LOCAL;
+        spec.values.append(0x30);
+        Vector<uint8_t> trie = singleExportTrie("_threadLocal", spec);
+        auto result = ExportsTrie::lookUp(trie.span(), "_threadLocal");
+        TEST_ASSERT(!result && result.error() == Failure::UnsupportedKind,
+            "a thread-local reports UnsupportedKind: its address differs per thread");
+    }
+    {
+        // The one value the kind mask can hold that Mach-O does not define. A kind
+        // this code does not know cannot be read as an address.
+        TerminalSpec spec;
+        spec.flags = 0x03;
+        spec.values.append(0x30);
+        Vector<uint8_t> trie = singleExportTrie("_unknownKind", spec);
+        auto result = ExportsTrie::lookUp(trie.span(), "_unknownKind");
+        TEST_ASSERT(!result && result.error() == Failure::UnsupportedKind,
+            "an unrecognized kind reports UnsupportedKind");
+    }
+    {
+        Vector<uint8_t> trie = singleExportTrie("_foo", regularExport(0x1234));
+        auto missing = ExportsTrie::lookUp(trie.span(), "_bar");
+        TEST_ASSERT(!missing && missing.error() == Failure::Absent,
+            "a name with no matching edge is Absent");
+        auto shortName = ExportsTrie::lookUp(trie.span(), "_fo");
+        TEST_ASSERT(!shortName && shortName.error() == Failure::Absent,
+            "a name shorter than the edge is Absent");
+        auto emptyName = ExportsTrie::lookUp(trie.span(), "");
+        TEST_ASSERT(!emptyName && emptyName.error() == Failure::Absent,
+            "the empty name is Absent when the root exports nothing");
+    }
+    {
+        // A node with neither a terminal nor children ends the walk without an answer.
+        TrieBytes builder;
+        builder.uleb128(0);
+        builder.byte(0);
+        Vector<uint8_t> trie = builder.take();
+        auto result = ExportsTrie::lookUp(trie.span(), "_foo");
+        TEST_ASSERT(!result && result.error() == Failure::Absent, "a childless root is Absent");
+    }
+}
+
+static void testMalformedTries()
+{
+    {
+        Vector<uint8_t> empty;
+        auto result = ExportsTrie::lookUp(empty.span(), "_foo");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed, "an empty trie is malformed");
+    }
+    {
+        Vector<uint8_t> trie { 0x80 }; // A terminal length that never ends.
+        auto result = ExportsTrie::lookUp(trie.span(), "_foo");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "a truncated terminal length is malformed");
+    }
+    {
+        // A terminal claiming more bytes than the trie has left. Rejecting this is
+        // what keeps the children position inside the buffer.
+        Vector<uint8_t> trie { 0x7f };
+        auto result = ExportsTrie::lookUp(trie.span(), "");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "a terminal longer than the trie is malformed");
+    }
+    {
+        // A terminal length so large that adding it to the position would wrap.
+        TrieBytes builder;
+        builder.uleb128(std::numeric_limits<uint64_t>::max());
+        builder.byte(0);
+        Vector<uint8_t> trie = builder.take();
+        auto result = ExportsTrie::lookUp(trie.span(), "");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "a terminal length that would wrap the position is malformed");
+    }
+    {
+        Vector<uint8_t> trie { 0x01, 0x80 }; // Terminal of one byte, holding half a ULEB128.
+        auto result = ExportsTrie::lookUp(trie.span(), "");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed, "truncated flags are malformed");
+    }
+    {
+        Vector<uint8_t> trie { 0x01, 0x00 }; // Flags say an ordinary export, but no offset follows.
+        auto result = ExportsTrie::lookUp(trie.span(), "");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "an export with no offset is malformed");
+    }
+    {
+        // Flags promise a stub offset that the trie does not hold.
+        TrieBytes builder;
+        TrieBytes payload;
+        payload.uleb128(EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER | EXPORT_SYMBOL_FLAGS_KIND_REGULAR);
+        Vector<uint8_t> payloadBytes = payload.take();
+        builder.uleb128(payloadBytes.size());
+        builder.bytes(payloadBytes.span());
+        Vector<uint8_t> trie = builder.take();
+        auto result = ExportsTrie::lookUp(trie.span(), "");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "a stub-and-resolver export with no offsets is malformed");
+    }
+    {
+        // Only six flag bits are defined. An unknown one may carry a ULEB128 ahead of
+        // the address, so the offset that follows it cannot be trusted to be one.
+        TerminalSpec spec;
+        spec.flags = 0x40;
+        spec.values.append(0x42);
+        Vector<uint8_t> trie = singleExportTrie("_unknownFlag", spec);
+        auto result = ExportsTrie::lookUp(trie.span(), "_unknownFlag");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "a terminal with an unknown flag bit is malformed");
+    }
+    {
+        // A terminal that declares only its flags holds no offset. Reading one anyway
+        // would take the children count that follows it as the symbol's address.
+        TrieBytes builder;
+        builder.uleb128(1); // Terminal length: room for the flags alone.
+        builder.uleb128(0); // Flags: an ordinary export, which needs an offset...
+        builder.byte(2); // ...but this is the children count, not one.
+        builder.cString("a");
+        builder.uleb128(0);
+        Vector<uint8_t> trie = builder.take();
+        auto result = ExportsTrie::lookUp(trie.span(), "");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "a terminal that ends before its offset is malformed");
+    }
+    {
+        // The offset's encoding runs off the end of the terminal, so completing it
+        // would take a byte belonging to the children.
+        TrieBytes builder;
+        builder.uleb128(2); // Terminal length: the flags and one offset byte.
+        builder.uleb128(0); // Flags.
+        builder.byte(0x80); // First byte of a two-byte offset...
+        builder.byte(0x01); // ...whose second byte lies outside the terminal.
+        builder.byte(0); // No children.
+        Vector<uint8_t> trie = builder.take();
+        auto result = ExportsTrie::lookUp(trie.span(), "");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "an offset whose encoding leaves the terminal is malformed");
+    }
+    {
+        // The children count sits past the end of the trie.
+        Vector<uint8_t> trie { 0x00 };
+        auto result = ExportsTrie::lookUp(trie.span(), "_foo");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "a missing children count is malformed");
+    }
+    {
+        TrieBytes builder;
+        builder.uleb128(0);
+        builder.byte(1);
+        builder.string("_foo"); // No terminator.
+        Vector<uint8_t> trie = builder.take();
+        auto result = ExportsTrie::lookUp(trie.span(), "_foo");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "an unterminated edge is malformed");
+    }
+    {
+        // An empty edge would match anything and consume none of the name, which is
+        // what would let a walk run forever.
+        TrieBytes builder;
+        builder.uleb128(0);
+        builder.byte(1);
+        builder.cString("");
+        builder.uleb128(0);
+        Vector<uint8_t> trie = builder.take();
+        auto result = ExportsTrie::lookUp(trie.span(), "_foo");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed, "an empty edge is malformed");
+    }
+    {
+        TrieBytes builder;
+        builder.uleb128(0);
+        builder.byte(1);
+        builder.cString("_foo");
+        builder.byte(0x80); // A child offset that never ends.
+        Vector<uint8_t> trie = builder.take();
+        auto result = ExportsTrie::lookUp(trie.span(), "_foo");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "a truncated child offset is malformed");
+    }
+    {
+        // An edge leading outside the trie.
+        TrieBytes builder;
+        builder.uleb128(0);
+        builder.byte(1);
+        builder.cString("_foo");
+        builder.uleb128(1000);
+        Vector<uint8_t> trie = builder.take();
+        auto result = ExportsTrie::lookUp(trie.span(), "_foo");
+        TEST_ASSERT(!result && result.error() == Failure::Malformed,
+            "a child offset past the end of the trie is malformed");
+    }
+    {
+        // An edge leading into the middle of the node it came from. Whatever that
+        // decodes to, it must be an answer rather than a crash or a hang.
+        TrieBytes builder;
+        builder.uleb128(0);
+        builder.byte(1);
+        builder.cString("_foo");
+        builder.uleb128(2);
+        Vector<uint8_t> trie = builder.take();
+        auto result = ExportsTrie::lookUp(trie.span(), "_foo");
+        TEST_ASSERT(!result, "a child offset into the middle of a node yields no export");
+    }
+    {
+        // A trie truncated part way through a node it claims to hold. The last byte
+        // is the terminal node's children count, which a look up that ends at that
+        // terminal never reads, so removing only that byte still resolves; every
+        // shorter prefix cuts into the terminal itself and must not.
+        Vector<uint8_t> trie = singleExportTrie("_foo", regularExport(0x1234));
+        for (size_t length = 1; length + 1 < trie.size(); ++length) {
+            auto result = ExportsTrie::lookUp(trie.span().first(length), "_foo");
+            TEST_ASSERT(!result, "a truncated trie yields no export");
+        }
+    }
+}
+
+static void testWalkIsBounded()
+{
+    // A node whose only edge leads back to itself. The walk may only follow an edge
+    // by consuming at least one character of the name, so it has to end even though
+    // the trie describes a cycle. Without that property this test would not return.
+    TrieBytes builder;
+    builder.uleb128(0);
+    builder.byte(1);
+    builder.cString("a");
+    builder.uleb128(0); // Back to the root.
+    Vector<uint8_t> trie = builder.take();
+
+    std::string name(20000, 'a');
+    auto result = ExportsTrie::lookUp(trie.span(), name);
+    TEST_ASSERT(!result, "a cyclic trie yields no export");
+
+    // The same cycle reached with a name it cannot consume.
+    auto other = ExportsTrie::lookUp(trie.span(), "b");
+    TEST_ASSERT(!other && other.error() == Failure::Absent, "a cycle whose edge does not match is Absent");
+}
+
+void testExportsTrie()
+{
+    if (!beginSuite("ExportsTrie"))
+        return;
+
+    testFoundExports();
+    testClassifiedFailures();
+    testMalformedTries();
+    testWalkIsBounded();
+}
+
+// A small deterministic generator, so that a failure can be reproduced from the
+// seed the run reports.
+class Random {
+public:
+    explicit Random(uint64_t seed)
+        : m_state(seed ? seed : 0x9e3779b97f4a7c15ull)
+    {
+    }
+
+    uint64_t next()
+    {
+        m_state ^= m_state >> 12;
+        m_state ^= m_state << 25;
+        m_state ^= m_state >> 27;
+        return m_state * 0x2545f4914f6cdd1dull;
+    }
+
+    uint32_t below(uint32_t bound) { return bound ? static_cast<uint32_t>(next() % bound) : 0; }
+
+private:
+    uint64_t m_state;
+};
+
+static Atomic<uint64_t> fuzzIteration;
+static Atomic<bool> fuzzFinished;
+
+static void* fuzzWatchdog(void*)
+{
+    uint64_t lastSeen = 0;
+    unsigned stalledPolls = 0;
+    static constexpr unsigned pollIntervalUsec = 250 * 1000;
+    static constexpr unsigned stallLimitPolls = 40; // Ten seconds.
+
+    while (!fuzzFinished.load()) {
+        usleep(pollIntervalUsec);
+        uint64_t current = fuzzIteration.load();
+        if (current != lastSeen) {
+            lastSeen = current;
+            stalledPolls = 0;
+            continue;
+        }
+        if (++stalledPolls < stallLimitPolls)
+            continue;
+        // The decoder promises to bound its work on any input. A stall means it
+        // does not, so crash here rather than let the run hang: a report with a
+        // stack in the decoder says far more than a timeout does.
+        dataLogLn("FAIL: exports trie look up did not finish on fuzz iteration ", lastSeen);
+        CRASH();
+    }
+    return nullptr;
+}
+
+void fuzzExportsTrie(uint64_t seed, unsigned iterations)
+{
+    if (!beginSuite("ExportsTrie fuzz"))
+        return;
+    dataLogLn("    seed ", RawHex(seed), ", ", iterations, " iterations");
+
+    Random random(seed);
+    fuzzIteration.store(0);
+    fuzzFinished.store(false);
+
+    pthread_t watchdog { };
+    bool watching = !pthread_create(&watchdog, nullptr, fuzzWatchdog, nullptr);
+    TEST_ASSERT(watching, "the fuzz watchdog started");
+
+    Vector<uint8_t> valid = singleExportTrie("_foo", regularExport(0x1234));
+    std::array<std::string_view, 6> names { "_foo", "_foobar", "_f", "", "_bar", "_fop" };
+
+    for (unsigned iteration = 0; iteration < iterations; ++iteration) {
+        fuzzIteration.store(iteration + 1);
+
+        Vector<uint8_t> trie;
+        if (random.below(4)) {
+            // Mostly near-valid tries: those reach further into the decoder than
+            // noise does, because their early fields still make sense.
+            trie = valid;
+            unsigned mutations = 1 + random.below(6);
+            for (unsigned mutation = 0; mutation < mutations; ++mutation)
+                trie[random.below(static_cast<uint32_t>(trie.size()))] = static_cast<uint8_t>(random.next());
+        } else {
+            unsigned length = random.below(64);
+            for (unsigned index = 0; index < length; ++index)
+                trie.append(static_cast<uint8_t>(random.next()));
+        }
+
+        std::string generatedName;
+        std::string_view name;
+        if (random.below(4))
+            name = names[random.below(names.size())];
+        else {
+            unsigned length = random.below(12);
+            for (unsigned index = 0; index < length; ++index)
+                generatedName += static_cast<char>('_' + random.below(48));
+            name = generatedName;
+        }
+
+        auto result = ExportsTrie::lookUp(trie.span(), name);
+        // Noise is allowed to decode as an export. What is not allowed is an
+        // export of a kind the caller cannot act on.
+        if (result) {
+            TEST_ASSERT(result->kind == Kind::Regular || result->kind == Kind::Absolute,
+                "a decoded export has a kind the caller understands");
+        }
+    }
+
+    fuzzFinished.store(true);
+    if (watching)
+        pthread_join(watchdog, nullptr);
+}
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseExportsTrieTest.h
+++ b/Source/JavaScriptCore/corpse/tests/CorpseExportsTrieTest.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <stdint.h>
+
+namespace JSCToolsTest {
+
+void testExportsTrie();
+
+// Feeds mutated and random tries to the decoder. A trie out of a corpse is
+// untrusted, and the decoder promises to bound its work on any input, which only
+// a run over inputs nobody wrote can really check.
+void fuzzExportsTrie(uint64_t seed, unsigned iterations);
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseProcessTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseProcessTest.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseProcessTest.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "LibJSCToolsTestUtilities.h"
+
+#include <JavaScriptCore/CorpseProcess.h>
+#include <signal.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace JSCToolsTest {
+
+using JSC::Corpse::Process;
+
+// A pid that is certainly not in use: a child that has been reaped. Returns 0 if
+// no child could be made.
+static pid_t reapedChildPid()
+{
+    pid_t child = fork();
+    if (!child)
+        _exit(0);
+    if (child < 0)
+        return 0;
+    int status = 0;
+    if (waitpid(child, &status, 0) != child)
+        return 0;
+    return child;
+}
+
+#if CPU(ARM64)
+// Launches /bin/sh as x86_64, which on Apple silicon means under translation.
+// Returns 0 if this machine cannot run x86_64 code.
+static pid_t spawnTranslatedChild()
+{
+    posix_spawnattr_t attributes;
+    if (posix_spawnattr_init(&attributes))
+        return 0;
+
+    cpu_type_t preference = CPU_TYPE_X86_64;
+    size_t counted = 0;
+    posix_spawnattr_setbinpref_np(&attributes, 1, &preference, &counted);
+
+    char* const arguments[] = {
+        const_cast<char*>("/bin/sh"),
+        const_cast<char*>("-c"),
+        const_cast<char*>("sleep 30"),
+        nullptr
+    };
+    pid_t child = 0;
+    int error = posix_spawn(&child, "/bin/sh", nullptr, &attributes, arguments, nullptr);
+    posix_spawnattr_destroy(&attributes);
+
+    if (error || counted != 1)
+        return 0;
+    return child;
+}
+#endif // CPU(ARM64)
+
+void testProcess()
+{
+    if (!beginSuite("Process"))
+        return;
+
+    {
+        RefPtr<Process> process = Process::create(getpid());
+        TEST_ASSERT(!process->isAttached(), "a new Process is not attached");
+        TEST_ASSERT_EQ(process->pid(), getpid(), "a Process keeps the pid it was given");
+
+        TEST_ASSERT(process->attach(), "attaching to this process succeeds");
+        TEST_ASSERT(process->isAttached(), "attaching leaves the Process attached");
+        TEST_ASSERT(process->holdsLiveTask(), "the task port names this very process");
+        TEST_ASSERT(process->attach(), "attaching an already attached Process succeeds");
+
+        process->detach();
+        TEST_ASSERT(!process->isAttached(), "detaching releases the task port");
+        TEST_ASSERT(!process->holdsLiveTask(), "a detached Process holds no task");
+
+        TEST_ASSERT(process->attach(), "a detached Process can attach again");
+        process->detach();
+        process->detach();
+        TEST_ASSERT(!process->isAttached(), "detaching twice is harmless");
+    }
+    {
+        // Attaching takes a send right to the target's task port, and every path out of
+        // an attach has to give it back. Attaching to this very process yields the name
+        // this task already holds for itself, so the kernel adds a reference to that
+        // name rather than handing out a new one: a right that is never given back
+        // shows up in the reference count and not in the size of the name space.
+        unsigned namesBefore = machPortNameCount();
+        mach_port_t port = MACH_PORT_NULL;
+        unsigned refsAttached = 0;
+        {
+            RefPtr<Process> process = Process::create(getpid());
+            TEST_ASSERT(process->attach(), "attaching to this process succeeds");
+            if (process->isAttached()) {
+                port = process->taskPort();
+                refsAttached = machPortSendRightCount(port);
+                TEST_ASSERT(refsAttached, "an attached Process holds a send right to the task port");
+
+                process->attach();
+                TEST_ASSERT_EQ(machPortSendRightCount(port), refsAttached,
+                    "attaching an attached Process takes no further send right");
+
+                process->detach();
+                TEST_ASSERT_EQ(machPortSendRightCount(port), refsAttached - 1,
+                    "detaching gives the send right back");
+                process->detach();
+                TEST_ASSERT_EQ(machPortSendRightCount(port), refsAttached - 1,
+                    "detaching twice gives back only what one attach took");
+
+                process->attach(); // Left attached, so the destructor has to release it.
+            }
+        }
+        if (refsAttached) {
+            TEST_ASSERT_EQ(machPortSendRightCount(port), refsAttached - 1,
+                "destroying an attached Process gives its send right back");
+            TEST_ASSERT_EQ(machPortNameCount(), namesBefore,
+                "attaching and detaching leaves no port name behind");
+        }
+    }
+    {
+        pid_t gone = reapedChildPid();
+        if (!gone)
+            TEST_ASSERT(gone, "a child could be forked and reaped");
+        else {
+            dataLogLn("    (the next line is the failure this test asks for)");
+            unsigned namesBefore = machPortNameCount();
+            RefPtr<Process> process = Process::create(gone);
+            TEST_ASSERT(!process->attach(), "attaching to a process that has exited fails");
+            TEST_ASSERT(!process->isAttached(), "a failed attach leaves the Process unattached");
+            TEST_ASSERT_EQ(machPortNameCount(), namesBefore, "a failed attach leaves no port name behind");
+        }
+    }
+    {
+        RefPtr<Process> process = Process::create(getpid());
+        TEST_ASSERT(!process->isTranslated(), "this process does not run under translation");
+        // Answering this needs no task port, only the pid.
+        TEST_ASSERT(!process->isAttached(), "asking about translation does not attach");
+    }
+    {
+        RefPtr<Process> initProcess = Process::create(1);
+        TEST_ASSERT(!initProcess->isTranslated(), "launchd does not run under translation");
+    }
+    {
+        pid_t gone = reapedChildPid();
+        if (gone) {
+            RefPtr<Process> process = Process::create(gone);
+            TEST_ASSERT(!process->isTranslated(), "a process that has exited is not translated");
+        }
+    }
+#if CPU(ARM64)
+    {
+        pid_t translated = spawnTranslatedChild();
+        if (!translated)
+            skipSuite("Process translation", "this machine cannot run x86_64 code");
+        else {
+            RefPtr<Process> process = Process::create(translated);
+            TEST_ASSERT(process->isTranslated(), "a process running x86_64 code is translated");
+            kill(translated, SIGKILL);
+            int status = 0;
+            waitpid(translated, &status, 0);
+        }
+    }
+#endif // CPU(ARM64)
+}
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseProcessTest.h
+++ b/Source/JavaScriptCore/corpse/tests/CorpseProcessTest.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+namespace JSCToolsTest {
+
+void testProcess();
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseRegionTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseRegionTest.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseRegionTest.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "LibJSCToolsTestUtilities.h"
+
+#include <JavaScriptCore/CorpseAddress.h>
+#include <JavaScriptCore/CorpseRegion.h>
+#include <JavaScriptCore/CorpseSnapshot.h>
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+namespace JSCToolsTest {
+
+using JSC::Corpse::Address;
+using JSC::Corpse::Region;
+
+void testRegion()
+{
+    if (!beginSuite("Region"))
+        return;
+
+    size_t pageSize = static_cast<size_t>(getpagesize());
+    static constexpr size_t mappedPages = 5;
+    static constexpr size_t writtenPages = 2;
+    static constexpr size_t readPages = 1; // Exclusive of writtenPages.
+
+    // The test scratch area is seven pages, with the first and last given back (holes), so
+    // that the five in the middle are a region of known size with a hole on either side.
+    // In this test, we'll check on those hole pages being holes. Hence, we need for them to
+    // stay unmapped.
+    //
+    // Unfortunately, bmalloc or other heaps, when expanding, may consume the lower unmapped
+    // page, and put it to use. This breaks our reliance on it being unmapped. So, we'll
+    // precede the test scratch area with a runway of 10 unmapped pages. This gives any heap
+    // some room to grow into without picking off our hole pages.
+    static constexpr size_t runwayPaddingPages = 10;
+    static constexpr size_t lowerSentinelPage = runwayPaddingPages;
+    static constexpr size_t holeBelowRegion = lowerSentinelPage + 1;
+    static constexpr size_t holeAboveRegion = holeBelowRegion + mappedPages + 1;
+    static constexpr size_t upperSentinelPage = holeAboveRegion + 1;
+    static constexpr size_t reservationPages = upperSentinelPage + 1;
+
+    size_t reservationSize = reservationPages * pageSize;
+    void* reservation = mmap(nullptr, reservationSize, PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (reservation == MAP_FAILED) {
+        TEST_ASSERT(false, "the required test VA should be mappable");
+        return;
+    }
+    auto addressAt = [&](size_t pageIndex) {
+        return reinterpret_cast<uintptr_t>(reservation) + pageIndex * pageSize;
+    };
+    auto unmapPages = [&](size_t pageIndex, size_t pageCount) {
+        munmap(reinterpret_cast<void*>(addressAt(pageIndex)), pageCount * pageSize);
+    };
+    unmapPages(0, runwayPaddingPages);
+    unmapPages(holeBelowRegion, 1);
+    unmapPages(holeAboveRegion, 1);
+
+    uintptr_t base = addressAt(holeBelowRegion + 1);
+    for (size_t page = 0; page < writtenPages; ++page)
+        *reinterpret_cast<volatile uint8_t*>(base + page * pageSize) = 1; // Touch with write.
+    for (size_t page = writtenPages; page < writtenPages + readPages; ++page)
+        (void)*reinterpret_cast<volatile uint8_t*>(base + page * pageSize); // Touch with read.
+
+    // Gives back everything this test still holds: the region and the two sentinels.
+    // The runwayPaddingPages are already unmapped.
+    auto unmapPagesStillHeld = [&]() {
+        unmapPages(lowerSentinelPage, 1);
+        unmapPages(holeBelowRegion + 1, mappedPages);
+        unmapPages(upperSentinelPage, 1);
+    };
+
+    SelfSnapshot self;
+    if (!self.isValid()) {
+        unmapPagesStillHeld();
+        return;
+    }
+    mach_port_t corpsePort = self.snapshot().corpsePort();
+
+    {
+        auto region = Region::findContaining(corpsePort, Address(static_cast<mach_vm_address_t>(base)));
+        TEST_ASSERT(region, "the region holding a known mapping is found");
+        if (region) {
+            TEST_ASSERT_HEX_EQ(region->base().toMachVMAddress(), base, "the region starts where the mapping does");
+            TEST_ASSERT_EQ(region->size(), mappedPages * pageSize, "the region is as large as the mapping");
+            TEST_ASSERT_HEX_EQ(region->end().toMachVMAddress(), base + mappedPages * pageSize,
+                "the region ends where the mapping does");
+            TEST_ASSERT_EQ(region->pageCount(),
+                static_cast<uint64_t>(mappedPages * pageSize / vm_kernel_page_size),
+                "the region holds as many pages as were mapped");
+            TEST_ASSERT(region->contains(region->base()), "a region contains its first byte");
+            TEST_ASSERT(region->contains(region->end() - 1), "a region contains its last byte");
+            TEST_ASSERT(!region->contains(region->end()), "a region does not contain the byte past its end");
+            TEST_ASSERT(!region->contains(region->base() - 1), "a region does not contain the byte before it");
+
+            uint64_t accessedKernelPages =
+                static_cast<uint64_t>((writtenPages + readPages) * pageSize / vm_kernel_page_size);
+            TEST_ASSERT_EQ(region->residentPageCount(), accessedKernelPages,
+                "the pages that were accessed are the resident ones");
+
+            // Dirty does not mean written: an anonymous page has no pager to be re-read
+            // from, so it counts as dirty from the moment a fault creates it, whether
+            // that fault was a write or a read. The page that was only read is dirty in
+            // most runs but not all, so the written pages are what can be counted on.
+            uint64_t writtenKernelPages = static_cast<uint64_t>(writtenPages * pageSize / vm_kernel_page_size);
+            TEST_ASSERT(region->dirtyPageCount() >= writtenKernelPages
+                && region->dirtyPageCount() <= accessedKernelPages,
+                "every page that was written is dirty and no page that was never accessed is");
+        }
+    }
+    {
+        // An address in the middle of the mapping still finds the whole region.
+        auto region = Region::findContaining(corpsePort,
+            Address(static_cast<mach_vm_address_t>(base + pageSize + 16)));
+        TEST_ASSERT(region, "an address inside the mapping finds the region");
+        if (region)
+            TEST_ASSERT_HEX_EQ(region->base().toMachVMAddress(), base, "any address in a region finds its base");
+    }
+    {
+        // The kernel reports the region at or above the address it is asked about,
+        // so a hole must be reported as a hole rather than as the region above it.
+        auto region = Region::findContaining(corpsePort,
+            Address(static_cast<mach_vm_address_t>(addressAt(holeBelowRegion))));
+        TEST_ASSERT(!region, "an address in an unmapped hole finds no region");
+    }
+    {
+        // The same question asked from the other side. An address in this hole sits past
+        // the end of the region below it, which must not be reported as containing it.
+        auto region = Region::findContaining(corpsePort,
+            Address(static_cast<mach_vm_address_t>(addressAt(holeAboveRegion))));
+        TEST_ASSERT(!region, "an address in the hole above a region finds no region");
+    }
+    {
+        // The shared cache is mapped as a submap, which the search has to descend
+        // into before it can describe what is actually there. A function's address
+        // arrives signed on arm64e, and is an address only once stripped.
+        Address inSharedCache = Address(reinterpret_cast<void*>(&memcpy)).stripped();
+        auto region = Region::findContaining(corpsePort, inSharedCache);
+        TEST_ASSERT(region, "an address in the shared cache finds a region");
+        if (region)
+            TEST_ASSERT(region->size(), "a shared cache region has a size");
+    }
+
+    unmapPagesStillHeld();
+}
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseRegionTest.h
+++ b/Source/JavaScriptCore/corpse/tests/CorpseRegionTest.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+namespace JSCToolsTest {
+
+// Takes a corpse of the running test itself, so that everything the corpse
+// reports can be checked against what this process already knows.
+
+void testRegion();
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseSnapshotTest.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "LibJSCToolsTestUtilities.h"
+
+#include <JavaScriptCore/CorpseProcess.h>
+#include <JavaScriptCore/CorpseSnapshot.h>
+#include <mach/mach.h>
+#include <unistd.h>
+
+namespace JSCToolsTest {
+
+using JSC::Corpse::Process;
+using JSC::Corpse::Snapshot;
+
+void testSnapshot()
+{
+    if (!beginSuite("Snapshot"))
+        return;
+
+    RefPtr<Process> process = Process::create(getpid());
+    if (!process->attach()) {
+        TEST_ASSERT(false, "attaching to this process succeeds");
+        return;
+    }
+
+    unsigned firstId = 0;
+    {
+        Snapshot snapshot(process);
+        TEST_ASSERT(snapshot.isValid(), "a snapshot of this process is valid");
+        TEST_ASSERT(MACH_PORT_VALID(snapshot.corpsePort()), "a valid snapshot holds a corpse port");
+        TEST_ASSERT(snapshot.process() == process.get(), "a snapshot keeps the process it came from");
+        firstId = snapshot.id();
+        TEST_ASSERT(firstId, "a snapshot has an identifier");
+
+        Snapshot second(process);
+        TEST_ASSERT(second.isValid(), "a second snapshot of the same process is valid");
+        TEST_ASSERT(second.id() > firstId, "identifiers increase");
+        TEST_ASSERT(second.corpsePort() != snapshot.corpsePort(),
+            "two snapshots hold two different corpses");
+    }
+    {
+        // The two above are gone; their identifiers must not come back.
+        Snapshot later(process);
+        TEST_ASSERT(later.id() > firstId + 1, "identifiers are not reused after a snapshot is destroyed");
+    }
+    {
+        RefPtr<Process> unattached = Process::create(getpid());
+        Snapshot snapshot(unattached);
+        TEST_ASSERT(!snapshot.isValid(), "a snapshot of an unattached process is invalid");
+        TEST_ASSERT(snapshot.threads().isEmpty(), "an invalid snapshot reports no threads");
+        TEST_ASSERT(!snapshot.symbol("g_config"), "an invalid snapshot resolves no symbol");
+    }
+    {
+        RefPtr<Process> none;
+        Snapshot snapshot(none);
+        TEST_ASSERT(!snapshot.isValid(), "a snapshot with no process is invalid");
+    }
+    {
+        Snapshot snapshot(process);
+        TEST_ASSERT(!snapshot.symbol(nullptr), "an unnamed symbol resolves to nothing");
+        TEST_ASSERT(!snapshot.symbol(""), "an empty symbol name resolves to nothing");
+    }
+
+    {
+        // A corpse and the threads read out of it are Mach ports. Taking many
+        // snapshots must not leave any of them behind.
+        static constexpr unsigned rounds = 100;
+        unsigned before = machPortNameCount();
+        for (unsigned round = 0; round < rounds; ++round) {
+            Snapshot snapshot(process);
+            if (!snapshot.isValid())
+                continue;
+            snapshot.threads();
+        }
+        unsigned after = machPortNameCount();
+        // A handful of names may come and go for reasons of their own; a leak of
+        // one port per round would be a hundred.
+        static constexpr unsigned allowedDrift = 8;
+        TEST_ASSERT(after <= before + allowedDrift, "taking and dropping snapshots leaks no Mach port");
+        if (after > before + allowedDrift)
+            dataLogLn("    port names before ", before, ", after ", after, ", over ", rounds, " snapshots");
+    }
+}
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.h
+++ b/Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+namespace JSCToolsTest {
+
+// Takes a corpse of the running test itself, so that everything the corpse
+// reports can be checked against what this process already knows.
+
+void testSnapshot();
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseSymbolTest.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "LibJSCToolsTestUtilities.h"
+
+#include <JavaScriptCore/CorpseAddress.h>
+#include <JavaScriptCore/CorpseSnapshot.h>
+#include <JavaScriptCore/CorpseSymbol.h>
+#include <dlfcn.h>
+#include <mach/mach.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/WTFConfig.h>
+
+// Exists in this binary but is not exported, so an exports trie cannot see it.
+// A look up must report that rather than find it some other way.
+extern "C" __attribute__((visibility("hidden"))) int jscToolsTestHiddenGlobal;
+int jscToolsTestHiddenGlobal = 42;
+
+namespace JSCToolsTest {
+
+using JSC::Corpse::Address;
+using JSC::Corpse::Snapshot;
+using JSC::Corpse::Symbol;
+
+// A symbol resolved out of a corpse of this very process must land on the same
+// address this process would use, because the corpse is a copy of this address
+// space. That makes every look up below checkable against ground truth.
+void testSymbol()
+{
+    if (!beginSuite("Symbol"))
+        return;
+
+    SelfSnapshot self;
+    if (!self.isValid())
+        return;
+    Snapshot& snapshot = self.snapshot();
+
+    {
+        // A data symbol exported by the JavaScriptCore framework: an image that is
+        // not in the shared cache, so this checks the slide from __TEXT's link-time
+        // address to where the image actually landed.
+        auto expected = reinterpret_cast<uintptr_t>(WebConfig::g_config);
+        Address found = snapshot.symbol("g_config");
+        TEST_ASSERT(found, "a symbol exported by JavaScriptCore is found");
+        TEST_ASSERT_HEX_EQ(found.toMachVMAddress(), expected,
+            "g_config resolves to the address this process uses for it");
+    }
+    {
+        // A function in the shared cache, where __LINKEDIT is shared between images
+        // and the trie is reached by a different route.
+        void* expected = dlsym(RTLD_DEFAULT, "malloc");
+        TEST_ASSERT(expected, "malloc can be looked up locally");
+        Address found = snapshot.symbol("malloc");
+        TEST_ASSERT(found, "a symbol exported by a shared cache image is found");
+        // A function pointer arrives signed on arm64e; only the address it names is
+        // being compared here.
+        TEST_ASSERT_HEX_EQ(found.stripped().toMachVMAddress(),
+            Address(expected).stripped().toMachVMAddress(),
+            "malloc resolves to the address this process uses for it");
+    }
+    {
+        // A data symbol in the shared cache.
+        void* expected = dlsym(RTLD_DEFAULT, "environ");
+        if (!expected)
+            skipSuite("Symbol environ", "this system does not export environ");
+        else {
+            Address found = snapshot.symbol("environ");
+            TEST_ASSERT(found, "a data symbol in the shared cache is found");
+            TEST_ASSERT_HEX_EQ(found.stripped().toMachVMAddress(),
+                Address(expected).stripped().toMachVMAddress(),
+                "environ resolves to the address this process uses for it");
+        }
+    }
+    {
+        TEST_ASSERT(!snapshot.symbol("jscToolsTestNoSuchSymbolAnywhere"),
+            "a name that is not exported anywhere is not found");
+        TEST_ASSERT(!snapshot.symbol(nullptr), "no name resolves to nothing");
+        TEST_ASSERT(!snapshot.symbol(""), "an empty name resolves to nothing");
+    }
+    {
+        // Only exported symbols appear in a trie. This one is in the binary, and
+        // still must not be found: saying so is the honest answer.
+        TEST_ASSERT(jscToolsTestHiddenGlobal == 42, "the hidden global is in this binary");
+        TEST_ASSERT(!snapshot.symbol("jscToolsTestHiddenGlobal"),
+            "a symbol hidden from the linker is not found");
+    }
+    {
+        // A look up prepends the underscore that a Mach-O symbol name carries, so a
+        // name that already has one is asking for a different symbol.
+        TEST_ASSERT(!snapshot.symbol("_malloc"),
+            "a name given with its underscore already attached is not found");
+    }
+    {
+        // Resolving is expensive, so a snapshot keeps what it has resolved.
+        Address first = snapshot.symbol("g_config");
+        Address second = snapshot.symbol("g_config");
+        TEST_ASSERT(first == second, "resolving the same name twice gives the same address");
+    }
+    {
+        Symbol symbol(snapshot, "g_config");
+        TEST_ASSERT(symbol.name() == "g_config", "a Symbol keeps the name it was asked for");
+        TEST_ASSERT(symbol.isValid(), "a Symbol that resolved is valid");
+        TEST_ASSERT(symbol.address() == snapshot.symbol("g_config"),
+            "a Symbol resolves to what the snapshot reports");
+
+        Symbol missing(snapshot, "jscToolsTestNoSuchSymbolAnywhere");
+        TEST_ASSERT(!missing.isValid(), "a Symbol that did not resolve is not valid");
+        TEST_ASSERT(!missing.address(), "a Symbol that did not resolve has no address");
+        TEST_ASSERT(missing.name() == "jscToolsTestNoSuchSymbolAnywhere",
+            "a Symbol that did not resolve still knows its name");
+
+        Symbol unnamed(snapshot, nullptr);
+        TEST_ASSERT(unnamed.name().empty(), "a Symbol with no name has an empty name");
+        TEST_ASSERT(!unnamed.isValid(), "a Symbol with no name is not valid");
+    }
+    {
+        // A name that is nowhere walks every image in the corpse, which is the most
+        // work a look up can be asked to do. It has to stay bounded.
+        static constexpr double budgetSeconds = 60;
+        MonotonicTime start = MonotonicTime::now();
+        TEST_ASSERT(!snapshot.symbol("jscToolsTestAnotherNameThatIsNowhere"),
+            "an absent name is reported absent");
+        double elapsed = (MonotonicTime::now() - start).seconds();
+        TEST_ASSERT(elapsed < budgetSeconds, "a look up that finds nothing still finishes");
+        if (elapsed >= budgetSeconds)
+            dataLogLn("    the search took ", elapsed, " seconds");
+    }
+}
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.h
+++ b/Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+namespace JSCToolsTest {
+
+void testSymbol();
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseThreadTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseThreadTest.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorpseThreadTest.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include "LibJSCToolsTestUtilities.h"
+
+#include <JavaScriptCore/CorpseRegion.h>
+#include <JavaScriptCore/CorpseSnapshot.h>
+#include <JavaScriptCore/CorpseThread.h>
+#include <string>
+#include <string_view>
+
+namespace JSCToolsTest {
+
+using JSC::Corpse::Thread;
+
+void testThreads()
+{
+    if (!beginSuite("Thread"))
+        return;
+
+    static constexpr const char* alphaName = "jsctools alpha";
+    static constexpr const char* betaName = "jsctools beta";
+    // Longer than a pthread name can hold, so that truncation is exercised.
+    static constexpr const char* longName =
+        "jsctools a thread whose name is far too long to fit in the space a pthread name has";
+
+    ParkedThreads parked;
+    TEST_ASSERT(parked.spawn(alphaName), "a named thread starts");
+    TEST_ASSERT(parked.spawn(betaName), "a second named thread starts");
+    TEST_ASSERT(parked.spawn(longName), "a thread with an overlong name starts");
+    if (!parked.waitUntilAllParked()) {
+        TEST_ASSERT(false, "the spawned threads parked themselves");
+        return;
+    }
+
+    SelfSnapshot self;
+    if (!self.isValid())
+        return;
+
+    const Vector<Thread>& threads = self.snapshot().threads();
+    TEST_ASSERT(threads.size() >= 1 + parked.count(),
+        "the corpse holds at least this process's own threads");
+
+    bool foundAlpha = false;
+    bool foundBeta = false;
+    bool foundTruncated = false;
+    std::string expectedTruncated(std::string_view(longName).substr(0, ParkedThreads::maximumNameLength));
+
+    for (const Thread& thread : threads) {
+        if (thread.name() == alphaName)
+            foundAlpha = true;
+        else if (thread.name() == betaName)
+            foundBeta = true;
+        else if (thread.name() == expectedTruncated)
+            foundTruncated = true;
+
+        TEST_ASSERT(thread.id(), "every thread has an identifier");
+        TEST_ASSERT(thread.name().length() <= ParkedThreads::maximumNameLength,
+            "no thread name is longer than a pthread name can be");
+
+        // The stack is defined as the region the stack pointer points into, so if
+        // both were read they have to agree.
+        if (thread.stackPointer()) {
+            TEST_ASSERT(thread.hasStack(), "a thread with a stack pointer has a stack region");
+            if (thread.hasStack()) {
+                TEST_ASSERT(thread.stackRegion().contains(thread.stackPointer()),
+                    "a thread's stack pointer lies inside its stack region");
+                TEST_ASSERT(thread.stackRegion().pageCount() >= thread.stackRegion().residentPageCount(),
+                    "a stack has at least as many pages as it has resident");
+            }
+        }
+
+        TEST_ASSERT(!std::string_view(thread.runStateDescription()).empty(),
+            "a thread's run state has a name");
+    }
+
+    TEST_ASSERT(foundAlpha, "a named thread appears in the corpse under its name");
+    TEST_ASSERT(foundBeta, "a second named thread appears under its name");
+    TEST_ASSERT(foundTruncated, "an overlong thread name appears cut to what a pthread name holds");
+
+    // Reading the threads is the expensive part, so it happens once.
+    const Vector<Thread>& again = self.snapshot().threads();
+    TEST_ASSERT(&again == &threads, "the threads of a snapshot are read once and kept");
+
+    parked.stopAndJoin();
+}
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/CorpseThreadTest.h
+++ b/Source/JavaScriptCore/corpse/tests/CorpseThreadTest.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+namespace JSCToolsTest {
+
+// Takes a corpse of the running test itself, so that everything the corpse
+// reports can be checked against what this process already knows.
+
+void testThreads();
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.cpp
+++ b/Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LibJSCToolsTestUtilities.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <JavaScriptCore/CorpseProcess.h>
+#include <JavaScriptCore/CorpseSnapshot.h>
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <pthread.h>
+#include <string>
+#include <unistd.h>
+#include <wtf/StdLibExtras.h>
+
+namespace JSCToolsTest {
+
+unsigned assertionsRun = 0;
+unsigned assertionsFailed = 0;
+unsigned suitesSkipped = 0;
+const char* suiteFilter = nullptr;
+
+bool beginSuite(const char* name)
+{
+    if (suiteFilter && !std::string_view(name).contains(std::string_view(suiteFilter)))
+        return false;
+    dataLogLn("--- ", name);
+    return true;
+}
+
+void skipSuite(const char* name, const char* why)
+{
+    ++suitesSkipped;
+    dataLogLn("SKIP: ", name, ": ", why);
+}
+
+unsigned machPortNameCount()
+{
+    mach_port_name_array_t names = nullptr;
+    mach_msg_type_number_t nameCount = 0;
+    mach_port_type_array_t types = nullptr;
+    mach_msg_type_number_t typeCount = 0;
+    auto result = mach_port_names(mach_task_self(), &names, &nameCount, &types, &typeCount);
+    RELEASE_ASSERT(result == KERN_SUCCESS);
+
+    mach_vm_deallocate(mach_task_self(), reinterpret_cast<mach_vm_address_t>(names), nameCount * sizeof(mach_port_name_t));
+    mach_vm_deallocate(mach_task_self(), reinterpret_cast<mach_vm_address_t>(types), typeCount * sizeof(mach_port_type_t));
+    return nameCount;
+}
+
+unsigned machPortSendRightCount(mach_port_t port)
+{
+    mach_port_urefs_t refs = 0;
+    auto result = mach_port_get_refs(mach_task_self(), port, MACH_PORT_RIGHT_SEND, &refs);
+    if (result == KERN_INVALID_NAME) {
+        // A name this task does not hold is an answer -- it holds no rights under it --
+        // rather than a failure. Hence, has no send right.
+        return 0;
+    }
+    RELEASE_ASSERT(result == KERN_SUCCESS);
+    return refs; // Can still be 0 (which still means no send right).
+}
+
+SelfSnapshot::SelfSnapshot()
+{
+    m_process = JSC::Corpse::Process::create(getpid());
+    if (!m_process->attach()) {
+        TEST_ASSERT(false, "attaching to this process succeeds");
+        return;
+    }
+    m_snapshot = WTF::makeUnique<JSC::Corpse::Snapshot>(m_process);
+    if (!m_snapshot->isValid())
+        TEST_ASSERT(false, "a snapshot of this process is valid");
+}
+
+SelfSnapshot::~SelfSnapshot() = default;
+
+bool SelfSnapshot::isValid() const
+{
+    return m_snapshot && m_snapshot->isValid();
+}
+
+JSC::Corpse::Snapshot& SelfSnapshot::snapshot() const
+{
+    return *m_snapshot;
+}
+
+RefPtr<JSC::Corpse::Process> SelfSnapshot::process() const
+{
+    return m_process;
+}
+
+// One control block for all parked threads, so that they can be told to stop
+// together. Only one ParkedThreads is expected to be alive at a time.
+static pthread_mutex_t parkMutex = PTHREAD_MUTEX_INITIALIZER;
+static unsigned parkedCount = 0;
+static bool parkStopping = false;
+
+struct ParkedThreads::Thread {
+    pthread_t handle { };
+    std::string name;
+};
+
+static void* parkThread(void* argument)
+{
+    auto* thread = static_cast<ParkedThreads::Thread*>(argument);
+    pthread_setname_np(thread->name.c_str());
+
+    pthread_mutex_lock(&parkMutex);
+    ++parkedCount;
+    while (!parkStopping) {
+        pthread_mutex_unlock(&parkMutex);
+        usleep(1000);
+        pthread_mutex_lock(&parkMutex);
+    }
+    pthread_mutex_unlock(&parkMutex);
+    return nullptr;
+}
+
+ParkedThreads::~ParkedThreads()
+{
+    stopAndJoin();
+}
+
+bool ParkedThreads::spawn(const char* name)
+{
+    auto* thread = new Thread;
+    // pthread cuts a name that does not fit, and so must this copy, so that the
+    // name asked for here is the name a corpse will report.
+    thread->name = std::string_view(name).substr(0, maximumNameLength);
+    if (pthread_create(&thread->handle, nullptr, parkThread, thread)) {
+        delete thread;
+        return false;
+    }
+    m_threads.append(thread);
+    return true;
+}
+
+bool ParkedThreads::waitUntilAllParked()
+{
+    // Bounded so that a thread that never starts fails the test rather than
+    // hanging it.
+    for (unsigned attempt = 0; attempt < 5000; ++attempt) {
+        pthread_mutex_lock(&parkMutex);
+        bool ready = parkedCount >= m_threads.size();
+        pthread_mutex_unlock(&parkMutex);
+        if (ready) {
+            // A thread counts itself as parked just before it settles into its
+            // wait, so give it that moment before anything reads its state.
+            usleep(50 * 1000);
+            return true;
+        }
+        usleep(1000);
+    }
+    return false;
+}
+
+void ParkedThreads::stopAndJoin()
+{
+    if (m_threads.isEmpty())
+        return;
+
+    pthread_mutex_lock(&parkMutex);
+    parkStopping = true;
+    pthread_mutex_unlock(&parkMutex);
+
+    for (Thread* thread : m_threads) {
+        pthread_join(thread->handle, nullptr);
+        delete thread;
+    }
+    m_threads.clear();
+
+    pthread_mutex_lock(&parkMutex);
+    parkStopping = false;
+    parkedCount = 0;
+    pthread_mutex_unlock(&parkMutex);
+}
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.h
+++ b/Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <mach/mach.h>
+#include <memory>
+#include <span>
+#include <stdint.h>
+#include <string_view>
+#include <wtf/DataLog.h>
+#include <wtf/HexNumber.h>
+#include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
+
+namespace JSC {
+namespace Corpse {
+class Process;
+class Snapshot;
+}
+}
+
+namespace JSCToolsTest {
+
+// Assertions report against these, and main reports the totals.
+extern unsigned assertionsRun;
+extern unsigned assertionsFailed;
+extern unsigned suitesSkipped;
+
+// Only suites whose name contains this substring run. Null runs all of them.
+extern const char* suiteFilter;
+
+bool beginSuite(const char* name);
+void skipSuite(const char* name, const char* why);
+
+// Nothing is printed for a passing assertion: a passing run should be quiet, and
+// a failing one should say only what failed.
+#define TEST_ASSERT(condition, message) \
+    do { \
+        ++JSCToolsTest::assertionsRun; \
+        if (!(condition)) { \
+            ++JSCToolsTest::assertionsFailed; \
+            dataLogLn("FAIL: ", message, " (", #condition, ") at ", __FILE__, ":", __LINE__); \
+        } \
+    } while (0)
+
+// For values dataLog can print. Reports both sides, which is what makes a
+// failure diagnosable without a debugger.
+#define TEST_ASSERT_EQ(actual, expected, message) \
+    do { \
+        ++JSCToolsTest::assertionsRun; \
+        auto testActual = (actual); \
+        auto testExpected = (expected); \
+        if (!(testActual == testExpected)) { \
+            ++JSCToolsTest::assertionsFailed; \
+            dataLogLn("FAIL: ", message, ": got ", testActual, ", expected ", testExpected, \
+                " at ", __FILE__, ":", __LINE__); \
+        } \
+    } while (0)
+
+#define TEST_ASSERT_HEX_EQ(actual, expected, message) \
+    do { \
+        ++JSCToolsTest::assertionsRun; \
+        uint64_t testActual = (actual); \
+        uint64_t testExpected = (expected); \
+        if (testActual != testExpected) { \
+            ++JSCToolsTest::assertionsFailed; \
+            dataLogLn("FAIL: ", message, ": got 0x", hex(testActual), ", expected 0x", hex(testExpected), \
+                " at ", __FILE__, ":", __LINE__); \
+        } \
+    } while (0)
+
+// The number of names in this task's Mach port name space. Used to show that a
+// sequence of operations leaves no port behind.
+unsigned machPortNameCount();
+
+// The number of send rights this task holds for `port`, or 0 if it holds no name for
+// it. A task that acquires a port it already has a name for gets another reference
+// under that same name rather than a new name, so a right that is taken and never
+// given back shows up here and not in machPortNameCount().
+unsigned machPortSendRightCount(mach_port_t);
+
+// Attaches to this process and takes a corpse of it. That is what lets a test
+// check what a corpse reports against what this process already knows about
+// itself, and it needs no privilege: a task may always snapshot itself.
+//
+// Reports the failure if either step does not work, so a caller only has to
+// check isValid() and return.
+class SelfSnapshot {
+public:
+    SelfSnapshot();
+    ~SelfSnapshot();
+
+    SelfSnapshot(const SelfSnapshot&) = delete;
+    SelfSnapshot& operator=(const SelfSnapshot&) = delete;
+
+    bool isValid() const;
+    JSC::Corpse::Snapshot& snapshot() const;
+    RefPtr<JSC::Corpse::Process> process() const;
+
+private:
+    RefPtr<JSC::Corpse::Process> m_process;
+    std::unique_ptr<JSC::Corpse::Snapshot> m_snapshot;
+};
+
+// Threads that park themselves until stopped, each under a name of our choosing,
+// so that a corpse of this process contains threads whose properties are known.
+class ParkedThreads {
+public:
+    struct Thread;
+
+    // pthread keeps a thread name in a fixed buffer, so a longer name arrives cut
+    // to this length.
+    static constexpr size_t maximumNameLength = 63;
+
+    ~ParkedThreads();
+
+    // Returns false if the thread could not be created.
+    bool spawn(const char* name);
+
+    // Blocks until every spawned thread is parked, so that a snapshot taken
+    // afterwards sees them with their names set and their stacks in use.
+    bool waitUntilAllParked();
+
+    void stopAndJoin();
+
+    size_t count() const { return m_threads.size(); }
+
+private:
+    Vector<Thread*> m_threads;
+};
+
+} // namespace JSCToolsTest
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/mya/mya.cpp
+++ b/Source/JavaScriptCore/mya/mya.cpp
@@ -1,0 +1,1407 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+#include <JavaScriptCore/CorpseAddress.h>
+#include <JavaScriptCore/CorpseClient.h>
+#include <JavaScriptCore/CorpseProcess.h>
+#include <JavaScriptCore/CorpseRegion.h>
+#include <JavaScriptCore/CorpseSnapshot.h>
+#include <JavaScriptCore/CorpseThread.h>
+#include <algorithm>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <memory>
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <string_view>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <vector>
+#include <wtf/ASCIICType.h>
+#include <wtf/Assertions.h>
+#include <wtf/CheckedArithmetic.h>
+#include <wtf/DoublyLinkedList.h>
+#include <wtf/HashMap.h>
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
+
+#if HAVE(READLINE)
+// readline/history.h has a Function typedef that conflicts with WTF::Function;
+// rename it across these includes to avoid the clash.
+#define Function ReadlineFunction
+#include <readline/history.h>
+#include <readline/readline.h>
+#undef Function
+#endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+using JSC::Corpse::Address;
+using JSC::Corpse::Process;
+using JSC::Corpse::Snapshot;
+using JSC::Corpse::Thread;
+
+namespace Mya {
+
+// A lexer over a null-terminated string. Parsing methods skip leading
+// whitespace and advance past whatever they consume; a failed parse leaves the
+// position where it was. A Lexer is essentially made up of a position in the
+// string. So copying one is how you look ahead without committing.
+class Lexer {
+public:
+    explicit Lexer(const char* text)
+        : m_at(text)
+    {
+    }
+
+    void skipWhitespace()
+    {
+        while (isTabOrSpace(*m_at))
+            ++m_at;
+    }
+
+    // True if only whitespace remains.
+    bool atEnd()
+    {
+        skipWhitespace();
+        return !*m_at;
+    }
+
+    // The next non-whitespace character, or '\0' at end of input.
+    char peek()
+    {
+        skipWhitespace();
+        return *m_at;
+    }
+
+    // Consumes and returns the next whitespace-delimited token, which is empty
+    // at end of input.
+    std::string_view nextToken()
+    {
+        skipWhitespace();
+        const char* start = m_at;
+        while (*m_at && !isTabOrSpace(*m_at))
+            ++m_at;
+        return std::string_view(start, static_cast<size_t>(m_at - start));
+    }
+
+    // Consumes the next token only if it matches word.
+    bool consumeToken(const char* word)
+    {
+        Lexer probe = *this;
+        if (probe.nextToken() != word)
+            return false;
+        *this = probe;
+        return true;
+    }
+
+    // Consumes the next non-whitespace character only if it matches c.
+    bool consumeChar(char c)
+    {
+        skipWhitespace();
+        if (*m_at != c)
+            return false;
+        ++m_at;
+        return true;
+    }
+
+    // Consumes a positive number from the specified `minimum` upwards, but capped at INT_MAX.
+    template<long minimum = 0, typename T>
+    bool consumeUint32(T& out)
+    {
+        skipWhitespace();
+        if (!isASCIIDigit(*m_at))
+            return false; // Rejects cases like -0, -1, +3, which strtol allows.
+        errno = 0;
+        char* end = nullptr;
+        long value = strtol(m_at, &end, 10);
+        if (end == m_at || errno || value < minimum || value > INT_MAX)
+            return false;
+        m_at = end;
+        out = static_cast<T>(value);
+        return true;
+    }
+
+    bool consumePID(pid_t& pid) { return consumeUint32<1>(pid); }
+
+private:
+    const char* m_at;
+};
+
+class Shell {
+public:
+    ~Shell()
+    {
+        cleanup();
+    }
+
+    int run(int argc, char** argv)
+    {
+        JSC::Corpse::Client::setName("mya"_s);
+        auto action = parseArguments(argc, argv);
+        switch (action) {
+        case ContinuationAction::Continue:
+            openHistory();
+            runInteractive();
+            return 0;
+        case ContinuationAction::Exit:
+            return 0;
+        case ContinuationAction::Error:
+            return 1;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+        return 1;
+    }
+
+private:
+    static constexpr const char* prompt = ">>> ";
+    static constexpr const char* historyDirName = ".mya";
+    static constexpr const char* historyFileName = "history";
+    static constexpr unsigned defaultMaxHistoryEntries = 50;
+    static constexpr unsigned minHistorySize = 5;
+
+    // The history file records the target max history entries in its first line, followed by
+    // historical commands. To avoid re-writing the file on every new command, we allow the file
+    // to exceed the max entries by maxOverflowEntries, before we do a re-write to purge
+    // the extra entries. We will keep appending to the same file until the re-write is needed.
+    static constexpr const char* maxEntriesHeaderPrefix = "max entries ";
+    static constexpr unsigned maxOverflowEntries = 100;
+
+    static void printUsage(FILE* out)
+    {
+        fputs("Mya (MY-uh /ˈmaɪə/) - MemorY Analyzer\n", out);
+        fputs("Usage:\n", out);
+        fputs("  mya [--pid|-p <pid>]\n", out);
+        fputs("  mya [--help|-h [<command>]]\n", out);
+        fputs("Commands:\n", out);
+        fputs("  attach [--pid|-p] <pid>   Set the target PID and attach\n", out);
+        fputs("  detach                    Detach from the current PID\n", out);
+        fputs("  status (st)               Show whether mya is attached\n", out);
+        fputs("  snapshot (sn, snap) ...   Capture and manage snapshots\n", out);
+        fputs("  thread (th) ...           Inspect the threads in a snapshot\n", out);
+        fputs("  p[/x] &<symbol>           Print a symbol's address, /x for hex\n", out);
+        fputs("  history (hi, hist) ...    Show and manage the command history\n", out);
+        fputs("  help [<command>]          Show this help, or help for <command>\n", out);
+        fputs("  quit (q, exit)            Exit mya\n", out);
+        fputs("\n", out);
+        fputs("  Use `help snapshot`, `help thread` or `help history` for their subcommands.\n", out);
+        fputs("\n", out);
+    }
+
+    static void printThreadUsage(FILE* out)
+    {
+        fputs("thread - inspect the threads captured in a snapshot\n", out);
+        fputs("  thread list (li)          List the threads in the snapshot in use\n", out);
+        fputs("\n", out);
+        fputs("  `thread` may be abbreviated as `th`, and lists by default.\n", out);
+        fputs("  Threads are read from the snapshot in use; see `help snapshot`.\n", out);
+        fputs("\n", out);
+    }
+
+    static void printSnapshotUsage(FILE* out)
+    {
+        fputs("snapshot - capture and manage snapshots of a process\n", out);
+        fputs("  snapshot                  Capture a snapshot of the current process\n", out);
+        fputs("  snapshot --pid|-p <pid>   Attach to <pid> and capture a snapshot of it\n", out);
+        fputs("  snapshot <n>              Switch to using snapshot <n>\n", out);
+        fputs("  snapshot list (li)        List captured snapshots (* marks the one in use)\n", out);
+        fputs("  snapshot info (inf) <n>   Show details of snapshot <n>\n", out);
+        fputs("  snapshot delete (del) <n> Delete snapshot <n>\n", out);
+        fputs("  snapshot diff <a> <b>     Diff snapshot <a> against snapshot <b>\n", out);
+        fputs("\n", out);
+        fputs("  `snapshot` may be abbreviated as `sn` or `snap`.\n", out);
+        fputs("  Capturing a snapshot switches to using it.\n", out);
+        fputs("\n", out);
+    }
+
+    static void printHistoryUsage(FILE* out)
+    {
+        fputs("history - show and manage the command history\n", out);
+        fputs("  history                   List the command history\n", out);
+        fputs("  history clear [<n>]       Clear the history, or its <n> oldest entries\n", out);
+        fputs("  history size [<n>]        Show or set the max entries kept\n", out);
+        fputs("  !<n>                      Replay history entry <n>\n", out);
+        fputs("  !!                        Replay the previous command\n", out);
+        fputs("\n", out);
+        fputs("  `history` may be abbreviated as `hi` or `hist`.\n", out);
+        fprintf(out, "  Command history is kept (defaults up to %u entries) in ~/%s/%s.\n",
+            defaultMaxHistoryEntries, historyDirName, historyFileName);
+#if HAVE(READLINE)
+        fputs("  It is navigable with the Up/Down arrows and Ctrl-R reverse search.\n", out);
+#endif
+        fputs("\n", out);
+    }
+
+    // Dispatches `help [<command>]`. `lex` is positioned after the "help" word.
+    static bool handleHelp(Lexer lex)
+    {
+        if (lex.atEnd()) {
+            printUsage(stdout);
+            return true;
+        }
+        std::string_view topic = lex.nextToken();
+        if (topic == "sn" || topic == "snap" || topic == "snapshot") {
+            printSnapshotUsage(stdout);
+            return true;
+        }
+        if (topic == "hi" || topic == "hist" || topic == "history") {
+            printHistoryUsage(stdout);
+            return true;
+        }
+        if (topic == "th" || topic == "thread") {
+            printThreadUsage(stdout);
+            return true;
+        }
+        fprintf(stderr, "mya: No help for '%.*s'\n", static_cast<int>(topic.length()), topic.data());
+        return false;
+    }
+
+    // Writes a byte count in the largest unit that keeps it readable, e.g. "512 KB" or "1.50 MB".
+    static void formatByteSize(size_t bytes, char* out, size_t outSize)
+    {
+        if (bytes >= 1024 * 1024)
+            snprintf(out, outSize, "%.2f MB", bytes / (1024.0 * 1024.0));
+        else if (bytes >= 1024)
+            snprintf(out, outSize, "%zu KB", bytes / 1024);
+        else
+            snprintf(out, outSize, "%zu B", bytes);
+    }
+
+    enum class ContinuationAction { Continue, Exit, Error };
+    ContinuationAction parseArguments(int argc, char** argv)
+    {
+        // Help is answered before anything else is acted on, so that asking for it
+        // never attaches to a process or takes a snapshot along the way.
+        for (int i = 1; i < argc; ++i) {
+            std::string_view arg = argv[i];
+            if (arg != "--help" && arg != "-h")
+                continue;
+            if (i + 1 >= argc) {
+                printUsage(stdout);
+                return ContinuationAction::Exit;
+            }
+            Lexer lex(argv[i + 1]);
+            return handleHelp(lex) ? ContinuationAction::Exit : ContinuationAction::Error;
+        }
+
+        for (int i = 1; i < argc; ++i) {
+            const char* argText = argv[i];
+            std::string_view arg = argText;
+            const char* pidText = nullptr;
+            if (arg == "--pid" || arg == "-p") {
+                if (i + 1 >= argc) {
+                    fprintf(stderr, "mya: %s requires an argument\n", argText);
+                    return ContinuationAction::Error;
+                }
+                pidText = argv[++i];
+            } else if (arg.starts_with("--pid="))
+                pidText = argText + 6;
+            else if (arg.starts_with("-p") && arg.size() > 2)
+                pidText = argText + 2; // "-p12345"
+            else {
+                fprintf(stderr, "mya: Unknown option '%s'\n", argText);
+                return ContinuationAction::Error;
+            }
+
+            pid_t pid = -1;
+            Lexer lex(pidText);
+            if (!lex.consumePID(pid) || !lex.atEnd()) {
+                fprintf(stderr, "mya: Invalid PID '%s'\n", pidText);
+                return ContinuationAction::Error;
+            }
+
+            attachAndSnapshot(pid);
+        }
+        return ContinuationAction::Continue;
+    }
+
+    void attach(pid_t pid)
+    {
+        RefPtr<Process> process;
+        auto existing = m_processes.find(pid);
+        if (existing != m_processes.end())
+            process = existing->value;
+        else {
+            process = Process::create(pid);
+            m_processes.add(pid, process);
+        }
+
+        if (!process->attach())
+            return;
+
+        if (m_currentProcess && m_currentProcess != process)
+            m_currentProcess->detach();
+
+        m_currentProcess = WTF::move(process);
+        printf("Attached to %d\n", static_cast<int>(m_currentProcess->pid()));
+    }
+
+    void detach()
+    {
+        if (!m_currentProcess) {
+            fputs("Not attached to any process.\n", stdout);
+            return;
+        }
+        pid_t pid = m_currentProcess->pid();
+        m_currentProcess->detach();
+        m_currentProcess = nullptr;
+        printf("Detached from %d\n", static_cast<int>(pid));
+    }
+
+    // `mya --pid <pid>` and `snapshot --pid <pid>` both attach then snapshot.
+    void attachAndSnapshot(pid_t pid)
+    {
+        attach(pid);
+        if (m_currentProcess && m_currentProcess->pid() == pid)
+            captureSnapshot();
+    }
+
+    void captureSnapshot()
+    {
+        if (!m_currentProcess) {
+            fputs("Unable to capture snapshot. Not attached to any process. Use `attach` command or specify `--pid` argument for the snapshot command.\n", stderr);
+            return;
+        }
+        auto snapshot = WTF::makeUnique<Snapshot>(m_currentProcess);
+        if (!snapshot->isValid())
+            return; // The Snapshot constructor already logged the failure.
+        unsigned id = snapshot->id();
+        // The map owns the Snapshot and the list only records capture order.
+        Snapshot* node = snapshot.get();
+        m_snapshotsById.add(id, WTF::move(snapshot));
+        m_snapshots.append(node);
+        printf("Captured Snapshot #%u of %d\n", id, static_cast<int>(m_currentProcess->pid()));
+        useSnapshot(id); // Capturing switches to the new snapshot.
+    }
+
+    // Sets the current snapshot used by subsequent commands.
+    void useSnapshot(unsigned id)
+    {
+        if (!snapshotById(id)) {
+            fprintf(stderr, "mya: No snapshot #%u\n", id);
+            return;
+        }
+        if (m_currentSnapshot) {
+            if (m_currentSnapshot == id)
+                printf("Already using snapshot %u\n", id);
+            else
+                printf("Switching to using snapshot %u\n", id);
+        }
+        m_currentSnapshot = id;
+    }
+
+    // Returns the snapshot with the given id, or nullptr if there is none.
+    Snapshot* snapshotById(unsigned id) const
+    {
+        auto entry = m_snapshotsById.find(id);
+        return entry != m_snapshotsById.end() ? entry->value.get() : nullptr;
+    }
+
+    void listSnapshots()
+    {
+        if (m_snapshots.isEmpty()) {
+            fputs("No snapshots.\n", stdout);
+            return;
+        }
+        for (Snapshot* snapshot = m_snapshots.head(); snapshot; snapshot = snapshot->next()) {
+            // Mark the snapshot currently in use.
+            const char* marker = snapshot->id() == m_currentSnapshot ? "*" : " ";
+            printf("%s #%u: pid %d\n", marker, snapshot->id(), static_cast<int>(snapshot->process()->pid()));
+        }
+    }
+
+    void snapshotInfo(unsigned id)
+    {
+        Snapshot* snapshot = snapshotById(id);
+        if (!snapshot) {
+            fprintf(stderr, "mya: No snapshot #%u\n", id);
+            return;
+        }
+        printf("Snapshot #%u: pid %d, corpse %s\n", id,
+            static_cast<int>(snapshot->process()->pid()), snapshot->isValid() ? "valid" : "invalid");
+    }
+
+    void snapshotDelete(unsigned id)
+    {
+        Snapshot* snapshot = snapshotById(id);
+        if (!snapshot) {
+            fprintf(stderr, "mya: No snapshot #%u\n", id);
+            return;
+        }
+        // Unlink before dropping the owning entry: the list does not own its
+        // nodes, so it must not be left pointing at a destroyed Snapshot.
+        m_snapshots.remove(snapshot);
+        m_snapshotsById.remove(id);
+        if (id == m_currentSnapshot)
+            m_currentSnapshot = 0;
+        printf("Deleted Snapshot #%u.\n", id);
+    }
+
+    void snapshotDiff(unsigned a, unsigned b)
+    {
+        if (!snapshotById(a)) {
+            fprintf(stderr, "mya: No snapshot #%u\n", a);
+            return;
+        }
+        if (!snapshotById(b)) {
+            fprintf(stderr, "mya: No snapshot #%u\n", b);
+            return;
+        }
+        printf("Snapshot diff #%u vs #%u is not implemented yet.\n", a, b);
+    }
+
+    // `lex` is positioned after the "snapshot" command word.
+    void handleSnapshot(Lexer lex)
+    {
+        if (lex.atEnd()) {
+            captureSnapshot();
+            return;
+        }
+        // A bare number switches to that snapshot e.g. "snapshot 3".
+        if (isASCIIDigit(static_cast<unsigned char>(lex.peek()))) {
+            unsigned number = 0;
+            if (!lex.consumeUint32(number) || !lex.atEnd()) {
+                fputs("Usage: snapshot <n>\n", stderr);
+                return;
+            }
+            useSnapshot(number);
+            return;
+        }
+        if (lex.consumeToken("--pid") || lex.consumeToken("-p")) {
+            pid_t pid = -1;
+            if (!lex.consumePID(pid) || !lex.atEnd()) {
+                fputs("Usage: snapshot [--pid|-p] <pid>\n", stderr);
+                return;
+            }
+            attachAndSnapshot(pid);
+            return;
+        }
+        if (lex.consumeToken("li") || lex.consumeToken("list")) {
+            listSnapshots();
+            return;
+        }
+        if (lex.consumeToken("inf") || lex.consumeToken("info")) {
+            unsigned number = 0;
+            if (!lex.consumeUint32(number) || !lex.atEnd()) {
+                fputs("Usage: snapshot info <n>\n", stderr);
+                return;
+            }
+            snapshotInfo(number);
+            return;
+        }
+        if (lex.consumeToken("del") || lex.consumeToken("delete")) {
+            unsigned number = 0;
+            if (!lex.consumeUint32(number) || !lex.atEnd()) {
+                fputs("Usage: snapshot delete <n>\n", stderr);
+                return;
+            }
+            snapshotDelete(number);
+            return;
+        }
+        if (lex.consumeToken("diff")) {
+            unsigned a = 0;
+            unsigned b = 0;
+            if (!lex.consumeUint32(a) || !lex.consumeUint32(b) || !lex.atEnd()) {
+                fputs("Usage: snapshot diff <a> <b>\n", stderr);
+                return;
+            }
+            snapshotDiff(a, b);
+            return;
+        }
+        std::string_view token = lex.nextToken();
+        fprintf(stderr, "mya: Unknown snapshot subcommand '%.*s'\n",
+            static_cast<int>(token.length()), token.data());
+    }
+
+    // Lists the threads captured in the snapshot currently in use.
+    void listThreads()
+    {
+        Snapshot* snapshot = snapshotById(m_currentSnapshot);
+        if (!snapshot) {
+            fputs("No snapshot in use. Capture one with `snapshot`, or select one with `snapshot <n>`.\n", stderr);
+            return;
+        }
+
+        const Vector<Thread>& threads = snapshot->threads();
+        if (threads.isEmpty()) {
+            fputs("No threads.\n", stdout);
+            return;
+        }
+
+        printf("Threads in snapshot #%u (pid %d):\n", snapshot->id(), static_cast<int>(snapshot->process()->pid()));
+
+        // Build the rows as text first so each column can be sized to its widest entry.
+        static constexpr size_t columnCount = 12;
+        static const char* const headings[columnCount] = {
+            "INDEX", "TID", "STATE", "USER(ms)", "SYS(ms)", "SP", "STACK", "SIZE",
+            "PAGES", "RESIDENT", "DIRTY", "NAME"
+        };
+        static const bool rightAligned[columnCount] = {
+            true, false, false, true, true, false, false, true, true, true, true, false
+        };
+
+        struct Row {
+            std::string cells[columnCount];
+        };
+        Vector<Row> rows;
+        rows.reserveCapacity(threads.size());
+
+        char buffer[64];
+        for (size_t i = 0; i < threads.size(); ++i) {
+            const Thread& thread = threads[i];
+            Row row;
+
+            snprintf(buffer, sizeof(buffer), "%zu", i + 1);
+            row.cells[0] = buffer;
+            snprintf(buffer, sizeof(buffer), "0x%llx", static_cast<unsigned long long>(thread.id()));
+            row.cells[1] = buffer;
+            row.cells[2] = thread.runStateDescription();
+            snprintf(buffer, sizeof(buffer), "%.3f", thread.userTimeUsec() / 1000.0);
+            row.cells[3] = buffer;
+            snprintf(buffer, sizeof(buffer), "%.3f", thread.systemTimeUsec() / 1000.0);
+            row.cells[4] = buffer;
+            if (thread.stackPointer()) {
+                snprintf(buffer, sizeof(buffer), "0x%llx",
+                    thread.stackPointer().toMachVMAddress());
+                row.cells[5] = buffer;
+            } else
+                row.cells[5] = "-";
+            if (thread.hasStack()) {
+                const auto& stack = thread.stackRegion();
+                snprintf(buffer, sizeof(buffer), "0x%llx-0x%llx",
+                    stack.base().toMachVMAddress(),
+                    stack.end().toMachVMAddress());
+                row.cells[6] = buffer;
+                formatByteSize(stack.size(), buffer, sizeof(buffer));
+                row.cells[7] = buffer;
+                snprintf(buffer, sizeof(buffer), "%llu",
+                    static_cast<unsigned long long>(stack.pageCount()));
+                row.cells[8] = buffer;
+                snprintf(buffer, sizeof(buffer), "%llu",
+                    static_cast<unsigned long long>(stack.residentPageCount()));
+                row.cells[9] = buffer;
+                snprintf(buffer, sizeof(buffer), "%llu",
+                    static_cast<unsigned long long>(stack.dirtyPageCount()));
+                row.cells[10] = buffer;
+            } else {
+                row.cells[6] = "-";
+                row.cells[7] = "-";
+                row.cells[8] = "-";
+                row.cells[9] = "-";
+                row.cells[10] = "-";
+            }
+            row.cells[11] = thread.name().empty() ? "-" : thread.name();
+
+            rows.append(WTF::move(row));
+        }
+
+        size_t widths[columnCount];
+        for (size_t column = 0; column < columnCount; ++column) {
+            widths[column] = strlen(headings[column]);
+            for (const Row& row : rows)
+                widths[column] = std::max(widths[column], row.cells[column].length());
+        }
+
+        auto printRow = [&](auto&& cellAt) {
+            fputs("  ", stdout);
+            for (size_t column = 0; column < columnCount; ++column) {
+                if (column)
+                    fputs("  ", stdout);
+                const char* text = cellAt(column);
+                // The last column needs no padding, which also avoids trailing
+                // whitespace on every line.
+                if (column == columnCount - 1)
+                    fputs(text, stdout);
+                else if (rightAligned[column])
+                    printf("%*s", static_cast<int>(widths[column]), text);
+                else
+                    printf("%-*s", static_cast<int>(widths[column]), text);
+            }
+            putchar('\n');
+        };
+
+        printRow([&](size_t column) { return headings[column]; });
+        for (const Row& row : rows)
+            printRow([&](size_t column) { return row.cells[column].c_str(); });
+    }
+
+    // Dispatches the `thread ...` subcommands. `lex` is positioned after the
+    // "thread" command word.
+    void handleThread(Lexer lex)
+    {
+        // Listing is the default, so a bare `thread` lists too.
+        if (lex.atEnd() || lex.consumeToken("li") || lex.consumeToken("list")) {
+            if (!lex.atEnd()) {
+                fputs("Usage: thread list\n", stderr);
+                return;
+            }
+            listThreads();
+            return;
+        }
+        std::string_view token = lex.nextToken();
+        fprintf(stderr, "mya: Unknown thread subcommand '%.*s'\n",
+            static_cast<int>(token.length()), token.data());
+    }
+
+    // Dispatches `p[/<format>] <expression>`. The only expression understood so
+    // far is `&<symbol>`, which resolves the symbol in the snapshot in use.
+    // `format` is the text after the '/', empty when none was given.
+    void handlePrint(std::string_view format, Lexer lex)
+    {
+        bool hex = false;
+        if (!format.empty()) {
+            if (format == "x")
+                hex = true;
+            else if (format != "d") {
+                fprintf(stderr, "mya: Unknown print format '%.*s'; use x or d\n",
+                    static_cast<int>(format.length()), format.data());
+                return;
+            }
+        }
+
+        Snapshot* snapshot = snapshotById(m_currentSnapshot);
+        if (!snapshot) {
+            fputs("No snapshot in use. Capture one with `snapshot`, or select one with `snapshot <n>`.\n", stderr);
+            return;
+        }
+
+        // Taking a symbol's address is all we can do without type information.
+        if (!lex.consumeChar('&')) {
+            fputs("Usage: p[/x] &<symbol>\n", stderr);
+            return;
+        }
+        std::string_view token = lex.nextToken();
+        if (token.empty() || !lex.atEnd()) {
+            fputs("Usage: p[/x] &<symbol>\n", stderr);
+            return;
+        }
+
+        std::string name(token);
+        Address address = snapshot->symbol(name.c_str());
+        if (!address) {
+            fprintf(stderr, "mya: No symbol '%s' in snapshot #%u\n", name.c_str(), snapshot->id());
+            return;
+        }
+        if (hex)
+            printf("&%s = 0x%llx\n", name.c_str(), address.toMachVMAddress());
+        else
+            printf("&%s = %llu\n", name.c_str(), address.toMachVMAddress());
+    }
+
+    // Releases resources without extra output. Dropping the current selection
+    // and clearing the containers runs ~Process / ~Snapshot, which release the
+    // task and corpse ports. Idempotent: safe from the quit path and destructor.
+    void cleanup()
+    {
+        m_currentProcess = nullptr;
+        m_processes.clear();
+        // Unlink the non-owning list before destroying the Snapshots it points at.
+        m_snapshots.clear();
+        m_snapshotsById.clear();
+        if (m_historyFile) {
+            fclose(m_historyFile);
+            m_historyFile = nullptr;
+        }
+        if (m_historyDirDescriptor >= 0) {
+            close(m_historyDirDescriptor);
+            m_historyDirDescriptor = -1;
+        }
+    }
+
+    // Prompts for confirmation before quitting. Enter (empty) defaults to yes.
+    bool confirmQuit()
+    {
+        for (;;) {
+            std::string response;
+#if HAVE(READLINE)
+            char* input = readline("Really quit? [Y/n] ");
+            if (!input) {
+                putchar('\n');
+                return true; // EOF: treat as yes.
+            }
+            response = input;
+            free(input);
+#else
+            fputs("Really quit? [Y/n] ", stdout);
+            fflush(stdout);
+            char buffer[64];
+            if (!fgets(buffer, sizeof(buffer), stdin)) {
+                putchar('\n');
+                return true; // EOF: treat as yes.
+            }
+            // Without a newline the answer was longer than the buffer, and the rest
+            // would be read as the answer to the next prompt. Discard it.
+            if (!std::string_view(buffer).contains('\n')) {
+                int discarded = 0;
+                while ((discarded = getchar()) != '\n' && discarded != EOF) { }
+            }
+            response = buffer;
+#endif
+            size_t start = 0;
+            while (start < response.size() && isASCIIWhitespace(static_cast<unsigned char>(response[start])))
+                ++start;
+            size_t stop = response.size();
+            while (stop > start && isASCIIWhitespace(static_cast<unsigned char>(response[stop - 1])))
+                --stop;
+            response = response.substr(start, stop - start);
+
+            if (response.empty() || response[0] == 'y' || response[0] == 'Y')
+                return true;
+            if (response[0] == 'n' || response[0] == 'N')
+                return false;
+            fputs("Please answer 'y' or 'n'.\n", stdout);
+        }
+    }
+
+    void printStatus()
+    {
+        if (m_currentProcess)
+            printf("Attached to pid %d\n", static_cast<int>(m_currentProcess->pid()));
+        else
+            fputs("Not attached to any process.\n", stdout);
+
+        if (Snapshot* snapshot = snapshotById(m_currentSnapshot))
+            printf("Using snapshot %u of pid %d\n", snapshot->id(), static_cast<int>(snapshot->process()->pid()));
+        else
+            fputs("No snapshot in use.\n", stdout);
+    }
+
+    void printHistory()
+    {
+        if (!m_history.size()) {
+            printf("History is empty.\n");
+            return;
+        }
+        for (size_t i = 0; i < m_history.size(); ++i)
+            printf("%5zu  %s\n", i + 1, m_history[i].c_str());
+    }
+
+    // Drops the `count` oldest entries.
+    void clearHistory(unsigned count)
+    {
+        if (!count) {
+            fputs("Nothing to do for clearing 0 history entries.\n", stdout);
+            return;
+        }
+        if (m_history.empty()) {
+            fputs("History is already empty.\n", stdout);
+            return;
+        }
+        unsigned removeCount = count >= m_history.size() ? safeCast<unsigned>(m_history.size()) : count;
+        m_history.erase(m_history.begin(), m_history.begin() + removeCount);
+#if HAVE(READLINE)
+        // readline has no way to drop individual entries, so rebuild its history
+        // from the cache to keep the arrow keys in sync.
+        clear_history();
+        for (const std::string& command : m_history)
+            add_history(command.c_str());
+#endif
+        if (m_historyFile && !rewriteHistoryFile()) {
+            fputs("mya: Failed to clear history file.\n", stderr);
+            return;
+        }
+        if (m_history.empty()) {
+            if (removeCount == 1)
+                printf("Cleared 1 history entry.\n");
+            else
+                printf("Cleared %u history entries.\n", removeCount);
+        } else if (removeCount == 1)
+            printf("Cleared the oldest history entry.\n");
+        else
+            printf("Cleared the %u oldest history entries.\n", removeCount);
+    }
+
+    void printHistorySize()
+    {
+        printf("History holds %zu of %u entries.\n", m_history.size(), m_maxHistoryEntries);
+    }
+
+    // Sets how many entries the history keeps, purging the oldest if the new
+    // capacity is smaller than what is currently stored.
+    void setMaxHistorySize(unsigned capacity)
+    {
+        if (capacity < minHistorySize) {
+            capacity = minHistorySize;
+            printf("Minimum history size is %u.\n", minHistorySize);
+        }
+        if (m_maxHistoryEntries == capacity) {
+            printf("Maximum history size is already %u.\n", m_maxHistoryEntries);
+            return;
+        }
+        m_maxHistoryEntries = capacity;
+        boundReadlineHistory();
+        if (m_history.size() > m_maxHistoryEntries) {
+            m_history.erase(m_history.begin(), m_history.end() - m_maxHistoryEntries);
+#if HAVE(READLINE)
+            clear_history();
+            for (const std::string& command : m_history)
+                add_history(command.c_str());
+#endif
+        }
+        if (!rewriteHistoryFile())
+            fputs("mya: The new size applies to this session only.\n", stderr);
+        printHistorySize();
+    }
+
+    // Dispatches the `history ...` subcommands. `lex` is positioned after the
+    // "history" command word.
+    void handleHistory(Lexer lex)
+    {
+        if (lex.atEnd()) {
+            printHistory();
+            return;
+        }
+        if (lex.consumeToken("clear")) {
+            unsigned count = UINT_MAX; // Default to  "all".
+            if (!lex.atEnd()) {
+                unsigned parsed = 0;
+                if (!lex.consumeUint32(parsed) || !lex.atEnd()) {
+                    fputs("Usage: history clear [<n>]\n", stderr);
+                    return;
+                }
+                count = parsed;
+            }
+            clearHistory(count);
+            return;
+        }
+        if (lex.consumeToken("size")) {
+            if (lex.atEnd()) {
+                printHistorySize();
+                return;
+            }
+            unsigned capacity = 0;
+            if (!lex.consumeUint32(capacity) || !lex.atEnd()) {
+                fputs("Usage: history size [<n>]\n", stderr);
+                return;
+            }
+            setMaxHistorySize(capacity);
+            return;
+        }
+        std::string_view token = lex.nextToken();
+        fprintf(stderr, "mya: Unknown history subcommand '%.*s'\n",
+            static_cast<int>(token.length()), token.data());
+    }
+
+    // Resolves a history reference ("!!" or "!<n>") to a stored command and
+    // replays it. `lex` is positioned after the leading '!'; `line` is the whole
+    // input, used for error reporting.
+    void replayHistory(const char* line, Lexer lex)
+    {
+        std::string command;
+        if (lex.consumeChar('!') && lex.atEnd()) {
+            if (m_history.empty()) {
+                fputs("mya: No commands in history\n", stderr);
+                return;
+            }
+            command = m_history.back();
+        } else {
+            unsigned index = 0;
+            if (!lex.consumeUint32(index) || !lex.atEnd() || index > m_history.size()) {
+                fprintf(stderr, "mya: %s: event not found\n", line);
+                return;
+            }
+            if (!index) {
+                fprintf(stderr, "mya: %s: invalid history entry\n", line);
+                return;
+            }
+            command = m_history[index - 1];
+        }
+        // Echo the resolved command, then run it as if it had been typed. The
+        // replayed command records itself; the "!" reference is not recorded.
+        printf("%s\n", command.c_str());
+        handleLine(command.c_str());
+    }
+
+    static bool isRunningAsRoot() { return !geteuid(); }
+
+    // The directory that holds the history file, empty if the user has no home
+    // directory to put it in.
+    //
+    // We deliberately keep root (when run with sudo)'s history file distinct from
+    // the non-root user's. This is better for security (root is not dependent on
+    // non-root user data), and does not block the non-root user from accessing
+    // their history if the last mya run was via sudo and the history file was
+    // updated by root (and ownership changed).
+    static std::string historyDirectory()
+    {
+        const char* home = nullptr;
+        if (isRunningAsRoot()) {
+            if (const struct passwd* entry = getpwuid(0))
+                home = entry->pw_dir;
+        } else {
+            home = getenv("HOME");
+            if (!home || !*home) {
+                if (const struct passwd* entry = getpwuid(getuid()))
+                    home = entry->pw_dir;
+            }
+        }
+        if (!home || !*home)
+            return { };
+
+        std::string directory = home;
+        if (directory.back() != '/')
+            directory += '/';
+        directory += historyDirName;
+        return directory;
+    }
+
+    void boundReadlineHistory()
+    {
+#if HAVE(READLINE)
+        // libedit only applies the bound when an entry is added, so lowering it does
+        // not shorten the existing list: callers that shrink the cache must rebuild
+        // readline's list as well for the change to take effect immediately.
+        stifle_history(safeCast<int>(m_maxHistoryEntries));
+#endif
+    }
+
+    // Opens the history file for read+write, creating it if absent, and loads any
+    // stored commands into the cache. If it cannot be opened, the cache stays in
+    // memory only for the session.
+    //
+    // The file lives under the user's home directory, not the working directory:
+    // mya carries a debugger entitlement and its own usage suggests running it as
+    // root, so it must not be steered into writing through a path controlled by
+    // whoever owns the directory it happens to be started in. Both path
+    // components are opened O_NOFOLLOW, so a symlink planted at either one is
+    // refused rather than followed, and the file is never opened with O_TRUNC.
+    void openHistory()
+    {
+        boundReadlineHistory();
+
+        std::string directory = historyDirectory();
+        if (directory.empty()) {
+            fputs("mya: No home directory, so command history will not be saved.\n", stderr);
+            return;
+        }
+
+        if (isRunningAsRoot()) {
+            fprintf(stderr, "mya: Running as root: using history file %s/%s.\n",
+                directory.c_str(), historyFileName);
+        }
+
+        if (mkdir(directory.c_str(), 0700) && errno != EEXIST) {
+            fprintf(stderr, "mya: Could not create %s: %s\n", directory.c_str(), strerror(errno));
+            return;
+        }
+
+        int directoryDescriptor = open(directory.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+        if (directoryDescriptor < 0) {
+            fprintf(stderr, "mya: Could not open %s: %s\n", directory.c_str(), strerror(errno));
+            return;
+        }
+
+        int fileDescriptor = openat(directoryDescriptor, historyFileName, O_RDWR | O_CREAT | O_NOFOLLOW | O_CLOEXEC, 0600);
+        if (fileDescriptor < 0) {
+            fprintf(stderr, "mya: Could not open %s/%s: %s\n", directory.c_str(), historyFileName, strerror(errno));
+            close(directoryDescriptor);
+            return;
+        }
+
+        // Anything other than a regular file is not something mya wrote: reading a
+        // FIFO here would block the shell before it ever prompted. So, we decline to open
+        // any non-regular files.
+        struct stat status;
+        if (fstat(fileDescriptor, &status) || !S_ISREG(status.st_mode)) {
+            fprintf(stderr, "mya: %s/%s is not a regular file, so command history will not be saved.\n",
+                directory.c_str(), historyFileName);
+            close(fileDescriptor);
+            close(directoryDescriptor);
+            return;
+        }
+
+        m_historyFile = fdopen(fileDescriptor, "r+");
+        if (!m_historyFile) {
+            close(fileDescriptor);
+            close(directoryDescriptor);
+            return;
+        }
+
+        // Held for the session: rewriting the file creates and renames through this
+        // descriptor, so the replacement lands in the directory that was checked
+        // here rather than wherever the path may point by then.
+        m_historyDirDescriptor = directoryDescriptor;
+
+        loadHistory();
+    }
+
+    // Reads the cap out of a "max entries <n>" header line. Returns 0 if `line` does not
+    // contain the header, which means the file is corrupted.
+    static unsigned parseMaxEntriesHeader(const char* line)
+    {
+        size_t prefixLength = strlen(maxEntriesHeaderPrefix);
+        if (!std::string_view(line).starts_with(maxEntriesHeaderPrefix))
+            return 0;
+        Lexer lex(line + prefixLength);
+        unsigned entries = 0;
+        if (!lex.consumeUint32<1>(entries) || !lex.atEnd())
+            return 0;
+        // We deliberately allow reading a capacity value below minHistorySize so that we can
+        // print a meaningful error message about it in the caller.
+        return entries;
+    }
+
+    void loadHistory()
+    {
+        if (!m_historyFile)
+            return;
+        rewind(m_historyFile);
+
+        char buffer[4096];
+        unsigned capacity = 0;
+        if (fgets(buffer, sizeof(buffer), m_historyFile)) {
+            buffer[strcspn(buffer, "\n")] = '\0';
+            capacity = parseMaxEntriesHeader(buffer);
+            if (!capacity) {
+                fprintf(stderr, "mya: Corrupted file: ~/%s/%s does not start with a valid header (\"%s<n>\"); starting a new one.\n",
+                    historyDirName, historyFileName, maxEntriesHeaderPrefix);
+            } else if (capacity < minHistorySize) {
+                fprintf(stderr, "mya: Corrupted file: ~/%s/%s header asks for fewer than the minimum %u entries;"
+                    " starting a new one.\n", historyDirName, historyFileName, minHistorySize);
+                capacity = 0; // Treat as error.
+            }
+        }
+        if (!capacity) {
+            rewriteHistoryFile(); // Invalid header. Reset the history file.
+            return;
+        }
+        m_maxHistoryEntries = capacity;
+        boundReadlineHistory();
+
+        Vector<std::string> entries;
+        while (fgets(buffer, sizeof(buffer), m_historyFile)) {
+            buffer[strcspn(buffer, "\n")] = '\0';
+            if (!buffer[0])
+                continue;
+            if (isReplayCommand(buffer))
+                continue; // A ! replay command in history is invalid and not allowed. Skip.
+            entries.append(buffer);
+        }
+        m_entriesInHistoryFile = safeCast<unsigned>(entries.size());
+
+        // The cache never holds more than the capacity, however much the file holds.
+        unsigned keep = std::min(m_entriesInHistoryFile, m_maxHistoryEntries);
+        for (size_t i = entries.size() - keep; i < entries.size(); ++i) {
+            m_history.push_back(entries[i]);
+#if HAVE(READLINE)
+            add_history(entries[i].c_str());
+#endif
+        }
+
+        // Seek to the end so later commands append, and to satisfy the C rule
+        // that a positioning call separates a read from a following write.
+        if (fseek(m_historyFile, 0, SEEK_END))
+            fallBackToMemoryOnly("Could not read the history file", errno);
+    }
+
+    // Report the failure condition and switch to in-memory cache only history.
+    // The history file itself is left exactly as it was, and whatever was already
+    // read from it stays in the cache.
+    void fallBackToMemoryOnly(const char* what, int error)
+    {
+        fprintf(stderr, "mya: %s: %s\n", what, strerror(error));
+        fputs("mya: Command history is kept in memory only from here, and the saved"
+            " history is left as it is.\n", stderr);
+        if (m_historyFile) {
+            fclose(m_historyFile);
+            m_historyFile = nullptr;
+        }
+        if (m_historyDirDescriptor >= 0) {
+            close(m_historyDirDescriptor);
+            m_historyDirDescriptor = -1;
+        }
+    }
+
+    // Replaces the history file as a transaction i.e. the file either has the new
+    // history or remains the old one if something went wrong. It is never left half
+    // modified. This is done by writing the new file completely before replacing the
+    // old history file with it.
+    //
+    // In the event something went wrong, the in-memory cache retains its state, and
+    // may become out of sync with the history file.
+    bool rewriteHistoryFile()
+    {
+        if (!m_historyFile || m_historyDirDescriptor < 0)
+            return false;
+
+        // Qualified by pid so two mya instances cannot land on the same temporary.
+        char temporaryName[64];
+        snprintf(temporaryName, sizeof(temporaryName), "%s.%d.tmp", historyFileName,
+            static_cast<int>(getpid()));
+
+        int descriptor = openat(m_historyDirDescriptor, temporaryName,
+            O_RDWR | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, 0600);
+        if (descriptor < 0 && errno == EEXIST) {
+            // Left behind by a run that died between creating and renaming.
+            unlinkat(m_historyDirDescriptor, temporaryName, 0);
+            descriptor = openat(m_historyDirDescriptor, temporaryName,
+                O_RDWR | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, 0600);
+        }
+        if (descriptor < 0) {
+            fallBackToMemoryOnly("Could not create a temporary history file", errno);
+            return false;
+        }
+
+        FILE* replacement = fdopen(descriptor, "w+");
+        if (!replacement) {
+            int error = errno;
+            close(descriptor);
+            unlinkat(m_historyDirDescriptor, temporaryName, 0);
+            fallBackToMemoryOnly("Could not rewrite the history file", error);
+            return false;
+        }
+
+        fprintf(replacement, "%s%u\n", maxEntriesHeaderPrefix, m_maxHistoryEntries);
+        for (const std::string& command : m_history)
+            fprintf(replacement, "%s\n", command.c_str());
+
+        // Commit the contents before publishing them, so a crash cannot leave the
+        // rename pointing at a file that was never written.
+        int error = 0;
+        if (fflush(replacement) || fsync(fileno(replacement)))
+            error = errno;
+        else if (ferror(replacement))
+            error = EIO;
+        if (!error && renameat(m_historyDirDescriptor, temporaryName, m_historyDirDescriptor, historyFileName))
+            error = errno;
+        if (error) {
+            fclose(replacement);
+            unlinkat(m_historyDirDescriptor, temporaryName, 0);
+            fallBackToMemoryOnly("Could not rewrite the history file", error);
+            return false;
+        }
+
+        // The rename published the temporary file, so it is the history file now.
+        fclose(m_historyFile);
+        m_historyFile = replacement;
+        m_entriesInHistoryFile = safeCast<unsigned>(m_history.size());
+        if (fseek(m_historyFile, 0, SEEK_END)) {
+            fallBackToMemoryOnly("Could not rewrite the history file", errno);
+            return false;
+        }
+        return true;
+    }
+
+    static bool isReplayCommand(const char* line)
+    {
+        Lexer lex(line);
+        return lex.peek() == '!';
+    }
+
+    void recordCommand(const char* line)
+    {
+        // Do not allow replay commands in the history. They just pollute the history, and
+        // add recursion complexities in the replay execution code, which we want to prevent.
+        if (isReplayCommand(line))
+            return;
+
+        // Only filter an immediate repeat of the previous command.
+        if (!m_history.empty() && m_history.back() == line)
+            return;
+
+        m_history.push_back(line);
+#if HAVE(READLINE)
+        add_history(line);
+#endif
+        if (m_history.size() > m_maxHistoryEntries)
+            m_history.erase(m_history.begin());
+
+        if (!m_historyFile)
+            return;
+
+        fprintf(m_historyFile, "%s\n", line);
+        int error = 0;
+        if (fflush(m_historyFile))
+            error = errno;
+        else if (ferror(m_historyFile))
+            error = EIO;
+        if (error) {
+            fallBackToMemoryOnly("Could not append to the history file", error);
+            return;
+        }
+        ++m_entriesInHistoryFile;
+        // The sum cannot overflow: the capacity only ever comes from Lexer::consumeUint32,
+        // which rejects anything above INT_MAX, leaving room for the overflow
+        // allowance on top.
+        if (m_entriesInHistoryFile >= m_maxHistoryEntries + maxOverflowEntries)
+            rewriteHistoryFile();
+    }
+
+    void handleLine(const char* line)
+    {
+        Lexer lex(line);
+        if (lex.atEnd())
+            return; // Blank line: not a command, not an error.
+
+        // History replay ("!!" / "!<n>") is expanded before command dispatch.
+        if (lex.consumeChar('!'))
+            return replayHistory(line, lex);
+
+        std::string_view word = lex.nextToken();
+        // `p` takes an lldb-style format suffix, as in "p/x", so the command and
+        // its format arrive as one token.
+        std::string_view command = word;
+        std::string_view format;
+        if (size_t slash = word.find('/'); slash != std::string_view::npos) {
+            command = word.substr(0, slash);
+            format = word.substr(slash + 1);
+        }
+
+        auto is = [&](const char* name) {
+            return word == name;
+        };
+
+        if (is("help")) {
+            handleHelp(lex);
+            return;
+        }
+        if (is("q") || is("quit") || is("exit")) {
+            m_isQuitting = confirmQuit();
+            return;
+        }
+        if (is("st") || is("status")) {
+            recordCommand(line);
+            printStatus();
+            return;
+        }
+        if (is("hi") || is("hist") || is("history")) {
+            // A bare `history` only lists the history. Recording it would make
+            // the last entry of every listing be the command that asked for it.
+            if (!lex.atEnd())
+                recordCommand(line);
+            handleHistory(lex);
+            return;
+        }
+        if (is("detach")) {
+            recordCommand(line);
+            detach();
+            return;
+        }
+        if (is("attach")) {
+            recordCommand(line);
+            // Optional "--pid"/"-p" before the number: "attach --pid 42" == "attach 42".
+            if (!lex.consumeToken("--pid"))
+                lex.consumeToken("-p");
+            pid_t pid = -1;
+            if (!lex.consumePID(pid) || !lex.atEnd()) {
+                fputs("Usage: attach [--pid|-p] <pid>\n", stderr);
+                return;
+            }
+            attach(pid);
+            return;
+        }
+        if (is("sn") || is("snap") || is("snapshot")) {
+            recordCommand(line);
+            handleSnapshot(lex);
+            return;
+        }
+        if (is("th") || is("thread")) {
+            recordCommand(line);
+            handleThread(lex);
+            return;
+        }
+        if (command == "p" || command == "print") {
+            recordCommand(line);
+            handlePrint(format, lex);
+            return;
+        }
+
+        recordCommand(line);
+        fprintf(stderr, "mya: Unknown command '%.*s'\n", static_cast<int>(word.length()), word.data());
+    }
+
+    void runInteractive()
+    {
+#if HAVE(READLINE)
+        for (;;) {
+            char* line = readline(prompt);
+            if (!line) {
+                putchar('\n');
+                break;
+            }
+            handleLine(line);
+            free(line);
+            if (m_isQuitting)
+                break;
+        }
+#else
+        char line[4096];
+        fputs(prompt, stdout);
+        fflush(stdout);
+        while (fgets(line, sizeof(line), stdin)) {
+            line[strcspn(line, "\n")] = '\0';
+            handleLine(line);
+            if (m_isQuitting)
+                break;
+            fputs(prompt, stdout);
+            fflush(stdout);
+        }
+        putchar('\n');
+#endif
+        cleanup(); // About to quit.
+    }
+
+    std::vector<std::string> m_history;
+    unsigned m_maxHistoryEntries { defaultMaxHistoryEntries };
+    unsigned m_entriesInHistoryFile { 0 }; // Actual number of commands in the file (may exceed target capacity).
+    FILE* m_historyFile { nullptr };
+    int m_historyDirDescriptor { -1 };
+    HashMap<pid_t, RefPtr<Process>> m_processes;
+    // m_snapshotsById owns the Snapshots; m_snapshots only records capture order.
+    HashMap<unsigned, std::unique_ptr<Snapshot>> m_snapshotsById;
+    DoublyLinkedList<Snapshot> m_snapshots;
+    RefPtr<Process> m_currentProcess;
+    unsigned m_currentSnapshot { 0 }; // Snapshot id in use; 0 means none.
+    bool m_isQuitting { false };
+};
+
+} // namespace Mya
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+
+int main(int argc, char** argv)
+{
+#if OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+    return Mya::Shell().run(argc, argv);
+#else
+    UNUSED_PARAM(argc);
+    UNUSED_PARAM(argv);
+    printf("Not supported platform\n");
+    return 1;
+#endif // OS(MACOS) || USE(APPLE_INTERNAL_SDK)
+}

--- a/Source/JavaScriptCore/shell/CMakeLists.txt
+++ b/Source/JavaScriptCore/shell/CMakeLists.txt
@@ -22,7 +22,29 @@ if (ENABLE_FUZZILLI)
   list(APPEND jsc_SOURCES ../fuzzilli/Fuzzilli.cpp)
 endif ()
 
+# mya analyzes process corpses through Mach task APIs, so it only builds on
+# Apple platforms. Its sources do not compile elsewhere.
+if (APPLE)
+    set(mya_SOURCES ../mya/mya.cpp)
+    set(mya_FRAMEWORKS
+        JavaScriptCore
+        WTF
+        bmalloc
+    )
+
+    set(mya_PRIVATE_INCLUDE_DIRECTORIES
+        $<TARGET_PROPERTY:JavaScriptCore,INCLUDE_DIRECTORIES>
+    )
+
+    # The corpse support mya uses lives in the tools static library.
+    set(mya_LIBRARIES JavaScriptCoreTools edit)
+endif ()
+
 WEBKIT_EXECUTABLE_DECLARE(jsc)
+
+if (APPLE)
+    WEBKIT_EXECUTABLE_DECLARE(mya)
+endif ()
 
 if (DEVELOPER_MODE)
     set(testapi_SOURCES
@@ -82,6 +104,30 @@ if (DEVELOPER_MODE)
     set(testdfg_PRIVATE_INCLUDE_DIRECTORIES ${jsc_PRIVATE_INCLUDE_DIRECTORIES})
     set(testdfg_FRAMEWORKS ${jsc_FRAMEWORKS})
 
+    # The tools library and its tests are only relevant for Apple platforms.
+    if (APPLE)
+        set(testLibJSCTools_SOURCES
+            ../corpse/testLibJSCTools.cpp
+
+            ../corpse/tests/CorpseAddressTest.cpp
+            ../corpse/tests/CorpseByteParserTest.cpp
+            ../corpse/tests/CorpseExportsTrieTest.cpp
+            ../corpse/tests/CorpseProcessTest.cpp
+            ../corpse/tests/CorpseRegionTest.cpp
+            ../corpse/tests/CorpseSnapshotTest.cpp
+            ../corpse/tests/CorpseSymbolTest.cpp
+            ../corpse/tests/CorpseThreadTest.cpp
+            ../corpse/tests/LibJSCToolsTestUtilities.cpp
+        )
+        set(testLibJSCTools_DEFINITIONS ${jsc_PRIVATE_DEFINITIONS})
+        set(testLibJSCTools_PRIVATE_INCLUDE_DIRECTORIES
+            ${jsc_PRIVATE_INCLUDE_DIRECTORIES}
+            ${JAVASCRIPTCORE_DIR}/corpse
+        )
+        set(testLibJSCTools_FRAMEWORKS ${jsc_FRAMEWORKS})
+        set(testLibJSCTools_LIBRARIES JavaScriptCoreTools)
+    endif ()
+
     set(testwasmdebugger_SOURCES
         ../wasm/debugger/testwasmdebugger.cpp
 
@@ -114,6 +160,10 @@ if (DEVELOPER_MODE)
     WEBKIT_EXECUTABLE_DECLARE(testdfg)
     WEBKIT_EXECUTABLE_DECLARE(testwasmdebugger)
 
+    if (APPLE)
+        WEBKIT_EXECUTABLE_DECLARE(testLibJSCTools)
+    endif ()
+
     if (COMPILER_IS_GCC_OR_CLANG)
         WEBKIT_ADD_TARGET_CXX_FLAGS(testb3 -Wno-array-bounds)
         WEBKIT_ADD_TARGET_CXX_FLAGS(testair -Wno-array-bounds)
@@ -129,6 +179,14 @@ if (SHOULD_INSTALL_JS_SHELL)
     install(TARGETS jsc DESTINATION "${LIBEXEC_INSTALL_DIR}")
 endif ()
 
+if (APPLE)
+    WEBKIT_EXECUTABLE(mya)
+
+    if (SHOULD_INSTALL_JS_SHELL)
+        install(TARGETS mya DESTINATION "${LIBEXEC_INSTALL_DIR}")
+    endif ()
+endif ()
+
 if (DEVELOPER_MODE)
     WEBKIT_EXECUTABLE(testapi)
     WEBKIT_EXECUTABLE(testRegExp)
@@ -137,6 +195,10 @@ if (DEVELOPER_MODE)
     WEBKIT_EXECUTABLE(testair)
     WEBKIT_EXECUTABLE(testdfg)
     WEBKIT_EXECUTABLE(testwasmdebugger)
+
+    if (APPLE)
+        WEBKIT_EXECUTABLE(testLibJSCTools)
+    endif ()
 
     WEBKIT_ADD_PREFIX_HEADER(testapi ../JavaScriptCorePrefix.h PREFIX_NO_CODEGEN PREFIX_LANGUAGES CXX)
     WEBKIT_REUSE_PREFIX_HEADER(testb3 testapi ../JavaScriptCorePrefix.h PREFIX_LANGUAGES CXX)

--- a/Source/JavaScriptCore/shell/PlatformCocoa.cmake
+++ b/Source/JavaScriptCore/shell/PlatformCocoa.cmake
@@ -14,6 +14,7 @@ set_source_files_properties(${testapi_OBJC_SOURCES} PROPERTIES
 )
 
 WEBKIT_GENERATE_ENTITLEMENTS(jsc USING ../Scripts/process-entitlements.sh)
+WEBKIT_GENERATE_ENTITLEMENTS(mya USING ../Scripts/process-entitlements.sh)
 if (DEVELOPER_MODE)
     WEBKIT_GENERATE_ENTITLEMENTS(testapi USING ../Scripts/process-entitlements.sh)
     WEBKIT_GENERATE_ENTITLEMENTS(testRegExp USING ../Scripts/process-entitlements.sh)
@@ -21,5 +22,6 @@ if (DEVELOPER_MODE)
     WEBKIT_GENERATE_ENTITLEMENTS(testb3 USING ../Scripts/process-entitlements.sh)
     WEBKIT_GENERATE_ENTITLEMENTS(testair USING ../Scripts/process-entitlements.sh)
     WEBKIT_GENERATE_ENTITLEMENTS(testdfg USING ../Scripts/process-entitlements.sh)
+    WEBKIT_GENERATE_ENTITLEMENTS(testLibJSCTools USING ../Scripts/process-entitlements.sh)
 endif ()
 

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3586,6 +3586,8 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
             self.binaryFailures.append('testdfg')
         if jsc_results.get('allApiTestsPassed') is False:
             self.binaryFailures.append('testapi')
+        if jsc_results.get('allLibJSCToolsTestsPassed') is False:
+            self.binaryFailures.append('testLibJSCTools')
         self.flaky = jsc_results.get('flakyAndPassed')
         if self.flaky:
             self.setProperty(self.prefix + 'flaky_and_passed', self.flaky)

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -100,6 +100,7 @@ my $runTestB3 = RUN_IF_NO_TESTS_SPECIFIED;
 my $runTestDFG = RUN_IF_NO_TESTS_SPECIFIED;
 my $runTestAPI = RUN_IF_NO_TESTS_SPECIFIED;
 my $runTestWasmDebugger = RUN_IF_NO_TESTS_SPECIFIED;
+my $runTestLibJSCTools = RUN_IF_NO_TESTS_SPECIFIED;
 my $runJSCStress = RUN_IF_NO_TESTS_SPECIFIED;
 my $runMozillaTests = RUN_IF_NO_TESTS_SPECIFIED;
 
@@ -207,6 +208,17 @@ if ($ENV{RUN_JAVASCRIPTCORE_TESTS_TESTWASMDEBUGGER}) {
     }
 }
 
+if ($ENV{RUN_JAVASCRIPTCORE_TESTS_TESTLIBJSCTOOLS}) {
+    if ($ENV{RUN_JAVASCRIPTCORE_TESTS_TESTLIBJSCTOOLS} eq "true") {
+        $runTestLibJSCTools = ENV_VAR_SAYS_DO_RUN;
+    } elsif ($ENV{RUN_JAVASCRIPTCORE_TESTS_TESTLIBJSCTOOLS} eq "false") {
+        $runTestLibJSCTools = ENV_VAR_SAYS_DONT_RUN;
+    } else {
+        print "Don't recognize value for RUN_JAVASCRIPTCORE_TESTS_TESTLIBJSCTOOLS environment variable: '"
+            . $ENV{RUN_JAVASCRIPTCORE_TESTS_TESTLIBJSCTOOLS} . "'. Should be set to 'true' or 'false'.\n";
+    }
+}
+
 if ($ENV{RUN_JAVASCRIPTCORE_TESTS_BUILD}) {
     if ($ENV{RUN_JAVASCRIPTCORE_TESTS_BUILD} eq "true") {
         $buildJSC = 1;
@@ -255,6 +267,7 @@ my $testb3Default = defaultStringForTestState($runTestB3);
 my $testDFGDefault = defaultStringForTestState($runTestDFG);
 my $testapiDefault = defaultStringForTestState($runTestAPI);
 my $testWasmDebuggerDefault = defaultStringForTestState($runTestWasmDebugger);
+my $testLibJSCToolsDefault = defaultStringForTestState($runTestLibJSCTools);
 my $jscStressDefault = defaultStringForTestState($runJSCStress);
 my $mozillaTestsDefault = defaultStringForTestState($runMozillaTests);
 my $jitStressTestsDefault = $runJITStressTests ? "will run" : " will not run";
@@ -280,6 +293,7 @@ Usage: $programName [options] [options to pass to build system]
   --[no-]testdfg                Only run (or don't run) testdfg (default: $testDFGDefault)
   --[no-]testapi                Only run (or don't run) testapi (default: $testapiDefault)
   --[no-]testwasmdebugger       Only run (or don't run) testwasmdebugger (default: $testWasmDebuggerDefault)
+  --[no-]testlibjsctools        Only run (or don't run) testLibJSCTools (default: $testLibJSCToolsDefault)
   --[no-]jsc-stress             Only run (or don't run) the JSC stress tests (default: $jscStressDefault)
   --[no-]mozilla-tests          Only run (or don't run) the Mozilla tests (default: $mozillaTestsDefault)
   --[no-]jit-stress-tests       Run (or don't run) the JIT stress tests (default: $jitStressTestsDefault)
@@ -347,6 +361,7 @@ Environment Variables:
   - set RUN_JAVASCRIPTCORE_TESTS_TESTDFG to "true" or "false" (no quotes) to determine if we run testdfg by default.
   - set RUN_JAVASCRIPTCORE_TESTS_TESTAPI to "true" or "false" (no quotes) to determine if we run testapi by default.
   - set RUN_JAVASCRIPTCORE_TESTS_TESTWASMDEBUGGER to "true" or "false" (no quotes) to determine if we run testwasmdebugger by default.
+  - set RUN_JAVASCRIPTCORE_TESTS_TESTLIBJSCTOOLS to "true" or "false" (no quotes) to determine if we run testLibJSCTools by default.
   - set RUN_JAVASCRIPTCORE_TESTS_BUILD to "true" or "false" (no quotes) to set the should-we-build-before-running-tests setting.
   - set RUN_JAVASCRIPTCORE_TESTS_EXTRA_TESTS to the path of a yaml file or a directory of JS files to be run as part of run-javascriptcore-tests.
 
@@ -368,6 +383,7 @@ GetOptions(
     'testdfg!' => \$runTestDFG,
     'testapi!' => \$runTestAPI,
     'testwasmdebugger!' => \$runTestWasmDebugger,
+    'testlibjsctools!' => \$runTestLibJSCTools,
     'jsc-stress!' => \$runJSCStress,
     'jitless-wasm!' => \$runJITlessWasm,
     'mozilla-tests!' => \$runMozillaTests,
@@ -423,6 +439,7 @@ if ($runTestMasm == DO_RUN
    || $runTestDFG == DO_RUN
    || $runTestAPI == DO_RUN
    || $runTestWasmDebugger == DO_RUN
+   || $runTestLibJSCTools == DO_RUN
    || $runJSCStress == DO_RUN
    || $runMozillaTests == DO_RUN) {
     $specificTestsSpecified = 1;
@@ -549,8 +566,15 @@ $runTestB3 = enableTestOrNot($runTestB3);
 $runTestDFG = enableTestOrNot($runTestDFG);
 $runTestAPI = enableTestOrNot($runTestAPI);
 $runTestWasmDebugger = enableTestOrNot($runTestWasmDebugger);
+$runTestLibJSCTools = enableTestOrNot($runTestLibJSCTools);
 $runJSCStress = enableTestOrNot($runJSCStress);
 $runMozillaTests = enableTestOrNot($runMozillaTests);
+
+# libJavaScriptCoreTools and its test is built on Mach APIs and only available on Apple platforms.
+if ($runTestLibJSCTools && $^O ne "darwin") {
+    print "Not running testLibJSCTools: it is only available on Apple platforms.\n";
+    $runTestLibJSCTools = DONT_RUN;
+}
 
 my @buildArgs;
 
@@ -815,6 +839,7 @@ if ($runTestAPI) {
     runTest("testapi", "allApiTestsPassedWithSystemMalloc", "Malloc=1");
 }
 if ($runTestWasmDebugger) { runTest("testwasmdebugger", "allWasmDebuggerTestsPassed") }
+if ($runTestLibJSCTools) { runTest("testLibJSCTools", "allLibJSCToolsTestsPassed") }
 
 # Find JavaScriptCore directory
 chdirWebKit();

--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -171,7 +171,9 @@ if (isCMakeBuild()) {
     unless (isAnyWindows()) {
         # By default we build using all of the available CPUs
         $makeArgs .= ($makeArgs ? " " : "") . "-j" . numberOfCPUs() if $makeArgs !~ /-j\s*\d+/;
-        $buildTarget = "jsc testb3 testair testapi testmasm testdfg testwasmdebugger $makeArgs";
+        $buildTarget = "jsc testb3 testair testapi testmasm testdfg testwasmdebugger";
+        $buildTarget .= " testLibJSCTools" if $^O eq "darwin"; # libJavaScriptCoreTools only available on Apple platforms.
+        $buildTarget .= " $makeArgs";
     } elsif (canUseNinja()) {
         $buildTarget .= "jsc testapi testmasm";
     }

--- a/Tools/Scripts/webkitpy/common/config/ports.py
+++ b/Tools/Scripts/webkitpy/common/config/ports.py
@@ -219,6 +219,7 @@ class JscOnlyPort(DeprecatedPort):
         command.append("--no-testdfg")
         command.append("--no-testapi")
         command.append("--no-testwasmdebugger")
+        command.append("--no-testlibjsctools")
         if 'JSCTESTS_OPTIONS' in os.environ:
             command += os.environ['JSCTESTS_OPTIONS'].split()
         return self._append_build_style_flag(command, build_style)

--- a/Tools/Scripts/webkitpy/common/config/ports_unittest.py
+++ b/Tools/Scripts/webkitpy/common/config/ports_unittest.py
@@ -67,4 +67,4 @@ class DeprecatedPortTest(unittest.TestCase):
         self.assertEqual(JscOnlyPort().build_jsc_command(), DeprecatedPort().script_shell_command("build-jsc") + ["--jsc-only"])
         self.assertEqual(JscOnlyPort().build_jsc_command(build_style="release"), DeprecatedPort().script_shell_command("build-jsc") + ["--jsc-only", "--release"])
         self.assertEqual(JscOnlyPort().build_jsc_command(build_style="debug"), DeprecatedPort().script_shell_command("build-jsc") + ["--jsc-only", "--debug"])
-        self.assertEqual(JscOnlyPort().run_javascriptcore_tests_command(build_style="debug"), DeprecatedPort().script_shell_command("run-javascriptcore-tests") + ['--no-fail-fast', '--no-testmasm', '--no-testair', '--no-testb3', '--no-testdfg', '--no-testapi', '--no-testwasmdebugger', '--debug'])
+        self.assertEqual(JscOnlyPort().run_javascriptcore_tests_command(build_style="debug"), DeprecatedPort().script_shell_command("run-javascriptcore-tests") + ['--no-fail-fast', '--no-testmasm', '--no-testair', '--no-testb3', '--no-testdfg', '--no-testapi', '--no-testwasmdebugger', '--no-testlibjsctools', '--debug'])


### PR DESCRIPTION
#### e5c29fb322200872ae3cce866c62c7f6529103fc
<pre>
Introducing Mya, a MemorY Analyzer, and libJavaScriptCoreTools.
<a href="https://bugs.webkit.org/show_bug.cgi?id=321334">https://bugs.webkit.org/show_bug.cgi?id=321334</a>
<a href="https://rdar.apple.com/184365506">rdar://184365506</a>

Reviewed by Elliott Williams and Dan Hecht.

Mya (pronounced like Maya) is a new command line tool for examining the JSC and
WebKit memory use in a running process.  It attaches to a target by PID and captures
snapshots of its memory (read-only Mach corpses of the process), and then enables
queries on these snapshots via a REPL.

Here is an example user work flow:

    # mya --help                    // Prints help text and exit.

    # mya --pid 12345               // Attach to the process, and take a snapshot.
    Attached to 12345
    Captured Snapshot #1 of 12345

    &gt;&gt;&gt; snapshot list               // Lists all existing snapshots.
    #1: pid 12345 ...               // Only one so far.

    &gt;&gt;&gt; snapshot                    // Take another snapshot, and switch to it.
    Captured Snapshot #2 of 12345   // Capture and switch to snapshot 2.

    &gt;&gt;&gt; status                      // Shows current pid and snapshot being examined.
    Using snapshot 2 of pid 12345   // The snapshot command above switched us.

    &gt;&gt;&gt; snapshot --pid 23456
    Attached to 23456               // Attach and switch to this second process.
    Captured Snapshot #3 of 23456   // Capture and switch to snapshot 3.

    &gt;&gt;&gt; snapshot list               // Lists all existing snapshots.
    #1: pid 12345 ...
    #2: pid 12345 ...
    #3: pid 23456 ...

    &gt;&gt;&gt; status                      // Shows current pid and snapshot being examined.
    Using snapshot 2 of pid 23456   // Note: the snapshot command above switched us.

    &gt;&gt;&gt; detach                      // Detach from the current process.
    Detached from 23456

    &gt;&gt;&gt; snapshot                    // Fails. No attached process.
    Unable to capture snapshot. Not attached to any process. Use `attach` command or specify `--pid` argument for the snapshot command.

    &gt;&gt; snapshot info 1              // Show info on snapshot 1.
    ...

    &gt;&gt;&gt; snapshot delete 2           // Delete snapshot 2.
    ...

    &gt;&gt;&gt; snapshot diff 1 3           // Diff between snapshots 1 and 3. Not yet implemented.
    ...

    &gt;&gt; snapshot 1                   // Select snapshot 1 for analysis.

    &gt;&gt;&gt; thread list                 // Prints info on all thread in the current snapshot.
    Threads in snapshot #1 (pid 12345):
      INDEX  TID        STATE    USER(ms)   SYS(ms)  SP           STACK                       SIZE  PAGES  RESIDENT  DIRTY  NAME
          1  0x12278c6  halted  23645.003  2937.065  0x16b7361e0  0x16af3c000-0x16b738000  7.98 MB    511         7      7  -
          2  0x12278c7  halted     56.147    23.816  0x167386aa0  0x167304000-0x16738c000   544 KB     34         1      1  WebCore: ServiceWorker
          3  0x12278c8  halted      0.211     0.472  0x105986b30  0x105904000-0x10598c000   544 KB     34         1      1  -

    &gt;&gt;&gt; p/x &amp;g_config              // Prints the address of the g_config record.
    &amp;g_config = 0x1f48e0000

The corpse management and analysis machinery lives in libJavaScriptCoreTools, a new
static library built alongside the JavaScriptCore framework. Clients that need to do
this type of snapshot analysis can link against it.  By design, the corpse management
and analysis code is not linked and packaged with the JavaScriptCore framework by
default because they are not needed there.

libJavaScriptCoreTools provides abstractions like Address, Process, Snapshot, Thread,
Region, Symbol, etc. for inspecting and analyzing such WebKit and JSC corpses.  Corpse
Addresses are numbered based on the target process&apos; address space mapping, not the
client tool like mya.  Currently, libJavaScriptCoreTools copies over memory from the
corpse for inspection as an initial bootstrap implementation.  In subsequent patches,
we will introduce a Memory Manager that will make reading corpse memory more efficient.

Symbol lookup resolves a name to an address by walking the dyld exports trie of
each image loaded in the corpse. That needs no cooperation from the target and no
debug information, but it only finds exported symbols.

Everything read out of a corpse is untrusted input: a corrupted target could otherwise
steer mya into unbounded work or bad reads. The parsing paths therefore bound the work
they will do and reject implausible sizes, counts, and offsets rather than trusting what
the target claims.

mya and libJavaScriptCoreTools are only for Apple platforms, since they are built on
Mach task APIs, which are only available on Apple platforms.

Also, it is not a goal to support analysis of Rosetta processes.  Some subset of
functionality may still work, but only on a WYSIWYG basis.

Tests: Source/JavaScriptCore/corpse/tests/

testLibJSCTools is a new test tool for libJavaScriptCoreTools, built with the other
JSC test tools and run by:

    run-javascriptcore-tests --testlibjsctools

A task may take a corpse of itself with no entitlement and no privilege, and the
tests are built on that: they snapshot the running test process and check what the
corpse reports against what that process already knows about itself. A symbol
resolved out of the corpse, for instance, has to land on the address this process
uses for it. The suites are:

    ByteParser   ULEB128 and C string decoding, including the truncated and out of
                 range encodings that untrusted data can hold.
    ExportsTrie  terminal and edge decoding for every export kind and flag, the
                 malformed tries that a corrupt corpse can present, and that a
                 cyclic trie still terminates. Also fuzzed from a fixed seed on
                 every run, under a watchdog, because the decoder&apos;s contract is to
                 bound its work on any input at all.
    Address      null, ordering, arithmetic, and the ptrauth and top-byte stripping
                 that a pointer out of a corpse needs.
    Process      attach, detach, re-attach, a pid that has exited, and a target
                 running under Rosetta translation.
    Snapshot     validity, identifier assignment, and that repeatedly snapshotting
                 leaves no Mach port behind.
    Region       a mapping of known size and residency, an unmapped hole, and an
                 address inside the shared cache submap.
    Thread       thread names and their truncation, and that a thread&apos;s stack
                 pointer lies inside the stack region reported for it.
    Symbol       g_config, malloc and environ resolved out of a corpse of this
                 process, each compared against the address it has locally, plus
                 the names that are deliberately not found: a symbol hidden from
                 the linker, and a name given with its underscore already attached.

For the build, libJavaScriptCoreTools, mya, and testLibJSCTools are deliberately put in
jsc&apos;s dependency closure in the JavaScriptCore_executables XBS project.  This is so that
they can piggy-back off of jsc shell&apos;s build phase i.e. only trigger a build after
JavaScriptCore.framework is done building, and trigger an install like the jsc shell is
(albeit to their respective install destinations, which may defer).

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/Configurations/Mya.xcconfig: Added.
* Source/JavaScriptCore/Configurations/TestLibJSCTools.xcconfig: Added.
* Source/JavaScriptCore/Configurations/libJavaScriptCoreTools.xcconfig: Added.
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Scripts/process-entitlements.sh:
* Source/JavaScriptCore/corpse/CMakeLists.txt: Added.
* Source/JavaScriptCore/corpse/CorpseAddress.h: Added.
* Source/JavaScriptCore/corpse/CorpseByteParser.cpp: Added.
* Source/JavaScriptCore/corpse/CorpseByteParser.h: Added.
* Source/JavaScriptCore/corpse/CorpseClient.cpp: Added.
* Source/JavaScriptCore/corpse/CorpseClient.h: Added.
* Source/JavaScriptCore/corpse/CorpseError.cpp: Added.
* Source/JavaScriptCore/corpse/CorpseError.h: Added.
* Source/JavaScriptCore/corpse/CorpseExportsTrie.cpp: Added.
* Source/JavaScriptCore/corpse/CorpseExportsTrie.h: Added.
* Source/JavaScriptCore/corpse/CorpseProcess.cpp: Added.
* Source/JavaScriptCore/corpse/CorpseProcess.h: Added.
* Source/JavaScriptCore/corpse/CorpseRegion.cpp: Added.
* Source/JavaScriptCore/corpse/CorpseRegion.h: Added.
* Source/JavaScriptCore/corpse/CorpseSnapshot.cpp: Added.
* Source/JavaScriptCore/corpse/CorpseSnapshot.h: Added.
* Source/JavaScriptCore/corpse/CorpseSymbol.cpp: Added.
* Source/JavaScriptCore/corpse/CorpseSymbol.h: Added.
* Source/JavaScriptCore/corpse/CorpseThread.cpp: Added.
* Source/JavaScriptCore/corpse/CorpseThread.h: Added.
* Source/JavaScriptCore/corpse/testLibJSCTools.cpp: Added.
* Source/JavaScriptCore/corpse/tests/CorpseAddressTest.cpp: Added.
* Source/JavaScriptCore/corpse/tests/CorpseAddressTest.h: Added.
* Source/JavaScriptCore/corpse/tests/CorpseByteParserTest.cpp: Added.
* Source/JavaScriptCore/corpse/tests/CorpseByteParserTest.h: Added.
* Source/JavaScriptCore/corpse/tests/CorpseExportsTrieTest.cpp: Added.
* Source/JavaScriptCore/corpse/tests/CorpseExportsTrieTest.h: Added.
* Source/JavaScriptCore/corpse/tests/CorpseProcessTest.cpp: Added.
* Source/JavaScriptCore/corpse/tests/CorpseProcessTest.h: Added.
* Source/JavaScriptCore/corpse/tests/CorpseRegionTest.cpp: Added.
* Source/JavaScriptCore/corpse/tests/CorpseRegionTest.h: Added.
* Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.cpp: Added.
* Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.h: Added.
* Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.cpp: Added.
* Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.h: Added.
* Source/JavaScriptCore/corpse/tests/CorpseThreadTest.cpp: Added.
* Source/JavaScriptCore/corpse/tests/CorpseThreadTest.h: Added.
* Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.cpp: Added.
* Source/JavaScriptCore/corpse/tests/LibJSCToolsTestUtilities.h: Added.
* Source/JavaScriptCore/mya/mya.cpp: Added.
* Source/JavaScriptCore/shell/CMakeLists.txt:
* Source/JavaScriptCore/shell/PlatformCocoa.cmake:
* Tools/CISupport/ews-build/steps.py:
* Tools/Scripts/run-javascriptcore-tests:
* Tools/Scripts/webkitperl/BuildSubproject.pm:
* Tools/Scripts/webkitpy/common/config/ports.py:
* Tools/Scripts/webkitpy/common/config/ports_unittest.py:

Canonical link: <a href="https://commits.webkit.org/319904@main">https://commits.webkit.org/319904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea0ac16a4114da58b425c6df4b29357254dd21b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182987 "96 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193204 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147275 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ca512f4-da32-4b79-b57d-d6ca4582245c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142824 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69b62dc7-6111-43f4-b872-ba409f161032) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123251 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfd13dbb-e708-40e3-967d-a7b357a8e8e8) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182313 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45236 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43483 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5221 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12054 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43114 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4377 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44257 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195145 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182390 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56579 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152291 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40841 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57284 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39730 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151987 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46546 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129553 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125660 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55792 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18125 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55163 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55400 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->