### PR TITLE
Cherry-pick 317834@main (e59b5d3cc487). https://bugs.webkit.org/show_bug.cgi?id=319610

### DIFF
--- a/LayoutTests/fast/html/details-display-contents-scrollable-content-crash-expected.txt
+++ b/LayoutTests/fast/html/details-display-contents-scrollable-content-crash-expected.txt
@@ -1,0 +1,7 @@
+Tests that a <details> element with `display: contents` whose `::details-content` establishes a scrollable area does not crash. Test passes if WebKit does not crash. PASS.
+toggle
+content
+toggle
+content
+toggle
+content

--- a/LayoutTests/fast/html/details-display-contents-scrollable-content-crash.html
+++ b/LayoutTests/fast/html/details-display-contents-scrollable-content-crash.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+/* The scroll corner style is resolved against the shadow host, which has no
+   renderer because of `display: contents`. */
+#scroll-corner { display: contents; }
+#scroll-corner::details-content { height: 0; overflow: hidden; }
+
+/* Same for the resizer style, which is resolved along a separate code path. */
+#resizer { display: contents; }
+#resizer::details-content { height: 0; overflow: hidden; resize: both; }
+
+/* And for scrollbar creation, which looks up the same renderer. */
+#scrollbar { display: contents; }
+#scrollbar::details-content { height: 10px; overflow: scroll; }
+</style>
+</head>
+<body>
+<p>Tests that a &lt;details&gt; element with `display: contents` whose `::details-content` establishes a scrollable area does not crash. Test passes if WebKit does not crash. PASS.</p>
+<details id="scroll-corner" open><summary>toggle</summary><div>content</div></details>
+<details id="resizer" open><summary>toggle</summary><div>content</div></details>
+<details id="scrollbar" open><summary>toggle</summary><div style="height: 500px; width: 500px;">content</div></details>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+// Force a layout so the scrollable areas, and with them the scroll corner,
+// resizer and scrollbar styles, get resolved.
+document.body.offsetHeight;
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/MIMESniffer.cpp
+++ b/Source/WebCore/platform/graphics/MIMESniffer.cpp
@@ -140,7 +140,7 @@ static bool hasSignatureForWebM(std::span<const uint8_t> sequence)
     //   6. While iter is less than length and iter is less than 38, continuously loop through these steps:
     while (iter < length && iter < 38) {
         //  1. If the two bytes from sequence[iter] to sequence[iter + 1] are equal to 0x42 0x82,
-        if (sequence[iter] == 0x42 && sequence[iter + 1] == 0x82) {
+        if (iter + 1 < length && sequence[iter] == 0x42 && sequence[iter + 1] == 0x82) {
             //  1. Increment iter by 2.
             iter += 2;
             //  2. If iter is greater or equal than length, abort these steps.

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -876,8 +876,10 @@ static inline RenderElement* rendererForScrollbar(RenderLayerModelObject& render
 {
     if (RefPtr element = renderer.element()) {
         if (RefPtr shadowRoot = element->containingShadowRoot()) {
-            if (shadowRoot->mode() == ShadowRootMode::UserAgent)
-                return shadowRoot->protectedHost()->renderer();
+            if (shadowRoot->mode() == ShadowRootMode::UserAgent) {
+                if (auto* hostRenderer = shadowRoot->protectedHost()->renderer())
+                    return hostRenderer;
+            }
         }
     }
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -426,7 +426,7 @@ void CacheStorageManager::sizeDecreased(uint64_t amount)
     if (!m_size || !amount)
         return;
 
-    m_size = *m_size - amount;
+    m_size = *m_size > amount ? *m_size - amount : 0;
     writeSizeFile(m_path, *m_size);
 }
 

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
@@ -248,6 +248,25 @@ Ref<WebPageProxy> SimulatedInputDispatcher::protectedPage() const
     return m_page.get();
 }
 
+#if ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
+static std::optional<TouchInteraction> touchInteractionForMouseInteraction(MouseInteraction interaction)
+{
+    switch (interaction) {
+    case MouseInteraction::Down:
+        return TouchInteraction::TouchDown;
+    case MouseInteraction::Up:
+        return TouchInteraction::LiftUp;
+    case MouseInteraction::Move:
+        return TouchInteraction::MoveTo;
+    case MouseInteraction::SingleClick:
+    case MouseInteraction::DoubleClick:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+#endif
+
 void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource& inputSource, SimulatedInputSourceState& newState, AutomationCompletionHandler&& completionHandler)
 {
     // Make cases and conditionals more readable by aliasing pre/post states as 'a' and 'b'.
@@ -279,9 +298,9 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
         break;
     case SimulatedInputSourceType::Mouse:
     case SimulatedInputSourceType::Pen: {
-#if !ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
+    #if !ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
         RELEASE_ASSERT_NOT_REACHED();
-#else
+    #else
         resolveLocation(valueOrDefault(a.location), b.location, b.origin.value_or(MouseMoveOrigin::Pointer), b.nodeHandle, [this, protectedThis = Ref { *this }, &a, &b, inputSource = inputSource.type, eventDispatchFinished = WTF::move(eventDispatchFinished)](std::optional<WebCore::IntPoint> location, std::optional<AutomationCommandError> error) mutable {
             if (error) {
                 eventDispatchFinished(error);
@@ -303,24 +322,24 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
                 }();
 
                 if (!stateTransitionIsNoop) {
-#if !LOG_DISABLED
+    #if !LOG_DISABLED
                     String interactionName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(b.mouseInteraction.value());
                     String mouseButtonName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(b.pressedMouseButton.value_or(MouseButton::None));
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating %s[button=%s] @ (%d, %d) for transition to %d.%d", this, interactionName.utf8().data(), mouseButtonName.utf8().data(), b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
-#endif
+    #endif
                     m_client.simulateMouseInteraction(protectedPage(), b.mouseInteraction.value(), b.pressedMouseButton.value_or(MouseButton::None), b.location.value(), pointerType, WTF::move(eventDispatchFinished));
                 } else
                     eventDispatchFinished({ });
             } else
                 eventDispatchFinished(std::nullopt);
         });
-#endif // ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
+    #endif // ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
         break;
     }
     case SimulatedInputSourceType::Touch: {
-#if !ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
+    #if !ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
         RELEASE_ASSERT_NOT_REACHED();
-#else
+    #else
         resolveLocation(valueOrDefault(a.location), b.location, b.origin.value_or(MouseMoveOrigin::Viewport), b.nodeHandle, [this, protectedThis = Ref { *this }, &a, &b, eventDispatchFinished = WTF::move(eventDispatchFinished)](std::optional<WebCore::IntPoint> location, std::optional<AutomationCommandError> error) mutable {
             if (error) {
                 eventDispatchFinished(error);
@@ -334,25 +353,36 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
 
             b.location = location;
             // The "dispatch a pointer{Down,Up,Move} action" algorithms (§17.4 Dispatching Actions).
-            if (!a.pressedMouseButton && b.pressedMouseButton) {
-                LOG(Automation, "SimulatedInputDispatcher[%p]: simulating TouchDown @ (%d, %d) for transition to %d.%d", this, b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
-                m_client.simulateTouchInteraction(protectedPage(), TouchInteraction::TouchDown, b.location.value(), std::nullopt, WTF::move(eventDispatchFinished));
-            } else if (a.pressedMouseButton && !b.pressedMouseButton) {
-                LOG(Automation, "SimulatedInputDispatcher[%p]: simulating LiftUp @ (%d, %d) for transition to %d.%d", this, b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
-                m_client.simulateTouchInteraction(protectedPage(), TouchInteraction::LiftUp, b.location.value(), std::nullopt, WTF::move(eventDispatchFinished));
-            } else if (a.location != b.location) {
-                LOG(Automation, "SimulatedInputDispatcher[%p]: simulating MoveTo from (%d, %d) to (%d, %d) for transition to %d.%d", this, a.location.value().x(), a.location.value().y(), b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
-                m_client.simulateTouchInteraction(protectedPage(), TouchInteraction::MoveTo, b.location.value(), a.duration.value_or(0_s), WTF::move(eventDispatchFinished));
+            if (b.mouseInteraction) {
+                const auto stateTransitionIsNoop = [&a, &b] {
+                    return std::tie(a.location, a.mouseInteraction, a.pressedMouseButton) == std::tie(b.location, b.mouseInteraction, b.pressedMouseButton);
+                }();
+
+                if (!stateTransitionIsNoop) {
+                    auto touchInteraction = touchInteractionForMouseInteraction(b.mouseInteraction.value());
+                    if (!touchInteraction || (touchInteraction == TouchInteraction::MoveTo && a.location == b.location)) {
+                        eventDispatchFinished(std::nullopt);
+                        return;
+                    }
+
+                    std::optional<Seconds> duration = touchInteraction == TouchInteraction::MoveTo ? std::optional<Seconds>(a.duration.value_or(0_s)) : std::nullopt;
+    #if !LOG_DISABLED
+                    String interactionName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(b.mouseInteraction.value());
+                    LOG(Automation, "SimulatedInputDispatcher[%p]: simulating touch %s @ (%d, %d) for transition to %d.%d", this, interactionName.utf8().data(), b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
+    #endif
+                    m_client.simulateTouchInteraction(protectedPage(), touchInteraction.value(), b.location.value(), duration, WTF::move(eventDispatchFinished));
+                } else
+                    eventDispatchFinished({ });
             } else
                 eventDispatchFinished(std::nullopt);
         });
-#endif // !ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
+    #endif // !ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
         break;
     }
     case SimulatedInputSourceType::Keyboard: {
-#if !ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
+    #if !ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
         RELEASE_ASSERT_NOT_REACHED();
-#else
+    #else
         auto comparePressedCharKeys = [](const auto& a, const auto& b) {
             if (a.size() != b.size())
                 return false;
@@ -368,37 +398,37 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
             bool simulatedAnInteraction = false;
             for (auto charKey : b.pressedCharKeys) {
                 if (!a.pressedCharKeys.contains(charKey)) {
-#if ENABLE(WEBDRIVER_KEYBOARD_GRAPHEME_CLUSTERS)
+    #if ENABLE(WEBDRIVER_KEYBOARD_GRAPHEME_CLUSTERS)
                     ASSERT_WITH_MESSAGE(WTF::numGraphemeClusters(charKey) <= 1, "A CharKey must either be a single unicode code point, a single grapheme cluster, or null.");
-#endif
+    #endif
                     ASSERT_WITH_MESSAGE(!simulatedAnInteraction, "Only one CharKey may differ at a time between two input source states.");
                     if (simulatedAnInteraction)
                         continue;
                     simulatedAnInteraction = true;
 
-#if ENABLE(WEBDRIVER_KEYBOARD_GRAPHEME_CLUSTERS)
+    #if ENABLE(WEBDRIVER_KEYBOARD_GRAPHEME_CLUSTERS)
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating KeyPress[key=%s] for transition to %d.%d", this, charKey.utf8().data(), m_keyframeIndex, m_inputSourceStateIndex);
-#else
+    #else
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating KeyPress[key=%c] for transition to %d.%d", this, charKey, m_keyframeIndex, m_inputSourceStateIndex);
-#endif
+    #endif
                     m_client.simulateKeyboardInteraction(protectedPage(), KeyboardInteraction::KeyPress, charKey, WTF::move(eventDispatchFinished));
                 }
             }
 
             for (auto charKey : copyToVector(a.pressedCharKeys)) {
                 if (!b.pressedCharKeys.contains(charKey)) {
-#if ENABLE(WEBDRIVER_KEYBOARD_GRAPHEME_CLUSTERS)
+    #if ENABLE(WEBDRIVER_KEYBOARD_GRAPHEME_CLUSTERS)
                     ASSERT_WITH_MESSAGE(WTF::numGraphemeClusters(charKey) <= 1, "A CharKey must either be a single unicode code point, a single grapheme cluster, or null.");
-#endif
+    #endif
                     ASSERT_WITH_MESSAGE(!simulatedAnInteraction, "Only one CharKey may differ at a time between two input source states.");
                     if (simulatedAnInteraction)
                         continue;
                     simulatedAnInteraction = true;
-#if ENABLE(WEBDRIVER_KEYBOARD_GRAPHEME_CLUSTERS)
+    #if ENABLE(WEBDRIVER_KEYBOARD_GRAPHEME_CLUSTERS)
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating KeyRelease[key=%s] for transition to %d.%d", this, charKey.utf8().data(), m_keyframeIndex, m_inputSourceStateIndex);
-#else
+    #else
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating KeyRelease[key=%c] for transition to %d.%d", this, charKey, m_keyframeIndex, m_inputSourceStateIndex);
-#endif
+    #endif
                     m_client.simulateKeyboardInteraction(protectedPage(), KeyboardInteraction::KeyRelease, charKey, WTF::move(eventDispatchFinished));
                 }
             }
@@ -410,10 +440,10 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
                     if (simulatedAnInteraction)
                         continue;
                     simulatedAnInteraction = true;
-#if !LOG_DISABLED
+    #if !LOG_DISABLED
                     String virtualKeyName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(iter.value);
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating KeyPress[key=%s] for transition to %d.%d", this, virtualKeyName.utf8().data(), m_keyframeIndex, m_inputSourceStateIndex);
-#endif
+    #endif
                     m_client.simulateKeyboardInteraction(protectedPage(), KeyboardInteraction::KeyPress, iter.value, WTF::move(eventDispatchFinished));
                 }
             }
@@ -424,22 +454,22 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
                     if (simulatedAnInteraction)
                         continue;
                     simulatedAnInteraction = true;
-#if !LOG_DISABLED
+    #if !LOG_DISABLED
                     String virtualKeyName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(iter.value);
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating KeyRelease[key=%s] for transition to %d.%d", this, virtualKeyName.utf8().data(), m_keyframeIndex, m_inputSourceStateIndex);
-#endif
+    #endif
                     m_client.simulateKeyboardInteraction(protectedPage(), KeyboardInteraction::KeyRelease, iter.value, WTF::move(eventDispatchFinished));
                 }
             }
         } else
             eventDispatchFinished(std::nullopt);
-#endif // !ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
+    #endif // !ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
         break;
     }
     case SimulatedInputSourceType::Wheel:
-#if !ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
+    #if !ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
         RELEASE_ASSERT_NOT_REACHED();
-#else
+    #else
         resolveLocation(valueOrDefault(a.location), b.location, b.origin.value_or(MouseMoveOrigin::Viewport), b.nodeHandle, [this, protectedThis = Ref { *this }, &a, &b, eventDispatchFinished = WTF::move(eventDispatchFinished)](std::optional<WebCore::IntPoint> location, std::optional<AutomationCommandError> error) mutable {
             if (error) {
                 eventDispatchFinished(error);
@@ -466,7 +496,7 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
             } else
                 eventDispatchFinished(std::nullopt);
         });
-#endif // !ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
+    #endif // !ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
         break;
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp
@@ -63,6 +63,12 @@ TEST(MIMESniffer, WebMSnifferDoesNotReadPastEnd)
     // read in MIMESniffer.cpp under ASan / libc++ hardened mode.
     constexpr std::array<const uint8_t, 7> truncatedWebM = { 0x1A, 0x45, 0xDF, 0xA3, 0x42, 0x82, 0x80 };
     MIMESniffer::getMIMETypeFromContent(std::span { truncatedWebM });
+
+    // EBML magic (4 bytes) followed by a lone 0x42 as the last byte. The loop
+    // guard only ensures iter < length, so the 0x42 0x82 two-byte compare reads
+    // sequence[iter + 1] one byte past the end when iter == length - 1.
+    constexpr std::array<const uint8_t, 5> truncatedWebMAtMagicByte = { 0x1A, 0x45, 0xDF, 0xA3, 0x42 };
+    MIMESniffer::getMIMETypeFromContent(std::span { truncatedWebMAtMagicByte });
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 4c2258af828b4833870638c838e4cba0457ee338
<pre>
Cherry-pick 317834@main (e59b5d3cc487). <a href="https://bugs.webkit.org/show_bug.cgi?id=319610">https://bugs.webkit.org/show_bug.cgi?id=319610</a>

    REGRESSION(283790@main): the touch path didn&apos;t adopt mouseInteraction and no longer works
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319610">https://bugs.webkit.org/show_bug.cgi?id=319610</a>
    <a href="https://rdar.apple.com/182438327">rdar://182438327</a>

    Reviewed by BJ Burg.

    The Touch branch of transitionInputSourceToState never adopted
    283790@main&apos;s change to dispatch off b.mouseInteraction: it still
    infers TouchDown/LiftUp/MoveTo purely from pressedMouseButton edges.
    safaridriver&apos;s paired fix for the same bug stopped clearing
    pressedMouseButton on pointerUp, relying on mouseInteraction alone to
    signal Up, so pressedMouseButton now stays set across the whole
    pointerDown/pointerUp pair. Since the Touch branch only emits LiftUp
    when pressedMouseButton goes from set to unset, no LiftUp is emitted
    for the pointerUp action itself; the touch stays held until the next
    command (or the Release Actions reset keyframe) lifts it late and at
    the wrong coordinate.

    Port 283790@main&apos;s approach to the Touch branch, mirroring the
    Mouse/Pen branch exactly: dispatch off b.mouseInteraction with no
    pressedMouseButton-delta fallback. This makes the Up keyframe&apos;s
    resolveLocation(origin=Pointer, location=(0,0)) resolve to the down
    coordinate, so LiftUp now fires in place during the pointerUp action&apos;s
    own keyframe transition.

    * Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp:
    (WebKit::touchInteractionForMouseInteraction):
    (WebKit::SimulatedInputDispatcher::transitionInputSourceToState):

    Canonical link: <a href="https://commits.webkit.org/317834@main">https://commits.webkit.org/317834@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1076@webkitglib/2.52">https://commits.webkit.org/305877.1076@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 8856064cd3338034000f916fb5997c7e9c5b0898
<pre>
Cherry-pick 318243@main (ef325e63cb21). <a href="https://bugs.webkit.org/show_bug.cgi?id=320634">https://bugs.webkit.org/show_bug.cgi?id=320634</a>

    Out-of-bounds read in WebM MIME sniffer at the 0x42 0x82 DocType check
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320634">https://bugs.webkit.org/show_bug.cgi?id=320634</a>

    Reviewed by Youenn Fablet.

    314498@main guarded the inner skip-NUL loop in hasSignatureForWebM(),
    but a second unguarded iter + 1 read remains at the top of the loop:
    ```
        while (iter &lt; length &amp;&amp; iter &lt; 38) {
            if (sequence[iter] == 0x42 &amp;&amp; sequence[iter + 1] == 0x82) {
    ```
    The loop guard only guarantees iter &lt; length, not iter + 1 &lt; length. When
    iter == length - 1 and sequence[iter] == 0x42, the short-circuit &amp;&amp; goes on
    to evaluate sequence[iter + 1], reading one byte past the end of the span.
    This is reachable before the skip-NUL path 314498@main fixed: a 5-byte
    input of EBML magic + a trailing 0x42 (0x1A 0x45 0xDF 0xA3 0x42) enters the
    loop at iter == 4 == length - 1 and reads sequence[5]. getMIMETypeFromContent()
    is called on attacker-controlled response bytes via MediaResourceSniffer with
    a span sized to the exact number of received bytes, so this is a remotely
    reachable crash. WebKit builds with hardened libc++, so std::span&apos;s bounds
    check turns it into a safe abort on every build.

    Guard the two-byte compare with iter + 1 &lt; length so the bounds check
    short-circuits the dereference, matching the guarded reads later in the
    function, and extend the regression test with the truncated 5-byte input.

    Test: MIMESniffer.WebMSnifferDoesNotReadPastEnd

    * Source/WebCore/platform/graphics/MIMESniffer.cpp:
    (WebCore::MIMESniffer::hasSignatureForWebM):
    * Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp:
    (TestWebKitAPI::TEST(MIMESniffer, WebMSnifferDoesNotReadPastEnd)):

    Canonical link: <a href="https://commits.webkit.org/318243@main">https://commits.webkit.org/318243@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1075@webkitglib/2.52">https://commits.webkit.org/305877.1075@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9ddc4037a53c86ca8c8d2d60f93556eea1e4f4e5
<pre>
Cherry-pick 318204@main (5d91250a8529). <a href="https://bugs.webkit.org/show_bug.cgi?id=320408">https://bugs.webkit.org/show_bug.cgi?id=320408</a>

    CacheStorage size accounting can underflow and persist a corrupt size
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320408">https://bugs.webkit.org/show_bug.cgi?id=320408</a>

    Reviewed by Youenn Fablet.

    CacheStorageManager::sizeDecreased() subtracted the given amount from m_size
    without checking that it did not exceed the current value. m_size is a uint64_t,
    so if the amount ever exceeds the tracked size the subtraction wraps to a value
    near UINT64_MAX, which is then written to the cache&apos;s size file and used for
    quota accounting, effectively corrupting quota reporting for the origin until
    the size is re-initialized.

    The tracked size is normally kept consistent (increments and decrements are
    balanced in putRecordsInStore), but removeRecords() and removeAllRecords() call
    sizeDecreased() directly, outside the space-request/initialization path, so the
    in-memory accounting and the asynchronously-measured cache size can in theory
    drift and the decrement can exceed m_size.

    Clamp the subtraction at zero, matching the saturating arithmetic used elsewhere
    in this code.

    * Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
    (WebKit::CacheStorageManager::sizeDecreased):

    Canonical link: <a href="https://commits.webkit.org/318204@main">https://commits.webkit.org/318204@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1074@webkitglib/2.52">https://commits.webkit.org/305877.1074@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### fe6390e70e71bf13a4c74dfd98cc6604cdc4f521
<pre>
Cherry-pick 318661@main (9510cbdd8452). <a href="https://bugs.webkit.org/show_bug.cgi?id=320447">https://bugs.webkit.org/show_bug.cgi?id=320447</a>

Unreviewed backport.

    Null-deref crash in RenderElement::resolvePseudoElementStyle() when a &lt;details&gt; element has `display: contents` and its ::details-content establishes a scrollable area
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320447">https://bugs.webkit.org/show_bug.cgi?id=320447</a>
    <a href="https://rdar.apple.com/183445758">rdar://183445758</a>

    Reviewed by Simon Fraser.

    rendererForScrollbar() maps a renderer inside a user agent shadow root to its
    shadow host&apos;s renderer, so that scrollbar pseudo element styles are resolved
    against the host. It returned the host&apos;s renderer unconditionally, but a host
    with `display: contents` has no renderer. Its user agent shadow content can
    still establish a scrollable area, so all three callers dereferenced null.

    A &lt;details&gt; is exactly that case: its ::details-content is a slot in the user
    agent shadow root, so giving the &lt;details&gt; `display: contents` and the
    ::details-content non-visible overflow crashed the WebContent process while
    resolving the scroll corner style during render tree construction. This is the
    standard way to build an animated disclosure widget whose summary participates
    in a parent grid, so it is reachable from ordinary content.

    Null check the host&apos;s renderer and fall back to the renderer establishing the
    scrollable area, which is the pre-existing behavior for content outside a user
    agent shadow root. Only the null case changes behavior.

    * Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
    (WebCore::rendererForScrollbar): The host is not guaranteed to have a renderer.
    It has none when it is `display: contents`, even though its user agent shadow
    content may still establish a scrollable area. Fall back to the renderer
    establishing the scrollable area rather than returning null, since the callers
    all dereference the result to resolve the scrollbar pseudo element styles
    against it: updateScrollCornerStyle(), updateResizerStyle() and
    createScrollbar().

    * LayoutTests/fast/html/details-display-contents-scrollable-content-crash.html: Added.
    * LayoutTests/fast/html/details-display-contents-scrollable-content-crash-expected.txt: Added.
    Covers all three call sites: a scroll corner, a resizer (`resize: both`) and
    scrollbar creation (`overflow: scroll` with overflowing content). Crashes
    without the fix, passes with it.

    Canonical link: <a href="https://commits.webkit.org/318661@main">https://commits.webkit.org/318661@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1073@webkitglib/2.52">https://commits.webkit.org/305877.1073@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65f4b86b821b6697060cae8557af788dc007f496

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179677 "33 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53616 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47414 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189509 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143986 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181540 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/54910 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53327 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140134 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143986 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182634 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/54910 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47414 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120585 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/54910 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53327 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47414 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/54910 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47414 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/963 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46222 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53327 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191731 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53286 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47414 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149409 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/53967 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47414 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149147 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27286 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/53967 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126239 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121254 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52484 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47414 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51869 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52110 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/51930 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->