### PR TITLE
[YARR] Unicode property escapes ignore case-insensitivity in u and v modes

### DIFF
--- a/JSTests/stress/regexp-unicode-property-escape-ignore-case.js
+++ b/JSTests/stress/regexp-unicode-property-escape-ignore-case.js
@@ -1,0 +1,114 @@
+function shouldBe(actual, expected, description) {
+    if (actual !== expected)
+        throw new Error(`${description}: expected ${expected} but got ${actual}`);
+}
+
+function test(pattern, flags, input, expected) {
+    const regexp = new RegExp("^(?:" + pattern + ")$", flags);
+    shouldBe(regexp.test(input), expected, `/${pattern}/${flags}.test(${JSON.stringify(input)})`);
+}
+
+// \p{...} matches case-insensitively in both u and v modes.
+for (const flags of ["iu", "iv"]) {
+    test("\\p{Lu}", flags, "a", true);
+    test("\\p{Lu}", flags, "A", true);
+    test("\\p{Lu}", flags, "1", false);
+    test("\\p{Ll}", flags, "A", true);
+    test("\\p{gc=Lu}", flags, "a", true);
+    test("\\p{General_Category=Ll}", flags, "A", true);
+    test("\\p{Uppercase}", flags, "a", true);
+    test("\\p{Lowercase}", flags, "A", true);
+    test("[\\p{Lu}]", flags, "a", true);
+    test("[\\p{Lu}0]", flags, "a", true);
+    test("[^\\p{Ll}]", flags, "A", false);
+    test("[^\\p{Ll}]", flags, "1", true);
+    test("\\p{Lu}+", flags, "aBcD", true);
+
+    // U+212A KELVIN SIGN and U+017F LATIN SMALL LETTER LONG S fold to k and s.
+    test("\\p{ASCII}", flags, "\u212A", true);
+    test("\\p{ASCII}", flags, "\u017F", true);
+    test("[\\p{ASCII}]", flags, "\u212A", true);
+    // U+00B5 MICRO SIGN folds to U+03BC GREEK SMALL LETTER MU.
+    test("\\p{sc=Greek}", flags, "\u00B5", true);
+    test("\\p{sc=Latin}", flags, "\u212A", true);
+    // U+01C5 (Lt) folds to U+01C6 (Ll); U+01C4 (Lu) folds there too.
+    test("\\p{Lt}", flags, "\u01C4", true);
+    test("\\p{Lt}", flags, "\u01C6", true);
+    // Non-BMP: U+10400 DESERET CAPITAL LETTER LONG I / U+10428 DESERET SMALL LETTER LONG I.
+    test("\\p{Lu}", flags, "\u{10428}", true);
+    test("\\p{Ll}", flags, "\u{10400}", true);
+
+    // Properties without cased code points are unaffected.
+    test("\\p{Nd}", flags, "a", false);
+    test("\\P{Nd}", flags, "a", true);
+    test("\\P{Nd}", flags, "1", false);
+
+    // The i modifier alone enables folding, and removing it disables folding.
+    test("(?i:\\p{Lu})", flags.replace("i", ""), "a", true);
+    test("(?i:[^\\p{Ll}])", flags.replace("i", ""), "A", false);
+    test("(?-i:\\p{Lu})", flags, "a", false);
+    test("(?-i:[^\\p{Ll}])", flags, "A", true);
+}
+
+// In u mode, \P{...} is complemented before case folding, so it matches any code point that has a case variant outside the property.
+test("\\P{Lu}", "iu", "A", true);
+test("\\P{Lu}", "iu", "a", true);
+test("\\P{Lu}", "iu", "1", true);
+test("\\P{Ll}", "iu", "a", true);
+test("[\\P{Ll}]", "iu", "a", true);
+test("[\\P{Ll}0]", "iu", "a", true);
+test("[^\\P{Ll}]", "iu", "a", false);
+test("[^\\P{Ll}]", "iu", "A", false);
+test("\\P{Lt}", "iu", "\u01C5", true);
+test("\\P{ASCII}", "iu", "k", true);
+test("\\P{ASCII}", "iu", "\u212A", true);
+test("\\P{ASCII}", "iu", "!", false);
+test("(?i:\\P{Lu})", "u", "A", true);
+test("(?-i:\\P{Lu})", "iu", "A", false);
+test(".(?<=\\P{Nd})x", "iu", "\u{1F600}x", true);
+test(".(?<=\\P{Nd})x", "iu", "1x", false);
+test(".(?<!\\P{L})x", "iu", "\u{1F600}x", false);
+test(".(?<!\\P{L})x", "iu", "\u{10400}x", true);
+
+// In v mode, \P{...} and [^...] are complemented after case folding, so they never match a case variant of a member.
+test("\\P{Lu}", "iv", "A", false);
+test("\\P{Lu}", "iv", "a", false);
+test("\\P{Lu}", "iv", "1", true);
+test("\\P{Ll}", "iv", "A", false);
+test("[\\P{Ll}]", "iv", "A", false);
+test("[\\P{Ll}0]", "iv", "A", false);
+test("[0\\P{Ll}]", "iv", "A", false);
+test("[^\\P{Ll}]", "iv", "a", true);
+test("[^\\P{Ll}]", "iv", "A", true);
+test("[^\\P{Ll}]", "iv", "1", false);
+test("\\P{Lt}", "iv", "\u01C5", false);
+test("\\P{ASCII}", "iv", "k", false);
+test("\\P{ASCII}", "iv", "\u212A", false);
+test("\\P{ASCII}", "iv", "\u00E9", true);
+test("[\\P{L}]", "iv", "\u017F", false);
+test("[\\P{L}]", "iv", "\u03C2", false);
+test("[\\P{L}]", "iv", "\u01C5", false);
+test("[\\P{L}]", "iv", "_", true);
+test("(?i:\\P{Lu})", "v", "A", false);
+test("(?-i:\\P{Lu})", "iv", "a", true);
+
+// v-mode set operations see the case-folded property.
+test("[\\p{Any}&&\\P{Lu}]", "iv", "a", false);
+test("[\\p{Any}&&\\P{Lu}]", "iv", "1", true);
+test("[\\p{Any}--\\p{Lu}]", "iv", "a", false);
+test("[\\p{Any}--\\P{Lu}]", "iv", "a", true);
+test("[\\p{Lu}&&\\p{Ll}]", "iv", "a", true);
+test("[\\p{Lu}&&\\p{Ll}]", "iv", "A", true);
+test("[\\p{Lu}&&\\p{Ll}]", "iv", "\u00AA", false);
+test("[\\p{Lu}--\\p{Ll}]", "iv", "A", false);
+test("[\\p{L}--\\p{Lu}]", "iv", "a", false);
+test("[\\p{L}--\\p{Lu}]", "iv", "\u00AA", true);
+test("[\\p{Lu}--[a-z]]", "iv", "K", false);
+test("[\\p{Lu}--[a-z]]", "iv", "\u212A", false);
+test("[\\p{Lu}--[a-z]]", "iv", "\u00C5", true);
+test("[\\P{ASCII}&&[A-Z]]", "iv", "\u212A", false);
+test("[[\\P{L}]&&[\\P{Ll}]]", "iv", "A", false);
+test("[[\\P{L}]&&[\\P{Ll}]]", "iv", "1", true);
+test("[^[\\p{L}]--\\q{a|K}]", "iv", "A", true);
+test("[^[\\p{L}]--\\q{a|K}]", "iv", "\u212A", true);
+test("[^[\\p{L}]--\\q{a|K}]", "iv", "b", false);

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -52,7 +52,3 @@ skip:
     - test/intl402/Locale/extensions-grandfathered.js
     - test/intl402/Locale/getters-grandfathered.js
     - test/intl402/Locale/likely-subtags-grandfathered.js
-
-    # Skipping temporarily due to a bug with handling case-insensitive \p escapes
-    - test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-upper-p.js
-    - test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-lower-p.js

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -336,6 +336,22 @@ public:
         }
     }
 
+    void putUnicodeIgnoreCase(const CharacterClass* other)
+    {
+        ASSERT(m_isCaseInsensitive && m_canonicalMode == CanonicalMode::Unicode && isUnionSetOp());
+        for (auto& string : other->m_strings)
+            m_strings.append(string);
+        for (char32_t ch : other->m_matches8)
+            putChar(ch);
+        for (auto& range : other->m_ranges8)
+            putRange(range.begin, range.end);
+        for (char32_t ch : other->m_matches32)
+            putChar(ch);
+        for (auto& range : other->m_ranges32)
+            putRange(range.begin, range.end);
+        m_mayContainStrings |= other->hasStrings();
+    }
+
     void atomClassStringDisjunction(Vector<Vector<char32_t>>& disjunctionStrings)
     {
         Vector<Vector<char32_t>> utf32Strings;
@@ -1076,8 +1092,12 @@ private:
                     }
                 }
 
-                while (matchesIndex < matches.size() && matches[matchesIndex] < ranges[rangesIndex].end + 1)
-                    matchesIndex++;
+                size_t endIndex = matchesIndex;
+                while (endIndex < matches.size() && matches[endIndex] < ranges[rangesIndex].end + 1)
+                    endIndex++;
+
+                if (matchesIndex != endIndex)
+                    matches.removeAt(matchesIndex, endIndex - matchesIndex);
 
                 if (matchesIndex < matches.size()) {
                     if (matches[matchesIndex] > ranges[rangesIndex].end + 1) {
@@ -1157,6 +1177,36 @@ private:
     Vector<char32_t> m_matches32;
     Vector<CharacterRange> m_ranges32;
 };
+
+static std::unique_ptr<CharacterClass> invertedCharacterClass(const CharacterClass* characterClass, CompileMode compileMode)
+{
+    CharacterClassConstructor constructor(false, compileMode);
+    constructor.appendInverted(characterClass);
+    return constructor.charClass();
+}
+
+CharacterClass* YarrPattern::unicodeCharacterClassFor(BuiltInCharacterClassID unicodeClassID, bool ignoreCase, bool invert)
+{
+    ASSERT(unicodeClassID >= BuiltInCharacterClassID::BaseUnicodePropertyID);
+
+    ignoreCase = ignoreCase && eitherUnicode();
+    invert = invert && ignoreCase && !unicodeSets();
+    unsigned key = static_cast<unsigned>(unicodeClassID) << 2 | static_cast<unsigned>(ignoreCase) << 1 | static_cast<unsigned>(invert);
+    return unicodePropertiesCached.ensure(key, [&] {
+        std::unique_ptr<CharacterClass> characterClass = createUnicodeCharacterClassFor(unicodeClassID);
+        if (ignoreCase) {
+            if (invert)
+                characterClass = invertedCharacterClass(characterClass.get(), compileMode());
+            CharacterClassConstructor constructor(true, compileMode());
+            constructor.putUnicodeIgnoreCase(characterClass.get());
+            characterClass = constructor.charClass();
+            if (invert)
+                characterClass = invertedCharacterClass(characterClass.get(), compileMode());
+        }
+        m_userCharacterClasses.append(WTF::move(characterClass));
+        return m_userCharacterClasses.last().get();
+    }).iterator->value;
+}
 
 class YarrPatternConstructor {
     class UnresolvedForwardReference {
@@ -1364,37 +1414,34 @@ public:
                 m_alternative->m_terms.append(PatternTerm(m_pattern.newlineCharacterClass(), true, m_flags, parenthesisMatchDirection()));
             break;
         default: {
-            if (characterClassMayContainStrings(classID)) {
-                auto characterClass = m_pattern.unicodeCharacterClassFor(classID);
-                if (characterClass->hasStrings()) {
-                    atomParenthesesSubpatternBegin(false);
-                    unsigned alternativeCount = 0;
-                    for (unsigned i = 0; i < characterClass->m_strings.size(); ++i) {
-                        if (alternativeCount)
-                            disjunction(CreateDisjunctionPurpose::ForNextAlternative);
+            CharacterClass* characterClass = m_pattern.unicodeCharacterClassFor(classID, ignoreCase(), invert);
+            if (characterClass->hasStrings()) {
+                atomParenthesesSubpatternBegin(false);
+                unsigned alternativeCount = 0;
+                for (unsigned i = 0; i < characterClass->m_strings.size(); ++i) {
+                    if (alternativeCount)
+                        disjunction(CreateDisjunctionPurpose::ForNextAlternative);
 
-                        auto string = characterClass->m_strings[i];
+                    auto string = characterClass->m_strings[i];
 
-                        for (auto ch : string)
-                            atomPatternCharacter(ch, /* hyphenIsRange */ false);
+                    for (auto ch : string)
+                        atomPatternCharacter(ch, /* hyphenIsRange */ false);
 
-                        ++alternativeCount;
-                    }
-
-                    if (characterClass->hasSingleCharacters()) {
-                        if (alternativeCount)
-                            disjunction(CreateDisjunctionPurpose::ForNextAlternative);
-
-                        m_alternative->m_terms.append(PatternTerm(characterClass, invert, m_flags, parenthesisMatchDirection()));
-                    }
-
-                    atomParenthesesEnd();
-                    break;
+                    ++alternativeCount;
                 }
-                // Fall through for the case where the characterClass REALLY doesn't have strings.
+
+                if (characterClass->hasSingleCharacters()) {
+                    if (alternativeCount)
+                        disjunction(CreateDisjunctionPurpose::ForNextAlternative);
+
+                    m_alternative->m_terms.append(PatternTerm(characterClass, invert, m_flags, parenthesisMatchDirection()));
+                }
+
+                atomParenthesesEnd();
+                break;
             }
 
-            m_alternative->m_terms.append(PatternTerm(m_pattern.unicodeCharacterClassFor(classID), invert, m_flags, parenthesisMatchDirection()));
+            m_alternative->m_terms.append(PatternTerm(characterClass, invert, m_flags, parenthesisMatchDirection()));
             break;
         }
         }
@@ -1438,11 +1485,13 @@ public:
                 m_currentCharacterClassConstructor->append(invert ? m_pattern.nonwordcharCharacterClass() : m_pattern.wordcharCharacterClass());
             break;
         
-        default:
+        default: {
+            CharacterClass* characterClass = m_pattern.unicodeCharacterClassFor(classID, ignoreCase(), invert);
             if (!invert)
-                m_currentCharacterClassConstructor->append(m_pattern.unicodeCharacterClassFor(classID));
+                m_currentCharacterClassConstructor->append(characterClass);
             else
-                m_currentCharacterClassConstructor->appendInverted(m_pattern.unicodeCharacterClassFor(classID));
+                m_currentCharacterClassConstructor->appendInverted(characterClass);
+        }
         }
     }
 

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -747,21 +747,7 @@ struct YarrPattern {
         }
         return nonwordUnicodeIgnoreCasecharCached;
     }
-    CharacterClass* unicodeCharacterClassFor(BuiltInCharacterClassID unicodeClassID)
-    {
-        ASSERT(unicodeClassID >= BuiltInCharacterClassID::BaseUnicodePropertyID);
-
-        unsigned classID = static_cast<unsigned>(unicodeClassID);
-
-        if (unicodePropertiesCached.find(classID) == unicodePropertiesCached.end()) {
-            m_userCharacterClasses.append(createUnicodeCharacterClassFor(unicodeClassID));
-            CharacterClass* result = m_userCharacterClasses.last().get();
-            unicodePropertiesCached.add(classID, result);
-            return result;
-        }
-
-        return unicodePropertiesCached.get(classID);
-    }
+    CharacterClass* unicodeCharacterClassFor(BuiltInCharacterClassID, bool ignoreCase, bool invert);
 
     unsigned offsetVectorBaseForNamedCaptures() const
     {


### PR DESCRIPTION
#### b7fac902847a0415841fc9965941403d2a6401a5
<pre>
[YARR] Unicode property escapes ignore case-insensitivity in u and v modes
<a href="https://bugs.webkit.org/show_bug.cgi?id=321422">https://bugs.webkit.org/show_bug.cgi?id=321422</a>

Reviewed by Yusuke Suzuki.

Character classes are matched without canonicalizing the input, so a class has to
carry the case-folding closure of its members when ignoreCase is set. \p{...} and
\P{...} handed the generated property table to PatternTerm / append() /
appendInverted() as is, so under /iu and /iv they only matched the exact code
points of the property, and \P{...} complemented before folding even in v mode,
where CharacterComplement applies to the folded set [1][2]:

    /\p{Lu}/iu.test(&quot;a&quot;)              // false, should be true
    /\P{Ll}/iv.test(&quot;A&quot;)              // true, should be false
    /[\p{Any}&amp;&amp;\P{Lu}]/iv.test(&quot;a&quot;)   // true, should be false

YarrPattern::unicodeIgnoreCaseCharacterClassFor() builds and caches the folded
class by feeding the table through CharacterClassConstructor::putChar()/putRange().
For \P{...} in u mode, where the complement is taken before folding [3], the table
is complemented before and after folding so that the term&apos;s invert flag and
appendInverted() keep applying unchanged. coalesceTables() now drops matches that
fall inside a range, since putRange() adds case variants without consulting the
ranges and appendInverted() relies on matches and ranges being disjoint.

This also unskips the two test262 regexp-modifiers tests that were disabled for
this bug.

[1]: <a href="https://tc39.es/ecma262/#sec-maybesimplecasefolding">https://tc39.es/ecma262/#sec-maybesimplecasefolding</a>
[2]: <a href="https://tc39.es/ecma262/#sec-charactercomplement">https://tc39.es/ecma262/#sec-charactercomplement</a>
[3]: <a href="https://tc39.es/ecma262/#sec-compiletocharset">https://tc39.es/ecma262/#sec-compiletocharset</a>

Test: JSTests/stress/regexp-unicode-property-escape-ignore-case.js

* JSTests/stress/regexp-unicode-property-escape-ignore-case.js: Added.
(shouldBe):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::putUnicodeIgnoreCase):
(JSC::Yarr::CharacterClassConstructor::coalesceTables):
(JSC::Yarr::invertedCharacterClass):
(JSC::Yarr::YarrPattern::unicodeIgnoreCaseCharacterClassFor):
(JSC::Yarr::YarrPatternConstructor::atomBuiltInCharacterClass):
(JSC::Yarr::YarrPatternConstructor::unicodePropertyCharacterClass):
(JSC::Yarr::YarrPatternConstructor::atomCharacterClassBuiltIn):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::YarrPattern::resetForReparsing):

Canonical link: <a href="https://commits.webkit.org/319064@main">https://commits.webkit.org/319064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a5845f54e0bba2c10821e932d787ce3bbab7688

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144538 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140560 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121012 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42892 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41198 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2979 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9829 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40873 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1589 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41493 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192365 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53830 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149905 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40171 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54518 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149634 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44276 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126781 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121928 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53035 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15862 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52417 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52654 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->