### PR TITLE
[css-values-5] Fix invalidation and serialization of properties using attr() with number or percentage

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4773,7 +4773,6 @@ imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-flex-008.html
 imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-flex-009.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-dynamic-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-scroll-vw-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-values/attr-pseudo-element-placeholder.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/urls/cross-origin/url-import-cross-origin-anonymous.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/urls/cross-origin/url-import-cross-origin-use-credentials.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/urls/cross-origin/url-svg-filter-cross-origin-anonymous.sub.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt
@@ -176,4 +176,6 @@ PASS CSS Values and Units Test: attr 172
 PASS CSS Values and Units Test: attr 173
 PASS CSS Values and Units Test: attr 174
 PASS CSS Values and Units Test: attr 175
+PASS CSS Values and Units Test: attr 176
+PASS CSS Values and Units Test: attr 177
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types.html
@@ -275,4 +275,7 @@
     test_invalid_attr('width', 'attr(data-foo type(<length> +))', '10px');
 
     test_invalid_attr('--x', 'attr(data-foo type(<url>))', 'url("https://does-not-exist.test/404.png")');
+
+    test_valid_attr("--data-foo", "attr(data-foo type(*))", "attr(data-bar number)", '3')
+    test_valid_attr("--data-foo", "attr(data-foo type(*))", "attr(data-bar %)", '3%')
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-cycle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-cycle-expected.txt
@@ -29,5 +29,5 @@ PASS CSS Values and Units Test: attr 26
 PASS CSS Values and Units Test: attr 27
 PASS CSS Values and Units Test: attr 28
 PASS CSS Values and Units Test: attr 29
-FAIL CSS Values and Units Test: attr 30 assert_equals: Value 'attr(data-foo type(*))', where 'data-foo=attr(data-bar number)' should be valid for the property '--data-foo'. expected "3" but got ""
+PASS CSS Values and Units Test: attr 30
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-number-invalidation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-number-invalidation-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="http://www.w3.org/TR/css3-values/#attr-notation"/>
+<style>
+	div {
+	    height: 100px;
+		width: 100px;
+		background: green;
+	}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-number-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-number-invalidation.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title> CSS Values and Units Test: Attribute references (number type) invalidation </title>
+<link rel="help" href="http://www.w3.org/TR/css3-values/#attr-notation" />
+<link rel="author" title="Suraj Thanugundla" href="mailto:contact@surajt.com" />
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html" />
+<style>
+    #container {
+   	    height: 100px;
+		width: 100px;
+		background: red;
+		columns: attr(data-foo number);
+		column-gap: 0;
+    }
+	#inner {
+	    height: 200px;
+		width: 50px;
+		background: green;
+	}
+</style>
+<div id="container" data-foo="3">
+    <div id="inner"></div>
+</div>
+<script>
+    const element = document.getElementById("container");
+    element.getBoundingClientRect();
+    element.setAttribute("data-foo", "2");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-percent-invalidation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-percent-invalidation-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="http://www.w3.org/TR/css3-values/#attr-notation"/>
+<style>
+	div {
+	    height: 100px;
+		width: 100px;
+		background: green;
+	}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-percent-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-percent-invalidation.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title> CSS Values and Units Test: Attribute references (percent length type) invalidation </title>
+<link rel="help" href="http://www.w3.org/TR/css3-values/#attr-notation" />
+<link rel="author" title="Suraj Thanugundla" href="mailto:contact@surajt.com" />
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html" />
+<style>
+	#container {
+	    height: 100px;
+		width: 100px;
+		background: red;
+	}
+
+   	#inner {
+        width: 100%;
+        height: attr(data %);
+        background: green;
+    }
+</style>
+<div id="container">
+   	<div id="inner" data="0"></div>
+</div>
+<script>
+    const element = document.getElementById("inner");
+    element.getBoundingClientRect();
+    element.setAttribute("data", "100");
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6653,7 +6653,6 @@ webkit.org/b/214468 imported/w3c/web-platform-tests/css/css-shapes/shape-outside
 webkit.org/b/214468 imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-016.html [ ImageOnlyFailure ]
 webkit.org/b/214468 imported/w3c/web-platform-tests/css/css-sizing/thin-element-render.html [ ImageOnlyFailure ]
 webkit.org/b/214468 imported/w3c/web-platform-tests/css/css-values/ch-unit-002.html [ ImageOnlyFailure ]
-webkit.org/b/277995 imported/w3c/web-platform-tests/css/css-values/attr-all-types.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-compute.html [ Skip ]
 
 #1px diff

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2223,8 +2223,6 @@ webkit.org/b/260320 imported/w3c/web-platform-tests/css/selectors/invalidation/n
 
 webkit.org/b/289275 media/media-garbage-collection.html [ Pass Failure Timeout ]
 
-[ x86_64 ] imported/w3c/web-platform-tests/css/css-values/attr-all-types.html [ Failure ]
-
 # webkit.org/b/290848 : AX: accessibility/mac/line-boundary-at-br.html asserts on Debug
 [ Debug ] accessibility/mac/line-boundary-at-br.html [ Skip ]
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -832,7 +832,8 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
     //  leading and trailing whitespace, to be parsed as a <number-token>. Values that fail to
     //  parse trigger fallback."
     case AttrType::Number: {
-        CSSTokenizer tokenizer(attributeValue.string().trim(isUnicodeCompatibleASCIIWhitespace<UChar>));
+        auto trimmedValue = attributeValue.string().trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        CSSTokenizer tokenizer(trimmedValue);
         auto tokenRange = tokenizer.tokenRange();
         tokenRange.consumeWhitespace();
         if (tokenRange.peek().type() != NumberToken)
@@ -840,7 +841,9 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         auto numberToken = tokenRange.consumeIncludingWhitespace();
         if (!tokenRange.atEnd())
             return substituteFailure();
-        tokens.append(CSSParserToken(numberToken.numericValue(), numberToken.numericValueType(), numberToken.numericSign(), StringView()));
+        m_intermediateTokenStrings.append(WTF::move(trimmedValue));
+        m_intermediateTokenStrings.appendVector(tokenizer.escapedStringsForAdoption());
+        tokens.append(CSSParserToken(numberToken.numericValue(), numberToken.numericValueType(), numberToken.numericSign(), numberToken.value()));
         return true;
     }
 
@@ -852,7 +855,8 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         // "If the <attr-unit> does not match a known CSS unit, it triggers fallback."
         if (attrType == AttrType::Unit && parsedAttrType->unitType == CSSUnitType::Unknown)
             return substituteFailure();
-        CSSTokenizer tokenizer(attributeValue.string().trim(isUnicodeCompatibleASCIIWhitespace<UChar>));
+        auto trimmedValue = attributeValue.string().trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        CSSTokenizer tokenizer(trimmedValue);
         auto tokenRange = tokenizer.tokenRange();
         tokenRange.consumeWhitespace();
         if (tokenRange.peek().type() != NumberToken)
@@ -860,11 +864,13 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         auto numberToken = tokenRange.consumeIncludingWhitespace();
         if (!tokenRange.atEnd())
             return substituteFailure();
-        auto token = CSSParserToken(numberToken.numericValue(), numberToken.numericValueType(), numberToken.numericSign(), StringView());
+        auto token = CSSParserToken(numberToken.numericValue(), numberToken.numericValueType(), numberToken.numericSign(), numberToken.value());
         if (attrType == AttrType::Percentage)
             token.convertToPercentage();
         else
             token.convertToDimensionWithUnit(parsedAttrType->unitType);
+        m_intermediateTokenStrings.append(WTF::move(trimmedValue));
+        m_intermediateTokenStrings.appendVector(tokenizer.escapedStringsForAdoption());
         tokens.append(token);
         return true;
     }


### PR DESCRIPTION
#### 4a983f13b9fc3a9ca790ebd9d5cc61cef61cd4f6
<pre>
[css-values-5] Fix invalidation and serialization of properties using attr() with number or percentage
<a href="https://bugs.webkit.org/show_bug.cgi?id=321425">https://bugs.webkit.org/show_bug.cgi?id=321425</a>

Reviewed by Antti Koivisto.

When an element&apos;s attribute changes, the substituted value for properties
using attr() with a number or percentage type was never updated and this
resulted in the stale property value always being used. The new value is
compared with the old one and old value is replaced if they are unequal.
CSSParserToken::operator== is used for comparison and always evaluated
to true for number or percentage values even when unequal as their
original text is used to check equality rather than the parsed values.
The issue was that during attr() substitution, the substituted value’s
text was never stored and only parsed value was stored in CSSParserToken.
In addition, when such CSS properties are serialized, the original text
of the substituted value is used and always returned an empty string.

This change ensures that the original text of the substituted valued is
always passed to CSSParserToken constructor during attr() substitution,
making it available for equality checks and serialization later.

Tests: imported/w3c/web-platform-tests/css/css-values/attr-number-invalidation.html
       imported/w3c/web-platform-tests/css/css-values/attr-percent-invalidation.html

attr-pseudo-element-placeholder.html, attr-cycle-expected.html now
pass as property invalidation and serialization work as expected.

* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):
Pass the attribute string value instead of an empty StringView
to CSSParserToken constructor for Number and Percentage types
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-cycle-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-number-invalidation-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-number-invalidation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-percent-invalidation-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-percent-invalidation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/TestExpectations:
Update test expectations to remove passing tests

Canonical link: <a href="https://commits.webkit.org/319994@main">https://commits.webkit.org/319994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41e390d1b01d5d4402854bcc6935933b872714d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193305 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147376 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142908 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99251 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123335 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45324 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43567 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43198 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4479 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195247 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163163 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40909 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57385 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152073 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46630 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129655 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125803 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55893 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18209 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55502 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55331 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->