### PR TITLE
Cherry-pick 317292@main (3aa0615a5649). https://bugs.webkit.org/show_bug.cgi?id=319520

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -331,7 +331,9 @@ constexpr bool hasTwoOrMoreBitsSet(T value)
 template<typename T>
 constexpr T divideRoundedUp(T a, T b)
 {
-    return (a + b - 1) / b;
+    // Mathematically equivalent to (a + b - 1) / b, but does not overflow
+    // when a is close to the maximum representable value of T.
+    return a / b + !!(a % b);
 }
 
 template<typename T>

--- a/Source/WebCore/inspector/InspectorThreadableLoaderClient.h
+++ b/Source/WebCore/inspector/InspectorThreadableLoaderClient.h
@@ -78,7 +78,7 @@ private:
     RefPtr<WebCore::TextResourceDecoder> m_decoder;
     String m_mimeType;
     StringBuilder m_responseText;
-    int m_statusCode;
+    int m_statusCode { 0 };
     bool m_hasCalledDeref { false };
 };
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
@@ -186,7 +186,7 @@ const Vector<size_t>& InlineContent::nonRootInlineBoxIndexesForLayoutBox(const L
                 return Vector<size_t> { };
             }).iterator->value.append(i);
         }
-        for (auto entry : *m_inlineBoxIndexCache)
+        for (auto& entry : *m_inlineBoxIndexCache)
             entry.value.shrinkToFit();
     }
 

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -83,10 +83,11 @@ static Seconds adjustedTimeoutForThermalState(Seconds timeout)
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AuxiliaryProcessProxy);
 
-AuxiliaryProcessProxy::AuxiliaryProcessProxy(ShouldTakeUIBackgroundAssertion shouldTakeUIBackgroundAssertion, AlwaysRunsAtBackgroundPriority alwaysRunsAtBackgroundPriority, Seconds responsivenessTimeout)
+AuxiliaryProcessProxy::AuxiliaryProcessProxy(ASCIILiteral clientName, ShouldTakeUIBackgroundAssertion shouldTakeUIBackgroundAssertion, AlwaysRunsAtBackgroundPriority alwaysRunsAtBackgroundPriority, Seconds responsivenessTimeout)
     : m_responsivenessTimer(ResponsivenessTimer::create(*this, adjustedTimeoutForThermalState(responsivenessTimeout)))
     , m_alwaysRunsAtBackgroundPriority(alwaysRunsAtBackgroundPriority == AlwaysRunsAtBackgroundPriority::Yes)
     , m_throttler(*this, shouldTakeUIBackgroundAssertion == ShouldTakeUIBackgroundAssertion::Yes)
+    , m_clientName(clientName)
 {
 }
 
@@ -652,6 +653,17 @@ AuxiliaryProcessProxy::InitializationActivityAndGrant AuxiliaryProcessProxy::ini
         , launchGrant()
 #endif
     };
+}
+
+String AuxiliaryProcessProxy::environmentIdentifier()
+{
+    if (m_environmentIdentifier.isEmpty()) {
+        StringBuilder builder;
+        builder.append(m_clientName);
+        builder.append(processID());
+        m_environmentIdentifier = builder.toString();
+    }
+    return m_environmentIdentifier;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -74,7 +74,7 @@ class AuxiliaryProcessProxy
     WTF_MAKE_TZONE_ALLOCATED(AuxiliaryProcessProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AuxiliaryProcessProxy);
 protected:
-    AuxiliaryProcessProxy(ShouldTakeUIBackgroundAssertion, AlwaysRunsAtBackgroundPriority = AlwaysRunsAtBackgroundPriority::No, Seconds responsivenessTimeout = ResponsivenessTimer::defaultResponsivenessTimeout);
+    AuxiliaryProcessProxy(ASCIILiteral clientName, ShouldTakeUIBackgroundAssertion, AlwaysRunsAtBackgroundPriority = AlwaysRunsAtBackgroundPriority::No, Seconds responsivenessTimeout = ResponsivenessTimer::defaultResponsivenessTimeout);
 
 public:
     USING_CAN_MAKE_WEAKPTR(ResponsivenessTimer::Client);
@@ -251,8 +251,8 @@ public:
     virtual void sendPrepareToSuspend(IsSuspensionImminent, double remainingRunTime, CompletionHandler<void()>&&) = 0;
     virtual void sendProcessDidResume(ResumeReason) = 0;
     virtual void didChangeThrottleState(ProcessThrottleState);
-    virtual ASCIILiteral clientName() const = 0;
-    virtual String environmentIdentifier() const { return emptyString(); }
+    ASCIILiteral clientName() const { return m_clientName; }
+    String environmentIdentifier();
     virtual void prepareToDropLastAssertion(CompletionHandler<void()>&& completionHandler) { completionHandler(); }
     virtual void didDropLastAssertion() { }
 
@@ -333,6 +333,8 @@ private:
 #if ENABLE(EXTENSION_CAPABILITIES)
     ExtensionCapabilityGrantMap m_extensionCapabilityGrants;
 #endif
+    String m_environmentIdentifier;
+    const ASCIILiteral m_clientName;
     HashMap<Vector<uint8_t>, std::pair<unsigned, std::unique_ptr<IPC::Encoder>>> m_messagesToSendOnResume;
     unsigned m_messagesToSendOnResumeIndex { 0 };
 } SWIFT_SHARED_REFERENCE(refAuxiliaryProcessProxy, derefAuxiliaryProcessProxy);

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -164,7 +164,7 @@ static String gpuProcessCachesDirectory()
 #endif
 
 GPUProcessProxy::GPUProcessProxy()
-    : AuxiliaryProcessProxy(WebProcessPool::anyProcessPoolNeedsUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No)
+    : AuxiliaryProcessProxy("GPUProcess"_s, WebProcessPool::anyProcessPoolNeedsUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No)
 #if ENABLE(MEDIA_STREAM)
     , m_useMockCaptureDevices(MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled())
 #endif

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -194,7 +194,6 @@ private:
     void gpuProcessExited(ProcessTerminationReason);
 
     // ProcessThrottlerClient
-    ASCIILiteral clientName() const final { return "GPUProcess"_s; }
     void sendPrepareToSuspend(IsSuspensionImminent, double remainingRunTime, CompletionHandler<void()>&&) final;
     void sendProcessDidResume(ResumeReason) final;
 

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -82,7 +82,7 @@ ModelProcessProxy* ModelProcessProxy::singletonIfCreated()
 }
 
 ModelProcessProxy::ModelProcessProxy()
-    : AuxiliaryProcessProxy(WebProcessPool::anyProcessPoolNeedsUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No)
+    : AuxiliaryProcessProxy("ModelProcess"_s, WebProcessPool::anyProcessPoolNeedsUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No)
 {
     connect();
 

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
@@ -95,7 +95,6 @@ private:
     void modelProcessExited(ProcessTerminationReason);
 
     // ProcessThrottlerClient
-    ASCIILiteral clientName() const final { return "ModelProcess"_s; }
     void sendPrepareToSuspend(IsSuspensionImminent, double remainingRunTime, CompletionHandler<void()>&&) final;
     void sendProcessDidResume(ResumeReason) final;
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -254,7 +254,7 @@ static bool anyProcessPoolAlwaysRunsAtBackgroundPriority()
 }
 
 NetworkProcessProxy::NetworkProcessProxy()
-    : AuxiliaryProcessProxy(WebProcessPool::anyProcessPoolNeedsUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No
+    : AuxiliaryProcessProxy("NetworkProcess"_s, WebProcessPool::anyProcessPoolNeedsUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No
     , anyProcessPoolAlwaysRunsAtBackgroundPriority() ? AlwaysRunsAtBackgroundPriority::Yes : AlwaysRunsAtBackgroundPriority::No
     , networkProcessResponsivenessTimeout)
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -254,8 +254,7 @@ public:
 
     // ProcessThrottlerClient
     void sendProcessDidResume(ResumeReason) final;
-    ASCIILiteral clientName() const final { return "NetworkProcess"_s; }
-    
+
     static void setSuspensionAllowedForTesting(bool);
     void sendProcessWillSuspendImminentlyForTesting();
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -312,7 +312,7 @@ Ref<WebProcessProxy> WebProcessProxy::createForRemoteWorkers(RemoteWorkerType wo
 }
 
 WebProcessProxy::WebProcessProxy(WebProcessPool& processPool, WebsiteDataStore* websiteDataStore, IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity)
-    : AuxiliaryProcessProxy(processPool.shouldTakeUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No
+    : AuxiliaryProcessProxy("WebProcess"_s, processPool.shouldTakeUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No
     , processPool.alwaysRunsAtBackgroundPriority() ? AlwaysRunsAtBackgroundPriority::Yes : AlwaysRunsAtBackgroundPriority::No)
     , m_backgroundResponsivenessTimer(makeUniqueRef<BackgroundProcessResponsivenessTimer>(*this))
     , m_processPool(processPool, isPrewarmed == IsPrewarmed::Yes ? IsWeak::Yes : IsWeak::No)
@@ -2044,17 +2044,6 @@ void WebProcessProxy::prepareToDropLastAssertion(CompletionHandler<void()>&& com
 #else
     completionHandler();
 #endif
-}
-
-String WebProcessProxy::environmentIdentifier() const
-{
-    if (m_environmentIdentifier.isEmpty()) {
-        StringBuilder builder;
-        builder.append(clientName());
-        builder.append(processID());
-        m_environmentIdentifier = builder.toString();
-    }
-    return m_environmentIdentifier;
 }
 
 void WebProcessProxy::updateAudibleMediaAssertions()

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -443,8 +443,6 @@ public:
     void didChangeThrottleState(ProcessThrottleState) final;
     void prepareToDropLastAssertion(CompletionHandler<void()>&&) final;
     void didDropLastAssertion() final;
-    ASCIILiteral clientName() const final { return "WebProcess"_s; }
-    String environmentIdentifier() const final;
 
 #if PLATFORM(COCOA)
     enum SandboxExtensionType : uint32_t {
@@ -895,7 +893,6 @@ private:
 #if PLATFORM(COCOA)
     bool m_platformSuspendDidReleaseNearSuspendedAssertion { false };
 #endif
-    mutable String m_environmentIdentifier;
     mutable SharedPreferencesForWebProcess m_sharedPreferencesForWebProcess;
     uint64_t m_sharedPreferencesVersionInNetworkProcess { 0 };
 #if ENABLE(GPU_PROCESS)

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -753,4 +753,29 @@ TEST(WTF, negate)
     EXPECT_EQ(WTF::negate<long long>(0LL), 0LL);
 }
 
+TEST(WTF, divideRoundedUp)
+{
+    // Basic rounding behavior.
+    EXPECT_EQ(divideRoundedUp<unsigned>(0, 3), 0U);
+    EXPECT_EQ(divideRoundedUp<unsigned>(1, 3), 1U);
+    EXPECT_EQ(divideRoundedUp<unsigned>(3, 3), 1U);
+    EXPECT_EQ(divideRoundedUp<unsigned>(4, 3), 2U);
+    EXPECT_EQ(divideRoundedUp<unsigned>(6, 3), 2U);
+    EXPECT_EQ(divideRoundedUp<unsigned>(7, 3), 3U);
+
+    // Divisor of 1 returns the dividend unchanged, even at the maximum.
+    EXPECT_EQ(divideRoundedUp<uint8_t>(std::numeric_limits<uint8_t>::max(), 1), std::numeric_limits<uint8_t>::max());
+    EXPECT_EQ(divideRoundedUp<size_t>(std::numeric_limits<size_t>::max(), 1), std::numeric_limits<size_t>::max());
+
+    // Dividends near the maximum must not overflow the (a + b - 1) intermediate.
+    EXPECT_EQ(divideRoundedUp<uint8_t>(std::numeric_limits<uint8_t>::max(), 2), 128U);
+    EXPECT_EQ(divideRoundedUp<uint16_t>(std::numeric_limits<uint16_t>::max(), 2), 32768U);
+    EXPECT_EQ(divideRoundedUp<uint32_t>(std::numeric_limits<uint32_t>::max(), 2), 2147483648U);
+    EXPECT_EQ(divideRoundedUp<uint64_t>(std::numeric_limits<uint64_t>::max(), 2), 9223372036854775808ULL);
+
+    EXPECT_EQ(divideRoundedUp<uint8_t>(std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()), 1U);
+    EXPECT_EQ(divideRoundedUp<size_t>(std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()), 1U);
+    EXPECT_EQ(divideRoundedUp<size_t>(std::numeric_limits<size_t>::max() - 1, std::numeric_limits<size_t>::max()), 1U);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 6a8fe579197b051d9e902b8af708081b5068a0c9
<pre>
Cherry-pick 317292@main (3aa0615a5649). <a href="https://bugs.webkit.org/show_bug.cgi?id=319520">https://bugs.webkit.org/show_bug.cgi?id=319520</a>

Unreviewed backport.

    WTF::divideRoundedUp can overflow for dividends near the type&apos;s maximum
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319520">https://bugs.webkit.org/show_bug.cgi?id=319520</a>
    <a href="https://rdar.apple.com/182336325">rdar://182336325</a>

    Reviewed by Chris Dumez.

    divideRoundedUp(a, b) computed (a + b - 1) / b, whose intermediate
    a + b - 1 overflows when a is close to the maximum representable value
    of T. All callers use size_t, so this wraps silently: for example
    divideRoundedUp&lt;uint8_t&gt;(255, 2) computes 255 + 2 - 1 = 256, which
    wraps to 0, yielding 0 instead of the correct 128.

    Rewrite it in the overflow-safe form a / b + !!(a % b), which is
    mathematically equivalent for non-negative operands (the ceil-division
    domain) and cannot overflow: a / b &lt;= a, and the +1 is never added when
    a / b is already at the maximum (b == 1 implies a % b == 0).

    Test: Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp

    * Source/WTF/wtf/MathExtras.h:
    (divideRoundedUp):
    * Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp:
    (TestWebKitAPI::TEST(WTF, divideRoundedUp)):

    Canonical link: <a href="https://commits.webkit.org/317292@main">https://commits.webkit.org/317292@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1068@webkitglib/2.52">https://commits.webkit.org/305877.1068@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 1ecf035a8c4739bae441c1a5dbef73cf28e766e9
<pre>
Cherry-pick 317456@main (06d1695c9a81). <a href="https://bugs.webkit.org/show_bug.cgi?id=319724">https://bugs.webkit.org/show_bug.cgi?id=319724</a>

    shrinkToFit() operates on a temporary copy in InlineContent::nonRootInlineBoxIndexesForLayoutBox()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319724">https://bugs.webkit.org/show_bug.cgi?id=319724</a>
    <a href="https://rdar.apple.com/182557883">rdar://182557883</a>

    Reviewed by Alan Baradlay.

    When building the inline box index cache, the loop that trims each
    vector&apos;s excess capacity iterated the HashMap by value:

        for (auto entry : *m_inlineBoxIndexCache)
            entry.value.shrinkToFit();

    Since InlineBoxIndexCache is a HashMap&lt;CheckedRef&lt;const Layout::Box&gt;,
    Vector&lt;size_t&gt;&gt;, `auto entry` copies each key-value pair, so shrinkToFit()
    trims a throwaway copy of the vector while the vector stored in the map
    keeps its over-allocated capacity. The optimization was a no-op, and each
    iteration paid for a needless copy of the vector (plus CheckedRef churn).

    Iterate by reference so shrinkToFit() acts on the stored vector.

    * Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp:
    (WebCore::LayoutIntegration::InlineContent::nonRootInlineBoxIndexesForLayoutBox const):

    Canonical link: <a href="https://commits.webkit.org/317456@main">https://commits.webkit.org/317456@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1067@webkitglib/2.52">https://commits.webkit.org/305877.1067@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3559e6b48d1cd2285af70263ca5f1b1357977cfd
<pre>
Cherry-pick 315828@main (87794cc4aa21). <a href="https://bugs.webkit.org/show_bug.cgi?id=317790">https://bugs.webkit.org/show_bug.cgi?id=317790</a>

    WKWebsiteDataStore dealloc crashes with pure virtual function call in WebKit::AuxiliaryProcessProxy
    <a href="https://rdar.apple.com/180473685">rdar://180473685</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317790">https://bugs.webkit.org/show_bug.cgi?id=317790</a>

    Reviewed by Alex Christensen.

    There was no need for this particular virtual dance. So let&apos;s just remove it.

    No new tests needed.

    * Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
    (WebKit::AuxiliaryProcessProxy::AuxiliaryProcessProxy):
    (WebKit::AuxiliaryProcessProxy::environmentIdentifier):
    * Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
    (WebKit::AuxiliaryProcessProxy::clientName const):
    * Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
    (WebKit::GPUProcessProxy::GPUProcessProxy):
    * Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
    * Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
    (WebKit::ModelProcessProxy::ModelProcessProxy):
    * Source/WebKit/UIProcess/Model/ModelProcessProxy.h:
    * Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
    (WebKit::NetworkProcessProxy::NetworkProcessProxy):
    * Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
    * Source/WebKit/UIProcess/WebProcessProxy.cpp:
    (WebKit::WebProcessProxy::WebProcessProxy):
    * Source/WebKit/UIProcess/WebProcessProxy.h:

    Canonical link: <a href="https://commits.webkit.org/315828@main">https://commits.webkit.org/315828@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1066@webkitglib/2.52">https://commits.webkit.org/305877.1066@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9898cd2f86822442ec3c1be243e5bb022eeae1bb
<pre>
Cherry-pick 317472@main (163805a73a69). <a href="https://bugs.webkit.org/show_bug.cgi?id=319738">https://bugs.webkit.org/show_bug.cgi?id=319738</a>

    Web Inspector: InspectorThreadableLoaderClient::m_statusCode is uninitialized
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319738">https://bugs.webkit.org/show_bug.cgi?id=319738</a>
    <a href="https://rdar.apple.com/182578510">rdar://182578510</a>

    Reviewed by Devin Rousso.

    m_statusCode had no default member initializer, unlike the other
    members of InspectorThreadableLoaderClient. It is set in
    didReceiveResponse() and read in didFinishLoading(), which relies on
    ThreadableLoaderClient&apos;s contract that didReceiveResponse() always
    precedes didFinishLoading(). Give it a safe default so a future
    change to that contract can&apos;t read uninitialized memory

    * Source/WebCore/inspector/InspectorThreadableLoaderClient.h:

    Canonical link: <a href="https://commits.webkit.org/317472@main">https://commits.webkit.org/317472@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1065@webkitglib/2.52">https://commits.webkit.org/305877.1065@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afc2304e12d03100d1682015ed37ddf50934c1f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179566 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53505 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47303 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189398 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143875 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181429 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54799 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53216 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140039 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143875 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182523 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54799 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47303 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120492 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54799 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53216 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2461 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47303 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54799 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47303 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/852 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/40841 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46111 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53216 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191619 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53175 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47303 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149301 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53856 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47303 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149047 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27271 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53856 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126128 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121057 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52373 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47303 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51758 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/51999 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51819 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->