### PR TITLE
[Legacy SVG] CSS clip-path basic-shape is mispositioned on a rotated or scaled SVG element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-container-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-container-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape on a rotated SVG container (reference)</title>
+<svg width="300" height="300">
+  <g transform="rotate(90 100 100)">
+    <rect x="50" y="50" width="100" height="100" fill="green"/>
+  </g>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-container-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-container-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape on a rotated SVG container (reference)</title>
+<svg width="300" height="300">
+  <g transform="rotate(90 100 100)">
+    <rect x="50" y="50" width="100" height="100" fill="green"/>
+  </g>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-container.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape on a rotated SVG container</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="match" href="clip-path-shape-svg-rotated-container-ref.html">
+<meta name="assert" content="The reference box of a rotated container is its own bounding box in its own user space, so inset() trims 100 user units from its right edge and the result rotates with the container.">
+<svg width="300" height="300">
+  <g transform="rotate(90 100 100)" style="clip-path: inset(0 100px 0 0)">
+    <rect x="50" y="50" width="200" height="100" fill="green"/>
+  </g>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape on a rotated SVG shape (reference)</title>
+<svg width="300" height="300">
+  <rect x="50" y="50" width="100" height="100" transform="rotate(90 100 100)" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape on a rotated SVG shape (reference)</title>
+<svg width="300" height="300">
+  <rect x="50" y="50" width="100" height="100" transform="rotate(90 100 100)" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape on a rotated SVG shape</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="match" href="clip-path-shape-svg-rotated-shape-ref.html">
+<meta name="assert" content="The reference box is the shape's own bounding box in its own user space, so inset() trims 100 user units from its right edge and the result rotates with the shape.">
+<svg width="300" height="300">
+  <rect x="50" y="50" width="200" height="100" transform="rotate(90 100 100)" style="clip-path: inset(0 100px 0 0)" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape lengths on a scaled SVG shape (reference)</title>
+<svg width="400" height="400">
+  <rect x="50" y="50" width="100" height="100" transform="scale(2)" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape lengths on a scaled SVG shape (reference)</title>
+<svg width="400" height="400">
+  <rect x="50" y="50" width="100" height="100" transform="scale(2)" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path basic shape lengths on a scaled SVG shape</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="match" href="clip-path-shape-svg-scaled-shape-ref.html">
+<meta name="assert" content="An absolute length in a basic shape resolves in the shape's own user space, so inset() on a scale(2) shape trims 100 user units rather than 100 units of the parent's space.">
+<svg width="400" height="400">
+  <rect x="50" y="50" width="200" height="100" transform="scale(2)" style="clip-path: inset(0 100px 0 0)" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path view-box reference box on a rotated SVG shape (reference)</title>
+<svg width="400" height="400">
+  <rect x="0" y="0" width="100" height="100" transform="rotate(90 100 100)" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path view-box reference box on a rotated SVG shape (reference)</title>
+<svg width="400" height="400">
+  <rect x="0" y="0" width="100" height="100" transform="rotate(90 100 100)" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path view-box reference box on a rotated SVG shape</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="match" href="clip-path-shape-svg-view-box-rotated-shape-ref.html">
+<meta name="assert" content="The view-box reference box is sized from the nearest SVG viewport but positioned in the rotated shape's own user space.">
+<svg width="400" height="400">
+  <rect x="0" y="0" width="200" height="100" transform="rotate(90 100 100)" style="clip-path: inset(0 300px 0 0) view-box" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path view-box reference box on a scaled SVG shape (reference)</title>
+<svg width="400" height="400">
+  <rect width="100" height="200" transform="scale(2)" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path view-box reference box on a scaled SVG shape (reference)</title>
+<svg width="400" height="400">
+  <rect width="100" height="200" transform="scale(2)" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Masking: clip-path view-box reference box on a scaled SVG shape</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792+github@gmail.com">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="match" href="clip-path-shape-svg-view-box-scaled-shape-ref.html">
+<meta name="assert" content="The view-box reference box is sized from the nearest SVG viewport but positioned in the scaled shape's own user space.">
+<svg width="400" height="400">
+  <rect width="200" height="200" transform="scale(2)" style="clip-path: inset(0 300px 0 0) view-box" fill="green"/>
+</svg>

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -494,15 +494,8 @@ void SVGRenderSupport::clipContextToCSSClippingArea(GraphicsContext& context, co
 {
     WTF::switchOn(renderer.style().clipPath(),
         [&](const Style::BasicShapePath& clipPath) {
-            auto localToParentTransform = renderer.localToParentTransform();
-
             auto referenceBox = clipPathReferenceBox(renderer, clipPath.referenceBox());
-            referenceBox = localToParentTransform.mapRect(referenceBox);
-
-            auto path = Style::path(clipPath.shape(), referenceBox, renderer.style().usedZoomForLength());
-            path.transform(valueOrDefault(localToParentTransform.inverse()));
-
-            context.clipPath(path, Style::windRule(clipPath.shape()));
+            context.clipPath(Style::path(clipPath.shape(), referenceBox, renderer.style().usedZoomForLength()), Style::windRule(clipPath.shape()));
         },
         [&](const Style::BoxPath& clipPath) {
             auto referenceBox = clipPathReferenceBox(renderer, clipPath.referenceBox());


### PR DESCRIPTION
#### 14f17f50a0e8de21487094c5c395ba6acd655a3c
<pre>
[Legacy SVG] CSS clip-path basic-shape is mispositioned on a rotated or scaled SVG element
<a href="https://bugs.webkit.org/show_bug.cgi?id=321424">https://bugs.webkit.org/show_bug.cgi?id=321424</a>
<a href="https://rdar.apple.com/184494108">rdar://184494108</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

clipContextToCSSClippingArea() mapped the clip-path reference box out through
localToParentTransform(), built the basic shape there, then mapped the resulting path back through
the inverse. The context is already in the renderer&apos;s local coordinate system when this runs -- every
legacy paint path applies its own transform before calling prepareToRenderSVGContent() -- and
clipPathReferenceBox() returns a box in that same space, so the round trip is redundant. It is also
lossy: mapRect() returns the axis-aligned bounding box, so a 200x100 box rotated 90 degrees becomes
100x200 and inset(0 100px 0 0) collapses to an empty clip; and absolute lengths resolve at the
parent&apos;s scale, so under scale(2) that same inset trimmed 50 user units rather than 100.

227370@main added the round trip for clip-path on the &lt;svg&gt; root, where the context is in viewBox
coordinates while the clip is in CSS coordinates. 281893@main then moved root clip-path handling to
RenderLayer::setupClipPath() and stopped calling this function for LegacyRenderSVGRoot, leaving the
round trip with no case to serve.

Resolve the shape directly against the reference box, matching the adjacent box path and
isPointInCSSClippingArea(), which both already treat it as local. Chrome and Firefox agree with the
new tests, including the view-box cases, where the box is sized from the nearest viewport but
positioned in the element&apos;s own user space.

NOTE: This bug does not reproduce in Layer Based SVG Engine (LBSE).

Tests: imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-container-ref.html
       imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-container.html
       imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape-ref.html
       imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape.html
       imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape-ref.html
       imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape.html
       imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape-ref.html
       imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape.html
       imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape-ref.html
       imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-container-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-container-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-container.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-rotated-shape.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-scaled-shape.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-rotated-shape.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-shape-svg-view-box-scaled-shape.html: Added.
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::clipContextToCSSClippingArea):

Canonical link: <a href="https://commits.webkit.org/318924@main">https://commits.webkit.org/318924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/941550e5e33c27393b5275759dc268f0bcaf111f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53827 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55124 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182837 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/152999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/1249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/192023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/192023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/54180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/192023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27310 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/54180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->