### PR TITLE
[GTK] Add WebKitWebExtensionContext Injected Content handlers

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.cpp
@@ -66,6 +66,7 @@ enum {
     PROP_WEB_EXTENSION,
     PROP_BASE_URI,
     PROP_OPTIONS_PAGE_URI,
+    PROP_HAS_INJECTED_CONTENT,
     N_PROPERTIES,
 };
 
@@ -84,6 +85,9 @@ static void webkitWebExtensionContextGetProperty(GObject* object, guint propId, 
         break;
     case PROP_OPTIONS_PAGE_URI:
         g_value_set_string(value, webkit_web_extension_context_get_options_page_uri(context));
+        break;
+    case PROP_HAS_INJECTED_CONTENT:
+        g_value_set_boolean(value, webkit_web_extension_context_get_has_injected_content(context));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -157,6 +161,22 @@ static void webkit_web_extension_context_class_init(WebKitWebExtensionContextCla
             "options-page-uri",
             nullptr, nullptr,
             nullptr,
+            WEBKIT_PARAM_READABLE
+        );
+
+    /**
+     * WebKitWebExtensionContext:has-injected-content:
+     * 
+     * Whether the extension has script or stylesheet content that can be injected into webpages.
+     * See [method@WebExtensionContext.get_has_injected_content] for more details.
+     *
+     * Since: 2.56
+     */
+    properties[PROP_HAS_INJECTED_CONTENT] =
+        g_param_spec_boolean(
+            "has-injected-content",
+            nullptr, nullptr,
+            FALSE,
             WEBKIT_PARAM_READABLE
         );
 
@@ -331,6 +351,50 @@ const gchar* webkit_web_extension_context_get_options_page_uri(WebKitWebExtensio
     return priv->optionsPageURI.data();
 }
 
+/**
+ * webkit_web_extension_context_get_has_injected_content:
+ * @context: a [class@WebExtensionContext]
+ *
+ * Get whether the extension has script or stylesheet content that can be injected into webpages.
+ * 
+ * If this property is %TRUE, the extension has content that can be injected by matching against the extension's requested match patterns.
+ * 
+ * Returns: %TRUE if the extension contains content that can be injected into webpages.
+ * 
+ * Since: 2.56
+ */
+gboolean webkit_web_extension_context_get_has_injected_content(WebKitWebExtensionContext* context)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION_CONTEXT(context), FALSE);
+    g_return_val_if_fail(context->priv->extension, FALSE);
+
+    WebKitWebExtensionContextPrivate* priv = context->priv;
+    return priv->context->hasInjectedContent();
+}
+
+/**
+ * webkit_web_extension_context_has_injected_content_for_uri:
+ * @context: a [class@WebExtensionContext]
+ * @uri: The webpage URI to check
+ *
+ * Checks if the extension has script or stylesheet content that can be injected into the specified URL.
+ * 
+ * The extension context will still need to be loaded and have granted website permissions for its content to actually be injected.
+ * 
+ * Returns: %TRUE if the extension has content that can be injected by matching the URL against the extension's requested match patterns.
+ * 
+ * Since: 2.56
+ */
+gboolean webkit_web_extension_context_has_injected_content_for_uri(WebKitWebExtensionContext* context, const gchar* uri)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION_CONTEXT(context), FALSE);
+    g_return_val_if_fail(context->priv->extension, FALSE);
+    g_return_val_if_fail(uri, FALSE);
+
+    WebKitWebExtensionContextPrivate* priv = context->priv;
+    return priv->context->hasInjectedContentForURL(URL { String::fromUTF8(uri) });
+}
+
 #else // ENABLE(WK_WEB_EXTENSIONS)
 
 void webkitWebExtensionContextSetWebExtension(WebKitWebExtensionContext* context, WebKitWebExtension* extension)
@@ -361,6 +425,16 @@ void webkit_web_extension_context_set_base_uri(WebKitWebExtensionContext* contex
 const gchar* webkit_web_extension_context_get_options_page_uri(WebKitWebExtensionContext* context)
 {
     return "";
+}
+
+gboolean webkit_web_extension_context_get_has_injected_content(WebKitWebExtensionContext* context)
+{
+    return FALSE;
+}
+
+gboolean webkit_web_extension_context_has_injected_content_for_uri(WebKitWebExtensionContext* context, const gchar* uri)
+{
+    return FALSE;
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.h.in
@@ -54,6 +54,13 @@ webkit_web_extension_context_set_base_uri                                   (Web
 WEBKIT_API const gchar *
 webkit_web_extension_context_get_options_page_uri                           (WebKitWebExtensionContext *context);
 
+WEBKIT_API gboolean
+webkit_web_extension_context_get_has_injected_content                       (WebKitWebExtensionContext *context);
+
+WEBKIT_API gboolean
+webkit_web_extension_context_has_injected_content_for_uri                   (WebKitWebExtensionContext *context,
+                                                                             const gchar               *uri);
+
 G_END_DECLS
 
 #endif // ENABLE(2022_GLIB_API)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebExtensionContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebExtensionContext.cpp
@@ -34,6 +34,118 @@ static GRefPtr<GBytes> createGBytes(const gchar* string)
     return adoptGRef(g_bytes_new_static(string, strlen(string)));
 }
 
+static void testContentScriptsParsing(Test* test, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parseExtensionManifest = [&](const gchar* contentScripts) {
+        auto manifestString = makeString("{ \"manifest_version\": 2, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\", \"content_scripts\": "_s, String::fromUTF8(contentScripts), " }"_s);
+        GRefPtr extension = adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString.utf8().data()) } }, &error.outPtr()));
+        test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(extension.get()));
+        return extension;
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parseExtensionManifest("[{ \"js\": [ \"test.js\", 1, \"\" ], \"css\": [ false, \"test.css\", \"\" ], \"matches\": [ \"*://*/\" ] }]");
+    g_assert_no_error(error.get());
+    GRefPtr<WebKitWebExtensionContext> context = adoptGRef(webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr()));
+    g_assert_no_error(error.get());
+
+    g_assert_true(webkit_web_extension_context_get_has_injected_content(context.get()));
+    g_assert_true(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://webkit.org/"));
+    g_assert_true(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://example.com/"));
+
+    extension = parseExtensionManifest("[{ \"js\": [ \"test.js\", 1, \"\" ], \"css\": [ false, \"test.css\", \"\" ], \"matches\": [ \"*://*/\" ], \"exclude_matches\": [ \"*://*.example.com/\" ] }]");
+    g_assert_no_error(error.get());
+    context = adoptGRef(webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr()));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(context.get()));
+    g_assert_no_error(error.get());
+
+    g_assert_true(webkit_web_extension_context_get_has_injected_content(context.get()));
+    g_assert_true(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://webkit.org/"));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://example.com/"));
+
+    extension = parseExtensionManifest("[{ \"js\": [ \"test.js\", 1, \"\" ], \"css\": [ false, \"test.css\", \"\" ], \"matches\": [ \"*://*.example.com/\" ] }]");
+    g_assert_no_error(error.get());
+    context = adoptGRef(webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr()));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(context.get()));
+    g_assert_no_error(error.get());
+
+    g_assert_true(webkit_web_extension_context_get_has_injected_content(context.get()));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://webkit.org/"));
+    g_assert_true(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://example.com/"));
+
+    extension = parseExtensionManifest("[{ \"css\": [ false, \"test.css\", \"\" ], \"css_origin\": \"user\", \"matches\": [ \"*://*.example.com/\" ] }]");
+    g_assert_no_error(error.get());
+    context = adoptGRef(webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr()));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(context.get()));
+    g_assert_no_error(error.get());
+
+    g_assert_true(webkit_web_extension_context_get_has_injected_content(context.get()));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://webkit.org/"));
+    g_assert_true(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://example.com/"));
+
+    extension = parseExtensionManifest("[{ \"css\": [ false, \"test.css\", \"\" ], \"css_origin\": \"author\", \"matches\": [ \"*://*.example.com/\" ] }]");
+    g_assert_no_error(error.get());
+    context = adoptGRef(webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr()));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(context.get()));
+    g_assert_no_error(error.get());
+
+    g_assert_true(webkit_web_extension_context_get_has_injected_content(context.get()));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://webkit.org/"));
+    g_assert_true(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://example.com/"));
+
+    // Invalid cases
+
+    extension = parseExtensionManifest("[]");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    context = adoptGRef(webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr()));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(context.get()));
+    g_assert_no_error(error.get());
+
+    g_assert_false(webkit_web_extension_context_get_has_injected_content(context.get()));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://webkit.org/"));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://example.com/"));
+
+    extension = parseExtensionManifest("{ \"invalid\": true }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    context = adoptGRef(webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr()));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(context.get()));
+    g_assert_no_error(error.get());
+
+    g_assert_false(webkit_web_extension_context_get_has_injected_content(context.get()));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://webkit.org/"));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://example.com/"));
+
+    extension = parseExtensionManifest("[{ \"js\": [ \"test.js\" ], \"matches\": [] }]");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    context = adoptGRef(webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr()));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(context.get()));
+    g_assert_no_error(error.get());
+
+    g_assert_false(webkit_web_extension_context_get_has_injected_content(context.get()));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://webkit.org/"));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://example.com/"));
+
+    extension = parseExtensionManifest("[{ \"js\": [ \"test.js\" ], \"matches\": [ \"*://*.example.com/\" ], \"world\": \"INVALID\" }]");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    context = adoptGRef(webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr()));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(context.get()));
+    g_assert_no_error(error.get());
+
+    g_assert_true(webkit_web_extension_context_get_has_injected_content(context.get()));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://webkit.org/"));
+    g_assert_true(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://example.com/"));
+
+    extension = parseExtensionManifest("[{ \"css\": [ false, \"test.css\", \"\" ], \"css_origin\": \"bad\", \"matches\": [ \"*://*.example.com/\" ] }]");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    context = adoptGRef(webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr()));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(context.get()));
+    g_assert_no_error(error.get());
+
+    g_assert_true(webkit_web_extension_context_get_has_injected_content(context.get()));
+    g_assert_false(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://webkit.org/"));
+    g_assert_true(webkit_web_extension_context_has_injected_content_for_uri(context.get(), "https://example.com/"));
+}
+
 static void testOptionsPageURIParsing(Test* test, gconstpointer)
 {
     GUniqueOutPtr<GError> error;
@@ -96,6 +208,7 @@ static void testOptionsPageURIParsing(Test* test, gconstpointer)
 
 void beforeAll()
 {
+    Test::add("WebKitWebExtensionContext", "content-scripts-parsing", testContentScriptsParsing);
     Test::add("WebKitWebExtensionContext", "options-page-uri-parsing", testOptionsPageURIParsing);
 }
 


### PR DESCRIPTION
#### 287ba174e26687c71bdd1ade9f1145c9dfd94a17
<pre>
[GTK] Add WebKitWebExtensionContext Injected Content handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321405">https://bugs.webkit.org/show_bug.cgi?id=321405</a>

Reviewed by Michael Catanzaro and Patrick Griffis.

Add APIs for getting whether an ExtensionContext
has injected content (script or stylesheets),
and for getting said injected content.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebExtensionContext.cpp

* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.cpp:
(webkitWebExtensionContextGetProperty):
(webkit_web_extension_context_class_init):
(webkit_web_extension_context_get_has_injected_content):
(webkit_web_extension_context_has_injected_content_for_uri):
* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.h.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebExtensionContext.cpp:
(testContentScriptsParsing):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/318949@main">https://commits.webkit.org/318949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e8c829b5dc93bbe694b3806f131b62c5c43a638

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144187 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53530 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120738 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40902 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40565 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1236 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192010 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53480 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149591 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40086 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54167 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149322 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43972 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126430 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121482 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52684 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15552 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52066 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52304 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->