### PR TITLE
Introduce an API test for MediaRecorder dropping a frame whenever the writer input reports not ready

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -715,6 +715,7 @@
 				WebCore/cocoa/IOSurfaceTests.mm,
 				WebCore/cocoa/ISOBMFFTrackInfoParserTests.cpp,
 				WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm,
+				WebCore/cocoa/MediaRecorderPrivateWriterTests.cpp,
 				WebCore/cocoa/PrivateClickMeasurementCocoa.mm,
 				WebCore/cocoa/ResourceMonitor.mm,
 				WebCore/cocoa/ScrollbarWidthCrash.mm,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaRecorderPrivateWriterTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaRecorderPrivateWriterTests.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 Fady Farag. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(MEDIA_RECORDER)
+
+#include "Test.h"
+#include <WebCore/MediaRecorderPrivateWriter.h>
+#include <WebCore/MediaSamplesBlock.h>
+#include <wtf/Deque.h>
+#include <wtf/MediaTime.h>
+#include <wtf/NativePromise.h>
+#include <wtf/UniqueRef.h>
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+class TestWriter final : public MediaRecorderPrivateWriter {
+public:
+    Deque<Result> plannedResults;
+    Vector<MediaTime> writtenTimes;
+
+private:
+    bool segmentsMustStartWithKeyframe() const final { return false; }
+    std::optional<uint8_t> addAudioTrack(const AudioInfo&) final { return 1; }
+    std::optional<uint8_t> addVideoTrack(const VideoInfo&, const std::optional<CGAffineTransform>&) final { return 2; }
+    bool allTracksAdded() final { return true; }
+    Result writeFrame(const MediaSamplesBlock& block) final
+    {
+        auto result = plannedResults.isEmpty() ? Result::Success : plannedResults.takeFirst();
+        if (result == Result::Success)
+            writtenTimes.append(block.presentationTime());
+        return result;
+    }
+    void forceNewSegment(const MediaTime&) final { }
+    Ref<GenericPromise> close(Deque<UniqueRef<MediaSamplesBlock>>&&, const MediaTime&) final { return GenericPromise::createAndResolve(); }
+};
+
+static UniqueRef<MediaSamplesBlock> makeSampleBlock(const MediaTime& presentationTime)
+{
+    MediaSamplesBlock::SamplesVector items;
+    items.append({ .presentationTime = presentationTime });
+    return makeUniqueRef<MediaSamplesBlock>(nullptr, WTF::move(items));
+}
+
+TEST(MediaRecorderPrivateWriter, WritesAllFramesInOrder)
+{
+    TestWriter writer;
+
+    Deque<UniqueRef<MediaSamplesBlock>> samples;
+    for (size_t i = 0; i < 3; ++i)
+        samples.append(makeSampleBlock(MediaTime(i, 1)));
+    writer.writeFrames(WTF::move(samples), MediaTime(3, 1));
+
+    ASSERT_EQ(writer.writtenTimes.size(), 3uz);
+    for (size_t i = 0; i < 3; ++i)
+        EXPECT_EQ(writer.writtenTimes[i], MediaTime(i, 1));
+}
+
+TEST(MediaRecorderPrivateWriter, NoFrameIsLostWhenWriterIsNotReady)
+{
+    TestWriter writer;
+    writer.plannedResults.append(TestWriter::Result::Success);
+    writer.plannedResults.append(TestWriter::Result::NotReady);
+
+    Deque<UniqueRef<MediaSamplesBlock>> samples;
+    for (size_t i = 0; i < 3; ++i)
+        samples.append(makeSampleBlock(MediaTime(i, 1)));
+    writer.writeFrames(WTF::move(samples), MediaTime(3, 1));
+
+    ASSERT_EQ(writer.writtenTimes.size(), 1uz);
+
+    writer.writeFrames({ }, MediaTime(3, 1));
+
+    ASSERT_EQ(writer.writtenTimes.size(), 3uz);
+    for (size_t i = 0; i < 3; ++i)
+        EXPECT_EQ(writer.writtenTimes[i], MediaTime(i, 1));
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(MEDIA_RECORDER)


### PR DESCRIPTION
#### 919642bf433d001fac3d84632615cedb6243be85
<pre>
Introduce an API test for MediaRecorder dropping a frame whenever the writer input reports not ready
<a href="https://bugs.webkit.org/show_bug.cgi?id=321373">https://bugs.webkit.org/show_bug.cgi?id=321373</a>
<a href="https://rdar.apple.com/184425255">rdar://184425255</a>

Reviewed by Darin Adler.

This is a follow-up to 318778@main. This asserts that a frame whose writeFrame()
returned NotReady is written by a subsequent writeFrames() retry call.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaRecorderPrivateWriterTests.cpp: Added.
(TestWebKitAPI::makeSampleBlock):
(TestWebKitAPI::TEST(MediaRecorderPrivateWriter, WritesAllFramesInOrder)):
(TestWebKitAPI::TEST(MediaRecorderPrivateWriter, NoFrameIsLostWhenWriterIsNotReady)):

Canonical link: <a href="https://commits.webkit.org/318850@main">https://commits.webkit.org/318850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/938818cda1fd2153f70776b37c9be3804de833b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143900 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140057 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120509 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42340 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40663 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40318 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/877 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191644 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53200 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149320 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40022 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53881 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149066 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43729 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121111 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52398 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15322 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51783 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52024 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->