### PR TITLE
[Custom Highlight] -webkit-text-stroke should apply to highlighted text.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8138,8 +8138,6 @@ webkit.org/b/308096 imported/w3c/web-platform-tests/css/cssom-view/scrollParent.
 webkit.org/b/296130 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-4.html [ Pass Failure ]
 webkit.org/b/281267 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html [ Pass Failure ]
 
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-021.html [ ImageOnlyFailure ]
-
 imported/w3c/web-platform-tests/cookies/third-party-cookies/third-party-cookie-heuristics.tentative.https.html [ Skip ] # Timeout
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-006.html [ Skip ] # Timeout
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_allow_top_navigation_by_user_activation_with_user_gesture.html [ Skip ] # Timeout

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -28,9 +28,13 @@
 
 #include "ColorBlending.h"
 #include "ElementRuleCollector.h"
+#include "IntSize.h"
+#include "LocalFrameView.h"
 #include "RenderElement.h"
+#include "RenderObjectDocument.h"
 #include "RenderText.h"
 #include "RenderTheme.h"
+#include "RenderView.h"
 #include "RenderedDocumentMarker.h"
 #include "StyleComputedStyle+GettersInlines.h"
 
@@ -61,7 +65,7 @@ static void computeDecorationStylesForPseudoElementStyle(StyledMarkedText::Style
     }
 }
 
-static void computeStyleForPseudoElementStyle(StyledMarkedText::Style& style, const Style::ComputedStyle* pseudoElementStyle, const PaintInfo& paintInfo)
+static void computeStyleForPseudoElementStyle(StyledMarkedText::Style& style, const Style::ComputedStyle* pseudoElementStyle, IntSize viewportSize, const PaintInfo& paintInfo)
 {
     if (!pseudoElementStyle)
         return;
@@ -69,7 +73,12 @@ static void computeStyleForPseudoElementStyle(StyledMarkedText::Style& style, co
     CheckedRef checkedPseudoElementStyle = *pseudoElementStyle;
     style.backgroundColor = checkedPseudoElementStyle->visitedDependentBackgroundColorApplyingColorFilter(paintInfo.paintBehavior);
     style.textStyles.fillColor = checkedPseudoElementStyle->visitedDependentTextFillColorApplyingColorFilter(paintInfo.paintBehavior);
-    style.textStyles.strokeColor = checkedPseudoElementStyle->usedStrokeColor();
+    // Highlight pseudos apply only the unprefixed stroke properties; the legacy -webkit-text-stroke pair does not apply, so don't inherit the originating element's text stroke.
+    if (checkedPseudoElementStyle->hasExplicitlySetStrokeColor()) {
+        style.textStyles.strokeColor = checkedPseudoElementStyle->usedStrokeColor();
+        style.textStyles.strokeWidth = checkedPseudoElementStyle->usedStrokeWidth(viewportSize);
+    } else
+        style.textStyles.strokeWidth = 0;
     style.textStyles.hasExplicitlySetFillColor = checkedPseudoElementStyle->hasExplicitlySetColor();
 
     computeDecorationStylesForPseudoElementStyle(style, checkedPseudoElementStyle.get(), paintInfo);
@@ -77,7 +86,7 @@ static void computeStyleForPseudoElementStyle(StyledMarkedText::Style& style, co
     style.textShadow = checkedPseudoElementStyle->textShadow();
 }
 
-static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, const StyledMarkedText::Style& baseStyle, const RenderText& renderer, const Style::ComputedStyle& lineStyle, const PaintInfo& paintInfo)
+static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, const StyledMarkedText::Style& baseStyle, const RenderText& renderer, const Style::ComputedStyle& lineStyle, IntSize viewportSize, const PaintInfo& paintInfo)
 {
     static constexpr OptionSet systemAppearanceOptions { StyleColorOptions::UseSystemAppearance };
 
@@ -96,22 +105,22 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
         break;
     case MarkedText::Type::GrammarError: {
         auto* renderStyle = renderer.grammarErrorPseudoStyle();
-        computeStyleForPseudoElementStyle(style, renderStyle, paintInfo);
+        computeStyleForPseudoElementStyle(style, renderStyle, viewportSize, paintInfo);
         break;
     }
     case MarkedText::Type::Highlight: {
         auto renderStyle = renderer.parent()->resolvePseudoElementStyle({ PseudoElementType::Highlight, markedText.highlightName }, &renderer.style());
-        computeStyleForPseudoElementStyle(style, renderStyle.get(), paintInfo);
+        computeStyleForPseudoElementStyle(style, renderStyle.get(), viewportSize, paintInfo);
         break;
     }
     case MarkedText::Type::SpellingError: {
         auto* renderStyle = renderer.spellingErrorPseudoStyle();
-        computeStyleForPseudoElementStyle(style, renderStyle, paintInfo);
+        computeStyleForPseudoElementStyle(style, renderStyle, viewportSize, paintInfo);
         break;
     }
     case MarkedText::Type::FragmentHighlight: {
         if (CheckedPtr renderStyle = renderer.targetTextPseudoStyle()) {
-            computeStyleForPseudoElementStyle(style, renderStyle.get(), paintInfo);
+            computeStyleForPseudoElementStyle(style, renderStyle.get(), viewportSize, paintInfo);
             break;
         }
 
@@ -225,9 +234,12 @@ static Vector<StyledMarkedText> coalesceAdjacentWithSameRanges(Vector<StyledMark
             // Take text color of StyledMarkedText, maintaining insertion and priority order.
             if (text.type != MarkedText::Type::Unmarked && text.style.textStyles.hasExplicitlySetFillColor)
                 previousStyledMarkedText.style.textStyles.fillColor = text.style.textStyles.fillColor;
-            // Take the text-shadow of the frontmost highlight.
-            if (!text.highlightName.isNull())
+            // Take the text-shadow and stroke of the frontmost highlight.
+            if (!text.highlightName.isNull()) {
                 previousStyledMarkedText.style.textShadow = text.style.textShadow;
+                previousStyledMarkedText.style.textStyles.strokeColor = text.style.textStyles.strokeColor;
+                previousStyledMarkedText.style.textStyles.strokeWidth = text.style.textStyles.strokeWidth;
+            }
             // Take the highlightName of the latest StyledMarkedText, regardless of priority.
             if (!text.highlightName.isNull())
                 previousStyledMarkedText.highlightName = text.highlightName;
@@ -296,6 +308,8 @@ Vector<StyledMarkedText> StyledMarkedText::subdivideAndResolve(const Vector<Mark
         return { styledMarkedText };
     }
 
+    auto viewportSize = renderer.view().frameView().size();
+
     auto markedTexts = MarkedText::subdivide(textsToSubdivide, OverlapStrategy::None);
     ASSERT(!markedTexts.isEmpty());
     if (markedTexts.isEmpty()) [[unlikely]]
@@ -312,7 +326,7 @@ Vector<StyledMarkedText> StyledMarkedText::subdivideAndResolve(const Vector<Mark
             orderHighlights(markedTextsNames, markedTexts);
 
             auto frontmostMarkedTexts = WTF::map(markedTexts, [&](auto& markedText) {
-                return resolveStyleForMarkedText(markedText, baseStyle, renderer, lineStyle, paintInfo);
+                return resolveStyleForMarkedText(markedText, baseStyle, renderer, lineStyle, viewportSize, paintInfo);
             });
 
             return coalesceAdjacentWithSameRanges(WTF::move(frontmostMarkedTexts));
@@ -322,16 +336,16 @@ Vector<StyledMarkedText> StyledMarkedText::subdivideAndResolve(const Vector<Mark
     // Compute frontmost overlapping styled marked texts.
     Vector<StyledMarkedText> frontmostMarkedTexts;
     frontmostMarkedTexts.reserveInitialCapacity(markedTexts.size());
-    frontmostMarkedTexts.append(resolveStyleForMarkedText(markedTexts[0], baseStyle, renderer, lineStyle, paintInfo));
+    frontmostMarkedTexts.append(resolveStyleForMarkedText(markedTexts[0], baseStyle, renderer, lineStyle, viewportSize, paintInfo));
     for (size_t i = 1; i < markedTexts.size(); ++i) {
         auto& text = markedTexts[i];
         auto& previousStyledMarkedText = frontmostMarkedTexts.last();
         // Marked texts completely cover each other.
         if (previousStyledMarkedText.startOffset == text.startOffset && previousStyledMarkedText.endOffset == text.endOffset) {
-            previousStyledMarkedText = resolveStyleForMarkedText(text, previousStyledMarkedText.style, renderer, lineStyle, paintInfo);
+            previousStyledMarkedText = resolveStyleForMarkedText(text, previousStyledMarkedText.style, renderer, lineStyle, viewportSize, paintInfo);
             continue;
         }
-        frontmostMarkedTexts.append(resolveStyleForMarkedText(text, baseStyle, renderer, lineStyle, paintInfo));
+        frontmostMarkedTexts.append(resolveStyleForMarkedText(text, baseStyle, renderer, lineStyle, viewportSize, paintInfo));
     }
 
     return frontmostMarkedTexts;

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -696,6 +696,29 @@ void TextBoxPainter::paintForeground(const StyledMarkedText& markedText)
 
     if (isInsideShapedContent() && paintForegroundForShapeRange(textPainter))
         return;
+
+    // Backgrounds paint before all text, so clip a stroked partial segment to its forward edge to keep its stroke overflow off a following highlight's background (adjacent inline boxes composite this way); the slack leaves the other edges effectively unclipped.
+    GraphicsContextStateSaver clipStateSaver(context, false);
+    if (markedText.style.textStyles.strokeWidth > 0 && markedText.endOffset < m_paintTextRun.length()) {
+        LayoutRect segmentRect { m_paintRect };
+        fontCascade().adjustSelectionRectForText(m_renderer->canUseSimplifiedTextMeasuring().value_or(false), m_paintTextRun, segmentRect, markedText.startOffset, markedText.endOffset);
+        auto snapped = snapRectToDevicePixelsWithWritingDirection(segmentRect, m_document->deviceScaleFactor(), m_paintTextRun.ltr());
+        static constexpr float overflowSlack = 4096;
+        bool ltr = m_paintTextRun.ltr();
+        FloatRect clipRect;
+        if (writingMode().isHorizontal()) {
+            float minX = ltr ? m_paintRect.x() - overflowSlack : snapped.x();
+            float maxX = ltr ? snapped.maxX() : m_paintRect.maxX() + overflowSlack;
+            clipRect = { minX, m_paintRect.y() - overflowSlack, maxX - minX, m_paintRect.height() + 2 * overflowSlack };
+        } else {
+            float minY = ltr ? m_paintRect.y() - overflowSlack : snapped.y();
+            float maxY = ltr ? snapped.maxY() : m_paintRect.maxY() + overflowSlack;
+            clipRect = { m_paintRect.x() - overflowSlack, minY, m_paintRect.width() + 2 * overflowSlack, maxY - minY };
+        }
+        clipStateSaver.save();
+        context.clip(clipRect);
+    }
+
     textPainter.setGlyphDisplayListIfNeeded(textBox().box(), m_paintInfo, m_style, m_paintTextRun);
     // TextPainter wants the box rectangle and text origin of the entire line box.
     textPainter.paintRange(m_paintTextRun, m_paintRect, textOriginFromPaintRect(m_paintRect), markedText.startOffset, markedText.endOffset);


### PR DESCRIPTION
#### 77d492d396f8be3fff8542d95bb8af9eea8358a5
<pre>
[Custom Highlight] -webkit-text-stroke should apply to highlighted text.
<a href="https://bugs.webkit.org/show_bug.cgi?id=321341">https://bugs.webkit.org/show_bug.cgi?id=321341</a>
<a href="https://rdar.apple.com/184375039">rdar://184375039</a>

Reviewed by Wenson Hsieh and Antti Koivisto.

The originating element&apos;s stroke width leaked into highlighted text, and the
highlight&apos;s own stroke was never painted.
Three changes fix it:
1) Mark -webkit-text-stroke-width as applying to highlight pseudo-elements so it
resolves to its initial 0px through the highlight cascade instead of inheriting the
element&apos;s value
2) Carry the pseudo&apos;s stroke width into the marked-text paint style in StyledMarkedText
(and propagate stroke width/color through coalesceAdjacentWithSameRanges, which dropped
them like it once did text-shadow)
3) Clip a stroked, partially-highlighted segment to its forward edge in TextBoxPainter
so a non-highlighted glyph&apos;s stroke overflow no longer paints over an adjacent highlight&apos;s
background.

imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-021.html

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::computeStyleForPseudoElementStyle):
(WebCore::resolveStyleForMarkedText):
(WebCore::coalesceAdjacentWithSameRanges):
(WebCore::StyledMarkedText::subdivideAndResolve):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paintForeground):

Canonical link: <a href="https://commits.webkit.org/318976@main">https://commits.webkit.org/318976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ad9ba03437d1fd42e403d9063d58d10b9102aea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144337 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d22c115-bfca-4cca-bd67-1ad5b794846a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140386 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c98f3ab-83a3-4b13-b1bd-737416ffb623) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120837 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aab087c1-dd48-4aa0-ba9f-1899b382a3ec) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41025 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40692 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1387 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192162 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149727 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40109 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54317 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149457 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44098 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126580 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121678 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52834 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15680 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52216 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52280 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->