### PR TITLE
Unreviewed, use WASM_FAIL_IF_HELPER_FAILS

### DIFF
--- a/JSTests/wasm/stress/const-expr-i32-wrap.js
+++ b/JSTests/wasm/stress/const-expr-i32-wrap.js
@@ -53,5 +53,3 @@ const extended = { extended_const: true };
     `, {}, extended);
     assert.eq(instance.exports.table.get(0)(), 42);
 }
-
-print("const-expr-i32-wrap: ok");

--- a/JSTests/wasm/stress/data-segment-offset-2gb.js
+++ b/JSTests/wasm/stress/data-segment-offset-2gb.js
@@ -76,4 +76,3 @@ try {
 }
 
 assert.eq(instance.exports.load(), 42);
-print("data-segment-offset-2gb: ok");

--- a/JSTests/wasm/stress/exception-trace-stack.js
+++ b/JSTests/wasm/stress/exception-trace-stack.js
@@ -36,4 +36,3 @@ testDefaultHasNoStack();
 testTraceStackFalse();
 testTraceStackTrue();
 testConstructorLength();
-print("exception-trace-stack: ok");

--- a/JSTests/wasm/stress/instance-anchor.js
+++ b/JSTests/wasm/stress/instance-anchor.js
@@ -34,9 +34,6 @@ function main() {
         instanceA.exports.foo();
 
     gc();
-
-    print("done (should have crashed above)");
-
 }
 
 main();

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -758,7 +758,7 @@ auto FunctionParser<Context>::load(Type memoryType) -> PartialResult
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
 
     uint8_t memoryIndex;
-    WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexAndFixupAlignment(alignment, memoryIndex));
 
     WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds load's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
 
@@ -785,7 +785,7 @@ auto FunctionParser<Context>::store(Type memoryType) -> PartialResult
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get store alignment"_s);
 
     uint8_t memoryIndex;
-    WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexAndFixupAlignment(alignment, memoryIndex));
 
     WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds store's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
 
@@ -825,7 +825,7 @@ auto FunctionParser<Context>::atomicLoad(ExtAtomicOpType op, Type memoryType) ->
     TypedExpression pointer;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
     uint8_t memoryIndex;
-    WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexAndFixupAlignment(alignment, memoryIndex));
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
 
     WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
@@ -850,7 +850,7 @@ auto FunctionParser<Context>::atomicStore(ExtAtomicOpType op, Type memoryType) -
     TypedExpression pointer;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get store alignment"_s);
     uint8_t memoryIndex;
-    WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexAndFixupAlignment(alignment, memoryIndex));
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
     WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
 
@@ -875,7 +875,7 @@ auto FunctionParser<Context>::atomicBinaryRMW(ExtAtomicOpType op, Type memoryTyp
     TypedExpression value;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
     uint8_t memoryIndex;
-    WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexAndFixupAlignment(alignment, memoryIndex));
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
     WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
@@ -902,7 +902,7 @@ auto FunctionParser<Context>::atomicCompareExchange(ExtAtomicOpType op, Type mem
     TypedExpression value;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
     uint8_t memoryIndex;
-    WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexAndFixupAlignment(alignment, memoryIndex));
     WASM_PARSER_FAIL_IF(alignment !=  memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
     WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
@@ -931,7 +931,7 @@ auto FunctionParser<Context>::atomicWait(ExtAtomicOpType op, Type memoryType) ->
     TypedExpression timeout;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
     uint8_t memoryIndex;
-    WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexAndFixupAlignment(alignment, memoryIndex));
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
     WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
     WASM_TRY_POP_EXPRESSION_STACK_INTO(timeout, "timeout"_s);
@@ -959,7 +959,7 @@ auto FunctionParser<Context>::atomicNotify(ExtAtomicOpType op) -> PartialResult
     TypedExpression count;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
     uint8_t memoryIndex;
-    WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
+    WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexAndFixupAlignment(alignment, memoryIndex));
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
     WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
     WASM_TRY_POP_EXPRESSION_STACK_INTO(count, "count"_s);
@@ -1045,7 +1045,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
 
         uint32_t alignment;
         WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get simd memory op alignment"_s);
-        WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get simd memory index"_s);
+        WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexAndFixupAlignment(alignment, memoryIndex));
         WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, offset));
 
         WASM_VALIDATOR_FAIL_IF(alignment > maxAlignment, "alignment: "_s, alignment, " can't be larger than max alignment for simd operation: "_s, maxAlignment);
@@ -4177,7 +4177,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         uint32_t alignment;
         WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get first immediate for "_s, m_currentOpcode, " in unreachable context"_s);
         uint8_t memoryIndex;
-        WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
+        WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexAndFixupAlignment(alignment, memoryIndex));
         WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds "_s, m_currentOpcode, "'s natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
         uint64_t unusedOffset;
         WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, unusedOffset));
@@ -4559,7 +4559,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             uint32_t alignment;
             WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
             uint8_t memoryIndex;
-            WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
+            WASM_FAIL_IF_HELPER_FAILS(parseMemoryIndexAndFixupAlignment(alignment, memoryIndex));
             WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
             uint64_t unusedOffset;
             WASM_FAIL_IF_HELPER_FAILS(parseMemoryOffset(memoryIndex, unusedOffset));


### PR DESCRIPTION
#### b1bfab65c61e36f4daccb86aee42f7ff31e45dc6
<pre>
Unreviewed, use WASM_FAIL_IF_HELPER_FAILS
<a href="https://bugs.webkit.org/show_bug.cgi?id=321348">https://bugs.webkit.org/show_bug.cgi?id=321348</a>
<a href="https://rdar.apple.com/184382576">rdar://184382576</a>

* JSTests/wasm/stress/const-expr-i32-wrap.js:
(assert.eq):
* JSTests/wasm/stress/data-segment-offset-2gb.js:
* JSTests/wasm/stress/exception-trace-stack.js:
* JSTests/wasm/stress/instance-anchor.js:
(main):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::load):
(JSC::Wasm::FunctionParser&lt;Context&gt;::store):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicLoad):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicStore):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicBinaryRMW):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicCompareExchange):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicWait):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicNotify):
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):

Canonical link: <a href="https://commits.webkit.org/318835@main">https://commits.webkit.org/318835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebd0f80dc09449251b19fba1fdf1163a187b08e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189368 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43b52bdc-3b90-4d96-9f52-e25247c2cf96) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140011 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b08ce45-ca35-41f3-b86a-32698da7124f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43622 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120464 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48154c07-bc40-43f7-a6bf-a4c212611101) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2433 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9240 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40267 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/822 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40811 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46081 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191589 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53145 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53826 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149021 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27261 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43681 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126098 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121003 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52343 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15253 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51728 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51969 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51789 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->