### PR TITLE
Safari MCP: default text extraction on www.yelp.com contains many hidden SVG elements

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-svg-sprite-sheet-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-svg-sprite-sheet-expected.txt
@@ -1,0 +1,1 @@
+root image uid=… class=sprite-sheet 'Visible content follows.' image uid=… label='Star icon' alt='Star icon' image uid=… id=sprite-alias image uid=… id=sprite-icon image uid=… label='Inline icon' alt='Inline icon'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-svg-sprite-sheet.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-svg-sprite-sheet.html
@@ -1,0 +1,44 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+.sprite-sheet {
+    display: block;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<svg class="sprite-sheet">
+    <symbol id="sprite-alias" width="16" height="16"><use href="#sprite-icon"></use></symbol>
+    <symbol id="sprite-icon" width="16" height="16"><path d="M8 1 L10 6 L15 6 L11 9 L13 15 L8 11 L3 15 L5 9 L1 6 L6 6 Z" fill="black"></path></symbol>
+    <symbol id="unreferenced-alias" width="16" height="16" aria-label="Unreferenced sprite icon"><use href="#sprite-icon"></use></symbol>
+    <defs>
+        <svg id="defs-icon" width="16" height="16" aria-label="Icon inside defs"><path d="M3 13 L11 5 L13 7 L5 15 Z" fill="black"></path></svg>
+    </defs>
+</svg>
+<p>Visible content follows.</p>
+<svg width="16" height="16" aria-label="Star icon"><use href="#sprite-alias"></use></svg>
+<svg width="16" height="16" aria-label="Inline icon"><path d="M3 13 L11 5 L13 7 L5 15 Z" fill="black"></path></svg>
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    document.body.textContent = await UIHelper.requestDebugText({
+        normalize: true,
+        nodeIdentifierInclusion: "interactive",
+        includeAccessibilityAttributes: true,
+    });
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -590,6 +590,9 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
     if (!renderer)
         return { SkipExtraction::SelfAndSubtree };
 
+    if (renderer->isRenderOrLegacyRenderSVGHiddenContainer())
+        return { SkipExtraction::SelfAndSubtree };
+
     if (context.skipNearlyTransparentContent && renderer->style().opacity() < minOpacityToConsiderVisible) {
         if (RefPtr input = dynamicDowncast<HTMLInputElement>(node); !input || !visibleAssociatedLabelBounds(*input))
             return { SkipExtraction::SelfAndSubtree };


### PR DESCRIPTION
#### 12b2b07ee6d1e90c5d396c3e38f34966f99a02f1
<pre>
Safari MCP: default text extraction on www.yelp.com contains many hidden SVG elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=321371">https://bugs.webkit.org/show_bug.cgi?id=321371</a>
<a href="https://rdar.apple.com/184323683">rdar://184323683</a>

Reviewed by Richard Robinson.

Avoid pathological context window bloat on Yelp, by skipping hidden SVG containers.

Test: fast/text-extraction/debug-text-extraction-svg-sprite-sheet.html

* LayoutTests/fast/text-extraction/debug-text-extraction-svg-sprite-sheet-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-svg-sprite-sheet.html: Added.
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):

Canonical link: <a href="https://commits.webkit.org/318849@main">https://commits.webkit.org/318849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/649b32f1d7766174acd61ea981549ddf04669d03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143897 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/782232f5-b519-4f68-8eda-1441dc417699) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140055 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6ddfb86-7c3d-481a-968d-498279d362cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120507 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3dccb4bf-7492-4fdc-bbee-a47a0a610898) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42342 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40662 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152743 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40312 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/abort.any.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/874 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46133 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191641 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149318 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40021 "Found 1 new test failure: imported/w3c/web-platform-tests/web-animations/animation-model/side-effects-of-animations-current.html (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53878 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36936 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149064 "Found 1 new API test failure: TestWebKitWebView:/webkit/WebKitWebView/web-context (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27278 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43728 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126150 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121107 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52395 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15300 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51780 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52021 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51841 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->