### PR TITLE
[JSC][Temporal] Fix non-ISO date field resolution at the range edges

### DIFF
--- a/JSTests/stress/temporal-lunisolar-extreme-year-arithmetic.js
+++ b/JSTests/stress/temporal-lunisolar-extreme-year-arithmetic.js
@@ -1,0 +1,71 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${String(expected)} but got ${String(actual)}`);
+}
+
+// Past the threshold the getters report the ISO month and day verbatim. That is the invariant the
+// arithmetic below has to agree with.
+{
+    const d = Temporal.PlainDate.from('+010001-06-15').withCalendar('chinese');
+    shouldBe(d.year, 10001);
+    shouldBe(d.monthCode, 'M06');
+    shouldBe(d.day, 15);
+}
+
+// add() and until() must produce answers rather than failing.
+for (const calendar of ['chinese', 'dangi']) {
+    for (const year of [100000, 270000, -270000]) {
+        const a = Temporal.PlainDate.from({ calendar, year, monthCode: 'M01', day: 1 });
+        shouldBe(a.year, year);
+
+        shouldBe(a.add({ years: 1 }).year, year + 1);
+        shouldBe(a.add({ months: 1 }).monthCode, 'M02');
+        shouldBe(a.add({ days: 1 }).day, 2);
+        shouldBe(a.subtract({ years: 1 }).year, year - 1);
+
+        const b = a.add({ years: 1 });
+        shouldBe(a.until(b, { largestUnit: 'year' }).toString(), 'P1Y');
+        shouldBe(a.since(b, { largestUnit: 'year' }).toString(), '-P1Y');
+        shouldBe(b.until(a, { largestUnit: 'year' }).toString(), '-P1Y');
+
+        // add and until have to stay mutually consistent out here.
+        const shifted = a.add({ years: 3, months: 2, days: 5 });
+        const diff = a.until(shifted, { largestUnit: 'year' });
+        shouldBe(diff.toString(), 'P3Y2M5D');
+        shouldBe(a.add(diff).equals(shifted), true);
+    }
+}
+
+// Spans with only one endpoint past the threshold must also answer rather than fail.
+{
+    const near = Temporal.PlainDate.from({ calendar: 'chinese', year: 9000, monthCode: 'M01', day: 1 });
+    const far = Temporal.PlainDate.from({ calendar: 'chinese', year: 270000, monthCode: 'M01', day: 1 });
+    const forward = near.until(far, { largestUnit: 'year' });
+    if (forward.years <= 0)
+        throw new Error(`expected a positive year count, got ${forward.toString()}`);
+    const backward = far.until(near, { largestUnit: 'year' });
+    if (backward.years >= 0)
+        throw new Error(`expected a negative year count, got ${backward.toString()}`);
+
+    const min = Temporal.PlainDate.from({ calendar: 'chinese', year: -270000, monthCode: 'M01', day: 1 });
+    const max = Temporal.PlainDate.from({ calendar: 'chinese', year: 270000, monthCode: 'M01', day: 1 });
+    shouldBe(min.until(max, { largestUnit: 'year' }).toString(), 'P540000Y');
+}
+
+// Day and week diffs were already calendar-independent and must not change.
+{
+    const a = Temporal.PlainDate.from({ calendar: 'chinese', year: 270000, monthCode: 'M01', day: 1 });
+    shouldBe(a.until(a.add({ days: 366 }), { largestUnit: 'day' }).toString(), 'P366D');
+    shouldBe(a.until(a.add({ days: 366 }), { largestUnit: 'week' }).toString(), 'P52W2D');
+}
+
+// Inside the trustworthy range nothing changes: these stay on the astronomical path.
+{
+    const a = Temporal.PlainDate.from({ calendar: 'chinese', year: 2024, monthCode: 'M01', day: 1 });
+    shouldBe(a.until(a.add({ years: 1 }), { largestUnit: 'year' }).toString(), 'P1Y');
+    shouldBe(a.until(a.add({ years: 1 }), { largestUnit: 'month' }).toString(), 'P12M');
+    const leap = Temporal.PlainDate.from({ calendar: 'chinese', year: 2004, monthCode: 'M02L', day: 1 });
+    shouldBe(leap.until(leap.add({ years: 1 }), { largestUnit: 'month' }).toString(), 'P12M');
+}

--- a/JSTests/stress/temporal-plainyearmonth-toplaindate-day-range.js
+++ b/JSTests/stress/temporal-plainyearmonth-toplaindate-day-range.js
@@ -1,0 +1,70 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${String(expected)} but got ${String(actual)}`);
+}
+function shouldThrowRangeError(fn) {
+    try { fn(); } catch (e) {
+        if (!(e instanceof RangeError))
+            throw new Error(`expected RangeError, got ${e}`);
+        return;
+    }
+    throw new Error("expected RangeError but no exception thrown");
+}
+
+const overlongDays = [31, 32, 255, 256, 257, 258, 512, 513, 2147483647, 2147483648, 1e10, Number.MAX_SAFE_INTEGER];
+
+// ISO: every value at or past the length of the month clamps to the last day.
+{
+    const jan = Temporal.PlainYearMonth.from('2024-01');
+    for (const day of overlongDays)
+        shouldBe(jan.toPlainDate({ day }).toString(), '2024-01-31');
+    shouldBe(jan.toPlainDate({ day: 1 }).toString(), '2024-01-01');
+    shouldBe(jan.toPlainDate({ day: 30 }).toString(), '2024-01-30');
+
+    // February of a leap year clamps to 29, not 31.
+    shouldBe(Temporal.PlainYearMonth.from('2024-02').toPlainDate({ day: 300 }).toString(), '2024-02-29');
+    shouldBe(Temporal.PlainYearMonth.from('2023-02').toPlainDate({ day: 300 }).toString(), '2023-02-28');
+}
+
+// Non-ISO calendars clamp the same way, including the Gregorian-structured ones that bypass ICU.
+{
+    const gregory = Temporal.PlainYearMonth.from({ year: 2024, month: 1, calendar: 'gregory' });
+    for (const day of overlongDays)
+        shouldBe(gregory.toPlainDate({ day }).toString(), '2024-01-31[u-ca=gregory]');
+    shouldBe(gregory.toPlainDate({ day: 1 }).toString(), '2024-01-01[u-ca=gregory]');
+
+    const buddhist = Temporal.PlainYearMonth.from({ year: 2567, month: 1, calendar: 'buddhist' });
+    for (const day of overlongDays) {
+        const d = buddhist.toPlainDate({ day });
+        shouldBe(d.toString(), '2024-01-31[u-ca=buddhist]');
+        // The result must be a representable date, so its own serialization round-trips.
+        shouldBe(Temporal.PlainDate.from(d.toString()).toString(), '2024-01-31[u-ca=buddhist]');
+        shouldBe(d.day, 31);
+    }
+
+    // A lunisolar calendar whose months are at most 30 days.
+    const hebrew = Temporal.PlainYearMonth.from({ year: 5784, monthCode: 'M01', calendar: 'hebrew' });
+    for (const day of overlongDays)
+        shouldBe(hebrew.toPlainDate({ day }).day, 30);
+}
+
+// day must still be rejected outright when it is not a positive integer.
+{
+    const jan = Temporal.PlainYearMonth.from('2024-01');
+    shouldThrowRangeError(() => jan.toPlainDate({ day: 0 }));
+    shouldThrowRangeError(() => jan.toPlainDate({ day: -1 }));
+    shouldThrowRangeError(() => jan.toPlainDate({ day: Infinity }));
+    shouldThrowRangeError(() => jan.toPlainDate({ day: -Infinity }));
+    shouldThrowRangeError(() => jan.toPlainDate({ day: NaN }));
+}
+
+// An overlong day under overflow 'reject' is a RangeError rather than a clamp. toPlainDate itself
+// pins ~constrain~, so exercise the same resolve path through from().
+{
+    shouldThrowRangeError(() => Temporal.PlainDate.from({ year: 2024, month: 1, day: 257 }, { overflow: 'reject' }));
+    shouldThrowRangeError(() => Temporal.PlainDate.from({ year: 2024, month: 1, day: 256, calendar: 'gregory' }, { overflow: 'reject' }));
+    shouldThrowRangeError(() => Temporal.PlainDate.from({ year: 2567, month: 1, day: 256, calendar: 'buddhist' }, { overflow: 'reject' }));
+    shouldBe(Temporal.PlainDate.from({ year: 2024, month: 1, day: 257 }).toString(), '2024-01-31');
+}

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
@@ -405,7 +405,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToPlainDate, (JSGlob
     //   so we specialize: read `day` and skip the general merge machinery. `day`'s Conversion
     //   in the calendar-fields table is ~to-positive-integer-with-truncation~, which throws
     //   RangeError for any non-finite value or value ≤ 0.
-    std::optional<int32_t> itemDay;
+    std::optional<uint8_t> itemDay;
     JSValue dayProperty = item->get(globalObject, vm.propertyNames->day);
     RETURN_IF_EXCEPTION(scope, { });
     if (!dayProperty.isUndefined()) {
@@ -415,7 +415,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToPlainDate, (JSGlob
             return throwVMRangeError(globalObject, scope, "day property must be finite"_s);
         if (doubleDay <= 0) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "day property must be a positive integer"_s);
-        itemDay = clampTo<int32_t>(doubleDay);
+        itemDay = clampTo<uint8_t>(doubleDay);
     }
     if (!itemDay) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.toPlainDate: item does not have a day field"_s);
@@ -423,7 +423,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToPlainDate, (JSGlob
     // Step 8: isoDate = ? CalendarDateFromFields(calendar, merged, ~constrain~).
     // Step 9: Return ! CreateTemporalDate(isoDate, calendar).
     if (yearMonth->calendarID() != iso8601CalendarID()) {
-        auto resolved = TemporalCore::plainYearMonthToPlainDate(yearMonth->calendarID(), yearMonth->plainYearMonth().isoPlainDate(), static_cast<uint8_t>(itemDay.value()));
+        auto resolved = TemporalCore::plainYearMonthToPlainDate(yearMonth->calendarID(), yearMonth->plainYearMonth().isoPlainDate(), itemDay.value());
         if (!resolved) [[unlikely]] {
             if (resolved.error().kind == TemporalErrorKind::TypeError)
                 throwTypeError(globalObject, scope, String(resolved.error().message));

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -1650,10 +1650,13 @@ int32_t monthCodeOrdinalInYear(CalendarID calendarId, ParsedMonthCode monthCode,
 }
 
 // nonISODateSurpasses — icu4x: surpasses() (components/calendar/src/calendar_arithmetic.rs) — two-phase lexicographic + ordinal check
+// sourceRelatedYear is the same instant as sourceYear in resolveMonthCodeToOrdinal's domain. Not
+// interchangeable: for chinese/dangi the two differ on some ICU versions.
 static bool nonISODateSurpasses(
     CalendarID calendarId,
     int32_t sign,
     int32_t sourceYear,
+    int32_t sourceRelatedYear,
     const String& sourceMonthCode,
     int32_t sourceDay,
     int32_t candidateYears,
@@ -1665,7 +1668,7 @@ static bool nonISODateSurpasses(
     int32_t y0 = sourceYear + candidateYears; // Phase 1: lexicographic check (year, monthCode, day).
     if (compareSurpassesLexicographic(sign, y0, sourceMonthCode, sourceDay, targetYear, targetMonthCode, targetDay))
         return true; // Phase 2: constrain source monthCode to year y0, compare ordinally.
-    int32_t m0 = resolveMonthCodeToOrdinal(calendarId, sourceMonthCode, y0);
+    int32_t m0 = resolveMonthCodeToOrdinal(calendarId, sourceMonthCode, sourceRelatedYear + candidateYears);
     return compareSurpassesOrdinally(sign, y0, m0, sourceDay, targetYear, targetOrdinalMonth, targetDay);
 }
 
@@ -1831,6 +1834,8 @@ TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const 
         return isoDateAdd(isoDate, duration, overflow);
     // Fast path: day/week-only durations are calendar-independent.
     if (!duration.years() && !duration.months())
+        return isoDateAdd(isoDate, duration, overflow);
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, isoDate.year()))
         return isoDateAdd(isoDate, duration, overflow);
     // Fixed solar calendars construct the exact expected native fields directly.
     if (calendarIsNonISOSolar(calendarId))
@@ -2030,6 +2035,8 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
     // Fast path: day/week diff is calendar-independent regardless of largestUnit.
     if (largestUnit == TemporalUnit::Day || largestUnit == TemporalUnit::Week)
         return diffISODate(one, two, largestUnit);
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, one.year()) || calendarUsesISOFallbackForExtremeYear(calendarId, two.year()))
+        return diffISODate(one, two, largestUnit);
 
     // Step 4 (non-ISO tail return): `Return NonISODateUntil(calendar, one, two, largestUnit)`.
     // https://tc39.es/proposal-intl-era-monthcode/#sup-temporal-nonisodateuntil
@@ -2038,11 +2045,14 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
     struct DateSnapshot {
         double epochMs { 0 };
         int32_t year { 0 };
+        // resolveMonthCodeToOrdinal's year domain; differs from year for chinese/dangi. Engaged only
+        // where a caller asked for it, so a use outside that path trips rather than reading `year`.
+        std::optional<int32_t> relatedYear;
         String monthCode;
         int32_t day { 0 };
         int32_t ordinalMonth { 0 };
     };
-    auto snapshotFields = [&](const ISO8601::PlainDate& date) -> TemporalResult<DateSnapshot> {
+    auto snapshotFields = [&](const ISO8601::PlainDate& date, bool needsRelatedYear) -> TemporalResult<DateSnapshot> {
         return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<DateSnapshot> {
             if (!cal) [[unlikely]]
                 return makeUnexpected(rangeError(icuOpenCalendarFailed));
@@ -2058,6 +2068,18 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
             snapshot.year = ucal_get(cal, calendarArithmeticYearField(calendarId), &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
+            if (needsRelatedYear) {
+                snapshot.relatedYear = snapshot.year;
+                if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) {
+                    auto stableYear = stableLunisolarYear(cal, calendarId, status);
+                    if (!stableYear) [[unlikely]]
+                        return makeUnexpected(rangeError(icuReadCalendarFailed));
+                    snapshot.relatedYear = *stableYear;
+                    ucal_setMillis(cal, snapshot.epochMs, &status);
+                    if (U_FAILURE(status)) [[unlikely]]
+                        return makeUnexpected(rangeError(icuSetCalendarFailed));
+                }
+            }
             if (hebrewY0Kislev) {
                 snapshot.monthCode = String("M03"_s);
                 snapshot.day = 30;
@@ -2078,12 +2100,13 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
             return snapshot;
         });
     };
-    auto targetOrError = snapshotFields(two);
+    // Only the source's related year is consumed, and only by the year loop below.
+    auto targetOrError = snapshotFields(two, false);
     if (!targetOrError) [[unlikely]]
         return makeUnexpected(targetOrError.error());
     auto& target = *targetOrError;
 
-    auto sourceOrError = snapshotFields(one);
+    auto sourceOrError = snapshotFields(one, largestUnit == TemporalUnit::Year);
     if (!sourceOrError) [[unlikely]]
         return makeUnexpected(sourceOrError.error());
     auto& source = *sourceOrError;
@@ -2133,7 +2156,7 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
     if (largestUnit == TemporalUnit::Year) {
         int64_t candidateYears = minYears ? minYears : sign;
         auto yearDoesNotSurpass = [&] {
-            return !nonISODateSurpasses(calendarId, sign, source.year, source.monthCode, source.day, static_cast<int32_t>(candidateYears), target.year, target.monthCode, target.ordinalMonth, target.day);
+            return !nonISODateSurpasses(calendarId, sign, source.year, *source.relatedYear, source.monthCode, source.day, static_cast<int32_t>(candidateYears), target.year, target.monthCode, target.ordinalMonth, target.day);
         };
         while (yearDoesNotSurpass()) {
             years = static_cast<int32_t>(candidateYears);
@@ -2598,13 +2621,12 @@ TemporalResult<ISO8601::PlainDate> nonISOCalendarDateToISO(CalendarID calendarId
                     return makeUnexpected(rangeError("month is out of range for this calendar"_s));
                 resolvedMonth = 12;
             }
-            uint8_t resolvedDay = day;
             uint8_t daysInMo = ISO8601::daysInMonth(isoYear, resolvedMonth);
             if (day > daysInMo) {
                 if (overflow == TemporalOverflow::Reject) [[unlikely]]
                     return makeUnexpected(rangeError("Day is out of range for the given month"_s));
-                resolvedDay = daysInMo;
             }
+            uint8_t resolvedDay = std::clamp<uint8_t>(day, 1, daysInMo);
             return ISO8601::PlainDate(isoYear, resolvedMonth, resolvedDay);
         }
     }
@@ -2741,13 +2763,11 @@ TemporalResult<ISO8601::PlainDate> nonISOCalendarDateToISO(CalendarID calendarId
         }
 
         // Steps 7-8: clamp day to daysInMonth (reject on out-of-range).
-        uint8_t resolvedDay;
         if (day > maxDay) {
             if (overflow == TemporalOverflow::Reject) [[unlikely]]
                 return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-            resolvedDay = static_cast<uint8_t>(maxDay);
-        } else
-            resolvedDay = day;
+        }
+        uint8_t resolvedDay = std::clamp<uint8_t>(day, 1, static_cast<uint8_t>(maxDay));
 
         // Advance cursor to resolvedDay.
         if (calendarIsLunisolar(calendarId)) {


### PR DESCRIPTION
#### 284afdacfb77ee797e4874af70539b8b8b3b16d9
<pre>
[JSC][Temporal] Fix non-ISO date field resolution at the range edges
<a href="https://bugs.webkit.org/show_bug.cgi?id=321414">https://bugs.webkit.org/show_bug.cgi?id=321414</a>
<a href="https://rdar.apple.com/184478785">rdar://184478785</a>

Reviewed by Yusuke Suzuki.

toPlainDate&apos;s non-ISO branch narrowed day to uint8_t, so day mod 256 decided the answer,
and both clamps in nonISOCalendarDateToISO were one-sided, letting the wrapped 0 build a
live PlainDate with day 00:

PlainYearMonth.from({ year: 2567, month: 1, calendar: &quot;buddhist&quot; })
       .toPlainDate({ day: 256 })     // 2024-01-00, want 2024-01-31

day is saturated with clampTo&lt;uint8_t&gt; now and both clamps are two-sided. V8 and
SpiderMonkey agree.

calendarDateAdd and calendarDateUntil queried ICU past the range where its astronomical
output is trustworthy, though the chinese and dangi getters already report plain ISO fields
there, so add({years: 1}) on {calendar: &quot;chinese&quot;, year: 270000} threw on a date that
constructs and reads fine. Both take the ISO path past the threshold now. That range is a
deliberate divergence, so the values are not expected to match V8; only the absence of a
failure is.

calendarDateUntil passed the calendar&apos;s arithmetic year to resolveMonthCodeToOrdinal, whose
year argument is the related year -- for chinese and dangi a different number on ICU 76
(4661 against 2024, 4353 against 2020) and the same one on ICU 78, so a local run cannot
tell them apart. The snapshot carries the related year separately now, computed from the
year&apos;s start instant rather than read from an ICU year field, and only the source endpoint
computes it because only the year loop consumes it. Comparisons still use the arithmetic
year, so both operands of one always come from the same field. Nothing branches on an ICU
version.

Tests: JSTests/stress/temporal-lunisolar-extreme-year-arithmetic.js
       JSTests/stress/temporal-plainyearmonth-toplaindate-day-range.js

Canonical link: <a href="https://commits.webkit.org/318940@main">https://commits.webkit.org/318940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaf8a8fdfab2ee8cd71f269df3dc235c109c210c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47632 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144209 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53552 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/91786f45-0497-47b9-a59d-29bb5fa708d5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161058 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/611d7bf6-9f56-4c22-b272-2ce4725a89e6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40920 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9543 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40585 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1258 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41164 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192032 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53502 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149610 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54189 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149340 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27317 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43992 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121504 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52706 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15571 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52088 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52152 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->