### PR TITLE
[Site Isolation] A destroyed hosted layer is left parented to its hosting layer

### DIFF
--- a/LayoutTests/http/tests/site-isolation/draw-after-two-cross-process-navigations-expected.html
+++ b/LayoutTests/http/tests/site-isolation/draw-after-two-cross-process-navigations-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { margin: 0; background: blue; }
+iframe { border: 0; }
+#testframe { width: 200px; height: 200px; }
+#sibling { position: absolute; top: 300px; left: 0; width: 1px; height: 1px; }
+</style>
+</head>
+<body>
+<iframe id="testframe" src="about:blank"></iframe>
+<iframe id="sibling" src="about:blank"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/draw-after-two-cross-process-navigations.html
+++ b/LayoutTests/http/tests/site-isolation/draw-after-two-cross-process-navigations.html
@@ -1,0 +1,52 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=112; totalPixels=900"/>
+<style>
+body { margin: 0; background: blue; }
+iframe { border: 0; }
+#testframe { width: 200px; height: 200px; }
+#sibling { position: absolute; top: 300px; left: 0; width: 1px; height: 1px; }
+</style>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function navigate(frame, url)
+{
+    return new Promise(resolve => {
+        frame.onload = resolve;
+        frame.src = url;
+    });
+}
+
+async function runTest()
+{
+    let testFrame = document.getElementById("testframe");
+
+    // Red, in the process #sibling keeps alive after this frame leaves it. That process reports
+    // the red layer as destroyed, which must detach it rather than leave the hosting layer
+    // retaining it.
+    await navigate(testFrame, "http://localhost:8000/site-isolation/resources/red-background.html");
+    await navigate(testFrame, "https://localhost:8443/site-isolation/resources/green-background.html");
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // Blocked, so a transparent document commits in a third process and nothing opaque is left
+    // to hide a stale layer.
+    await navigate(testFrame, "https://127.0.0.1:8443/security/XFrameOptions/resources/x-frame-options-deny.cgi");
+
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }));
+}
+
+onload = runTest;
+</script>
+</head>
+<body>
+<iframe id="testframe"></iframe>
+<iframe id="sibling" src="http://localhost:8000/site-isolation/resources/no-background.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/red-background.html
+++ b/LayoutTests/http/tests/site-isolation/resources/red-background.html
@@ -1,0 +1,1 @@
+<body style='background-color:red'/>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -293,16 +293,26 @@ void RemoteLayerTreeHost::layerWillBeRemoved(WebCore::ProcessIdentifier processI
 #if ENABLE(THREADED_ANIMATIONS)
         animationsWereRemovedFromNode(*node);
 #endif
-        if (auto hostingIdentifier = node->remoteContextHostingIdentifier())
-            m_hostingLayers.remove(*hostingIdentifier);
+        // A hosting context identifier outlives the layers on both of its sides, so its entry may
+        // already have been reassigned to a layer that is still in use. Only clear an entry that
+        // still refers to the layer going away.
+        if (auto hostingIdentifier = node->remoteContextHostingIdentifier()) {
+            if (m_hostingLayers.getOptional(*hostingIdentifier) == layerID)
+                m_hostingLayers.remove(*hostingIdentifier);
+        }
         if (auto hostedIdentifier = node->remoteContextHostedIdentifier()) {
-            if (auto layerID = m_hostedLayers.takeOptional(*hostedIdentifier)) {
-                auto it = m_hostedLayersInProcess.find(processIdentifier);
-                if (it != m_hostedLayersInProcess.end()) {
-                    it->value.remove(*layerID);
-                    if (it->value.isEmpty())
-                        m_hostedLayersInProcess.remove(it);
-                }
+            // The hosting node retains this layer, so dropping the node does not stop it being
+            // drawn.
+            node->removeFromHostingNode();
+
+            if (m_hostedLayers.getOptional(*hostedIdentifier) == layerID)
+                m_hostedLayers.remove(*hostedIdentifier);
+
+            auto it = m_hostedLayersInProcess.find(processIdentifier);
+            if (it != m_hostedLayersInProcess.end()) {
+                it->value.remove(layerID);
+                if (it->value.isEmpty())
+                    m_hostedLayersInProcess.remove(it);
             }
         }
     }
@@ -536,11 +546,8 @@ RefPtr<const RemoteAnimationStack> RemoteLayerTreeHost::animationStackForNodeWit
 
 void RemoteLayerTreeHost::remotePageProcessDidTerminate(WebCore::ProcessIdentifier processIdentifier)
 {
-    for (auto layerID : m_hostedLayersInProcess.take(processIdentifier)) {
-        if (RefPtr node = nodeForID(layerID))
-            node->removeFromHostingNode();
+    for (auto layerID : m_hostedLayersInProcess.take(processIdentifier))
         layerWillBeRemoved(processIdentifier, layerID);
-    }
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### d4b0840eea7761c9fa3184392d4c6659d60252e3
<pre>
[Site Isolation] A destroyed hosted layer is left parented to its hosting layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=321401">https://bugs.webkit.org/show_bug.cgi?id=321401</a>
<a href="https://rdar.apple.com/184468834">rdar://184468834</a>

Reviewed by Alex Christensen.

RemoteLayerTreeHost::layerWillBeRemoved took the node out of m_nodes but never detached its layer, i.e. does not invoke
removeFromHostingNode. A CALayer is retained by its superlayer, so dropping the RemoteLayerTreeNode does not stop the
layer being drawn: the hosted root layer of a frame that has moved to another process stays parented to the hosting
layer and keeps compositing.

remotePageProcessDidTerminate already called removeFromHostingNode, bit it covered this for the process-termination path
only -- if the process is not destroyed when layer is removed, then no one is removing it from layer tree. This patch
fixes that by having RemoteLayerTreeHost::layerWillBeRemoved invoke removeFromHostingNode. By doing so, the call in
remotePageProcessDidTerminate becomes redundant.

The patch also contains two drive-by fixes for issues found in RemoteLayerTreeHost::layerWillBeRemoved:
- A LayerHostingContextIdentifier is reused across a frame&apos;s cross-process navigations, so it outlives the layers keyed
by it and an entry may already have been reassigned to a layer in another process (e.g. the new layer of the frame is
added before the the old layer is removed); clearing m_hostedLayers and m_hostingLayers by identifier alone could
therefore discard a live entry. Both removals now confirm that the entry still refers to the layer going away before
removal and update.
- When removing layer from m_hostedLayersInProcess, the key layerID is read from m_hostedLayers instead of using the
layerID parameter passed to the function. In the edge case mentioned above, the key stored in the map might already be
updated to new layer, and we will remove the new key by mistake. Now use function parameter as the key.
These two are races that no layout test can currently force.

Test: http/tests/site-isolation/draw-after-two-cross-process-navigations.html.

* LayoutTests/http/tests/site-isolation/draw-after-two-cross-process-navigations-expected.html: Added.
* LayoutTests/http/tests/site-isolation/draw-after-two-cross-process-navigations.html: Added.
* LayoutTests/http/tests/site-isolation/resources/red-background.html: Added. The regression test page is blue with a
200x200 iframe that navigates three times: a red page on localhost, a green page on a third site, and finally a URL on a
fourth site that responds with X-Frame-Options: deny, so a transparent document commits and nothing opaque is left to
hide a stale layer. The 1x1 #sibling frame is load-bearing: it is same-site with the red page, so that process stays
alive after the frame leaves it and reports the red layer as destroyed. Without it the process terminates instead and
takes the path that was already correct, and the test passes either way.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::layerWillBeRemoved):
(WebKit::RemoteLayerTreeHost::remotePageProcessDidTerminate):

Canonical link: <a href="https://commits.webkit.org/318978@main">https://commits.webkit.org/318978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f53373be26e288536b610a119b3097ccbd45634

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189505 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143982 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/784084e9-e80b-41da-9eff-b20ab6c03fa7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140132 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96958 "2 flakes 6 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/416ff597-6590-4ebf-a822-51aad3116a6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120583 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/63031ab3-0717-4d13-bc55-ff95e08a146a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42412 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40734 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40387 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/959 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191727 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160390 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149399 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40112 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53963 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37011 "Too many flaky failures: http/tests/media/video-useragent.html, http/tests/navigation/subframe-pagehide-handler-starts-load2.html, http/tests/security/contentSecurityPolicy/shared-worker-blob-url-inherits-csp-importScripts-blocked.html, http/tests/security/cors-post-redirect-301.html, http/tests/storageAccess/request-and-grant-access-then-detach-should-not-have-access.https.html, http/tests/xmlhttprequest/access-control-repeated-failed-preflight-crash.html, http/wpt/service-workers/fetch-service-worker-navigation-preload.https.html, ietestcenter/Javascript/15.4.4.16-8-6.html, imported/mozilla/svg/filters/feGaussianBlur-2.svg, imported/mozilla/svg/image/image-x-01.svg (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149143 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43802 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126235 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121246 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52480 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15378 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51865 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52106 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51926 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->