### PR TITLE
[Wasm] `call_indirect` in unreachable code should validate the table element type and the signature kind

### DIFF
--- a/JSTests/wasm/stress/unreachable-immediates-validation.js
+++ b/JSTests/wasm/stress/unreachable-immediates-validation.js
@@ -25,12 +25,17 @@ function section(id, payload) {
     return [id, ...leb(payload.length), ...payload];
 }
 
-function moduleBytes({ withMemory = false, withTable = false, body }) {
+function moduleBytes({ withMemory = false, withTable = false, withExternrefTable = false, withStructType = false, body }) {
     let bytes = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
-    bytes.push(...section(SECTION_TYPE, [0x01, 0x60, 0x00, 0x00])); // one type: () -> ()
+    if (withStructType)
+        bytes.push(...section(SECTION_TYPE, [0x02, 0x60, 0x00, 0x00, 0x5f, 0x00])); // type 0: () -> (), type 1: (struct)
+    else
+        bytes.push(...section(SECTION_TYPE, [0x01, 0x60, 0x00, 0x00])); // one type: () -> ()
     bytes.push(...section(SECTION_FUNCTION, [0x01, 0x00]));
     if (withTable)
         bytes.push(...section(SECTION_TABLE, [0x01, 0x70, 0x00, 0x01])); // one funcref table, min 1
+    else if (withExternrefTable)
+        bytes.push(...section(SECTION_TABLE, [0x01, 0x6f, 0x00, 0x01])); // one externref table, min 1
     if (withMemory)
         bytes.push(...section(SECTION_MEMORY, [0x01, 0x00, 0x01])); // one memory, min 1
     const code = [0x00, 0x00, ...body, 0x0b]; // no locals, unreachable, body, end
@@ -72,7 +77,12 @@ assertValid("table.get 0", { withTable: true, body: [0x25, 0x00] });
 assertInvalid("call_indirect type 0 table 7", { withTable: true, body: [0x11, 0x00, 0x07] });
 assertInvalid("call_indirect type 99 table 0", { withTable: true, body: [0x11, 0x63, 0x00] });
 assertInvalid("call_indirect with no table section", { body: [0x11, 0x00, 0x00] });
+assertInvalid("call_indirect over an externref table", { withExternrefTable: true, body: [0x11, 0x00, 0x00] });
+assertInvalid("call_indirect with a struct type index", { withTable: true, withStructType: true, body: [0x11, 0x01, 0x00] });
+assertInvalid("return_call_indirect over an externref table", { withExternrefTable: true, body: [0x13, 0x00, 0x00] });
+assertInvalid("return_call_indirect with a struct type index", { withTable: true, withStructType: true, body: [0x13, 0x01, 0x00] });
 assertValid("call_indirect type 0 table 0", { withTable: true, body: [0x11, 0x00, 0x00] });
+assertValid("call_indirect type 0 table 0 alongside a struct type", { withTable: true, withStructType: true, body: [0x11, 0x00, 0x00] });
 
 // ref.func needs an index inside the function index space, and a declaration.
 assertInvalid("ref.func 99", { body: [0xd2, 0x63, 0x1a] });

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -320,6 +320,8 @@ private:
     };
     [[nodiscard]] PartialResult parseTableCopyImmediates(TableCopyImmediates&);
 
+    [[nodiscard]] PartialResult parseCallIndirectImmediates(uint32_t& signatureIndex, uint32_t& tableIndex);
+
     struct AnnotatedSelectImmediates {
         unsigned sizeOfAnnotationVector;
         Type targetType;
@@ -1741,6 +1743,19 @@ auto FunctionParser<Context>::parseTableCopyImmediates(TableCopyImmediates& resu
     result.dstTableIndex = dstTableIndex;
     result.srcTableIndex = srcTableIndex;
 
+    return { };
+}
+
+template<typename Context>
+auto FunctionParser<Context>::parseCallIndirectImmediates(uint32_t& signatureIndex, uint32_t& tableIndex) -> PartialResult
+{
+    WASM_PARSER_FAIL_IF(!m_info.tableCount(), "call_indirect is only valid when a table is defined or imported"_s);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(signatureIndex), "can't get call_indirect's signature index"_s);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get call_indirect's table index"_s);
+    WASM_PARSER_FAIL_IF(tableIndex >= m_info.tableCount(), "call_indirect's table index "_s, tableIndex, " invalid, limit is "_s, m_info.tableCount());
+    WASM_PARSER_FAIL_IF(m_info.typeCount() <= signatureIndex, "call_indirect's signature index "_s, signatureIndex, " exceeds known signatures "_s, m_info.typeCount());
+    WASM_PARSER_FAIL_IF(m_info.tables[tableIndex].type() != TableElementType::Funcref, "call_indirect is only valid when a table has type funcref"_s);
+    WASM_VALIDATOR_FAIL_IF(m_info.rtt(TypeSignatureIndex(signatureIndex)).kind() != RTTKind::Function, "invalid type index (not a function signature) for call_indirect, got ", signatureIndex);
     return { };
 }
 
@@ -3325,16 +3340,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     case CallIndirect: {
         uint32_t signatureIndex;
         uint32_t tableIndex;
-        WASM_PARSER_FAIL_IF(!m_info.tableCount(), "call_indirect is only valid when a table is defined or imported"_s);
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(signatureIndex), "can't get call_indirect's signature index"_s);
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get call_indirect's table index"_s);
-        WASM_PARSER_FAIL_IF(tableIndex >= m_info.tableCount(), "call_indirect's table index "_s, tableIndex, " invalid, limit is "_s, m_info.tableCount());
-        WASM_PARSER_FAIL_IF(m_info.typeCount() <= signatureIndex, "call_indirect's signature index "_s, signatureIndex, " exceeds known signatures "_s, m_info.typeCount());
-        WASM_PARSER_FAIL_IF(m_info.tables[tableIndex].type() != TableElementType::Funcref, "call_indirect is only valid when a table has type funcref"_s);
+        WASM_FAIL_IF_HELPER_FAILS(parseCallIndirectImmediates(signatureIndex, tableIndex));
 
-        auto index = TypeSignatureIndex(signatureIndex);
-        const auto& calleeSignature = m_info.rtt(index);
-        WASM_VALIDATOR_FAIL_IF(calleeSignature.kind() != RTTKind::Function, "invalid type index (not a function signature) for call_indirect, got ", signatureIndex);
+        const auto& calleeSignature = m_info.rtt(TypeSignatureIndex(signatureIndex));
         size_t argumentCount = calleeSignature.argumentCount() + 1; // Add the callee's index.
         WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size() - m_currentStackBegin, "call_indirect expects "_s, argumentCount, " arguments, but the expression stack currently holds "_s, m_expressionStack.size() - m_currentStackBegin, " values"_s);
 
@@ -4129,11 +4137,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     case CallIndirect: {
         uint32_t signatureIndex;
         uint32_t tableIndex;
-        WASM_PARSER_FAIL_IF(!m_info.tableCount(), "call_indirect is only valid when a table is defined or imported"_s);
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(signatureIndex), "can't get call_indirect's signature index in unreachable context"_s);
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get call_indirect's table index in unreachable context"_s);
-        WASM_PARSER_FAIL_IF(tableIndex >= m_info.tableCount(), "call_indirect's table index "_s, tableIndex, " invalid, limit is "_s, m_info.tableCount());
-        WASM_PARSER_FAIL_IF(m_info.typeCount() <= signatureIndex, "call_indirect's signature index "_s, signatureIndex, " exceeds known signatures "_s, m_info.typeCount());
+        WASM_FAIL_IF_HELPER_FAILS(parseCallIndirectImmediates(signatureIndex, tableIndex));
         return { };
     }
 


### PR DESCRIPTION
#### 47f20d8cfd63af0e383c7094c03189100d3253f7
<pre>
[Wasm] `call_indirect` in unreachable code should validate the table element type and the signature kind
<a href="https://bugs.webkit.org/show_bug.cgi?id=321416">https://bugs.webkit.org/show_bug.cgi?id=321416</a>

Reviewed by Yusuke Suzuki.

parseUnreachableExpression&apos;s CallIndirect case checked table existence and
the bounds of both immediates, but not that the table holds funcref or that
the type index names a function type, so these invalid modules compiled when
the call_indirect was dead code:

    (table 1 externref)
    (func unreachable (call_indirect (type 0)))          ;; accepted

    (type (func)) (type (struct))
    (table 1 funcref)
    (func unreachable (call_indirect (type 1)))          ;; accepted

The reachable path rejects both. Move the immediate checks into
parseCallIndirectImmediates and use it from both parseExpression and
parseUnreachableExpression so the two paths cannot drift again.

* JSTests/wasm/stress/unreachable-immediates-validation.js:
(moduleBytes):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseCallIndirectImmediates):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):

Canonical link: <a href="https://commits.webkit.org/318962@main">https://commits.webkit.org/318962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdc5fc192afcff580abd8b4b57b942c60f056d84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144071 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140215 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160951 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42492 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40812 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2635 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9436 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40470 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1046 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41035 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46305 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191814 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53369 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149493 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40098 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54050 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37089 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149227 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43881 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126322 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121347 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52567 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15460 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51952 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52193 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52013 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->