### PR TITLE
[LBSE] Cache the SVG fill and stroke paint server on the renderer

### DIFF
--- a/LayoutTests/svg/repaint/pending-fill-paint-server-repaint-expected.txt
+++ b/LayoutTests/svg/repaint/pending-fill-paint-server-repaint-expected.txt
@@ -1,0 +1,4 @@
+(repaint rects
+  (rect 8 8 200 200)
+)
+

--- a/LayoutTests/svg/repaint/pending-fill-paint-server-repaint.html
+++ b/LayoutTests/svg/repaint/pending-fill-paint-server-repaint.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+svg { display: block; }
+</style>
+<script src="../../fast/repaint/resources/text-based-repaint.js"></script>
+<script>
+// Handing the id to the gradient has to repaint the square, otherwise the square keeps its
+// unpainted appearance on screen until something unrelated repaints it.
+function repaintTest()
+{
+    document.getElementById('not-the-gradient-yet').id = 'gradient';
+}
+
+window.addEventListener('load', () => {
+    // Paint once while nothing carries the id the square asks for. That first paint is what makes
+    // the square wait for the id, and snapshotNode() is what gets us a paint at all: a text test
+    // otherwise never paints, and testRunner.display() does not paint either.
+    if (window.internals)
+        internals.snapshotNode(document.getElementById('svg'));
+
+    runRepaintTest();
+}, false);
+</script>
+</head>
+<body>
+<svg id="svg" xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+    <defs>
+        <linearGradient id="not-the-gradient-yet">
+            <stop offset="0" stop-color="green"/>
+            <stop offset="1" stop-color="blue"/>
+        </linearGradient>
+    </defs>
+    <rect x="0" y="0" width="200" height="200" fill="url(#gradient)"/>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -20178,6 +20178,8 @@
 		BCAB417F13E356E800D8AAF3 /* Region.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Region.cpp; sourceTree = "<group>"; };
 		BCAB418013E356E800D8AAF3 /* Region.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Region.h; sourceTree = "<group>"; };
 		BCAB56F32F01A4E50087F79C /* SVGPaintServerHandlingInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGPaintServerHandlingInlines.h; sourceTree = "<group>"; };
+		BCAB56F42F01A4E50087F79C /* SVGPaintServerCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGPaintServerCache.h; sourceTree = "<group>"; };
+		BCAB56F52F01A4E50087F79C /* SVGPaintServerCacheInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGPaintServerCacheInlines.h; sourceTree = "<group>"; };
 		BCAB57052F02F3FC0087F79C /* StyleCaretColor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleCaretColor.h; sourceTree = "<group>"; };
 		BCAB57062F02F3FC0087F79C /* StyleCaretColor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleCaretColor.cpp; sourceTree = "<group>"; };
 		BCACF3BA1072921A00C0C8A3 /* UserContentURLPattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserContentURLPattern.cpp; sourceTree = "<group>"; };
@@ -24826,6 +24828,8 @@
 				CDF747E5270F6966008FEEEC /* SVGInlineTextBoxInlines.h */,
 				3344077412D9BC4A00044234 /* SVGLayerTransformUpdater.h */,
 				436708AF12D9CA4B00044234 /* SVGMarkerData.h */,
+				BCAB56F42F01A4E50087F79C /* SVGPaintServerCache.h */,
+				BCAB56F52F01A4E50087F79C /* SVGPaintServerCacheInlines.h */,
 				42E48B662BAC7C6E0044526B /* SVGPaintServerHandling.h */,
 				BCAB56F32F01A4E50087F79C /* SVGPaintServerHandlingInlines.h */,
 				715379FE146BD9D6008BD615 /* SVGPathFromElement.cpp */,

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -38,7 +38,6 @@
 #include "RenderObjectInlines.h"
 #include "RenderSVGPath.h"
 #include "RenderSVGResourceGradient.h"
-#include "RenderSVGResourcePaintServer.h"
 #include "RenderSVGResourcePattern.h"
 #include "SVGClipPathElement.h"
 #include "SVGDocument.h"
@@ -181,25 +180,6 @@ void ReferencedSVGResources::removeClientForTarget(const AtomString& targetID)
     auto entry = m_elementClients.take(targetID);
     if (RefPtr targetElement = entry.targetElement)
         targetElement->removeReferencingCSSClient(protect(*entry.client));
-}
-
-RenderSVGResourcePaintServer* ReferencedSVGResources::cachedFillPaintServer() const
-{
-    return m_cachedFillPaintServer.get();
-}
-
-RenderSVGResourcePaintServer* ReferencedSVGResources::cachedStrokePaintServer() const
-{
-    return m_cachedStrokePaintServer.get();
-}
-
-void ReferencedSVGResources::setCachedPaintServer(SVGPaintType paintType, RenderSVGResourcePaintServer& paintServer)
-{
-    ASSERT(paintType == SVGPaintType::Fill || paintType == SVGPaintType::Stroke);
-    if (paintType == SVGPaintType::Fill)
-        m_cachedFillPaintServer = paintServer;
-    else
-        m_cachedStrokePaintServer = paintServer;
 }
 
 ReferencedSVGResources::SVGElementIdentifierAndTagPairs ReferencedSVGResources::referencedSVGResourceIDs(const Style::ComputedStyle& style, const Document& document)

--- a/Source/WebCore/rendering/ReferencedSVGResources.h
+++ b/Source/WebCore/rendering/ReferencedSVGResources.h
@@ -43,14 +43,12 @@ class LegacyRenderSVGResourceContainer;
 class QualifiedName;
 class RenderElement;
 class RenderSVGResourceFilter;
-class RenderSVGResourcePaintServer;
 class SVGClipPathElement;
 class SVGElement;
 class SVGFilterElement;
 class SVGMarkerElement;
 class SVGMaskElement;
 class TreeScope;
-enum class SVGPaintType : bool;
 
 namespace Style {
 class ComputedStyle;
@@ -87,18 +85,6 @@ public:
     static RefPtr<SVGMaskElement> referencedMaskElement(TreeScope&, const AtomString&);
     static RefPtr<SVGElement> referencedPaintServerElement(TreeScope&, const Style::URL&);
 
-    // Cached fill and stroke paint server, filled in by RenderLayerModelObject. The weak pointer
-    // clears itself if the paint server dies, so a live pointer is a hit and a null one re-resolves.
-    // Defined out of line, they need the complete RenderSVGResourcePaintServer type for the weak pointer.
-    RenderSVGResourcePaintServer* cachedFillPaintServer() const;
-    RenderSVGResourcePaintServer* cachedStrokePaintServer() const;
-    void setCachedPaintServer(SVGPaintType, RenderSVGResourcePaintServer&);
-    void invalidatePaintServerCache()
-    {
-        m_cachedFillPaintServer = nullptr;
-        m_cachedStrokePaintServer = nullptr;
-    }
-
 private:
     static RefPtr<SVGElement> elementForResourceID(TreeScope&, const AtomString& resourceID, const SVGQualifiedName& tagName);
     static RefPtr<SVGElement> elementForResourceIDs(TreeScope&, const AtomString& resourceID, const SVGQualifiedNames& tagNames);
@@ -112,9 +98,6 @@ private:
         WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> targetElement;
     };
     MemoryCompactRobinHoodHashMap<AtomString, ClientEntry> m_elementClients;
-
-    SingleThreadWeakPtr<RenderSVGResourcePaintServer> m_cachedFillPaintServer;
-    SingleThreadWeakPtr<RenderSVGResourcePaintServer> m_cachedStrokePaintServer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -56,6 +56,7 @@
 #include "SVGGraphicsElement.h"
 #include "SVGMarkerElement.h"
 #include "SVGMaskElement.h"
+#include "SVGPaintServerCacheInlines.h"
 #include "SVGTextElement.h"
 #include "SVGURIReference.h"
 #include "Settings.h"
@@ -69,6 +70,7 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderLayerModelObject);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGPaintServerCache);
 
 bool RenderLayerModelObject::s_wasFloating = false;
 bool RenderLayerModelObject::s_hadLayer = false;
@@ -659,11 +661,10 @@ RenderSVGResourcePaintServer* RenderLayerModelObject::svgPaintServerResourceFrom
         return nullptr;
 
     // Only the renderer's own style is cached. A foreign style from the text selection or
-    // decoration painters resolves fresh. The cache lives on ReferencedSVGResources, which exists
-    // whenever this renderer references a paint server.
-    CheckedPtr resources = &style == &this->style() ? referencedSVGResources() : nullptr;
-    if (resources) {
-        if (auto* cached = paintType == SVGPaintType::Fill ? resources->cachedFillPaintServer() : resources->cachedStrokePaintServer())
+    // decoration painters resolves fresh.
+    CheckedPtr cache = &style == &this->style() ? svgPaintServerCache() : nullptr;
+    if (cache) {
+        if (auto* cached = cache->paintServer(paintType))
             return cached;
     }
 
@@ -671,16 +672,26 @@ RenderSVGResourcePaintServer* RenderLayerModelObject::svgPaintServerResourceFrom
     if (!paintURL)
         return nullptr;
 
+    // A paint server in an external document yields an empty fragment identifier here, since the
+    // URL does not match this document's. Such a reference registers no CSSSVGResourceElementClient,
+    // and that client is what drops the cache when the referenced element changes, so it has to
+    // resolve fresh every time.
+    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(*paintURL, protect(document()));
+    if (resourceID.isEmpty())
+        cache = nullptr;
+
     if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), *paintURL)) {
         if (auto* referencedPaintServerRenderer = dynamicDowncast<RenderSVGResourcePaintServer>(referencedElement->renderer())) {
-            if (resources)
-                resources->setCachedPaintServer(paintType, *referencedPaintServerRenderer);
+            if (cache)
+                cache->setPaintServer(paintType, *referencedPaintServerRenderer);
             return referencedPaintServerRenderer;
         }
     }
 
-    if (RefPtr element = this->element())
-        document().addPendingSVGResource(AtomString(paintURL->resolved.string()), downcast<SVGElement>(*element));
+    if (!resourceID.isEmpty()) {
+        if (RefPtr element = dynamicDowncast<SVGElement>(this->element()))
+            treeScopeForSVGReferences().addPendingSVGResource(resourceID, *element);
+    }
 
     return nullptr;
 }
@@ -697,8 +708,8 @@ RenderSVGResourcePaintServer* RenderLayerModelObject::svgStrokePaintServerResour
 
 void RenderLayerModelObject::invalidateSVGPaintServerCache() const
 {
-    if (CheckedPtr resources = referencedSVGResources())
-        resources->invalidatePaintServerCache();
+    if (CheckedPtr cache = svgPaintServerCache())
+        cache->clear();
 }
 
 LegacyRenderSVGResourceClipper* RenderLayerModelObject::legacySVGClipperResourceFromStyle() const

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -40,6 +40,8 @@ class RenderSVGResourceMarker;
 class RenderSVGResourceMasker;
 class RenderSVGResourcePaintServer;
 class SVGGraphicsElement;
+class SVGPaintServerCache;
+enum class SVGPaintType : bool;
 
 namespace Style {
 struct SVGMarkerResource;
@@ -58,8 +60,6 @@ enum class ContentChangeType : uint8_t {
     FullScreen,
     Model
 };
-
-enum class SVGPaintType : bool { Fill, Stroke };
 
 class RenderLayerModelObject : public RenderElement {
     WTF_MAKE_TZONE_ALLOCATED(RenderLayerModelObject);
@@ -190,6 +190,8 @@ private:
     RenderSVGResourceMarker* svgMarkerResourceFromStyle(const Style::SVGMarkerResource&) const;
 
     RenderSVGResourcePaintServer* svgPaintServerResourceFromStyle(const Style::SVGPaint&, const Style::ComputedStyle&, SVGPaintType) const;
+
+    virtual SVGPaintServerCache* svgPaintServerCache() const { return nullptr; }
 
     UniquelyOwnedPtr<RenderLayer> m_layer;
 

--- a/Source/WebCore/rendering/svg/RenderSVGInline.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "RenderInline.h"
+#include "SVGPaintServerCache.h"
 
 namespace WebCore {
 
@@ -74,6 +75,10 @@ private:
 
     void willBeDestroyed() final;
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) final;
+
+    SVGPaintServerCache* svgPaintServerCache() const final { return &m_svgPaintServerCache; }
+
+    mutable SVGPaintServerCache m_svgPaintServerCache;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -32,6 +32,7 @@
 #include "SVGBoundingBoxComputation.h"
 #include "SVGGraphicsElement.h"
 #include "SVGMarkerData.h"
+#include "SVGPaintServerCache.h"
 #include <memory>
 #include <wtf/Vector.h>
 
@@ -143,6 +144,9 @@ private:
     void fillShape(const Style::ComputedStyle&, GraphicsContext&);
     void strokeShape(const Style::ComputedStyle&, GraphicsContext&);
     void fillStrokeMarkers(PaintInfo&);
+
+    SVGPaintServerCache* svgPaintServerCache() const final { return &m_svgPaintServerCache; }
+
     virtual void drawMarkers(PaintInfo&) { }
 
     void styleWillChange(Style::Difference, const Style::ComputedStyle& newStyle) override;
@@ -160,6 +164,7 @@ protected:
     ShapeType m_shapeType : 3 { ShapeType::Empty };
 private:
     std::unique_ptr<Path> m_path;
+    mutable SVGPaintServerCache m_svgPaintServerCache;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -25,6 +25,7 @@
 #include "AffineTransform.h"
 #include "RenderSVGBlock.h"
 #include "SVGBoundingBoxComputation.h"
+#include "SVGPaintServerCache.h"
 #include "SVGTextChunk.h"
 #include "SVGTextLayoutAttributesBuilder.h"
 
@@ -124,6 +125,8 @@ private:
 
     bool NODELETE shouldHandleSubtreeMutations() const;
 
+    SVGPaintServerCache* svgPaintServerCache() const final { return &m_svgPaintServerCache; }
+
     bool m_needsReordering : 1 { false };
     bool m_needsPositioningValuesUpdate : 1 { false };
     bool m_needsTransformUpdate : 1 { true }; // FIXME: [LBSE] Only needed for legacy SVG engine.
@@ -134,6 +137,7 @@ private:
     Vector<SVGTextLayoutAttributes*> m_layoutAttributes;
     FloatRect m_objectBoundingBox;
     mutable std::optional<LayoutRect> m_cachedVisualOverflowRect;
+    mutable SVGPaintServerCache m_svgPaintServerCache;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGPaintServerCache.h
+++ b/Source/WebCore/rendering/svg/SVGPaintServerCache.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class RenderSVGResourcePaintServer;
+
+enum class SVGPaintType : bool { Fill, Stroke };
+
+// Cached fill and stroke paint server resolution, held by the renderers that paint fill and stroke
+// (shapes and SVG text). The weak pointer clears itself if the paint server dies, so a live pointer
+// is a hit and a null one re-resolves. invalidateSVGPaintServerCache() drops it when the fill or
+// stroke style changes, and when the referenced paint server changes.
+class SVGPaintServerCache final : public CanMakeCheckedPtr<SVGPaintServerCache, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
+    WTF_MAKE_TZONE_ALLOCATED(SVGPaintServerCache);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGPaintServerCache);
+public:
+    // Defined in SVGPaintServerCacheInlines.h, they need the complete RenderSVGResourcePaintServer type.
+    inline RenderSVGResourcePaintServer* paintServer(SVGPaintType) const;
+    inline void setPaintServer(SVGPaintType, RenderSVGResourcePaintServer&);
+
+    void clear()
+    {
+        m_fillPaintServer = nullptr;
+        m_strokePaintServer = nullptr;
+    }
+
+private:
+    SingleThreadWeakPtr<RenderSVGResourcePaintServer> m_fillPaintServer;
+    SingleThreadWeakPtr<RenderSVGResourcePaintServer> m_strokePaintServer;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGPaintServerCacheInlines.h
+++ b/Source/WebCore/rendering/svg/SVGPaintServerCacheInlines.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RenderSVGResourcePaintServer.h"
+#include "SVGPaintServerCache.h"
+
+namespace WebCore {
+
+inline RenderSVGResourcePaintServer* SVGPaintServerCache::paintServer(SVGPaintType paintType) const
+{
+    return paintType == SVGPaintType::Fill ? m_fillPaintServer.get() : m_strokePaintServer.get();
+}
+
+inline void SVGPaintServerCache::setPaintServer(SVGPaintType paintType, RenderSVGResourcePaintServer& paintServer)
+{
+    if (paintType == SVGPaintType::Fill)
+        m_fillPaintServer = paintServer;
+    else
+        m_strokePaintServer = paintServer;
+}
+
+} // namespace WebCore


### PR DESCRIPTION
#### 05449891110d798e44001fd9078b35eaf1491798
<pre>
[LBSE] Cache the SVG fill and stroke paint server on the renderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=321404">https://bugs.webkit.org/show_bug.cgi?id=321404</a>

Reviewed by Simon Fraser.

Resolving fill and stroke was cached on ReferencedSVGResources, which lives in
RenderElement&apos;s rare data, so every fill and every stroke paid the cost of a
rare data hash map lookup to reach the cache. Move the two cached weak pointers
into the new SVGPaintServerCache class, held by the renderers that paint fill
and stroke: RenderSVGShape, RenderSVGText and RenderSVGInline. They are reached
through a single new virtual, RenderLayerModelObject::svgPaintServerCache(),
which returns null for every other renderer.

Also fix a shape that references a paint server which does not exist yet. Once
an element finally takes that id, the shape keeps painting unfilled. The shape
registers itself as a pending resource under the full resolved URL, while both
readers look the id up bare, so the shape is neither registered as a client of
the new paint server nor repainted. Register the bare fragment identifier, in
the tree scope the readers use.

Covered by existing tests + a new reftest. Small win in LBSE Suits performance.

* LayoutTests/svg/repaint/pending-fill-paint-server-repaint-expected.txt: Added.
* LayoutTests/svg/repaint/pending-fill-paint-server-repaint.html: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::cachedFillPaintServer const): Deleted.
(WebCore::ReferencedSVGResources::cachedStrokePaintServer const): Deleted.
(WebCore::ReferencedSVGResources::setCachedPaintServer): Deleted.
* Source/WebCore/rendering/ReferencedSVGResources.h:
(WebCore::ReferencedSVGResources::invalidatePaintServerCache): Deleted.
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::svgPaintServerResourceFromStyle const):
(WebCore::RenderLayerModelObject::invalidateSVGPaintServerCache const):
* Source/WebCore/rendering/RenderLayerModelObject.h:
(WebCore::RenderLayerModelObject::svgPaintServerCache const):
* Source/WebCore/rendering/svg/RenderSVGInline.h:
* Source/WebCore/rendering/svg/RenderSVGShape.h:
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/SVGPaintServerCache.h: Added.
(WebCore::SVGPaintServerCache::clear):
* Source/WebCore/rendering/svg/SVGPaintServerCacheInlines.h: Added.
(WebCore::SVGPaintServerCache::paintServer const):
(WebCore::SVGPaintServerCache::setPaintServer):

Canonical link: <a href="https://commits.webkit.org/318882@main">https://commits.webkit.org/318882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24e66639a14ff742b4bc61af6a0b8bb9822e37f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140243 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120694 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40502 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1075 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191843 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149522 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40051 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54079 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149256 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43910 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126351 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121383 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52596 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15491 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51981 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52222 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->