### PR TITLE
Cherry-pick 318630@main (4bfeff8c67ad). https://bugs.webkit.org/show_bug.cgi?id=321081

### DIFF
--- a/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt
@@ -1,0 +1,18 @@
+Tests that navigation.navigate() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. This is the navigate() counterpart of navigation-reload-state-clone-exception-crash.html: navigate() and reload() share the same Navigation::createErrorResult(), which used to call DeferredPromise::reject() twice with the same ExceptionCode::ExistingExceptionError exception, and only the first call could recover the pending JS exception.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof result is 'object'
+PASS 'committed' in result is true
+PASS 'finished' in result is true
+PASS result.committed instanceof Promise is true
+PASS result.finished instanceof Promise is true
+PASS committedError.message is "state clone error"
+PASS finishedError.message is "state clone error"
+PASS committedError === finishedError is true
+PASS did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html
+++ b/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.navigate() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. This is the navigate() counterpart of navigation-reload-state-clone-exception-crash.html: navigate() and reload() share the same Navigation::createErrorResult(), which used to call DeferredPromise::reject() twice with the same ExceptionCode::ExistingExceptionError exception, and only the first call could recover the pending JS exception.");
+
+jsTestIsAsync = true;
+
+var result;
+var committedError;
+var finishedError;
+
+window.onload = async () => {
+    result = navigation.navigate("about:blank#navigated", { state: { get x() { throw new Error("state clone error"); } } });
+
+    shouldBe("typeof result", "'object'");
+    shouldBeTrue("'committed' in result");
+    shouldBeTrue("'finished' in result");
+    shouldBeTrue("result.committed instanceof Promise");
+    shouldBeTrue("result.finished instanceof Promise");
+
+    try {
+        await result.committed;
+        testFailed("committed promise should be rejected");
+    } catch (e) {
+        committedError = e;
+    }
+    shouldBeEqualToString("committedError.message", "state clone error");
+
+    try {
+        await result.finished;
+        testFailed("finished promise should be rejected");
+    } catch (e) {
+        finishedError = e;
+    }
+    shouldBeEqualToString("finishedError.message", "state clone error");
+
+    shouldBeTrue("committedError === finishedError");
+
+    testPassed("did not crash");
+    finishJSTest();
+};
+</script>

--- a/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt
@@ -1,0 +1,18 @@
+Tests that navigation.reload() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. Found by a fuzzer: a throwing getter on the state object made Navigation::serializeState() fail with ExceptionCode::ExistingExceptionError, and DeferredPromise::reject() was only able to recover the pending JS exception once, so the second of the two reject() calls in Navigation::createErrorResult() hit an assertion.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof result is 'object'
+PASS 'committed' in result is true
+PASS 'finished' in result is true
+PASS result.committed instanceof Promise is true
+PASS result.finished instanceof Promise is true
+PASS committedError.message is "state clone error"
+PASS finishedError.message is "state clone error"
+PASS committedError === finishedError is true
+PASS did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html
+++ b/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.reload() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. Found by a fuzzer: a throwing getter on the state object made Navigation::serializeState() fail with ExceptionCode::ExistingExceptionError, and DeferredPromise::reject() was only able to recover the pending JS exception once, so the second of the two reject() calls in Navigation::createErrorResult() hit an assertion.");
+
+jsTestIsAsync = true;
+
+var result;
+var committedError;
+var finishedError;
+
+window.onload = async () => {
+    result = navigation.reload({ state: { get x() { throw new Error("state clone error"); } } });
+
+    shouldBe("typeof result", "'object'");
+    shouldBeTrue("'committed' in result");
+    shouldBeTrue("'finished' in result");
+    shouldBeTrue("result.committed instanceof Promise");
+    shouldBeTrue("result.finished instanceof Promise");
+
+    try {
+        await result.committed;
+        testFailed("committed promise should be rejected");
+    } catch (e) {
+        committedError = e;
+    }
+    shouldBeEqualToString("committedError.message", "state clone error");
+
+    try {
+        await result.finished;
+        testFailed("finished promise should be rejected");
+    } catch (e) {
+        finishedError = e;
+    }
+    shouldBeEqualToString("finishedError.message", "state clone error");
+
+    shouldBeTrue("committedError === finishedError");
+
+    testPassed("did not crash");
+    finishJSTest();
+};
+</script>

--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -273,7 +273,9 @@ bool AudioParam::hasSampleAccurateValues() const
 
 float AudioParam::finalValue()
 {
-    float value;
+    // Initialize to the intrinsic value since calculateFinalValues() may bail out
+    // without writing anything (e.g. when called off the audio thread).
+    float value = m_value;
     calculateFinalValues(singleElementSpan(value), false);
     return value;
 }

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -19,7 +19,6 @@ accessibility/AccessibilityListBoxOption.cpp
 accessibility/AccessibilityMathMLElement.cpp
 accessibility/AccessibilityMenuList.cpp
 accessibility/AccessibilityMenuListOption.cpp
-accessibility/AccessibilityMenuListPopup.cpp
 accessibility/AccessibilityNodeObject.cpp
 accessibility/AccessibilityObject.cpp
 accessibility/AccessibilityObjectInlines.h

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -77,7 +77,11 @@ AccessibilityMenuListOption* AccessibilityMenuListPopup::menuListOptionAccessibi
     if (!element || !element->inRenderedDocument())
         return nullptr;
 
-    return dynamicDowncast<AccessibilityMenuListOption>(document()->axObjectCache()->getOrCreate(*element));
+    CheckedPtr cache = document()->axObjectCache();
+    if (!cache)
+        return nullptr;
+
+    return dynamicDowncast<AccessibilityMenuListOption>(cache->getOrCreate(*element));
 }
 
 bool AccessibilityMenuListPopup::press()

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -179,13 +179,15 @@ void DeferredPromise::reject(Exception exception, RejectAsHandled rejectAsHandle
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
     if (exception.code() == ExceptionCode::ExistingExceptionError) {
-        EXCEPTION_ASSERT(scope.exception());
-        auto error = scope.exception()->value();
-        bool isTerminating = handleTerminationExceptionIfNeeded(scope, lexicalGlobalObject);
-        if (!isTerminating) {
+        if (exceptionObject.isEmpty()) {
+            EXCEPTION_ASSERT(scope.exception());
+            auto error = scope.exception()->value();
+            if (handleTerminationExceptionIfNeeded(scope, lexicalGlobalObject))
+                return;
             scope.clearException();
-            reject<IDLAny>(error, rejectAsHandled);
+            exceptionObject = error;
         }
+        reject<IDLAny>(exceptionObject, rejectAsHandled);
         return;
     }
 

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -308,7 +308,7 @@ macro(_WEBKIT_TARGET_LINK_FRAMEWORK _target)
         get_property(_linked_into GLOBAL PROPERTY ${framework}_LINKED_INTO)
 
         # See if the target is linking a framework that the specified framework is already linked into
-        if ((NOT _linked_into) OR (${framework} STREQUAL ${_linked_into}) OR (NOT ${_linked_into} IN_LIST ${_target}_FRAMEWORKS))
+        if ((NOT _linked_into) OR (framework STREQUAL _linked_into) OR (NOT _linked_into IN_LIST ${_target}_FRAMEWORKS))
             list(APPEND ${_target}_PRIVATE_LIBRARIES WebKit::${framework})
 
             # The WebKit:: alias targets do not propagate OBJECT libraries so the


### PR DESCRIPTION
#### 97b45927eca5408ac86edc492f6116af436bd3d4
<pre>
Cherry-pick 318630@main (4bfeff8c67ad). <a href="https://bugs.webkit.org/show_bug.cgi?id=321081">https://bugs.webkit.org/show_bug.cgi?id=321081</a>

    [CMake 4.4][WPE] _WEBKIT_TARGET_LINK_FRAMEWORK reports &quot;Unknown arguments specified&quot; error
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321081">https://bugs.webkit.org/show_bug.cgi?id=321081</a>

    Reviewed by Adrian Perez de Castro.

    CMake 4.4 reports the following error for WPE.

    &gt; -- Using platform-specific CMakeLists: /run/build/webkitwpe/Source/JavaScriptCore/shell/PlatformWPE.cmake
    &gt; CMake Error at Source/cmake/WebKitMacros.cmake:554 (if):
    &gt;   if given arguments:
    &gt;
    &gt;     &quot;(&quot; &quot;NOT&quot; &quot;_linked_into&quot; &quot;)&quot; &quot;OR&quot; &quot;(&quot; &quot;JavaScriptCore&quot; &quot;STREQUAL&quot; &quot;)&quot; &quot;OR&quot; &quot;(&quot; &quot;NOT&quot; &quot;IN_LIST&quot; &quot;jsc_FRAMEWORKS&quot; &quot;)&quot;
    &gt;
    &gt;   Unknown arguments specified
    &gt; Call Stack (most recent call first):
    &gt;   Source/cmake/WebKitMacros.cmake:756 (_WEBKIT_TARGET_LINK_FRAMEWORK)
    &gt;   Source/JavaScriptCore/shell/CMakeLists.txt:126 (WEBKIT_EXECUTABLE)

    Replaced `${_linked_into}` with `_linked_into`.

    * Source/cmake/WebKitMacros.cmake(_WEBKIT_TARGET_LINK_FRAMEWORK):

    Canonical link: <a href="https://commits.webkit.org/318630@main">https://commits.webkit.org/318630@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1072@webkitglib/2.52">https://commits.webkit.org/305877.1072@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 719d55a174aed27d36c534c93f351b835976d7de
<pre>
Cherry-pick 318692@main (e04f9dd61dc4). <a href="https://bugs.webkit.org/show_bug.cgi?id=321077">https://bugs.webkit.org/show_bug.cgi?id=321077</a>

    Crash in AccessibilityMenuListPopup::menuListOptionAccessibilityObject
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321077">https://bugs.webkit.org/show_bug.cgi?id=321077</a>

    Reviewed by Tyler Wilcock.

    Null check AXCache we get from document and return early if it&apos;s nullptr.

    * Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
    (WebCore::AccessibilityMenuListPopup::menuListOptionAccessibilityObject const):
    * Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:

    Canonical link: <a href="https://commits.webkit.org/318692@main">https://commits.webkit.org/318692@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1071@webkitglib/2.52">https://commits.webkit.org/305877.1071@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3b7f04245471524fa756022fb1aaba184674cb67
<pre>
Cherry-pick 318836@main (37cfccb3c6c9). <a href="https://bugs.webkit.org/show_bug.cgi?id=321250">https://bugs.webkit.org/show_bug.cgi?id=321250</a>

    Fix crash from double-consuming the pending exception in DeferredPromise::reject() during Navigation reload()/navigate() error handling
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321250">https://bugs.webkit.org/show_bug.cgi?id=321250</a>
    <a href="https://rdar.apple.com/183911429">rdar://183911429</a>

    Reviewed by Rupin Mittal.

    Navigation::createErrorResult() rejects both the committed and finished promises with the same Exception. When that exception carries ExceptionCode::ExistingExceptionError — the
    sentinel meaning &quot;the real JS exception is already sitting on the VM&apos;s exception scope&quot; — DeferredPromise::reject() pulled the value straight off scope.exception() and called
    scope.clearException() as a side effect. That works for the first reject() call, but clears the exception before the second call runs, so it finds nothing there: an assert in
    debug/ASan builds, a null-pointer read of Exception::m_value in release builds — either way, a crash on every reload()/navigate() whose state argument throws during
    structured-clone.

    The fix reuses the exceptionObject out-parameter that&apos;s already threaded through both reject() calls (the same parameter the plain-ExceptionCode branch a few lines below already
    uses to build the DOMException once and share it across calls). On the first call, if exceptionObject is still empty, it extracts the value from the exception scope, clears it, and
    caches the result in exceptionObject; on the second call, exceptionObject is already populated, so it skips touching the exception scope entirely and just rejects with the cached
    value. This matches the pattern already used elsewhere in Navigation.cpp (rejectFinishedPromise, which precomputes a DOMException once and passes it to both promise rejections),
    and it satisfies the spec requirement that committed and finished reject with the identical error value — which a &quot;swallow and fall back to a generic error&quot; fix would not have.

    Tests: navigation-api/navigation-navigate-state-clone-exception-crash.html
           navigation-api/navigation-reload-state-clone-exception-crash.html

    * LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt: Added.
    * LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html: Added.
    * LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt: Added.
    * LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html: Added.
    * Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
    (WebCore::DeferredPromise::reject):

    Canonical link: <a href="https://commits.webkit.org/318836@main">https://commits.webkit.org/318836@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1070@webkitglib/2.52">https://commits.webkit.org/305877.1070@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### a630c95c5e834713c8dde5bfaf7c259d782a6af1
<pre>
Cherry-pick 318052@main (2a2036f697b1). <a href="https://bugs.webkit.org/show_bug.cgi?id=320375">https://bugs.webkit.org/show_bug.cgi?id=320375</a>

Unreviewed backport.

    AudioParam::finalValue() returns an uninitialized float when calculateFinalValues() bails out
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320375">https://bugs.webkit.org/show_bug.cgi?id=320375</a>
    <a href="https://rdar.apple.com/183342212">rdar://183342212</a>

    Reviewed by Chris Dumez.

    finalValue() declared `float value;` uninitialized and relied on calculateFinalValues()
    to write it, but that function early-returns without touching the output span when there
    is no context, we are off the audio thread, or the span is empty. The garbage value then
    flows into DSP as an oscillator frequency, filter cutoff, delay time, pan, compressor
    threshold, etc.

    Initialize `value` to m_value, which is always set from defaultValue in the constructor.
    The k-rate path fills the span with m_value anyway, so this only changes the
    previously-garbage path.

    No new test.

    * Source/WebCore/Modules/webaudio/AudioParam.cpp:
    (WebCore::AudioParam::finalValue):

    Canonical link: <a href="https://commits.webkit.org/318052@main">https://commits.webkit.org/318052@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1069@webkitglib/2.52">https://commits.webkit.org/305877.1069@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ce3d0082d6f5a6e56d244948d4f5539919088d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179650 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53589 "Build is in progress. Recent messages:") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47387 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189482 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143959 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181513 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54883 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53300 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140111 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143959 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182607 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54883 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47387 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120563 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54883 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53300 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2532 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47387 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54883 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47387 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/936 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/40925 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46195 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53300 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191703 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53259 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47387 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149377 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53940 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47387 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149122 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27283 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53940 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126212 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121209 "The change is no longer eligible for processing.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52457 "Build is in progress. Recent messages:") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47387 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51842 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52083 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51903 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->