### PR TITLE
AX: An append queued after a subtree removal can be incorrectly discarded as stale

### DIFF
--- a/LayoutTests/accessibility/append-and-remove-in-one-cycle-expected.txt
+++ b/LayoutTests/accessibility/append-and-remove-in-one-cycle-expected.txt
@@ -1,0 +1,13 @@
+This test makes sure the isolated tree resolves a node correctly when a subtree removal and a later re-append of that same node reach the accessibility thread in one committed batch.
+
+PASS: parentCountAfterOwnerRemoved === 1
+PASS: restoredRole === expectedButtonRole
+PASS: movedOwnerCount === 1
+PASS: movedRole === expectedButtonRole
+PASS: movedParentCount === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Child
+Moved child

--- a/LayoutTests/accessibility/append-and-remove-in-one-cycle.html
+++ b/LayoutTests/accessibility/append-and-remove-in-one-cycle.html
@@ -1,0 +1,84 @@
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="owner" role="group"></div>
+<div id="parent" role="group">
+    <button id="child">Child</button>
+</div>
+
+<div id="movedOwner" role="group"></div>
+<div id="movedParent" role="group">
+    <button id="movedChild">Moved child</button>
+</div>
+
+<script>
+var testOutput = "This test makes sure the isolated tree resolves a node correctly when a subtree removal and a later re-append of that same node reach the accessibility thread in one committed batch.\n\n";
+
+// Waits without touching the accessibility tree. Any AX query forces the AX thread to apply
+// whatever has been committed so far, which would split the mutations below into separate
+// batches and defeat the point of the test.
+async function waitFramesWithoutQueryingAX(count)
+{
+    for (var i = 0; i < count; i++)
+        await new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)));
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        window.expectedButtonRole = "AXRole: AXButton";
+
+        var axParent = await waitForElementById("parent");
+        await waitFor(() => axParent.childrenCount === 1);
+
+        // aria-owns moves the button in the accessibility tree without touching the DOM or the
+        // render tree, so the object keeps its AXID. That is what puts one AXID in both the
+        // append and the subtree-removal vector of a single batch. A DOM reparent can't do this,
+        // as it destroys and recreates the renderer, so the new parent's append is for a new AXID.
+        //
+        // Stealing the button queues a removal of it from #parent. Deleting the owner then makes
+        // it a child of #parent again, queueing an append of that same AXID under #parent. Both
+        // land in one batch, with the append being the newer of the two, so deciding staleness by
+        // comparing parents alone cannot tell them apart and discards the append -- dropping the
+        // button from the tree even though it is a child of #parent again.
+        //
+        // Nothing may query the accessibility tree between these two mutations. Doing so applies
+        // the first batch, and then there is no merged batch left to get wrong.
+        document.getElementById("owner").setAttribute("aria-owns", "child");
+        await waitFramesWithoutQueryingAX(4);
+        document.getElementById("owner").remove();
+        await waitFramesWithoutQueryingAX(4);
+
+        window.parentCountAfterOwnerRemoved = axParent.childrenCount;
+        testOutput += expect("parentCountAfterOwnerRemoved", "1");
+        window.restoredRole = axParent.childrenCount ? axParent.childAtIndex(0).role : "<no child>";
+        testOutput += expect("restoredRole", "expectedButtonRole");
+
+        // The same batch shape as above, except the append genuinely is a move, with the removal and the
+        // append being from different parents, so the append must be kept rather than treated as stale.
+        var axMovedOwner = await waitForElementById("movedOwner");
+        var axMovedParent = await waitForElementById("movedParent");
+        await waitFor(() => axMovedParent.childrenCount === 1);
+
+        document.getElementById("movedOwner").setAttribute("aria-owns", "movedChild");
+        await waitFor(() => axMovedOwner.childrenCount === 1);
+
+        window.movedOwnerCount = axMovedOwner.childrenCount;
+        testOutput += expect("movedOwnerCount", "1");
+        window.movedRole = axMovedOwner.childrenCount ? axMovedOwner.childAtIndex(0).role : "<no child>";
+        testOutput += expect("movedRole", "expectedButtonRole");
+        window.movedParentCount = axMovedParent.childrenCount;
+        testOutput += expect("movedParentCount", "0");
+
+        debug(testOutput);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -157,7 +157,7 @@ void AXIsolatedTree::createEmptyContent(AccessibilityObject& axRoot)
     // derived dynamically from the tree's frame geometry, so we don't need to cache it.
     rootData.setProperty(AXProperty::ScreenRelativePosition, axRoot.screenRelativePosition());
 #endif
-    NodeChange rootAppend { WTF::move(rootData), axRoot.wrapper() };
+    NodeChange rootAppend { WTF::move(rootData), axRoot.wrapper(), nextChangeSequence() };
 
     RefPtr axWebArea = Accessibility::findUnignoredChild(axRoot, [] (auto& object) {
         return object->isWebArea();
@@ -169,7 +169,7 @@ void AXIsolatedTree::createEmptyContent(AccessibilityObject& axRoot)
     }
     auto webAreaData = createIsolatedObjectData(*axWebArea, *this);
     webAreaData.setProperty(AXProperty::ScreenRelativePosition, axWebArea->screenRelativePosition());
-    NodeChange webAreaAppend { WTF::move(webAreaData), axWebArea->wrapper() };
+    NodeChange webAreaAppend { WTF::move(webAreaData), axWebArea->wrapper(), nextChangeSequence() };
 
     m_nodeMap.set(axRoot.objectID(), ParentChildrenIDs { std::nullopt, { axWebArea->objectID() } });
     m_nodeMap.set(axWebArea->objectID(), ParentChildrenIDs { axRoot.objectID(), { } });
@@ -334,7 +334,7 @@ bool AXIsolatedTree::shouldCreateNodeChange(AccessibilityObject& axObject)
             || m_unconnectedNodes.contains(axObject.objectID()));
 }
 
-std::optional<AXIsolatedTree::NodeChange> AXIsolatedTree::nodeChangeForObject(Ref<AccessibilityObject> axObject)
+std::optional<AXIsolatedTree::NodeChange> AXIsolatedTree::nodeChangeForObject(Ref<AccessibilityObject> axObject, std::optional<uint64_t> sequence)
 {
     AX_ASSERT(isMainThread());
     AX_ASSERT(!axObject->isDetached());
@@ -355,7 +355,8 @@ std::optional<AXIsolatedTree::NodeChange> AXIsolatedTree::nodeChangeForObject(Re
         // objects for new children, and / or leak old ones. |collectNodeChangesForSubtree| has the same behavior.
         iterator->value.parentID = parentID;
     }
-    NodeChange nodeChange { WTF::move(data), axObject->wrapper() };
+
+    NodeChange nodeChange { WTF::move(data), axObject->wrapper(), sequence.value_or(nextChangeSequence()) };
 
     if (axObject->isRoot())
         setPendingRootNodeID(axObject->objectID());
@@ -436,7 +437,7 @@ void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
     // Instead, just directly create and queue the node change so m_readerThreadNodeMap can hold a reference
     // to it. It will be removed from m_readerThreadNodeMap when the corresponding DOM element, renderer, or
     // other entity is removed from the page.
-    NodeChange nodeChange { createIsolatedObjectData(axObject, *this), axObject->wrapper() };
+    NodeChange nodeChange { createIsolatedObjectData(axObject, *this), axObject->wrapper(), nextChangeSequence() };
     Locker locker { m_changeLogLock };
     mutablePendingChanges()->appends.append(WTF::move(nodeChange));
 }
@@ -484,7 +485,7 @@ Vector<AXIsolatedTree::NodeChange> AXIsolatedTree::resolveAppends()
     // The process of resolving appends can add more IDs to m_unresolvedPendingAppends as we iterate over it, so
     // iterate over an exchanged map instead. Any late-appended IDs will get picked up in the next cycle.
     auto unresolvedPendingAppends = std::exchange(m_unresolvedPendingAppends, { });
-    for (const auto& axID : unresolvedPendingAppends) {
+    for (const auto& [axID, sequence] : unresolvedPendingAppends) {
         if (m_replacingTree) {
             ++counter;
             if (MonotonicTime::now() - lastFeedbackTime > CreationFeedbackInterval) {
@@ -494,7 +495,11 @@ Vector<AXIsolatedTree::NodeChange> AXIsolatedTree::resolveAppends()
         }
 
         if (RefPtr axObject = cache->objectForID(axID)) {
-            if (std::optional nodeChange = nodeChangeForObject(*axObject))
+            // Pass along the sequence that was recorded when the decision to make this append
+            // was decided. The sequence captures when the *decision* to make the append was
+            // made, not the timing of when that append is actually resolved (now). Creating
+            // a fresh sequence ID here would be logically incorrect and potentially cause bugs.
+            if (std::optional nodeChange = nodeChangeForObject(*axObject, sequence))
                 resolvedAppends.append(WTF::move(*nodeChange));
         }
     }
@@ -541,7 +546,7 @@ void AXIsolatedTree::collectNodeChangesForSubtree(AccessibilityObject& axObject)
 
     auto iterator = m_nodeMap.find(axObject.objectID());
     if (iterator == m_nodeMap.end()) {
-        m_unresolvedPendingAppends.add(axObject.objectID());
+        m_unresolvedPendingAppends.set(axObject.objectID(), nextChangeSequence());
 
         Vector<AXID> axChildrenIDs;
         axChildrenIDs.reserveInitialCapacity(axChildrenCopy.size());
@@ -596,7 +601,7 @@ void AXIsolatedTree::updateNode(AccessibilityObject& axObject)
     // AccessibilityRenderObject::updateRoleAfterChildrenCreation), queue the append up to be resolved with the rest
     // of the collected changes. This prevents us from creating two node changes for the same object.
     if (isCollectingNodeChanges() || !m_unresolvedPendingAppends.isEmpty()) {
-        m_unresolvedPendingAppends.add(axObject.objectID());
+        m_unresolvedPendingAppends.set(axObject.objectID(), nextChangeSequence());
         return;
     }
 
@@ -1137,7 +1142,7 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
 
     AXID parentID = axAncestor->objectID();
     for (AXID childID : oldChildrenIDs)
-        m_subtreesToRemove.append({ childID, parentID });
+        m_subtreesToRemove.append({ childID, parentID, nextChangeSequence() });
     if (resolveNodeChanges == ResolveNodeChanges::Yes)
         queueRemovalsAndUnresolvedChanges();
 }
@@ -1372,7 +1377,7 @@ void AXIsolatedTree::removeNode(AXID axID, std::optional<AXID> parentID)
 
     m_unresolvedPendingAppends.remove(axID);
     removeSubtreeFromNodeMap(axID, parentID);
-    queueRemovals({ { axID, parentID } });
+    queueRemovals({ { axID, parentID, nextChangeSequence() } });
 }
 
 void AXIsolatedTree::removeSubtreeFromNodeMap(std::optional<AXID> objectID, std::optional<AXID> axParentID)
@@ -1502,67 +1507,130 @@ void AXIsolatedTree::clearTreeContentsLocked()
     // will be cleaned up automatically when the tree is destroyed.
 }
 
-// When a node is queued for both subtree removal and appending in the same
-// batch (e.g. when an in-process FrameHost is replaced with an out-of-process
-// one during site isolation), the old subtree snapshot and the new one can
-// both end up in m_pendingChanges.appends. The removal root may not yet be in the
-// node map, so deleteSubtree won't encounter it.
+// When a node is queued for both subtree removal and appending in the same batch (e.g. when an
+// in-process FrameHost is replaced with an out-of-process one due to site isolation), the old
+// subtree snapshot and the new one can both end up in m_pendingChanges.appends. The removal root
+// may not yet be in the node map, so deleteSubtree won't encounter it, and removeStaleAppends is what
+// keeps the stale snapshot from being applied.
 //
-// For each unique appended ID, this function walks up its parent chain to
-// check whether any ancestor was removed from the same parent it's being
-// appended under. Results are memoized so each node is visited at most once
-// across all walks, giving O(n) total work.
+// More generally, a batch of pending changes carries appends and subtree removals in two separate
+// vectors, and the same AXID can legitimately appear in both. Two independent guards keep that from
+// corrupting the tree, and it's worth being precise about which does what, because they serve
+// different purposes.
 //
-// Nodes that were removed from one parent but appended under a different
-// parent are reparenting operations and should be kept.
+//   m_protectedFromDeletionIDs  "don't destroy a live object"
+//   removeStaleAppends          "don't resurrect a dead one"
+//
+// They also run at different times. applyPendingChanges applies removals first, destroying
+// objects as it goes, and only then calls removeStaleAppends to filter the appends. So by the
+// time we get here, destruction has already happened (unless m_protectedFromDeletionIDs saved the object).
+//
+// These variables are relevant in several scenarios.
+//
+// Scenario 1: A reparent that queues no append at all. #child is moved under a new parent by
+// aria-owns, which changes its accessibility parent without touching the render tree:
+//
+//     <div id="oldParent"><span id="child"></span></div>
+//     <div id="newParent"></div>
+//     newParent.setAttribute("aria-owns", "child");
+//
+// #child's isolated object already exists, so collectNodeChangesForSubtree takes its
+// "already in the isolated tree" branch and deliberately does not build a NodeChange (because it's
+// expensive). It protects the ID and queues a parent update instead. Meanwhile updateChildren
+// for #oldParent queues a removal of #child. The batch therefore holds a removal for #child and
+// no append for it. Without m_protectedFromDeletionIDs, deleteSubtree destroys a live object
+// that #newParent's childrenUpdates still points at.
+//
+// Scenario 2: A genuine deletion with a leftover append. A new child is added and its whole
+// subtree is then torn down in the same tree-update cycle:
+//
+//     oldParent.appendChild(newSpan);   // queues an append of newSpan under oldParent
+//     oldParent.remove();               // queues the removal
+//
+// newSpan has never been applied, so it isn't in m_readerThreadNodeMap and deleteSubtree never
+// encounters it. There is nothing to protect and nothing to destroy. Only removeStaleAppends
+// helps, as without it we materialize an object whose parent no longer exists, and which holds a
+// Ref to this tree. The FrameHost replacement described at the top of this comment is an instance
+// of this shape -- a removal root that was never applied, and so is absent from the node map.
+//
+// Scenario 3: The same parent, removed and then re-added. Pending changes accumulate until the
+// AX thread applies them, so decisions from two main-thread cycles can share one batch.
+//
+//     owner.setAttribute("aria-owns", "child");  // cycle 1: remove child from parent,
+//                                                //          append child under owner
+//     owner.remove();                            // cycle 2: append child under parent again
+//
+// The last append and the removal both name the original parent, so comparing parents alone
+// calls the newer append stale and drops it, and the object disappears while its parent's
+// childrenUpdates still lists it as a child. The sequence IDs ensure correctness in this case,
+// leaning on the append having been decided after the removal and thus having a larger ID.
+//
+// Finally, it's worth explaining why we still compare parents even though we have sequence IDs.
+// A reparent inside a single cycle queues the removal from updateChildren(oldParent) and the
+// append from updateChildren(newParent). Which of those happens first (and thus has a smaller
+// sequence ID) depends solely on the order m_needsUpdateChildren is iterated, so if the new
+// parent is visited first, the append is older than the removal and would be discarded.
+//
+// Comparing parents says these two decisions concern different parents and cannot invalidate each
+// other, making the outcome iteration-order independent.
+//
+// For each unique appended ID, this function walks up its parent chain looking for a removal
+// that invalidates it. Results are memoized so each node is visited at most once across all
+// walks, giving O(n) total work.
 void AXIsolatedTree::removeStaleAppends(const Vector<NodeAndParentID>& removals, Vector<NodeChange>& pendingAppends)
 {
-    // Build a map from removed AXID to the parent it was removed from, for
-    // O(1) lookups during the ancestor walk.
+    // Build maps from removed AXID to the parent it was removed from and when, for
+    // O(1) lookups during the ancestor walk. Kept as two maps rather than one keyed on
+    // NodeAndParentID because AXID isn't default-constructible, so it can't be a HashMap value.
     HashMap<AXID, Markable<AXID>> removedNodeToParentMap;
-    for (const auto& removal : removals)
+    HashMap<AXID, uint64_t> removedSequences;
+    for (const auto& removal : removals) {
         removedNodeToParentMap.set(removal.nodeID, removal.parentID);
+        removedSequences.set(removal.nodeID, removal.sequence);
+    }
 
-    // Build a map from appended AXID to its final parentID (last entry wins,
+    // Build maps from appended AXID to its final parentID and sequence (last entry wins,
     // since later appends override earlier ones in the append loop).
     HashMap<AXID, Markable<AXID>> appendedParentIDs;
-    for (const auto& item : pendingAppends)
+    HashMap<AXID, uint64_t> appendedSequences;
+    for (const auto& item : pendingAppends) {
         appendedParentIDs.set(item.data.axID, item.data.parentID);
+        appendedSequences.set(item.data.axID, item.sequence);
+    }
 
-    // For each unique appended ID, walk up the parent chain to determine
-    // whether it or any ancestor was removed from the same parent it's being
-    // appended under. Memoize results so shared ancestors are only resolved
-    // once.
-    HashMap<AXID, bool> ancestorWasRemoved;
+    // For each unique appended ID, walk up the parent chain looking for a removal that
+    // invalidates it. The memoized value is the sequence of the nearest such removal, or
+    // nullopt when there is none, so it doesn't depend on which descendant started the walk.
+    HashMap<AXID, std::optional<uint64_t>> invalidatingRemovalSequence;
     HashSet<AXID> idsToRemove;
 
     for (const auto& appendedID : appendedParentIDs.keys()) {
-        if (ancestorWasRemoved.contains(appendedID))
-            continue;
-
         Vector<AXID> unresolvedAncestors;
         AXID currentID = appendedID;
-        std::optional<bool> result;
+        bool resolved = false;
+        std::optional<uint64_t> invalidatingSequence;
 
-        while (!result) {
-            auto cachedIterator = ancestorWasRemoved.find(currentID);
-            if (cachedIterator != ancestorWasRemoved.end()) {
-                result = cachedIterator->value;
+        while (!resolved) {
+            auto cachedIterator = invalidatingRemovalSequence.find(currentID);
+            if (cachedIterator != invalidatingRemovalSequence.end()) {
+                invalidatingSequence = cachedIterator->value;
                 break;
             }
 
             unresolvedAncestors.append(currentID);
 
-            // Check if this node was removed. If so, compare parents: only
-            // keep it if both parents are known and differ (a reparent).
-            // If either parent is unknown, treat as stale to be safe.
+            // Check if this node was removed. A removal doesn't invalidate the append when the
+            // parents are known and differ, since that's a reparent rather than a deletion.
+            // Otherwise it invalidates any append decided before it.
             auto removedIterator = removedNodeToParentMap.find(currentID);
             if (removedIterator != removedNodeToParentMap.end()) {
                 auto currentAppendIterator = appendedParentIDs.find(currentID);
                 Markable<AXID> appendedParentID = (currentAppendIterator != appendedParentIDs.end()) ? currentAppendIterator->value : Markable<AXID> { };
                 Markable<AXID> removedParentID = removedIterator->value;
                 bool isReparent = appendedParentID && removedParentID && *appendedParentID != *removedParentID;
-                result = !isReparent;
+                if (!isReparent)
+                    invalidatingSequence = removedSequences.get(currentID);
+                resolved = true;
                 break;
             }
 
@@ -1582,14 +1650,17 @@ void AXIsolatedTree::removeStaleAppends(const Vector<NodeAndParentID>& removals,
             }
 
             // Reached a root or dead end — no removed ancestor.
-            result = false;
+            resolved = true;
         }
 
-        for (const auto& axID : unresolvedAncestors) {
-            ancestorWasRemoved.set(axID, *result);
-            if (*result)
-                idsToRemove.add(axID);
-        }
+        for (const auto& axID : unresolvedAncestors)
+            invalidatingRemovalSequence.set(axID, invalidatingSequence);
+
+        // The append only survives if it was decided after the removal that would invalidate it.
+        // A same-parent remove-then-re-add lands here with a newer append and must be kept, or the
+        // object is deleted while its parent's childrenUpdates still lists it as a child.
+        if (invalidatingSequence && appendedSequences.get(appendedID) < *invalidatingSequence)
+            idsToRemove.add(appendedID);
     }
 
     if (!idsToRemove.isEmpty()) {
@@ -1930,7 +2001,7 @@ void AXIsolatedTree::processQueuedNodeUpdates()
     m_needsUpdateChildren.clear();
 
     for (AXID objectID : m_needsUpdateNode)
-        m_unresolvedPendingAppends.add(objectID);
+        m_unresolvedPendingAppends.set(objectID, nextChangeSequence());
     m_needsUpdateNode.clear();
 
     // Updating properties can trigger side-effects (e.g. isIgnored() detecting an

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -388,6 +388,10 @@ void setPropertyIn(AXProperty, AXPropertyValueVariant&&, AXPropertyVector&, Opti
 struct NodeAndParentID {
     AXID nodeID;
     Markable<AXID> parentID;
+    // Monotonic ID of when the main thread decided on this removal, used by
+    // removeStaleAppends to tell a leftover append apart from a re-add queued afterwards.
+    // See AXIsolatedTree::nextChangeSequence.
+    uint64_t sequence { 0 };
 };
 
 struct IsolatedObjectData {
@@ -637,9 +641,14 @@ private:
 #elif USE(ATSPI)
         RefPtr<AccessibilityObjectWrapper> wrapper;
 #endif
-        explicit NodeChange(IsolatedObjectData&& isolatedData, RetainPtr<AccessibilityObjectWrapper> wrapper)
+        // Monotonic ID of when the main thread decided on this append. Compared against
+        // NodeAndParentID::sequence in removeStaleAppends. See nextChangeSequence.
+        uint64_t sequence { 0 };
+
+        explicit NodeChange(IsolatedObjectData&& isolatedData, RetainPtr<AccessibilityObjectWrapper> wrapper, uint64_t sequence = 0)
             : data(WTF::move(isolatedData))
             , wrapper(WTF::move(wrapper))
+            , sequence(sequence)
         { }
 
         NodeChange(const NodeChange&) = delete;
@@ -707,7 +716,7 @@ private:
     void updateNode(AccessibilityObject&);
     void updateNodeProperties(AccessibilityObject&, const AXPropertySet&);
 
-    std::optional<NodeChange> nodeChangeForObject(Ref<AccessibilityObject>);
+    std::optional<NodeChange> nodeChangeForObject(Ref<AccessibilityObject>, std::optional<uint64_t> sequence = std::nullopt);
     void collectNodeChangesForSubtree(AccessibilityObject&);
     bool isCollectingNodeChanges() const { return m_isCollectingNodeChanges; }
     void queueChange(NodeChange&&) WTF_REQUIRES_LOCK(m_changeLogLock);
@@ -742,7 +751,9 @@ private:
 
     // Only accessed on the main thread.
     // The key is the ID of the object that will be resolved into an m_pendingAppends NodeChange.
-    HashSet<AXID> m_unresolvedPendingAppends;
+    // The value is the sequence ID created when the append was decided, carried into the resulting
+    // NodeChange so removeStaleAppends can order it against removals.
+    HashMap<AXID, uint64_t> m_unresolvedPendingAppends;
     // Only accessed on the main thread.
     // While performing tree updates, we append nodes to this list that are no longer connected
     // in the tree and should be removed. This list turns into m_pendingSubtreeRemovals when
@@ -753,6 +764,9 @@ private:
     // It is required to protect objects from being incorrectly deleted when they are re-parented,
     // as the original parent will want to queue it for removal, but we need to keep the object around
     // for the new parent.
+    //
+    // See the comment above AXIsolatedTree::removeStaleAppends for a detailed explanation and specific
+    // scenarios where this member variable is relevant.
     HashSet<AXID> m_protectedFromDeletionIDs;
     // Only accessed on the main thread.
     // Objects whose parent has changed, and said change needs to be synced to the secondary thread.
@@ -764,6 +778,17 @@ private:
 
     // Written to by main thread under lock, accessed and applied by AX thread.
     PendingChanges m_pendingChanges WTF_GUARDED_BY_LOCK(m_changeLogLock);
+
+    // Main thread only. Marks appends and subtree removals with the order in which the main
+    // thread decided on them. applyPendingChanges replays appends and removals from separate
+    // vectors, so their relative order isn't otherwise recoverable, and removeStaleAppends needs
+    // it to tell a leftover append apart from a re-add that happened after the removal.
+    uint64_t nextChangeSequence()
+    {
+        AX_ASSERT(isMainThread());
+        return ++m_lastChangeSequence;
+    }
+    uint64_t m_lastChangeSequence { 0 };
 
     // These are placed here to fit in padding that would otherwise be between m_pendingSortedLiveRegionIDs and m_pendingSortedNonRootWebAreaIDs.
     OptionSet<ActivityState> m_pageActivityState;


### PR DESCRIPTION
#### 507dba2fa32ad23cba904af464524b9d8c62af0d
<pre>
AX: An append queued after a subtree removal can be incorrectly discarded as stale
<a href="https://bugs.webkit.org/show_bug.cgi?id=321357">https://bugs.webkit.org/show_bug.cgi?id=321357</a>
<a href="https://rdar.apple.com/184389421">rdar://184389421</a>

Reviewed by Dominic Mazzoni.

A batch of pending changes carries appends and subtree removals in two separate
vectors, so the same AXID can appear in both, and the relative order of the two
decisions is not recoverable from the batch. removeStaleAppends has to tell a
leftover append (the object was appended, then genuinely deleted, so applying the
append would resurrect a dead object) apart from a reparent (the object was removed
from its old parent and appended under a new one, so the append must be kept), and
it inferred the order from parentage. Differing parents meant a move, matching
parents meant stale.

That inference is wrong when a node is removed from a parent and then legitimately
re-added under that same parent. The parents match, so the append is judged stale
and dropped, even though it is the newer decision. The object is then missing from
the tree while the main thread&apos;s node map still lists it as a child of that parent.

owner.setAttribute(&quot;aria-owns&quot;, &quot;child&quot;);  // cycle 1: remove child from parent,
                                           //          append child under owner
owner.remove();                            // cycle 2: append child under natural parent again

Fix this by recording the order instead of inferring it. nextChangeSequence() creates a monotonic
counter onto NodeChange and NodeAndParentID at the point the main thread decides on
the append or removal, and removeStaleAppends now drops an append only when it was
decided before the removal that would invalidate it.

The test exercises the merged-batch case via aria-owns, which moves an object in the
accessibility tree without touching the render tree so the object keeps its AXID. A
DOM reparent cannot reach this code, as it destroys and recreates the renderer and the
new parent&apos;s append is therefore for a new AXID.

Note the test passes both with and without this change on trunk. Reaching the bug
requires two main-thread update cycles to land in one batch before the accessibility
thread applies it, which only happens deterministically with the browser-tick-based
batching atomic tree updates in <a href="https://bugs.webkit.org/show_bug.cgi?id=316148">https://bugs.webkit.org/show_bug.cgi?id=316148</a>, where
this test does fail without this fix.

* LayoutTests/accessibility/append-and-remove-in-one-cycle-expected.txt: Added.
* LayoutTests/accessibility/append-and-remove-in-one-cycle.html: Added.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::nodeChangeForObject):
(WebCore::AXIsolatedTree::addUnconnectedNode):
(WebCore::AXIsolatedTree::resolveAppends):
(WebCore::AXIsolatedTree::collectNodeChangesForSubtree):
(WebCore::AXIsolatedTree::updateNode):
(WebCore::AXIsolatedTree::updateChildren):
(WebCore::AXIsolatedTree::removeNode):
(WebCore::AXIsolatedTree::removeStaleAppends):
(WebCore::AXIsolatedTree::processQueuedNodeUpdates):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::NodeChange::NodeChange):
(WebCore::AXIsolatedTree::nextChangeSequence):

Canonical link: <a href="https://commits.webkit.org/318905@main">https://commits.webkit.org/318905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a492e2d6b93a9722ed387487b32cb49d0ed70498

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189389 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143866 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5c7fe0a-9351-477d-b843-be60f9e62c00) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140029 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96873 "layout-tests (failure) (timed out)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120482 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/717c6843-c09f-4951-9ff8-94529eb7857c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42312 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40637 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152713 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40285 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/abort.any.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/843 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191610 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149292 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40059 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53847 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149039 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43702 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126119 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121038 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52364 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15271 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51749 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51990 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51810 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->