### PR TITLE
Cherry-pick 318769@main (3ef900755534). https://bugs.webkit.org/show_bug.cgi?id=321211

### DIFF
--- a/Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp
@@ -150,10 +150,9 @@ void ScrollerCoordinated::updateValues()
 
     canvas->clear(SK_ColorTRANSPARENT);
 
-    Damage damage(state.frameRect);
     GraphicsContextSkia context(*canvas, RenderingMode::Accelerated, RenderingPurpose::DOM);
     context.scale(contentsScale);
-    scrollerImp->paint(context, state.frameRect, state, damage);
+    scrollerImp->paint(context, state.frameRect, state);
 
     grContext->flushAndSubmit(surface.get(), GLFence::isSupported(display.glDisplay()) ? GrSyncCpu::kNo : GrSyncCpu::kYes);
     auto buffer = CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), { TextureMapperFlags::ShouldBlend }, GLFence::create(display.glDisplay()));
@@ -163,7 +162,7 @@ void ScrollerCoordinated::updateValues()
     Locker layerLocker { hostLayer->lock() };
     hostLayer->setContentsRect(state.frameRect);
     hostLayer->setContentsClippingRect(FloatRoundedRect(state.frameRect));
-    hostLayer->setContentsBuffer(WTF::move(buffer), WTF::move(damage));
+    hostLayer->setContentsBuffer(WTF::move(buffer));
 }
 
 void ScrollerCoordinated::setHoveredAndPressedParts(ScrollbarPart hoveredPart, ScrollbarPart pressedPart)

--- a/Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.cpp
+++ b/Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.cpp
@@ -28,12 +28,11 @@
 
 #if USE(THEME_ADWAITA)
 
-#include "Damage.h"
 #include "GraphicsContext.h"
 
 namespace WebCore::AdwaitaScrollbarPainter {
 
-void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const State& scrollbar, Damage* damageOut)
+void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const State& scrollbar)
 {
     if (graphicsContext.paintingDisabled())
         return;
@@ -110,11 +109,6 @@ void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const St
         } else
             frame.setHeight(scrollbarBorderSize);
         graphicsContext.fillRect(frame, scrollbarBorderColor);
-
-        if (damageOut && opacity) {
-            frame.intersect(damageRect);
-            damageOut->add(frame);
-        }
     } else if (scrollbar.hoveredPart != NoPart) {
         int thumbCornerSize = thumbSize / 2;
         FloatSize corner(thumbCornerSize, thumbCornerSize);
@@ -149,11 +143,6 @@ void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const St
         graphicsContext.setFillRule(WindRule::EvenOdd);
         graphicsContext.setFillColor(overlayTroughBorderColor);
         graphicsContext.fillPath(path);
-
-        if (damageOut && opacity) {
-            troughBorder.intersect(damageRect);
-            damageOut->add(troughBorder);
-        }
     }
 
     int thumbCornerSize;
@@ -217,11 +206,6 @@ void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const St
         graphicsContext.setFillRule(WindRule::EvenOdd);
         graphicsContext.setFillColor(overlayThumbBorderColor);
         graphicsContext.fillPath(path);
-
-        if (damageOut && opacity) {
-            thumbBorder.intersect(damageRect);
-            damageOut->add(thumbBorder);
-        }
     }
 
     if (opacity != 1)

--- a/Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.h
+++ b/Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.h
@@ -32,7 +32,6 @@
 
 namespace WebCore {
 
-class Damage;
 class GraphicsContext;
 
 namespace AdwaitaScrollbarPainter {
@@ -77,7 +76,7 @@ struct State {
     std::optional<ScrollbarColor> scrollbarColor;
 };
 
-void paint(GraphicsContext&, const IntRect&, const State&, Damage* damageOut = nullptr);
+void paint(GraphicsContext&, const IntRect&, const State&);
 
 } // namespace AdwaitaScrollbarPainter
 } // namespace WebCore

--- a/Source/WebCore/platform/adwaita/ScrollerImpAdwaita.h
+++ b/Source/WebCore/platform/adwaita/ScrollerImpAdwaita.h
@@ -33,9 +33,9 @@ namespace WebCore {
 
 class ScrollerImpAdwaita : public ThreadSafeRefCounted<ScrollerImpAdwaita> {
 public:
-    void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const AdwaitaScrollbarPainter::State& state, Damage& damageOut)
+    void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const AdwaitaScrollbarPainter::State& state)
     {
-        AdwaitaScrollbarPainter::paint(graphicsContext, damageRect, state, &damageOut);
+        AdwaitaScrollbarPainter::paint(graphicsContext, damageRect, state);
     }
 };
 

--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if USE(COORDINATED_GRAPHICS) || USE(THEME_ADWAITA)
+#if USE(COORDINATED_GRAPHICS)
 #include "FloatRect.h"
 #include "LayoutSize.h"
 #include "Region.h"
@@ -640,4 +640,4 @@ static inline WTF::TextStream& operator<<(WTF::TextStream& ts, const Damage& dam
 
 } // namespace WebCore
 
-#endif // USE(COORDINATED_GRAPHICS) || USE(THEME_ADWAITA)
+#endif // USE(COORDINATED_GRAPHICS)


### PR DESCRIPTION
#### 6002a6fffa6aebfc4b1e7eee135536325e280ba8
<pre>
Cherry-pick 318769@main (3ef900755534). <a href="https://bugs.webkit.org/show_bug.cgi?id=321211">https://bugs.webkit.org/show_bug.cgi?id=321211</a>

Unreviewed backport.

    REGRESSION(314540@main): When damage propagation is turned on, scrollbars are flickering
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321211">https://bugs.webkit.org/show_bug.cgi?id=321211</a>

    Reviewed by Carlos Garcia Campos and Fujii Hironori.

    The scrollbar buffer is cleared and painted from scratch on every update, so the
    region that changes is the union of what the previous buffer painted and what
    this one paints. 314540@main reported only the latter, so the frame that erases
    the faded out overlay thumb propagated no damage and left the thumb on
    screen.

    It flickers rather than just leaving a stale thumb because an empty frame damage
    makes ThreadedCompositor::recordFrameDamage() skip setFrameDamage() altogether,
    and that is also what accumulates the frame into every swap chain target. The
    target being composited still repaints the thumb region, since its own
    accumulated damage covers it, but the other targets never learn that region
    changed and keep the old thumb. The thumb then comes and goes with the target
    that happens to be current...

    This is only visible on WPE since 318729@main turned damage propagation
    on by default there -- GTK was already affected.

    This gives up 314540@main&apos;s optimization. Restoring it needs the previous
    buffer&apos;s painted area tracked across updates, which is not worth it.

    * Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp:
    (WebCore::ScrollerCoordinated::updateValues):
    * Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.cpp:
    (WebCore::AdwaitaScrollbarPainter::paint):
    * Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.h:
    * Source/WebCore/platform/adwaita/ScrollerImpAdwaita.h:
    (WebCore::ScrollerImpAdwaita::paint):
    * Source/WebCore/platform/graphics/Damage.h:

    Canonical link: <a href="https://commits.webkit.org/318769@main">https://commits.webkit.org/318769@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.72@webkitglib/2.54">https://commits.webkit.org/317695.72@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b40325a802509af42f0690215c57929df876fcd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179510 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53449 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47246 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189342 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143819 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181373 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54743 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53160 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139987 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143819 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182467 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54743 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47246 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120440 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54743 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53160 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47246 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54743 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47246 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/796 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46055 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53160 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191563 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53119 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47246 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149247 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53800 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47246 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148991 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27265 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53800 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126072 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/120970 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52317 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47246 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51702 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51943 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51763 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->