### PR TITLE
Setting ConvolverNode.buffer to null does not release the impulse response

### DIFF
--- a/LayoutTests/webaudio/convolver-setBuffer-null-expected.txt
+++ b/LayoutTests/webaudio/convolver-setBuffer-null-expected.txt
@@ -1,13 +1,7 @@
-Tests that ConvolverNode impulse response buffer can be set to null.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS conv.buffer = null did not throw exception.
-PASS conv.buffer is null
-PASS conv.buffer = document threw exception TypeError: The ConvolverNode.buffer attribute must be an instance of AudioBuffer.
-PASS conv.buffer is null
-PASS successfullyParsed is true
-
-TEST COMPLETE
+PASS Setting the buffer to null on a new ConvolverNode leaves it null
+PASS Setting the buffer to a non-AudioBuffer throws and leaves it null
+PASS Setting the buffer to null after a response was set clears the attribute
+PASS A ConvolverNode with a response renders a non-silent signal
+PASS Setting the buffer to null after a response was set stops the convolution
 

--- a/LayoutTests/webaudio/convolver-setBuffer-null.html
+++ b/LayoutTests/webaudio/convolver-setBuffer-null.html
@@ -1,22 +1,94 @@
 <!DOCTYPE html>
 <html>
-<head>
-<script src="resources/audio-testing.js"></script>
-<script src="../resources/js-test-pre.js"></script>
-</head>
-<body>
-<script>
-description("Tests that ConvolverNode impulse response buffer can be set to null.");
+  <head>
+    <title>
+      Tests that ConvolverNode impulse response buffer can be set to null
+    </title>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      // Fairly arbitrary, except that a power of two makes 1/sampleRate exactly
+      // representable as a single-precision float.
+      const sampleRate = 8192;
 
-var context = new AudioContext();
-var conv = context.createConvolver();
+      // More than a few render quanta.
+      const renderFrames = 4 * 128;
 
-shouldNotThrow("conv.buffer = null");
-shouldBe("conv.buffer", "null");
+      function createContext() {
+        return new OfflineAudioContext(1, renderFrames, sampleRate);
+      }
 
-shouldThrow("conv.buffer = document");
-shouldBe("conv.buffer", "null");
-</script>
-<script src="../resources/js-test-post.js"></script>
-</body>
+      // A response that convolves to a copy of the input, so that a stale
+      // response is trivially distinguishable from silence.
+      function createResponse(context) {
+        const response = context.createBuffer(1, 2, sampleRate);
+        response.getChannelData(0)[0] = 1;
+        return response;
+      }
+
+      // Render a unit DC signal through a convolver set up by |configure|.
+      async function renderThroughConvolver(configure) {
+        const context = createContext();
+
+        // Normalization is disabled so that the response is applied with unit
+        // scale and the expected output magnitude is predictable.
+        const convolver = new ConvolverNode(context, {disableNormalization: true});
+        configure(convolver, createResponse(context));
+
+        const source = new ConstantSourceNode(context, {offset: 1});
+        source.connect(convolver).connect(context.destination);
+        source.start();
+
+        const rendered = await context.startRendering();
+        return rendered.getChannelData(0);
+      }
+
+      test(() => {
+        const convolver = new ConvolverNode(createContext());
+        convolver.buffer = null;
+        assert_equals(convolver.buffer, null, 'convolver.buffer');
+      }, 'Setting the buffer to null on a new ConvolverNode leaves it null');
+
+      test(() => {
+        const convolver = new ConvolverNode(createContext());
+        assert_throws_js(TypeError, () => {
+          convolver.buffer = document;
+        }, 'setting the buffer to a non-AudioBuffer');
+        assert_equals(convolver.buffer, null, 'convolver.buffer');
+      }, 'Setting the buffer to a non-AudioBuffer throws and leaves it null');
+
+      test(() => {
+        const context = createContext();
+        const convolver = new ConvolverNode(context);
+        const response = createResponse(context);
+
+        convolver.buffer = response;
+        assert_equals(convolver.buffer, response, 'convolver.buffer');
+
+        convolver.buffer = null;
+        assert_equals(convolver.buffer, null, 'convolver.buffer after null');
+      }, 'Setting the buffer to null after a response was set clears the attribute');
+
+      // Guards the test below: if the convolver were silent for some unrelated
+      // reason, asserting that it goes silent would pass for the wrong reason.
+      promise_test(async () => {
+        const output = await renderThroughConvolver((convolver, response) => {
+          convolver.buffer = response;
+        });
+        assert_true(output.some(sample => sample != 0), 'some sample is non-zero');
+      }, 'A ConvolverNode with a response renders a non-silent signal');
+
+      promise_test(async () => {
+        const output = await renderThroughConvolver((convolver, response) => {
+          convolver.buffer = response;
+          convolver.buffer = null;
+        });
+        const index = output.findIndex(sample => sample != 0);
+        assert_equals(index, -1,
+            `first non-zero sample index (value ${index < 0 ? 0 : output[index]})`);
+      }, 'Setting the buffer to null after a response was set stops the convolution');
+    </script>
+  </body>
 </html>

--- a/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
@@ -116,9 +116,13 @@ void ConvolverNode::process(size_t framesToProcess)
 ExceptionOr<void> ConvolverNode::setBufferForBindings(RefPtr<AudioBuffer>&& buffer)
 {
     ASSERT(isMainThread());
-    
-    if (!buffer)
+
+    if (!buffer) {
+        Locker locker { m_processLock };
+        m_reverb = nullptr;
+        m_buffer = nullptr;
         return { };
+    }
 
     if (buffer->sampleRate() != context().sampleRate())
         return Exception { ExceptionCode::NotSupportedError, "Buffer sample rate does not match the context's sample rate"_s };
@@ -154,10 +158,9 @@ ExceptionOr<void> ConvolverNode::setBufferForBindings(RefPtr<AudioBuffer>&& buff
 
         m_reverb = WTF::move(reverb);
         m_buffer = WTF::move(buffer);
-        if (m_buffer) {
-            // This will propagate the channel count to any nodes connected further downstream in the graph.
-            protect(output(0))->setNumberOfChannels(computeNumberOfOutputChannels(protect(input(0))->numberOfChannels(), m_buffer->numberOfChannels()));
-        }
+
+        // This will propagate the channel count to any nodes connected further downstream in the graph.
+        protect(output(0))->setNumberOfChannels(computeNumberOfOutputChannels(protect(input(0))->numberOfChannels(), m_buffer->numberOfChannels()));
     }
 
     return { };


### PR DESCRIPTION
#### 3b45c0a014e66a261fa7937747a44dce01589f4f
<pre>
Setting ConvolverNode.buffer to null does not release the impulse response
<a href="https://bugs.webkit.org/show_bug.cgi?id=321384">https://bugs.webkit.org/show_bug.cgi?id=321384</a>
<a href="https://rdar.apple.com/184434803">rdar://184434803</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

setBufferForBindings() returned early on a null buffer without touching m_reverb
or m_buffer, so assigning null left the node fully configured with the previous
impulse response. Two consequences: the attribute stopped round-tripping, since
bufferForBindings() returns m_buffer and ConvolverNode.idl declares a plain
nullable attribute with no custom setter, so conv.buffer = ir followed by
conv.buffer = null still returned ir; and process() only zeroes its output when
m_reverb is null, so the stale response kept convolving indefinitely. tailTime()
and latencyTime() likewise kept reporting the old response length, holding the
node in tail processing.

The early return predates 2012; 103415@main only removed the adjacent
ASSERT(buffer) that fired on it, leaving the clearing unimplemented. Clear
m_reverb and m_buffer under m_processLock instead, which is the lock both are
guarded by. The graph lock the non-null path takes is not needed here, since
nothing propagates a channel count on this path.

The output channel count is deliberately left alone. It was propagated
downstream when the response was set, and checkNumberOfChannelsForInput()
already leaves it untouched while m_buffer is null, so resetting it would
reconfigure downstream nodes with no basis in the specification.

Also remove the null check guarding the channel-count propagation in the
non-null path, which the early return above made unreachable as false.

The existing webaudio/convolver-setBuffer-null.html only set null on a fresh
convolver, where m_buffer is already null, so it passed throughout. Convert it
from js-test-pre.js to testharness.js so it runs in other engines, and extend it
to cover the round-trip after a response is set and an offline render that must
be silent afterwards. The render assertion is exact rather than thresholded,
because the fixed path zeroes the bus without running the FFT. A companion
assertion checks that a convolver with a response renders non-silent, so the
silence check cannot pass for the wrong reason.

* LayoutTests/webaudio/convolver-setBuffer-null-expected.txt:
* LayoutTests/webaudio/convolver-setBuffer-null.html:
* Source/WebCore/Modules/webaudio/ConvolverNode.cpp:
(WebCore::ConvolverNode::setBufferForBindings):

Canonical link: <a href="https://commits.webkit.org/318870@main">https://commits.webkit.org/318870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b77af74db31519ec7c1d2ae5c69aa68ccbfc47d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189447 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143924 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd22785b-35ba-4601-837b-1f59c45751ba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140078 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e7f0b3c-0d5f-4cd4-aa70-00064ca2c1f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120530 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f98f171-79ae-408c-b2bb-31b43057d589) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42364 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40687 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152765 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40337 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/901 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191668 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149343 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40041 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53905 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36961 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/media/media-element-frame-destroyed-crash.html, http/tests/navigation/javascriptlink-frames.html, http/tests/navigation/post-frames-goback1-uncached.html, http/tests/privateClickMeasurement/store-private-click-measurement-nested.html, http/tests/resourceLoadStatistics/dont-count-third-party-image-as-third-party-script.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/image-redirect-allowed.html, http/tests/security/mixedContent/redirect-http-to-https-script-in-iframe-UpgradeMixedContent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149089 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43754 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126177 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121145 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52422 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15326 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51807 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52048 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51868 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->