### PR TITLE
[JSC] memory64 should accept large sized page numbers in module parsing, and should reject creation at runtime

### DIFF
--- a/JSTests/wasm/js-api/memory64-js-api-errors.js
+++ b/JSTests/wasm/js-api/memory64-js-api-errors.js
@@ -57,12 +57,13 @@ for (const address of ["i65", "", "I64", "u64", null, 1, {}]) {
     assert.throws(() => table.grow(-1n), TypeError, "Expect an integer argument in the range: [0, 2^64 - 1]");
 }
 
-// A memory64's declared maximum may exceed the memory32 page limit, up to 262144 pages (16 GiB).
+// A memory64's declared maximum may exceed the memory32 page limit, up to the 2**48 pages spanning its
+// address space.
 {
     const mem = new WebAssembly.Memory({ initial: 1n, maximum: 131072n, address: "i64" });
     assert.eq(mem.type().maximum, 131072n);
-    assert.eq(new WebAssembly.Memory({ initial: 0n, maximum: 262144n, address: "i64" }).type().maximum, 262144n);
-    assert.throws(() => new WebAssembly.Memory({ initial: 1n, maximum: 262145n, address: "i64" }), RangeError,
+    assert.eq(new WebAssembly.Memory({ initial: 0n, maximum: 1n << 48n, address: "i64" }).type().maximum, 1n << 48n);
+    assert.throws(() => new WebAssembly.Memory({ initial: 1n, maximum: (1n << 48n) + 1n, address: "i64" }), RangeError,
         "WebAssembly.Memory 'maximum' page count is too large");
     // An i32 memory keeps the memory32 limit.
     assert.throws(() => new WebAssembly.Memory({ initial: 1, maximum: 65537 }), RangeError,

--- a/JSTests/wasm/js-api/memory64-js-api.js
+++ b/JSTests/wasm/js-api/memory64-js-api.js
@@ -52,13 +52,19 @@ const pageSize = 64 * 1024;
 }
 
 // Constructor: initial page count too large throws. An initial page count is declarative in the same
-// way a maximum is, so the limit is the largest count a module may declare for an i64 memory, which
-// is 262144 pages (16 GiB).
+// way a maximum is, so the limit is the largest count a module may declare for an i64 memory, which is
+// the 2**48 pages spanning its address space. A count within that bound is refused at allocation time
+// instead, with an out of memory RangeError.
 {
     assert.throws(
-        () => new WebAssembly.Memory({ initial: 262145n, address: "i64" }),
+        () => new WebAssembly.Memory({ initial: (1n << 48n) + 1n, address: "i64" }),
         RangeError,
         "WebAssembly.Memory 'initial' page count is too large"
+    );
+    assert.throws(
+        () => new WebAssembly.Memory({ initial: 1n << 48n, address: "i64" }),
+        RangeError,
+        "Out of memory"
     );
 }
 
@@ -66,13 +72,13 @@ const pageSize = 64 * 1024;
 // rather than by the memory32 page limit.
 {
     assert.throws(
-        () => new WebAssembly.Memory({ initial: 1n, maximum: 262145n, address: "i64" }),
+        () => new WebAssembly.Memory({ initial: 1n, maximum: (1n << 48n) + 1n, address: "i64" }),
         RangeError,
         "WebAssembly.Memory 'maximum' page count is too large"
     );
     const memory = new WebAssembly.Memory({ initial: 1n, maximum: 65537n, address: "i64" });
     assert.eq(memory.type().maximum, 65537n);
-    assert.eq(new WebAssembly.Memory({ initial: 1n, maximum: 262144n, address: "i64" }).type().maximum, 262144n);
+    assert.eq(new WebAssembly.Memory({ initial: 1n, maximum: 1n << 48n, address: "i64" }).type().maximum, 1n << 48n);
 }
 
 // Constructor: passing invalid address

--- a/JSTests/wasm/stress/memory64-maximum-limits.js
+++ b/JSTests/wasm/stress/memory64-maximum-limits.js
@@ -4,45 +4,57 @@
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 
-// A memory64's declared maximum is bounded so that it is always representable as an ArrayBuffer byte
-// length. What its buffer reports is bounded further, by the address space one reservation may claim on
-// this platform, so that a resize within maxByteLength never fails deterministically.
+// A memory64 may declare a maximum anywhere in its 2**48-page address space, well past what any port
+// could map. What its buffer reports is bounded twice over: by the largest representable ArrayBuffer
+// byte length, and by the address space one reservation may claim on this platform, so that a resize
+// within maxByteLength never fails deterministically.
 
 const options = { memory64: true, threads: true };
 const pageSize = 65536;
-const maxMemory64Pages = 262144;
+const maxMemory64Pages = 2 ** 48;
+const maxRepresentablePages = 262144;
 const maxMemory32Pages = 65536;
 
 // A memory with no declared maximum reports its own address type's ceiling, so it discovers what this
 // platform will reserve. A memory32's ceiling is reservable in full everywhere.
 const ceilingBytes = new WebAssembly.Memory({ initial: 1n, address: "i64" }).toResizableBuffer().maxByteLength;
-assert.truthy(ceilingBytes <= maxMemory64Pages * pageSize, `memory64 ceiling ${ceilingBytes} exceeds the declarable maximum`);
+assert.truthy(ceilingBytes <= maxRepresentablePages * pageSize, `memory64 ceiling ${ceilingBytes} is not a representable byte length`);
 assert.truthy(ceilingBytes >= maxMemory32Pages * pageSize, `memory64 ceiling ${ceilingBytes} is below the memory32 ceiling`);
 assert.eq(new WebAssembly.Memory({ initial: 1 }).toResizableBuffer().maxByteLength, maxMemory32Pages * pageSize);
 
-// A declared maximum at the limit is accepted, and the buffer reports it clamped to that ceiling. The
-// shared memory reserves the whole thing up front, so this arm is why the file is a memory hog, and a
-// port that cannot spare the address space must refuse cleanly rather than fail the test.
+// A declared maximum at the largest representable byte length is accepted, and the buffer reports it
+// clamped to that ceiling. The shared memory reserves the whole thing up front, so this arm is why the
+// file is a memory hog, and a port that cannot spare the address space must refuse cleanly rather than
+// fail the test.
 for (const shared of [false, true]) {
     let mem;
     try {
         mem = (await instantiate(`
         (module
-            (memory (export "mem") i64 1 ${maxMemory64Pages} ${shared ? "shared" : ""}))
+            (memory (export "mem") i64 1 ${maxRepresentablePages} ${shared ? "shared" : ""}))
         `, {}, options)).exports.mem;
     } catch (e) {
         assert.truthy(e instanceof RangeError && e.message === "Out of memory", `expected an out of memory RangeError, got ${e}`);
         continue;
     }
 
-    assert.eq(mem.type().maximum, BigInt(maxMemory64Pages));
+    assert.eq(mem.type().maximum, BigInt(maxRepresentablePages));
     assert.eq(mem.type().address, "i64");
-    assert.eq(mem.toResizableBuffer().maxByteLength, Math.min(maxMemory64Pages * pageSize, ceilingBytes));
+    assert.eq(mem.toResizableBuffer().maxByteLength, Math.min(maxRepresentablePages * pageSize, ceilingBytes));
+}
+
+// A maximum past that is a declaration and nothing more: it is reported back verbatim, and the buffer
+// still only advertises what could be reached. A non-shared memory reserves nothing up front, so this
+// costs no address space.
+{
+    const mem = new WebAssembly.Memory({ initial: 1n, maximum: BigInt(maxMemory64Pages), address: "i64" });
+    assert.eq(mem.type().maximum, BigInt(maxMemory64Pages));
+    assert.eq(mem.toResizableBuffer().maxByteLength, ceilingBytes);
 }
 
 // The JS constructor applies the same bound. Module decoding is covered by
 // memory64-oversized-limits.js.
-assert.throws(() => new WebAssembly.Memory({ initial: 1n, maximum: BigInt(maxMemory64Pages + 1), address: "i64" }),
+assert.throws(() => new WebAssembly.Memory({ initial: 1n, maximum: BigInt(maxMemory64Pages) + 1n, address: "i64" }),
     RangeError, "WebAssembly.Memory 'maximum' page count is too large");
 
 // A memory32 is bounded by the memory32 page limit rather than the memory64 one.

--- a/JSTests/wasm/stress/memory64-oversized-limits.js
+++ b/JSTests/wasm/stress/memory64-oversized-limits.js
@@ -29,14 +29,16 @@ function moduleBytesWithMemoryLimits({ initial, maximum, is64bit = true }) {
     ]);
 }
 
-// The JS API caps the limits a memory may declare at 262144 pages (16 GiB) for a 64-bit memory and
-// 65536 pages (4 GiB) for a 32-bit one. https://www.w3.org/TR/wasm-js-api-2/#limits
-const maxMemory64Pages = 262144n;
+// A memory's declared limits are bounded by its address type: an i64 memory may declare up to 2**48
+// pages, the whole of its 2**64-byte address space, and an i32 memory 2**16. A declaration is only a
+// declaration, so anything within the bound compiles no matter how far past what a port could map;
+// what cannot be allocated is refused at instantiation instead.
+const maxMemory64Pages = 1n << 48n;
 const pageSize = 65536;
 
-// An initial page count is checked against that cap and nothing else, so every count up to it
+// An initial page count is checked against that bound and nothing else, so every count up to it
 // compiles, and instantiation must honor it verbatim rather than clamp it to a smaller size.
-for (const initial of [65537n, maxMemory64Pages]) {
+for (const initial of [65537n, 262144n]) {
     const module = new WebAssembly.Module(moduleBytesWithMemoryLimits({ initial }));
     let memory;
     try {
@@ -49,23 +51,26 @@ for (const initial of [65537n, maxMemory64Pages]) {
     assert.eq(memory.buffer.byteLength, Number(initial) * pageSize);
 }
 
-// A maximum is only a declaration, so even one at the cap costs nothing to instantiate: the memory
+// No port can host the largest declarable initial size, so that one compiles and then always fails to
+// instantiate. It must not wrap around to a size that looks allocatable.
+{
+    const module = new WebAssembly.Module(moduleBytesWithMemoryLimits({ initial: maxMemory64Pages }));
+    assert.throws(() => new WebAssembly.Instance(module), RangeError, "Out of memory");
+}
+
+// A maximum is only a declaration, so even one at the bound costs nothing to instantiate: the memory
 // is created at its initial size.
-for (const maximum of [65537n, maxMemory64Pages]) {
+for (const maximum of [65537n, 262144n, 1n << 32n, (1n << 37n) - 1n, maxMemory64Pages]) {
     const { mem } = new WebAssembly.Instance(new WebAssembly.Module(moduleBytesWithMemoryLimits({ initial: 1n, maximum }))).exports;
     assert.eq(mem.buffer.byteLength, pageSize);
 }
 
-// Anything above the cap is invalid, including page counts that used to be declarable when the bound
-// was PageCount's own 2**37-1, and the UINT64_MAX that PageCount reserves to mean "no page count".
-// A memory32 above 2**16 pages is invalid too.
+// Anything above the bound is invalid, including the UINT64_MAX that PageCount reserves to mean "no
+// page count". A memory32 above 2**16 pages is invalid too.
 const pageCountSentinel = (1n << 64n) - 1n;
 for (const [limits, message] of [
     [{ initial: maxMemory64Pages + 1n }, `Memory's initial page count of ${maxMemory64Pages + 1n} is invalid`],
     [{ initial: 0n, maximum: maxMemory64Pages + 1n }, `Memory's maximum page count of ${maxMemory64Pages + 1n} is invalid`],
-    [{ initial: 0n, maximum: (1n << 32n) - 1n }, `Memory's maximum page count of ${(1n << 32n) - 1n} is invalid`],
-    [{ initial: 0n, maximum: 1n << 32n }, `Memory's maximum page count of ${1n << 32n} is invalid`],
-    [{ initial: 0n, maximum: (1n << 37n) - 1n }, `Memory's maximum page count of ${(1n << 37n) - 1n} is invalid`],
     [{ initial: pageCountSentinel }, `Memory's initial page count of ${pageCountSentinel} is invalid`],
     [{ initial: 0n, maximum: pageCountSentinel }, `Memory's maximum page count of ${pageCountSentinel} is invalid`],
     [{ initial: 65537n, is64bit: false }, "Memory's initial page count of 65537 is invalid"],

--- a/JSTests/wasm/v8/memory64.js
+++ b/JSTests/wasm/v8/memory64.js
@@ -114,26 +114,27 @@ function allowOOM(fn) {
   allowOOM(() => BasicMemory64Tests(max_num_pages));
 })();
 
-(function TestTooBigDeclaredInitial() {
+// A page count is a declaration bounded only by the i64 address space, so a count past the 16GB that
+// can be allocated still validates and compiles; allocating it is what fails. The bound itself is
+// covered by JSTests/wasm/stress/memory64-oversized-limits.js, which can encode a 2**48 page count.
+(function TestDeclaredInitialPastWhatCanBeAllocated() {
   // print(arguments.callee.name);
   let builder = new WasmModuleBuilder();
   builder.addMemory64(max_num_pages + 1);
 
-  assertFalse(WebAssembly.validate(builder.toBuffer()));
-  assertThrows(
-      () => builder.toModule(), WebAssembly.CompileError,
-      /Memory's initial page count of 262145 is invalid/);
+  assertTrue(WebAssembly.validate(builder.toBuffer()));
+  builder.toModule();
+  assertThrows(() => builder.instantiate(), RangeError, /Out of memory/);
 })();
 
-(function TestTooBigDeclaredMaximum() {
+(function TestDeclaredMaximumPastWhatCanBeAllocated() {
   // print(arguments.callee.name);
   let builder = new WasmModuleBuilder();
   builder.addMemory64(1, max_num_pages + 1);
 
-  assertFalse(WebAssembly.validate(builder.toBuffer()));
-  assertThrows(
-      () => builder.toModule(), WebAssembly.CompileError,
-      /Memory's maximum page count of 262145 is invalid/);
+  // A maximum costs nothing until it is reached, so this instantiates at its initial size.
+  assertTrue(WebAssembly.validate(builder.toBuffer()));
+  builder.instantiate();
 })();
 
 (function TestGrow64() {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js-expected.txt
@@ -4,8 +4,8 @@ PASS #2 Test that WebAssembly compilation succeeds (memory64.wast:4)
 PASS #3 Test that WebAssembly compilation succeeds (memory64.wast:5)
 PASS #4 Test that WebAssembly compilation succeeds (memory64.wast:6)
 PASS #5 Test that WebAssembly compilation succeeds (memory64.wast:7)
-FAIL #6 Test that WebAssembly compilation succeeds (memory64.wast:8) assert_equals: expected false but got true
-FAIL #7 Test that WebAssembly compilation succeeds (memory64.wast:9) assert_equals: expected false but got true
+PASS #6 Test that WebAssembly compilation succeeds (memory64.wast:8)
+PASS #7 Test that WebAssembly compilation succeeds (memory64.wast:9)
 PASS #8 Test that WebAssembly compilation succeeds (memory64.wast:11)
 PASS #9 Test that WebAssembly compilation succeeds (memory64.wast:13)
 PASS #10 Test that WebAssembly compilation succeeds (memory64.wast:15)
@@ -34,11 +34,9 @@ PASS #32 Test that WebAssembly compilation succeeds (memory64.wast:6)
 PASS #33 Test that WebAssembly instantiation succeeds (memory64.wast:6)
 PASS #34 Test that WebAssembly compilation succeeds (memory64.wast:7)
 PASS #35 Test that WebAssembly instantiation succeeds (memory64.wast:7)
-FAIL #36 Test that WebAssembly compilation succeeds (memory64.wast:8) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 23: Memory's initial page count of 281474976710656 is invalid at {loc} expected true got false
-FAIL #37 Test that WebAssembly compilation succeeds (memory64.wast:9) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 24: Memory's maximum page count of 281474976710656 is invalid at {loc} expected true got false
-FAIL #38 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-memory64_wast_js@memory64.wast.js:34:18
-global code@memory64.wast.js:237:3 expected true got false
+PASS #36 Test that WebAssembly compilation succeeds (memory64.wast:8)
+PASS #37 Test that WebAssembly compilation succeeds (memory64.wast:9)
+PASS #38 Test that WebAssembly instantiation succeeds (memory64.wast:9)
 PASS #39 Test that WebAssembly compilation succeeds (memory64.wast:11)
 PASS #40 Test that WebAssembly instantiation succeeds (memory64.wast:11)
 PASS #41 Test that a WebAssembly code returns a specific result (memory64.wast:12)

--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -56,7 +56,14 @@ public:
 
     void dump(WTF::PrintStream&) const;
 
-    uint64_t bytes() const { return m_pageCount * static_cast<uint64_t>(pageSize); }
+    // A page count may be larger than any byte count can express, so saturate rather than wrap: every
+    // byte-based bound (what can be allocated, what a buffer may advertise) must keep rejecting it.
+    uint64_t bytes() const
+    {
+        if (m_pageCount > std::numeric_limits<uint64_t>::max() / pageSize)
+            return std::numeric_limits<uint64_t>::max();
+        return m_pageCount * static_cast<uint64_t>(pageSize);
+    }
     uint64_t pageCount() const { return m_pageCount; }
 
     static bool isValid(uint64_t pageCount)
@@ -112,8 +119,9 @@ public:
     static constexpr uint32_t pageSize = 64 * KB;
 
     // Page counts are declarative: a memory may declare a maximum this process cannot map, and must
-    // still parse and instantiate at its initial size. This is the largest count any memory may declare.
-    static constexpr uint32_t maxPageCount = 256 * 1024;
+    // still parse and instantiate at its initial size. This is the largest count any memory may
+    // declare, the number of pages spanning an i64 memory's entire address space.
+    static constexpr uint64_t maxPageCount = std::numeric_limits<uint64_t>::max() / pageSize + 1;
 
     static constexpr uint32_t maxMemory32PageCount = 64 * 1024;
     static constexpr uint64_t maxMemory32Bytes = static_cast<uint64_t>(maxMemory32PageCount) * pageSize;
@@ -122,7 +130,7 @@ private:
     static constexpr uint64_t invalidPageCount = std::numeric_limits<uint64_t>::max();
     static_assert(maxPageCount < invalidPageCount);
     // fromBytes() must accept the byte length of any array buffer.
-    static_assert(MAX_ARRAY_BUFFER_SIZE <= static_cast<uint64_t>(maxPageCount) * pageSize);
+    static_assert(MAX_ARRAY_BUFFER_SIZE / pageSize <= maxPageCount);
 
     uint64_t m_pageCount;
 };

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -80,16 +80,17 @@ constexpr uint64_t maxDeclarablePages(AddressType addressType)
 // MAX_ARRAY_BUFFER_SIZE is not a page multiple on 32-bit, and a memory's size always is.
 constexpr uint64_t maxPageAlignedArrayBufferBytes = (MAX_ARRAY_BUFFER_SIZE / PageCount::pageSize) * PageCount::pageSize;
 
-// The largest byte length the buffer of a memory of this address type may advertise. The clamp only
-// bites on 32-bit, where a declared maximum need not be representable; growth is bounded separately.
+// The largest byte length the buffer of a memory of this address type may advertise. A memory64 may
+// declare more pages than a byte length can express, and on 32-bit a declared maximum need not be
+// representable either; growth is bounded separately.
 constexpr uint64_t maxBufferByteLength(AddressType addressType)
 {
-    return std::min<uint64_t>(maxDeclarablePages(addressType) * PageCount::pageSize, maxPageAlignedArrayBufferBytes);
+    return std::min<uint64_t>(maxDeclarablePages(addressType), maxPageAlignedArrayBufferBytes / PageCount::pageSize) * PageCount::pageSize;
 }
 
 #if USE(LARGE_TYPED_ARRAYS)
 static_assert(maxBufferByteLength(AddressType { AddressType::I32 }) == maxMemory32Pages * PageCount::pageSize);
-static_assert(maxBufferByteLength(AddressType { AddressType::I64 }) == maxMemory64Pages * PageCount::pageSize);
+static_assert(maxBufferByteLength(AddressType { AddressType::I64 }) == maxPageAlignedArrayBufferBytes);
 #endif
 
 // Limit of GC arrays in bytes. This is not included in the limits in the


### PR DESCRIPTION
#### 40d37f36527f72f11f033b0353643099a40437f7
<pre>
[JSC] memory64 should accept large sized page numbers in module parsing, and should reject creation at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=321372">https://bugs.webkit.org/show_bug.cgi?id=321372</a>
<a href="https://rdar.apple.com/184424841">rdar://184424841</a>

Reviewed by Sosuke Suzuki.

We should do the same to table64. Module parsing should accept very large
number of memory size limits. But we should reject creation / growth at
runtime.

* JSTests/wasm/js-api/memory64-js-api-errors.js:
(assert.throws):
* JSTests/wasm/js-api/memory64-js-api.js:
(assert.throws):
* JSTests/wasm/stress/memory64-maximum-limits.js:
(Math.min):
* JSTests/wasm/stress/memory64-oversized-limits.js:
* JSTests/wasm/v8/memory64.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js-expected.txt:
* Source/JavaScriptCore/runtime/PageCount.h:
(JSC::PageCount::bytes const):
* Source/JavaScriptCore/wasm/WasmLimits.h:
(JSC::Wasm::maxBufferByteLength):
(JSC::Wasm::static_assert):

Canonical link: <a href="https://commits.webkit.org/318874@main">https://commits.webkit.org/318874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a8048553242dd695adb9c88daa008c2c2059f31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189421 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143898 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/576254c5-89c1-4c9b-acf3-0f7478fa4cde) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140064 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae30f7df-87fc-4fab-b6d3-adb99304ecc3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120516 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fdf450c-589f-440e-9147-2f956bd32089) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42339 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40664 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2485 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9289 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40316 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/875 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40864 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191642 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53198 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149322 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53879 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149068 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27288 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43731 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126151 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121108 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52396 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15304 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51781 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52022 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51842 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->