### PR TITLE
Use `inline constexpr` instead of `constexpr inline` in JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirCCallingConvention.h
+++ b/Source/JavaScriptCore/b3/air/AirCCallingConvention.h
@@ -61,20 +61,20 @@ Tmp NODELETE cCallResult(Code&, CCallValue*, unsigned);
 
 Inst buildCCall(Code&, Value* origin, const Vector<Arg>&);
 
-template<unsigned size> constexpr inline Type b3IntegerType;
-template<> constexpr inline Type b3IntegerType<4> = Int32;
-template<> constexpr inline Type b3IntegerType<8> = Int64;
+template<unsigned size> inline constexpr Type b3IntegerType;
+template<> inline constexpr Type b3IntegerType<4> = Int32;
+template<> inline constexpr Type b3IntegerType<8> = Int64;
 
-template<typename T> constexpr inline Type b3Type;
-template<> constexpr inline Type b3Type<int> = b3IntegerType<sizeof(int)>;
-template<> constexpr inline Type b3Type<long> = b3IntegerType<sizeof(long)>;
-template<> constexpr inline Type b3Type<long long> = b3IntegerType<sizeof(long long)>;
-template<> constexpr inline Type b3Type<unsigned> = b3IntegerType<sizeof(unsigned)>;
-template<> constexpr inline Type b3Type<unsigned long> = b3IntegerType<sizeof(unsigned long)>;
-template<> constexpr inline Type b3Type<unsigned long long> = b3IntegerType<sizeof(unsigned long long)>;
-template<> constexpr inline Type b3Type<float> = Float;
-template<> constexpr inline Type b3Type<double> = Double;
-template<typename T> constexpr inline Type b3Type<T*> = pointerType();
+template<typename T> inline constexpr Type b3Type;
+template<> inline constexpr Type b3Type<int> = b3IntegerType<sizeof(int)>;
+template<> inline constexpr Type b3Type<long> = b3IntegerType<sizeof(long)>;
+template<> inline constexpr Type b3Type<long long> = b3IntegerType<sizeof(long long)>;
+template<> inline constexpr Type b3Type<unsigned> = b3IntegerType<sizeof(unsigned)>;
+template<> inline constexpr Type b3Type<unsigned long> = b3IntegerType<sizeof(unsigned long)>;
+template<> inline constexpr Type b3Type<unsigned long long> = b3IntegerType<sizeof(unsigned long long)>;
+template<> inline constexpr Type b3Type<float> = Float;
+template<> inline constexpr Type b3Type<double> = Double;
+template<typename T> inline constexpr Type b3Type<T*> = pointerType();
 
 // This maps between B3 args and air args.
 struct ArgumentValueList {

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -1267,7 +1267,7 @@ inline bool JSObject::putDirect(VM& vm, PropertyName propertyName, JSValue value
     return putDirectInternal<PutModeDefineOwnProperty>(vm, propertyName, value, 0, slot).isNull();
 }
 
-constexpr inline intptr_t offsetInButterfly(PropertyOffset offset)
+inline constexpr intptr_t offsetInButterfly(PropertyOffset offset)
 {
     return offsetInOutOfLineStorage(offset) + Butterfly::indexOfPropertyStorage();
 }

--- a/Source/JavaScriptCore/runtime/PropertyOffset.h
+++ b/Source/JavaScriptCore/runtime/PropertyOffset.h
@@ -37,26 +37,26 @@ static constexpr PropertyOffset knownPolyProtoOffset = 0;
 static_assert(knownPolyProtoOffset < firstOutOfLineOffset, "We assume in all the JITs that the poly proto offset is an inline offset");
 
 // Declare all of the functions because they tend to do forward calls.
-constexpr inline void checkOffset(PropertyOffset);
-constexpr inline void checkOffset(PropertyOffset, int inlineCapacity);
-constexpr inline void validateOffset(PropertyOffset);
-constexpr inline void validateOffset(PropertyOffset, int inlineCapacity);
-constexpr inline bool isValidOffset(PropertyOffset);
-constexpr inline bool isInlineOffset(PropertyOffset);
-constexpr inline bool isOutOfLineOffset(PropertyOffset);
-constexpr inline intptr_t offsetInInlineStorage(PropertyOffset);
-constexpr inline intptr_t offsetInOutOfLineStorage(PropertyOffset);
-constexpr inline intptr_t offsetInRespectiveStorage(PropertyOffset);
-constexpr inline size_t numberOfOutOfLineSlotsForMaxOffset(PropertyOffset);
-constexpr inline size_t numberOfSlotsForMaxOffset(PropertyOffset, int inlineCapacity);
+inline constexpr void checkOffset(PropertyOffset);
+inline constexpr void checkOffset(PropertyOffset, int inlineCapacity);
+inline constexpr void validateOffset(PropertyOffset);
+inline constexpr void validateOffset(PropertyOffset, int inlineCapacity);
+inline constexpr bool isValidOffset(PropertyOffset);
+inline constexpr bool isInlineOffset(PropertyOffset);
+inline constexpr bool isOutOfLineOffset(PropertyOffset);
+inline constexpr intptr_t offsetInInlineStorage(PropertyOffset);
+inline constexpr intptr_t offsetInOutOfLineStorage(PropertyOffset);
+inline constexpr intptr_t offsetInRespectiveStorage(PropertyOffset);
+inline constexpr size_t numberOfOutOfLineSlotsForMaxOffset(PropertyOffset);
+inline constexpr size_t numberOfSlotsForMaxOffset(PropertyOffset, int inlineCapacity);
 
-constexpr inline void checkOffset(PropertyOffset offset)
+inline constexpr void checkOffset(PropertyOffset offset)
 {
     UNUSED_PARAM(offset);
     ASSERT(offset >= invalidOffset);
 }
 
-constexpr inline void checkOffset(PropertyOffset offset, int inlineCapacity)
+inline constexpr void checkOffset(PropertyOffset offset, int inlineCapacity)
 {
     UNUSED_PARAM(offset);
     UNUSED_PARAM(inlineCapacity);
@@ -66,58 +66,58 @@ constexpr inline void checkOffset(PropertyOffset offset, int inlineCapacity)
         || isOutOfLineOffset(offset));
 }
 
-constexpr inline void validateOffset(PropertyOffset offset)
+inline constexpr void validateOffset(PropertyOffset offset)
 {
     checkOffset(offset);
     ASSERT(isValidOffset(offset));
 }
 
-constexpr inline void validateOffset(PropertyOffset offset, int inlineCapacity)
+inline constexpr void validateOffset(PropertyOffset offset, int inlineCapacity)
 {
     checkOffset(offset, inlineCapacity);
     ASSERT(isValidOffset(offset));
 }
 
-constexpr inline bool isValidOffset(PropertyOffset offset)
+inline constexpr bool isValidOffset(PropertyOffset offset)
 {
     checkOffset(offset);
     return offset != invalidOffset;
 }
 
-constexpr inline bool isInlineOffset(PropertyOffset offset)
+inline constexpr bool isInlineOffset(PropertyOffset offset)
 {
     checkOffset(offset);
     return offset < firstOutOfLineOffset;
 }
 
-constexpr inline bool isOutOfLineOffset(PropertyOffset offset)
+inline constexpr bool isOutOfLineOffset(PropertyOffset offset)
 {
     checkOffset(offset);
     return !isInlineOffset(offset);
 }
 
-constexpr inline intptr_t offsetInInlineStorage(PropertyOffset offset)
+inline constexpr intptr_t offsetInInlineStorage(PropertyOffset offset)
 {
     validateOffset(offset);
     ASSERT(isInlineOffset(offset));
     return offset;
 }
 
-constexpr inline intptr_t offsetInOutOfLineStorage(PropertyOffset offset)
+inline constexpr intptr_t offsetInOutOfLineStorage(PropertyOffset offset)
 {
     validateOffset(offset);
     ASSERT(isOutOfLineOffset(offset));
     return -static_cast<ptrdiff_t>(offset - firstOutOfLineOffset) - 1;
 }
 
-constexpr inline intptr_t offsetInRespectiveStorage(PropertyOffset offset)
+inline constexpr intptr_t offsetInRespectiveStorage(PropertyOffset offset)
 {
     if (isInlineOffset(offset))
         return offsetInInlineStorage(offset);
     return offsetInOutOfLineStorage(offset);
 }
 
-constexpr inline size_t numberOfOutOfLineSlotsForMaxOffset(PropertyOffset offset)
+inline constexpr size_t numberOfOutOfLineSlotsForMaxOffset(PropertyOffset offset)
 {
     checkOffset(offset);
     if (offset < firstOutOfLineOffset)
@@ -125,7 +125,7 @@ constexpr inline size_t numberOfOutOfLineSlotsForMaxOffset(PropertyOffset offset
     return offset - firstOutOfLineOffset + 1;
 }
 
-constexpr inline size_t numberOfSlotsForMaxOffset(PropertyOffset offset, int inlineCapacity)
+inline constexpr size_t numberOfSlotsForMaxOffset(PropertyOffset offset, int inlineCapacity)
 {
     checkOffset(offset, inlineCapacity);
     if (offset < inlineCapacity)
@@ -133,7 +133,7 @@ constexpr inline size_t numberOfSlotsForMaxOffset(PropertyOffset offset, int inl
     return inlineCapacity + numberOfOutOfLineSlotsForMaxOffset(offset);
 }
 
-constexpr inline PropertyOffset offsetForPropertyNumber(int propertyNumber, int inlineCapacity)
+inline constexpr PropertyOffset offsetForPropertyNumber(int propertyNumber, int inlineCapacity)
 {
     PropertyOffset offset = propertyNumber;
     if (offset >= inlineCapacity) {

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
@@ -43,7 +43,7 @@ enum class CompilationMode : uint8_t {
     RestoreFrameMode
 };
 
-constexpr inline bool isAnyInterpreter(CompilationMode compilationMode)
+inline constexpr bool isAnyInterpreter(CompilationMode compilationMode)
 {
     switch (compilationMode) {
     case CompilationMode::IPIntMode:
@@ -61,7 +61,7 @@ constexpr inline bool isAnyInterpreter(CompilationMode compilationMode)
     RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
 }
 
-constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
+inline constexpr bool isAnyBBQ(CompilationMode compilationMode)
 {
     switch (compilationMode) {
     case CompilationMode::BBQMode:
@@ -79,7 +79,7 @@ constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
     RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
 }
 
-constexpr inline bool isAnyOMG(CompilationMode compilationMode)
+inline constexpr bool isAnyOMG(CompilationMode compilationMode)
 {
     switch (compilationMode) {
     case CompilationMode::OMGMode:
@@ -97,7 +97,7 @@ constexpr inline bool isAnyOMG(CompilationMode compilationMode)
     RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
 }
 
-constexpr inline bool isAnyWasmToJS(CompilationMode compilationMode)
+inline constexpr bool isAnyWasmToJS(CompilationMode compilationMode)
 {
     switch (compilationMode) {
     case CompilationMode::WasmToJSMode:


### PR DESCRIPTION
#### 66f7ee58d73d45e83b16c4b4022bfaef5a5711bb
<pre>
Use `inline constexpr` instead of `constexpr inline` in JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=321379">https://bugs.webkit.org/show_bug.cgi?id=321379</a>
<a href="https://rdar.apple.com/184429352">rdar://184429352</a>

Reviewed by Keith Miller.

inline constexpr is the more common order in JSC (113 to 45).
This purely improves consistency and doesn&apos;t introduce any behavioral change.

* Source/JavaScriptCore/b3/air/AirCCallingConvention.h:
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::offsetInButterfly):
* Source/JavaScriptCore/runtime/PropertyOffset.h:
(JSC::checkOffset):
(JSC::validateOffset):
(JSC::isValidOffset):
(JSC::isInlineOffset):
(JSC::isOutOfLineOffset):
(JSC::offsetInInlineStorage):
(JSC::offsetInOutOfLineStorage):
(JSC::offsetInRespectiveStorage):
(JSC::numberOfOutOfLineSlotsForMaxOffset):
(JSC::numberOfSlotsForMaxOffset):
(JSC::offsetForPropertyNumber):
* Source/JavaScriptCore/wasm/WasmCompilationMode.h:
(JSC::Wasm::isAnyInterpreter):
(JSC::Wasm::isAnyBBQ):
(JSC::Wasm::isAnyOMG):
(JSC::Wasm::isAnyWasmToJS):

Canonical link: <a href="https://commits.webkit.org/318899@main">https://commits.webkit.org/318899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d8aeef4da2ddd2b161bdccd0c41cbd68fdca343

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143912 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181466 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140070 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42355 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40679 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2491 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9302 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40329 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/889 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/40878 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191656 "Built successfully") | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53212 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149336 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40058 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53893 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149082 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43745 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126165 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121127 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52410 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15317 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->