### PR TITLE
Media queries should include scrollbars in viewport dimensions

### DIFF
--- a/LayoutTests/fast/media/media-query-viewport-includes-scrollbars-expected.txt
+++ b/LayoutTests/fast/media/media-query-viewport-includes-scrollbars-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Viewport media features include rendered scrollbars
+

--- a/LayoutTests/fast/media/media-query-viewport-includes-scrollbars.html
+++ b/LayoutTests/fast/media/media-query-viewport-includes-scrollbars.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+html {
+    overflow: hidden;
+}
+
+body {
+    height: 200vh;
+    width: 200vw;
+}
+</style>
+</head>
+<body>
+<script>
+internals.setUsesOverlayScrollbars(false);
+
+promise_test(async () => {
+    const viewportWidth = innerWidth;
+    const viewportHeight = innerHeight;
+    const widthQuery = matchMedia(`(width: ${viewportWidth}px)`);
+    const heightQuery = matchMedia(`(height: ${viewportHeight}px)`);
+    const aspectRatioQuery = matchMedia(`(aspect-ratio: ${viewportWidth}/${viewportHeight})`);
+
+    assert_true(widthQuery.matches, "width matches before scrollbars are shown");
+    assert_true(heightQuery.matches, "height matches before scrollbars are shown");
+    assert_true(aspectRatioQuery.matches, "aspect-ratio matches before scrollbars are shown");
+
+    document.documentElement.style.overflow = "scroll";
+    document.documentElement.clientWidth;
+    await new Promise(requestAnimationFrame);
+
+    assert_greater_than(innerWidth, document.documentElement.clientWidth, "the vertical scrollbar occupies viewport space");
+    assert_greater_than(innerHeight, document.documentElement.clientHeight, "the horizontal scrollbar occupies viewport space");
+    assert_true(widthQuery.matches, "width includes the vertical scrollbar");
+    assert_true(heightQuery.matches, "height includes the horizontal scrollbar");
+    assert_true(aspectRatioQuery.matches, "aspect-ratio includes both scrollbars");
+    assert_true(matchMedia(`(width: ${viewportWidth}px)`).matches, "a newly evaluated width includes the vertical scrollbar");
+    assert_true(matchMedia(`(height: ${viewportHeight}px)`).matches, "a newly evaluated height includes the horizontal scrollbar");
+    assert_true(matchMedia(`(aspect-ratio: ${viewportWidth}/${viewportHeight})`).matches, "a newly evaluated aspect-ratio includes both scrollbars");
+}, "Viewport media features include rendered scrollbars");
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -272,7 +272,7 @@ static const RatioSchema& aspectRatioFeatureSchema()
         MediaQueryDynamicDependency::Viewport,
         [](auto& context) {
             auto& view = *context.document->view();
-            return FloatSize(view.layoutWidth(), view.layoutHeight());
+            return FloatSize(view.layoutSizeIncludingScrollbars());
         }
     };
     return schema;
@@ -427,7 +427,7 @@ static const LengthSchema& heightFeatureSchema()
         "height"_s,
         MediaQueryDynamicDependency::Viewport,
         [](auto& context) {
-            auto height = protect(context.document->view())->layoutHeight();
+            auto height = protect(context.document->view())->layoutSizeIncludingScrollbars().height();
             if (CheckedPtr renderView = context.document->renderView())
                 height = Style::adjustForAbsoluteZoom(height, *renderView);
             return height;
@@ -511,7 +511,8 @@ static const IdentifierSchema& orientationFeatureSchema()
 
             Ref view = *context.document->view();
             // Square viewport is portrait.
-            bool isPortrait = view->layoutHeight() >= view->layoutWidth();
+            auto viewportSize = view->layoutSizeIncludingScrollbars();
+            bool isPortrait = viewportSize.height() >= viewportSize.width();
             return MatchingIdentifiers { isPortrait ? CSSValuePortrait : CSSValueLandscape };
         }
     };
@@ -727,7 +728,7 @@ static const LengthSchema& widthFeatureSchema()
         "width"_s,
         MediaQueryDynamicDependency::Viewport,
         [](auto& context) {
-            auto width = protect(context.document->view())->layoutWidth();
+            auto width = protect(context.document->view())->layoutSizeIncludingScrollbars().width();
             if (CheckedPtr renderView = context.document->renderView())
                 width = Style::adjustForAbsoluteZoom(width, *renderView);
             return width;

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -369,6 +369,11 @@ IntSize ScrollView::layoutSize() const
     return m_fixedLayoutSize.isEmpty() || !m_useFixedLayout ? sizeForUnobscuredContent() : m_fixedLayoutSize;
 }
 
+IntSize ScrollView::layoutSizeIncludingScrollbars() const
+{
+    return m_fixedLayoutSize.isEmpty() || !m_useFixedLayout ? sizeForUnobscuredContent(VisibleContentRectIncludesScrollbars::Yes) : m_fixedLayoutSize;
+}
+
 IntSize ScrollView::fixedLayoutSize() const
 {
     return m_fixedLayoutSize;

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -236,6 +236,7 @@ public:
     // Functions for getting/setting the size webkit should use to layout the contents. By default this is the same as the visible
     // content size. Explicitly setting a layout size value will cause webkit to layout the contents using this size instead.
     WEBCORE_EXPORT IntSize layoutSize() const;
+    IntSize layoutSizeIncludingScrollbars() const;
     int layoutWidth() const { return layoutSize().width(); }
     int layoutHeight() const { return layoutSize().height(); }
 

--- a/Source/WebCore/style/StyleDocumentScope.cpp
+++ b/Source/WebCore/style/StyleDocumentScope.cpp
@@ -134,7 +134,7 @@ void DocumentScope::setPreferredStylesheetSetName(const WTF::String& name)
 auto DocumentScope::mediaQueryViewportStateForDocument(const Document& document) -> MediaQueryViewportState
 {
     // These things affect evaluation of viewport dependent media queries.
-    return { document.view()->layoutSize(), document.frame()->pageZoomFactor(), document.printing() };
+    return { document.view()->layoutSizeIncludingScrollbars(), document.frame()->pageZoomFactor(), document.printing() };
 }
 
 void DocumentScope::evaluateMediaQueriesForViewportChange()


### PR DESCRIPTION
## Summary

- evaluate viewport `width`, `height`, `aspect-ratio`, and `orientation` media features using scrollbar-inclusive viewport dimensions
- keep viewport media-query invalidation state consistent with that definition
- add regression coverage for classic scrollbars and both existing and freshly evaluated `MediaQueryList`s

## Root cause

Viewport media features used `ScrollView::layoutSize()`, which excludes classic scrollbar intrusion. As a result, an 800px viewport with a 15px scrollbar was evaluated as 785px even though media queries are defined against the full viewport.

Bug: https://bugs.webkit.org/show_bug.cgi?id=52653

## Testing

- `Tools/Scripts/build-webkit --release --only=WebCore`
- `Tools/Scripts/build-webkit --release --only=WebKit`
- `Tools/Scripts/build-webkit --release --only=WebKitTestRunner`
- `Tools/Scripts/run-webkit-tests --release fast/media/media-query-viewport-includes-scrollbars.html`
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c24998cf8547e6fb5aa7c9dc4a13a32fe4060c30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189396 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140035 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182521 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43649 "Found 1 new test failure: fast/media/media-query-viewport-includes-scrollbars.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120488 "Passed tests") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42319 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Exiting early after 10 failures. 10 tests run. 1 failures; Uploaded test results; 1 new passes 3 flakes; Running re-run-layout-tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40643 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152720 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40292 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/execute-start.tentative.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/850 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191617 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149299 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53854 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149045 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43709 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126126 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121048 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52371 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15278 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51756 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->