### PR TITLE
[anon-block-removal] An outside list marker makes its list item's children inline

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-content-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-content-expected.txt
@@ -1,0 +1,6 @@
+x
+x
+
+PASS A list item with an outside marker and block level content is as tall as that content
+PASS The same holds after the marker changes from inside to outside
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-content.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AnonymousBlockGenerationDisabled=true ] -->
+<meta charset="utf-8">
+<title>CSS Lists: an outside marker does not make its list item's children inline</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-outside">
+<meta name="assert" content="An outside marker takes no part in the list item's in-flow layout, so a list item whose content is a block level box has that box at the top of its content box, not below a line of the marker's own.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+ul { margin: 0; padding: 0 0 0 40px; }
+li { font: 16px/18px monospace; }
+.block { height: 40px; }
+</style>
+
+<ul><li id="static"><div class="block">x</div></li></ul>
+<ul><li id="dynamic" style="list-style-position: inside"><div class="block">x</div></li></ul>
+
+<script>
+document.body.offsetHeight;
+document.getElementById("dynamic").style.listStylePosition = "outside";
+
+test(() => {
+    assert_equals(document.getElementById("static").offsetHeight, 40);
+}, "A list item with an outside marker and block level content is as tall as that content");
+
+test(() => {
+    assert_equals(document.getElementById("dynamic").offsetHeight, 40);
+}, "The same holds after the marker changes from inside to outside");
+</script>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -100,6 +100,17 @@ static bool isExcludedMarker(const RenderBlock& parent, const RenderObject& chil
     return listItem && !markerNeedsOwnLine(*listItem);
 }
 
+static bool hasInlineInFlowChild(const RenderBlock& parent)
+{
+    for (CheckedPtr child = parent.firstChild(); child; child = child->nextSibling()) {
+        if (child->isFloatingOrOutOfFlowPositioned() || isExcludedMarker(parent, *child))
+            continue;
+        if (child->isInline())
+            return true;
+    }
+    return false;
+}
+
 static std::optional<ParentAndBeforeChild> findParentAndBeforeChildForNonSibling(RenderBlock& parent, const RenderObject& child, RenderObject& beforeChild)
 {
     auto* beforeChildContainer = beforeChild.parent();
@@ -191,8 +202,10 @@ void RenderTreeBuilder::Block::attach(RenderBlock& parent, RenderPtr<RenderObjec
     if (!shouldBuildAnonymousBlock()) {
         if (!parent.firstChild() && !child->isFloatingOrOutOfFlowPositioned())
             parent.setChildrenInline(child->isInline());
-        else if (child->isInline())
+        else if (child->isInline() && !isExcludedMarker(parent, *child)) {
+            // An excluded marker takes no part in in-flow layout, so it does not make the children inline.
             parent.setChildrenInline(true);
+        }
         m_builder.attachToRenderElement(parent, WTF::move(child), beforeChild);
         return;
     }
@@ -390,6 +403,9 @@ RenderPtr<RenderObject> RenderTreeBuilder::Block::detach(RenderBlock& parent, Re
         // If this was our last child be sure to clear out our line boxes.
         if (CheckedPtr blockFlow = dynamicDowncast<RenderBlockFlow>(parent); blockFlow && blockFlow->childrenInline())
             blockFlow->invalidateLineLayout(RenderBlockFlow::InvalidationReason::InternalMove);
+    } else if (!m_buildsSimpleAnonymousBlocks) {
+        if (auto hasInlineChild = hasInlineInFlowChild(parent); parent.childrenInline() != hasInlineChild)
+            parent.setChildrenInline(hasInlineChild);
     }
     return takenChild;
 }


### PR DESCRIPTION
#### 56493b12464b673b3c5baa6f7dee77a18dd1b44b
<pre>
[anon-block-removal] An outside list marker makes its list item&apos;s children inline
<a href="https://bugs.webkit.org/show_bug.cgi?id=321343">https://bugs.webkit.org/show_bug.cgi?id=321343</a>
&lt;<a href="https://rdar.apple.com/problem/184380304">rdar://problem/184380304</a>&gt;

Reviewed by Antti Koivisto.

An outside marker takes no part in the list item&apos;s in-flow layout, so it must not turn childrenInline() on.
Letting it puts a list item whose content is a block level box onto the inline path, where the marker takes a
line of its own and the block starts below it - &lt;ul&gt;&lt;li&gt;&lt;div&gt;text&lt;/div&gt;&lt;/li&gt;&lt;/ul&gt; is 58 tall instead of 40.

Nothing rebuilds anonymous wrappers on this path, so childrenInline() also has to be recomputed when a child
is detached. A marker changing from inside to outside is destroyed and reattached, and the bit the inside
marker turned on would otherwise stay on.

* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
(WebCore::hasInlineInFlowChild):
(WebCore::RenderTreeBuilder::Block::attach):
(WebCore::RenderTreeBuilder::Block::detach):
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-content.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-content-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/318891@main">https://commits.webkit.org/318891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e61229bfa350cc05be6919ec3379f14761eea539

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143835 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/932d4737-1e09-45df-8eb4-075f9d79cbb4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140003 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96859 "2 flakes 5 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d19b853c-d546-4295-989b-99008f929300) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120456 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4de4f31-1a08-4452-96af-ef1930f1acf9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42282 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40607 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152683 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40255 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/812 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191579 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149265 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40054 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53816 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149012 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43672 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126088 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120986 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52333 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15241 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51718 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51779 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->