### PR TITLE
[ANGLE] Avoid showing windows for dEQP tests

### DIFF
--- a/Source/ThirdParty/ANGLE/src/tests/deqp_support/angle_deqp_gtest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/deqp_support/angle_deqp_gtest.cpp
@@ -23,6 +23,7 @@
 #include "common/base/anglebase/no_destructor.h"
 #include "common/debug.h"
 #include "common/platform.h"
+#include "common/platform_helpers.h"
 #include "common/string_utils.h"
 #include "common/system_utils.h"
 #include "platform/PlatformMethods.h"
@@ -177,6 +178,7 @@ constexpr char kGTestFilter[]               = "--gtest_filter=";
 constexpr char kdEQPSurfaceWidth[]          = "--deqp-surface-width=";
 constexpr char kdEQPSurfaceHeight[]         = "--deqp-surface-height=";
 constexpr char kdEQPBaseSeed[]              = "--deqp-base-seed";
+constexpr char kdEQPVisibility[]            = "--deqp-visibility";
 constexpr const char gdEQPLogImagesString[] = "--deqp-log-images=";
 
 // Use the config name defined in gTestSuiteConfigParameters by default
@@ -671,8 +673,18 @@ void dEQPTest::SetUpTestSuite()
         argv.push_back(configParam);
     }
 
+    // Hide the test windows on Mac to avoid stealing focus during the long test runs. Skipped when
+    // --deqp-visibility was already given since dEQP rejects a repeated option.
+    bool visibilitySpecifiedFromCmdLine = false;
+    for (const char *flag : gdEQPForwardFlags)
+    {
+        visibilitySpecifiedFromCmdLine |=
+            strncmp(flag, kdEQPVisibility, strlen(kdEQPVisibility)) == 0;
+    }
+
     // Hide SwiftShader window to prevent a race with Xvfb causing hangs on test bots
-    if (gInitAPI && gInitAPI->second == GPUTestConfig::kAPISwiftShader)
+    const bool isSwiftShader = (gInitAPI && gInitAPI->second == GPUTestConfig::kAPISwiftShader);
+    if (!visibilitySpecifiedFromCmdLine && (IsMac() || isSwiftShader))
     {
         argv.push_back("--deqp-visibility=hidden");
     }


### PR DESCRIPTION
#### 1090551beb5074aa12cdd754271c6f719f8f9371
<pre>
[ANGLE] Avoid showing windows for dEQP tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=321342">https://bugs.webkit.org/show_bug.cgi?id=321342</a>
<a href="https://rdar.apple.com/184376301">rdar://184376301</a>

Reviewed by Dan Glastonbury.

313716@main hid the test windows for ANGLEEnd2EndTests. Make hidden the
default for the dEQP suites on Mac too, so long test runs don&apos;t steal focus.

dEQP creates its windows in tcuANGLENativeDisplayFactory.cpp from dEQP&apos;s own
--deqp-visibility option, which defaults to windowed. Extend the existing
SwiftShader-only check to pass --deqp-visibility=hidden on Mac as well. Skip it
when the option was already given, since dEQP rejects a command line that
specifies the same option twice.

* Source/ThirdParty/ANGLE/src/tests/deqp_support/angle_deqp_gtest.cpp:

Canonical link: <a href="https://commits.webkit.org/319112@main">https://commits.webkit.org/319112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1a10634e7df1565df4da1289b200e61bae4a90e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144503 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4dfbd3e-fb61-46da-a442-a8f46051bf0f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140529 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97327 "3 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62c589b2-536b-43ce-8afd-549449a434eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120981 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42859 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41164 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40839 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1555 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192330 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53796 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149877 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40199 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54484 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149604 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44245 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121882 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53001 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15828 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52383 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52448 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->