### PR TITLE
[GFC] Convert percentages in grid-auto-rows/grid-auto-columns to auto when computing intrinsic grid container size

### DIFF
--- a/LayoutTests/fast/css-grid-layout/grid-auto-rows-percentage-intrinsic-width-crash-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-auto-rows-percentage-intrinsic-width-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash and you see a green "PASS" below.
+
+PASS

--- a/LayoutTests/fast/css-grid-layout/grid-auto-rows-percentage-intrinsic-width-crash.html
+++ b/LayoutTests/fast/css-grid-layout/grid-auto-rows-percentage-intrinsic-width-crash.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<p>This test passes if it does not crash and you see a green "PASS" below.</p>
+<div style="display: grid; width: min-content; grid-auto-rows: 50%; color: green;">
+    PASS
+</div>

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -172,6 +172,11 @@ static Style::RepeatTrackList repeatTrackListWithPercentagesConvertedToAuto(cons
     });
 }
 
+static Style::GridTrackSizes gridAutoTrackSizesWithPercentagesConvertedToAuto(const Style::GridTrackSizes& gridAutoTrackSizes)
+{
+    return Style::GridTrackSizes { Style::GridTrackSizeList::map(gridAutoTrackSizes, trackSizeWithPercentagesConvertedToAuto) };
+}
+
 static Style::GridTemplateList gridTemplateListWithPercentagesConvertedToAuto(const Style::GridTemplateList& computedGridTemplateList)
 {
     Style::GridTrackList transformedList = computedGridTemplateList.list.map([](const Style::GridTrackEntry& entry) {
@@ -219,8 +224,10 @@ GridLayoutResult GridFormattingContext::layout(GridLayoutConstraints layoutConst
 
     auto gridTemplateColumns = inlineAxisDependsOnTracks ? gridTemplateListWithPercentagesConvertedToAuto(gridStyle->gridTemplateColumns()) : gridStyle->gridTemplateColumns();
     auto gridTemplateRows = blockAxisDependsOnTracks ? gridTemplateListWithPercentagesConvertedToAuto(gridStyle->gridTemplateRows()) : gridStyle->gridTemplateRows();
+    auto gridAutoColumns = inlineAxisDependsOnTracks ? gridAutoTrackSizesWithPercentagesConvertedToAuto(gridStyle->gridAutoColumns()) : gridStyle->gridAutoColumns();
+    auto gridAutoRows = blockAxisDependsOnTracks ? gridAutoTrackSizesWithPercentagesConvertedToAuto(gridStyle->gridAutoRows()) : gridStyle->gridAutoRows();
 
-    GridDefinition gridDefinition { gridTemplateColumns, gridTemplateRows, gridStyle->gridAutoColumns(), gridStyle->gridAutoRows(), autoFlowOptions, gridStyle->usedZoomForLength() };
+    GridDefinition gridDefinition { gridTemplateColumns, gridTemplateRows, gridAutoColumns, gridAutoRows, autoFlowOptions, gridStyle->usedZoomForLength() };
 
     auto usedJustifyContent = gridStyle->justifyContent().resolve();
     auto usedAlignContent = gridStyle->alignContent().resolve();
@@ -325,8 +332,8 @@ GridFormattingContext::IntrinsicWidths GridFormattingContext::computeIntrinsicWi
     GridDefinition gridDefinition {
         gridTemplateListWithPercentagesConvertedToAuto(gridStyle->gridTemplateColumns()),
         gridTemplateListWithPercentagesConvertedToAuto(gridStyle->gridTemplateRows()),
-        gridStyle->gridAutoColumns(),
-        gridStyle->gridAutoRows(),
+        gridAutoTrackSizesWithPercentagesConvertedToAuto(gridStyle->gridAutoColumns()),
+        gridAutoTrackSizesWithPercentagesConvertedToAuto(gridStyle->gridAutoRows()),
         autoFlowOptions,
         gridStyle->usedZoomForLength(),
     };


### PR DESCRIPTION
#### e10f76756319604596dad0ab29f5676732c18846
<pre>
[GFC] Convert percentages in grid-auto-rows/grid-auto-columns to auto when computing intrinsic grid container size
<a href="https://bugs.webkit.org/show_bug.cgi?id=321353">https://bugs.webkit.org/show_bug.cgi?id=321353</a>
<a href="https://rdar.apple.com/184019251">rdar://184019251</a>

Reviewed by Sammy Gill.

The crash happens because rowSizesForFirstIterationColumnSizing (GridLayout.cpp:391-423) assumes every row track&apos;s percentage sizing function has already been converted to auto
before it runs. Its own comment says as much, and the ASSERT at line 399 documents that assumption directly: &quot;The formatting context should have transformed this track size to
auto.&quot; When a row track is still a raw Percentage at that point, the function unconditionally dereferences the optional gridContainerInnerInlineSize, which is only empty in exactly
this situation.

That assumption was correctly upheld for grid-template-columns and grid-template-rows. The helper gridTemplateListWithPercentagesConvertedToAuto was already applied to both, in
both computeIntrinsicWidths and layout. But it was silently not upheld for grid-auto-columns and grid-auto-rows, which were passed through to GridDefinition untouched. Since
implicit tracks are sized from grid-auto-rows and grid-auto-columns (generateImplicitTrackSizingFunctions, GridLayout.cpp:346), any grid whose rows are entirely implicit, including
the common case of an empty explicit grid as in the crash testcase, could carry a raw percentage all the way into rowSizesForFirstIterationColumnSizing, with the container&apos;s
inline size still indefinite because the code is in the middle of computing that container&apos;s own intrinsic width. The precondition the code was written to depend on simply never
held for this input.

The fix closes that gap by applying the exact same percentage-to-auto conversion to grid-auto-columns and grid-auto-rows that already existed for the template lists, in the same
two call sites and under the same conditions. In layout, the conversion is gated on inlineAxisDependsOnTracks and blockAxisDependsOnTracks. In computeIntrinsicWidths, it is applied
unconditionally, since intrinsic sizing is always against an indefinite constraint. Once grid-auto-rows: 0% is converted to auto before reaching GridLayout,
rowSizesForFirstIterationColumnSizing takes the Auto branch at line 412 instead of the Percentage branch, and that branch returns LayoutUnit::max() without touching
gridContainerInnerInlineSize at all.

The ASSERT&apos;s precondition is now actually satisfied, so the fix is not &quot;handle the null case defensively,&quot; which would just convert a clean crash into silently wrong track sizing.
It is &quot;make sure the data reaching this code matches what the code was always written to assume.&quot; That is also exactly what the CSS Grid spec requires: percentage track sizes must
resolve as auto whenever the axis they depend on is indefinite, and that rule applies equally to grid-template-* and grid-auto-*, not just the former.

Test: fast/css-grid-layout/grid-auto-rows-percentage-intrinsic-width-crash.html

* LayoutTests/fast/css-grid-layout/grid-auto-rows-percentage-intrinsic-width-crash-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/grid-auto-rows-percentage-intrinsic-width-crash.html: Added.
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::gridAutoTrackSizesWithPercentagesConvertedToAuto):
(WebCore::Layout::GridFormattingContext::layout):
(WebCore::Layout::GridFormattingContext::computeIntrinsicWidths):

Canonical link: <a href="https://commits.webkit.org/318842@main">https://commits.webkit.org/318842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e2027446b66dcccdd5150d320ab6d2f8d48d06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189377 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b4045fb-c19e-4942-b573-9a1307fdf3fe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140018 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ee77df8-e012-4323-82e3-33d06c6f0879) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120471 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2cd76fc-8501-4fe2-809c-0dc44b995b8e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42304 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40625 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40279 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/831 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191598 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149284 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40020 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53835 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149031 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43695 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126107 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121020 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52352 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15265 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51737 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51978 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51798 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->