### PR TITLE
[Skia] Skip damage restriction when the damage covers the whole draw

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
@@ -102,13 +102,17 @@ void SkiaCompositingLayerImageSetBatch::addImageSet(SkCanvas& canvas, SkiaBackin
     // Planned once for the whole layer. appendImageSetEntries() then splits each tile by the rects that touch it.
     const auto layerDeviceRect = ctm.mapRect(SkRect(FloatRect { { }, backingStore.size() }));
 
-    if (!planRestrictedDraw(canvas, transform, ctm, layerDeviceRect, *damageRegion, [&](SkCanvas& canvas) {
+    SkMatrix inverse;
+    const auto plan = planRestrictedDraw(canvas, transform, ctm, layerDeviceRect, *damageRegion, inverse, [&](SkCanvas& canvas) {
         backingStore.paintToCanvas(canvas, fallbackPaint, damageRegion);
-    }))
+    });
+    if (plan == RestrictedDraw::Done)
         return;
 
     updateSamplingOptions(canvas, sampling);
-    backingStore.appendImageSetEntries(canvas, ctm, matrixIndexForDraw(ctm), opacity, enableAntialias, m_imageSet, damageRegion);
+    // A covered layer has every tile inside the damage, so there is nothing to split by.
+    backingStore.appendImageSetEntries(canvas, ctm, matrixIndexForDraw(ctm), opacity, enableAntialias, m_imageSet,
+        plan == RestrictedDraw::Whole ? nullptr : damageRegion);
 }
 
 void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<SkImage>& image, const FloatRect& rect, const SkM44& transform, float opacity, bool enableAntialias, const SkiaDamageRegion* damageRegion, const SkPaint& fallbackPaint)
@@ -127,19 +131,28 @@ void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<S
 
     const auto deviceRect = ctm.mapRect(dstRectFull);
 
-    const auto inverse = planRestrictedDraw(canvas, transform, ctm, deviceRect, *damageRegion, [&](SkCanvas& canvas) {
+    SkMatrix inverse;
+    const auto plan = planRestrictedDraw(canvas, transform, ctm, deviceRect, *damageRegion, inverse, [&](SkCanvas& canvas) {
         canvas.drawImageRect(image, srcRectFull, dstRectFull, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &fallbackPaint, SkCanvas::kFast_SrcRectConstraint);
     });
-    if (!inverse)
+    if (plan == RestrictedDraw::Done)
         return;
+
+    updateSamplingOptions(canvas, samplingOptionsForImage(canvas, image, rect, ctm));
+    const auto matrixIndex = matrixIndexForDraw(ctm);
+
+    // Drawn whole, so it has no interior edges and antialiases like a draw with no damage.
+    if (plan == RestrictedDraw::Whole) {
+        const unsigned aaFlags = enableAntialias ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
+        m_imageSet.append(SkCanvas::ImageSetEntry(image, srcRectFull, dstRectFull, matrixIndex, opacity, aaFlags, false));
+        return;
+    }
 
     // Splitting creates edges inside the image, and antialiasing them would blend along those edges. This
     // never happens: a split needs a CTM that keeps rects as rects, which is never antialiased.
     ASSERT(!enableAntialias);
 
-    updateSamplingOptions(canvas, samplingOptionsForImage(canvas, image, rect, ctm));
-    const auto matrixIndex = matrixIndexForDraw(ctm);
-    damageRegion->forEachDamagedSubRect(deviceRect, dstRectFull, srcRectFull, *inverse, [&](const SkRect& srcSubRect, const SkRect& dstSubRect) {
+    damageRegion->forEachDamagedSubRect(deviceRect, dstRectFull, srcRectFull, inverse, [&](const SkRect& srcSubRect, const SkRect& dstSubRect) {
         m_imageSet.append(SkCanvas::ImageSetEntry(image, srcSubRect, dstSubRect, matrixIndex, opacity, SkCanvas::kNone_QuadAAFlags, false));
     });
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
@@ -50,9 +50,9 @@ public:
 
     void updatePaintProperties(SkCanvas&, const sk_sp<SkColorFilter>&, const std::optional<SkBlendMode>&);
 
-    // A null damage region draws everything. Otherwise the draw is split by the rects of the region. A
-    // rotated or skewed transform cannot be split, so it is flushed and drawn under a damage clip with
-    // fallbackPaint, which is used in that case only.
+    // A null damage region draws everything. Otherwise the draw is drawn whole when the damage covers it,
+    // split by the rects of the region when the transform allows, and otherwise flushed and drawn under a
+    // damage clip with fallbackPaint, which is used in that case only.
     void addImageSet(SkCanvas&, SkiaBackingStore&, const SkM44& transform, float opacity, bool enableAntialias, const SkiaDamageRegion*, const SkPaint& fallbackPaint);
     void addImage(SkCanvas&, const sk_sp<SkImage>&, const FloatRect&, const SkM44& transform, float opacity, bool enableAntialias, const SkiaDamageRegion*, const SkPaint& fallbackPaint);
 
@@ -77,30 +77,37 @@ public:
     };
 
 private:
-    // Decides how to limit one draw to the damage. Returns the inverse to split it with, or nothing when
-    // the draw is already handled, either because it misses the damage or because fallbackDraw() has drawn
-    // it under a damage clip, which ends the batch.
+    // What the caller has left to do to limit one draw to the damage.
+    enum class RestrictedDraw : uint8_t {
+        Done,
+        Whole,
+        Split
+    };
+
+    // Entries here carry no clip quad, so a draw needing a damage clip ends the batch.
     template<typename FallbackDrawFunction>
-    std::optional<SkMatrix> planRestrictedDraw(SkCanvas& canvas, const SkM44& transform, const SkMatrix& ctm, const SkRect& deviceRect, const SkiaDamageRegion& damageRegion, NOESCAPE const FallbackDrawFunction& fallbackDraw)
+    RestrictedDraw planRestrictedDraw(SkCanvas& canvas, const SkM44& transform, const SkMatrix& ctm, const SkRect& deviceRect, const SkiaDamageRegion& damageRegion, SkMatrix& inverse, NOESCAPE const FallbackDrawFunction& fallbackDraw)
     {
         ASSERT(!damageRegion.isEmpty());
 
-        SkMatrix inverse;
+        if (damageRegion.covers(deviceRect))
+            return RestrictedDraw::Whole;
+
         switch (damageRegion.planDraw(ctm, deviceRect, inverse)) {
         case SkiaDamageRegion::DrawDamageStrategy::Skip:
-            return std::nullopt;
+            return RestrictedDraw::Done;
         case SkiaDamageRegion::DrawDamageStrategy::ClipToDamage: {
             ScopedFlush autoFlush(canvas, *this, ScopedFlush::Mode::FlushBefore);
             canvas.concat(transform);
             damageRegion.clipCanvasInDeviceSpace(canvas);
             fallbackDraw(canvas);
-            return std::nullopt;
+            return RestrictedDraw::Done;
         }
         case SkiaDamageRegion::DrawDamageStrategy::SplitByRect:
             break;
         }
 
-        return inverse;
+        return RestrictedDraw::Split;
     }
 
     void updateSamplingOptions(SkCanvas&, SkSamplingOptions);

--- a/Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h
@@ -89,6 +89,9 @@ public:
     // region along an edge triggers an intersection - this is conservative, but for sure not wrong.
     bool intersects(const SkRect& deviceRect) const { return m_region.intersects(deviceRect.roundOut()); }
 
+    // roundOut() grows the rect, so coverage is under-reported, never over-reported.
+    bool covers(const SkRect& deviceRect) const { return m_region.contains(deviceRect.roundOut()); }
+
     // How to limit one draw to the damage. A draw is split into as many rects as touch it, with no limit,
     // because the parts share a paint and Skia batches them into one op. Clipping is the slow path instead:
     // a clip of more than one rect cannot be a scissor, so it costs a stencil buffer or a mask texture.
@@ -140,6 +143,11 @@ public:
         const auto ctm = canvas.getLocalToDeviceAs3x3();
         SkRect deviceRect;
         ctm.mapRect(&deviceRect, dstRectFull);
+
+        if (covers(deviceRect)) {
+            draw(srcRectFull, dstRectFull);
+            return;
+        }
 
         SkMatrix inverse;
         switch (planDraw(ctm, deviceRect, inverse)) {


### PR DESCRIPTION
#### 2f72b3d7740d588f216e4fc2e746e963931f0d93
<pre>
[Skia] Skip damage restriction when the damage covers the whole draw
<a href="https://bugs.webkit.org/show_bug.cgi?id=321377">https://bugs.webkit.org/show_bug.cgi?id=321377</a>

Reviewed by Alejandro G. Castro.

Respecting the damage information in compositing regressed the MotionMark
composition suite by about 20%, and two of its tests by more than 50%.

A draw is restricted to the damage either by splitting it into multiple
source-rect-to-destination-rect pieces, which needs a transform that keeps
rects as rects, or by drawing it under a device-space clip of the damage
region. Neither restricts a draw that the damage already covers. A composited
layer in the affected tests is much smaller than a damage grid cell, so most
layers are covered. Draw those the way they are drawn with damage off.
The extra clips add nothing and only stop the batching.

Skia turned a region of more than one rect into a clip path, and the image set
batch entries carry no clip quad, so a draw needing a clip also flushed the
batch, leaving it an order of magnitude smaller than it is without damage.
Solid color layers never reach the batch and paid the clip alone, and filters
paid it again per layer, compositing their intermediate surface back under
the clip as well.

Fix that and recover the performance losses, while keeping damage
propagation intact for the cases where it pays off.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp:
(WebCore::SkiaCompositingLayerImageSetBatch::addImageSet):
(WebCore::SkiaCompositingLayerImageSetBatch::addImage):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h:
(WebCore::SkiaCompositingLayerImageSetBatch::planRestrictedDraw):
* Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h:
(WebCore::SkiaDamageRegion::covers const):
(WebCore::SkiaDamageRegion::restrictDraw const):

Canonical link: <a href="https://commits.webkit.org/318856@main">https://commits.webkit.org/318856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4032fb9449d33ce05977612533da21a6daaa739b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143908 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140065 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120517 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42350 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40673 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40325 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/885 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191652 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53208 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149330 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53889 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149076 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27281 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43740 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126161 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121121 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52406 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15313 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51791 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52032 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51852 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->