### PR TITLE
[site-isolation] media/media-source/media-source-duplicate-seeked.html is a permanent failure

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4593,7 +4593,7 @@ void HTMLMediaElement::play()
     playInternal();
 }
 
-void HTMLMediaElement::completePlayInternal()
+void HTMLMediaElement::completePlayInternal(bool shouldSeekToStart)
 {
     // 4.8.10.9. Playing the media resource
     // The NETWORK_EMPTY + no-src case is handled synchronously in playInternal().
@@ -4613,7 +4613,7 @@ void HTMLMediaElement::completePlayInternal()
     if (needsResourceSelection)
         selectMediaResource();
 
-    if (endedPlayback())
+    if (shouldSeekToStart)
         seekInternal(MediaTime::zeroTime());
 
     if (RefPtr mediaController = m_mediaController)
@@ -4707,13 +4707,16 @@ void HTMLMediaElement::playInternal()
     // True if the admission completion handler below is guaranteed to settle
     // m_pendingPlayPromises itself, even if pause() races the in-flight admission.
     m_playPromiseSettlementGuaranteed = shouldNotifyAboutPlaying || shouldResolvePromises;
+    // Whether the spec's seek-to-start step applies is decided at play() time: playback can reach the
+    // end of the media during the admission round trip.
+    bool shouldSeekToStart = endedPlayback();
     if (didTransitionFromPaused && m_readyState <= HAVE_CURRENT_DATA)
         scheduleEvent(eventNames().waitingEvent);
 
     if (m_playRequest->hasCallback())
         m_playRequest->disconnect();
 
-    auto onAdmissionSettled = [weakThis = WeakPtr { *this }, didTransitionFromPaused, shouldNotifyAboutPlaying, shouldResolvePromises, logSiteIdentifier](bool canBegin) {
+    auto onAdmissionSettled = [weakThis = WeakPtr { *this }, didTransitionFromPaused, shouldNotifyAboutPlaying, shouldResolvePromises, shouldSeekToStart, logSiteIdentifier](bool canBegin) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -4756,7 +4759,7 @@ void HTMLMediaElement::playInternal()
             protectedThis->scheduleNotifyAboutPlaying(false);
         else if (shouldResolvePromises)
             protectedThis->scheduleResolvePendingPlayPromises();
-        protectedThis->completePlayInternal();
+        protectedThis->completePlayInternal(shouldSeekToStart);
     };
 
     // Already admitted (e.g. resuming after endInterruption() restores state() to Playing): run inline instead of deferring through whenSettled().

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1023,7 +1023,7 @@ private:
     // These "internal" functions do not check user gesture restrictions.
     void playInternal();
     void pauseInternal();
-    void completePlayInternal();
+    void completePlayInternal(bool shouldSeekToStart);
 
     enum class IsExplicitLoad : bool { No, Yes };
     void prepareForLoad(IsExplicitLoad = IsExplicitLoad::No);


### PR DESCRIPTION
#### ce9f06404fc2e96a2f0a837ac3dcfb4650f9e328
<pre>
[site-isolation] media/media-source/media-source-duplicate-seeked.html is a permanent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=321421">https://bugs.webkit.org/show_bug.cgi?id=321421</a>
<a href="https://rdar.apple.com/184489618">rdar://184489618</a>

Reviewed by Eric Carlson.

The test seeked to 0.9 of a one-second resource, called play(), and expected an ended event with no
further seeked event. With site isolation enabled an extra seeked arrived after ended.
completePlayInternal() implements the spec&apos;s &quot;if playback has ended, seek to the start&quot; step and
evaluated endedPlayback() when it ran, which is after the playback admission round trip. Playback
reached the end of the media during that round trip, so endedPlayback() was true by then and
seekInternal() ran a seek to zero the page never asked for. Without site isolation the admission
completed in the same task or one runloop turn, well inside the test&apos;s 100ms margin, so endedPlayback()
was still false.

playInternal() now captures endedPlayback() at play() time and passes it to completePlayInternal(),
alongside the shouldNotifyAboutPlaying and shouldResolvePromises decisions it already captures there
for the same reason.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::completePlayInternal): Take the seek-to-start decision as a parameter.
(WebCore::HTMLMediaElement::playInternal): Capture endedPlayback() at play() time and pass it through
the admission completion handler.
* Source/WebCore/html/HTMLMediaElement.h:

Canonical link: <a href="https://commits.webkit.org/318932@main">https://commits.webkit.org/318932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b92940c46374e3d3e797d6dd95842ef143643729

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189612 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144090 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/922e9358-0835-44e9-8ea3-fad3c946ffd9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140232 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/533405ee-de9e-4aff-bb5b-dfbb389a1683) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120683 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6fc103c3-954a-4bf8-ac7f-a74875c2cc9e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42516 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40830 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40490 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1065 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191833 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53388 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149511 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40078 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54069 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149245 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43904 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126341 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121371 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52586 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15480 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51971 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52212 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52032 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->