### PR TITLE
CORS preflight fetch hangs indefinitely when the OPTIONS response body never terminates

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS CORS preflight response with a body that never terminates does not stall the fetch
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.js
@@ -1,0 +1,12 @@
+// META: script=/common/utils.js
+// META: script=../resources/utils.js
+// META: script=/common/get-host-info.sub.js
+
+promise_test(async () => {
+    const url = get_host_info().HTTP_REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR
+        + "preflight-unterminated-body.py?token=" + token();
+    const response = await fetch(url, { "mode": "cors", "headers": { "x-preflight-test": "1" } });
+
+    assert_equals(response.status, 200, "Actual request succeeded");
+    assert_equals(await response.text(), "actual request", "Body came from the actual request");
+}, "CORS preflight response with a body that never terminates does not stall the fetch");

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS CORS preflight response with a body that never terminates does not stall the fetch
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/resources/preflight-unterminated-body.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/resources/preflight-unterminated-body.py
@@ -1,0 +1,23 @@
+import time
+
+
+def main(request, response):
+    headers = [
+        (b"Access-Control-Allow-Origin", request.headers.get(b"Origin", b"*")),
+        (b"Access-Control-Allow-Methods", b"GET"),
+        (b"Access-Control-Allow-Headers", b"x-preflight-test"),
+        (b"Access-Control-Max-Age", b"0"),
+    ]
+
+    if request.method != u"OPTIONS":
+        headers.append((b"Content-Type", b"text/plain"))
+        return 200, headers, b"actual request"
+
+    response.status = 200
+    for name, value in headers:
+        response.headers.set(name, value)
+    response.headers.set(b"Content-Type", b"text/plain")
+    response.write_status_headers()
+
+    while response.writer.write(b"." * 1024):
+        time.sleep(0.01)

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
@@ -124,13 +124,19 @@ void NetworkCORSPreflightChecker::didReceiveChallenge(WebCore::AuthenticationCha
 
 void NetworkCORSPreflightChecker::didReceiveResponse(WebCore::ResourceResponse&& response, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&& completionHandler)
 {
-    CORS_CHECKER_RELEASE_LOG("didReceiveResponse");
-
     if (m_shouldCaptureExtraNetworkLoadMetrics)
         m_loadInformation.response = response;
 
     m_response = WTF::move(response);
-    completionHandler(PolicyAction::Use);
+
+    CORS_CHECKER_RELEASE_LOG("didReceiveResponse http_status_code=%d", m_response.httpStatusCode());
+
+    completionHandler(PolicyAction::Ignore);
+    if (RefPtr task = std::exchange(m_task, nullptr)) {
+        task->clearClient();
+        task->cancel();
+    }
+    completePreflight(ResourceError { });
 }
 
 void NetworkCORSPreflightChecker::didReceiveData(const WebCore::SharedBuffer&)
@@ -143,9 +149,16 @@ void NetworkCORSPreflightChecker::didCompleteWithError(const WebCore::ResourceEr
     if (m_shouldCaptureExtraNetworkLoadMetrics)
         m_loadInformation.metrics = metrics;
 
+    completePreflight(ResourceError { preflightError });
+}
+
+void NetworkCORSPreflightChecker::completePreflight(ResourceError&& preflightError)
+{
+    ASSERT(m_completionCallback);
+
     if (!preflightError.isNull()) {
         CORS_CHECKER_RELEASE_LOG("didCompleteWithError");
-        auto error = preflightError;
+        auto error = WTF::move(preflightError);
         if (error.isNull() || error.isGeneral())
             error.setType(ResourceError::Type::AccessControl);
 

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
@@ -93,6 +93,8 @@ private:
     void wasBlockedByRestrictions() final;
     void wasBlockedByDisabledFTP() final;
 
+    void completePreflight(WebCore::ResourceError&&);
+
     Parameters m_parameters;
     const Ref<NetworkProcess> m_networkProcess;
     WebCore::ResourceResponse m_response;


### PR DESCRIPTION
#### a6b87573f6bfc30bb841afe4c9e5c74ac91fa4e1
<pre>
CORS preflight fetch hangs indefinitely when the OPTIONS response body never terminates
<a href="https://bugs.webkit.org/show_bug.cgi?id=320657">https://bugs.webkit.org/show_bug.cgi?id=320657</a>
<a href="https://rdar.apple.com/184231090">rdar://184231090</a>

Reviewed by Youenn Fablet.

NetworkCORSPreflightChecker only validated the preflight in didCompleteWithError, so
the outcome was gated on the response body finishing. A server that answers OPTIONS
with valid Access-Control-Allow-* headers followed by a body that never terminates
stalled the preflight, and with it the actual request, forever: fetch() never settled
and the bytes were streamed and discarded until the page aborted. Chrome and Firefox
conclude the preflight from the headers, so this was a WebKit-only hang.

The body must not control the result. Every step of CORS-preflight fetch [1] after the
response is obtained reads only its status and header list -- &quot;response&apos;s status is an
ok status&quot;, then Access-Control-Allow-Methods, Access-Control-Allow-Headers and
Access-Control-Max-Age -- and the response it returns is inspected by HTTP fetch only
for being a network error. validatePreflightResponse already touches nothing else.

So conclude the preflight from the status and headers as soon as they arrive, via a new
completePreflight() that didCompleteWithError also routes through. Answer
PolicyAction::Ignore, which cancels the load rather than draining it, then clear the
task&apos;s client and cancel it, so didCompleteWithError cannot follow and report a second
result.

Do this for every preflight response rather than only for ones that declare a body.
expectedContentLength() is not comparable across ports -- CFNetwork reports -1 for an
undeclared length while soup_message_headers_get_content_length() reports 0 -- so
treating a zero length as an empty body would leave the GLib ports on the old path and
still hanging.

m_loadInformation.metrics, the Inspector&apos;s extra metrics for the preflight transaction,
is no longer populated, as it came only from didCompleteWithError. Now that the body is
deliberately not read, final metrics are not meaningful for a preflight.

[1] <a href="https://fetch.spec.whatwg.org/#cors-preflight-fetch">https://fetch.spec.whatwg.org/#cors-preflight-fetch</a>

Tests: imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.html
       imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.worker.html

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-preflight-unterminated-body.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/resources/preflight-unterminated-body.py: Added.
(main):
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp:
(WebKit::NetworkCORSPreflightChecker::didReceiveResponse):
(WebKit::NetworkCORSPreflightChecker::didCompleteWithError):
(WebKit::NetworkCORSPreflightChecker::completePreflight):
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h:

Canonical link: <a href="https://commits.webkit.org/319485@main">https://commits.webkit.org/319485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b77896949eadf3e2345b0eb5f2a209ef3d2b978b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145911 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55252 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45419 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122166 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05e16dbc-42a8-4f00-883c-767710e8c2c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44101 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42017 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2968 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193735 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161988 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40481 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55890 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150841 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45429 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128173 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123863 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54403 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17010 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53785 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54024 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53850 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->