### PR TITLE
[AppKit Gestures] NSWindows are left behind after each test when running several tests sequentially

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift
@@ -50,8 +50,31 @@ actor Recap {
     }
 }
 
+/// Presents a SwiftUI view in a key window, and closes that window once this object is deallocated.
+///
+/// Test suites should hold onto this rather than creating a window directly, so that the window does not
+/// outlive the suite. The window itself cannot perform this cleanup in its own `deinit`, since AppKit keeps
+/// an on-screen window alive until it is ordered out.
 @MainActor
-protocol AppKitGestureTestSuite {
+final class TestWindowHost {
+    let window: NSWindow
+
+    init(size: NSSize, @ViewBuilder rootView: () -> some View) {
+        self.window = NSWindow(size: size, rootView: rootView)
+        self.window.setFrameOrigin(.zero)
+
+        NSApp.activate(ignoringOtherApps: true)
+        self.window.makeKeyAndOrderFront(nil)
+    }
+
+    isolated deinit {
+        window.resignKey()
+        window.orderOut(nil)
+    }
+}
+
+@MainActor
+protocol AppKitGestureTestSuite: AnyObject {
     static var text: String { get }
 
     static var topInset: CGFloat { get }
@@ -60,7 +83,7 @@ protocol AppKitGestureTestSuite {
 
     var page: WebPage { get }
 
-    var window: NSWindow { get }
+    var windowHost: TestWindowHost { get }
 
     init() async throws
 }
@@ -68,6 +91,10 @@ protocol AppKitGestureTestSuite {
 extension AppKitGestureTestSuite {
     static var topInset: CGFloat {
         0
+    }
+
+    var window: NSWindow {
+        windowHost.window
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -37,7 +37,7 @@ private import AppKit_Private.NSMenu_Private
 extension AppKitGesturesTests {
     @MainActor
     @Suite(.serialized, .timeLimit(.minutes(1)))
-    struct Basic: AppKitGestureTestSuite {
+    final class Basic: AppKitGestureTestSuite {
         static let text = "Here's to the crazy ones."
 
         let recap = Recap.shared
@@ -48,19 +48,15 @@ extension AppKitGesturesTests {
             return WebPage(configuration: configuration)
         }()
 
-        let window: NSWindow
+        let windowHost: TestWindowHost
 
         init() async throws {
             let contentSize = NSSize(width: 800, height: 600)
 
-            self.window = NSWindow(size: contentSize) { [page] in
+            self.windowHost = TestWindowHost(size: contentSize) { [page] in
                 WebView(page)
                     .webViewBackForwardNavigationGestures(.enabled)
             }
-
-            self.window.setFrameOrigin(.zero)
-            NSApp.activate(ignoringOtherApps: true)
-            self.window.makeKeyAndOrderFront(nil)
 
             await NSApp.waitForActivation()
         }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/DoubleClickGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/DoubleClickGesturesTests.swift
@@ -37,7 +37,7 @@ private import AppKit_Private.NSMenu_Private
 extension AppKitGesturesTests {
     @MainActor
     @Suite(.serialized, .timeLimit(.minutes(1)))
-    struct DoubleClick: AppKitGestureTestSuite {
+    final class DoubleClick: AppKitGestureTestSuite {
         static let text = "Here's to the crazy ones."
 
         let recap = Recap.shared
@@ -48,19 +48,15 @@ extension AppKitGesturesTests {
             return WebPage(configuration: configuration)
         }()
 
-        let window: NSWindow
+        let windowHost: TestWindowHost
 
         init() async throws {
             let contentSize = NSSize(width: 800, height: 600)
 
-            self.window = NSWindow(size: contentSize) { [page] in
+            self.windowHost = TestWindowHost(size: contentSize) { [page] in
                 WebView(page)
                     .webViewBackForwardNavigationGestures(.enabled)
             }
-
-            self.window.setFrameOrigin(.zero)
-            NSApp.activate(ignoringOtherApps: true)
-            self.window.makeKeyAndOrderFront(nil)
 
             await NSApp.waitForActivation()
         }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift
@@ -38,7 +38,7 @@ private import AppKit_Private.NSMenu_Private
 extension AppKitGesturesTests {
     @MainActor
     @Suite(.serialized, .timeLimit(.minutes(1)))
-    struct Embedded: AppKitGestureTestSuite {
+    final class Embedded: AppKitGestureTestSuite {
         @MainActor
         private final class ContentOffsetStorage {
             var value = CGPoint.zero
@@ -56,7 +56,7 @@ extension AppKitGesturesTests {
             return WebPage(configuration: configuration)
         }()
 
-        let window: NSWindow
+        let windowHost: TestWindowHost
 
         private let windowSize = NSSize(width: 800, height: 600)
         private let contentHeight: CGFloat = 2000
@@ -64,7 +64,7 @@ extension AppKitGesturesTests {
         private var contentOffset = ContentOffsetStorage()
 
         init() async throws {
-            self.window = NSWindow(size: windowSize) { [windowSize, contentHeight, contentOffset, page] in
+            self.windowHost = TestWindowHost(size: windowSize) { [windowSize, contentHeight, contentOffset, page] in
                 ScrollView {
                     VStack(spacing: 0) {
                         WebView(page)
@@ -80,10 +80,6 @@ extension AppKitGesturesTests {
                     contentOffset.value = newContentOffset
                 }
             }
-
-            self.window.setFrameOrigin(.zero)
-            NSApp.activate(ignoringOtherApps: true)
-            self.window.makeKeyAndOrderFront(nil)
 
             await NSApp.waitForActivation()
         }


### PR DESCRIPTION
#### 0e348afd1843d37b1a41bb1f650ccbe87cf482f6
<pre>
[AppKit Gestures] NSWindows are left behind after each test when running several tests sequentially
<a href="https://bugs.webkit.org/show_bug.cgi?id=321356">https://bugs.webkit.org/show_bug.cgi?id=321356</a>
<a href="https://rdar.apple.com/184388647">rdar://184388647</a>

Reviewed by NOBODY (OOPS!).

Remove the window during test teardown.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/DoubleClickGesturesTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e348afd1843d37b1a41bb1f650ccbe87cf482f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53494 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189387 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53205 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182512 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/160771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/120480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/841 "Failed to checkout and rebase branch from PR 71212") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/191608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53164 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/160288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/191608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53845 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/191608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27264 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/43700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121036 "Failed to checkout and rebase branch from PR 71212") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52362 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/15269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51747 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51988 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51808 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->