### PR TITLE
AudioBuffer noise injection can be negated by writing a single sample with copyToChannel()

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -272,18 +272,21 @@ ExceptionOr<void> AudioBuffer::copyToChannel(Ref<Float32Array>&& source, unsigne
     
     if (bufferOffset >= dataLength)
         return { };
-    
+
+    // This only overwrites one channel from bufferOffset onwards, so noise the rest of the buffer
+    // first; otherwise a single-sample write would negate noise injection for everything it misses.
+    applyNoiseIfNeeded();
+
     size_t count = dataLength - bufferOffset;
     count = std::min(source.get().length(), count);
-    
+
     auto src = source->typedSpan();
     auto dst = channelData->typedMutableSpan();
-    
+
     ASSERT(src.data());
     ASSERT(dst.data());
-    
+
     memmoveSpan(dst.subspan(bufferOffset), src.first(count));
-    m_noiseInjectionMultiplier = 0;
     return { };
 }
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/audio-fingerprinting.js
+++ b/Tools/TestWebKitAPI/Resources/cocoa/audio-fingerprinting.js
@@ -76,6 +76,39 @@ async function testFeedbackCycle() {
     return renderedBuffer.length;
 }
 
+async function testOscillatorCompressorAfterCopyToChannel() {
+    // Regression test for noise injection being negated by AudioBuffer.copyToChannel(): the
+    // rendered buffer's noise multiplier was cleared on any write, even though copyToChannel()
+    // only overwrites part of one channel. Writing a single sample therefore handed back
+    // pristine, un-noised data for every other channel and every untouched frame.
+    const context = new OfflineAudioContext(2, 5000, 44100);
+    const oscillator = context.createOscillator();
+    oscillator.type = "triangle";
+    oscillator.frequency.value = 1000;
+
+    const compressor = context.createDynamicsCompressor();
+    compressor.threshold.value = -50;
+    compressor.knee.value = 40;
+    compressor.ratio.value = 12;
+    compressor.attack.value = 0;
+    compressor.release.value = 0.2;
+
+    oscillator.connect(compressor);
+    compressor.connect(context.destination);
+
+    oscillator.start();
+    const renderedBuffer = await context.startRendering();
+    oscillator.disconnect();
+    compressor.disconnect();
+
+    // Overwrite a single sample of channel 0, then fingerprint only data this write did not
+    // touch: the remainder of channel 0, plus the whole of channel 1.
+    renderedBuffer.copyToChannel(new Float32Array(1), 0, 0);
+
+    return combineSamples(renderedBuffer.getChannelData(0).subarray(1))
+        + combineSamples(renderedBuffer.getChannelData(1));
+}
+
 function testOscillatorCompressorWorklet() {
     return new Promise(async resolve => {
         const context = new AudioContext;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdvancedPrivacyProtections.mm
@@ -1317,6 +1317,7 @@ TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIs)
     };
 
     checkFingerprintForNoise(@"testOscillatorCompressor");
+    checkFingerprintForNoise(@"testOscillatorCompressorAfterCopyToChannel");
     checkFingerprintForNoise(@"testOscillatorCompressorWorklet");
     checkFingerprintForNoise(@"testOscillatorCompressorAnalyzer");
     checkFingerprintForNoise(@"testLoopingOscillatorCompressorBiquadFilter");


### PR DESCRIPTION
#### 748488313022c8547a89f33b3607cba059655679
<pre>
AudioBuffer noise injection can be negated by writing a single sample with copyToChannel()
<a href="https://bugs.webkit.org/show_bug.cgi?id=321387">https://bugs.webkit.org/show_bug.cgi?id=321387</a>
<a href="https://rdar.apple.com/184440845">rdar://184440845</a>

Reviewed by NOBODY (OOPS!).

copyToChannel() cleared m_noiseInjectionMultiplier unconditionally after writing, without
applying the pending noise first. That only makes sense for a write covering the whole buffer,
but copyToChannel() addresses a single channel and honors a bufferOffset.

Since applyNoiseIfNeeded() is the only whole-buffer noise application and early-returns once the
multiplier is zero, script could render an OfflineAudioContext, write one sample, and read back
pristine samples for every other channel and every frame the write missed.

Apply pending noise at the top of copyToChannel(), mirroring copyFromChannel(). The separate
assignment is dropped since applyNoiseIfNeeded() already clears the multiplier. zero() still
clears it directly, which stays correct: it wipes every channel in full.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdvancedPrivacyProtections.mm

* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::copyToChannel):
* Tools/TestWebKitAPI/Resources/cocoa/audio-fingerprinting.js:
(async testOscillatorCompressorAfterCopyToChannel):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIs)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/748488313022c8547a89f33b3607cba059655679

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143936 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee0b9259-df16-4519-972c-131222777051) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140090 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96926 "2 flakes 5 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/286b3390-3586-4448-8297-fce259ca309f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120542 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b70f551-512d-4b0b-a806-e3ec4576e4f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42377 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40700 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152778 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40351 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/913 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191680 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53236 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149356 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53917 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149102 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43767 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126189 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121180 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52434 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15340 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51819 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52060 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51880 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->