### PR TITLE
[LBSE] Don't rebuild objectBoundingBox gradients on layout size change

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
@@ -80,6 +80,15 @@ ColorInterpolationMethod RenderSVGResourceGradient::gradientColorInterpolationMe
     return { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied };
 }
 
+void RenderSVGResourceGradient::invalidateGradientOnLayoutSizeChange()
+{
+    if (gradientUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
+        repaintAllClients();
+        return;
+    }
+    invalidateGradient();
+}
+
 bool RenderSVGResourceGradient::buildGradientIfNeeded(const RenderLayerModelObject& targetRenderer, const Style::ComputedStyle& style, AffineTransform& userspaceTransform)
 {
     if (!m_gradient) {

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -38,6 +38,7 @@ public:
     bool prepareStrokeOperation(GraphicsContext&, const RenderLayerModelObject&, const Style::ComputedStyle&) final;
 
     virtual void invalidateGradient() = 0;
+    void invalidateGradientOnLayoutSizeChange();
 
     virtual SVGUnitTypes::SVGUnitType gradientUnits() const = 0;
 

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -86,7 +86,7 @@ void SVGContainerLayout::layoutChildren(bool containerNeedsLayout)
                         svgText->setNeedsPositioningValuesUpdate();
                         needsLayout = true;
                     } else if (CheckedPtr resource = dynamicDowncast<RenderSVGResourceGradient>(child))
-                        resource->invalidateGradient();
+                        resource->invalidateGradientOnLayoutSizeChange();
                     // FIXME: [LBSE] Add pattern support.
                 }
             }


### PR DESCRIPTION
#### 291f67b116a80125379aebecec1861ecd5eb0206
<pre>
[LBSE] Don&apos;t rebuild objectBoundingBox gradients on layout size change
<a href="https://bugs.webkit.org/show_bug.cgi?id=321375">https://bugs.webkit.org/show_bug.cgi?id=321375</a>

Reviewed by Simon Fraser.

On a layout size change, SVGContainerLayout invalidated any gradient using
relative lengths via invalidateGradient(), which nulls both m_gradient and
m_attributes. The next paint then re-runs collectGradientAttributesIfNeeded()
(SVGElement::synchronizeAllAttributes, serializing _every_ animated property\
to a string including the gradientTransform) and createGradient().

For an objectBoundingBox gradient this is wasted: its coordinates resolve
against the object bounding box, and buildGradientIfNeeded already recomputes
that userspace transform on every paint regardless of m_gradient. Only the
object bounding box changed, not the gradient&apos;s own resolved data, so the cached
gradient and attributes stay valid. userSpaceOnUse gradients resolve against
the viewport and genuinely change with the layout size.

Introduce invalidateGradientOnLayoutSizeChange(), which only repaints the
gradient clients when objectBoundingBox units are used, keeping the cached
gradient.

* Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp:
(WebCore::RenderSVGResourceGradient::invalidateGradientOnLayoutSizeChange):
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
(WebCore::SVGContainerLayout::layoutChildren):

Canonical link: <a href="https://commits.webkit.org/318873@main">https://commits.webkit.org/318873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d3721b118c342a089bc29932ef9edac87ba3b53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189428 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143905 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140061 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120513 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42344 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40669 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40315 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/882 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191649 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53205 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149325 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40046 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53886 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149071 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43734 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126158 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121118 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52403 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15303 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51788 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52029 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->