### PR TITLE
[GTK] Add New Tab Page override to WebKitWebExtensionContext

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.cpp
@@ -52,6 +52,7 @@ struct _WebKitWebExtensionContextPrivate {
     GWeakPtr<WebKitWebExtension> extension;
     CString baseURI;
     CString optionsPageURI;
+    CString overrideNewTabPageURI;
 #endif
 };
 
@@ -67,6 +68,7 @@ enum {
     PROP_BASE_URI,
     PROP_OPTIONS_PAGE_URI,
     PROP_HAS_INJECTED_CONTENT,
+    PROP_OVERRIDE_NEW_TAB_PAGE_URI,
     N_PROPERTIES,
 };
 
@@ -88,6 +90,9 @@ static void webkitWebExtensionContextGetProperty(GObject* object, guint propId, 
         break;
     case PROP_HAS_INJECTED_CONTENT:
         g_value_set_boolean(value, webkit_web_extension_context_get_has_injected_content(context));
+        break;
+    case PROP_OVERRIDE_NEW_TAB_PAGE_URI:
+        g_value_set_string(value, webkit_web_extension_context_get_override_new_tab_page_uri(context));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -177,6 +182,22 @@ static void webkit_web_extension_context_class_init(WebKitWebExtensionContextCla
             "has-injected-content",
             nullptr, nullptr,
             FALSE,
+            WEBKIT_PARAM_READABLE
+        );
+
+    /**
+     * WebKitWebExtensionContext:override-new-tab-page-uri:
+     * 
+     * The URI to use as an alternative to the default new tab page.
+     * See [method@WebExtensionContext.get_override_new_tab_page_uri] for more details.
+     *
+     * Since: 2.56
+     */
+    properties[PROP_OVERRIDE_NEW_TAB_PAGE_URI] =
+        g_param_spec_string(
+            "override-new-tab-page-uri",
+            nullptr, nullptr,
+            nullptr,
             WEBKIT_PARAM_READABLE
         );
 
@@ -395,6 +416,38 @@ gboolean webkit_web_extension_context_has_injected_content_for_uri(WebKitWebExte
     return priv->context->hasInjectedContentForURL(URL { String::fromUTF8(uri) });
 }
 
+/**
+ * webkit_web_extension_context_get_override_new_tab_page_uri:
+ * @context: a [class@WebExtensionContext]
+ *
+ * Get the URI to use as an alternative to the default new tab page, if the extension has one.
+ * 
+ * Provides the URI for a new tab page, if provided by the extension; otherwise %NULL if no page is defined.
+ * The app should prompt the user for permission to use the extension's new tab page as the default.
+ * Navigation to the override new tab page is only possible after this extension has been loaded.
+ * 
+ * Returns: (nullable): the URI to use as an alternative to the default new tab page, or %NULL if the extension
+ * does not have one.
+ * 
+ * Since: 2.56
+ */
+const gchar* webkit_web_extension_context_get_override_new_tab_page_uri(WebKitWebExtensionContext* context)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION_CONTEXT(context), nullptr);
+    g_return_val_if_fail(context->priv->extension, nullptr);
+
+    WebKitWebExtensionContextPrivate* priv = context->priv;
+    if (!priv->overrideNewTabPageURI.isNull())
+        return priv->overrideNewTabPageURI.data();
+
+    auto overrideNewTabPageURI = priv->context->overrideNewTabPageURL();
+    if (overrideNewTabPageURI.isEmpty())
+        return nullptr;
+
+    priv->overrideNewTabPageURI = overrideNewTabPageURI.string().utf8();
+    return priv->overrideNewTabPageURI.data();
+}
+
 #else // ENABLE(WK_WEB_EXTENSIONS)
 
 void webkitWebExtensionContextSetWebExtension(WebKitWebExtensionContext* context, WebKitWebExtension* extension)
@@ -435,6 +488,11 @@ gboolean webkit_web_extension_context_get_has_injected_content(WebKitWebExtensio
 gboolean webkit_web_extension_context_has_injected_content_for_uri(WebKitWebExtensionContext* context, const gchar* uri)
 {
     return FALSE;
+}
+
+const gchar* webkit_web_extension_context_get_override_new_tab_page_uri(WebKitWebExtensionContext* context)
+{
+    return "";
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.h.in
@@ -61,6 +61,9 @@ WEBKIT_API gboolean
 webkit_web_extension_context_has_injected_content_for_uri                   (WebKitWebExtensionContext *context,
                                                                              const gchar               *uri);
 
+WEBKIT_API const gchar *
+webkit_web_extension_context_get_override_new_tab_page_uri                  (WebKitWebExtensionContext *context);
+
 G_END_DECLS
 
 #endif // ENABLE(2022_GLIB_API)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebExtensionContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebExtensionContext.cpp
@@ -206,10 +206,77 @@ static void testOptionsPageURIParsing(Test* test, gconstpointer)
     g_assert_null(webkit_web_extension_context_get_options_page_uri(context.get()));
 }
 
+static void testURIOverridesParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parseExtensionManifest = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parseExtensionManifest("{ \"browser_url_overrides\": { \"newtab\": \"newtab.html\" }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+    GRefPtr<WebKitWebExtensionContext> context = webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr());
+    g_assert_no_error(error.get());
+
+    GUniquePtr<char> newTabPageURI(g_strconcat(webkit_web_extension_context_get_base_uri(context.get()), "newtab.html", nullptr));
+    g_assert_cmpstr(webkit_web_extension_context_get_override_new_tab_page_uri(context.get()), ==, newTabPageURI.get());
+
+    extension = parseExtensionManifest("{ \"browser_url_overrides\": { \"newtab\": 123 }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    context = webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr());
+    g_assert_no_error(error.get());
+
+    g_assert_null(webkit_web_extension_context_get_override_new_tab_page_uri(context.get()));
+
+    extension = parseExtensionManifest("{ \"browser_url_overrides\": { }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    context = webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr());
+    g_assert_no_error(error.get());
+
+    g_assert_null(webkit_web_extension_context_get_override_new_tab_page_uri(context.get()));
+
+    extension = parseExtensionManifest("{ \"browser_url_overrides\": { \"newtab\": \"\" }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    context = webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr());
+    g_assert_no_error(error.get());
+
+    g_assert_null(webkit_web_extension_context_get_override_new_tab_page_uri(context.get()));
+
+    extension = parseExtensionManifest("{ \"chrome_url_overrides\": { \"newtab\": \"newtab.html\" }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+    context = webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr());
+    g_assert_no_error(error.get());
+
+    newTabPageURI.reset(g_strconcat(webkit_web_extension_context_get_base_uri(context.get()), "newtab.html", nullptr));
+    g_assert_cmpstr(webkit_web_extension_context_get_override_new_tab_page_uri(context.get()), ==, newTabPageURI.get());
+
+    extension = parseExtensionManifest("{ \"chrome_url_overrides\": { \"newtab\": 123 }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    context = webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr());
+    g_assert_no_error(error.get());
+
+    g_assert_null(webkit_web_extension_context_get_override_new_tab_page_uri(context.get()));
+
+    extension = parseExtensionManifest("{ \"chrome_url_overrides\": { }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    context = webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr());
+    g_assert_no_error(error.get());
+
+    g_assert_null(webkit_web_extension_context_get_override_new_tab_page_uri(context.get()));
+
+    extension = parseExtensionManifest("{ \"chrome_url_overrides\": { \"newtab\": \"\" }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    context = webkit_web_extension_context_new_for_extension(extension.get(), &error.outPtr());
+    g_assert_no_error(error.get());
+
+    g_assert_null(webkit_web_extension_context_get_override_new_tab_page_uri(context.get()));
+}
+
 void beforeAll()
 {
     Test::add("WebKitWebExtensionContext", "content-scripts-parsing", testContentScriptsParsing);
     Test::add("WebKitWebExtensionContext", "options-page-uri-parsing", testOptionsPageURIParsing);
+    Test::add("WebKitWebExtensionContext", "uri-overrides-parsing", testURIOverridesParsing);
 }
 
 void afterAll()


### PR DESCRIPTION
#### b794eab6c6050b1c7a76aaad2e1dc7e857a3c95b
<pre>
[GTK] Add New Tab Page override to WebKitWebExtensionContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=321419">https://bugs.webkit.org/show_bug.cgi?id=321419</a>

Reviewed by Patrick Griffis.

Adds Override New Tab properties and functionality
to WebKitWebExtensionContext to match Cocoa.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebExtensionContext.cpp

* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.cpp:
(webkitWebExtensionContextGetProperty):
(webkit_web_extension_context_class_init):
(webkit_web_extension_context_get_override_new_tab_page_uri):
* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionContext.h.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitWebExtensionContext.cpp:
(testURIOverridesParsing):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/318972@main">https://commits.webkit.org/318972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1a5eb3def6c722708613e44f5134d265e312015

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181838 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140349 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97179 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120800 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42685 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40997 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40659 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1345 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192120 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53588 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149691 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40106 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54275 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149422 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44069 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126538 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121612 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52792 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15647 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52238 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->