### PR TITLE
[site-isolation] media/audioSession/audioSessionType-web-audio.html is a permanent failure

### DIFF
--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -247,6 +247,12 @@ void RemoteMediaSessionManagerProxy::webProcessWillShutDown(WebCore::ProcessIden
         updateSessionState();
 
 #if USE(AUDIO_SESSION)
+    // Drop any override that process had set, so it no longer affects the category.
+    if (m_categoryOverridesByPage.removeIf([processIdentifier](auto& entry) {
+        return entry.key.processIdentifier() == processIdentifier;
+    }))
+        updateSessionState();
+
     // If we had activated the audio session on behalf of this now-gone process, forget it: its GPU
     // audio-session proxy was torn down with the process, and removeSession() above already drives the
     // shared session inactive once nothing else needs it. This keeps a later deactivation from being
@@ -271,7 +277,7 @@ void RemoteMediaSessionManagerProxy::refreshSessionStates(IPC::Connection& conne
     }
 }
 
-void RemoteMediaSessionManagerProxy::updateMediaSessionStates(IPC::Connection& connection, WebCore::PageIdentifier pageIdentifier, Vector<RemoteMediaSessionState>&& sessions, uint64_t audioCaptureSourceCount, CompletionHandler<void(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&& completionHandler)
+void RemoteMediaSessionManagerProxy::updateMediaSessionStates(IPC::Connection& connection, WebCore::PageIdentifier pageIdentifier, Vector<RemoteMediaSessionState>&& sessions, uint64_t audioCaptureSourceCount, WebCore::AudioSessionCategory categoryOverride, CompletionHandler<void(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&& completionHandler)
 {
     refreshSessionStates(connection, sessions);
 
@@ -280,6 +286,17 @@ void RemoteMediaSessionManagerProxy::updateMediaSessionStates(IPC::Connection& c
         m_audioCaptureSourceCountsByPage.remove(key);
     else
         m_audioCaptureSourceCountsByPage.set(key, audioCaptureSourceCount);
+
+#if USE(AUDIO_SESSION)
+    // Each page reports its own override. Keep them separate so that a page without one does not clear
+    // the override another page has set.
+    if (categoryOverride == WebCore::AudioSessionCategory::None)
+        m_categoryOverridesByPage.remove(key);
+    else
+        m_categoryOverridesByPage.set(key, categoryOverride);
+#else
+    UNUSED_PARAM(categoryOverride);
+#endif
 
     updateSessionState();
 #if USE(AUDIO_SESSION)
@@ -354,6 +371,16 @@ void RemoteMediaSessionManagerProxy::resetMediaSessionRestrictions()
 }
 
 #if USE(AUDIO_SESSION)
+WebCore::AudioSessionCategory RemoteMediaSessionManagerProxy::categoryOverride() const
+{
+    // Use the override of any page that has set one. Pages without an override have no entry here.
+    for (auto category : m_categoryOverridesByPage.values()) {
+        if (category != WebCore::AudioSessionCategory::None)
+            return category;
+    }
+    return WebCore::AudioSessionCategory::None;
+}
+
 void RemoteMediaSessionManagerProxy::remoteAudioConfigurationChanged(RemoteAudioSessionConfiguration&& configuration)
 {
     m_audioConfiguration = WTF::move(configuration);

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -103,7 +103,7 @@ private:
     void addMediaSession(IPC::Connection&, RemoteMediaSessionState&&);
     void removeMediaSession(IPC::Connection&, RemoteMediaSessionState&&);
     void setCurrentMediaSession(IPC::Connection&, RemoteMediaSessionState&&);
-    void updateMediaSessionStates(IPC::Connection&, WebCore::PageIdentifier, Vector<RemoteMediaSessionState>&&, uint64_t audioCaptureSourceCount, CompletionHandler<void(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&&);
+    void updateMediaSessionStates(IPC::Connection&, WebCore::PageIdentifier, Vector<RemoteMediaSessionState>&&, uint64_t audioCaptureSourceCount, WebCore::AudioSessionCategory categoryOverride, CompletionHandler<void(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&&);
     void mediaSessionStateChanged(IPC::Connection&, WebKit::RemoteMediaSessionState&&);
     void mediaSessionWillBeginPlayback(IPC::Connection&, RemoteMediaSessionState&&, CompletionHandler<void(bool, WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&&);
 
@@ -143,7 +143,7 @@ private:
     size_t preferredBufferSize() const final { return m_audioConfiguration.preferredBufferSize; }
     void setPreferredBufferSize(size_t) final;
 
-    CategoryType categoryOverride() const final  { return m_audioConfiguration.categoryOverride; }
+    CategoryType categoryOverride() const final;
 #endif
 
     RefPtr<WebCore::PlatformMediaSessionInterface> findAndUpdateSession(IPC::Connection&, const RemoteMediaSessionState&);
@@ -158,6 +158,9 @@ private:
 
     HashMap<WebCore::ProcessQualified<WebCore::MediaSessionIdentifier>, Ref<RemoteMediaSessionProxy>> m_sessionProxies;
     HashMap<WebCore::ProcessQualified<WebCore::PageIdentifier>, uint64_t> m_audioCaptureSourceCountsByPage;
+#if USE(AUDIO_SESSION)
+    HashMap<WebCore::ProcessQualified<WebCore::PageIdentifier>, WebCore::AudioSessionCategory> m_categoryOverridesByPage;
+#endif
 
 #if PLATFORM(COCOA)
     RefPtr<RemoteMediaSessionManagerAudioHardwareListener> m_audioHardwareListenerProxy;

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
@@ -29,7 +29,7 @@
     EnabledBy=RemoteMediaSessionManagerEnabled || SiteIsolationEnabled
 ]
 messages -> RemoteMediaSessionManagerProxy {
-    UpdateMediaSessionStates(WebCore::PageIdentifier pageIdentifier, Vector<WebKit::RemoteMediaSessionState> sessions, uint64_t audioCaptureSourceCount) -> (enum:uint8_t WebCore::AudioSessionCategory category, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
+    UpdateMediaSessionStates(WebCore::PageIdentifier pageIdentifier, Vector<WebKit::RemoteMediaSessionState> sessions, uint64_t audioCaptureSourceCount, enum:uint8_t WebCore::AudioSessionCategory categoryOverride) -> (enum:uint8_t WebCore::AudioSessionCategory category, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
     void AddMediaSession(struct WebKit::RemoteMediaSessionState session);
     void RemoveMediaSession(struct WebKit::RemoteMediaSessionState session);
     void SetCurrentMediaSession(struct WebKit::RemoteMediaSessionState session);

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
@@ -152,7 +152,15 @@ Ref<GenericPromise> RemoteMediaSessionManager::updateSessionState()
         return currentSessionState(*session);
     });
 
-    return sendWithPromisedReply(Messages::RemoteMediaSessionManagerProxy::UpdateMediaSessionStates(m_webPageID, WTF::move(sessions), countActiveAudioCaptureSources()))->whenSettled(RunLoop::mainSingleton(),
+    // navigator.audioSession.type sets the override on this process's AudioSession, but the category is
+    // computed in the UI process, which has no audio session of its own to read it from.
+#if USE(AUDIO_SESSION)
+    auto categoryOverride = WebCore::AudioSession::singleton().categoryOverride();
+#else
+    auto categoryOverride = WebCore::AudioSessionCategory::None;
+#endif
+
+    return sendWithPromisedReply(Messages::RemoteMediaSessionManagerProxy::UpdateMediaSessionStates(m_webPageID, WTF::move(sessions), countActiveAudioCaptureSources(), categoryOverride))->whenSettled(RunLoop::mainSingleton(),
         [](auto&& result) -> Ref<GenericPromise> {
             if (!result)
                 return GenericPromise::createAndReject();


### PR DESCRIPTION
#### ec92002c1155560ee158e7aea473098c075c2793
<pre>
[site-isolation] media/audioSession/audioSessionType-web-audio.html is a permanent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=321275">https://bugs.webkit.org/show_bug.cgi?id=321275</a>
<a href="https://rdar.apple.com/184323410">rdar://184323410</a>

Reviewed by Eric Carlson.

navigator.audioSession.type had no effect once the audio session category was recomputed:
media/audioSession/audioSessionType-web-audio.html read &quot;AmbientSound&quot; where it expected
&quot;PlayAndRecord&quot; after starting an AudioContext. The category is computed in the UI process, whose
RemoteMediaSessionManagerProxy read the override out of a configuration built in the GPU process
from the GPU&apos;s own audio session, which never carries one. navigator.audioSession.type set the
override on the WebContent process&apos;s AudioSession, and nothing forwarded it, so the UI process kept
CategoryType::None and fell through to the WebAudio branch. 100% failure with site isolation
enabled; without it the category is computed in the process that set the override, and the test
passed.

The override now travels in the UpdateMediaSessionStates message, so the UI process has it before
the reply computes a category. The proxy keeps one override per page, so that a page which never
set one does not clear the override belonging to another page, and it drops a page&apos;s entry when
that page&apos;s process goes away.

* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxy::webProcessWillShutDown): Drop the overrides of the
departing process.
(WebKit::RemoteMediaSessionManagerProxy::updateMediaSessionStates): Record the sending page&apos;s
override.
(WebKit::RemoteMediaSessionManagerProxy::categoryOverride): Added; returns the override of any page
that set one.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in: Carry the category
override in UpdateMediaSessionStates.
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp:
(WebKit::RemoteMediaSessionManager::updateSessionState): Send this process&apos;s category override.

Canonical link: <a href="https://commits.webkit.org/318865@main">https://commits.webkit.org/318865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/684a51b7eb03f540e877f832548dc7c1158d2c97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143862 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84af064f-fdb2-4647-9465-3349caf98e64) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140025 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5372ae16-9d67-423f-9c17-2fae4869e89c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120478 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1bb5ab7-0cd7-4845-8573-4e2e27aa4f26) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42309 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40633 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40281 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/839 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191606 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53162 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149290 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40036 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53843 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149037 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43699 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126115 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121032 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52360 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15267 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51745 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51986 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51806 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->