### PR TITLE
Reverse playback of buffers longer than 2^23 frames extrapolates outside the source samples

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-reverse-long-buffer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-reverse-long-buffer-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Reverse playback of a short buffer renders a sub-sample interpolated signal
+PASS Reverse playback from a buffer longer than 2^23 frames matches an equivalent short buffer
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-reverse-long-buffer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-reverse-long-buffer.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>audiobuffersource-reverse-long-buffer.html</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      // Reverse playback of an AudioBuffer longer than 2^23 frames.
+      //
+      // The playback position of an AudioBufferSourceNode has to carry a
+      // sub-sample fraction. Truncating that position through a
+      // single-precision intermediate loses the fraction once the position
+      // passes 2^23, where the spacing of float reaches 1.0: at that magnitude
+      // a single-precision floor rounds to nearest rather than down, so it can
+      // return a value greater than its argument. The interpolation factor
+      // derived from it then goes negative and the interpolation extrapolates
+      // outside the pair of frames it is meant to be mixing between.
+      //
+      // Playback only depends on position relative to the grain being played,
+      // so a buffer longer than 2^23 frames must render exactly the same output
+      // as a short buffer holding the same samples at the same distance from
+      // the buffer end. Asserting that equivalence keeps the test independent
+      // of which interpolation or resampling filter an implementation uses.
+
+      const sampleRate = 44100;
+
+      // Two render quanta suffice: at a rate of -0.5 the defect first appears
+      // on the 4th output frame.
+      const renderLength = 256;
+
+      // 2^23 is where the spacing of float reaches 1.0. The buffer has to be at
+      // least this long for the read position to reach that magnitude, so the
+      // ~32MB allocation below is inherent to what is being tested.
+      const longLength = Math.pow(2, 23) + 512;
+      const shortLength = 4096;
+
+      // The pattern must not be a linear ramp. Linearly extrapolating a linear
+      // signal happens to land on the correct value, which would hide the
+      // defect entirely. Alternating between two values maximises sensitivity.
+      const patternLength = 256;
+      const patternValue = k => k % 2;
+
+      function renderReverse(length) {
+        const context = new OfflineAudioContext(1, renderLength, sampleRate);
+
+        // The buffer rate matches the context rate so that the playback rate is
+        // exactly -0.5 and no resampling factor is folded into it.
+        const buffer = new AudioBuffer({length, sampleRate});
+
+        // Fill relative to the END of the buffer. Reverse playback starts at
+        // the last frame, so indexing by distance from the end gives both
+        // buffers identical content along the direction they are read.
+        const channel = buffer.getChannelData(0);
+        for (let k = 0; k < patternLength; k++)
+          channel[length - 1 - k] = patternValue(k);
+
+        // playbackRate has to be negative before start() is called, because the
+        // initial read position depends on the playback direction. Passing it
+        // to the constructor guarantees that ordering. -0.5 rather than -1 so
+        // that playback lands on sub-sample positions at all.
+        const source =
+            new AudioBufferSourceNode(context, {buffer, playbackRate: -0.5});
+        source.connect(context.destination);
+
+        // Start from the last frame explicitly rather than relying on a bare
+        // start() to begin at the end of the buffer when the rate is negative,
+        // which is not a behaviour implementations agree on.
+        source.start(0, (length - 1) / sampleRate);
+
+        return context.startRendering().then(
+            rendered => rendered.getChannelData(0));
+      }
+
+      // Guards the comparison below: an implementation that rendered silence,
+      // or that ignored the sub-sample position, would otherwise match
+      // trivially.
+      promise_test(async t => {
+        const output = await renderReverse(shortLength);
+
+        assert_true(
+            Array.prototype.some.call(output, v => v !== output[0]),
+            'reverse playback should not produce a constant signal');
+        assert_true(
+            Array.prototype.some.call(output, v => v > 0 && v < 1),
+            'reverse playback at a rate of -0.5 should produce values between ' +
+                'the source frames, indicating a sub-sample read position');
+      }, 'Reverse playback of a short buffer renders a sub-sample interpolated ' +
+          'signal');
+
+      promise_test(async t => {
+        const [shortOutput, longOutput] =
+            await Promise.all([
+              renderReverse(shortLength), renderReverse(longLength)]);
+
+        assert_equals(
+            longOutput.length, shortOutput.length,
+            'both renders should be the same length');
+
+        let mismatches = 0;
+        let first = -1;
+        for (let i = 0; i < shortOutput.length; i++) {
+          if (Math.abs(longOutput[i] - shortOutput[i]) > 1e-5) {
+            if (first < 0)
+              first = i;
+            mismatches++;
+          }
+        }
+
+        assert_equals(
+            mismatches, 0,
+            first < 0 ? '' :
+                `output differs from the equivalent short buffer at ` +
+                    `${mismatches} of ${shortOutput.length} frames; first at ` +
+                    `index ${first}, where the short buffer rendered ` +
+                    `${shortOutput[first]} and the long buffer rendered ` +
+                    `${longOutput[first]}`);
+      }, 'Reverse playback from a buffer longer than 2^23 frames matches an ' +
+          'equivalent short buffer');
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -355,10 +355,10 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
         virtualReadIndex = readIndex;
     } else if (reverse) {
         unsigned maxFrame = static_cast<unsigned>(virtualMaxFrame);
-        unsigned minFrame = static_cast<unsigned>(floorf(virtualMinFrame));
+        unsigned minFrame = static_cast<unsigned>(std::floor(virtualMinFrame));
 
         while (framesToProcess--) {
-            unsigned readIndex = static_cast<unsigned>(floorf(virtualReadIndex));
+            unsigned readIndex = static_cast<unsigned>(std::floor(virtualReadIndex));
             float interpolationFactor = virtualReadIndex - readIndex;
 
             unsigned readIndex2 = readIndex + 1;


### PR DESCRIPTION
#### f075fe96bb0ef74cc09c4dfb1903c9fa03c252f2
<pre>
Reverse playback of buffers longer than 2^23 frames extrapolates outside the source samples
<a href="https://bugs.webkit.org/show_bug.cgi?id=321386">https://bugs.webkit.org/show_bug.cgi?id=321386</a>
<a href="https://rdar.apple.com/184439324">rdar://184439324</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

renderFromBuffer() keeps its playback position in double precision, but the
reverse branch rounded that position down through floorf(), narrowing the
double to float. Above 2^23 the spacing of float is 1.0, so floorf() rounds to
nearest rather than down and can return a value greater than its argument:
floorf(8388609.5) is 8388610. The interpolation factor derived from it on the
next line is then negative, and computeSampleUsingLinearInterpolation()
extrapolates past the pair of frames it is meant to be mixing between rather
than interpolating between them. A read index rounded up to bufferLength also
trips the bounds check at the top of the loop, breaking out and leaving the
rest of the render quantum unwritten.

The threshold is 2^23 frames, roughly 190 seconds at 44.1kHz. Only the reverse
branch is affected; the forward branch truncates the double directly. The
surrounding code already uses the double overload of floor() when computing
needsInterpolation, so use std::floor() at both sites.

The test renders the same content from a short buffer and from a buffer longer
than 2^23 frames and requires the two to match, since playback depends only on
position relative to the grain. Comparing the two rather than checking absolute
sample values keeps the test independent of the interpolation or resampling
filter an implementation chooses. The pattern deliberately is not a linear
ramp: linearly extrapolating a linear signal happens to land on the correct
value, which is why the existing negative-playbackRate tests do not catch this.

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-reverse-long-buffer.html

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-reverse-long-buffer-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-reverse-long-buffer.html: Added.
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::renderFromBuffer):

Canonical link: <a href="https://commits.webkit.org/318869@main">https://commits.webkit.org/318869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc2a68cb657203c152e87319afabbec828ed50f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143934 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a4c1047-9b43-432b-ad92-1842db369a41) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140089 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52e5824d-58ff-42c1-9e49-a9238003b656) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120541 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28b6507a-6074-4b17-b9e7-aa29cc1af117) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42375 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40698 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40349 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/911 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191678 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149354 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40039 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53915 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149100 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43765 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126187 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121169 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52432 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15338 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51817 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52058 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51878 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->