### PR TITLE
Add tests to check lazy-loading frames from multiple, distinct cross-site sites

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-nested-cross-site.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-nested-cross-site.sub-expected.txt
@@ -1,0 +1,8 @@
+
+
+
+PASS In-viewport iframes load eagerly
+PASS Below-viewport iframes load lazily
+PASS In-viewport iframe nested in a cross-site frame loads eagerly
+PASS Below-viewport iframe nested in a cross-site frame loads lazily
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-nested-cross-site.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-nested-cross-site.sub.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<head>
+  <title>Nested cross-site iframes with loading='lazy' load when in the viewport</title>
+  <meta name="timeout" content="long">
+  <link rel="help" href="https://github.com/whatwg/html/pull/5579">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<script>
+  const t_in_viewport =
+    async_test('In-viewport iframes load eagerly');
+  const t_below_viewport =
+    async_test('Below-viewport iframes load lazily');
+  const t_nested_in_viewport =
+    async_test('In-viewport iframe nested in a cross-site frame loads eagerly');
+  const t_nested_below_viewport =
+    async_test('Below-viewport iframe nested in a cross-site frame loads lazily');
+
+  const expected_subframe_url = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/iframe-loading-lazy-nested-subframe.sub.html?below-viewport";
+  const expected_nested_subframe_url = "https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport";
+
+  let has_window_loaded = false;
+
+  const in_viewport_iframe_onload = t_in_viewport.step_func_done(() => {
+    assert_false(has_window_loaded,
+      "The outer in_viewport iframe should not block the load event");
+  });
+
+  window.addEventListener("load", () => {
+    has_window_loaded = true;
+    document.getElementById("below_viewport").scrollIntoView();
+  });
+
+  const below_viewport_iframe_onload = t_below_viewport.step_func_done(() => {
+    assert_true(has_window_loaded,
+                "The outer window load event should have fired before the outer below-viewport iframe loads");
+  });
+
+  window.addEventListener("message", event => {
+    if (event.data?.info === "nested-in-viewport-loaded") {
+      t_nested_in_viewport.step_func_done(() => {
+        assert_false(event.data.hasWindowLoaded,
+                     "The nested in-viewport iframe should not block its own load event");
+      })();
+    } else if (event.data?.info === "nested-below-viewport-loaded") {
+      t_nested_below_viewport.step_func_done(() => {
+        assert_equals(event.data.subframeSrc, expected_subframe_url,
+                      "The below-viewport iframe should have loaded its cross-site document");
+        assert_equals(event.data.nestedSubframeSrc, expected_nested_subframe_url,
+                      "The nested below-viewport iframe should have loaded its cross-site document");
+        assert_true(event.data.hasWindowLoaded,
+                    "The nested window load event should have fired before the nested below-viewport iframe loads");
+      })();
+    }
+  });
+
+</script>
+
+<body>
+  <iframe id="in_viewport"
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?in-viewport"
+          loading="lazy" width="200px" height="100px"
+          onload="in_viewport_iframe_onload();"></iframe>
+
+
+ <div style="height:2000vh;"></div>
+  <iframe id="below_viewport"
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/iframe-loading-lazy-nested-subframe.sub.html?below-viewport"
+          loading="lazy" width="200px" height="100px"
+          onload="below_viewport_iframe_onload();"></iframe>
+
+
+  <!-- This async script loads very slowly in order to ensure that, if the
+       below_viewport* elements have started loading, it has a chance to finish
+       loading before window load event fires, so that the test will dependably
+       fail in that case instead of potentially passing depending on how long
+       different resource fetches take. -->
+  <script async src="/common/slow.py"></script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-siblings-cross-site.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-siblings-cross-site.sub-expected.txt
@@ -1,0 +1,8 @@
+
+
+
+PASS In-viewport left iframe loads eagerly
+PASS Below-viewport left iframe loads lazily
+PASS In-viewport right iframe loads eagerly
+PASS Below-viewport right iframe loads lazily
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-siblings-cross-site.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-siblings-cross-site.sub.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<head>
+  <title>Side-by-side cross-site iframes with loading='lazy' load when in the viewport</title>
+  <link rel="help" href="https://github.com/whatwg/html/pull/5579">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<script>
+  const t_in_viewport_left =
+    async_test('In-viewport left iframe loads eagerly');
+  const t_below_viewport_left =
+    async_test('Below-viewport left iframe loads lazily');
+  const t_in_viewport_right =
+    async_test('In-viewport right iframe loads eagerly');
+  const t_below_viewport_right =
+    async_test('Below-viewport right iframe loads lazily');
+
+  const expected_left_url = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport-left";
+  const expected_right_url = "https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport-right";
+
+  let has_window_loaded = false;
+
+  const in_viewport_left_iframe_onload = t_in_viewport_left.step_func_done(() => {
+    assert_false(has_window_loaded,
+      "The left in_viewport iframe should not block the load event");
+  });
+
+  const in_viewport_right_iframe_onload = t_in_viewport_right.step_func_done(() => {
+    assert_false(has_window_loaded,
+      "The right in_viewport iframe should not block the load event");
+  });
+
+  window.addEventListener("load", () => {
+    has_window_loaded = true;
+    document.getElementById("below_viewport_left").scrollIntoView();
+  });
+
+  window.addEventListener("message", event => {
+    if (event.source === document.getElementById("below_viewport_left").contentWindow) {
+      t_below_viewport_left.step_func_done(() => {
+        assert_equals(event.data, expected_left_url,
+                      "The left below-viewport iframe should have loaded its cross-site document");
+        assert_true(has_window_loaded,
+                    "The window load event should have fired before the left below-viewport iframe loads");
+      })();
+    } else if (event.source === document.getElementById("below_viewport_right").contentWindow) {
+      t_below_viewport_right.step_func_done(() => {
+        assert_equals(event.data, expected_right_url,
+                      "The right below-viewport iframe should have loaded its cross-site document");
+        assert_true(has_window_loaded,
+                    "The window load event should have fired before the right below-viewport iframe loads");
+      })();
+    }
+  });
+
+</script>
+
+<body>
+  <div style="display: flex; gap: 10px;">
+    <iframe id="in_viewport_left"
+            src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?in-viewport"
+            loading="lazy" width="200px" height="100px"
+            onload="in_viewport_left_iframe_onload();"></iframe>
+    <iframe id="in_viewport_right"
+            src="https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?in-viewport"
+            loading="lazy" width="200px" height="100px"
+            onload="in_viewport_right_iframe_onload();"></iframe>
+  </div>
+
+
+ <div style="height:2000vh;"></div>
+  <div style="display: flex; gap: 10px;">
+    <iframe id="below_viewport_left"
+            src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport-left"
+            loading="lazy" width="200px" height="100px"></iframe>
+    <iframe id="below_viewport_right"
+            src="https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport-right"
+            loading="lazy" width="200px" height="100px"></iframe>
+  </div>
+
+
+  <!-- This async script loads very slowly in order to ensure that, if the
+       below_viewport* elements have started loading, it has a chance to finish
+       loading before window load event fires, so that the test will dependably
+       fail in that case instead of potentially passing depending on how long
+       different resource fetches take. -->
+  <script async src="/common/slow.py"></script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/resources/iframe-loading-lazy-nested-subframe.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/resources/iframe-loading-lazy-nested-subframe.sub.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+
+<script>
+  let has_window_loaded = false;
+
+  function in_viewport_iframe_onload() {
+    parent.postMessage({ info: "nested-in-viewport-loaded",
+                         hasWindowLoaded: has_window_loaded }, "*");
+  }
+
+  window.addEventListener("load", () => {
+    has_window_loaded = true;
+    document.getElementById("below_viewport").scrollIntoView();
+  });
+
+  window.addEventListener("message", event => {
+    parent.postMessage({ info: "nested-below-viewport-loaded",
+                         hasWindowLoaded: has_window_loaded,
+                         nestedSubframeSrc: event.data,
+                         subframeSrc: location.href }, "*");
+  });
+
+</script>
+
+<body>
+  <iframe id="in_viewport"
+          src="https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?in-viewport"
+          loading="lazy" width="200px" height="100px"
+          onload="in_viewport_iframe_onload();"></iframe>
+
+
+ <div style="height:2000vh;"></div>
+  <iframe id="below_viewport"
+          src="https://{{hosts[alt][]}}:{{ports[https][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport"
+          loading="lazy" width="200px" height="100px"></iframe>
+
+
+  <!-- This async script loads very slowly in order to ensure that, if the
+       below_viewport* elements have started loading, it has a chance to finish
+       loading before window load event fires, so that the test will dependably
+       fail in that case instead of potentially passing depending on how long
+       different resource fetches take. -->
+  <script async src="/common/slow.py"></script>
+</body>

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -3974,6 +3974,9 @@
     "imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-markup.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-nested-cross-site.sub.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_navigation_download_allow_downloads.sub.tentative.html": [
         "slow"
     ],

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10484,6 +10484,9 @@ static void updateAndNotifyIntersectionObservers(const Vector<WeakPtr<Intersecti
 
 void Document::updateRemoteIntersectionObservers()
 {
+    if (m_remoteIntersectionObservers.isEmpty())
+        return;
+
     RefPtr page = this->page();
     if (!page)
         return;
@@ -10491,6 +10494,16 @@ void Document::updateRemoteIntersectionObservers()
     RefPtr mainFrame = this->page()->mainFrame();
     if (!mainFrame)
         return;
+
+    RefPtr frameView = view();
+    if (!frameView)
+        return;
+
+    bool needsLayout = frameView->layoutContext().isLayoutPending() || (renderView() && renderView()->needsLayout());
+    if (needsLayout || hasPendingStyleRecalc()) {
+        scheduleRenderingUpdate(RenderingUpdateStep::IntersectionObservations);
+        return;
+    }
 
     updateAndNotifyIntersectionObservers(m_remoteIntersectionObservers, *mainFrame);
 }


### PR DESCRIPTION
#### 811414ccc1d605644b63daf5a173ae1463a38f8e
<pre>
Add tests to check lazy-loading frames from multiple, distinct cross-site sites
<a href="https://bugs.webkit.org/show_bug.cgi?id=321350">https://bugs.webkit.org/show_bug.cgi?id=321350</a>
<a href="https://rdar.apple.com/184384527">rdar://184384527</a>

Reviewed by Sihui Liu and Kiet Ho.

Adding iframe-loading-lazy-siblings-cross-site and iframe-loading-lazy-nested-cross-site which
check lazy-loading across 3 distinct sites.

Non-deterministic IPC timing sometimes caused the intersection to be computed before layout, in which the
target becomes a zero-area rect that counts as intersecting and which results in a deferred frame being
loaded eagerly. The fix is to copy the existing guard from Document::updateIntersectionObservers() to
Document::updateRemoteIntersectionObservers().

Tests: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-nested-cross-site.sub.html
       imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-siblings-cross-site.sub.html

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-nested-cross-site.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-nested-cross-site.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-siblings-cross-site.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-siblings-cross-site.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/resources/iframe-loading-lazy-nested-subframe.sub.html: Added.
* LayoutTests/tests-options.json:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateRemoteIntersectionObservers):

Canonical link: <a href="https://commits.webkit.org/319139@main">https://commits.webkit.org/319139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/977b589d6aed0458087c8577b3293e18112a476f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190610 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144720 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d299d158-f4e0-4acd-aa64-23602f7ff0a9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140704 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e97e277-40b5-457f-87da-7d733ef4d355) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121156 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed283543-df8a-4e21-a52e-6a030b25c3cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43033 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41326 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9967 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41011 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1769 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192545 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161000 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150056 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54698 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149779 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27405 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44414 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126961 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122123 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53215 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16000 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52597 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52834 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52662 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->