### PR TITLE
Out-of-bounds read in OpenType vertical GSUB coverage range fill

### DIFF
--- a/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
@@ -173,9 +173,9 @@ struct LookupTable : TableBase {
                 if (!isValidEnd(buffer, &coverage2->ranges[countRange]))
                     return false;
                 for (uint16_t i = 0, indexTo = 0; i < countRange; ++i) {
-                    uint16_t from = coverage2->ranges[i].start;
-                    uint16_t fromEnd = coverage2->ranges[i].end + 1; // OpenType "end" is inclusive
-                    if (indexTo + (fromEnd - from) > countTo)
+                    unsigned from = coverage2->ranges[i].start;
+                    unsigned fromEnd = coverage2->ranges[i].end + 1; // OpenType "end" is inclusive
+                    if (fromEnd <= from || indexTo + (fromEnd - from) > countTo)
                         return false;
                     for (; from != fromEnd; ++from, ++indexTo)
                         map->set(from, singleSubstitution2->substitute[indexTo]);


### PR DESCRIPTION
#### 2196077a54c42c97792ab2e69a97e3661827acf6
<pre>
Out-of-bounds read in OpenType vertical GSUB coverage range fill
<a href="https://bugs.webkit.org/show_bug.cgi?id=">https://bugs.webkit.org/show_bug.cgi?id=</a>

Reviewed by Michael Catanzaro.

OpenTypeVerticalData loads vertical glyph substitutions from a
downloaded font&apos;s GSUB table, which is attacker controlled.
LookupTable::getSubstitutions() fills the substitution map one Coverage
Format 2 range at a time. from and fromEnd were uint16_t with fromEnd
set to end + 1, so a range whose end is 0xffff wraps fromEnd to 0. The
guard indexTo + (fromEnd - from) &gt; countTo then underflows on the
truncated value and passes, and the inner loop walks from start through
0xffff before from wraps back to 0, reading
singleSubstitution2-&gt;substitute[indexTo] far past its validated
glyphCount entries. substitute is a raw pointer into the GSUB buffer, so
this is an unchecked heap read past the table. A reversed range with
start greater than end underflows the same guard.

Widen from and fromEnd to unsigned so end + 1 stays exact, and reject
fromEnd &lt;= from to drop reversed and empty ranges before the copy. Valid
ranges map the same glyphs as before.

* Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp:
(WebCore::OpenType::LookupTable::getSubstitutions):

Canonical link: <a href="https://commits.webkit.org/319036@main">https://commits.webkit.org/319036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d563db15ab66c285e8691468d81de78404ccacf1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143988 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140135 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96962 "6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120586 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42417 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40739 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40390 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/965 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191733 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53288 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149406 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40150 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53969 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149149 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43806 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126241 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121257 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52486 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15381 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51871 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->