### PR TITLE
[JSC] Shrink `StructureRareData` back to 96 bytes

### DIFF
--- a/Source/JavaScriptCore/runtime/StructureRareData.cpp
+++ b/Source/JavaScriptCore/runtime/StructureRareData.cpp
@@ -123,7 +123,7 @@ SpecialPropertyCache& StructureRareData::ensureSpecialPropertyCacheSlow()
 inline void StructureRareData::giveUpOnSpecialPropertyCache(CachedSpecialPropertyKey key)
 {
     // Invalidate the memoized fast-path verdict along with the cache it is derived from.
-    m_cachedHasDefaultToPrimitiveFastAndNonObservable = TriState::Indeterminate;
+    setCachedHasDefaultToPrimitiveFastAndNonObservable(TriState::Indeterminate);
     ensureSpecialPropertyCache().m_cache[static_cast<unsigned>(key)].m_value.setWithoutWriteBarrier(JSCell::seenMultipleCalleeObjects());
 }
 
@@ -225,7 +225,7 @@ void StructureRareData::clearCachedSpecialProperty(CachedSpecialPropertyKey key)
     // The fast-path verdict is derived from every special property except ToJSON, so invalidate it
     // whenever one of those caches is cleared.
     if (key != CachedSpecialPropertyKey::ToJSON)
-        m_cachedHasDefaultToPrimitiveFastAndNonObservable = TriState::Indeterminate;
+        setCachedHasDefaultToPrimitiveFastAndNonObservable(TriState::Indeterminate);
 
     auto* objectToStringCache = m_specialPropertyCache.get();
     if (!objectToStringCache)

--- a/Source/JavaScriptCore/runtime/StructureRareData.h
+++ b/Source/JavaScriptCore/runtime/StructureRareData.h
@@ -87,8 +87,8 @@ public:
     JSValue cachedSpecialProperty(CachedSpecialPropertyKey) const;
     void cacheSpecialProperty(JSGlobalObject*, VM&, Structure* baseStructure, JSValue, CachedSpecialPropertyKey, const PropertySlot&);
 
-    TriState cachedHasDefaultToPrimitiveFastAndNonObservable() const { return m_cachedHasDefaultToPrimitiveFastAndNonObservable; }
-    void setCachedHasDefaultToPrimitiveFastAndNonObservable(TriState mode) { m_cachedHasDefaultToPrimitiveFastAndNonObservable = mode; }
+    TriState cachedHasDefaultToPrimitiveFastAndNonObservable() const { return static_cast<TriState>(m_cachedHasDefaultToPrimitiveFastAndNonObservable); }
+    void setCachedHasDefaultToPrimitiveFastAndNonObservable(TriState mode) { m_cachedHasDefaultToPrimitiveFastAndNonObservable = static_cast<unsigned>(mode); }
 
     JSPropertyNameEnumerator* cachedPropertyNameEnumerator() const;
     uintptr_t cachedPropertyNameEnumeratorAndFlag() const;
@@ -180,8 +180,11 @@ private:
     WriteBarrierStructureID m_previous;
     PropertyOffset m_maxOffset;
     PropertyOffset m_transitionOffset;
-    unsigned m_activeReplacementWatchpointSet { 0 };
-    TriState m_cachedHasDefaultToPrimitiveFastAndNonObservable : 2 { TriState::Indeterminate };
+    unsigned m_activeReplacementWatchpointSet : 30 { 0 };
+    unsigned m_cachedHasDefaultToPrimitiveFastAndNonObservable : 2 { static_cast<unsigned>(TriState::Indeterminate) }; // TriState
 };
+#ifdef NDEBUG
+static_assert(sizeof(StructureRareData) <= 96, "StructureRareData should remain small");
+#endif
 
 } // namespace JSC


### PR DESCRIPTION
#### edd953757f9fb56212a3fd02b16b79a1e8f51d8d
<pre>
[JSC] Shrink `StructureRareData` back to 96 bytes
<a href="https://bugs.webkit.org/show_bug.cgi?id=321423">https://bugs.webkit.org/show_bug.cgi?id=321423</a>

Reviewed by Keith Miller.

317978@main appended a 2-bit TriState bit-field to StructureRareData, whose
members already filled exactly 96 bytes. The new field spilled into byte 97,
so sizeof(StructureRareData) became 104 and its IsoSubspace cell grew from
96 to 112 bytes.

Make m_activeReplacementWatchpointSet a 30-bit bit-field so that it shares a
32-bit word with m_cachedHasDefaultToPrimitiveFastAndNonObservable. The counter
tracks the number of entries in m_replacementWatchpointSets, which is bounded by
the number of property offsets and cannot approach 2^30. Also add a
static_assert on sizeof(StructureRareData) so that this does not regress
silently again; like the existing PropertyWatchpointMap assert it is NDEBUG-only
because HashTable grows in debug builds.

* Source/JavaScriptCore/runtime/StructureRareData.h:

Canonical link: <a href="https://commits.webkit.org/318955@main">https://commits.webkit.org/318955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/126e257a7b92a8cd772d1bd5273d543633980ad4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144127 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140263 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120713 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42531 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40851 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2682 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9475 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152932 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40513 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/webapi/abort.any.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1172 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41082 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191950 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53420 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149541 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40090 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54105 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37128 "Found 1 new test failure: imported/w3c/web-platform-tests/largest-contentful-paint/observe-svg-data-uri-image.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149275 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43924 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126369 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121426 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52622 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15503 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52006 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->