### PR TITLE
[JSC] Update import-defer implementation based on the proposal update

### DIFF
--- a/JSTests/modules/import-defer-async-cycle-sync-access.js
+++ b/JSTests/modules/import-defer-async-cycle-sync-access.js
@@ -1,0 +1,26 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe, shouldThrow } from "./resources/assert.js";
+import { blocker, aStarted } from "./import-defer/async-cycle-setup.js";
+
+// SCC {tla, member}: tla has TLA and is the cycle root, member is the non-root member.
+// While tla is suspended on the blocker, member has already reached EVALUATED even though the
+// cycle has not finished. The deferred module behind ns depends on member, so it still cannot be
+// evaluated synchronously: ReadyForSyncExecution must consult IsModuleSCCEvaluated(member), which
+// follows [[CycleRoot]], rather than member's own [[Status]].
+
+const evaluations = globalThis.asyncCycleEvaluations;
+
+const pTLA = import("./import-defer/async-cycle-tla.js");
+await aStarted.promise;
+
+shouldBe(JSON.stringify(evaluations), JSON.stringify(["toucher", "member", "A-before-await"]));
+
+shouldThrow(() => globalThis.asyncCycleTouch(), "TypeError: Unable to synchronously evaluate deferred module");
+shouldBe(JSON.stringify(evaluations), JSON.stringify(["toucher", "member", "A-before-await"]));
+
+blocker.resolve();
+await pTLA;
+
+// The cycle root is EVALUATED now, so the same access succeeds and evaluates only the deferred module.
+shouldBe(globalThis.asyncCycleTouch(), 1);
+shouldBe(JSON.stringify(evaluations), JSON.stringify(["toucher", "member", "A-before-await", "A-after-await", "deferred"]));

--- a/JSTests/modules/import-defer/async-cycle-deferred.js
+++ b/JSTests/modules/import-defer/async-cycle-deferred.js
@@ -1,0 +1,4 @@
+import "./async-cycle-member.js";
+
+globalThis.asyncCycleEvaluations.push("deferred");
+export const value = 1;

--- a/JSTests/modules/import-defer/async-cycle-member.js
+++ b/JSTests/modules/import-defer/async-cycle-member.js
@@ -1,0 +1,4 @@
+import "./async-cycle-tla.js";
+import "./async-cycle-toucher.js";
+
+globalThis.asyncCycleEvaluations.push("member");

--- a/JSTests/modules/import-defer/async-cycle-setup.js
+++ b/JSTests/modules/import-defer/async-cycle-setup.js
@@ -1,0 +1,4 @@
+globalThis.asyncCycleEvaluations = [];
+
+export const blocker = Promise.withResolvers();
+export const aStarted = Promise.withResolvers();

--- a/JSTests/modules/import-defer/async-cycle-tla.js
+++ b/JSTests/modules/import-defer/async-cycle-tla.js
@@ -1,0 +1,7 @@
+import { blocker, aStarted } from "./async-cycle-setup.js";
+import "./async-cycle-member.js";
+
+globalThis.asyncCycleEvaluations.push("A-before-await");
+aStarted.resolve();
+await blocker.promise;
+globalThis.asyncCycleEvaluations.push("A-after-await");

--- a/JSTests/modules/import-defer/async-cycle-toucher.js
+++ b/JSTests/modules/import-defer/async-cycle-toucher.js
@@ -1,0 +1,7 @@
+import defer * as ns from "./async-cycle-deferred.js";
+
+// This module is evaluated while the cycle it belongs to is still on the evaluation stack, so
+// GatherAsynchronousTransitiveDependencies finds nothing to await and the deferred graph stays
+// unevaluated. Handing the access out lets the test poke it at a chosen point.
+globalThis.asyncCycleTouch = () => ns.value;
+globalThis.asyncCycleEvaluations.push("toucher");

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -144,8 +144,6 @@ test/language/import/import-attributes/text-string.js:
   module: 3
 test/language/import/import-attributes/text-via-namespace.js:
   module: 3
-test/language/import/import-defer/evaluation-top-level-await/async-cycle-dependency-of-deferred-module/main.js:
-  module: 3
 test/language/statements/class/elements/private-class-field-on-nonextensible-objects.js:
   strict mode: 3
 test/language/statements/class/subclass/private-class-field-on-nonextensible-return-override.js:

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -956,8 +956,8 @@ void AbstractModuleRecord::gatherAsynchronousTransitiveDependencies(OrderedHashS
         auto* cyclic = dynamicDowncast<CyclicModuleRecord>(module);
         if (!cyclic)
             continue;
-        // 6. If module.[[Status]] is either EVALUATING or EVALUATED, return result.
-        if (cyclic->status() == CyclicModuleRecord::Status::Evaluating || cyclic->status() == CyclicModuleRecord::Status::Evaluated)
+        // 6. If module.[[Status]] is either EVALUATING or IsModuleSCCEvaluated(module), return result.
+        if (cyclic->status() == CyclicModuleRecord::Status::Evaluating || cyclic->isSCCEvaluated())
             continue;
         // 7. If module.[[HasTLA]] is true, then
         if (cyclic->hasTLA()) {
@@ -994,14 +994,17 @@ bool AbstractModuleRecord::readyForSyncExecution()
         // 4. Append module to seen.
         if (!seen.add(module).isNewEntry)
             continue;
-        // 5. If module.[[Status]] is EVALUATED, return true.
-        if (cyclic->status() == CyclicModuleRecord::Status::Evaluated)
+        // 5. If IsModuleSCCEvaluated(module), return true.
+        if (cyclic->isSCCEvaluated())
             continue;
         // 6. If module.[[Status]] is either EVALUATING or EVALUATING-ASYNC, return false.
         if (cyclic->status() == CyclicModuleRecord::Status::Evaluating || cyclic->status() == CyclicModuleRecord::Status::EvaluatingAsync)
             return false;
-        // 7. Assert: module.[[Status]] is LINKED.
-        ASSERT(cyclic->status() == CyclicModuleRecord::Status::Linked);
+        // 7. Assert: module.[[Status]] is LINKED or EVALUATED.
+        // EVALUATED is reachable for a module whose own body has run inside a cycle that is still
+        // awaiting; the walk below then reaches its EVALUATING-ASYNC cycle root and returns false.
+        // https://github.com/tc39/proposal-defer-import-eval/issues/86
+        ASSERT(cyclic->status() == CyclicModuleRecord::Status::Linked || cyclic->status() == CyclicModuleRecord::Status::Evaluated);
         // 8. If module.[[HasTLA]] is true, return false.
         if (cyclic->hasTLA())
             return false;

--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.h
@@ -67,6 +67,21 @@ public:
     JSValue evaluationError() const { return m_evaluationError.get(); }
     unsigned dfsAncestorIndex() const { return m_dfsAncestorIndex; }
 
+    // https://tc39.es/proposal-defer-import-eval/#sec-IsModuleSCCEvaluated
+    // A module in an import cycle reaches EVALUATED once its own body has run, so only its cycle
+    // root reaching EVALUATED tells you the whole cycle is done.
+    bool isSCCEvaluated() const
+    {
+        // 1. If module.[[CycleRoot]] is not EMPTY, then
+        //   1.a. If module.[[CycleRoot]].[[Status]] is EVALUATED, return true.
+        //   1.b. Return false.
+        if (CyclicModuleRecord* root = cycleRoot())
+            return root->status() == Status::Evaluated;
+        // 2. If module.[[Status]] is EVALUATED, return true.
+        // 3. Return false.
+        return status() == Status::Evaluated;
+    }
+
     void setStatus(Status newStatus) { m_status = newStatus; }
     void setEvaluationError(VM& vm, JSValue error) { m_evaluationError.set(vm, this, error); }
     void setDFSAncestorIndex(unsigned newIndex) { m_dfsAncestorIndex = newIndex; }


### PR DESCRIPTION
#### cc673d7b23bf95edb4b50924009a193ecbe56a05
<pre>
[JSC] Update import-defer implementation based on the proposal update
<a href="https://bugs.webkit.org/show_bug.cgi?id=321369">https://bugs.webkit.org/show_bug.cgi?id=321369</a>
<a href="https://rdar.apple.com/184423667">rdar://184423667</a>

Reviewed by Sosuke Suzuki.

After 313139@main implemented import-defer, the proposal fixed several
bugs. This patch applies these fixes.

1. <a href="https://github.com/tc39/proposal-defer-import-eval/pull/85">https://github.com/tc39/proposal-defer-import-eval/pull/85</a>
   Consider SCC status when deciding to short circuit on ReadyForSyncExecution
   and GatherAsynchronousTransitiveDependencies
2. <a href="https://github.com/tc39/proposal-defer-import-eval/pull/87">https://github.com/tc39/proposal-defer-import-eval/pull/87</a>
   (1) introduced an assertion inconsistency, and the PR fixes it.

Tests: JSTests/modules/import-defer-async-cycle-sync-access.js
       JSTests/modules/import-defer/async-cycle-deferred.js
       JSTests/modules/import-defer/async-cycle-member.js
       JSTests/modules/import-defer/async-cycle-setup.js
       JSTests/modules/import-defer/async-cycle-tla.js
       JSTests/modules/import-defer/async-cycle-toucher.js

* JSTests/modules/import-defer-async-cycle-sync-access.js: Added.
* JSTests/modules/import-defer/async-cycle-deferred.js: Added.
* JSTests/modules/import-defer/async-cycle-member.js: Added.
* JSTests/modules/import-defer/async-cycle-setup.js: Added.
* JSTests/modules/import-defer/async-cycle-tla.js: Added.
* JSTests/modules/import-defer/async-cycle-toucher.js: Added.
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp:
(JSC::AbstractModuleRecord::gatherAsynchronousTransitiveDependencies):
(JSC::AbstractModuleRecord::readyForSyncExecution):
* Source/JavaScriptCore/runtime/CyclicModuleRecord.h:
(JSC::CyclicModuleRecord::isSCCEvaluated const):

Canonical link: <a href="https://commits.webkit.org/318875@main">https://commits.webkit.org/318875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/580917e95ebe8f8d33aee45c6138ea58ee9a2b9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143895 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e8f110bb-d0aa-4600-b9e5-f3b5f1f8e8d3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140054 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ee641aa-8212-4074-97e2-4d1535398fc4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120506 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0132a2c-fe48-445e-b197-8370f8e289f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42337 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40660 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2475 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9283 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152738 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40310 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/execute-start.tentative.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/872 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40861 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191639 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53195 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149317 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53876 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149063 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27289 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43727 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126148 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121105 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52393 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15298 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51778 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52019 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51839 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->