### PR TITLE
Implement child model lifecycle for spatial portals

### DIFF
--- a/LayoutTests/model-element/model-element-suspend-resume.html
+++ b/LayoutTests/model-element/model-element-suspend-resume.html
@@ -13,7 +13,7 @@
 
     var lastRecordedCurrentTime;
 
-    window.addEventListener("pageshow", async () => {
+    window.addEventListener("pageshow", async (event) => {
         assert_equals(document.visibilityState, "visible");
 
         if (!event.persisted)

--- a/LayoutTests/spatial-css/spatial-portal-action-multi-model.html
+++ b/LayoutTests/spatial-css/spatial-portal-action-multi-model.html
@@ -20,13 +20,17 @@ const spreadAssets = ["2x2x2-center.usdz", "2x2x2-at-100x50x200.usdz", "2x2x2-po
 const loadPortalInOrder = async (test, assets, options) => {
     const portal = createPortal(test, options);
 
+    const loaded = [];
     let previous = null;
-    for (const [index, asset] of assets.entries()) {
+    for (const asset of assets) {
         const model = appendModel(portal, asset);
+        loaded.push({ model, asset });
         await model.ready;
         await UIHelper.ensureStablePresentationUpdate();
 
-        assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), index + 1, `${index + 1} model(s) loaded after ${asset}`);
+        loaded.forEach(each => {
+            assert_equals(internals.modelElementState(each.model), "Loaded", `${each.asset} is loaded (${loaded.length}/${assets.length} appended)`);
+        });
 
         const transform = await waitForPortalTransform(portal, portalTransformIsResolved, `fit after loading ${asset}`);
         if (previous)

--- a/LayoutTests/spatial-css/spatial-portal-display-none-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-display-none-expected.txt
@@ -1,0 +1,4 @@
+
+PASS display:none on a spatial portal unloads its models, and restoring it reloads them
+PASS Removing a spatial portal from the document tears down its controller
+

--- a/LayoutTests/spatial-css/spatial-portal-display-none.html
+++ b/LayoutTests/spatial-css/spatial-portal-display-none.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<meta charset="utf-8">
+<title>A spatial portal without a renderer tears down its models</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="../model-element/resources/model-element-test-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, "cube.usdz");
+    await model.ready;
+
+    assert_true(internals.establishesSpatialPortal(portal), "the portal is a portal while rendered");
+
+    portal.style.display = "none";
+    await UIHelper.ensureStablePresentationUpdate();
+
+    assert_false(internals.establishesSpatialPortal(portal), "a display:none portal is no longer a portal");
+    await waitForModelState(model, "Unloaded");
+
+    portal.style.display = "";
+    await UIHelper.ensureStablePresentationUpdate();
+
+    assert_true(internals.establishesSpatialPortal(portal), "the portal is re-established");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 1, "its child is hosted again");
+    await waitForModelState(model, "Loaded");
+}, "display:none on a spatial portal unloads its models, and restoring it reloads them");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, "cube.usdz");
+    await model.ready;
+
+    portal.remove();
+    await UIHelper.ensureStablePresentationUpdate();
+
+    assert_false(internals.establishesSpatialPortal(portal), "a removed portal is no longer a portal");
+}, "Removing a spatial portal from the document tears down its controller");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-layers-dynamic-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-layers-dynamic-expected.txt
@@ -1,0 +1,46 @@
+hosted models after removal: 0
+layer count with model: 6
+layer count after removal: 2
+layer count never hosted: 2
+
+With one hosted model:
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 300 height: 150])
+  (layer position [x: 158 y: 83])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 300 height: 150])
+      (layer position [x: 150 y: 75])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 300 height: 150])
+          (layer position [x: 150 y: 75]))
+        (
+          (layer bounds [x: 0 y: 0 width: 300 height: 150])
+          (layer position [x: 150 y: 75])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 300 height: 150])
+              (layer position [x: 150 y: 75]))))))
+    (
+      (layer bounds [x: 0 y: 0 width: 300 height: 150])
+      (layer position [x: 150 y: 75]))))
+After removing it:
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 300 height: 150])
+  (layer position [x: 158 y: 83])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 300 height: 150])
+      (layer position [x: 150 y: 75]))))
+Portal that never hosted a model:
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 300 height: 150])
+  (layer position [x: 158 y: 233])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 300 height: 150])
+      (layer position [x: 150 y: 75]))))

--- a/LayoutTests/spatial-css/spatial-portal-layers-dynamic.html
+++ b/LayoutTests/spatial-css/spatial-portal-layers-dynamic.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<head>
+<script src="../resources/ui-helper.js"></script>
+<style>
+    .portal {
+        spatial: portal;
+        width: 300px;
+        height: 150px;
+    }
+</style>
+</head>
+<body>
+<div id="portal" class="portal">
+    <model id="model" src="../model-element/resources/cube.usdz"></model>
+</div>
+<div id="neverHosted" class="portal"></div>
+<pre id="results"></pre>
+<script>
+window.onload = async function () {
+    window.internals?.disableModelLoadDelaysForTesting();
+    window.testRunner?.waitUntilDone();
+    window.testRunner?.dumpAsText();
+
+    const portal = document.getElementById("portal");
+    const model = document.getElementById("model");
+    const lines = [];
+
+    // Only layer counts are comparable across portals, since their positions differ.
+    const layerCount = tree => (tree.match(/\(layer bounds/g) ?? []).length;
+
+    await model.ready;
+    await UIHelper.ensureStablePresentationUpdate();
+    const withModel = await UIHelper.getCALayerTreeForCompositedElement(portal);
+
+    model.remove();
+    await UIHelper.ensureStablePresentationUpdate();
+    const afterRemoval = await UIHelper.getCALayerTreeForCompositedElement(portal);
+    const neverHosted = await UIHelper.getCALayerTreeForCompositedElement(document.getElementById("neverHosted"));
+
+    lines.push(`hosted models after removal: ${window.internals?.numberOfHostedModelsInSpatialPortal(portal)}`);
+    lines.push(`layer count with model: ${layerCount(withModel)}`);
+    lines.push(`layer count after removal: ${layerCount(afterRemoval)}`);
+    lines.push(`layer count never hosted: ${layerCount(neverHosted)}`);
+    lines.push("");
+    lines.push("With one hosted model:", withModel);
+    lines.push("After removing it:", afterRemoval);
+    lines.push("Portal that never hosted a model:", neverHosted);
+
+    results.textContent = lines.join("\n");
+
+    portal.remove();
+
+    window.testRunner?.notifyDone();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-lifecycle-visibility-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-lifecycle-visibility-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Hiding the page unloads a <model> nested in a spatial portal, and showing it reloads it
+PASS Both <model>s in a spatial portal are unloaded and reloaded together
+

--- a/LayoutTests/spatial-css/spatial-portal-lifecycle-visibility.html
+++ b/LayoutTests/spatial-css/spatial-portal-lifecycle-visibility.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<meta charset="utf-8">
+<title>A spatial portal releases its models while the page is hidden</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="../model-element/resources/model-element-test-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, "cube.usdz");
+    await model.ready;
+
+    t.add_cleanup(() => testRunner.setPageVisibility("visible"));
+
+    assert_equals(internals.modelElementState(model), "Loaded", "the child is loaded while visible");
+
+    testRunner.setPageVisibility("hidden");
+    await sleepForSeconds(0.1);
+    assert_true(document.hidden, "the page is hidden");
+
+    await waitForModelState(model, "Unloaded");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 1, "the child stays registered with the portal");
+
+    testRunner.setPageVisibility("visible");
+    await sleepForSeconds(0.1);
+    assert_false(document.hidden, "the page is visible again");
+
+    await waitForModelState(model, "Loaded");
+}, "Hiding the page unloads a <model> nested in a spatial portal, and showing it reloads it");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const first = appendModel(portal, "cube.usdz");
+    const second = appendModel(portal, "2x2x2-center.usdz");
+    await Promise.all([first.ready, second.ready]);
+
+    t.add_cleanup(() => testRunner.setPageVisibility("visible"));
+
+    testRunner.setPageVisibility("hidden");
+    await sleepForSeconds(0.1);
+    await Promise.all([waitForModelState(first, "Unloaded"), waitForModelState(second, "Unloaded")]);
+
+    testRunner.setPageVisibility("visible");
+    await sleepForSeconds(0.1);
+    await Promise.all([waitForModelState(first, "Loaded"), waitForModelState(second, "Loaded")]);
+
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 2, "both children stay registered");
+}, "Both <model>s in a spatial portal are unloaded and reloaded together");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-multi-model-error.html
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model-error.html
@@ -23,7 +23,8 @@ promise_test(async t => {
     await valid.ready;
 
     assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 2, "the failed load leaves both models registered with the portal");
-    assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), 1, "only the valid model is loaded");
+    assert_equals(internals.modelElementState(valid), "Loaded", "the valid model is loaded");
+    assert_not_equals(internals.modelElementState(invalid), "Loaded", "the undecodable model is not loaded");
 }, "A failing <model> in a spatial portal does not prevent its sibling from loading");
 
 </script>

--- a/LayoutTests/spatial-css/spatial-portal-multi-model-source-change.html
+++ b/LayoutTests/spatial-css/spatial-portal-multi-model-source-change.html
@@ -24,7 +24,8 @@ promise_test(async t => {
 
     assert_equals(untouched.ready, untouchedReadyBeforeChange, "the sibling's ready promise was not reset");
     await untouched.ready;
-    assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), 2, "both models are loaded after the source swap");
+    assert_equals(internals.modelElementState(changing), "Loaded", "the re-sourced model is loaded");
+    assert_equals(internals.modelElementState(untouched), "Loaded", "its sibling is still loaded");
 }, "Changing the source of one <model> in a spatial portal leaves its sibling loaded");
 
 promise_test(async t => {
@@ -43,7 +44,8 @@ promise_test(async t => {
     assert_not_equals(unloading.ready, unloadingReadyBeforeChange, "the unsourced model's ready promise was replaced");
     assert_equals(untouched.ready, untouchedReadyBeforeChange, "the sibling's ready promise was not reset");
     assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 2, "the unsourced model stays registered with the portal");
-    assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), 1, "only the sibling is still loaded");
+    assert_equals(internals.modelElementState(unloading), "Deferred", "the unsourced model has nothing to load");
+    assert_equals(internals.modelElementState(untouched), "Loaded", "only the sibling is still loaded");
     await untouched.ready;
 }, "Clearing the source of one <model> in a spatial portal unloads only that model");
 

--- a/LayoutTests/spatial-css/spatial-portal-on-hidden-page-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-on-hidden-page-expected.txt
@@ -1,0 +1,4 @@
+
+PASS A <model> in a spatial portal keeps its animation running while the page is hidden
+PASS Siblings in a spatial portal resume independently after an unload
+

--- a/LayoutTests/spatial-css/spatial-portal-on-hidden-page.html
+++ b/LayoutTests/spatial-css/spatial-portal-on-hidden-page.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<meta charset="utf-8">
+<title>&lt;model> animation survives an unload inside a spatial portal</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="../model-element/resources/model-element-test-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, "stopwatch-60s.usdz");
+    const initialModelReadyPromise = model.ready;
+    await model.ready;
+
+    model.loop = true;
+    await model.play();
+
+    t.add_cleanup(() => testRunner.setPageVisibility("visible"));
+    assert_false(document.hidden, "Page should be initially visible");
+
+    testRunner.setPageVisibility("hidden");
+    await sleepForSeconds(0.5);
+
+    assert_true(document.hidden, "Page should be hidden");
+    assert_equals(internals.modelElementState(model), "Unloaded", "the child model was unloaded");
+    assert_false(model.paused, "the child model is still playing after hiding the page");
+    assert_true(model.currentTime >= 0.5, "its animation is still progressing while unloaded");
+
+    model.currentTime = model.duration - 1.0;
+    model.playbackRate = 4;
+    await sleepForSeconds(0.5);
+    assert_true(model.currentTime >= 1.0, "a seek and playback rate set while unloaded take effect and loop");
+
+    testRunner.setPageVisibility("visible");
+    await sleepForSeconds(0.5);
+
+    assert_false(document.hidden, "Page should be visible");
+    assert_equals(model.ready, initialModelReadyPromise, "ready was not reset by the unload");
+    await waitForModelState(model, "Loaded");
+    assert_false(model.paused, "the child model is still playing after re-showing the page");
+    assert_true(model.currentTime >= 3.0, "its animation resumed rather than restarting");
+}, "A <model> in a spatial portal keeps its animation running while the page is hidden");
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const slow = appendModel(portal, "stopwatch-60s.usdz");
+    const fast = appendModel(portal, "stopwatch-60s.usdz");
+    await Promise.all([slow.ready, fast.ready]);
+
+    slow.playbackRate = 1;
+    fast.playbackRate = 10;
+    await Promise.all([slow.play(), fast.play()]);
+
+    t.add_cleanup(() => testRunner.setPageVisibility("visible"));
+
+    testRunner.setPageVisibility("hidden");
+    await sleepForSeconds(0.5);
+    assert_true(document.hidden, "Page should be hidden");
+
+    assert_greater_than(fast.currentTime, slow.currentTime, "each child advances at its own rate while unloaded");
+
+    testRunner.setPageVisibility("visible");
+    await sleepForSeconds(0.5);
+
+    await Promise.all([waitForModelState(slow, "Loaded"), waitForModelState(fast, "Loaded")]);
+    assert_false(slow.paused, "the slower child resumed playing");
+    assert_false(fast.paused, "the faster child resumed playing");
+    assert_greater_than(fast.currentTime, slow.currentTime, "they resume from their own clocks, not a shared one");
+}, "Siblings in a spatial portal resume independently after an unload");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-scroll-to-load.html
+++ b/LayoutTests/spatial-css/spatial-portal-scroll-to-load.html
@@ -24,11 +24,11 @@ promise_test(async t => {
     model.appendChild(source);
 
     await UIHelper.ensureStablePresentationUpdate();
-    assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), 0, "portal does not load its model while off-screen");
+    assert_not_equals(internals.modelElementState(model), "Loaded", "portal does not load its model while off-screen");
 
     portal.scrollIntoView();
     await model.ready;
-    assert_equals(internals.numberOfLoadedModelsInSpatialPortal(portal), 1, "portal loads the model after scrolling into view");
+    assert_equals(internals.modelElementState(model), "Loaded", "portal loads the model after scrolling into view");
 }, "A <model> in a spatial portal loads only once the portal is scrolled into view");
 </script>
 </body>

--- a/LayoutTests/spatial-css/spatial-portal-scroll-to-unload-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-scroll-to-unload-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A <model> in a spatial portal unloads when scrolled out of view and reloads when scrolled back
+

--- a/LayoutTests/spatial-css/spatial-portal-scroll-to-unload.html
+++ b/LayoutTests/spatial-css/spatial-portal-scroll-to-unload.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .spacer { height: 500vh; }
+    #portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<body>
+<div class="spacer"></div>
+<div id="portal"></div>
+<script>
+'use strict';
+
+promise_test(async t => {
+    // Must precede the portal's player: the unload delay is disabled per player at creation.
+    internals.disableModelLoadDelaysForTesting();
+
+    const portal = document.getElementById("portal");
+
+    const model = document.createElement("model");
+    t.add_cleanup(() => model.remove());
+    portal.appendChild(model);
+    const source = document.createElement("source");
+    source.src = "../model-element/resources/cube.usdz";
+    model.appendChild(source);
+
+    portal.scrollIntoView();
+    await model.ready;
+    assert_equals(internals.modelElementState(model), "Loaded", "portal loads the model once scrolled into view");
+
+    // The observer uses a 100% scroll margin, so scroll a full page away.
+    window.scrollTo(0, 0);
+    await waitFor(() => internals.modelElementState(model) != "Loaded", "the model to unload");
+    assert_equals(internals.numberOfHostedModelsInSpatialPortal(portal), 1, "the portal still hosts the child while unloaded");
+
+    portal.scrollIntoView();
+    await waitFor(() => internals.modelElementState(model) == "Loaded", "the model to reload");
+}, "A <model> in a spatial portal unloads when scrolled out of view and reloads when scrolled back");
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-suspend-resume-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-suspend-resume-expected.txt
@@ -1,0 +1,1 @@
+PASSED: portal children are resumed after being suspended

--- a/LayoutTests/spatial-css/spatial-portal-suspend-resume.html
+++ b/LayoutTests/spatial-css/spatial-portal-suspend-resume.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UsesBackForwardCache=true SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<head>
+<title>&lt;model> state in a spatial portal after suspend and resume</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<style>
+    #portal { spatial: portal; width: 300px; height: 150px; }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    window.internals?.disableModelLoadDelaysForTesting();
+
+    var lastRecordedCurrentTimes;
+
+    const models = () => [...document.querySelectorAll("model")];
+
+    window.addEventListener("pageshow", async (event) => {
+        assert_equals(document.visibilityState, "visible");
+
+        if (!event.persisted)
+            return;
+
+        // This page was restored from the page cache.
+        models().forEach((model, index) => {
+            assert_true(model.currentTime < lastRecordedCurrentTimes[index] + 0.2,
+                `Child ${index}'s animation current time shouldn't have progressed much while suspended (go-back-on-load.html takes 0.5 seconds to navigate back)`);
+        });
+        lastRecordedCurrentTimes = models().map(model => model.currentTime);
+
+        // The reload of a suspended model is not synchronous.
+        await sleepForSeconds(0.5);
+
+        models().forEach((model, index) => {
+            assert_false(model.paused, `Child ${index}'s animation should be running after resume`);
+            assert_true(model.currentTime > lastRecordedCurrentTimes[index], `Child ${index}'s animation current time should progress after resume`);
+        });
+
+        assert_equals(internals.numberOfHostedModelsInSpatialPortal(document.getElementById("portal")), 2, "the portal still hosts both children");
+
+        document.getElementById("result").innerText = "PASSED: portal children are resumed after being suspended";
+        testRunner.dumpAsText();
+        testRunner.notifyDone();
+    }, false);
+
+    window.addEventListener("pagehide", function(event) {
+        assert_true(event.persisted, "Page should have entered the page cache");
+    }, false);
+
+    window.addEventListener('load', async () => {
+        assert_equals(models().length, 2, "Both model elements should exist");
+        await Promise.all(models().map(model => model.ready));
+
+        // Distinct rates so a child resuming from a sibling's clock would be visible.
+        models()[0].playbackRate = 2;
+        models()[1].playbackRate = 4;
+
+        await sleepForSeconds(0.5);
+        models().forEach((model, index) => {
+            assert_false(model.paused, `Child ${index} should autoplay`);
+            assert_true(model.currentTime > 0, `Child ${index}'s animation current time should have progressed`);
+        });
+
+        lastRecordedCurrentTimes = models().map(model => model.currentTime);
+
+        window.location.href = "../model-element/resources/go-back-on-load.html";
+    }, false);
+</script>
+<body>
+    <div id="portal">
+        <model autoplay loop><source src='../model-element/resources/stopwatch-60s.usdz'/></model>
+        <model autoplay loop><source src='../model-element/resources/stopwatch-60s.usdz'/></model>
+    </div>
+    <div id="result"></div>
+</body>
+</html>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -200,13 +200,30 @@ void HTMLModelElement::suspend(ReasonForSuspension reasonForSuspension)
 {
     RELEASE_LOG(ModelElement, "%p - HTMLModelElement::suspend(): %d", this, static_cast<int>(reasonForSuspension));
 
-    if (reasonForSuspension == ReasonForSuspension::BackForwardCache)
-        unloadModelPlayer(true);
+    if (reasonForSuspension != ReasonForSuspension::BackForwardCache)
+        return;
+
+#if ENABLE(SPATIAL_PORTAL)
+    if (CheckedPtr controller = m_lastRegisteredPortalController.get()) {
+        controller->childWasSuspended(*this);
+        return;
+    }
+#endif
+
+    unloadModelPlayer(true);
 }
 
 void HTMLModelElement::resume()
 {
     RELEASE_LOG(ModelElement, "%p - HTMLModelElement::resume()", this);
+
+#if ENABLE(SPATIAL_PORTAL)
+    if (CheckedPtr controller = m_lastRegisteredPortalController.get()) {
+        controller->childVisibilityStateChanged(*this);
+        return;
+    }
+#endif
+
     startLoadModelTimer();
 }
 
@@ -342,6 +359,21 @@ HTMLModelElement& HTMLModelElement::readyPromiseResolve()
 
 void HTMLModelElement::visibilityStateChanged()
 {
+#if ENABLE(SPATIAL_PORTAL)
+    if (CheckedPtr controller = m_lastRegisteredPortalController.get()) {
+        controller->childVisibilityStateChanged(*this);
+
+        if (!isVisible()) {
+            m_loadModelTimer = nullptr;
+            return;
+        }
+
+        if (isModelDeferred())
+            startLoadModelTimer();
+        return;
+    }
+#endif
+
     RefPtr modelPlayer = m_modelPlayer;
     if (modelPlayer)
         modelPlayer->visibilityStateDidChange();
@@ -774,6 +806,11 @@ void HTMLModelElement::createModelPlayer()
     RefPtr model = m_model;
     if (!model)
         return;
+
+#if ENABLE(SPATIAL_PORTAL)
+    if (isInsidePortal())
+        return triggerModelPlayerCreationCallbacksIfNeeded(Exception { ExceptionCode::AbortError, "Model is hosted by a spatial portal"_s });
+#endif
 
     if (modelContainerSizeIsEmpty())
         return triggerModelPlayerCreationCallbacksIfNeeded(Exception { ExceptionCode::AbortError, "Model container size is empty"_s });
@@ -1458,7 +1495,7 @@ ModelPlayer* HTMLModelElement::modelPlayerForAnimation() const
 
 #if ENABLE(SPATIAL_PORTAL)
     if (CheckedPtr controller = m_lastRegisteredPortalController.get())
-        return controller->modelPlayer();
+        return controller->playerForChild(nodeIdentifier());
 #endif
 
     return nullptr;
@@ -2036,6 +2073,12 @@ void HTMLModelElement::stop()
 
     m_loadModelTimer = nullptr;
 
+#if ENABLE(SPATIAL_PORTAL)
+    if (CheckedPtr controller = m_lastRegisteredPortalController.get())
+        controller->unregisterChildModel(*this);
+    m_lastRegisteredPortalController = nullptr;
+#endif
+
     // Once an active DOM object has been stopped it cannot be restarted,
     // so we can delete the model player now.
     deletePendingModelPlayer();
@@ -2220,43 +2263,40 @@ bool HTMLModelElement::isModelDeferred() const
     return !m_model && !m_resource;
 }
 
+bool HTMLModelElement::hasLiveModelPlayer() const
+{
+#if ENABLE(SPATIAL_PORTAL)
+    if (CheckedPtr controller = m_lastRegisteredPortalController.get())
+        return controller->childIsLoaded(nodeIdentifier());
+#endif
+    RefPtr modelPlayer = m_modelPlayer;
+    return modelPlayer && !modelPlayer->isPlaceholder();
+}
+
 bool HTMLModelElement::isModelLoading() const
 {
     if (!isVisible())
         return false;
 
-    if ((!m_model && m_resource) || (m_model && !m_modelPlayer))
-        return true;
+    if (!m_model)
+        return !!m_resource;
 
-    RefPtr modelPlayer = m_modelPlayer;
-    return modelPlayer && modelPlayer->isPlaceholder();
+    return !hasLiveModelPlayer();
 }
 
 bool HTMLModelElement::isModelLoaded() const
 {
-    if (!isVisible())
-        return false;
-
-    RefPtr modelPlayer = m_modelPlayer;
-    return modelPlayer && !modelPlayer->isPlaceholder();
+    return isVisible() && hasLiveModelPlayer();
 }
 
 bool HTMLModelElement::isModelUnloading() const
 {
-    if (isVisible())
-        return false;
-
-    RefPtr modelPlayer = m_modelPlayer;
-    return modelPlayer && !modelPlayer->isPlaceholder();
+    return !isVisible() && hasLiveModelPlayer();
 }
 
 bool HTMLModelElement::isModelUnloaded() const
 {
-    if (isVisible() || !m_model)
-        return false;
-
-    RefPtr modelPlayer = m_modelPlayer;
-    return !modelPlayer || modelPlayer->isPlaceholder();
+    return !isVisible() && m_model && !hasLiveModelPlayer();
 }
 
 String HTMLModelElement::modelElementStateForTesting() const

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -351,6 +351,7 @@ private:
     void sourceRequestResource();
     bool shouldDeferLoading() const;
     bool NODELETE isModelDeferred() const;
+    bool hasLiveModelPlayer() const;
     bool isModelLoading() const;
     bool isModelLoaded() const;
     bool isModelUnloading() const;

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
@@ -46,12 +46,14 @@
 #include "ModelPlayerClient.h"
 #include "ModelPlayerProvider.h"
 #include "Page.h"
+#include "PlaceholderModelPlayer.h"
 #include "RenderBox.h"
 #include "RenderBoxInlines.h"
 #include "RenderLayer.h"
 #include "RenderLayerBacking.h"
 #include "RenderLayerModelObject.h"
 #include "ResourceError.h"
+#include "VisibilityChangeClient.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
@@ -160,6 +162,31 @@ private:
     const WeakPtr<SpatialPortalController> m_controller;
 };
 
+class PortalVisibilityChangeClient final : public RefCounted<PortalVisibilityChangeClient>, public VisibilityChangeClient {
+public:
+    static Ref<PortalVisibilityChangeClient> create(SpatialPortalController& controller)
+    {
+        return adoptRef(*new PortalVisibilityChangeClient(controller));
+    }
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
+    explicit PortalVisibilityChangeClient(SpatialPortalController& controller)
+        : m_controller(controller)
+    {
+    }
+
+    void visibilityStateChanged() final
+    {
+        if (CheckedPtr controller = m_controller.get())
+            controller->documentVisibilityChanged();
+    }
+
+    const WeakPtr<SpatialPortalController> m_controller;
+};
+
 class PortalIntersectionObserverCallback final : public IntersectionObserverCallback {
 public:
     static Ref<PortalIntersectionObserverCallback> create(Document& document, SpatialPortalController& controller)
@@ -205,10 +232,10 @@ SpatialPortalController::SpatialPortalController(Element& element)
 
 SpatialPortalController::~SpatialPortalController()
 {
-    if (RefPtr observer = m_intersectionObserver)
-        observer->disconnect();
-
     ASSERT(!m_handlesGesture);
+
+    m_intersectionObserver = nullptr;
+    m_visibilityChangeClient = nullptr;
 
     deleteModelPlayer();
 }
@@ -217,16 +244,8 @@ void SpatialPortalController::prepareForRemoval()
 {
     m_portalAction = PortalActionKind::None;
     updateGestureHandling();
-}
 
-unsigned SpatialPortalController::numberOfLoadedModels() const
-{
-    unsigned count = 0;
-    for (auto& hostedModel : m_hostedModels.values()) {
-        if (hostedModel.loadedModel)
-            ++count;
-    }
-    return count;
+    stopObservingPortalVisibility();
 }
 
 HTMLModelElement* SpatialPortalController::hostedModelElement(NodeIdentifier nodeID) const
@@ -249,8 +268,11 @@ void SpatialPortalController::unregisterChildModel(HTMLModelElement& model)
     if (RefPtr player = m_modelPlayer)
         player->unload(nodeID);
 
-    if (m_hostedModels.isEmpty())
+    if (m_hostedModels.isEmpty()) {
         deleteModelPlayer();
+        stopObservingPortalVisibility();
+        reconfigurePortalLayer();
+    }
 }
 
 void SpatialPortalController::registerChildModel(HTMLModelElement& model)
@@ -262,7 +284,6 @@ void SpatialPortalController::registerChildModel(HTMLModelElement& model)
     observePortalVisibility();
 
     model.visibilityStateChanged();
-    loadChildModelIfReady(model);
 }
 
 void SpatialPortalController::childModelDidChange(HTMLModelElement& model)
@@ -303,22 +324,52 @@ void SpatialPortalController::loadChildModelIfReady(HTMLModelElement& model)
 
     it->value.loadedModel = modelData;
 
+    if (RefPtr<ModelPlayer> placeholder = std::exchange(it->value.placeholder, nullptr)) {
+        auto animationState = placeholder->currentAnimationState(nodeID);
+        auto transformState = placeholder->currentTransformState(nodeID);
+        if (animationState && transformState) {
+            player->reload(nodeID, *modelData, portalContentSize(), *animationState, WTF::move(*transformState));
+            return;
+        }
+    }
+
 #if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
     model.applyInitialAnimationState(*player);
 #endif
     player->load(nodeID, *modelData, portalContentSize(), false);
 }
 
+bool SpatialPortalController::childIsLoaded(NodeIdentifier nodeID) const
+{
+    auto it = m_hostedModels.find(nodeID);
+    return it != m_hostedModels.end() && !!it->value.loadedModel;
+}
+
+ModelPlayer* SpatialPortalController::playerForChild(NodeIdentifier nodeID) const
+{
+    auto it = m_hostedModels.find(nodeID);
+    if (it != m_hostedModels.end() && it->value.placeholder)
+        return it->value.placeholder.get();
+
+    return m_modelPlayer.get();
+}
+
 void SpatialPortalController::observePortalVisibility()
 {
-    if (m_intersectionObserver)
-        return;
-
     RefPtr element = m_portalElement.get();
     if (!element)
         return;
 
     Ref document = element->document();
+
+    if (!m_visibilityChangeClient) {
+        m_visibilityChangeClient = PortalVisibilityChangeClient::create(*this);
+        document->registerForVisibilityStateChangedCallbacks(*m_visibilityChangeClient);
+    }
+
+    if (m_intersectionObserver)
+        return;
+
     auto callback = PortalIntersectionObserverCallback::create(document, *this);
     IntersectionObserver::Init options { .scrollMargin = "100%"_s };
     auto observer = IntersectionObserver::create(document, WTF::move(callback), WTF::move(options));
@@ -327,6 +378,19 @@ void SpatialPortalController::observePortalVisibility()
 
     m_intersectionObserver = observer.returnValue().ptr();
     m_intersectionObserver->observe(*element);
+}
+
+void SpatialPortalController::stopObservingPortalVisibility()
+{
+    if (RefPtr observer = std::exchange(m_intersectionObserver, nullptr))
+        observer->disconnect();
+
+    if (RefPtr client = std::exchange(m_visibilityChangeClient, nullptr)) {
+        if (RefPtr element = m_portalElement.get())
+            element->document().unregisterForVisibilityStateChangedCallbacks(*client);
+    }
+
+    m_isIntersectingViewport = false;
 }
 
 void SpatialPortalController::viewportIntersectionChanged(bool isIntersecting)
@@ -343,9 +407,18 @@ void SpatialPortalController::viewportIntersectionChanged(bool isIntersecting)
         if (RefPtr element = hostedModel.element.get())
             element->visibilityStateChanged();
     }
+}
 
-    if (isIntersecting)
-        loadChildModelsIfReady();
+void SpatialPortalController::documentVisibilityChanged()
+{
+    if (RefPtr player = m_modelPlayer)
+        player->visibilityStateDidChange();
+}
+
+void SpatialPortalController::childVisibilityStateChanged(HTMLModelElement& child)
+{
+    if (isPortalVisible())
+        loadChildModelIfReady(child);
 }
 
 ModelPlayer* SpatialPortalController::ensureModelPlayer()
@@ -499,13 +572,66 @@ void SpatialPortalController::deleteModelPlayer()
 void SpatialPortalController::unloadChildModel(NodeIdentifier nodeID)
 {
     auto it = m_hostedModels.find(nodeID);
-    if (it == m_hostedModels.end() || !it->value.loadedModel)
+    if (it == m_hostedModels.end())
+        return;
+
+    it->value.placeholder = nullptr;
+
+    if (!it->value.loadedModel)
         return;
 
     it->value.loadedModel = nullptr;
 
     if (RefPtr player = m_modelPlayer)
         player->unload(nodeID);
+}
+
+void SpatialPortalController::saveChildState(NodeIdentifier nodeID, HostedModel& hostedModel, bool onSuspend)
+{
+    RefPtr player = m_modelPlayer;
+    if (!player || !hostedModel.loadedModel)
+        return;
+
+    auto animationState = player->currentAnimationState(nodeID);
+    auto transformState = player->currentTransformState(nodeID);
+    if (!animationState || !transformState)
+        return;
+
+    hostedModel.placeholder = PlaceholderModelPlayer::create(onSuspend, *animationState, WTF::move(*transformState));
+}
+
+void SpatialPortalController::unloadAllChildModels()
+{
+    if (!m_modelPlayer)
+        return;
+
+    for (auto& entry : m_hostedModels)
+        saveChildState(entry.key, entry.value, /* onSuspend */ false);
+
+    deleteModelPlayer();
+}
+
+void SpatialPortalController::childWasSuspended(HTMLModelElement& child)
+{
+    RefPtr player = m_modelPlayer;
+    if (!player)
+        return;
+
+    auto nodeID = child.nodeIdentifier();
+    auto it = m_hostedModels.find(nodeID);
+    if (it == m_hostedModels.end())
+        return;
+
+    saveChildState(nodeID, it->value, /* onSuspend */ true);
+    it->value.loadedModel = nullptr;
+    player->unload(nodeID);
+
+    for (auto& hostedModel : m_hostedModels.values()) {
+        if (hostedModel.loadedModel)
+            return;
+    }
+
+    deleteModelPlayer();
 }
 
 LayoutSize SpatialPortalController::portalContentSize() const
@@ -520,6 +646,11 @@ LayoutSize SpatialPortalController::portalContentSize() const
 
 void SpatialPortalController::configureGraphicsLayer(GraphicsLayer& graphicsLayer, const Color& backgroundColor)
 {
+    if (m_hostedModels.isEmpty()) {
+        graphicsLayer.removeModelContents();
+        return;
+    }
+
     RefPtr player = ensureModelPlayer();
     if (!player)
         return;
@@ -582,7 +713,7 @@ void SpatialPortalController::modelDidUnload(ModelPlayer& player)
     if (m_modelPlayer != &player)
         return;
 
-    deleteModelPlayer();
+    unloadAllChildModels();
     // FIXME: rdar://148027600 Prevent infinite reloading of model.
     loadChildModelsIfReady();
 }
@@ -615,10 +746,15 @@ void SpatialPortalController::logWarning(ModelPlayer& player, const String& warn
 
 void SpatialPortalController::reconfigurePortalLayer()
 {
-    if (RefPtr element = m_portalElement.get()) {
-        if (CheckedPtr renderer = dynamicDowncast<RenderLayerModelObject>(element->renderer()))
-            renderer->contentChanged(ContentChangeType::Model);
-    }
+    RefPtr element = m_portalElement.get();
+    if (!element)
+        return;
+
+    CheckedPtr renderer = dynamicDowncast<RenderLayerModelObject>(element->renderer());
+    if (!renderer || renderer->renderTreeBeingDestroyed())
+        return;
+
+    renderer->contentChanged(ContentChangeType::Model);
 }
 
 RefPtr<GraphicsLayer> SpatialPortalController::portalGraphicsLayer() const

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.h
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.h
@@ -50,7 +50,9 @@ class Model;
 class ModelPlayer;
 class ModelPlayerProvider;
 class Page;
+class PlaceholderModelPlayer;
 class PortalModelPlayerClient;
+class PortalVisibilityChangeClient;
 class ResourceError;
 class SpatialPortalEventListener;
 class WeakPtrImplWithEventTargetData;
@@ -61,6 +63,7 @@ class SpatialPortalController : public CanMakeWeakPtr<SpatialPortalController>, 
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SpatialPortalController);
     friend class PortalModelPlayerClient;
     friend class PortalIntersectionObserverCallback;
+    friend class PortalVisibilityChangeClient;
 public:
     explicit SpatialPortalController(Element&);
     ~SpatialPortalController();
@@ -70,11 +73,13 @@ public:
     void unregisterChildModel(HTMLModelElement&);
     void registerChildModel(HTMLModelElement&);
     void childModelDidChange(HTMLModelElement&);
+    void childVisibilityStateChanged(HTMLModelElement&);
+    void childWasSuspended(HTMLModelElement&);
 
-    ModelPlayer* modelPlayer() const { return m_modelPlayer.get(); }
     Element* portalElement() const { return m_portalElement.get(); }
     unsigned numberOfHostedModels() const { return m_hostedModels.size(); }
-    WEBCORE_EXPORT unsigned numberOfLoadedModels() const;
+    bool childIsLoaded(NodeIdentifier) const;
+    ModelPlayer* playerForChild(NodeIdentifier) const;
     void configureGraphicsLayer(GraphicsLayer&, const Color& backgroundColor);
     void sizeMayHaveChanged();
 
@@ -94,6 +99,12 @@ public:
     bool isPortalVisible() const;
 
 private:
+    struct HostedModel {
+        WeakPtr<HTMLModelElement, WeakPtrImplWithEventTargetData> element;
+        RefPtr<Model> loadedModel;
+        RefPtr<PlaceholderModelPlayer> placeholder;
+    };
+
     void modelDidFinishLoading(ModelPlayer&, NodeIdentifier);
     void modelDidFailLoading(ModelPlayer&, NodeIdentifier, const ResourceError&);
     void modelDidUnload(ModelPlayer&);
@@ -102,24 +113,24 @@ private:
     void logWarning(ModelPlayer&, const String&);
     RefPtr<GraphicsLayer> portalGraphicsLayer() const;
     void viewportIntersectionChanged(bool isIntersecting);
+    void documentVisibilityChanged();
 
     ModelPlayer* ensureModelPlayer();
     void loadChildModelsIfReady();
     void loadChildModelIfReady(HTMLModelElement&);
     void deleteModelPlayer();
     void unloadChildModel(NodeIdentifier);
+    void unloadAllChildModels();
+    void saveChildState(NodeIdentifier, HostedModel&, bool onSuspend);
     HTMLModelElement* hostedModelElement(NodeIdentifier) const;
     void reconfigurePortalLayer();
     void observePortalVisibility();
+    void stopObservingPortalVisibility();
     LayoutSize portalContentSize() const;
     void updateGestureHandling();
 
     const WeakPtr<Element, WeakPtrImplWithEventTargetData> m_portalElement;
 
-    struct HostedModel {
-        WeakPtr<HTMLModelElement, WeakPtrImplWithEventTargetData> element;
-        RefPtr<Model> loadedModel;
-    };
     HashMap<NodeIdentifier, HostedModel> m_hostedModels;
 
     WeakPtr<ModelPlayerProvider> m_modelPlayerProvider;
@@ -129,6 +140,7 @@ private:
     RefPtr<ModelPlayer> m_modelPlayer;
     const RefPtr<PortalModelPlayerClient> m_playerClient;
     RefPtr<IntersectionObserver> m_intersectionObserver;
+    RefPtr<PortalVisibilityChangeClient> m_visibilityChangeClient;
 #if ENABLE(TOUCH_EVENTS)
     RefPtr<SpatialPortalEventListener> m_eventListener;
 #endif

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -400,7 +400,7 @@ public:
 #if ENABLE(MODEL_CONTEXT)
     virtual void setContentsToModelContext(Ref<ModelContext>, ContentsLayerPurpose) { }
 #endif
-#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE) || ENABLE(SPATIAL_PORTAL)
     virtual void removeModelContents() { }
 #endif
     virtual void setContentsToVideoElement(HTMLVideoElement&, ContentsLayerPurpose) { }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1464,7 +1464,7 @@ void GraphicsLayerCA::setContentsToModelContext(Ref<ModelContext> modelContext, 
 }
 #endif
 
-#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE) || ENABLE(SPATIAL_PORTAL)
 void GraphicsLayerCA::removeModelContents()
 {
     if (!m_contentsLayer)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -178,7 +178,7 @@ public:
 #if ENABLE(MODEL_CONTEXT) && !ENABLE(GPU_PROCESS_MODEL)
     WEBCORE_EXPORT void setContentsToModelContext(Ref<ModelContext>, ContentsLayerPurpose) override;
 #endif
-#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE) || ENABLE(SPATIAL_PORTAL)
     WEBCORE_EXPORT void removeModelContents() override;
 #endif
     WEBCORE_EXPORT void setContentsToVideoElement(HTMLVideoElement&, ContentsLayerPurpose) override;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -208,7 +208,7 @@ void RenderBox::willBeDestroyed()
     }
 
 #if ENABLE(SPATIAL_PORTAL)
-    if (hasInitializedStyle() && style().spatial() == SpatialType::Portal) {
+    if (hasInitializedStyle() && style().spatial() == SpatialType::Portal && !renderTreeBeingDestroyed()) {
         if (RefPtr element = this->element())
             element->clearSpatialPortalController();
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -8755,12 +8755,6 @@ unsigned Internals::numberOfHostedModelsInSpatialPortal(Element& element)
     return controller ? controller->numberOfHostedModels() : 0;
 }
 
-unsigned Internals::numberOfLoadedModelsInSpatialPortal(Element& element)
-{
-    CheckedPtr controller = element.spatialPortalController();
-    return controller ? controller->numberOfLoadedModels() : 0;
-}
-
 bool Internals::establishesSpatialPortal(Element& element)
 {
     return element.establishesSpatialPortal();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1696,7 +1696,6 @@ public:
 
 #if ENABLE(SPATIAL_PORTAL)
     unsigned NODELETE numberOfHostedModelsInSpatialPortal(Element&);
-    unsigned NODELETE numberOfLoadedModelsInSpatialPortal(Element&);
     bool NODELETE establishesSpatialPortal(Element&);
     std::optional<Vector<double>> NODELETE spatialPortalResolvedTransform(Element&);
 #endif

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1553,7 +1553,6 @@ enum ContentsFormat {
     [Conditional=MODEL_ELEMENT] boolean isModelElementIntersectingViewport(HTMLModelElement element);
 
     [Conditional=SPATIAL_PORTAL] unsigned long numberOfHostedModelsInSpatialPortal(Element element);
-    [Conditional=SPATIAL_PORTAL] unsigned long numberOfLoadedModelsInSpatialPortal(Element element);
     [Conditional=SPATIAL_PORTAL] boolean establishesSpatialPortal(Element element);
     [Conditional=SPATIAL_PORTAL] sequence<unrestricted double>? spatialPortalResolvedTransform(Element element);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpatialPortal.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpatialPortal.mm
@@ -80,6 +80,96 @@ TEST(SpatialPortal, DisabledRendersModelsStandalone)
     EXPECT_EQ([webView modelProcessModelPlayerCount], 2u);
 }
 
+static void enableSpatialPortalPreferences(WKWebViewConfiguration *configuration)
+{
+    [configuration _setAllowTestOnlyIPC:YES];
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)configuration.preferences, true, WKStringCreateWithUTF8CString("ModelElementEnabled"));
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)configuration.preferences, true, WKStringCreateWithUTF8CString("ModelProcessEnabled"));
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)configuration.preferences, true, WKStringCreateWithUTF8CString("SpatialPortalEnabled"));
+}
+
+// A spatial portal shares one player across its children, so a leaked portal leaks the whole group.
+// These mirror ModelProcess.mm's clean-up tests, which cover the same paths for a standalone <model>.
+TEST(SpatialPortal, CleanUpOnNavigate)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableSpatialPortalPreferences(configuration.get());
+
+    RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"spatial-portal-two-models-page"];
+
+    while (![messageHandler modelIsReady])
+        Util::spinRunLoop();
+
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 1u);
+
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 0u);
+}
+
+TEST(SpatialPortal, CleanUpOnReload)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableSpatialPortalPreferences(configuration.get());
+
+    RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"spatial-portal-two-models-page"];
+
+    while (![messageHandler modelIsReady])
+        Util::spinRunLoop();
+
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 1u);
+
+    [messageHandler setModelIsReady:NO];
+    [webView reload];
+
+    while (![messageHandler modelIsReady])
+        Util::spinRunLoop();
+
+    // Still one: the reloaded portal must not leave the previous page's player behind.
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 1u);
+}
+
+TEST(SpatialPortal, CleanUpOnHide)
+{
+    WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    enableSpatialPortalPreferences(configuration);
+
+    RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
+    [configuration.userContentController addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration]);
+    [webView synchronouslyLoadTestPageNamed:@"spatial-portal-two-models-page"];
+
+    bool isHidden = false;
+    [webView performAfterReceivingMessage:@"hidden" action:[&] { isHidden = true; }];
+    [webView objectByEvaluatingJavaScript:@"document.addEventListener('visibilitychange', event => { if (document.hidden) window.webkit.messageHandlers.testHandler.postMessage('hidden') })"];
+
+    while (![messageHandler modelIsReady])
+        Util::spinRunLoop();
+
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 1u);
+
+    [webView objectByEvaluatingJavaScript:@"window.internals.setPageVisibility(false)"];
+    TestWebKitAPI::Util::run(&isHidden);
+
+    // Hiding reaches the portal's player through its children, and the model process then unloads it.
+    // That is a cross-process round trip, so the count drops shortly after visibilitychange rather
+    // than synchronously with it.
+    while ([webView modelProcessModelPlayerCount])
+        Util::spinRunLoop();
+
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 0u);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(MODEL_PROCESS) && ENABLE(SPATIAL_PORTAL)


### PR DESCRIPTION
#### 6caa27b1860bcdbd79a677185a2b8246bccc291d
<pre>
Implement child model lifecycle for spatial portals
<a href="https://bugs.webkit.org/show_bug.cgi?id=321324">https://bugs.webkit.org/show_bug.cgi?id=321324</a>
<a href="https://rdar.apple.com/182292370">rdar://182292370</a>

Reviewed by Etienne Segonzac.

A &lt;model&gt; inside a `spatial: portal` has no renderer of its own, so the
renderer- and player-driven lifecycle paths in HTMLModelElement did nothing for
it. The portal now drives them: its children forward visibility and suspension
to the controller, which owns the ModelPlayer they share and saves each child&apos;s
state in a PlaceholderModelPlayer, so a reload resumes rather than restarts.
Resource loading stays with the element. A child now behaves as a standalone
&lt;model&gt; does.

Tests: spatial-css/spatial-portal-lifecycle-visibility.html
       spatial-css/spatial-portal-display-none.html
       spatial-css/spatial-portal-on-hidden-page.html
       spatial-css/spatial-portal-suspend-resume.html
       spatial-css/spatial-portal-scroll-to-unload.html
       spatial-css/spatial-portal-layers-dynamic.html
       TestWebKitAPI.SpatialPortal.CleanUpOnNavigate/OnReload/OnHide

* LayoutTests/model-element/model-element-suspend-resume.html:
Its pageshow handler now declares the event parameter it was reading from the global.

* LayoutTests/spatial-css/spatial-portal-action-multi-model.html:
* LayoutTests/spatial-css/spatial-portal-display-none-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-display-none.html: Added.
* LayoutTests/spatial-css/spatial-portal-layers-dynamic-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-layers-dynamic.html: Added.
* LayoutTests/spatial-css/spatial-portal-lifecycle-visibility-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-lifecycle-visibility.html: Added.
* LayoutTests/spatial-css/spatial-portal-multi-model-error.html:
* LayoutTests/spatial-css/spatial-portal-multi-model-source-change.html:
* LayoutTests/spatial-css/spatial-portal-on-hidden-page-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-on-hidden-page.html: Added.
* LayoutTests/spatial-css/spatial-portal-scroll-to-load.html:
* LayoutTests/spatial-css/spatial-portal-scroll-to-unload-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-scroll-to-unload.html: Added.
* LayoutTests/spatial-css/spatial-portal-suspend-resume-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-suspend-resume.html: Added.
Six new tests cover visibility unload/reload, teardown with the portal&apos;s box, the
hidden-page and back/forward cache cases, scrolling out and back, and the layers
left behind when a portal&apos;s last model goes away. The four existing ones move to
per-element internals.modelElementState().

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::suspend):
(WebCore::HTMLModelElement::resume):
(WebCore::HTMLModelElement::visibilityStateChanged):
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::modelPlayerForAnimation const):
(WebCore::HTMLModelElement::stop):
(WebCore::HTMLModelElement::hasLiveModelPlayer const):
API reaches the child&apos;s placeholder while it is unloaded.

(WebCore::HTMLModelElement::isModelLoading const):
(WebCore::HTMLModelElement::isModelLoaded const):
(WebCore::HTMLModelElement::isModelUnloading const):
(WebCore::HTMLModelElement::isModelUnloaded const):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/SpatialPortalController.cpp:
(WebCore::SpatialPortalController::~SpatialPortalController):
(WebCore::SpatialPortalController::prepareForRemoval):
(WebCore::SpatialPortalController::unregisterChildModel):
(WebCore::SpatialPortalController::registerChildModel):
(WebCore::SpatialPortalController::loadChildModelsIfReady):
(WebCore::SpatialPortalController::loadChildModelIfReady):
(WebCore::SpatialPortalController::childIsLoaded const):
(WebCore::SpatialPortalController::playerForChild const):
(WebCore::SpatialPortalController::observePortalVisibility):
(WebCore::SpatialPortalController::stopObservingPortalVisibility):
(WebCore::SpatialPortalController::viewportIntersectionChanged):
(WebCore::SpatialPortalController::documentVisibilityChanged):
(WebCore::SpatialPortalController::childVisibilityStateChanged):
(WebCore::SpatialPortalController::unloadChildModel):
(WebCore::SpatialPortalController::saveChildState):
(WebCore::SpatialPortalController::unloadAllChildModels):
(WebCore::SpatialPortalController::childWasSuspended):
(WebCore::SpatialPortalController::configureGraphicsLayer):
(WebCore::SpatialPortalController::modelDidUnload):
(WebCore::SpatialPortalController::reconfigurePortalLayer):
(WebCore::SpatialPortalController::numberOfLoadedModels const): Deleted.
Suspension is per child; the last out deletes the shared player, after state
capture. The controller observes document visibility so the player hears it once.

* Source/WebCore/Modules/model-element/SpatialPortalController.h:
(WebCore::SpatialPortalController::modelPlayer const): Deleted.
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
removeModelContents() is no longer immersive-only; a portal needs it too.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::willBeDestroyed):
Clear the portal controller, but not while the render tree is being destroyed: the
back/forward cache destroys it before suspending, and the player must outlive that
for suspend() to save state.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::numberOfLoadedModelsInSpatialPortal): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
modelElementState() answers for portal children now.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpatialPortal.mm:
(TestWebKitAPI::enableSpatialPortalPreferences):
(TestWebKitAPI::TEST(SpatialPortal, CleanUpOnNavigate)):
(TestWebKitAPI::TEST(SpatialPortal, CleanUpOnReload)):
(TestWebKitAPI::TEST(SpatialPortal, CleanUpOnHide)):
Portal clean-up tests, mirroring ModelProcess.mm&apos;s.

Canonical link: <a href="https://commits.webkit.org/319008@main">https://commits.webkit.org/319008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2654b37d875336a8b3a79001622a39046c5555dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144433 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fcd0865-162d-45f4-a122-97a0cd7dadf4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140471 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27c2cf47-eded-4de0-b840-543538134493) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183070 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161250 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120923 "Found 1 new API test failure: TestWebKit.WebKit.PageLoadState (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50a4983c-4d16-403f-8fd3-02b4b4676d91) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41108 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153199 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40778 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1485 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46659 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45360 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192260 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160767 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149817 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40128 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54414 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149544 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44184 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126677 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121794 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52931 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15765 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52313 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52550 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52378 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->