### PR TITLE
Zero-duration exponentialRampToValueAtTime() at a non-frame-aligned time renders NaN

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-zero-duration-ramp-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-zero-duration-ramp-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Zero-duration exponentialRampToValueAtTime at frame 546 renders finite values
+PASS Zero-duration exponentialRampToValueAtTime at frame 546.25 renders finite values
+PASS Zero-duration exponentialRampToValueAtTime at frame 546.5 renders finite values
+PASS Zero-duration exponentialRampToValueAtTime at frame 546.75 renders finite values
+PASS Zero-duration linearRampToValueAtTime at frame 546 renders finite values
+PASS Zero-duration linearRampToValueAtTime at frame 546.25 renders finite values
+PASS Zero-duration linearRampToValueAtTime at frame 546.5 renders finite values
+PASS Zero-duration linearRampToValueAtTime at frame 546.75 renders finite values
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-zero-duration-ramp.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-zero-duration-ramp.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html>
+  <head>
+    <title>AudioParam: zero-duration ramps scheduled at a non-frame-aligned time</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+    <script>
+      // Power of two so that frame/sampleRate is exact and the event times below are
+      // representable without round-off.
+      const sampleRate = 8192;
+      const renderQuantum = 128;
+
+      // Coincident automation event times are legal, so a ramp can legitimately have
+      // zero duration (time2 - time1 == 0). Evaluating the exponential ramp formula
+      //
+      //   v(t) = value1 * (value2 / value1) ^ ((t - time1) / (time2 - time1))
+      //
+      // then divides by zero, and the per-sample multiplier (value2 / value1) raised to
+      // 1 / (0 frames) is infinite. Implementations must not let those non-finite
+      // intermediates reach the output: per
+      // https://webaudio.github.io/web-audio-api/#computation-of-value a NaN
+      // computedValue must be replaced by the AudioParam's defaultValue, so the rendered
+      // signal is required to be finite regardless.
+      //
+      // What varies below is where the coincident events fall relative to a frame
+      // boundary. An event time that is not frame-aligned leaves the internal write
+      // cursor already at the end of the region the ramp covers, so the ramp's per-sample
+      // loop runs zero times. That is the path worth covering: with no iterations there is
+      // nothing to overwrite a poisoned starting value, and a frame-aligned event time can
+      // mask the problem because a later event overwrites the value instead.
+      //
+      // The events are placed inside the render quantum starting at frame 512, offset by
+      // a fraction of a frame. Offset 0 is the frame-aligned control.
+      const baseEventFrame = 4 * renderQuantum + 34;
+      const subFrameOffsets = [0, 0.25, 0.5, 0.75];
+
+      // A trailing setTargetAtTime keeps consuming the value the ramp left behind, so it
+      // is what makes a poisoned value observable in the output. Its timeConstant is
+      // chosen large enough that setTargetAtTime cannot force-converge to its target
+      // within the render (it does so after 10 time constants), which would otherwise
+      // mask the failure partway through the buffer.
+      const timeConstant = 10;
+
+      // Renders three coincident events at |eventFrame| / sampleRate, where |method| is
+      // the zero-duration ramp under test, and returns the rendered samples.
+      async function renderCoincidentRamp(method, eventFrame) {
+        const context = new OfflineAudioContext({
+          numberOfChannels: 1,
+          length: sampleRate,
+          sampleRate: sampleRate
+        });
+
+        // offset has no audio-rate inputs, which is the common case and the one where an
+        // implementation cannot rely on input summing to sanitize the value.
+        const src = new ConstantSourceNode(context, {offset: 0});
+        src.connect(context.destination);
+
+        const eventTime = eventFrame / sampleRate;
+
+        // value1 is non-zero and has the same sign as value2, so the exponential ramp
+        // formula above applies rather than the "v(t) = value1" special case.
+        src.offset.setValueAtTime(1, eventTime);
+        src.offset[method](2, eventTime);
+        src.offset.setTargetAtTime(5, eventTime, timeConstant);
+
+        src.start();
+
+        const buffer = await context.startRendering();
+        return buffer.getChannelData(0);
+      }
+
+      // Asserts every sample is finite, reporting the first offender and how far the
+      // damage extends.
+      function assert_all_finite(output, description) {
+        const firstBad = output.findIndex(value => !Number.isFinite(value));
+        if (firstBad < 0)
+          return;
+
+        let count = 0;
+        for (let i = firstBad; i < output.length; ++i) {
+          if (!Number.isFinite(output[i]))
+            ++count;
+        }
+
+        assert_unreached(
+            `${description}: output[${firstBad}] is ${output[firstBad]} ` +
+            `(${count} of ${output.length} samples are not finite)`);
+      }
+
+      for (const method of ['exponentialRampToValueAtTime',
+                            'linearRampToValueAtTime']) {
+        for (const offset of subFrameOffsets) {
+          const eventFrame = baseEventFrame + offset;
+          promise_test(async () => {
+            const output = await renderCoincidentRamp(method, eventFrame);
+            assert_all_finite(output, `${method} at frame ${eventFrame}`);
+          }, `Zero-duration ${method} at frame ${eventFrame} renders finite values`);
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
@@ -578,6 +578,18 @@ void AudioParamTimeline::processExponentialRamp(const AutomationState& currentSt
     }
 
     auto deltaTime = currentState.time2 - currentState.time1;
+
+    // Coincident event times are legal, so deltaTime can be zero. Guard against it the way
+    // processLinearRamp() does, before it can poison the recurrence below: 1 / numSampleFrames
+    // would be infinite, making |multiplier| infinite, and the exponent computed for
+    // |currentValue| would be 0 / 0. Such a ramp has no duration, so every frame we could write
+    // here is already at or past its end time and the value is simply value2.
+    if (deltaTime.value() <= std::numeric_limits<float>::min()) {
+        value = currentState.value2;
+        fillWithValue(values, value, currentState.fillToFrame, writeIndex);
+        return;
+    }
+
     double numSampleFrames = deltaTime.value() * currentState.sampleRate;
     double ratio = currentState.value2 / static_cast<double>(currentState.value1);
     // The value goes exponentially from value1 to value2 in a duration of deltaTime seconds (corresponding to numSampleFrames).


### PR DESCRIPTION
#### c5b0051e172e0ea5bab5188bddc403bbd03a09b0
<pre>
Zero-duration exponentialRampToValueAtTime() at a non-frame-aligned time renders NaN
<a href="https://bugs.webkit.org/show_bug.cgi?id=321383">https://bugs.webkit.org/show_bug.cgi?id=321383</a>
<a href="https://rdar.apple.com/184434164">rdar://184434164</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Coincident automation event times are legal, so an exponential ramp can have zero
duration. processExponentialRamp() had no guard for that, unlike processLinearRamp().

With deltaTime == 0 the per-sample multiplier is infinite and the starting value&apos;s
exponent is 0 / 0. When the event time is not frame-aligned the write cursor is already
at fillToFrame, so the sample loop runs zero times -- but the trailing restore step keys
off writeIndex rather than off whether the loop ran, and computes inf / inf. isEventCurrent()
then skips the ramp, so the branch that would reset the value never runs; a following
setTargetAtTime() writes the NaN to the output until it force-converges after 10 time
constants.

Guard deltaTime the way processLinearRamp() does. A zero-duration ramp has no frames left
to interpolate, so the value is value2 -- which is also what WebKit already produces when
the same events are frame-aligned.

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-zero-duration-ramp.html

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-zero-duration-ramp-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-zero-duration-ramp.html: Added.
* Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp:
(WebCore::AudioParamTimeline::processExponentialRamp):

Canonical link: <a href="https://commits.webkit.org/318868@main">https://commits.webkit.org/318868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10fd70c7fba2113e226fea79724b6cc624be1011

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143921 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96ef3a24-afaa-4116-acef-0bdca26da9c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140077 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b80f8ea-9404-4cf8-91c4-7125c86662c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120529 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c209c0d9-f99c-42b9-8fb9-1af4e664e3dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42363 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40686 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152764 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40348 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/898 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191665 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149342 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40040 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53902 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149088 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43753 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126174 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121140 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52419 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15337 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51804 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52045 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51865 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->