### PR TITLE
Release Mach port rights

### DIFF
--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -35,6 +35,7 @@ extern "C" {
 #endif
 
 #include <cstdio>
+#include <pthread.h>
 #include <signal.h>
 #include <wtf/StdLibExtras.h>
 
@@ -211,7 +212,7 @@ inline ptrauth_generic_signature_t hashThreadState(std::span<const natural_t> so
 
     ptrauth_generic_signature_t hash = 0;
 
-    hash = ptrauth_sign_generic_data(hash, mach_thread_self());
+    hash = ptrauth_sign_generic_data(hash, pthread_mach_thread_np(pthread_self()));
 
     auto srcSpan = spanReinterpretCast<const uintptr_t>(source).first(threadStateSizeInPointers);
 
@@ -289,9 +290,13 @@ kern_return_t catch_mach_exception_raise_state_identity_protected(
     mach_msg_type_number_t* outStateCount)
 {
     UNUSED_PARAM(threadID);
-    UNUSED_PARAM(taskIDToken);
-    return catch_mach_exception_raise_state(exceptionPort, exceptionType, exceptionData,
+    kern_return_t kr = catch_mach_exception_raise_state(exceptionPort, exceptionType, exceptionData,
         dataCount, stateFlavor, inState, inStateCount, outState, outStateCount);
+    // MIG moves the task ID token send right into this routine, but only a successful return owns it:
+    // on failure mach_msg_server_once destroys the request message and releases the right for us.
+    if (kr == KERN_SUCCESS && MACH_PORT_VALID(taskIDToken))
+        mach_port_deallocate(mach_task_self(), taskIDToken);
+    return kr;
 }
 
 #endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED)

--- a/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm
@@ -153,7 +153,7 @@ void ResourceUsageThread::platformCollectCPUData(JSC::VM*, ResourceUsageData& da
         return;
     }
 
-    mach_port_t resourceUsageMachThread = mach_thread_self();
+    auto resourceUsageMachThread = MachSendRight::adopt(mach_thread_self());
 
     // Main thread is always first.
     mach_port_t mainThreadMachThread = threads[0].sendRight.sendRight();
@@ -181,7 +181,7 @@ void ResourceUsageThread::platformCollectCPUData(JSC::VM*, ResourceUsageData& da
 
     auto isDebuggerThread = [&](const ThreadInfo& thread) -> bool {
         mach_port_t machThread = thread.sendRight.sendRight();
-        if (machThread == resourceUsageMachThread)
+        if (machThread == resourceUsageMachThread.sendRight())
             return true;
 #if ENABLE(SAMPLING_PROFILER)
         if (machThread == m_samplingProfilerMachThread)

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -34,6 +34,7 @@
 #import "WebPushDaemonConstants.h"
 #import <WebCore/SecurityOriginData.h>
 #import <mach/mach_init.h>
+#import <mach/mach_port.h>
 #import <mach/task.h>
 #import <pal/spi/cocoa/ServersSPI.h>
 #import <wtf/BlockPtr.h>
@@ -54,11 +55,13 @@ Ref<Connection> Connection::create(PreferTestService preferTestService, String b
 
 static mach_port_t maybeConnectToService(const char* serviceName)
 {
-    mach_port_t bsPort;
-    task_get_special_port(mach_task_self(), TASK_BOOTSTRAP_PORT, &bsPort);
+    mach_port_t bsPort = MACH_PORT_NULL;
+    if (task_get_special_port(mach_task_self(), TASK_BOOTSTRAP_PORT, &bsPort) != KERN_SUCCESS)
+        return MACH_PORT_NULL;
 
     mach_port_t servicePort;
     kern_return_t err = bootstrap_look_up(bsPort, serviceName, &servicePort);
+    mach_port_deallocate(mach_task_self(), bsPort);
 
     if (err == KERN_SUCCESS)
         return servicePort;
@@ -99,6 +102,7 @@ void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
             usleep(1000);
             result = maybeConnectToService(m_serviceName);
         }
+        mach_port_deallocate(mach_task_self(), result);
     }
 
     SAFE_PRINTF("Connecting to service '%s'\n", m_serviceName);


### PR DESCRIPTION
#### c4357d1dbdecfa5938c08bf8e4e7d33fbac6ab03
<pre>
Release Mach port rights
<a href="https://bugs.webkit.org/show_bug.cgi?id=321354">https://bugs.webkit.org/show_bug.cgi?id=321354</a>
<a href="https://rdar.apple.com/184386480">rdar://184386480</a>

Reviewed by Mark Lam.

Several code sites are leaking mach port rights incorrectly.

1. mach_thread_self() retains Mach port rights. Let&apos;s just use
   pthread_mach_thread_np(pthread_self()), which does not need to retain
   it.
2. catch_mach_exception_raise_state_identity_protected receives the task
   ID token. When routine succeeds, we need to release the ownership.
3. ResourceUsageThread leaked a mach_thread_self(). Adopt it into a
   MachSendRight instead.

* Source/WTF/wtf/threads/Signals.cpp:
(WTF::hashThreadState):
* Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm:
(WebCore::ResourceUsageThread::platformCollectCPUData):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::maybeConnectToService):
(WebPushTool::Connection::connectToService):

Canonical link: <a href="https://commits.webkit.org/318844@main">https://commits.webkit.org/318844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0ce9b2a7979215be61cd468f82ac2849ea5b9ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189378 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143855 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eacb2c89-04ac-40f7-bbf2-f39723de59a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140020 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/175cb903-eaee-4ea1-9c18-40dd3fe1a518) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120473 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a45c266c-bdb3-4f04-8931-210619a1c477) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42299 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40627 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2442 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9249 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40276 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/832 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40821 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191599 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53155 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149282 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53836 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149029 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27273 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43691 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126108 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121022 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52353 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15262 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51738 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51799 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->