### PR TITLE
text-autospace: a text run containing only combining marks discards the preceding base character

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-only-run-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-only-run-expected.txt
@@ -1,0 +1,8 @@
+á̂永
+á̂永
+á̂永
+á̂永
+
+PASS baseline: text-autospace applies between a base character and a following ideograph
+PASS a text run of only combining marks preserves the preceding base character
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-only-run.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-only-run.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>text-autospace: a text run of only combining marks must not discard the preceding base character</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  div {
+    font: 40px/1 sans-serif;
+    width: fit-content;
+  }
+  .normal { text-autospace: normal; }
+  .none { text-autospace: no-autospace; }
+</style>
+
+<!-- The combining marks share a text run with their base character. -->
+<div class="normal" id="singleNormal">a&#x0301;&#x0302;&#x6C38;</div>
+<div class="none" id="singleNone">a&#x0301;&#x0302;&#x6C38;</div>
+
+<!-- display: contents splits the grapheme cluster into separate text runs without
+     generating an inline box, so the middle run consists only of combining marks. -->
+<div class="normal" id="splitNormal">a<span style="display: contents">&#x0301;&#x0302;</span>&#x6C38;</div>
+<div class="none" id="splitNone">a<span style="display: contents">&#x0301;&#x0302;</span>&#x6C38;</div>
+
+<script>
+const widthOf = id => document.getElementById(id).getBoundingClientRect().width;
+
+// Comparing each structure against its own no-autospace twin isolates the autospace
+// contribution from any difference in how the split cluster is shaped.
+const singleDelta = () => widthOf("singleNormal") - widthOf("singleNone");
+const splitDelta = () => widthOf("splitNormal") - widthOf("splitNone");
+
+test(() => {
+  assert_greater_than(singleDelta(), 0,
+    "autospace should widen the ideograph boundary when the cluster is one run");
+}, "baseline: text-autospace applies between a base character and a following ideograph");
+
+test(() => {
+  assert_approx_equals(splitDelta(), singleDelta(), 0.5,
+    "a run of only combining marks should be transparent to autospace state");
+}, "a text run of only combining marks preserves the preceding base character");
+</script>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -313,9 +313,16 @@ void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings(const InlineItemLi
         auto length = inlineTextItem->length();
         CheckedRef inlineTextBox = inlineTextItem->inlineTextBox();
         auto content = inlineTextBox->content().substring(start, length);
+        // A run made up of nothing but combining marks has no base character of its own (the marks belong to the
+        // grapheme cluster started by an earlier run), so it must not clobber the base character we are tracking.
+        auto updateLastBaseCharacter = [&] {
+            if (auto lastBaseCharacter = TextUtil::lastBaseCharacterFromText(content)) {
+                lastCharacterFromPreviousRun = lastBaseCharacter;
+                lastCharacterDepth = currentCharacterDepth;
+            }
+        };
         if (!processInlineBoxBoundary || !lastCharacterFromPreviousRun) {
-            lastCharacterFromPreviousRun = TextUtil::lastBaseCharacterFromText(content);
-            lastCharacterDepth = currentCharacterDepth;
+            updateLastBaseCharacter();
             processInlineBoxBoundary = false;
             continue;
         }
@@ -328,8 +335,7 @@ void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings(const InlineItemLi
         if (!boundaryTextAutospace.isNoAutospace() && boundaryTextAutospace.shouldApplySpacing(inlineTextBox->content().codePointAt(start), lastCharacterFromPreviousRun))
             spacings.add(boundaryIndex, TextAutospace::textAutospaceSize(boundaryOwnerStyle->fontCascade().primaryFont()));
 
-        lastCharacterFromPreviousRun = TextUtil::lastBaseCharacterFromText(content);
-        lastCharacterDepth = currentCharacterDepth;
+        updateLastBaseCharacter();
         processInlineBoxBoundary = false;
     }
     if (!spacings.isEmpty())
@@ -903,8 +909,10 @@ static void handleTextSpacing(TextSpacing::SpacingState& spacingState, Trimmable
         if (autospace.shouldApplySpacing(spacingState.lastCharacterClassFromPreviousRun, characterClass))
             trimmableTextSpacings.add(inlineItemIndex, TextAutospace::textAutospaceSize(inlineTextItem.style().fontCascade().primaryFont()));
 
-        auto lastCharacterFromPreviousRun = TextUtil::lastBaseCharacterFromText(inlineTextItem.content());
-        spacingState.lastCharacterClassFromPreviousRun = TextSpacing::characterClass(lastCharacterFromPreviousRun);
+        auto lastBaseCharacter = TextUtil::lastBaseCharacterFromText(inlineTextItem.content());
+        // A run made up of nothing but combining marks has no base character of its own, so leave the state from the previous run intact.
+        if (lastBaseCharacter)
+            spacingState.lastCharacterClassFromPreviousRun = TextSpacing::characterClass(lastBaseCharacter);
     } else
         spacingState.lastCharacterClassFromPreviousRun = TextSpacing::CharacterClass::Undefined;
 }


### PR DESCRIPTION
#### 92d763f202230b3084562320fbca66c36c7644ae
<pre>
text-autospace: a text run containing only combining marks discards the preceding base character
<a href="https://bugs.webkit.org/show_bug.cgi?id=321388">https://bugs.webkit.org/show_bug.cgi?id=321388</a>
<a href="https://rdar.apple.com/184442972">rdar://184442972</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox.

TextUtil::lastBaseCharacterFromText() walks a run backwards and returns the first
non-combining-mark code point, or 0 when the run has no base character at all. A run made
up of nothing but combining marks is exactly that case: the marks belong to a grapheme
cluster whose base lives in an earlier run, so there is no base character to report.

Both text-autospace paths in InlineItemsBuilder stored that 0 over the base character they
were tracking. In computeInlineBoxBoundaryTextSpacings() the tracked character became 0, so
the next iteration hit the !lastCharacterFromPreviousRun early-out and never evaluated the
seam. In handleTextSpacing() the 0 was fed through TextSpacing::characterClass(), which maps
it to CharacterClass::Undefined, and Undefined never pairs with anything in
shouldApplySpacing(). Either way the real preceding character was lost and no autospace was
inserted at the following ideograph.

Only overwrite the tracked base character when lastBaseCharacterFromText() finds one, so a
marks-only run is transparent to autospace state. In the inline-box-boundary loop the
matching lastCharacterDepth update moves under the same guard, since the depth describes the
character being tracked and must not be advanced past a character that was kept. The guarded
update is hoisted into a lambda because the loop performs it at two points: the early-out
branch and after a boundary has been evaluated.

The new test uses display: contents to split a grapheme cluster into separate text runs
without generating an inline box, so the middle run consists only of combining marks and the
intra-run spacing state is exercised directly. Splitting the cluster also changes how it is
shaped, so each structure is measured against its own no-autospace twin; that isolates the
autospace contribution from the shaping difference. The ideograph boundary gains 0.125ic
after this change and gained nothing before it.

text-autospace-elements-007.html additionally requires spacing to be attachable to a seam
that follows an inline box end, which InlineBoxBoundaryTextSpacings cannot key today, so it
remains an ImageOnlyFailure.

Test: imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-only-run.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-only-run-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-only-run.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings):
(WebCore::Layout::handleTextSpacing):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92d763f202230b3084562320fbca66c36c7644ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143946 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3552c8a5-70fe-45e9-ab61-239890adbafb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181500 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140095 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96931 "27 flakes 19 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4499d04a-e671-4ba0-9e92-a8fe039e242e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120547 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e61edaaf-2821-45e7-ba05-ef80a5c29d21) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42384 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40707 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152785 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40360 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/923 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191690 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149363 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53927 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149109 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43773 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126199 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121192 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52444 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15353 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51829 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52070 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51890 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->