### PR TITLE
[WebDriver][BiDi] Use OS-provided free port instead of guessing based on the http port

### DIFF
--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -190,12 +190,17 @@ int WebDriverService::run(int argc, char** argv)
     }
 
 #if ENABLE(WEBDRIVER_BIDI)
-    auto bidiPort = parseInteger<uint16_t>(bidiPortString);
-    if (!bidiPort) {
-        const int16_t bidiPortIncrement = *port == std::numeric_limits<uint16_t>::max() ? -1 : 1;
-        bidiPort = { *port + bidiPortIncrement };
-        RELEASE_LOG_INFO(WebDriverBiDi, "Invalid WebSocket BiDi port %s provided. Defaulting to %d.", bidiPortString.utf8().data(), *bidiPort);
-        fprintf(stderr, "Invalid WebSocket BiDi port %s provided. Defaulting to %d.\n", bidiPortString.utf8().data(), *bidiPort);
+    std::optional<uint16_t> bidiPort;
+    if (!bidiPortString.isNull()) {
+        bidiPort = parseInteger<uint16_t>(bidiPortString);
+        if (!bidiPort) {
+            RELEASE_LOG_ERROR(WebDriverBiDi, "Invalid WebSocket BiDi port %s explicitly provided. Aborting.", bidiPortString.utf8().data());
+            SAFE_FPRINTF(stderr, "Invalid WebSocket BiDi port %s explicitly provided. Aborting.\n", bidiPortString.utf8());
+            return EXIT_FAILURE;
+        }
+    } else {
+        RELEASE_LOG_INFO(WebDriverBiDi, "No explicit WebSocket BiDi port requested. Defaulting to an OS-provided one.");
+        bidiPort = 0;
     }
 #endif
 
@@ -219,20 +224,21 @@ int WebDriverService::run(int argc, char** argv)
         RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d target=%s:%d", programNameStr.data(), hostStr.data(), *port, m_targetAddress.utf8().data(), m_targetPort);
 #endif
 
-#if ENABLE(WEBDRIVER_BIDI)
-    if (!m_bidiServer->listen(host ? *host : nullString(), *bidiPort)) {
-        RELEASE_LOG_ERROR(WebDriverBiDi, "Unable to listen for WebSocket BiDi server at host %s and port %d", hostStr.data(), *bidiPort);
-        fprintf(stderr, "FATAL: Unable to listen for WebSocket BiDi server at host %s and port %d.\n", hostStr.data(), *bidiPort);
-        return EXIT_FAILURE;
-    }
-    RELEASE_LOG_INFO(WebDriverBiDi, "Started WebSocket BiDi server with host %s and port %d", hostStr.data(), *bidiPort);
-#endif // ENABLE(WEBDRIVER_BIDI)
     if (!m_server.listen(host, *port)) {
         RELEASE_LOG_ERROR(WebDriverClassic, "Unable to listen for HTTP server at host %s and port %d", hostStr.data(), *port);
         fprintf(stderr, "FATAL: Unable to listen for HTTP server at host %s and port %d.\n", hostStr.data(), *port);
         return EXIT_FAILURE;
     }
     RELEASE_LOG_INFO(WebDriverClassic, "Started HTTP server with host %s and port %d", hostStr.data(), *port);
+#if ENABLE(WEBDRIVER_BIDI)
+    auto bidiServerURL = m_bidiServer->listen(host ? *host : nullString(), *bidiPort);
+    if (!bidiServerURL) {
+        RELEASE_LOG_ERROR(WebDriverBiDi, "Unable to listen for WebSocket BiDi server at host %s and port %d", hostStr.data(), *bidiPort);
+        fprintf(stderr, "FATAL: Unable to listen for WebSocket BiDi server at host %s and port %d.\n", hostStr.data(), *bidiPort);
+        return EXIT_FAILURE;
+    }
+    RELEASE_LOG_INFO(WebDriverBiDi, "Started WebSocket BiDi server at %s", bidiServerURL->utf8().data());
+#endif // ENABLE(WEBDRIVER_BIDI)
 
     RunLoop::run();
 

--- a/Source/WebDriver/soup/WebSocketServerSoup.cpp
+++ b/Source/WebDriver/soup/WebSocketServerSoup.cpp
@@ -144,6 +144,21 @@ std::optional<String> WebSocketServer::listen(const String& host, unsigned port)
         return std::nullopt;
     }
 
+    unsigned boundPort = port;
+    if (!boundPort) {
+        if (GSList* uris = soup_server_get_uris(m_soupServer.get())) {
+            int effectivePort = g_uri_get_port(static_cast<GUri*>(uris->data));
+            if (effectivePort > 0)
+                boundPort = effectivePort;
+            g_slist_free_full(uris, reinterpret_cast<GDestroyNotify>(g_uri_unref));
+        }
+        ASSERT_WITH_MESSAGE(boundPort, "Failed to find actual WebSocket listening port");
+        if (!boundPort) {
+            soup_server_disconnect(m_soupServer.get());
+            return std::nullopt;
+        }
+    }
+
     // Callback for handling incoming WebSocket handshake requests
     soup_server_add_handler(m_soupServer.get(), nullptr, handleIncomingHandshake, this, nullptr);
 
@@ -153,7 +168,7 @@ std::optional<String> WebSocketServer::listen(const String& host, unsigned port)
     // "/session" is the default resource to start bidi-only sessions
     m_listener = WebSocketListener::create(
         host.isNull() ? "localhost"_s : host,
-        port,
+        boundPort,
         false,
         { "/session"_s }
     );


### PR DESCRIPTION
#### 717e0fa523368649b0d4e8acc984897c248d057d
<pre>
[WebDriver][BiDi] Use OS-provided free port instead of guessing based on the http port
<a href="https://bugs.webkit.org/show_bug.cgi?id=321314">https://bugs.webkit.org/show_bug.cgi?id=321314</a>

Reviewed by Carlos Alberto Lopez Perez.

Currently, the WebDriver service chooses the WebDriverBiDi WebSockets
port based on the HTTP server port if the latter is not explicitly
defined by the user.

While this works fine in low churn scenarios, this does not guarantee
that the server will pick a free port, potentially leading to fatal
startup errors and test failures.

This commit makes the WebDriverBiDi server let the OS provide a free
port if the user does not provide one, reporting that port back through
the `webSocketURL` capability. Also, to ensure the os-provided port does
not clash with the explicit port requested for the HTTP server, the
WebSocket server is now started after it.

For bidi-only connections (not yet supported, though), the user can just
provide the port explicitly.

* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::run):
* Source/WebDriver/soup/WebSocketServerSoup.cpp:
(WebDriver::WebSocketServer::listen):

Canonical link: <a href="https://commits.webkit.org/318931@main">https://commits.webkit.org/318931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86c25f656c0edf1c7ea715854d9880f432224063

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179886 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47628 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53548 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161050 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40576 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1254 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192028 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53498 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54185 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149337 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27315 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43989 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121500 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52702 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15563 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52084 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->