### PR TITLE
[WebDriver][Tools] Ensure selenium tests print the driver and browser output

### DIFF
--- a/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
@@ -192,7 +192,7 @@ def collect(directory, args, ignore_param=None):
     return collect_recorder.tests
 
 
-def run(path, args, timeout, env, expectations, ignore_param=None):
+def run(path, args, timeout, env, expectations, ignore_param=None, extra_plugins=None):
     harness_recorder = HarnessResultRecorder()
     subtests_recorder = SubtestResultRecorder()
     expectations_marker = TestExpectationsMarker(expectations, timeout, ignore_param)
@@ -210,7 +210,7 @@ def run(path, args, timeout, env, expectations, ignore_param=None):
                    '-p', 'no:cacheprovider']
             cmd.extend(args)
             cmd.append(path)
-            result = pytest.main(cmd, plugins=[harness_recorder, subtests_recorder, expectations_marker])
+            result = pytest.main(cmd, plugins=[harness_recorder, subtests_recorder, expectations_marker, *(extra_plugins or [])])
 
             if result == ExitCode.INTERNAL_ERROR:
                 harness_recorder.outcome = ('ERROR', None)

--- a/Tools/Scripts/webkitpy/webdriver_tests/webdriver_selenium_executor.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/webdriver_selenium_executor.py
@@ -21,6 +21,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
+import subprocess
 
 pytest_runner = None
 
@@ -31,6 +32,27 @@ def do_delayed_imports():
 
 
 _log = logging.getLogger(__name__)
+
+
+class _BrowserOutputPlugin(object):
+    """Route the selenium-launched driver's stdout/stderr to the console"""
+
+    def pytest_configure(self, config):
+        # Deferred so we import the exact same selenium as the the tests
+        from selenium.webdriver.common import service
+
+        if getattr(service.Service, '_webkit_inherits_stdio', False):
+            return
+
+        original_init = service.Service.__init__
+
+        def init_inheriting_stdio(self, *args, **kwargs):
+            if kwargs.get('log_output') is None:
+                kwargs['log_output'] = subprocess.STDOUT
+            original_init(self, *args, **kwargs)
+
+        service.Service.__init__ = init_inheriting_stdio
+        service.Service._webkit_inherits_stdio = True
 
 
 class WebDriverSeleniumExecutor(object):
@@ -62,6 +84,10 @@ class WebDriverSeleniumExecutor(object):
         if browser_args:
             self._args.extend(['--browser-args=%s' % ' '.join(browser_args)])
 
+        self._extra_plugins = []
+        if self._port.get_option('verbose'):
+            self._extra_plugins.append(_BrowserOutputPlugin())
+
         if pytest_runner is None:
             do_delayed_imports()
 
@@ -69,4 +95,4 @@ class WebDriverSeleniumExecutor(object):
         return pytest_runner.collect(directory, self._args, self._driver_name)
 
     def run(self, test, timeout, expectations):
-        return pytest_runner.run(test, self._args, timeout, self._env, expectations, self._driver_name)
+        return pytest_runner.run(test, self._args, timeout, self._env, expectations, self._driver_name, extra_plugins=self._extra_plugins)


### PR DESCRIPTION
#### 01e439d2c3498c1cf84d6f62ba07d7c847c3670b
<pre>
[WebDriver][Tools] Ensure selenium tests print the driver and browser output
<a href="https://bugs.webkit.org/show_bug.cgi?id=321320">https://bugs.webkit.org/show_bug.cgi?id=321320</a>

Reviewed by Carlos Alberto Lopez Perez.

Imported Selenium tests conftest.py does not provide a verbose option,
effectively hiding the browser and driver output. This makes it harder
to identify issues that would be otherwise reported by this hidden
output. While the service class provides the `log_output` parameter, its
creation for the tests is handled within the imported code, in
comparison to other scripts like run-mvt-tests.

This commit adds a pytest plugin that, when --verbose is active,
monkeypatches Selenium&apos;s Service class (the one that wraps the driver),
ensuring the underlying driver inherits the descriptors from the harness
if it would be redirected to /dev/null by the original constructor. It
also defers importing selenium to the pytest_configure hook, when pytest
already configured the path to the vendored selenium used in the
imported tests.

* Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py:
(run):
* Tools/Scripts/webkitpy/webdriver_tests/webdriver_selenium_executor.py:
(_BrowserOutputPlugin):
(_BrowserOutputPlugin.pytest_configure):
(_BrowserOutputPlugin.pytest_configure.init_inheriting_stdio):
(WebDriverSeleniumExecutor.__init__):
(WebDriverSeleniumExecutor.run):

Canonical link: <a href="https://commits.webkit.org/318925@main">https://commits.webkit.org/318925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d54be5f1adc090554c28347cefa8983ff3185293

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53823 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53539 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182833 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/179202 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1245 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192019 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53489 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/160565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40074 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54176 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149329 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43979 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121491 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52693 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/15561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52075 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52313 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->