### PR TITLE
[site-isolation] media/media-session/interruption-sends-pause-action.html  is a permanent timeout

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -100,7 +100,6 @@ imported/blink/fast/forms/datetimelocal-multiple-fields/datetimelocal-multiple-f
 imported/blink/fast/forms/month-multiple-fields/month-multiple-fields-clearbutton-visibility-after-restore.html [ Timeout ]
 imported/blink/fast/forms/time-multiple-fields/time-multiple-fields-clearbutton-visibility-after-restore.html [ Timeout ]
 imported/blink/fast/forms/week-multiple-fields/week-multiple-fields-clearbutton-visibility-after-restore.html [ Timeout ]
-media/media-session/interruption-sends-pause-action.html [ Timeout ]
 media/remote-control-command-paused-with-webaudio.html [ Timeout ]
 media/video-play-pause-exception.html [ Timeout ]
 platform/ios/mediastream/audio-muted-in-background-tab.html [ Timeout ]

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -217,7 +217,9 @@ void PlatformMediaSession::beginInterruption(InterruptionType type)
     }
     m_interruptionStack.append({ type, false });
 
-    m_stateToRestore = state();
+    // A playback admission may still be in flight. If so the session is not in State::Playing yet even
+    // though play is intended, and we should restore State::Playing when the interruption ends.
+    m_stateToRestore = m_preparingToPlay ? State::Playing : state();
     m_notifyingClient = true;
     setState(State::Interrupted);
     protect(client())->suspendPlayback();


### PR DESCRIPTION
#### 1ac68abf2d3ef078ede465e86da86474faea533b
<pre>
[site-isolation] media/media-session/interruption-sends-pause-action.html  is a permanent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=321362">https://bugs.webkit.org/show_bug.cgi?id=321362</a>
<a href="https://rdar.apple.com/184409252">rdar://184409252</a>

Reviewed by Eric Carlson.

The test waited for a pause action that never arrived: MediaSession never calls PlatformMediaSession::setActive(), and
RemoteMediaSessionManager::sessionWillBeginPlayback() did not call setCurrentSession() either, so the
session was in no session list and beginInterruption()&apos;s forEachSession() never reached it.

Registering it was not enough. Setting playbackState to &quot;playing&quot; asked the UI process whether playback
could begin and completed on the reply, while the test began and ended the interruption within one task.
beginInterruption() sampled m_stateToRestore mid-request and recorded State::Idle, so
endInterruption(MayResumePlaying) computed shouldResume as false and sent no play action.

The web process now registers the session with the base class setCurrentSession(), and
beginInterruption() records State::Playing while a playback request is in flight.

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::beginInterruption): Restore State::Playing when a playback request is
in flight.
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp:
(WebKit::RemoteMediaSessionManager::sessionWillBeginPlayback): Register the session with the base class
setCurrentSession().

Canonical link: <a href="https://commits.webkit.org/318941@main">https://commits.webkit.org/318941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbb6c5adc55e0a0a33d1a2ecf48639b1cafa1514

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47648 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d76b879d-78a8-462a-b4d5-711671ff124a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53568 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/00ffeb47-0e02-4846-a81d-233123ed5a29) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43942 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9440ce76-6780-432e-bc22-034c4d3f9953) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40602 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1274 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192049 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53518 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149621 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40082 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54205 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149351 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43998 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126468 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121524 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52722 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15588 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52104 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52342 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52168 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->