### PR TITLE
[JSC][Intl] formatToParts must emit the era separator that format() inserts

### DIFF
--- a/JSTests/stress/intl-datetimeformat-era-override-parts.js
+++ b/JSTests/stress/intl-datetimeformat-era-override-parts.js
@@ -1,0 +1,59 @@
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+// Locales chosen so era placement and trailing-space behaviour both vary.
+const locales = ["en-US", "ja-JP", "zh-CN", "ar-EG", "he-IL", "de-DE", "fi-FI", "th-TH"];
+
+const shapes = [
+    { era: "short" },
+    { era: "long" },
+    { era: "narrow" },
+    { era: "short", year: "numeric" },
+    { era: "short", year: "numeric", month: "long", day: "numeric" },
+    { era: "long", year: "2-digit", month: "2-digit", day: "2-digit" },
+    { era: "short", year: "numeric", month: "numeric", day: "numeric", weekday: "long" },
+    // Ends in dayPeriod for en-US, so ICU leaves no trailing space: the broken case.
+    { era: "short", year: "numeric", hour: "numeric", minute: "numeric" },
+];
+
+// Dates before each calendar's era epoch, so the override fires.
+const cases = [
+    ["coptic", Date.UTC(100, 0, 1)],
+    ["coptic", Date.UTC(283, 7, 1)],
+    ["islamic-civil", Date.UTC(300, 0, 1)],
+    ["islamic-umalqura", Date.UTC(500, 0, 1)],
+    ["islamic-tbla", Date.UTC(300, 0, 1)],
+    // Controls: era present natively, and a calendar with no override at all.
+    ["coptic", Date.UTC(2020, 0, 1)],
+    ["gregory", Date.UTC(100, 0, 1)],
+];
+
+let checked = 0;
+let sawOverride = false;
+for (const locale of locales) {
+    for (const [calendar, epochMs] of cases) {
+        for (const shape of shapes) {
+            const format = new Intl.DateTimeFormat(locale, { calendar, timeZone: "UTC", ...shape });
+            const formatted = format.format(epochMs);
+            const parts = format.formatToParts(epochMs);
+            const joined = parts.map(part => part.value).join("");
+            expect(`${locale} ${calendar} ${JSON.stringify(shape)}`, joined, formatted);
+
+            // A double-synthesized separator needs no separate check: it would make joined
+            // longer than format(), which the assertion above already catches.
+            for (const part of parts)
+                expect(`${locale} ${calendar} empty ${part.type} part`, part.value.length > 0, true);
+
+            if (parts.some(part => part.type === "era") && format.resolvedOptions().calendar === calendar)
+                sawOverride = true;
+            ++checked;
+        }
+    }
+}
+
+expect("cases checked", checked, locales.length * cases.length * shapes.length);
+// Keeps the test from passing vacuously if era parts stop being produced.
+expect("saw at least one era part", sawOverride, true);

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -1624,6 +1624,14 @@ static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFo
     {
         // ICU4C-WORKAROUND: rdar://182953351 - append era override as a distinct part when ICU emitted no era field (coptic pre-AM).
         if (!eraOverride.isNull() && !sawEra) {
+            if (resultStringView.isEmpty() || !WTF::isUnicodeWhitespace(resultStringView[resultLength - 1])) {
+                auto separator = jsSingleCharacterString(vm, static_cast<char16_t>(' '));
+                JSObject* separatorPart = sourceType
+                    ? createIntlPartObjectWithSource(globalObject, literalString, separator, sourceType)
+                    : createIntlPartObject(globalObject, literalString, separator);
+                parts->putDirectIndex(globalObject, parts->length(), separatorPart);
+                RETURN_IF_EXCEPTION(scope, { });
+            }
             auto type = jsNontrivialString(vm, "era"_s);
             auto valueStr = jsNontrivialString(vm, String(eraOverride));
             JSObject* part = sourceType

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -967,9 +967,8 @@ static std::optional<ISO8601::PlainDate> indianSakaToISO(int32_t sakaYear, uint8
     return ISO8601::PlainDate(isoYear, isoMonth, isoDay);
 }
 
-// Design choice, not an ICU4C workaround: beyond icu4x's WELL_BEHAVED_ASTRONOMICAL_RANGE
-// (±10000 years), chinese/dangi astronomical output isn't trustworthy. Every getter below
-// falls back to ISO fields here, matching nonISOCalendarDateToISO's construction-side fallback.
+// Design choice, not an ICU4C workaround: ±10000 is icu4x's WELL_BEHAVED_ASTRONOMICAL_RANGE, and
+// must track nonISOCalendarDateToISO's fallback. ICU is only accurate inside gregorian 1900-2100.
 static bool calendarUsesISOFallbackForExtremeYear(CalendarID calendarId, int32_t isoYear)
 {
     return (calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) && std::abs(isoYear) > 10000;


### PR DESCRIPTION
#### b2ec9a4586eec8c6fd9d9871980b6ddc525174d3
<pre>
[JSC][Intl] formatToParts must emit the era separator that format() inserts
<a href="https://bugs.webkit.org/show_bug.cgi?id=321347">https://bugs.webkit.org/show_bug.cgi?id=321347</a>
<a href="https://rdar.apple.com/184382546">rdar://184382546</a>

Reviewed by Yusuke Suzuki.

ICU emits no era name for coptic dates before Anno Martyrum or islamic-* dates
before the Hijra, so both format() overloads synthesize one. format() also
inserts a separating space before the appended era; formatToParts() did not, so
concatenating the parts stopped reproducing format() — 90 of 720 locale and
option combinations, for example ja-JP coptic {era:&quot;short&quot;} formatting
&quot;185/5/7 Anno Martyrum&quot; against joined parts &quot;185/5/7Anno Martyrum&quot;.

The separator stays conditional. Where ICU leaves a trailing space in the empty
era slot, the parts loop already emits it as a literal, so synthesizing one
unconditionally would double it. jsSingleCharacterString rather than
jsNontrivialString, which asserts a length above one.

Only the appended-era path is affected; where ICU emits an era field its own
pattern supplies the separator.

Also correct calendarUsesISOFallbackForExtremeYear&apos;s comment: ±10000 is icu4x&apos;s
WELL_BEHAVED_ASTRONOMICAL_RANGE, not a claim that ICU is accurate within it —
ICU&apos;s chinese winter-solstice table covers only gregorian 1900-2100.

Test: JSTests/stress/intl-datetimeformat-era-override-parts.js
Canonical link: <a href="https://commits.webkit.org/318847@main">https://commits.webkit.org/318847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2ce1b748eaeace2155d993ea4abfa6e45a7fff4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189369 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143846 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9d8a1bd4-0dad-491c-8b33-2b3a6ca5f3a7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140012 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7ebf5dd-35e2-49e3-a551-5e13d890d111) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120465 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52ebf2fa-7591-470b-bd09-9c1ef886b712) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42294 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40618 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2434 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9241 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152695 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40268 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/execute-start.tentative.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/823 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40812 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191590 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53146 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149275 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53827 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149022 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27276 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43683 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126099 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121006 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52344 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15254 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51729 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51970 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51790 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->