### PR TITLE
[JSC][Temporal] Fix undefined behavior, a loose bound, and remove dead code

### DIFF
--- a/JSTests/stress/temporal-duration-round-zero-length-nudge-window.js
+++ b/JSTests/stress/temporal-duration-round-zero-length-nudge-window.js
@@ -5,6 +5,12 @@
 // from -10:00 to +14:00) produces a zero-length nudge window in NudgeToCalendarUnit:
 // startEpochNs equals endEpochNs, so computing the progress fraction divides by zero.
 // This must throw a RangeError instead of dividing by zero.
+//
+// NudgeToZonedTime reaches the same zero-length day from its step 3, which computes
+// endDate = AddDaysToISODate(start, sign): with sign = -1 that steps backward onto the
+// skipped day, so steps 5-6 resolve both bounds to one instant and daySpan is 0. There
+// the span is only ever subtracted, never divided by, so it computes normally -- only
+// step 8's assertion had to stop claiming TimeDurationSign(daySpan) is never 0.
 // https://github.com/tc39/proposal-temporal/issues/3310
 
 function shouldBe(actual, expected) {
@@ -61,3 +67,35 @@ function shouldThrowRangeError(fn) {
     const y = Temporal.ZonedDateTime.from('1996-07-17T23:59:07.540000748+04:30[Asia/Tehran]');
     shouldBe(y.since(x, { smallestUnit: 'day', roundingMode: 'floor', largestUnit: 'year' }).toString(), '-P1Y2M4D');
 }
+
+// NudgeToZonedTime: a TIME smallestUnit with a zoned relativeTo takes step 6 instead of
+// the irregular-length branch above, so daySpan = 0 reaches step 8's assertion rather
+// than the division. These must produce answers. Values agree with V8 and SpiderMonkey.
+{
+    const cases = [
+        ['Pacific/Apia', '2011-12-31T12:00', { days: -1, minutes: -30 }, 'hour', '-P1D'],
+        ['Pacific/Apia', '2011-12-31T12:00', { days: -1, minutes: -30 }, 'minute', '-P1DT30M'],
+        ['Pacific/Apia', '2011-12-31T12:00', { days: -1, seconds: -1 }, 'hour', '-P1D'],
+        ['Pacific/Apia', '2011-12-31T00:00', { days: -1, minutes: -30 }, 'minute', '-P1DT30M'],
+        ['Pacific/Kiritimati', '1995-01-01T12:00', { days: -1, minutes: -30 }, 'hour', '-P1D'],
+        ['Pacific/Kiritimati', '1995-01-01T12:00', { days: -1, minutes: -30 }, 'minute', '-P1DT30M'],
+        ['Pacific/Kiritimati', '1995-01-01T06:30', { days: -1, seconds: -1 }, 'minute', '-P1D'],
+    ];
+    for (const [timeZone, iso, duration, smallestUnit, expected] of cases) {
+        const relativeTo = Temporal.PlainDateTime.from(iso).toZonedDateTime(timeZone);
+        shouldBe(Temporal.Duration.from(duration).round({
+            largestUnit: 'day', smallestUnit, roundingMode: 'ceil', relativeTo }).toString(), expected);
+    }
+}
+
+// Guard against tzdata dropping either gap, which would make every case above vacuous:
+// the day preceding each reference date must have zero length.
+{
+    const precedingDayHours = (timeZone, date) => {
+        const at = d => Temporal.PlainDateTime.from(`${d}T12:00`).toZonedDateTime(timeZone).epochNanoseconds;
+        return Number((at(date) - at(Temporal.PlainDate.from(date).subtract({ days: 1 }).toString())) / 3600000000000n);
+    };
+    shouldBe(precedingDayHours('Pacific/Apia', '2011-12-31'), 0);
+    shouldBe(precedingDayHours('Pacific/Kiritimati', '1995-01-01'), 0);
+}
+

--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -906,36 +906,6 @@ static void testToDateDurationRecordWithoutTime()
     TCHECK_EQ(static_cast<int64_t>(r->hours()), 0LL, "stripTime: hours=0");
     TCHECK_EQ(static_cast<int64_t>(r->minutes()), 0LL, "stripTime: minutes=0");
 }
-
-// ---------------------------------------------------------------------------
-// totalSeconds / totalSubseconds — internal balance helpers
-// ---------------------------------------------------------------------------
-
-static void testTotalSecondsAndSubseconds()
-{
-    // temporal_rs: internal balance helpers
-    // 1h30m = 5400s
-    ISO8601::Duration d1(0, 0, 0, 0, 1, 30, 0, 0, 0, 0);
-    TCHECK_EQ(totalSeconds(d1), 5400LL, "totalSec: 1h30m=5400s");
-
-    // 1d2h = 26*3600 = 93600s
-    ISO8601::Duration d2(0, 0, 0, 1, 2, 0, 0, 0, 0, 0);
-    TCHECK_EQ(totalSeconds(d2), 93600LL, "totalSec: 1d2h=93600s");
-
-    // 0 duration -> 0s
-    ISO8601::Duration z;
-    TCHECK_EQ(totalSeconds(z), 0LL, "totalSec: zero");
-
-    // 999ms + 999999µs + 999999999ns = 999*1e6 + 999999*1e3 + 999999999 = 2998998999 ns
-    ISO8601::Duration d3(0, 0, 0, 0, 0, 0, 0, 999, 999999, 999999999);
-    Int128 expected = Int128(2998998999LL);
-    TCHECK_EQ(totalSubseconds(d3), expected, "totalSub: max subseconds");
-
-    // 1s = 0 subseconds (only ms/µs/ns contribute)
-    ISO8601::Duration d4(0, 0, 0, 0, 0, 0, 1, 0, 0, 0);
-    TCHECK_EQ(totalSubseconds(d4), Int128(0LL), "totalSub: 1s=0 subseconds");
-}
-
 // ---------------------------------------------------------------------------
 // totalTimeDuration — fractional unit conversion
 // ---------------------------------------------------------------------------
@@ -954,38 +924,6 @@ static void testTotalTimeDuration()
     // 1000000 ns = 1 ms
     TCHECK_EQ(totalTimeDuration(Int128(1000000LL), TemporalUnit::Millisecond), 1.0, "totalTD: 1ms");
 }
-
-// ---------------------------------------------------------------------------
-// balanceDuration — redistribute time fields
-// ---------------------------------------------------------------------------
-
-static void testBalanceDuration()
-{
-    // temporal_rs: Duration::balance — redistributes seconds/minutes/hours
-    // 90min -> 1h30m when largestUnit=Hour
-    ISO8601::Duration d1(0, 0, 0, 0, 0, 90, 0, 0, 0, 0);
-    balanceDuration(d1, TemporalUnit::Hour);
-    TCHECK_EQ(static_cast<int64_t>(d1.hours()), 1LL, "balance: 90m -> 1h");
-    TCHECK_EQ(static_cast<int64_t>(d1.minutes()), 30LL, "balance: 90m -> 30m");
-
-    // 3600s -> 1h when largestUnit=Hour
-    ISO8601::Duration d2(0, 0, 0, 0, 0, 0, 3600, 0, 0, 0);
-    balanceDuration(d2, TemporalUnit::Hour);
-    TCHECK_EQ(static_cast<int64_t>(d2.hours()), 1LL, "balance: 3600s -> 1h");
-    TCHECK_EQ(static_cast<int64_t>(d2.seconds()), 0LL, "balance: 3600s -> 0s");
-
-    // 2000ms -> 2s when largestUnit=Second (ms overflow folds into seconds)
-    ISO8601::Duration d3(0, 0, 0, 0, 0, 0, 0, 2000, 0, 0);
-    balanceDuration(d3, TemporalUnit::Second);
-    TCHECK_EQ(static_cast<int64_t>(d3.seconds()), 2LL, "balance: 2000ms -> 2s");
-    TCHECK_EQ(static_cast<int64_t>(d3.milliseconds()), 0LL, "balance: 2000ms -> 0ms");
-
-    // 500ms with largestUnit=Millisecond -> unchanged
-    ISO8601::Duration d4(0, 0, 0, 0, 0, 0, 0, 500, 0, 0);
-    balanceDuration(d4, TemporalUnit::Millisecond);
-    TCHECK_EQ(static_cast<int64_t>(d4.milliseconds()), 500LL, "balance: 500ms unchanged");
-}
-
 // ---------------------------------------------------------------------------
 // toInternalDuration / toInternalDurationRecordWith24HourDays
 // ---------------------------------------------------------------------------
@@ -3920,9 +3858,7 @@ static void runStressTests()
     testTemporalDurationFromInternal(); // InternalDuration -> Duration
     testToInternalDuration(); // Duration -> InternalDuration
     testToDateDurationRecordWithoutTime(); // time field stripping
-    testTotalSecondsAndSubseconds(); // totalSeconds/totalSubseconds helpers
     testTotalTimeDuration(); // fractional unit conversion
-    testBalanceDuration(); // duration field redistribution
 
     // Rounding helpers
     testCalendarDateAdd(); // ISO calendarDateAdd

--- a/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
@@ -90,79 +90,6 @@ TemporalUnit NODELETE largestSubduration(const ISO8601::Duration& d)
     return static_cast<TemporalUnit>(index);
 }
 
-// totalSeconds — internal BalanceDuration helper; folds days/hours/minutes into total seconds for redistribution.
-int64_t totalSeconds(const ISO8601::Duration& d)
-{
-    constexpr int64_t hourPerDay = 24;
-    constexpr int64_t minPerHour = 60;
-    constexpr int64_t secPerMin = 60;
-    int64_t hours = hourPerDay * d.days() + d.hours();
-    int64_t minutes = minPerHour * hours + d.minutes();
-    return secPerMin * minutes + d.seconds();
-}
-
-// totalSubseconds — internal BalanceDuration helper; returns total sub-second nanoseconds (ms×1e6 + µs×1e3 + ns).
-Int128 totalSubseconds(const ISO8601::Duration& d)
-{
-    constexpr int64_t usPerMs = 1000;
-    constexpr int64_t nsPerUs = 1000;
-    Int128 microseconds = Int128(usPerMs) * d.milliseconds() + d.microseconds();
-    return Int128(nsPerUs) * microseconds + d.nanoseconds();
-}
-
-// balanceDuration — temporal_rs: balance is performed inline in Duration::compare.
-// Redistributes time fields up to largestUnit. Returns std::nullopt (always).
-std::optional<double> balanceDuration(ISO8601::Duration& duration, TemporalUnit largestUnit)
-{
-    constexpr int64_t nsPerUs = 1000;
-    constexpr int64_t usPerMs = 1000;
-    constexpr int64_t msPerSec = 1000;
-    constexpr int64_t secPerMin = 60;
-    constexpr int64_t minPerHour = 60;
-    Int128 nanoseconds = totalSubseconds(duration);
-    int64_t seconds = totalSeconds(duration);
-    duration.clear();
-    constexpr int64_t secondsPerDay = 86400;
-    if (largestUnit <= TemporalUnit::Day) {
-        duration.setDays(seconds / secondsPerDay);
-        seconds = seconds % secondsPerDay;
-    }
-    Int128 microseconds = nanoseconds / nsPerUs;
-    Int128 milliseconds = microseconds / Int128(usPerMs);
-    // Fold ms overflow into seconds: ms >= 1000 must carry into seconds.
-    int64_t secondsFromMs = static_cast<int64_t>(milliseconds / Int128(msPerSec));
-    int64_t totalSecs = seconds + secondsFromMs;
-    int64_t minutes = totalSecs / secPerMin;
-    if (largestUnit <= TemporalUnit::Hour) {
-        duration.setNanoseconds(nanoseconds % nsPerUs);
-        duration.setMicroseconds(microseconds % Int128(usPerMs));
-        duration.setMilliseconds(static_cast<int64_t>(milliseconds % Int128(msPerSec)));
-        duration.setSeconds(totalSecs % secPerMin);
-        duration.setMinutes(minutes % minPerHour);
-        duration.setHours(minutes / minPerHour);
-    } else if (largestUnit == TemporalUnit::Minute) {
-        duration.setNanoseconds(nanoseconds % nsPerUs);
-        duration.setMicroseconds(microseconds % Int128(usPerMs));
-        duration.setMilliseconds(static_cast<int64_t>(milliseconds % Int128(msPerSec)));
-        duration.setSeconds(totalSecs % secPerMin);
-        duration.setMinutes(minutes);
-    } else if (largestUnit == TemporalUnit::Second) {
-        duration.setNanoseconds(nanoseconds % nsPerUs);
-        duration.setMicroseconds(microseconds % Int128(usPerMs));
-        duration.setMilliseconds(static_cast<int64_t>(milliseconds % Int128(msPerSec)));
-        duration.setSeconds(totalSecs);
-    } else if (largestUnit == TemporalUnit::Millisecond) {
-        duration.setNanoseconds(nanoseconds % nsPerUs);
-        duration.setMicroseconds(microseconds % Int128(usPerMs));
-        duration.setMilliseconds(static_cast<int64_t>(milliseconds) + seconds * msPerSec);
-    } else if (largestUnit == TemporalUnit::Microsecond) {
-        duration.setNanoseconds(nanoseconds % nsPerUs);
-        duration.setMicroseconds(microseconds + Int128(seconds) * (ISO8601::ExactTime::nsPerSecond / ISO8601::ExactTime::nsPerMicrosecond));
-    } else
-        duration.setNanoseconds(nanoseconds + Int128(seconds) * ISO8601::ExactTime::nsPerSecond);
-    return std::nullopt;
-}
-
 // timeDurationFromComponents — temporal_rs: TimeDuration::from_components
 // Converts duration time fields to a total nanosecond Int128.
 Int128 timeDurationFromComponents(double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds)
@@ -395,7 +322,7 @@ Int128 getUTCEpochNanoseconds(ISO8601::PlainDate date, ISO8601::PlainTime time)
         + Int128(time.nanosecond());
 }
 
-constexpr int32_t unitIndexInTable(TemporalUnit unit)
+static constexpr int32_t unitIndexInTable(TemporalUnit unit)
 {
     switch (unit) {
     case TemporalUnit::Year:
@@ -423,7 +350,7 @@ constexpr int32_t unitIndexInTable(TemporalUnit unit)
     }
 }
 
-constexpr TemporalUnit unitInTable(int32_t i)
+static constexpr TemporalUnit unitInTable(int32_t i)
 {
     switch (i) {
     case 0:
@@ -754,8 +681,9 @@ TemporalResult<NudgeResult> nudgeToZonedTime(int32_t sign,
     Int128 endEpochNs = *endNsResult;
     // Step 7: daySpan = TimeDurationFromEpochNanosecondsDifference(endEpochNs, startEpochNs).
     Int128 daySpan = endEpochNs - startEpochNs;
-    // Step 8: Assert: TimeDurationSign(daySpan) = sign.
-    ASSERT((daySpan < 0 ? -1 : daySpan > 0 ? 1 : 0) == sign);
+    // Step 8's assert is violable: a zone that skips a whole calendar day makes daySpan zero
+    // (tc39/proposal-temporal#3310). Only subtracted, never divided by, so zero needs no handling.
+    ASSERT(!daySpan || (daySpan < 0 ? -1 : 1) == sign);
     // Step 9: Let unitLength be the nanoseconds length of unit.
     Int128 unitLength = lengthInNanoseconds(unit);
     // Step 10: Let roundedTimeDuration be ? RoundTimeDurationToIncrement(duration.[[Time]], increment × unitLength, roundingMode).

--- a/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.h
@@ -45,9 +45,9 @@ namespace JSC {
 // temporal_rs: NudgeResultRecord (src/builtins/core/duration.rs)
 struct NudgeResult {
     ISO8601::InternalDuration duration;
-    Int128 nudgedEpochNs;
-    bool didExpandCalendarUnit;
-    NudgeResult() { }
+    Int128 nudgedEpochNs { 0 };
+    bool didExpandCalendarUnit { false };
+    NudgeResult() = default;
     NudgeResult(ISO8601::InternalDuration d, Int128 ns, bool expanded)
         : duration(d)
         , nudgedEpochNs(ns)
@@ -60,8 +60,8 @@ struct NudgeResult {
 // temporal_rs: NudgedRecord (src/builtins/core/duration.rs)
 struct Nudged {
     NudgeResult nudgeResult;
-    double total;
-    Nudged() { }
+    double total { 0 };
+    Nudged() = default;
     Nudged(NudgeResult n, double t)
         : nudgeResult(n)
         , total(t)
@@ -81,12 +81,6 @@ JS_EXPORT_PRIVATE ISO8601::Duration negateDuration(const ISO8601::Duration&);
 JS_EXPORT_PRIVATE ISO8601::Duration absDuration(const ISO8601::Duration&);
 
 JS_EXPORT_PRIVATE TemporalUnit NODELETE largestSubduration(const ISO8601::Duration&);
-
-JS_EXPORT_PRIVATE int64_t totalSeconds(const ISO8601::Duration&);
-
-JS_EXPORT_PRIVATE Int128 totalSubseconds(const ISO8601::Duration&);
-
-JS_EXPORT_PRIVATE std::optional<double> balanceDuration(ISO8601::Duration&, TemporalUnit largestUnit);
 
 JS_EXPORT_PRIVATE Int128 timeDurationFromComponents(double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds);
 
@@ -109,10 +103,6 @@ JS_EXPORT_PRIVATE TemporalResult<ISO8601::InternalDuration> toInternalDurationRe
 JS_EXPORT_PRIVATE TemporalResult<ISO8601::Duration> toDateDurationRecordWithoutTime(ISO8601::Duration);
 
 JS_EXPORT_PRIVATE Int128 getUTCEpochNanoseconds(ISO8601::PlainDate, ISO8601::PlainTime);
-
-constexpr int32_t unitIndexInTable(TemporalUnit);
-
-constexpr TemporalUnit unitInTable(int32_t);
 
 JS_EXPORT_PRIVATE TemporalResult<ISO8601::Duration> adjustDateDurationRecord(const ISO8601::Duration& dateDuration, int64_t days, std::optional<int64_t> weeks, std::optional<int64_t> months);
 

--- a/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
@@ -81,7 +81,10 @@ ISO8601::PlainDate addDaysToISODate(const ISO8601::PlainDate& date, int64_t days
     // 2. Let ms be EpochDaysToEpochMs(epochDays, 0).
     double ms = makeDate(epochDays, 0);
     double daysToUse = msToDays(ms);
-    if (!isInBounds<int32_t>(daysToUse)) [[unlikely]]
+    // yearMonthDayFromDays adds a ~1.47e8 day offset internally, so its domain is narrower than its
+    // int32_t parameter. Real dates are within 1e8 days of the epoch, so this excludes nothing.
+    static constexpr double maxSafeEpochDays = 1e9;
+    if (std::abs(daysToUse) > maxSafeEpochDays) [[unlikely]]
         return ISO8601::PlainDate::sentinel();
     // 3. Return CreateISODateRecord(EpochTimeToEpochYear(ms), EpochTimeToMonthInYear(ms) + 1, EpochTimeToDate(ms)).
     auto [y, m, d] = WTF::yearMonthDayFromDays(static_cast<int32_t>(daysToUse));


### PR DESCRIPTION
#### b2233ac176432e7d890d5d7aef59e1e34b111e24
<pre>
[JSC][Temporal] Fix undefined behavior, a loose bound, and remove dead code
<a href="https://bugs.webkit.org/show_bug.cgi?id=321415">https://bugs.webkit.org/show_bug.cgi?id=321415</a>
<a href="https://rdar.apple.com/184484038">rdar://184484038</a>

Reviewed by Sosuke Suzuki.

NudgeResult and Nudged left members uninitialized, and roundRelativeDuration
default-constructs a NudgeResult before the branch that fills it in.

addDaysToISODate guarded with isInBounds&lt;int32_t&gt;, but yearMonthDayFromDays adds a ~1.47e8
day offset internally, so anything above 2000667119 overflows a signed int inside it.
Bounded by 1e9 instead, well above the 1e8-day representable range. No observable change.

nudgeToZonedTime&apos;s step 8 asserted TimeDurationSign(daySpan) = sign, but sign is only +/-1
while TimeDurationSign also returns 0. With sign = -1, step 3&apos;s endDate = start - 1 can land
on a calendar day the zone skips entirely, collapsing daySpan to 0 and crashing debug
builds. 170ee738c6f1 removed the same violable assertion from nudgeToCalendarUnit per
tc39/proposal-temporal#3310; there the span is divided by and needs a RangeError, here it is
only subtracted, so tolerating zero suffices.

unitIndexInTable and unitInTable were constexpr in the header with definitions in the .cpp,
so no other translation unit could use them. Now static in DurationArithmetic.cpp.

balanceDuration, totalSeconds and totalSubseconds have no production callers; only
TemporalCoreTest.cpp reached them.

Test: Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
Canonical link: <a href="https://commits.webkit.org/318900@main">https://commits.webkit.org/318900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d32483dcc7b873312394966bbabfdaea1741baf1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189591 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144070 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b334c3e0-6920-4009-b255-f7caa97c87bb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140214 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f840e65-656a-4108-8ee2-8893c9f0085d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120665 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a53a42f7-ec8b-4c90-85c8-e2067dea8801) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42491 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40811 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2634 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9435 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152892 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40469 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/esm-integration/execute-start.tentative.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1045 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41034 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191813 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53368 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149492 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54049 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37088 "Too many flaky failures: http/tests/media/track-in-band-hls-metadata-removecue-non-datacue-crash.html, http/tests/misc/slow-preload-cancel.html, http/tests/navigation/redirect-to-random-url-versus-memory-cache.html, http/tests/resourceLoadStatistics/omit-referrer-for-navigation-ephemeral.html, http/tests/security/canvas-remote-read-remote-video-allowed-redirect.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/shared-worker-blob-url-inherits-csp-importScripts-blocked.html, http/tests/site-isolation/iframe-transform-2d-rotate.html, http/tests/storageAccess/has-storage-access-true-if-third-party-has-cookies.https.html, http/tests/websocket/tests/hybi/long-control-frame.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149226 "Passed tests") | | 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27303 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Failed to checkout and rebase branch from PR 71271") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43880 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126321 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121346 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52566 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15459 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51951 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52192 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52012 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->