### PR TITLE
Update fast/canvas/webgl/bufferData-offset-length.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3342,9 +3342,6 @@ webkit.org/b/163706 imported/w3c/web-platform-tests/css/css-shapes/shape-outside
 # This old test case fails with Firefox and Chrome.
 webkit.org/b/163706 imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside-008.html [ ImageOnlyFailure ]
 
-# Temporary failure until we start using ANGLE as a WebGL backend
-webkit.org/b/163924 fast/canvas/webgl/bufferData-offset-length.html [ Pass Failure ]
-
 webkit.org/b/164080 http/tests/websocket/tests/hybi/closed-when-entering-page-cache.html [ Pass Failure ]
 webkit.org/b/164080 http/tests/websocket/tests/hybi/stop-on-resume-in-error-handler.html [ Pass Failure ]
 

--- a/LayoutTests/fast/canvas/webgl/bufferData-offset-length.html
+++ b/LayoutTests/fast/canvas/webgl/bufferData-offset-length.html
@@ -44,47 +44,56 @@ function init()
     gl.disable(gl.DEPTH_TEST);
     gl.disable(gl.BLEND);
 
-    var coordinates = new Float32Array([ -1,1,0, 0,1,0, -1,-1,0, -1,-1,0, 0,1,0, 0,-1,0,
-                                         0,1,0, 1,1,0, 0,-1,0, 0,-1,0, 1,1,0, 1,-1,0 ]);
+    // The first 6 vertices draw the left canvas half, the last 6 the right.
+    const coordinates = new Float32Array([ -1,1,0, 0,1,0, -1,-1,0, -1,-1,0, 0,1,0, 0,-1,0,
+                                           0,1,0, 1,1,0, 0,-1,0, 0,-1,0, 1,1,0, 1,-1,0 ]);
 
-    var vertexObject = gl.createBuffer();
+    // bufferData(target, srcData, usage, srcOffset, length)
+    // bufferSubData(target, dstByteOffset, srcData, srcOffset, length)
+    // srcOffset and length count elements of srcData. Only dstByteOffset counts bytes.
+    const verticesPerHalf = 6;
+    const floatsPerHalf = verticesPerHalf * 3;
+
+    const vertexObject = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
-    gl.bufferData(gl.ARRAY_BUFFER, coordinates, gl.STATIC_DRAW, 0, 4 * 3 * 6);
+    gl.bufferData(gl.ARRAY_BUFFER, coordinates, gl.STATIC_DRAW, 0, floatsPerHalf);
     shouldBe("gl.getError()", "gl.NO_ERROR");
     gl.enableVertexAttribArray(0);
     gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
     shouldBe("gl.getError()", "gl.NO_ERROR");
 
-    checkRedValue(10, 10, 0, "Left half of canvas should be filled");
-    checkRedValue(30, 10, 255, "Right half of canvas should be empty");
+    checkRedValue(0, 10, 10, 0, "Left half of canvas should be filled");
+    checkRedValue(0, 30, 10, 255, "Right half of canvas should be empty");
 
-    gl.bufferData(gl.ARRAY_BUFFER, coordinates, gl.STATIC_DRAW, 4 * 3 * 6, 4 * 3 * 6);
+    gl.bufferData(gl.ARRAY_BUFFER, coordinates, gl.STATIC_DRAW, floatsPerHalf, floatsPerHalf);
     shouldBe("gl.getError()", "gl.NO_ERROR");
 
-    checkRedValue(10, 10, 255, "Left half of canvas should be empty");
-    checkRedValue(30, 10, 0, "Right half of canvas should be filled");
+    checkRedValue(0, 10, 10, 255, "Left half of canvas should be empty");
+    checkRedValue(0, 30, 10, 0, "Right half of canvas should be filled");
 
-    gl.bufferData(gl.ARRAY_BUFFER, coordinates, gl.STATIC_DRAW, 0, 2 * 4 * 3 * 6);
-    gl.bufferSubData(gl.ARRAY_BUFFER, 0, coordinates, 4 * 3 * 6, 4 * 3 * 6);
+    gl.bufferData(gl.ARRAY_BUFFER, coordinates, gl.STATIC_DRAW, 0, 2 * floatsPerHalf);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, coordinates, floatsPerHalf, floatsPerHalf);
     shouldBe("gl.getError()", "gl.NO_ERROR");
 
-    checkRedValue(10, 10, 255, "Left half of canvas should be empty");
-    checkRedValue(30, 10, 0, "Right half of canvas should be filled");
+    checkRedValue(0, 10, 10, 255, "Left half of canvas should be empty");
+    checkRedValue(0, 30, 10, 0, "Right half of canvas should be filled");
 
-    gl.bufferData(gl.ARRAY_BUFFER, coordinates, gl.STATIC_DRAW, 0, 2 * 4 * 3 * 6);
-    gl.bufferSubData(gl.ARRAY_BUFFER, 4 * 3 * 6, coordinates, 0, 4 * 3 * 6);
+    const bytesPerHalf = floatsPerHalf * Float32Array.BYTES_PER_ELEMENT;
+    gl.bufferData(gl.ARRAY_BUFFER, coordinates, gl.STATIC_DRAW, 0, 2 * floatsPerHalf);
+    gl.bufferSubData(gl.ARRAY_BUFFER, bytesPerHalf, coordinates, 0, floatsPerHalf);
     shouldBe("gl.getError()", "gl.NO_ERROR");
 
-    checkRedValue(10, 10, 0, "Left half of canvas should be filled");
-    checkRedValue(30, 10, 255, "Right half of canvas should be empty");
+    // Draw the last 6 vertices, where the bufferSubData() above wrote.
+    checkRedValue(verticesPerHalf, 10, 10, 0, "Left half of canvas should be filled");
+    checkRedValue(verticesPerHalf, 30, 10, 255, "Right half of canvas should be empty");
 
     gl.deleteBuffer(vertexObject);
 
-    function checkRedValue(x, y, value, msg) {
+    function checkRedValue(first, x, y, value, msg) {
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        gl.drawArrays(gl.TRIANGLES, 0, 6);
+        gl.drawArrays(gl.TRIANGLES, first, verticesPerHalf);
         gl.flush();
-        var buf = new Uint8Array(4);
+        const buf = new Uint8Array(4);
         gl.readPixels(x, y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
         if (buf[0] != value || buf[3] != 255) {
             debug('expected: red channel should = ' + value + ' but was = ' + buf[0] + '.');

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -775,7 +775,6 @@ webkit.org/b/279023 imported/w3c/web-platform-tests/css/css-transforms/composite
 webkit.org/b/244474 fast/canvas/webgl/oes-texture-float-linear.html [ Failure ]
 webkit.org/b/244476 fast/canvas/webgl/webgl-compressed-texture-size-limit.html [ Failure ]
 
-webkit.org/b/244489 fast/canvas/webgl/bufferData-offset-length.html [ Failure ]
 webkit.org/b/244491 fast/canvas/webgl/webgl2-texture-upload-enums.html [ Failure ]
 
 webgl/1.0.x/conformance/extensions/oes-texture-float-with-video.html [ Timeout ]


### PR DESCRIPTION
#### 080b3f4b8fa9836436c3b613e83ef7cf727ceb52
<pre>
Update fast/canvas/webgl/bufferData-offset-length.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=321417">https://bugs.webkit.org/show_bug.cgi?id=321417</a>
<a href="https://rdar.apple.com/184485974">rdar://184485974</a>

Reviewed by Dan Glastonbury.

The WebGL2 bufferData()/bufferSubData() sub-source overloads count srcOffset and
length in elements of the source view, not bytes. The test&apos;s byte arithmetic put
all six calls out of bounds, so each raised INVALID_VALUE and left the buffer
empty. Update the test.

* LayoutTests/TestExpectations:
* LayoutTests/fast/canvas/webgl/bufferData-offset-length.html:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/319047@main">https://commits.webkit.org/319047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f283e14f3047827ee0271dfd5fcbdfcf358bf6ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144073 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f820ba4f-e218-435a-8dda-ae3d1ee45c23) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140216 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97038 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae01647d-10d6-424a-ae31-1be480d1a7e6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120667 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9717c92-9a0a-4561-85b7-7af4cf790e07) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42495 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40814 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40472 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1048 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191816 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149495 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40158 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54052 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149229 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43883 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121349 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52569 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15462 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51954 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52195 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52015 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->