### PR TITLE
[WebRTC] Concurrent RTCPeerConnections allocate O(N^2) UDP sockets

### DIFF
--- a/LayoutTests/webrtc/concurrent-gathering-host-ports-expected.txt
+++ b/LayoutTests/webrtc/concurrent-gathering-host-ports-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Checking concurrently gathering connections do not allocate a port per connection
+

--- a/LayoutTests/webrtc/concurrent-gathering-host-ports.html
+++ b/LayoutTests/webrtc/concurrent-gathering-host-ports.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="timeout" content="long">
+        <title>Ensuring concurrently gathering connections do not allocate a port per connection</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+function gatherHostEndpoints(test)
+{
+    var pc = new RTCPeerConnection();
+    test.add_cleanup(() => pc.close());
+    pc.createDataChannel("");
+
+    var endpoints = new Set();
+    return new Promise((resolve, reject) => {
+        var timeout = setTimeout(() => {
+            reject("gathering did time out with " + endpoints.size + " endpoints");
+        }, 20000);
+        pc.onicecandidate = (event) => {
+            if (event.candidate === null) {
+                clearTimeout(timeout);
+                resolve(endpoints);
+                return;
+            }
+            var candidate = event.candidate.candidate;
+            var items = candidate.split(" ");
+            // TCP host candidates are all reported on the discard port, so only UDP ones can be counted.
+            if (items[2].toLowerCase() !== "udp" || candidate.indexOf(" typ host") === -1)
+                return;
+            endpoints.add(items[4] + ":" + items[5]);
+        };
+        pc.createOffer().then((offer) => {
+            return pc.setLocalDescription(offer);
+        }).catch(reject);
+    });
+}
+
+function gatherConcurrently(test, count)
+{
+    var connections = [];
+    for (var i = 0; i < count; ++i)
+        connections.push(gatherHostEndpoints(test));
+    return Promise.all(connections).then((results) => {
+        return results.map((endpoints) => endpoints.size);
+    });
+}
+
+promise_test((test) => {
+    // How many endpoints one connection gathers depends on this host's interfaces. This also primes
+    // the network list, the state in which concurrent gathering used to fan out.
+    return gatherConcurrently(test, 1).then((baselineCounts) => {
+        var baseline = baselineCounts[0];
+        assert_greater_than(baseline, 0, "a single connection should gather host candidates");
+
+        // Connections used to allocate a port per concurrently gathering connection, so gathering on
+        // many at once should not allocate more endpoints per connection than gathering on one.
+        var connectionCount = 10;
+        return gatherConcurrently(test, connectionCount).then((counts) => {
+            counts.forEach((count) => {
+                assert_less_than_equal(count, baseline, "gathering on " + connectionCount + " connections at once should not allocate extra ports, but one of them gathered " + count + " endpoints for a baseline of " + baseline);
+            });
+        });
+    });
+}, "Checking concurrently gathering connections do not allocate a port per connection");
+        </script>
+    </body>
+</html>

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -111,17 +111,24 @@ void LibWebRTCNetworkManager::setEnumeratingVisibleNetworkInterfacesEnabled(bool
 
 void LibWebRTCNetworkManager::StartUpdating()
 {
+    // Called on the WebRTC network thread. Signaling from here rather than after a round trip through
+    // the main run loop keeps the signal ahead of the session's own allocation, where it is free; a
+    // later one makes every already allocating session of the document reallocate its ports.
+    if (m_hasMergedNetworkList && !m_hasPendingNetworksChangedNotification.exchange(true)) {
+        WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread([protectedThis = Ref { *this }] {
+            // Cleared before signaling so that a session starting to gather from within it reschedules.
+            protectedThis->m_hasPendingNetworksChangedNotification.store(false);
+            protectedThis->NotifyNetworksChanged();
+        });
+    }
+
     callOnMainRunLoop([weakThis = WeakPtr { *this }] {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
         Ref monitor = WebProcess::singleton().libWebRTCNetwork().monitor();
-        if (protectedThis->m_receivedNetworkList) {
-            WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread([protectedThis] {
-                protectedThis->NotifyNetworksChanged();
-            });
-        } else if (monitor->didReceiveNetworkList())
+        if (!protectedThis->m_receivedNetworkList && monitor->didReceiveNetworkList())
             protectedThis->networksChanged(monitor->networkList() , monitor->ipv4(), monitor->ipv6());
         monitor->startUpdating();
     });
@@ -192,6 +199,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
         bool hasChanged;
         set_default_local_addresses(ipv4.rtcAddress(), ipv6.rtcAddress());
         MergeNetworkList(WTF::move(networkList), &hasChanged);
+        m_hasMergedNetworkList.store(true);
         if (hasChanged || forceSignaling)
             NotifyNetworksChanged();
     });

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
@@ -32,6 +32,7 @@
 #include <WebCore/ProcessQualified.h>
 #include <WebCore/RTCNetworkManager.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
+#include <atomic>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
@@ -80,6 +81,9 @@ private:
     WebCore::ScriptExecutionContextIdentifier m_documentIdentifier;
     bool m_useMDNSCandidates { true };
     bool m_receivedNetworkList { false };
+    // Set on the WebRTC network thread, read there by StartUpdating.
+    std::atomic<bool> m_hasMergedNetworkList { false };
+    std::atomic<bool> m_hasPendingNetworksChangedNotification { false };
 #if ASSERT_ENABLED
     bool m_isClosed { false };
 #endif


### PR DESCRIPTION
#### fb8113d0071b5de5e00714bc8cce88a2e03ec90b
<pre>
[WebRTC] Concurrent RTCPeerConnections allocate O(N^2) UDP sockets
<a href="https://bugs.webkit.org/show_bug.cgi?id=321225">https://bugs.webkit.org/show_bug.cgi?id=321225</a>
<a href="https://rdar.apple.com/184396090">rdar://184396090</a>

Reviewed by NOBODY (OOPS!).

All the RTCPeerConnections of a document share one LibWebRTCNetworkManager and
every port allocator session subscribes to it, so StartUpdating() signals all of
them. libwebrtc is built for that: OnNetworksChanged() only allocates once
allocation_started_ has been set in OnAllocate(), so a signal arriving before a
session allocates is free.

StartUpdating() signaled after a round trip through the main run loop, which
delayed every signal past the allocation chain of all the sessions.
allocation_started_ was set by then, so each signal made each session allocate
another set of ports: N per connection and N^2 in total. Signal on the WebRTC
network thread that StartUpdating() is called on instead, which queues it ahead
of the session&apos;s own allocation as it is upstream. The main run loop is still
used for the network monitor, which is main thread only.

Also coalesce the pending notification. That no longer changes how many ports
are allocated, but it avoids N^2 OnNetworksChanged() calls that each build and
filter a network list.

Host ports per connection with 20 concurrent connections goes from 36 to 2,
which is what a single connection gathers on the same host. srflx yield is
unaffected: 240/720 before and 16/40 after. It degrades between 10 and 20
connections on both and would be tackled separately.

Test: webrtc/concurrent-gathering-host-ports.html

* LayoutTests/webrtc/concurrent-gathering-host-ports-expected.txt: Added.
* LayoutTests/webrtc/concurrent-gathering-host-ports.html: Added.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::StartUpdating):
(WebKit::LibWebRTCNetworkManager::networksChanged):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb8113d0071b5de5e00714bc8cce88a2e03ec90b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189391 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143868 "Failed to checkout and rebase branch from PR 71215") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28b4caf5-af1d-4461-92ce-875f163d5bbe) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140031 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/143868 "Failed to checkout and rebase branch from PR 71215") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9d65305f-bfcb-42a4-9a60-8dc35cbe03e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120484 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa3f02d8-6755-4cdb-8389-679f6450aed1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42315 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40639 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152716 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40288 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/abort.any.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/845 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191612 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149294 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53849 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36912 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149041 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43705 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126121 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121043 "Failed to checkout and rebase branch from PR 71215") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52366 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15274 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51751 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51812 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->