### PR TITLE
Make it possible to to have an additional collection of LayoutTests outside of OpenSource

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2012 Google Inc. All rights reserved.
+# Copyright (C) 2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -61,16 +62,23 @@ class LayoutTestFinder(object):
         self._filesystem = self._port.host.filesystem
         self.LAYOUT_TESTS_DIRECTORY = 'LayoutTests'
         self._test_list_expectations = []
-        # Cache the inner finder per device_type. Bound here, not module-level, so the
+        # Cache the inner finders per device_type. Bound here, not module-level, so the
         # cache doesn't outlive this LayoutTestFinder instance.
-        self._inner_finder = functools.cache(self._make_inner_finder)
+        self._inner_finders = functools.cache(self._make_inner_finders)
 
-    def _make_inner_finder(self, device_type=None):
-        return LayoutTestFinder_New(
-            self._port.host.filesystem,
-            self._port.layout_tests_dir(),
-            self._port.baseline_search_path(device_type),
+    def _make_inner_finders(self, device_type=None):
+        baseline_search_paths = self._port.baseline_search_path(device_type)
+        return tuple(
+            LayoutTestFinder_New(
+                self._port.host.filesystem,
+                root,
+                baseline_search_paths,
+            )
+            for root in self._port.layout_tests_dirs()
         )
+
+    def _primary_inner_finder(self, device_type=None):
+        return self._inner_finders(device_type)[-1]
 
     def find_tests(self, options, args, device_type=None, with_expectations=False):
         paths = self._strip_test_dir_prefixes(args)
@@ -106,16 +114,35 @@ class LayoutTestFinder(object):
 
     def find_tests_by_path(self, paths, device_type=None, with_expectations=False):
         """Return the list of tests found. Both generic and platform-specific tests matching paths should be returned."""
-        return list(self._inner_finder(device_type).get_tests(paths))
+        finders = self._inner_finders(device_type)
+        if len(finders) == 1:
+            return list(finders[0].get_tests(paths))
+
+        # With multiple roots, search alternate roots first so an alternate test overrides an
+        # open-source one of the same name, but only dedup across roots -- duplicates
+        # produced within a single root (e.g. a test named twice in `paths`) are kept.
+        roots = self._port.layout_tests_dirs()
+        assert len(roots) == len(finders)
+        tests = []
+        seen_root_by_path = {}
+        for root, finder in zip(roots, finders):
+            for t in finder.get_tests(paths):
+                shadowing_root = seen_root_by_path.get(t.test_path)
+                if shadowing_root is not None and shadowing_root != root:
+                    _log.warning("Test collision: '%s' exists in both '%s' (used) and '%s' (ignored).", t.test_path, shadowing_root, root)
+                    continue
+                seen_root_by_path.setdefault(t.test_path, root)
+                tests.append(t)
+        return tests
 
     def _is_test_file(self, filesystem, dirname, filename):
-        finder = self._inner_finder()
+        finder = self._primary_inner_finder()
         return finder.is_test_file(
             dirname, filename
         ) and not self._is_w3c_resource_file(filesystem, dirname, filename)
 
     def _is_w3c_resource_file(self, filesystem, dirname, filename):
-        finder = self._inner_finder()
+        finder = self._primary_inner_finder()
 
         if dirname:
             dirname = self._filesystem.relpath(dirname, self._port.layout_tests_dir())

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
@@ -289,7 +289,7 @@ class SingleTestRunner(object):
         ):
             # The baseline path applying to the Port.
             output_dir = fs.join(
-                port.baseline_platform_dir(), fs.dirname(self._test_name)
+                port.baseline_platform_dir_for_test(self._test_name), fs.dirname(self._test_name)
             )
         else:
             # The directory containing the test.
@@ -307,7 +307,7 @@ class SingleTestRunner(object):
                 fs.join(p, fs.dirname(self._test_name))
                 for p in (
                     port.baseline_search_path(device_type=device_type)
-                    + [port.layout_tests_dir()]
+                    + port.layout_tests_dirs()
                 )
             ]
             seen_output_dir = False

--- a/Tools/Scripts/webkitpy/port/apple.py
+++ b/Tools/Scripts/webkitpy/port/apple.py
@@ -130,6 +130,7 @@ class ApplePort(Port):
                 else set()
             )
             | set(self._filesystem.glob(self._webkit_baseline_path("*")))
+            | self._additional_root_platform_baselines()
         )
 
         assert {p for p in paths if self._filesystem.isdir(p)}.issuperset(

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2010 Google Inc. All rights reserved.
-# Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+# Copyright (C) 2013-2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -265,13 +265,60 @@ class Port(object):
         """Return the absolute path to the default (version-independent) platform-specific results."""
         return self._filesystem.join(self.layout_tests_dir(), 'platform', self.port_name)
 
+    def baseline_platform_dir_for_test(self, test_name):
+        """Version-independent, port-specific directory to store new platform baselines for a test.
+
+        Baselines are written under the platform/<port> directory of the test's own root,
+        so a test discovered from an additional root (see layout_tests_dirs()) keeps its
+        platform baselines within that root."""
+        return self._filesystem.join(self._test_root(test_name), 'platform', self.port_name)
+
+    def _test_root(self, test_name):
+        """The layout tests root (see layout_tests_dirs()) that test_name is discovered from."""
+        (test_name, _) = Port.test_name_and_variant(test_name)
+        abspath = self.abspath_for_test(test_name)
+        sep = self._filesystem.sep
+        for root in self.additional_layout_tests_dirs():
+            if abspath == root or abspath.startswith(root + sep):
+                return root
+        return self.layout_tests_dir()
+
     def baseline_version_dir(self, device_type=None):
         """Return the absolute path to the platform-and-version-specific results."""
         baseline_search_paths = self.baseline_search_path(device_type=device_type)
         return baseline_search_paths[0]
 
     def baseline_search_path(self, device_type=None):
-        return self.get_option('additional_platform_directory', []) + self._compare_baseline() + self.default_baseline_search_path(device_type=device_type)
+        search_paths = self.get_option('additional_platform_directory', []) + self._compare_baseline() + self.default_baseline_search_path(device_type=device_type)
+        return self._with_additional_root_baselines(search_paths)
+
+    def _with_additional_root_baselines(self, search_paths):
+        """Mirror each open-source platform baseline dir into every additional test root.
+
+        A test in an additional root (see layout_tests_dirs()) can carry platform-specific
+        baselines under <root>/platform/<name>, searched just before the corresponding
+        open-source LayoutTests/platform/<name> directory."""
+        additional_roots = self.additional_layout_tests_dirs()
+        if not additional_roots:
+            return search_paths
+        fs = self._filesystem
+        platform_prefix = fs.join(self.layout_tests_dir(), 'platform') + fs.sep
+        result = []
+        for path in search_paths:
+            if path.startswith(platform_prefix):
+                name = path[len(platform_prefix):]
+                for root in additional_roots:
+                    result.append(fs.join(root, 'platform', name))
+            result.append(path)
+        return result
+
+    def _additional_root_platform_baselines(self):
+        """All existing <additional root>/platform/* baseline directories."""
+        fs = self._filesystem
+        result = set()
+        for root in self.additional_layout_tests_dirs():
+            result |= set(fs.glob(fs.join(root, 'platform', '*')))
+        return result
 
     def default_baseline_search_path(self, device_type=None):
         """Return a list of absolute paths to directories to search under for
@@ -297,6 +344,7 @@ class Port(object):
             set(self.get_option("additional_platform_directory", []))
             | set(self._compare_baseline())
             | set(self._filesystem.glob(self._webkit_baseline_path("*")))
+            | self._additional_root_platform_baselines()
         )
 
         assert {p for p in paths if self._filesystem.isdir(p)}.issuperset(
@@ -461,7 +509,7 @@ class Port(object):
         return self.determine_driver_name(self._options)
 
     def _expected_baselines_for_suffixes(self, test_name, suffixes, all_baselines=False, device_type=None):
-        baseline_search_path = self.baseline_search_path(device_type=device_type) + [self.layout_tests_dir()]
+        baseline_search_path = self.baseline_search_path(device_type=device_type) + self.layout_tests_dirs()
         fs = self._filesystem
 
         (test_name, variant) = Port.test_name_and_variant(test_name)
@@ -542,7 +590,9 @@ class Port(object):
         """
         platform_dir, baseline_filename = self.expected_baselines(test_name, suffix, device_type=device_type)[0]
         if platform_dir or return_default:
-            return self._filesystem.join(platform_dir or self.layout_tests_dir(), baseline_filename)
+            # Fall back to the generic baseline location in the test's own root, so a test
+            # discovered from an additional root keeps its generic baseline within that root.
+            return self._filesystem.join(platform_dir or self._test_root(test_name), baseline_filename)
         return None
 
     def is_unexpected_crash(self, test_name):
@@ -642,6 +692,17 @@ class Port(object):
             return self._layout_tests_dir
         return self._filesystem.join(self.webkit_base(), "LayoutTests")
 
+    @memoized
+    def additional_layout_tests_dirs(self):
+        additions = port_config.apple_additions()
+        if additions and getattr(additions, 'additional_layout_tests_dirs', None):
+            return [self._filesystem.abspath(d) for d in additions.additional_layout_tests_dirs()]
+        return []
+
+    def layout_tests_dirs(self):
+        """All roots to discover layout tests in, most specific first."""
+        return self.additional_layout_tests_dirs() + [self.layout_tests_dir()]
+
     def perf_tests_dir(self):
         return self._filesystem.join(self.webkit_base(), "PerformanceTests")
 
@@ -731,17 +792,25 @@ class Port(object):
         directory. Ports may legitimately return abspaths here if no relpath makes sense."""
         # Ports that run on windows need to override this method to deal with
         # filenames with backslashes in them.
-        if filename.startswith(self.layout_tests_dir()):
-            return self.host.filesystem.relpath(filename, self.layout_tests_dir()).replace(self.host.filesystem.sep, self.TEST_PATH_SEPARATOR)
-        else:
-            return self.host.filesystem.abspath(filename)
+        for root in self.layout_tests_dirs():
+            if filename.startswith(root):
+                return self.host.filesystem.relpath(filename, root).replace(self.host.filesystem.sep, self.TEST_PATH_SEPARATOR)
+        return self.host.filesystem.abspath(filename)
 
     @memoized
     def abspath_for_test(self, test_name, target_host=None):
         """Returns the full path to the file for a given test name. This is the
         inverse of relative_test_filename() if no target_host is specified."""
         host = target_host or self.host
-        return host.filesystem.join(host.filesystem.map_base_host_path(self.layout_tests_dir()), test_name.replace(self.TEST_PATH_SEPARATOR, self.host.filesystem.sep))
+        relative_path = test_name.replace(self.TEST_PATH_SEPARATOR, self.host.filesystem.sep)
+        # A test name may resolve into any test root; tests in alternative roots override
+        # tests in the default root.
+        roots = self.layout_tests_dirs()
+        for root in roots[:-1]:
+            candidate = host.filesystem.join(host.filesystem.map_base_host_path(root), relative_path)
+            if host.filesystem.exists(candidate):
+                return candidate
+        return host.filesystem.join(host.filesystem.map_base_host_path(roots[-1]), relative_path)
 
     def results_directory(self):
         """Absolute path to the place to store the test results (uses --results-directory)."""


### PR DESCRIPTION
#### fad80bf56b436649c8e10b33a73c9eb58044a559
<pre>
Make it possible to to have an additional collection of LayoutTests outside of OpenSource
<a href="https://bugs.webkit.org/show_bug.cgi?id=321374">https://bugs.webkit.org/show_bug.cgi?id=321374</a>
<a href="https://rdar.apple.com/184426028">rdar://184426028</a>

Reviewed by NOBODY (OOPS!).

If `apple_additions` implements `additional_layout_tests_dirs()`, then that supplies one or
more additional testing root directories, which vend tests that will be picked up by
`run-webkit-tests`. Reference files continue to be found next to the test file, and for
a text test in a given root, the expected file will live in `&lt;root&gt;/platform/&lt;platform&gt;/...`.

Those tests show up as if they lived in `LayoutTests` in results.html; the primary use case
is for tests that will be upstreamed to OpenSource in the future.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py:
(LayoutTestFinder.__init__):
(LayoutTestFinder):
(LayoutTestFinder._make_inner_finders):
(LayoutTestFinder._primary_inner_finder):
(LayoutTestFinder.find_tests_by_path):
(LayoutTestFinder._is_test_file):
(LayoutTestFinder._is_w3c_resource_file):
(LayoutTestFinder._make_inner_finder): Deleted.
* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py:
(SingleTestRunner):
* Tools/Scripts/webkitpy/port/apple.py:
(ApplePort.all_baseline_search_paths):
* Tools/Scripts/webkitpy/port/base.py:
(Port.baseline_platform_dir_for_test):
(Port):
(Port._test_root):
(Port.baseline_search_path):
(Port._with_additional_root_baselines):
(Port._additional_root_platform_baselines):
(Port.all_baseline_search_paths):
(Port._expected_baselines_for_suffixes):
(Port.expected_filename):
(Port.additional_layout_tests_dirs):
(Port.layout_tests_dirs):
(Port.relative_test_filename):
(Port.abspath_for_test):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fad80bf56b436649c8e10b33a73c9eb58044a559

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189426 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143903 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57a8a7ff-bf94-4113-a990-98ce82312cb3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140059 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96894 "2 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7c22a05-015c-4389-a92b-eae3bf497308) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120511 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48ae1417-a34a-4a68-9fdc-30c32c752b09) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/178919 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42346 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40668 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152747 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40320 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/execute-start.tentative.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/880 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191647 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53203 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149324 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53884 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149070 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43733 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121116 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52401 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15308 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51786 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52027 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51847 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->