### PR TITLE
Background image is not repainted when only the URL fragment identifier changes

### DIFF
--- a/LayoutTests/http/tests/svg/svg-fragment-background-repaint-expected.html
+++ b/LayoutTests/http/tests/svg/svg-fragment-background-repaint-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Radio button customized using an SVG fragment is redrawn when the checked value changes</title>
+    <style>
+        input[type=radio] { appearance: none; margin: 0; display: block; }
+        input[type=radio]::before {
+            content: "";
+            display: block;
+            width: 100px;
+            height: 100px;
+            background: url(resources/rgb-icons-3.svg#green-icon) no-repeat;
+        }
+        input[type=radio]:checked::before {
+            background: url(resources/rgb-icons-3.svg#red-icon) no-repeat;
+        }
+    </style>
+</head>
+<body>
+    <input type="radio" name="group" id="a">
+    <input type="radio" name="group" id="b" checked>
+</body>
+</html>

--- a/LayoutTests/http/tests/svg/svg-fragment-background-repaint.html
+++ b/LayoutTests/http/tests/svg/svg-fragment-background-repaint.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Radio button customized using an SVG fragment is redrawn when the checked value changes</title>
+    <style>
+        input[type=radio] { appearance: none; margin: 0; display: block; }
+        input[type=radio]::before {
+            content: "";
+            display: block;
+            width: 100px;
+            height: 100px;
+            background: url(resources/rgb-icons-3.svg#green-icon) no-repeat;
+        }
+        input[type=radio]:checked::before {
+            background: url(resources/rgb-icons-3.svg#red-icon) no-repeat;
+        }
+    </style>
+</head>
+<body>
+    <!-- This test has to be served over HTTP: the memory cache only strips the fragment
+         identifier from HTTP-family URLs, so that is the only case where two background
+         images differing solely by fragment share one CachedResource. -->
+    <input type="radio" name="group" id="a" checked>
+    <input type="radio" name="group" id="b">
+    <script>
+        window.addEventListener("load", () => {
+            // Checking b implicitly unchecks a, so both ::before backgrounds now resolve to
+            // a different fragment of the same SVG and both have to be redrawn.
+            document.getElementById("b").checked = true;
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/style/values/images/kinds/StyleCachedImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCachedImage.cpp
@@ -96,7 +96,8 @@ bool CachedImage::equals(const CachedImage& other) const
         return false;
     if (m_cssValue.ptr() == other.m_cssValue.ptr() || m_cssValue->equals(other.m_cssValue.get()))
         return true;
-    if (m_cachedImage && m_cachedImage == other.m_cachedImage)
+    if (m_cachedImage && m_cachedImage == other.m_cachedImage
+        && m_url.resolved.fragmentIdentifier() == other.m_url.resolved.fragmentIdentifier())
         return true;
     return false;
 }


### PR DESCRIPTION
#### 0e231f0bf3490ce61283cbac27a1fc9c48865a8d
<pre>
Background image is not repainted when only the URL fragment identifier changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=251424">https://bugs.webkit.org/show_bug.cgi?id=251424</a>
<a href="https://rdar.apple.com/105118256">rdar://105118256</a>

Reviewed by Nikolas Zimmermann.

The memory cache strips the fragment identifier from HTTP URLs, so two background
images differing only by fragment share one CachedResource. Style::CachedImage::equals()
returned true whenever the CachedResource pointers matched, ignoring the fragment.

The fragment is not cosmetic: SVGImage::drawForContainer() applies it to select the
view to draw, so those two images paint differently. Comparing them equal propagated
to changeRequiresRepaint(), which then skipped the repaint, leaving the old image on
screen until something else invalidated the element.

Only take the shared-CachedResource shortcut when the fragments also match.

The test is under http/tests/ because fragments are only stripped for HTTP-family
URLs; a file:// test cannot reproduce this.

* LayoutTests/http/tests/svg/svg-fragment-background-repaint-expected.html: Added.
* LayoutTests/http/tests/svg/svg-fragment-background-repaint.html: Added.
* Source/WebCore/style/values/images/kinds/StyleCachedImage.cpp:
(WebCore::Style::CachedImage::equals const):

Canonical link: <a href="https://commits.webkit.org/318879@main">https://commits.webkit.org/318879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ffe8eb98d9c58034ba539a439947b285009898e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144068 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e982de8a-a299-4ecf-959e-abddaf717e91) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140213 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b3c4b2e-72fe-494c-b6bf-d2e7fc29e166) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120664 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6be38ab-8d10-457f-80c1-bc887f3f75b7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40466 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1043 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191811 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160464 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149491 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40047 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54047 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149225 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43878 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126319 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121342 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52564 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15456 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51949 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52010 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->