### PR TITLE
[YARR] `tryConsumeBackReference` should restore input position when a surrogate pair read fails in interpreter

### DIFF
--- a/JSTests/stress/regexp-backreference-greedy-non-bmp-capture-restore-pos.js
+++ b/JSTests/stress/regexp-backreference-greedy-non-bmp-capture-restore-pos.js
@@ -1,0 +1,25 @@
+//@ runDefault("--useRegExpJIT=false")
+
+function shouldBe(actual, expected)
+{
+    actual = JSON.stringify(actual);
+    expected = JSON.stringify(expected);
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " (expected " + expected + ")");
+}
+
+// E is a non-BMP code point, so a back reference to a capture containing it
+// reads the input as a surrogate pair. When that read fails mid-way through a
+// greedy back reference iteration, the input position must be restored.
+var E = "\u{1F601}";
+
+shouldBe(new RegExp("(" + E + ")(\\1*)?", "u").exec(E + "\n" + E), [E, E, undefined]);
+shouldBe(new RegExp("(" + E + ")\\1*$", "u").exec(E + "ab"), null);
+shouldBe(new RegExp("(" + E + ")\\1*(a)", "u").exec(E + "xya"), null);
+shouldBe(new RegExp("(" + E + ")\\1+$", "u").exec(E + E + "ab"), null);
+shouldBe(new RegExp("(a" + E + ")\\1*X", "u").exec("a" + E + "abcX"), null);
+shouldBe(new RegExp("(?<n>" + E + ")\\k<n>*$", "u").exec(E + "zz"), null);
+shouldBe(new RegExp("(" + E + ")\\1*$", "v").exec(E + "ab"), null);
+
+shouldBe(new RegExp("(" + E + ")\\1*$", "u").exec(E + E + E), [E + E + E, E]);
+shouldBe(new RegExp("(" + E + ")\\1*(a)", "u").exec(E + E + "a"), [E + E + "a", E, "a"]);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -666,24 +666,20 @@ public:
             } else
                 ch = term.matchDirection() == Forward ? input.readCheckedDontAdvance(negativeInputOffset) : input.tryReadBackward(negativeInputOffset);
 
-            if (oldCh == errorCodePoint || ch == errorCodePoint) {
-                if (term.matchDirection() == Backward)
-                    input.setPos(savedPos);
-                return false;
-            }
-
-            if (oldCh == ch)
-                continue;
-
-            if (term.ignoreCase()) {
-                // See ES 6.0, 21.2.2.8.2 for the definition of Canonicalize(). For non-Unicode
-                // patterns, Unicode values are never allowed to match against ASCII ones.
-                // For Unicode, we need to check all canonical equivalents of a character.
-                if (isLegacyCompilation() && (isASCII(oldCh) || isASCII(ch))) {
-                    if (toASCIIUpper(oldCh) == toASCIIUpper(ch))
-                        continue;
-                } else if (areCanonicallyEquivalent(oldCh, ch, isEitherUnicodeCompilation() ? CanonicalMode::Unicode : CanonicalMode::UCS2))
+            if (oldCh != errorCodePoint && ch != errorCodePoint) {
+                if (oldCh == ch)
                     continue;
+
+                if (term.ignoreCase()) {
+                    // See ES 6.0, 21.2.2.8.2 for the definition of Canonicalize(). For non-Unicode
+                    // patterns, Unicode values are never allowed to match against ASCII ones.
+                    // For Unicode, we need to check all canonical equivalents of a character.
+                    if (isLegacyCompilation() && (isASCII(oldCh) || isASCII(ch))) {
+                        if (toASCIIUpper(oldCh) == toASCIIUpper(ch))
+                            continue;
+                    } else if (areCanonicallyEquivalent(oldCh, ch, isEitherUnicodeCompilation() ? CanonicalMode::Unicode : CanonicalMode::UCS2))
+                        continue;
+                }
             }
 
             if (term.matchDirection() == Forward)


### PR DESCRIPTION
#### 2165451fd3ee573c8dec57c8e05aac5910ffe877
<pre>
[YARR] `tryConsumeBackReference` should restore input position when a surrogate pair read fails in interpreter
<a href="https://bugs.webkit.org/show_bug.cgi?id=321409">https://bugs.webkit.org/show_bug.cgi?id=321409</a>

Reviewed by Yusuke Suzuki.

In tryConsumeBackReference, the Forward direction speculatively advances the
input by matchSize before comparing. When the captured character is non-BMP and
the input at that offset is not a valid surrogate pair, readSurrogatePairChecked
returns errorCodePoint and we took an early return that only restored the
position for Backward, leaving Forward matchSize code units ahead. FixedCount and
NonGreedy callers overwrite the position afterwards, but the Greedy loop relies
on tryConsumeBackReference to restore it, so a failed iteration consumed input:

    /(\u{1F601})\1*$/u.exec(&quot;\u{1F601}ab&quot;)        // [&quot;\u{1F601}ab&quot;, ...], should be null
    /(\u{1F601})(\1*)?/u.exec(&quot;\u{1F601}\n\u{1F601}&quot;) // splits the second surrogate pair

280563@main introduced the early return so that errorCodePoint is not passed to
areCanonicallyEquivalent; 313026@main added the Backward restore. This patch
instead guards the comparison with the errorCodePoint check and falls through to
the existing mismatch path, which restores the position for both directions.

Test: JSTests/stress/regexp-backreference-greedy-non-bmp-capture-restore-pos.js

* JSTests/stress/regexp-backreference-greedy-non-bmp-capture-restore-pos.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::tryConsumeBackReference):

Canonical link: <a href="https://commits.webkit.org/319560@main">https://commits.webkit.org/319560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/212274cf9c29c6acb1f3edbc4a2c04de93c6724c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146071 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141868 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44236 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42509 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4271 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11083 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42141 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3128 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43021 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193893 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55359 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151280 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40533 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56048 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150984 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45556 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128331 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124060 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54561 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17137 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53943 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->