### PR TITLE
Cherry-pick 318630@main (4bfeff8c67ad). https://bugs.webkit.org/show_bug.cgi?id=321081

### DIFF
--- a/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt
@@ -1,0 +1,18 @@
+Tests that navigation.navigate() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. This is the navigate() counterpart of navigation-reload-state-clone-exception-crash.html: navigate() and reload() share the same Navigation::createErrorResult(), which used to call DeferredPromise::reject() twice with the same ExceptionCode::ExistingExceptionError exception, and only the first call could recover the pending JS exception.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof result is 'object'
+PASS 'committed' in result is true
+PASS 'finished' in result is true
+PASS result.committed instanceof Promise is true
+PASS result.finished instanceof Promise is true
+PASS committedError.message is "state clone error"
+PASS finishedError.message is "state clone error"
+PASS committedError === finishedError is true
+PASS did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html
+++ b/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.navigate() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. This is the navigate() counterpart of navigation-reload-state-clone-exception-crash.html: navigate() and reload() share the same Navigation::createErrorResult(), which used to call DeferredPromise::reject() twice with the same ExceptionCode::ExistingExceptionError exception, and only the first call could recover the pending JS exception.");
+
+jsTestIsAsync = true;
+
+var result;
+var committedError;
+var finishedError;
+
+window.onload = async () => {
+    result = navigation.navigate("about:blank#navigated", { state: { get x() { throw new Error("state clone error"); } } });
+
+    shouldBe("typeof result", "'object'");
+    shouldBeTrue("'committed' in result");
+    shouldBeTrue("'finished' in result");
+    shouldBeTrue("result.committed instanceof Promise");
+    shouldBeTrue("result.finished instanceof Promise");
+
+    try {
+        await result.committed;
+        testFailed("committed promise should be rejected");
+    } catch (e) {
+        committedError = e;
+    }
+    shouldBeEqualToString("committedError.message", "state clone error");
+
+    try {
+        await result.finished;
+        testFailed("finished promise should be rejected");
+    } catch (e) {
+        finishedError = e;
+    }
+    shouldBeEqualToString("finishedError.message", "state clone error");
+
+    shouldBeTrue("committedError === finishedError");
+
+    testPassed("did not crash");
+    finishJSTest();
+};
+</script>

--- a/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt
@@ -1,0 +1,18 @@
+Tests that navigation.reload() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. Found by a fuzzer: a throwing getter on the state object made Navigation::serializeState() fail with ExceptionCode::ExistingExceptionError, and DeferredPromise::reject() was only able to recover the pending JS exception once, so the second of the two reject() calls in Navigation::createErrorResult() hit an assertion.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof result is 'object'
+PASS 'committed' in result is true
+PASS 'finished' in result is true
+PASS result.committed instanceof Promise is true
+PASS result.finished instanceof Promise is true
+PASS committedError.message is "state clone error"
+PASS finishedError.message is "state clone error"
+PASS committedError === finishedError is true
+PASS did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html
+++ b/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.reload() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. Found by a fuzzer: a throwing getter on the state object made Navigation::serializeState() fail with ExceptionCode::ExistingExceptionError, and DeferredPromise::reject() was only able to recover the pending JS exception once, so the second of the two reject() calls in Navigation::createErrorResult() hit an assertion.");
+
+jsTestIsAsync = true;
+
+var result;
+var committedError;
+var finishedError;
+
+window.onload = async () => {
+    result = navigation.reload({ state: { get x() { throw new Error("state clone error"); } } });
+
+    shouldBe("typeof result", "'object'");
+    shouldBeTrue("'committed' in result");
+    shouldBeTrue("'finished' in result");
+    shouldBeTrue("result.committed instanceof Promise");
+    shouldBeTrue("result.finished instanceof Promise");
+
+    try {
+        await result.committed;
+        testFailed("committed promise should be rejected");
+    } catch (e) {
+        committedError = e;
+    }
+    shouldBeEqualToString("committedError.message", "state clone error");
+
+    try {
+        await result.finished;
+        testFailed("finished promise should be rejected");
+    } catch (e) {
+        finishedError = e;
+    }
+    shouldBeEqualToString("finishedError.message", "state clone error");
+
+    shouldBeTrue("committedError === finishedError");
+
+    testPassed("did not crash");
+    finishJSTest();
+};
+</script>

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -16,7 +16,6 @@ accessibility/AXObjectCache.cpp
 accessibility/AccessibilityListBoxOption.cpp
 accessibility/AccessibilityMathMLElement.cpp
 accessibility/AccessibilityMenuListOption.cpp
-accessibility/AccessibilityMenuListPopup.cpp
 accessibility/AccessibilityNodeObject.cpp
 accessibility/AccessibilityObject.cpp
 accessibility/AccessibilityObjectInlines.h

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -77,7 +77,11 @@ AccessibilityMenuListOption* AccessibilityMenuListPopup::menuListOptionAccessibi
     if (!element || !element->inRenderedDocument())
         return nullptr;
 
-    return dynamicDowncast<AccessibilityMenuListOption>(protect(document())->axObjectCache()->getOrCreate(*element));
+    CheckedPtr cache = protect(document())->axObjectCache();
+    if (!cache)
+        return nullptr;
+
+    return dynamicDowncast<AccessibilityMenuListOption>(cache->getOrCreate(*element));
 }
 
 bool AccessibilityMenuListPopup::press()

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -192,13 +192,15 @@ void DeferredPromise::reject(Exception exception, RejectAsHandled rejectAsHandle
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     if (exception.code() == ExceptionCode::ExistingExceptionError) {
-        EXCEPTION_ASSERT(scope.exception());
-        auto error = scope.exception()->value();
-        bool isTerminating = handleTerminationExceptionIfNeeded(scope, lexicalGlobalObject);
-        if (!isTerminating) {
+        if (exceptionObject.isEmpty()) {
+            EXCEPTION_ASSERT(scope.exception());
+            auto error = scope.exception()->value();
+            if (handleTerminationExceptionIfNeeded(scope, lexicalGlobalObject))
+                return;
             scope.clearException();
-            reject<IDLAny>(error, rejectAsHandled);
+            exceptionObject = error;
         }
+        reject<IDLAny>(exceptionObject, rejectAsHandled);
         return;
     }
 

--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -94,6 +94,19 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
 
     string(TOLOWER ${PORT} WEBKIT_PORT_DIR)
 
+    # -----------------------------------------------------------------------------
+    # Check the CMake generator.
+    # -----------------------------------------------------------------------------
+    # The GTK and WPE ports only support the Ninja generator.
+    # Ninja has its own dependency graph, used for dependencies between targets
+    if (PORT STREQUAL "GTK" OR PORT STREQUAL "WPE")
+        if (NOT CMAKE_GENERATOR MATCHES "Ninja")
+            message(FATAL_ERROR "The ${PORT} port requires the Ninja generator, but this build "
+                "directory was configured with the \"${CMAKE_GENERATOR}\" generator.\n"
+                "Re-run CMake with -GNinja or export CMAKE_GENERATOR=Ninja\n")
+        endif ()
+    endif ()
+
     set(_stamp_content "")
     foreach (_var IN LISTS WEBKIT_IDENTITY_VARS)
         if (DEFINED CACHE{${_var}})

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -551,7 +551,7 @@ macro(_WEBKIT_TARGET_LINK_FRAMEWORK _target)
         get_property(_linked_into GLOBAL PROPERTY ${framework}_LINKED_INTO)
 
         # See if the target is linking a framework that the specified framework is already linked into
-        if ((NOT _linked_into) OR (${framework} STREQUAL ${_linked_into}) OR (NOT ${_linked_into} IN_LIST ${_target}_FRAMEWORKS))
+        if ((NOT _linked_into) OR (framework STREQUAL _linked_into) OR (NOT _linked_into IN_LIST ${_target}_FRAMEWORKS))
             list(APPEND ${_target}_PRIVATE_LIBRARIES WebKit::${framework})
 
             # The WebKit:: alias targets do not propagate OBJECT libraries so the

--- a/Tools/Scripts/make-dist
+++ b/Tools/Scripts/make-dist
@@ -244,18 +244,19 @@ class Distcheck(object):
         create_dir(build_dir, "build")
         create_dir(install_dir, "install")
 
-        command = ['cmake', '-DPORT=%s' % port, '-DCMAKE_INSTALL_PREFIX=%s' % install_dir, '-DCMAKE_BUILD_TYPE=Release', dist_dir]
+        command = ['cmake', '-GNinja', '-DPORT=%s' % port, '-DCMAKE_INSTALL_PREFIX=%s' % install_dir, '-DCMAKE_BUILD_TYPE=Release', dist_dir]
         if not build_unified:
             command.append('-DENABLE_UNIFIED_BUILDS=OFF')
         subprocess.check_call(command, cwd=build_dir)
 
     def build(self, build_dir):
-        command = ['make']
+        command = ['cmake', '--build', '.']
         make_args = os.getenv('MAKE_ARGS')
         if make_args:
+            command.append('--')
             command.extend(make_args.split(' '))
         else:
-            command.append('-j%d' % multiprocessing.cpu_count())
+            command.extend(['-j', '%d' % multiprocessing.cpu_count()])
         subprocess.check_call(command, cwd=build_dir)
 
     def check_symbols(self, build_dir):
@@ -269,7 +270,7 @@ class Distcheck(object):
         subprocess.check_call([check_version_script, version_script, libwk])
 
     def install(self, build_dir):
-        subprocess.check_call(['make', 'install'], cwd=build_dir)
+        subprocess.check_call(['cmake', '--install', '.'], cwd=build_dir)
 
     def clean(self, dist_dir):
         shutil.rmtree(dist_dir)


### PR DESCRIPTION
#### 552a4d6d6d1c9e5b36b2474c30d6cb4e25ffcbff
<pre>
Cherry-pick 318630@main (4bfeff8c67ad). <a href="https://bugs.webkit.org/show_bug.cgi?id=321081">https://bugs.webkit.org/show_bug.cgi?id=321081</a>

    [CMake 4.4][WPE] _WEBKIT_TARGET_LINK_FRAMEWORK reports &quot;Unknown arguments specified&quot; error
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321081">https://bugs.webkit.org/show_bug.cgi?id=321081</a>

    Reviewed by Adrian Perez de Castro.

    CMake 4.4 reports the following error for WPE.

    &gt; -- Using platform-specific CMakeLists: /run/build/webkitwpe/Source/JavaScriptCore/shell/PlatformWPE.cmake
    &gt; CMake Error at Source/cmake/WebKitMacros.cmake:554 (if):
    &gt;   if given arguments:
    &gt;
    &gt;     &quot;(&quot; &quot;NOT&quot; &quot;_linked_into&quot; &quot;)&quot; &quot;OR&quot; &quot;(&quot; &quot;JavaScriptCore&quot; &quot;STREQUAL&quot; &quot;)&quot; &quot;OR&quot; &quot;(&quot; &quot;NOT&quot; &quot;IN_LIST&quot; &quot;jsc_FRAMEWORKS&quot; &quot;)&quot;
    &gt;
    &gt;   Unknown arguments specified
    &gt; Call Stack (most recent call first):
    &gt;   Source/cmake/WebKitMacros.cmake:756 (_WEBKIT_TARGET_LINK_FRAMEWORK)
    &gt;   Source/JavaScriptCore/shell/CMakeLists.txt:126 (WEBKIT_EXECUTABLE)

    Replaced `${_linked_into}` with `_linked_into`.

    * Source/cmake/WebKitMacros.cmake(_WEBKIT_TARGET_LINK_FRAMEWORK):

    Canonical link: <a href="https://commits.webkit.org/318630@main">https://commits.webkit.org/318630@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.77@webkitglib/2.54">https://commits.webkit.org/317695.77@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 206d9afe94771a46e91eaeacf8ce44d14ff8cd14
<pre>
Cherry-pick 318773@main (aa6c61fcb002). <a href="https://bugs.webkit.org/show_bug.cgi?id=321266">https://bugs.webkit.org/show_bug.cgi?id=321266</a>

Unreviewed backport.

    [GTK][WPE][CMake] Do not allow to build with make, require ninja instead.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321266">https://bugs.webkit.org/show_bug.cgi?id=321266</a>

    Reviewed by Carlos Garcia Campos.

    Currently for building GTK or WPE there are two ways: use the build-webkit script
    or use CMake directly. The build-webkit script is only intended for webkit
    developers, for production releases or users of webkit the idea is to use cmake
    directly.

    The problem is that we have a split on how WebKit is built. With build-webkit
    ninja is used by default, but when using cmake directly it uses whatever cmake
    generator has as default (make usually) and that is causing issues because of
    build errors due to dependencies between targets, ninja has its own dependency
    graph, but plain makefiles don&apos;t.

    And this causes issues when someone tries to use make because no one usually
    tests the make build.

    This patch makes ninja mandatory for GTK and WPE ports and also changes the
    make-dist script to use it.

    * Source/cmake/WebKitCommon.cmake:
    * Tools/Scripts/make-dist:
    (Distcheck.configure):
    (Distcheck.build):
    (Distcheck.install):

    Canonical link: <a href="https://commits.webkit.org/318773@main">https://commits.webkit.org/318773@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.76@webkitglib/2.54">https://commits.webkit.org/317695.76@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### abd16f7c6829960df159123fedd823eabacd4594
<pre>
Cherry-pick 318692@main (e04f9dd61dc4). <a href="https://bugs.webkit.org/show_bug.cgi?id=321077">https://bugs.webkit.org/show_bug.cgi?id=321077</a>

    Crash in AccessibilityMenuListPopup::menuListOptionAccessibilityObject
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321077">https://bugs.webkit.org/show_bug.cgi?id=321077</a>

    Reviewed by Tyler Wilcock.

    Null check AXCache we get from document and return early if it&apos;s nullptr.

    * Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
    (WebCore::AccessibilityMenuListPopup::menuListOptionAccessibilityObject const):
    * Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:

    Canonical link: <a href="https://commits.webkit.org/318692@main">https://commits.webkit.org/318692@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.75@webkitglib/2.54">https://commits.webkit.org/317695.75@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 6dd10a05129d283ee3ec5e79bcf19d3830c3852e
<pre>
Cherry-pick 318836@main (37cfccb3c6c9). <a href="https://bugs.webkit.org/show_bug.cgi?id=321250">https://bugs.webkit.org/show_bug.cgi?id=321250</a>

    Fix crash from double-consuming the pending exception in DeferredPromise::reject() during Navigation reload()/navigate() error handling
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321250">https://bugs.webkit.org/show_bug.cgi?id=321250</a>
    <a href="https://rdar.apple.com/183911429">rdar://183911429</a>

    Reviewed by Rupin Mittal.

    Navigation::createErrorResult() rejects both the committed and finished promises with the same Exception. When that exception carries ExceptionCode::ExistingExceptionError — the
    sentinel meaning &quot;the real JS exception is already sitting on the VM&apos;s exception scope&quot; — DeferredPromise::reject() pulled the value straight off scope.exception() and called
    scope.clearException() as a side effect. That works for the first reject() call, but clears the exception before the second call runs, so it finds nothing there: an assert in
    debug/ASan builds, a null-pointer read of Exception::m_value in release builds — either way, a crash on every reload()/navigate() whose state argument throws during
    structured-clone.

    The fix reuses the exceptionObject out-parameter that&apos;s already threaded through both reject() calls (the same parameter the plain-ExceptionCode branch a few lines below already
    uses to build the DOMException once and share it across calls). On the first call, if exceptionObject is still empty, it extracts the value from the exception scope, clears it, and
    caches the result in exceptionObject; on the second call, exceptionObject is already populated, so it skips touching the exception scope entirely and just rejects with the cached
    value. This matches the pattern already used elsewhere in Navigation.cpp (rejectFinishedPromise, which precomputes a DOMException once and passes it to both promise rejections),
    and it satisfies the spec requirement that committed and finished reject with the identical error value — which a &quot;swallow and fall back to a generic error&quot; fix would not have.

    Tests: navigation-api/navigation-navigate-state-clone-exception-crash.html
           navigation-api/navigation-reload-state-clone-exception-crash.html

    * LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt: Added.
    * LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html: Added.
    * LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt: Added.
    * LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html: Added.
    * Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
    (WebCore::DeferredPromise::reject):

    Canonical link: <a href="https://commits.webkit.org/318836@main">https://commits.webkit.org/318836@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.74@webkitglib/2.54">https://commits.webkit.org/317695.74@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/792d2416d93020a8f41777849e205fe3d8f2cd14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179651 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53590 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47388 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189483 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143960 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181514 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54884 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53301 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140130 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143960 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182608 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54884 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47388 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120564 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54884 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53301 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2533 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47388 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54884 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47388 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/937 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/40926 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46196 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53301 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191704 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53260 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47388 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149378 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53941 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47388 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149123 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27285 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53941 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126213 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121211 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52458 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47388 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51843 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52084 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51904 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->