### PR TITLE
[JSC] Address -Wunused-template warnings

### DIFF
--- a/Source/JavaScriptCore/Configurations/Base.xcconfig
+++ b/Source/JavaScriptCore/Configurations/Base.xcconfig
@@ -93,7 +93,7 @@ GCC_WARN_UNUSED_FUNCTION = YES;
 GCC_WARN_UNUSED_VARIABLE = YES;
 CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 PREBINDING = NO;
-WARNING_CFLAGS = $(inherited) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-profile-instr-out-of-date -Wno-profile-instr-unprofiled -Wno-backend-plugin -Wunsafe-buffer-usage -Wno-unknown-warning-option;
+WARNING_CFLAGS = $(inherited) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-profile-instr-out-of-date -Wno-profile-instr-unprofiled -Wno-backend-plugin -Wunsafe-buffer-usage -Wno-unknown-warning-option -Wunused-template;
 
 HEADER_SEARCH_PATHS = $(SRCROOT) "$(BUILT_PRODUCTS_DIR)$(WK_LIBRARY_HEADERS_FOLDER_PATH)" $(HEADER_SEARCH_PATHS);
 LIBRARY_SEARCH_PATHS = $(SDK_DIR)$(WK_LIBRARY_INSTALL_PATH) $(inherited);

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -4394,7 +4394,7 @@ void testLoadExtend_BaseIndex_RegisterID(const Scenario* scenarios, size_t numbe
 }
 
 template<typename T, typename Scenario, typename CompileFunctor>
-void testLoadExtend_voidp_RegisterID(const Scenario* scenarios, size_t numberOfScenarios, CompileFunctor compileFunctor)
+UNUSED_FUNCTION void testLoadExtend_voidp_RegisterID(const Scenario* scenarios, size_t numberOfScenarios, CompileFunctor compileFunctor)
 {
     for (size_t i = 0; i < numberOfScenarios; ++i) {
         auto test = compile([&] (CCallHelpers& jit) {

--- a/Source/JavaScriptCore/b3/B3Common.h
+++ b/Source/JavaScriptCore/b3/B3Common.h
@@ -54,7 +54,7 @@ bool NODELETE shouldValidateIRAtEachPhase();
 bool NODELETE shouldSaveIRBeforePhase();
 
 template<typename IntType>
-static IntType chillDiv(IntType numerator, IntType denominator)
+IntType chillDiv(IntType numerator, IntType denominator)
 {
     if (!denominator)
         return 0;
@@ -64,7 +64,7 @@ static IntType chillDiv(IntType numerator, IntType denominator)
 }
 
 template<typename IntType>
-static IntType chillMod(IntType numerator, IntType denominator)
+IntType chillMod(IntType numerator, IntType denominator)
 {
     if (!denominator)
         return 0;
@@ -74,7 +74,7 @@ static IntType chillMod(IntType numerator, IntType denominator)
 }
 
 template<typename IntType>
-static IntType chillUDiv(IntType numerator, IntType denominator)
+IntType chillUDiv(IntType numerator, IntType denominator)
 {
     auto unsignedNumerator = unsignedCast(numerator);
     auto unsignedDenominator = unsignedCast(denominator);
@@ -84,7 +84,7 @@ static IntType chillUDiv(IntType numerator, IntType denominator)
 }
 
 template<typename IntType>
-static IntType chillUMod(IntType numerator, IntType denominator)
+IntType chillUMod(IntType numerator, IntType denominator)
 {
     auto unsignedNumerator = unsignedCast(numerator);
     auto unsignedDenominator = unsignedCast(denominator);
@@ -94,7 +94,7 @@ static IntType chillUMod(IntType numerator, IntType denominator)
 }
 
 template<typename IntType>
-static IntType rotateRight(IntType value, int32_t shift)
+IntType rotateRight(IntType value, int32_t shift)
 {
     auto uValue = unsignedCast(value);
     int32_t bits = sizeof(IntType) * 8;
@@ -104,7 +104,7 @@ static IntType rotateRight(IntType value, int32_t shift)
 }
 
 template<typename IntType>
-static IntType rotateLeft(IntType value, int32_t shift)
+IntType rotateLeft(IntType value, int32_t shift)
 {
     auto uValue = unsignedCast(value);
     int32_t bits = sizeof(IntType) * 8;

--- a/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
@@ -905,16 +905,6 @@ private:
         return true;
     }
 
-    template<typename Filter>
-    void handleMemoryValue(Value* ptr, HeapRange range, const Filter& filter)
-    {
-        handleMemoryValue(
-            ptr, range, filter,
-            [] (MemoryValue*, Vector<Value*>&) -> Value* {
-                return nullptr;
-            });
-    }
-
     template<typename Filter, typename Replace>
     void handleMemoryValue(
         Value* ptr, HeapRange range, const Filter& filter, const Replace& replace)

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -1155,12 +1155,6 @@ private:
         append(opcode, tmp(right), result);
     }
 
-    template<Air::Opcode opcode32, Air::Opcode opcode64, Commutativity commutativity = NotCommutative>
-    void appendBinOp(Value* left, Value* right)
-    {
-        appendBinOp<opcode32, opcode64, Air::Oops, Air::Oops, commutativity>(left, right);
-    }
-
     template<Air::Opcode opcode32, Air::Opcode opcode64>
     void appendShift(Value* value, Value* amount)
     {
@@ -1724,15 +1718,16 @@ private:
         append(Air::MoveFloatTo32, vectorTmp, dst);
     }
 
+    // Kept for debugging: emits a runtime print of the given values.
     template<typename... Arguments>
-    void print(Arguments&&... arguments)
+    [[maybe_unused]] void print(Arguments&&... arguments)
     {
         Value* origin = m_value;
         print(origin, std::forward<Arguments>(arguments)...);
     }
 
     template<typename... Arguments>
-    void print(Value* origin, Arguments&&... arguments)
+    [[maybe_unused]] void print(Value* origin, Arguments&&... arguments)
     {
         auto printList = Printer::makePrintRecordList(arguments...);
         auto printSpecial = static_cast<Air::PrintSpecial*>(m_code.addSpecial(makeUnique<Air::PrintSpecial>(printList)));

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -222,8 +222,6 @@ static unsigned asyncTestExpectedPasses { 0 };
 
 }
 
-template<typename Vector>
-static bool fillBufferWithContentsOfFile(const String& fileName, Vector& buffer);
 static RefPtr<Uint8Array> fillBufferWithContentsOfFile(const String& fileName);
 
 class CommandLine;

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -381,15 +381,6 @@ static void decode(Decoder& decoder, const T& src, SourceType<T>& dst, Args... a
         src.decode(decoder, dst, args...);
 }
 
-template<typename T>
-static T decode(Decoder& decoder, T src)
-{
-    if constexpr (std::is_same_v<T, SourceType<T>>)
-        return src;
-    else
-        return src.decode(decoder);
-}
-
 template<typename Source>
 class CachedObject {
     WTF_MAKE_NONCOPYABLE(CachedObject);

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -457,7 +457,7 @@ auto FunctionParser<Context>::parseBlockSignatureAndNotifySIMDUseIfNeeded(BlockS
 }
 
 template<typename ControlType>
-static bool isTryOrCatch(ControlType& data)
+bool isTryOrCatch(ControlType& data)
 {
     return ControlType::isTry(data) || ControlType::isCatch(data);
 }

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -75,7 +75,7 @@ static uint32_t failuresFound = 0;
 static uint32_t expectedVMCount = 0;
 static DebugServer* debugServer = nullptr;
 static ExecutionHandler* executionHandler = nullptr;
-static const TestScript* currentScript = nullptr;
+UNUSED_FUNCTION static const TestScript* currentScript = nullptr;
 UNUSED_FUNCTION bool doneTesting = false;
 
 #define VLOG(...) dataLogLnIf(verboseLogging, __VA_ARGS__)


### PR DESCRIPTION
#### af6d6f483e633128594fb7ceb35f5e46169aba03
<pre>
[JSC] Address -Wunused-template warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=321339">https://bugs.webkit.org/show_bug.cgi?id=321339</a>
<a href="https://rdar.apple.com/184187975">rdar://184187975</a>

Reviewed by Yusuke Suzuki and Keith Miller.

Address -Wunused-template warnings in JSC. Mostly this is removing dead code or
moving templates in headers from internal to external linkage.

No tests as this is a clang warning fix.

* Source/JavaScriptCore/Configurations/Base.xcconfig:
* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testLoadExtend_voidp_RegisterID):
* Source/JavaScriptCore/b3/B3Common.h:
(JSC::B3::chillDiv):
(JSC::B3::chillMod):
(JSC::B3::chillUDiv):
(JSC::B3::chillUMod):
(JSC::B3::rotateRight):
(JSC::B3::rotateLeft):
* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::isTryOrCatch):
* Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp:

Canonical link: <a href="https://commits.webkit.org/318979@main">https://commits.webkit.org/318979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd6bfbebe081e2aece40c38a14a41167bd965942

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144227 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d7f256c-9549-4f00-b601-96d95c5e46f1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140302 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec24c2f4-baeb-4fb6-a76a-f34e077e395d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120753 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8cdc1d5e-d4fd-4081-9875-af039a39cf5e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42617 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40936 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2721 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9558 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153019 "Found 1 new API test failure: TestWebKitAPI.SafeBrowsing.DeferredModalsClearedOnNavigation (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40600 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1276 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41182 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192051 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53520 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149628 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40111 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54207 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149357 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44003 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126470 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121527 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52724 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15586 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52106 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52344 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52170 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->