### PR TITLE
[JSC][Temporal] Decide duration rounding on exact integers, not doubles

### DIFF
--- a/JSTests/stress/temporal-duration-round-day-exact.js
+++ b/JSTests/stress/temporal-duration-round-day-exact.js
@@ -1,0 +1,57 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${String(expected)} but got ${String(actual)}`);
+}
+
+// One nanosecond past 255 days must round up under ceil and expand, and stay put under trunc/floor.
+{
+    const justOver = Temporal.Duration.from({ days: 255, nanoseconds: 1 });
+    shouldBe(justOver.round({ smallestUnit: 'day', roundingMode: 'ceil' }).toString(), 'P256D');
+    shouldBe(justOver.round({ smallestUnit: 'day', roundingMode: 'expand' }).toString(), 'P256D');
+    shouldBe(justOver.round({ smallestUnit: 'day', roundingMode: 'trunc' }).toString(), 'P255D');
+    shouldBe(justOver.round({ smallestUnit: 'day', roundingMode: 'floor' }).toString(), 'P255D');
+}
+
+// One nanosecond short of 255 days must round down under floor and trunc, and up under ceil.
+{
+    const justUnder = Temporal.Duration.from({ days: 254, hours: 23, minutes: 59, seconds: 59, milliseconds: 999, microseconds: 999, nanoseconds: 999 });
+    shouldBe(justUnder.round({ smallestUnit: 'day', roundingMode: 'floor' }).toString(), 'P254D');
+    shouldBe(justUnder.round({ smallestUnit: 'day', roundingMode: 'trunc' }).toString(), 'P254D');
+    shouldBe(justUnder.round({ smallestUnit: 'day', roundingMode: 'ceil' }).toString(), 'P255D');
+}
+
+// One nanosecond below the exact midpoint must round down, not up. total() legitimately reports
+// 255.5 here because the nearest double to the exact value is 255.5; the rounding decision must not
+// be taken from it.
+{
+    const justBelowHalf = Temporal.Duration.from({ days: 255, hours: 11, minutes: 59, seconds: 59, milliseconds: 999, microseconds: 999, nanoseconds: 999 });
+    shouldBe(justBelowHalf.round({ smallestUnit: 'day' }).toString(), 'P255D');
+    shouldBe(justBelowHalf.round({ smallestUnit: 'day', roundingMode: 'halfExpand' }).toString(), 'P255D');
+    shouldBe(justBelowHalf.total({ unit: 'day' }), 255.5);
+}
+
+// An exact midpoint still breaks the tie by mode.
+{
+    const exactlyHalf = Temporal.Duration.from({ days: 255, hours: 12 });
+    shouldBe(exactlyHalf.round({ smallestUnit: 'day', roundingMode: 'halfExpand' }).toString(), 'P256D');
+    shouldBe(exactlyHalf.round({ smallestUnit: 'day', roundingMode: 'halfTrunc' }).toString(), 'P255D');
+    shouldBe(exactlyHalf.round({ smallestUnit: 'day', roundingMode: 'halfEven' }).toString(), 'P256D');
+}
+
+// Negative durations round away from zero under expand and toward it under trunc.
+{
+    const negative = Temporal.Duration.from({ days: -255, nanoseconds: -1 });
+    shouldBe(negative.round({ smallestUnit: 'day', roundingMode: 'expand' }).toString(), '-P256D');
+    shouldBe(negative.round({ smallestUnit: 'day', roundingMode: 'trunc' }).toString(), '-P255D');
+    shouldBe(negative.round({ smallestUnit: 'day', roundingMode: 'floor' }).toString(), '-P256D');
+    shouldBe(negative.round({ smallestUnit: 'day', roundingMode: 'ceil' }).toString(), '-P255D');
+}
+
+// A rounding increment greater than one still divides evenly into the day span.
+{
+    const d = Temporal.Duration.from({ days: 255, nanoseconds: 1 });
+    shouldBe(d.round({ smallestUnit: 'day', roundingIncrement: 2, roundingMode: 'ceil' }).toString(), 'P256D');
+    shouldBe(d.round({ smallestUnit: 'day', roundingIncrement: 2, roundingMode: 'trunc' }).toString(), 'P254D');
+}

--- a/JSTests/stress/temporal-nudge-to-calendar-unit-exact-total.js
+++ b/JSTests/stress/temporal-nudge-to-calendar-unit-exact-total.js
@@ -1,0 +1,43 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${String(expected)} but got ${String(actual)}`);
+}
+
+// One nanosecond past a whole number of calendar units must still round away from zero.
+{
+    const origin = Temporal.PlainDateTime.from('2000-01-01T00:00:00');
+
+    shouldBe(origin.until('2008-05-01T00:00:00.000000001', { smallestUnit: 'month', largestUnit: 'month', roundingMode: 'ceil' }).toString(), 'P101M');
+    shouldBe(origin.until('2008-05-01T00:00:00.000000001', { smallestUnit: 'month', largestUnit: 'month', roundingMode: 'expand' }).toString(), 'P101M');
+    shouldBe(origin.until('2100-01-01T00:00:00.000000001', { smallestUnit: 'year', largestUnit: 'year', roundingMode: 'ceil' }).toString(), 'P101Y');
+    shouldBe(origin.until('2008-05-01T00:00:00.000000001', { smallestUnit: 'month', largestUnit: 'month', roundingMode: 'trunc' }).toString(), 'P100M');
+    shouldBe(origin.until('2008-05-01T00:00:00.000000001', { smallestUnit: 'month', largestUnit: 'month', roundingMode: 'floor' }).toString(), 'P100M');
+
+    shouldBe(Temporal.ZonedDateTime.from('2000-01-01T00:00:00[UTC]')
+        .until('2005-06-01T00:00:00.000000001[UTC]', { smallestUnit: 'day', roundingMode: 'ceil' }).toString(), 'P1979D');
+
+    shouldBe(Temporal.Duration.from({ months: 100, nanoseconds: 1 })
+        .round({ smallestUnit: 'month', largestUnit: 'month', relativeTo: '2000-01-01T00:00:00', roundingMode: 'ceil' }).toString(), 'P101M');
+
+    // Exactly on a unit boundary must not be nudged outward by any mode.
+    shouldBe(origin.until('2008-05-01T00:00:00', { smallestUnit: 'month', largestUnit: 'month', roundingMode: 'ceil' }).toString(), 'P100M');
+    shouldBe(origin.until('2100-01-01T00:00:00', { smallestUnit: 'year', largestUnit: 'year', roundingMode: 'expand' }).toString(), 'P100Y');
+}
+
+// A one-nanosecond shortfall on either side of the midpoint must break the tie the right way, which
+// requires resolving below one ULP of the double total.
+{
+    const origin = Temporal.PlainDateTime.from('2000-01-01T00:00:00');
+    shouldBe(origin.until('2008-05-16T11:59:59.999999999', { smallestUnit: 'month', largestUnit: 'month', roundingMode: 'halfExpand' }).toString(), 'P100M');
+}
+
+// halfEven's cardinality is (r1 / (r2 - r1)) modulo 2, so it depends on the rounding increment and
+// not on r1 alone. Exercise an increment greater than one.
+{
+    const origin = Temporal.PlainDateTime.from('2000-01-01T00:00:00');
+    shouldBe(origin.until('2000-04-01T00:00:00.000000001', { smallestUnit: 'month', largestUnit: 'month', roundingIncrement: 2, roundingMode: 'ceil' }).toString(), 'P4M');
+    shouldBe(origin.until('2000-03-01T00:00:00', { smallestUnit: 'month', largestUnit: 'month', roundingIncrement: 2, roundingMode: 'ceil' }).toString(), 'P2M');
+    shouldBe(origin.until('2000-03-01T00:00:00.000000001', { smallestUnit: 'month', largestUnit: 'month', roundingIncrement: 2, roundingMode: 'ceil' }).toString(), 'P4M');
+}

--- a/JSTests/stress/temporal-nudge-to-day-or-time-exact-whole-days.js
+++ b/JSTests/stress/temporal-nudge-to-day-or-time-exact-whole-days.js
@@ -1,0 +1,44 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${String(expected)} but got ${String(actual)}`);
+}
+
+// didExpandDays must stay false when rounding moves the time within a single day.
+{
+    const start = Temporal.PlainDateTime.from('2000-01-31T00:00');
+    const end = Temporal.PlainDateTime.from('2000-02-29T00:01');
+
+    shouldBe(start.until(end, { largestUnit: 'month', smallestUnit: 'hour', roundingMode: 'ceil' }).toString(), 'P29DT1H');
+    shouldBe(start.until(end, { largestUnit: 'month', smallestUnit: 'hour', roundingIncrement: 2, roundingMode: 'expand' }).toString(), 'P29DT2H');
+    shouldBe(start.since(end, { largestUnit: 'month', smallestUnit: 'hour', roundingMode: 'floor' }).toString(), '-P29DT1H');
+    shouldBe(start.withCalendar('gregory').until(end.withCalendar('gregory'), { largestUnit: 'month', smallestUnit: 'hour', roundingMode: 'ceil' }).toString(), 'P29DT1H');
+
+    shouldBe(Temporal.PlainDateTime.from('1999-12-31T23:30').until('2000-02-29T23:59:59.999999999', { largestUnit: 'year', smallestUnit: 'minute', roundingIncrement: 2, roundingMode: 'halfExpand' }).toString(), 'P1M29DT30M');
+    shouldBe(Temporal.PlainDateTime.from('1999-01-31T00:00').until('1999-02-28T00:00:01', { largestUnit: 'month', smallestUnit: 'second', roundingIncrement: 30, roundingMode: 'expand' }).toString(), 'P28DT30S');
+
+    shouldBe(new Temporal.Duration(0, 0, 0, 29, 0, 1).round({ relativeTo: '2000-01-31', largestUnit: 'month', smallestUnit: 'hour', roundingMode: 'ceil' }).toString(), 'P29DT1H');
+    shouldBe(new Temporal.Duration(0, 0, 0, 29, 0, 1).round({ relativeTo: '2000-01-31T00:00', largestUnit: 'year', smallestUnit: 'hour', roundingMode: 'expand' }).toString(), 'P29DT1H');
+
+    // A date largestUnit never reaches the bubble, and a smallestUnit that needs no rounding
+    // leaves the time duration untouched. Both were already correct.
+    shouldBe(start.until(end, { largestUnit: 'day', smallestUnit: 'hour', roundingMode: 'ceil' }).toString(), 'P29DT1H');
+    shouldBe(start.until(end, { largestUnit: 'week', smallestUnit: 'hour', roundingMode: 'ceil' }).toString(), 'P4W1DT1H');
+    shouldBe(start.until(end, { largestUnit: 'month', smallestUnit: 'minute', roundingMode: 'ceil' }).toString(), 'P29DT1M');
+}
+
+// The whole-day count must be exact. At microsecond granularity a double stops resolving one
+// microsecond in a day once the day count reaches 2^17, so 131072 days used to throw.
+{
+    const origin = Temporal.PlainDateTime.from('1970-01-01T00:00:00');
+    const options = { smallestUnit: 'microsecond', largestUnit: 'day', roundingMode: 'trunc' };
+
+    shouldBe(origin.until('2328-11-11T23:59:59.999999', options).toString(), 'P131071DT23H59M59.999999S');
+    shouldBe(origin.until('2328-11-12T23:59:59.999999', options).toString(), 'P131072DT23H59M59.999999S');
+    shouldBe(origin.until('2328-11-13T23:59:59.999999', options).toString(), 'P131073DT23H59M59.999999S');
+
+    shouldBe(Temporal.Duration.from({ days: 131072, hours: 23, minutes: 59, seconds: 59, milliseconds: 999, microseconds: 999 })
+        .round({ smallestUnit: 'microsecond', largestUnit: 'day', relativeTo: '1970-01-01', roundingMode: 'trunc' }).toString(),
+        'P131072DT23H59M59.999999S');
+}

--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -731,16 +731,16 @@ static void testISOTimeCompare()
 static void testApplyUnsignedRoundingMode()
 {
     // x between r1 and r2 — direction modes
-    TCHECK_EQ(applyUnsignedRoundingMode(1.3, 1.0, 2.0, UnsignedRoundingMode::Zero), 1.0, "applyURM: 1.3 Zero");
-    TCHECK_EQ(applyUnsignedRoundingMode(1.3, 1.0, 2.0, UnsignedRoundingMode::Infinity), 2.0, "applyURM: 1.3 Inf");
+    TCHECK_EQ(applyUnsignedRoundingMode(Int128(13), Int128(10), Int128(1), Int128(2), UnsignedRoundingMode::Zero), Int128(1), "applyURM: 13/10 Zero");
+    TCHECK_EQ(applyUnsignedRoundingMode(Int128(13), Int128(10), Int128(1), Int128(2), UnsignedRoundingMode::Infinity), Int128(2), "applyURM: 13/10 Inf");
     // x == r1 (exact lower bound)
-    TCHECK_EQ(applyUnsignedRoundingMode(1.0, 1.0, 2.0, UnsignedRoundingMode::Zero), 1.0, "applyURM: exact=r1");
+    TCHECK_EQ(applyUnsignedRoundingMode(Int128(10), Int128(10), Int128(1), Int128(2), UnsignedRoundingMode::Zero), Int128(1), "applyURM: exact=r1");
     // HalfZero at midpoint
-    TCHECK_EQ(applyUnsignedRoundingMode(1.5, 1.0, 2.0, UnsignedRoundingMode::HalfZero), 1.0, "applyURM: 1.5 HalfZero");
-    TCHECK_EQ(applyUnsignedRoundingMode(1.5, 1.0, 2.0, UnsignedRoundingMode::HalfInfinity), 2.0, "applyURM: 1.5 HalfInf");
+    TCHECK_EQ(applyUnsignedRoundingMode(Int128(3), Int128(2), Int128(1), Int128(2), UnsignedRoundingMode::HalfZero), Int128(1), "applyURM: 3/2 HalfZero");
+    TCHECK_EQ(applyUnsignedRoundingMode(Int128(3), Int128(2), Int128(1), Int128(2), UnsignedRoundingMode::HalfInfinity), Int128(2), "applyURM: 3/2 HalfInf");
     // HalfEven: 2.5 -> 2 (even lower), 3.5 -> 4 (even upper)
-    TCHECK_EQ(applyUnsignedRoundingMode(2.5, 2.0, 3.0, UnsignedRoundingMode::HalfEven), 2.0, "applyURM: 2.5 HalfEven->2");
-    TCHECK_EQ(applyUnsignedRoundingMode(3.5, 3.0, 4.0, UnsignedRoundingMode::HalfEven), 4.0, "applyURM: 3.5 HalfEven->4");
+    TCHECK_EQ(applyUnsignedRoundingMode(Int128(5), Int128(2), Int128(2), Int128(3), UnsignedRoundingMode::HalfEven), Int128(2), "applyURM: 5/2 HalfEven->2");
+    TCHECK_EQ(applyUnsignedRoundingMode(Int128(7), Int128(2), Int128(3), Int128(4), UnsignedRoundingMode::HalfEven), Int128(4), "applyURM: 7/2 HalfEven->4");
 }
 
 static void testNegateDuration()

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -622,10 +622,15 @@ ISO8601::InternalDuration TemporalDuration::round(JSGlobalObject* globalObject, 
 
     // Step 32: smallestUnit is ~day~.
     if (unit == TemporalUnit::Day) {
-        double fractionalDays = TemporalCore::totalTimeDuration(internalDuration.time(), TemporalUnit::Day);
-        double days = TemporalCore::roundNumberToIncrementDouble(fractionalDays, increment, mode);
+        // Steps 32.a-b, on the exact rational: past 128 days one ULP of a double day count exceeds
+        // 1ns expressed in days, so materializing fractionalDays moves the value before rounding.
+        Int128 fractionalDaysNumerator = internalDuration.time();
+        Int128 fractionalDaysDenominator = ISO8601::ExactTime::nsPerDay;
+        Int128 roundingIncrementNs = fractionalDaysDenominator * static_cast<Int128>(std::trunc(increment));
+        Int128 roundedNs = TemporalCore::roundNumberToIncrementInt128(fractionalDaysNumerator, roundingIncrementNs, mode);
+        // Steps 32.c-d: the day-range check is enforced by TemporalDurationFromInternal below.
         return ISO8601::InternalDuration::combineDateAndTimeDuration(
-            ISO8601::Duration { 0LL, 0LL, 0LL, static_cast<int64_t>(days), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0) },
+            ISO8601::Duration { 0LL, 0LL, 0LL, static_cast<int64_t>(roundedNs / fractionalDaysDenominator), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0) },
             0);
     }
 

--- a/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
@@ -430,8 +430,8 @@ TemporalResult<ISO8601::Duration> adjustDateDurationRecord(const ISO8601::Durati
 
 // NudgeWindow — internal; holds the floor/ceiling epoch-ns bounds and durations for a single calendar nudge step.
 struct NudgeWindow {
-    double r1;
-    double r2;
+    int64_t r1;
+    int64_t r2;
     Int128 startEpochNs;
     Int128 endEpochNs;
     ISO8601::Duration startDuration;
@@ -447,7 +447,8 @@ static TemporalResult<std::optional<NudgeWindow>> computeNudgeWindow(
     double increment, TemporalUnit unit, bool additionalShift,
     const TimeZone* timeZone = nullptr, CalendarID calendarId = iso8601CalendarID())
 {
-    double r1 = 0, r2 = 0;
+    int64_t r1 = 0, r2 = 0;
+    int64_t shift = static_cast<int64_t>(increment) * sign;
     ISO8601::Duration startDuration, endDuration;
     // Steps 1-4: compute r1, r2, startDuration, endDuration based on unit.
     switch (unit) {
@@ -455,29 +456,29 @@ static TemporalResult<std::optional<NudgeWindow>> computeNudgeWindow(
         // Step 1.a: years = RoundNumberToIncrement(duration.[[Date]].[[Years]], increment, trunc).
         Int128 years = roundNumberToIncrementInt128((Int128)duration.dateDuration().years(), (Int128)increment, RoundingMode::Trunc);
         // Step 1.b-c: r1 = years; or if additionalShift, r1 = years + increment × sign.
-        r1 = additionalShift ? (double)years + increment * sign : (double)years;
+        r1 = static_cast<int64_t>(years) + (additionalShift ? shift : 0);
         // Step 1.d: r2 = r1 + increment × sign.
-        r2 = r1 + increment * sign;
+        r2 = r1 + shift;
         // Step 1.e: startDuration = CreateDateDurationRecord(r1, 0, 0, 0).
-        startDuration = ISO8601::Duration { static_cast<int64_t>(r1), 0, 0, 0, 0, 0, 0, 0, Int128(0), Int128(0) };
+        startDuration = ISO8601::Duration { r1, 0, 0, 0, 0, 0, 0, 0, Int128(0), Int128(0) };
         // Step 1.f: endDuration = CreateDateDurationRecord(r2, 0, 0, 0).
-        endDuration = ISO8601::Duration { static_cast<int64_t>(r2), 0, 0, 0, 0, 0, 0, 0, Int128(0), Int128(0) };
+        endDuration = ISO8601::Duration { r2, 0, 0, 0, 0, 0, 0, 0, Int128(0), Int128(0) };
         break;
     }
     case TemporalUnit::Month: {
         // Step 2.a: months = RoundNumberToIncrement(duration.[[Date]].[[Months]], increment, trunc).
         Int128 months = roundNumberToIncrementInt128((Int128)duration.dateDuration().months(), (Int128)increment, RoundingMode::Trunc);
         // Step 2.b-c: r1 = months; or if additionalShift, r1 = months + increment × sign.
-        r1 = additionalShift ? (double)months + increment * sign : (double)months;
+        r1 = static_cast<int64_t>(months) + (additionalShift ? shift : 0);
         // Step 2.d: r2 = r1 + increment × sign.
-        r2 = r1 + increment * sign;
+        r2 = r1 + shift;
         // Step 2.e: startDuration = AdjustDateDurationRecord(duration.[[Date]], 0, 0, r1).
-        auto sd = adjustDateDurationRecord(duration.dateDuration(), 0, 0, static_cast<int64_t>(r1));
+        auto sd = adjustDateDurationRecord(duration.dateDuration(), 0, 0, r1);
         if (!sd)
             return makeUnexpected(sd.error());
         startDuration = *sd;
         // Step 2.f: endDuration = AdjustDateDurationRecord(duration.[[Date]], 0, 0, r2).
-        auto ed = adjustDateDurationRecord(duration.dateDuration(), 0, 0, static_cast<int64_t>(r2));
+        auto ed = adjustDateDurationRecord(duration.dateDuration(), 0, 0, r2);
         if (!ed)
             return makeUnexpected(ed.error());
         endDuration = *ed;
@@ -502,15 +503,15 @@ static TemporalResult<std::optional<NudgeWindow>> computeNudgeWindow(
         // Step 3.e: weeks = RoundNumberToIncrement(duration.[[Date]].[[Weeks]] + untilResult.[[Weeks]], increment, trunc).
         Int128 weeks = roundNumberToIncrementInt128((Int128)(duration.dateDuration().weeks() + untilResult->weeks()), (Int128)increment, RoundingMode::Trunc);
         // Step 3.f: r1 = weeks. Step 3.g: r2 = weeks + increment × sign.
-        r1 = (double)weeks;
-        r2 = (double)weeks + increment * sign;
+        r1 = static_cast<int64_t>(weeks);
+        r2 = r1 + shift;
         // Step 3.h: startDuration = AdjustDateDurationRecord(duration.[[Date]], 0, r1).
-        auto sd = adjustDateDurationRecord(duration.dateDuration(), 0, static_cast<int64_t>(r1), std::nullopt);
+        auto sd = adjustDateDurationRecord(duration.dateDuration(), 0, r1, std::nullopt);
         if (!sd)
             return makeUnexpected(sd.error());
         startDuration = *sd;
         // Step 3.i: endDuration = AdjustDateDurationRecord(duration.[[Date]], 0, r2).
-        auto ed = adjustDateDurationRecord(duration.dateDuration(), 0, static_cast<int64_t>(r2), std::nullopt);
+        auto ed = adjustDateDurationRecord(duration.dateDuration(), 0, r2, std::nullopt);
         if (!ed)
             return makeUnexpected(ed.error());
         endDuration = *ed;
@@ -522,15 +523,15 @@ static TemporalResult<std::optional<NudgeWindow>> computeNudgeWindow(
         // Step 4.b: days = RoundNumberToIncrement(duration.[[Date]].[[Days]], increment, trunc).
         Int128 days = roundNumberToIncrementInt128((Int128)duration.dateDuration().days(), (Int128)increment, RoundingMode::Trunc);
         // Step 4.c: r1 = days. Step 4.d: r2 = days + increment × sign.
-        r1 = (double)days;
-        r2 = (double)days + increment * sign;
+        r1 = static_cast<int64_t>(days);
+        r2 = r1 + shift;
         // Step 4.e: startDuration = AdjustDateDurationRecord(duration.[[Date]], r1).
-        auto sd = adjustDateDurationRecord(duration.dateDuration(), static_cast<int64_t>(r1), std::nullopt, std::nullopt);
+        auto sd = adjustDateDurationRecord(duration.dateDuration(), r1, std::nullopt, std::nullopt);
         if (!sd)
             return makeUnexpected(sd.error());
         startDuration = *sd;
         // Step 4.f: endDuration = AdjustDateDurationRecord(duration.[[Date]], r2).
-        auto ed = adjustDateDurationRecord(duration.dateDuration(), static_cast<int64_t>(r2), std::nullopt, std::nullopt);
+        auto ed = adjustDateDurationRecord(duration.dateDuration(), r2, std::nullopt, std::nullopt);
         if (!ed)
             return makeUnexpected(ed.error());
         endDuration = *ed;
@@ -610,7 +611,7 @@ TemporalResult<Nudged> nudgeToCalendarUnit(int32_t sign,
             return makeUnexpected(retried.error());
         ASSERT(retried->has_value());
         nudgeWindow = **retried;
-        // Step 5.a.ii / 6.a.ii: Set didExpandCalendarUnit to true. (The spec also asserts bounds
+        // Step 5.a.iii / 6.a.iii: Set didExpandCalendarUnit to true. (The spec also asserts bounds
         // hold after retry, but the assertion is violable: https://github.com/tc39/proposal-temporal/issues/3310)
         didExpandCalendarUnit = true;
     }
@@ -628,27 +629,29 @@ TemporalResult<Nudged> nudgeToCalendarUnit(int32_t sign,
     Int128 progressDenominator = nudgeWindow.endEpochNs - nudgeWindow.startEpochNs;
     // Step 15: Let total be r1 + progress × increment × sign.
     // (NOTE: computed via integer arithmetic before the final float division per spec note.)
-    Int128 totalNumerator = Int128(static_cast<int64_t>(nudgeWindow.r1)) * progressDenominator + progressNumerator * Int128(static_cast<int64_t>(increment)) * Int128(sign);
+    Int128 totalNumerator = Int128(nudgeWindow.r1) * progressDenominator + progressNumerator * Int128(static_cast<int64_t>(increment)) * Int128(sign);
     double total = fractionToDouble(totalNumerator, absInt128(progressDenominator)) * (progressDenominator < 0 ? -1.0 : 1.0);
     Int128 progress = progressNumerator / progressDenominator;
-    // Step 16: Assert: 0 ≤ progress ≤ 1.
+    // Step 17: Assert: 0 ≤ progress ≤ 1.
     ASSERT(0 <= progress && progress <= 1);
-    // Step 17: Let unsignedRoundingMode be GetUnsignedRoundingMode(roundingMode, isNegative).
+    // Steps 18-19: isNegative, then unsignedRoundingMode = GetUnsignedRoundingMode(roundingMode, isNegative).
     UnsignedRoundingMode unsignedRoundingMode = getUnsignedRoundingMode(roundingMode, sign < 0);
-    // Step 18-19: If progress = 1, roundedUnit = abs(r2); else apply unsigned rounding.
-    double roundedUnit = std::abs(nudgeWindow.r2);
-    if (progress != 1) {
-        ASSERT(std::abs(nudgeWindow.r1) <= std::abs(total) && std::abs(total) < std::abs(nudgeWindow.r2));
-        roundedUnit = applyUnsignedRoundingMode(std::abs(total), std::abs(nudgeWindow.r1), std::abs(nudgeWindow.r2), unsignedRoundingMode);
-    }
-    // Step 20: If roundedUnit = abs(r2), set didExpandCalendarUnit to true and use endDuration/endEpochNs; else use start.
-    didExpandCalendarUnit |= (roundedUnit == std::abs(nudgeWindow.r2));
-    ISO8601::Duration resultDuration = (roundedUnit == std::abs(nudgeWindow.r2)) ? endDuration : startDuration;
-    Int128 nudgedEpochNs = (roundedUnit == std::abs(nudgeWindow.r2)) ? nudgeWindow.endEpochNs : nudgeWindow.startEpochNs;
-    // Step 21: Let nudgeResult be Duration Nudge Result Record { [[Duration]]: resultDuration, [[NudgedEpochNs]]: nudgedEpochNs, [[DidExpandCalendarUnit]]: didExpandCalendarUnit }.
+    // Steps 20-21: If progress = 1, roundedUnit = abs(r2); else apply unsigned rounding.
+    // Passes the exact rational rather than the `total` double computed above, because
+    // ApplyUnsignedRoundingMode compares for exact equality.
+    Int128 absR1 = absInt128(Int128(nudgeWindow.r1));
+    Int128 absR2 = absInt128(Int128(nudgeWindow.r2));
+    bool roundedToR2 = true;
+    if (progress != 1)
+        roundedToR2 = applyUnsignedRoundingMode(absInt128(totalNumerator), absInt128(progressDenominator), absR1, absR2, unsignedRoundingMode) == absR2;
+    // Steps 22-23: If roundedUnit = abs(r2), set didExpandCalendarUnit and use endDuration/endEpochNs; else start.
+    didExpandCalendarUnit |= roundedToR2;
+    ISO8601::Duration resultDuration = roundedToR2 ? endDuration : startDuration;
+    Int128 nudgedEpochNs = roundedToR2 ? nudgeWindow.endEpochNs : nudgeWindow.startEpochNs;
+    // Step 24: Let nudgeResult be Duration Nudge Result Record { [[Duration]]: resultDuration, [[NudgedEpochNs]]: nudgedEpochNs, [[DidExpandCalendarUnit]]: didExpandCalendarUnit }.
     // (computeNudgeWindow steps 13-14 deferred here: CombineDateAndTimeDuration applied only to the selected path.)
     auto resultDurationInternal = ISO8601::InternalDuration::combineDateAndTimeDuration(resultDuration, 0);
-    // Step 22: Return the Record { [[NudgeResult]]: nudgeResult, [[Total]]: total }.
+    // Step 25: Return the Record { [[NudgeResult]]: nudgeResult, [[Total]]: total }.
     return Nudged(NudgeResult(resultDurationInternal, nudgedEpochNs, didExpandCalendarUnit), total);
 }
 
@@ -734,15 +737,16 @@ TemporalResult<NudgeResult> nudgeToDayOrTime(ISO8601::InternalDuration duration,
     Int128 roundedTime = roundNumberToIncrementInt128(timeDuration, unitLength * (Int128)std::trunc(increment), roundingMode);
     // Step 4: Let diffTime be ! AddTimeDuration(roundedTime, -timeDuration).
     Int128 diffTime = roundedTime - timeDuration;
-    // Step 5: wholeDays = truncate(TotalTimeDuration(timeDuration, day)).
-    // (totalTimeDuration returns int64_t-truncated double, so truncate is implicit.)
-    double wholeDays = totalTimeDuration(timeDuration, TemporalUnit::Day);
-    // Step 6: roundedWholeDays = truncate(TotalTimeDuration(roundedTime, day)). (same)
-    double roundedWholeDays = totalTimeDuration(roundedTime, TemporalUnit::Day);
+    // Steps 5-6: wholeDays/roundedWholeDays = truncate(TotalTimeDuration(..., day)).
+    // Integer division truncates; a double would round, and past 128 days the distinctions steps 7-9
+    // and 13 rest on are below one ULP.
+    Int128 nsPerDay = lengthInNanoseconds(TemporalUnit::Day);
+    Int128 wholeDays = timeDuration / nsPerDay;
+    Int128 roundedWholeDays = roundedTime / nsPerDay;
     // Step 7: Let dayDelta be roundedWholeDays - wholeDays.
-    auto dayDelta = roundedWholeDays - wholeDays;
+    Int128 dayDelta = roundedWholeDays - wholeDays;
     // Step 8: If dayDelta < 0, let dayDeltaSign be -1; else if dayDelta > 0, let dayDeltaSign be 1; else 0.
-    auto dayDeltaSign = dayDelta < 0 ? -1 : dayDelta > 0 ? 1 : 0;
+    int32_t dayDeltaSign = dayDelta < 0 ? -1 : dayDelta > 0 ? 1 : 0;
     // Step 9: If dayDeltaSign = TimeDurationSign(timeDuration), let didExpandDays be true; else false.
     bool didExpandDays = dayDeltaSign == (timeDuration < 0 ? -1 : timeDuration > 0 ? 1 : 0);
     // Step 10: Let nudgedEpochNs be AddTimeDurationToEpochNanoseconds(diffTime, destEpochNs).
@@ -755,8 +759,8 @@ TemporalResult<NudgeResult> nudgeToDayOrTime(ISO8601::InternalDuration duration,
     if (largestUnit <= TemporalUnit::Day) {
         // Step 13.a: Set days to roundedWholeDays.
         days = static_cast<int64_t>(roundedWholeDays);
-        // Step 13.b: remainder = roundedTime - roundedWholeDays×hoursPerDay (days==roundedWholeDays here).
-        remainder = roundedTime + timeDurationFromComponents(-static_cast<double>(days) * WTF::hoursPerDay, 0, 0, 0, 0, 0);
+        // Step 13.b: Set remainder to roundedTime - (roundedWholeDays x nsPerDay).
+        remainder = roundedTime - roundedWholeDays * nsPerDay;
     }
     // Step 14: Let dateDuration be ! AdjustDateDurationRecord(duration.[[Date]], days).
     auto dateDurationResult = adjustDateDurationRecord(duration.dateDuration(), days, std::nullopt, std::nullopt);

--- a/Source/JavaScriptCore/runtime/temporal/core/Rounding.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/Rounding.cpp
@@ -52,32 +52,29 @@ RoundingMode negateTemporalRoundingMode(RoundingMode roundingMode)
 
 // ApplyUnsignedRoundingMode — temporal_rs: apply_unsigned_rounding_mode
 // https://tc39.es/proposal-temporal/#sec-applyunsignedroundingmode
-double applyUnsignedRoundingMode(double x, double r1, double r2, UnsignedRoundingMode unsignedRoundingMode)
+Int128 applyUnsignedRoundingMode(Int128 xNumerator, Int128 xDenominator, Int128 r1, Int128 r2, UnsignedRoundingMode unsignedRoundingMode)
 {
+    ASSERT(xDenominator > 0);
+    Int128 scaledR1 = r1 * xDenominator;
     // 1. If x = r1, return r1.
-    if (x == r1)
+    if (xNumerator == scaledR1)
         return r1;
-    // 2. Assert: r1 < x < r2.
-    ASSERT(r1 < x && x < r2);
-    // 3. Assert: unsignedRoundingMode is not undefined.
+    // 2. Assert: r1 < x < r2. 3. Assert: unsignedRoundingMode is not undefined.
+    ASSERT(scaledR1 < xNumerator && xNumerator < r2 * xDenominator);
     // 4. If unsignedRoundingMode is ~zero~, return r1.
     if (unsignedRoundingMode == UnsignedRoundingMode::Zero)
         return r1;
     // 5. If unsignedRoundingMode is ~infinity~, return r2.
     if (unsignedRoundingMode == UnsignedRoundingMode::Infinity)
         return r2;
-    // 6. Let d1 be x - r1.
-    double d1 = x - r1;
-    // 7. Let d2 be r2 - x.
-    double d2 = r2 - x;
-    // 8. If d1 < d2, return r1.
-    if (d1 < d2)
+    // 6-9. d1 = x - r1, d2 = r2 - x; d1 < d2 iff 2x < r1 + r2.
+    Int128 doubledX = xNumerator * 2;
+    Int128 sumOfBounds = (r1 + r2) * xDenominator;
+    if (doubledX < sumOfBounds)
         return r1;
-    // 9. If d2 < d1, return r2.
-    if (d2 < d1)
+    if (doubledX > sumOfBounds)
         return r2;
     // 10. Assert: d1 is equal to d2.
-    ASSERT(d1 == d2);
     // 11. If unsignedRoundingMode is ~half-zero~, return r1.
     if (unsignedRoundingMode == UnsignedRoundingMode::HalfZero)
         return r1;
@@ -86,38 +83,10 @@ double applyUnsignedRoundingMode(double x, double r1, double r2, UnsignedRoundin
         return r2;
     // 13. Assert: unsignedRoundingMode is ~half-even~.
     ASSERT(unsignedRoundingMode == UnsignedRoundingMode::HalfEven);
-    // 14. Let cardinality be (r1 / (r2 - r1)) modulo 2.
-    auto cardinality = std::fmod(r1 / (r2 - r1), 2);
-    // 15. If cardinality = 0, return r1. 16. Return r2.
-    return !cardinality ? r1 : r2;
+    // 14-16. cardinality = (r1 / (r2 - r1)) modulo 2.
+    return !((r1 / (r2 - r1)) % 2) ? r1 : r2;
 }
 
-// ApplyUnsignedRoundingMode (Int128 path) — integer analogue of the double version above.
-// https://tc39.es/proposal-temporal/#sec-applyunsignedroundingmode
-// cmp: -1 if x is closer to r1, +1 if closer to r2, 0 if exactly at midpoint.
-// Callers handle the exact case (x = r1) before calling this.
-static Int128 applyUnsignedRoundingModeInt128(Int128 r1, Int128 r2, int cmp, UnsignedRoundingMode unsignedRoundingMode)
-{
-    // 4. If unsignedRoundingMode is ~zero~, return r1.
-    if (unsignedRoundingMode == UnsignedRoundingMode::Zero)
-        return r1;
-    // 5. If unsignedRoundingMode is ~infinity~, return r2.
-    if (unsignedRoundingMode == UnsignedRoundingMode::Infinity)
-        return r2;
-    // 8. If d1 < d2, return r1. 9. If d2 < d1, return r2.
-    if (cmp < 0)
-        return r1;
-    if (cmp > 0)
-        return r2;
-    // 11. If unsignedRoundingMode is ~half-zero~, return r1.
-    if (unsignedRoundingMode == UnsignedRoundingMode::HalfZero)
-        return r1;
-    // 12. If unsignedRoundingMode is ~half-infinity~, return r2.
-    if (unsignedRoundingMode == UnsignedRoundingMode::HalfInfinity)
-        return r2;
-    // 13-16. ~half-even~: return r1 if r1 is even, else r2.
-    return !(r1 % 2) ? r1 : r2;
-}
 // MaximumTemporalDurationRoundingIncrement — temporal_rs: Unit::to_maximum_rounding_increment (src/options.rs)
 // https://tc39.es/proposal-temporal/#sec-temporal-maximumtemporaldurationroundingincrement
 std::optional<unsigned> maximumRoundingIncrement(TemporalUnit unit)
@@ -198,11 +167,9 @@ Int128 roundNumberToIncrementAsIfPositive(Int128 x, Int128 increment, RoundingMo
         r1 = quotient - 1;
         r2 = quotient;
     }
-    auto doubleRemainder = absInt128(remainder * 2);
-    int cmp = (doubleRemainder < increment ? -1 : doubleRemainder == increment ? 0 : 1) * (x < 0 ? -1 : 1);
     // 5. Let rounded be ApplyUnsignedRoundingMode(quotient, r1, r2, unsignedRoundingMode).
     // 6. Return rounded × increment.
-    return applyUnsignedRoundingModeInt128(r1, r2, cmp, unsignedRoundingMode) * increment;
+    return applyUnsignedRoundingMode(x, increment, r1, r2, unsignedRoundingMode) * increment;
 }
 
 // RoundNumberToIncrement (Int128 path) — temporal_rs: IncrementRounder<i128>::round (src/rounding.rs)
@@ -222,9 +189,8 @@ Int128 roundNumberToIncrementInt128(Int128 x, Int128 increment, RoundingMode mod
     Int128 r1 = absInt128(quotient);
     // 6. Let r2 be the smallest integer such that r2 > abs(quotient).
     Int128 r2 = r1 + 1;
-    int cmp = absInt128(remainder * 2) < increment ? -1 : absInt128(remainder * 2) > increment ? 1 : 0;
     // 7. Let rounded be ApplyUnsignedRoundingMode(abs(quotient), r1, r2, unsignedRoundingMode).
-    Int128 rounded = applyUnsignedRoundingModeInt128(r1, r2, cmp, unsignedRoundingMode);
+    Int128 rounded = applyUnsignedRoundingMode(absInt128(x), increment, r1, r2, unsignedRoundingMode);
     // 8. If isNegative is ~negative~, set rounded to -rounded.
     if (isNegative)
         rounded = -rounded;

--- a/Source/JavaScriptCore/runtime/temporal/core/Rounding.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/Rounding.h
@@ -41,7 +41,8 @@ namespace TemporalCore {
 
 JS_EXPORT_PRIVATE RoundingMode negateTemporalRoundingMode(RoundingMode);
 
-JS_EXPORT_PRIVATE double applyUnsignedRoundingMode(double x, double r1, double r2, UnsignedRoundingMode);
+
+JS_EXPORT_PRIVATE Int128 applyUnsignedRoundingMode(Int128 xNumerator, Int128 xDenominator, Int128 r1, Int128 r2, UnsignedRoundingMode);
 
 JS_EXPORT_PRIVATE std::optional<unsigned> maximumRoundingIncrement(TemporalUnit);
 


### PR DESCRIPTION
#### 11615f86705a3ca40514087f48cac4c05a3abb0a
<pre>
[JSC][Temporal] Decide duration rounding on exact integers, not doubles
<a href="https://bugs.webkit.org/show_bug.cgi?id=321407">https://bugs.webkit.org/show_bug.cgi?id=321407</a>
<a href="https://rdar.apple.com/184472920">rdar://184472920</a>

Reviewed by Sosuke Suzuki.

Three rounding paths decided on a double that had already lost the distinction the
decision rests on.

    until(&quot;2000-02-29T00:01&quot;, month/hour/ceil)           P1M   -&gt; P29DT1H
    until(&quot;2008-05-01T00:00:00.000000001&quot;, month/ceil)   P100M -&gt; P101M
    {days: 255, nanoseconds: 1} day/ceil                 P255D -&gt; P256D
    254d23:59:59.999999999 day/floor                     P255D -&gt; P254D

NudgeToDayOrTime read its whole-day counts from totalTimeDuration, which rounds rather
than truncates. NudgeToCalendarUnit and Duration.prototype.round&apos;s &apos;day&apos; branch rounded a
double where the spec&apos;s value is exact. All three now decide on Int128.

ApplyUnsignedRoundingMode existed twice, over doubles and over Int128 with a precomputed
comparison, and all three callers implemented steps 1 and 6-10 themselves. It is now one
function taking x as an exact rational. Its half-even branch divided r1 by 2, correct only
when r2 - r1 is 1, and now divides by r2 - r1 per step 14.

Tests: JSTests/stress/temporal-duration-round-day-exact.js
       JSTests/stress/temporal-nudge-to-calendar-unit-exact-total.js
       JSTests/stress/temporal-nudge-to-day-or-time-exact-whole-days.js
       Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp

Canonical link: <a href="https://commits.webkit.org/318901@main">https://commits.webkit.org/318901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d4c8884bfba86cb0d54443a967bc8e4a32f5649

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189577 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144056 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4748ada-9d2d-466b-abf5-cf4e116a2e2f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140202 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/445f8765-ac9c-4f2f-b134-6565e32a00c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120653 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4edbaf63-b024-4861-942b-387c8f0513c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42477 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40798 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2622 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9423 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152878 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40454 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1031 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41020 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191799 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53354 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149480 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54035 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37076 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149214 "Found 1 new API test failure: TestAutomationSession:/webkit/WebKitAutomationSession/request-session (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27304 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43867 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126307 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121326 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52552 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15445 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51937 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52178 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51998 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->