### PR TITLE
[JSC] Adjust / Fix wasm limit numbers

### DIFF
--- a/JSTests/wasm/stress/table-initial-upper-bound.js
+++ b/JSTests/wasm/stress/table-initial-upper-bound.js
@@ -1,0 +1,37 @@
+import * as assert from "../assert.js";
+
+// https://www.w3.org/TR/wasm-js-api-2/#limits says the maximum size of a table
+// is 10,000,000, so that size itself is creatable and only larger ones throw.
+const maxTableEntries = 10000000;
+
+for (const element of ["externref", "anyfunc"]) {
+    for (const address of [undefined, "i32", "i64"]) {
+        const is64 = address === "i64";
+        const size = value => is64 ? BigInt(value) : value;
+        const descriptor = value => {
+            const result = { element, initial: size(value) };
+            if (address !== undefined)
+                result.address = address;
+            return result;
+        };
+
+        const message = `WebAssembly.Table 'initial' value is above the upper bound ${maxTableEntries}`;
+        assert.throws(() => new WebAssembly.Table(descriptor(maxTableEntries + 1)), RangeError, message);
+
+        // A declared maximum is not bounded by what can be allocated, so only
+        // the initial size is rejected here.
+        const table = new WebAssembly.Table({ ...descriptor(1), maximum: size(maxTableEntries + 1) });
+        assert.eq(table.length, size(1));
+    }
+}
+
+// The bound itself is accepted, both at creation and by growth. Only externref
+// is exercised: a funcref table of this size also allocates an inline function
+// table.
+const table = new WebAssembly.Table({ element: "externref", initial: maxTableEntries });
+assert.eq(table.length, maxTableEntries);
+
+const grown = new WebAssembly.Table({ element: "externref", initial: 1 });
+assert.eq(grown.grow(maxTableEntries - 1), 1);
+assert.eq(grown.length, maxTableEntries);
+assert.throws(() => grown.grow(1), RangeError, "WebAssembly.Table.prototype.grow could not grow the table");

--- a/JSTests/wasm/stress/table64-maximum.js
+++ b/JSTests/wasm/stress/table64-maximum.js
@@ -42,13 +42,13 @@ for (const maximum of ["4294967296", "4294967301", "18446744073709551615"]) {
         )
     )`, {}, { memory64: true });
 
-    // 9999999 lands exactly on the bound, 10000000 just past it, and the last delta
-    // overflows the u64 length computation.
-    for (const delta of [9999999n, 10000000n, 18446744073709551615n]) {
+    // The table already holds one entry, so 10000000 lands one past the bound, and
+    // the last delta overflows the u64 length computation.
+    for (const delta of [10000000n, 18446744073709551615n]) {
         assert.eq(instance.exports.grow(delta), -1n);
         assert.eq(instance.exports.size(), 1n);
     }
 
-    assert.throws(() => instance.exports.table.grow(9999999n), RangeError, "WebAssembly.Table.prototype.grow could not grow the table");
+    assert.throws(() => instance.exports.table.grow(10000000n), RangeError, "WebAssembly.Table.prototype.grow could not grow the table");
     assert.eq(instance.exports.table.length, 1n);
 }

--- a/JSTests/wasm/stress/tag-section-limit.js
+++ b/JSTests/wasm/stress/tag-section-limit.js
@@ -1,0 +1,40 @@
+import * as assert from "../assert.js";
+
+// https://www.w3.org/TR/wasm-js-api-2/#limits says a module may define at most
+// 1,000,000 tags, and one that exceeds a limit must be rejected with a
+// CompileError.
+const maxTags = 1000000;
+
+function leb(value) {
+    let bytes = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value)
+            byte |= 0x80;
+        bytes.push(byte);
+    } while (value);
+    return bytes;
+}
+
+// Every tag refers to type 0, an empty function type, and takes two bytes: the
+// exception attribute and the type index.
+function moduleWithTags(count) {
+    const countBytes = leb(count);
+    const header = [
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        0x0d, ...leb(countBytes.length + 2 * count), ...countBytes,
+    ];
+    const bytes = new Uint8Array(header.length + 2 * count);
+    bytes.set(header);
+    return bytes;
+}
+
+new WebAssembly.Module(moduleWithTags(maxTags));
+
+assert.throws(
+    () => new WebAssembly.Module(moduleWithTags(maxTags + 1)),
+    WebAssembly.CompileError,
+    `WebAssembly.Module doesn't parse at byte 21: Exception section's count is too big ${maxTags + 1} maximum ${maxTags}`
+);

--- a/JSTests/wasm/v8/table.js
+++ b/JSTests/wasm/v8/table.js
@@ -13,7 +13,7 @@ load("wasm-module-builder.js");
 // Basic tests.
 
 const outOfUint32RangeValue = 1e12;
-const kV8MaxWasmTableSize = 9999999;
+const kV8MaxWasmTableSize = 10000000;
 
 function assertTableIsValid(table, length) {
   assertSame(WebAssembly.Table.prototype, table.__proto__);
@@ -97,7 +97,7 @@ function assertTableIsValid(table, length) {
   assertThrows(
     () => new WebAssembly.Table(
       {element: "anyfunc", initial: kV8MaxWasmTableSize + 1}),
-    RangeError, /couldn't create Table/);
+    RangeError, /above the upper bound/);
 })();
 
 (function TestMaximumIsReadOnce() {

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -48,7 +48,7 @@ constexpr size_t maxTypes = 1000000;
 constexpr size_t maxFunctions = 1000000;
 constexpr size_t maxImports = 1000000;
 constexpr size_t maxExports = 1000000;
-constexpr size_t maxExceptions = 100000;
+constexpr size_t maxExceptions = 1000000;
 constexpr size_t maxGlobals = 1000000;
 constexpr size_t maxDataSegments = 100000;
 constexpr size_t maxMemories = 100;
@@ -66,7 +66,6 @@ constexpr size_t maxFunctionParams = 1000;
 constexpr size_t maxFunctionReturns = 1000;
 
 constexpr size_t maxTableEntries = 10000000;
-constexpr size_t maxTableInitializationEntries = 10000000;
 constexpr unsigned maxTables = 100000;
 
 constexpr uint64_t maxMemory32Pages = PageCount::maxMemory32PageCount;

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -1270,11 +1270,11 @@ auto SectionParser::parseElementKind(uint8_t& resultElementKind) -> PartialResul
 
 auto SectionParser::parseIndexCountForElementSection(uint32_t& resultIndexCount, const unsigned elementNum) -> PartialResult
 {
-    static_assert(maxTableInitializationEntries < std::numeric_limits<uint32_t>::max());
+    static_assert(maxTableEntries < std::numeric_limits<uint32_t>::max());
 
     uint32_t indexCount;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(indexCount), "can't get "_s, elementNum, "th index count for Element section"_s);
-    WASM_PARSER_FAIL_IF(indexCount > maxTableInitializationEntries, "Element section's "_s, elementNum, "th index count of "_s, indexCount, " is too big, maximum "_s, maxTableInitializationEntries);
+    WASM_PARSER_FAIL_IF(indexCount > maxTableEntries, "Element section's "_s, elementNum, "th index count of "_s, indexCount, " is too big, maximum "_s, maxTableEntries);
     resultIndexCount = indexCount;
 
     return { };
@@ -1450,7 +1450,7 @@ auto SectionParser::parseException() -> PartialResult
 {
     uint32_t exceptionCount;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(exceptionCount), "can't get Exception section's count"_s);
-    WASM_PARSER_FAIL_IF(exceptionCount > maxExceptions, "Export section's count is too big "_s, exceptionCount, " maximum "_s, maxExceptions);
+    WASM_PARSER_FAIL_IF(exceptionCount > maxExceptions, "Exception section's count is too big "_s, exceptionCount, " maximum "_s, maxExceptions);
     RELEASE_ASSERT(!m_info->internalExceptionTypeSignatureIndices.capacity());
     WASM_ALLOCATOR_FAIL_IF(!m_info->internalExceptionTypeSignatureIndices.tryReserveInitialCapacity(exceptionCount), "can't allocate enough memory for "_s, exceptionCount, " exceptions"_s);
 

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -81,7 +81,7 @@ public:
     Wasm::AddressType addressType() const { return m_addressType; }
     FuncRefTable* NODELETE asFuncrefTable();
 
-    static bool isValidLength(uint64_t length) { return length < maxTableEntries; }
+    static bool isValidLength(uint64_t length) { return length <= maxTableEntries; }
 
     void clear(uint32_t);
     void set(uint32_t, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
@@ -115,10 +115,10 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTable, (JSGlobalObject* globalObj
     uint64_t initial64 = addressValueToUint64(globalObject, initialSizeValue, addressType);
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
-    if (initial64 > Wasm::maxTableInitializationEntries)
-        return throwVMRangeError(globalObject, throwScope, WTF::makeString("WebAssembly.Table 'initial' value is above the upper bound "_s, Wasm::maxTableInitializationEntries));
+    if (!Wasm::Table::isValidLength(initial64))
+        return throwVMRangeError(globalObject, throwScope, WTF::makeString("WebAssembly.Table 'initial' value is above the upper bound "_s, Wasm::maxTableEntries));
 
-    uint32_t initial = initial64;
+    uint32_t initial = static_cast<uint32_t>(initial64);
 
     // In WebIDL, "present" means that [[Get]] result is undefined, not [[HasProperty]] result.
     // https://webidl.spec.whatwg.org/#idl-dictionaries


### PR DESCRIPTION
#### 2194da86b3829247fdf9a78bf1979b8de2539cf7
<pre>
[JSC] Adjust / Fix wasm limit numbers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321428">https://bugs.webkit.org/show_bug.cgi?id=321428</a>
<a href="https://rdar.apple.com/184501304">rdar://184501304</a>

Reviewed by Sosuke Suzuki.

This patch adjusts / fixes wasm limit numbers we are using based on the
spec.

Tests: JSTests/wasm/stress/table-initial-upper-bound.js
       JSTests/wasm/stress/tag-section-limit.js

* JSTests/wasm/stress/table-initial-upper-bound.js: Added.
* JSTests/wasm/stress/table64-maximum.js:
(assert.eq.instance.exports.grow):
* JSTests/wasm/stress/tag-section-limit.js: Added.
(leb):
(moduleWithTags):
* JSTests/wasm/v8/table.js:
(TestConstructor):
* Source/JavaScriptCore/wasm/WasmLimits.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseIndexCountForElementSection):
(JSC::Wasm::SectionParser::parseException):
* Source/JavaScriptCore/wasm/WasmTable.h:
(JSC::Wasm::Table::isValidLength):
* Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/318917@main">https://commits.webkit.org/318917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/906ae8b9fc60b1cbdefdbbb175aad129bb820a0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144102 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8117c5b9-a239-4d1a-88cf-a92b17376700) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140246 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97065 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/248b5ee9-49ba-4e0d-8b63-687ef25924bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120697 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0a889a2-349c-44f8-abcd-580c050ca9a2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42524 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40843 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2666 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9467 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40504 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1077 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41066 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191845 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53400 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149525 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54081 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37120 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149259 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43913 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126353 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121388 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52598 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15495 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51983 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52224 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52044 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->