### PR TITLE
Cherry-picks - webkitglib/2.52

### DIFF
--- a/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt
@@ -1,0 +1,18 @@
+Tests that navigation.navigate() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. This is the navigate() counterpart of navigation-reload-state-clone-exception-crash.html: navigate() and reload() share the same Navigation::createErrorResult(), which used to call DeferredPromise::reject() twice with the same ExceptionCode::ExistingExceptionError exception, and only the first call could recover the pending JS exception.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof result is 'object'
+PASS 'committed' in result is true
+PASS 'finished' in result is true
+PASS result.committed instanceof Promise is true
+PASS result.finished instanceof Promise is true
+PASS committedError.message is "state clone error"
+PASS finishedError.message is "state clone error"
+PASS committedError === finishedError is true
+PASS did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html
+++ b/LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.navigate() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. This is the navigate() counterpart of navigation-reload-state-clone-exception-crash.html: navigate() and reload() share the same Navigation::createErrorResult(), which used to call DeferredPromise::reject() twice with the same ExceptionCode::ExistingExceptionError exception, and only the first call could recover the pending JS exception.");
+
+jsTestIsAsync = true;
+
+var result;
+var committedError;
+var finishedError;
+
+window.onload = async () => {
+    result = navigation.navigate("about:blank#navigated", { state: { get x() { throw new Error("state clone error"); } } });
+
+    shouldBe("typeof result", "'object'");
+    shouldBeTrue("'committed' in result");
+    shouldBeTrue("'finished' in result");
+    shouldBeTrue("result.committed instanceof Promise");
+    shouldBeTrue("result.finished instanceof Promise");
+
+    try {
+        await result.committed;
+        testFailed("committed promise should be rejected");
+    } catch (e) {
+        committedError = e;
+    }
+    shouldBeEqualToString("committedError.message", "state clone error");
+
+    try {
+        await result.finished;
+        testFailed("finished promise should be rejected");
+    } catch (e) {
+        finishedError = e;
+    }
+    shouldBeEqualToString("finishedError.message", "state clone error");
+
+    shouldBeTrue("committedError === finishedError");
+
+    testPassed("did not crash");
+    finishJSTest();
+};
+</script>

--- a/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt
@@ -1,0 +1,18 @@
+Tests that navigation.reload() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. Found by a fuzzer: a throwing getter on the state object made Navigation::serializeState() fail with ExceptionCode::ExistingExceptionError, and DeferredPromise::reject() was only able to recover the pending JS exception once, so the second of the two reject() calls in Navigation::createErrorResult() hit an assertion.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof result is 'object'
+PASS 'committed' in result is true
+PASS 'finished' in result is true
+PASS result.committed instanceof Promise is true
+PASS result.finished instanceof Promise is true
+PASS committedError.message is "state clone error"
+PASS finishedError.message is "state clone error"
+PASS committedError === finishedError is true
+PASS did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html
+++ b/LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.reload() does not crash when structured-cloning the state option throws, and that the committed and finished promises reject with the same error. Found by a fuzzer: a throwing getter on the state object made Navigation::serializeState() fail with ExceptionCode::ExistingExceptionError, and DeferredPromise::reject() was only able to recover the pending JS exception once, so the second of the two reject() calls in Navigation::createErrorResult() hit an assertion.");
+
+jsTestIsAsync = true;
+
+var result;
+var committedError;
+var finishedError;
+
+window.onload = async () => {
+    result = navigation.reload({ state: { get x() { throw new Error("state clone error"); } } });
+
+    shouldBe("typeof result", "'object'");
+    shouldBeTrue("'committed' in result");
+    shouldBeTrue("'finished' in result");
+    shouldBeTrue("result.committed instanceof Promise");
+    shouldBeTrue("result.finished instanceof Promise");
+
+    try {
+        await result.committed;
+        testFailed("committed promise should be rejected");
+    } catch (e) {
+        committedError = e;
+    }
+    shouldBeEqualToString("committedError.message", "state clone error");
+
+    try {
+        await result.finished;
+        testFailed("finished promise should be rejected");
+    } catch (e) {
+        finishedError = e;
+    }
+    shouldBeEqualToString("finishedError.message", "state clone error");
+
+    shouldBeTrue("committedError === finishedError");
+
+    testPassed("did not crash");
+    finishJSTest();
+};
+</script>

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -19,7 +19,6 @@ accessibility/AccessibilityListBoxOption.cpp
 accessibility/AccessibilityMathMLElement.cpp
 accessibility/AccessibilityMenuList.cpp
 accessibility/AccessibilityMenuListOption.cpp
-accessibility/AccessibilityMenuListPopup.cpp
 accessibility/AccessibilityNodeObject.cpp
 accessibility/AccessibilityObject.cpp
 accessibility/AccessibilityObjectInlines.h

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -77,7 +77,11 @@ AccessibilityMenuListOption* AccessibilityMenuListPopup::menuListOptionAccessibi
     if (!element || !element->inRenderedDocument())
         return nullptr;
 
-    return dynamicDowncast<AccessibilityMenuListOption>(document()->axObjectCache()->getOrCreate(*element));
+    CheckedPtr cache = document()->axObjectCache();
+    if (!cache)
+        return nullptr;
+
+    return dynamicDowncast<AccessibilityMenuListOption>(cache->getOrCreate(*element));
 }
 
 bool AccessibilityMenuListPopup::press()

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -179,13 +179,15 @@ void DeferredPromise::reject(Exception exception, RejectAsHandled rejectAsHandle
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
     if (exception.code() == ExceptionCode::ExistingExceptionError) {
-        EXCEPTION_ASSERT(scope.exception());
-        auto error = scope.exception()->value();
-        bool isTerminating = handleTerminationExceptionIfNeeded(scope, lexicalGlobalObject);
-        if (!isTerminating) {
+        if (exceptionObject.isEmpty()) {
+            EXCEPTION_ASSERT(scope.exception());
+            auto error = scope.exception()->value();
+            if (handleTerminationExceptionIfNeeded(scope, lexicalGlobalObject))
+                return;
             scope.clearException();
-            reject<IDLAny>(error, rejectAsHandled);
+            exceptionObject = error;
         }
+        reject<IDLAny>(exceptionObject, rejectAsHandled);
         return;
     }
 


### PR DESCRIPTION
#### d0a1928c820447872d520fb7d2d759668d1fcd6f
<pre>
Cherry-pick <a href="https://commits.webkit.org/318692@main">318692@main</a> (e04f9dd61dc4). <a href="https://bugs.webkit.org/show_bug.cgi?id=321077">https://bugs.webkit.org/show_bug.cgi?id=321077</a>

Unreviewed backport.

    Crash in AccessibilityMenuListPopup::menuListOptionAccessibilityObject
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321077">https://bugs.webkit.org/show_bug.cgi?id=321077</a>

    Reviewed by Tyler Wilcock.

    Null check AXCache we get from document and return early if it&apos;s nullptr.

    * Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
    (WebCore::AccessibilityMenuListPopup::menuListOptionAccessibilityObject const):
    * Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:

    Canonical link: <a href="https://commits.webkit.org/318692@main">https://commits.webkit.org/318692@main</a>
</pre>
----------------------------------------------------------------------
#### e6c098f195548dbb08516801f25607054a6d17ee
<pre>
Cherry-pick <a href="https://commits.webkit.org/318836@main">318836@main</a> (37cfccb3c6c9). <a href="https://bugs.webkit.org/show_bug.cgi?id=321250">https://bugs.webkit.org/show_bug.cgi?id=321250</a>

    Fix crash from double-consuming the pending exception in DeferredPromise::reject() during Navigation reload()/navigate() error handling
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321250">https://bugs.webkit.org/show_bug.cgi?id=321250</a>
    <a href="https://rdar.apple.com/183911429">rdar://183911429</a>

    Reviewed by Rupin Mittal.

    Navigation::createErrorResult() rejects both the committed and finished promises with the same Exception. When that exception carries ExceptionCode::ExistingExceptionError — the
    sentinel meaning &quot;the real JS exception is already sitting on the VM&apos;s exception scope&quot; — DeferredPromise::reject() pulled the value straight off scope.exception() and called
    scope.clearException() as a side effect. That works for the first reject() call, but clears the exception before the second call runs, so it finds nothing there: an assert in
    debug/ASan builds, a null-pointer read of Exception::m_value in release builds — either way, a crash on every reload()/navigate() whose state argument throws during
    structured-clone.

    The fix reuses the exceptionObject out-parameter that&apos;s already threaded through both reject() calls (the same parameter the plain-ExceptionCode branch a few lines below already
    uses to build the DOMException once and share it across calls). On the first call, if exceptionObject is still empty, it extracts the value from the exception scope, clears it, and
    caches the result in exceptionObject; on the second call, exceptionObject is already populated, so it skips touching the exception scope entirely and just rejects with the cached
    value. This matches the pattern already used elsewhere in Navigation.cpp (rejectFinishedPromise, which precomputes a DOMException once and passes it to both promise rejections),
    and it satisfies the spec requirement that committed and finished reject with the identical error value — which a &quot;swallow and fall back to a generic error&quot; fix would not have.

    Tests: navigation-api/navigation-navigate-state-clone-exception-crash.html
           navigation-api/navigation-reload-state-clone-exception-crash.html

    * LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash-expected.txt: Added.
    * LayoutTests/navigation-api/navigation-navigate-state-clone-exception-crash.html: Added.
    * LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash-expected.txt: Added.
    * LayoutTests/navigation-api/navigation-reload-state-clone-exception-crash.html: Added.
    * Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
    (WebCore::DeferredPromise::reject):

    Canonical link: <a href="https://commits.webkit.org/318836@main">https://commits.webkit.org/318836@main</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0a1928c820447872d520fb7d2d759668d1fcd6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179652 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53591 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47389 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189484 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143961 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181515 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54885 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53302 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140113 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143961 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182609 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54885 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47389 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120565 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54885 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53302 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47389 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54885 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47389 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/938 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46197 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53302 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191705 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53261 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47389 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149379 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53942 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47389 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149124 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53942 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126214 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121212 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52459 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47389 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51844 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52085 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51905 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->