### PR TITLE
Cherry-pick 317758@main (38e3c810c7af). https://bugs.webkit.org/show_bug.cgi?id=320013

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4046,6 +4046,13 @@ imported/w3c/web-platform-tests/css/css-overflow/overflow-canvas.html [ ImageOnl
 imported/w3c/web-platform-tests/css/css-overflow/overflow-clip-margin-border-radius-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/overflow-clip-margin-border-radius.html [ ImageOnlyFailure ]
 
+imported/w3c/web-platform-tests/css/css-overflow/flex-column-container-with-scrollable-descendant.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-overflow/flex-container-multiple-items-with-scrollable-descendant.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-overflow/flex-container-with-scrollable-descendant.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-overflow/flex-nested-container-with-scrollable-descendant.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-overflow/grid-container-with-scrollable-descendant.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-overflow/grid-nested-container-with-scrollable-descendant.html [ ImageOnlyFailure ]
+
 # Tests that failed on the 2026-02-02 import of css-overflow
 imported/w3c/web-platform-tests/css/css-overflow/clip-008.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/column-style-change-triggers-relayout.html [ ImageOnlyFailure ]

--- a/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
@@ -173,14 +173,14 @@
             if (this._getIsInline()) {
                 this._mirrorTrack.mode = 'hidden';
                 if (captionContainer)
-                    captionContainer.style.removeProperty('display');
+                    captionContainer.style.removeProperty('visibility');
                 return;
             }
 
             this._player.loadModule('captions');
             this._mirrorTrack.mode = 'showing';
             if (captionContainer)
-                captionContainer.style.setProperty('display', 'none', 'important');
+                captionContainer.style.setProperty('visibility', 'hidden', 'important');
         }
 
         _handleMediaSessionAction(details) {

--- a/Source/WebCore/Modules/webauthn/cbor/CBORValue.h
+++ b/Source/WebCore/Modules/webauthn/cbor/CBORValue.h
@@ -197,7 +197,7 @@ private:
     };
 
     void internalMoveConstructFrom(CBORValue&&);
-    void NODELETE internalCleanup();
+    void internalCleanup();
 };
 
 } // namespace cbor

--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -2,7 +2,6 @@ Modules/indexeddb/server/IndexValueStore.cpp
 Modules/notifications/NotificationPayload.cpp
 Modules/streams/ReadableByteStreamController.cpp
 Modules/streams/ReadableStreamBYOBReader.cpp
-Modules/webauthn/cbor/CBORValue.cpp
 Modules/websockets/WebSocketChannelInspector.cpp
 Modules/webtransport/WebTransportDatagramsWritable.cpp
 css/CSSComputedStyleDeclaration.cpp

--- a/Source/WebCore/platform/graphics/MIMESniffer.cpp
+++ b/Source/WebCore/platform/graphics/MIMESniffer.cpp
@@ -140,7 +140,7 @@ static bool NODELETE hasSignatureForWebM(std::span<const uint8_t> sequence)
     //   6. While iter is less than length and iter is less than 38, continuously loop through these steps:
     while (iter < length && iter < 38) {
         //  1. If the two bytes from sequence[iter] to sequence[iter + 1] are equal to 0x42 0x82,
-        if (sequence[iter] == 0x42 && sequence[iter + 1] == 0x82) {
+        if (iter + 1 < length && sequence[iter] == 0x42 && sequence[iter + 1] == 0x82) {
             //  1. Increment iter by 2.
             iter += 2;
             //  2. If iter is greater or equal than length, abort these steps.

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -553,22 +553,18 @@ static EnumSet<LogicalBoxAxis> sizesAffectedByScrollbarsForSubtreeRoot(const Ren
     if (layoutContext.subtreeScrollbarChangesState())
         return { };
 
-    EnumSet<LogicalBoxAxis> sizesAffected;
-
     auto& style = renderBlock.style();
     auto& computedLogicalWidth = style.logicalWidth();
-    if (!computedLogicalWidth.isFixed() && (computedLogicalWidth.isIntrinsic() || computedLogicalWidth.isMinIntrinsic() || renderBlock.sizesLogicalWidthToFitContent()))
-        sizesAffected.add(LogicalBoxAxis::Inline);
+    if (computedLogicalWidth.isFixed())
+        return { };
 
-    auto& computedLogicalHeight = style.logicalHeight();
+    if (computedLogicalWidth.isIntrinsic() || computedLogicalWidth.isMinIntrinsic())
+        return LogicalBoxAxis::Inline;
 
-    if (renderBlock.isRenderFlexibleBox() && renderBlock.isBlockLevelBox() && (computedLogicalHeight.isAuto() || computedLogicalHeight.isIntrinsic()))
-        sizesAffected.add(LogicalBoxAxis::Block);
+    if (renderBlock.sizesLogicalWidthToFitContent())
+        return LogicalBoxAxis::Inline;
 
-    if (renderBlock.isRenderGrid() && (computedLogicalHeight.isAuto() || computedLogicalHeight.isIntrinsic()))
-        sizesAffected.add(LogicalBoxAxis::Block);
-
-    return sizesAffected;
+    return { };
 }
 
 static bool canContainDescendantScrollbarChanges(const RenderBlock& renderBlock, const LocalFrameViewLayoutContext& layoutContext)

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
@@ -147,12 +147,9 @@ SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler()
 
     auto& subtreeRoot = subtreeScrollbarChangesState->subtreeRoot;
     for (auto& rendererScrollbarChange : descendantsWithScrollbarChange) {
-        CheckedRef renderer = rendererScrollbarChange.renderer;
-        ASSERT(renderer->isDescendantOf(subtreeRoot.ptr()));
-        if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.contains(LogicalBoxAxis::Block))
-            renderer->setNeedsLayout();
-        if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.contains(LogicalBoxAxis::Inline))
-            renderer->invalidateContentLogicalWidths(MarkingBehavior::MarkContainingBlockChain, protect(subtreeRoot->containingBlock()));
+        if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.containsOnly(LogicalBoxAxis::Block))
+            continue;
+        protect(rendererScrollbarChange.renderer)->invalidateContentLogicalWidths(MarkingBehavior::MarkContainingBlockChain, protect(subtreeRoot->containingBlock()));
     }
     descendantsWithScrollbarChange.clear();
 

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
@@ -243,6 +243,25 @@ void SimulatedInputDispatcher::resolveLocation(const WebCore::IntPoint& currentL
     }
 }
 
+#if ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
+static std::optional<TouchInteraction> touchInteractionForMouseInteraction(MouseInteraction interaction)
+{
+    switch (interaction) {
+    case MouseInteraction::Down:
+        return TouchInteraction::TouchDown;
+    case MouseInteraction::Up:
+        return TouchInteraction::LiftUp;
+    case MouseInteraction::Move:
+        return TouchInteraction::MoveTo;
+    case MouseInteraction::SingleClick:
+    case MouseInteraction::DoubleClick:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+#endif
+
 void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource& inputSource, SimulatedInputSourceState& newState, AutomationCompletionHandler&& completionHandler)
 {
     // Make cases and conditionals more readable by aliasing pre/post states as 'a' and 'b'.
@@ -329,15 +348,26 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
 
             b.location = location;
             // The "dispatch a pointer{Down,Up,Move} action" algorithms (§17.4 Dispatching Actions).
-            if (!a.pressedMouseButton && b.pressedMouseButton) {
-                LOG(Automation, "SimulatedInputDispatcher[%p]: simulating TouchDown @ (%d, %d) for transition to %d.%d", this, b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
-                m_client.simulateTouchInteraction(protect(m_page), TouchInteraction::TouchDown, b.location.value(), std::nullopt, WTF::move(eventDispatchFinished));
-            } else if (a.pressedMouseButton && !b.pressedMouseButton) {
-                LOG(Automation, "SimulatedInputDispatcher[%p]: simulating LiftUp @ (%d, %d) for transition to %d.%d", this, b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
-                m_client.simulateTouchInteraction(protect(m_page), TouchInteraction::LiftUp, b.location.value(), std::nullopt, WTF::move(eventDispatchFinished));
-            } else if (a.location != b.location) {
-                LOG(Automation, "SimulatedInputDispatcher[%p]: simulating MoveTo from (%d, %d) to (%d, %d) for transition to %d.%d", this, a.location.value().x(), a.location.value().y(), b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
-                m_client.simulateTouchInteraction(protect(m_page), TouchInteraction::MoveTo, b.location.value(), a.duration.value_or(0_s), WTF::move(eventDispatchFinished));
+            if (b.mouseInteraction) {
+                const auto stateTransitionIsNoop = [&a, &b] {
+                    return std::tie(a.location, a.mouseInteraction, a.pressedMouseButton) == std::tie(b.location, b.mouseInteraction, b.pressedMouseButton);
+                }();
+
+                if (!stateTransitionIsNoop) {
+                    auto touchInteraction = touchInteractionForMouseInteraction(b.mouseInteraction.value());
+                    if (!touchInteraction || (touchInteraction == TouchInteraction::MoveTo && a.location == b.location)) {
+                        eventDispatchFinished(std::nullopt);
+                        return;
+                    }
+
+                    std::optional<Seconds> duration = touchInteraction == TouchInteraction::MoveTo ? std::optional<Seconds>(a.duration.value_or(0_s)) : std::nullopt;
+#if !LOG_DISABLED
+                    String interactionName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(b.mouseInteraction.value());
+                    LOG(Automation, "SimulatedInputDispatcher[%p]: simulating touch %s @ (%d, %d) for transition to %d.%d", this, interactionName.utf8().data(), b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
+#endif
+                    m_client.simulateTouchInteraction(protect(m_page), touchInteraction.value(), b.location.value(), duration, WTF::move(eventDispatchFinished));
+                } else
+                    eventDispatchFinished({ });
             } else
                 eventDispatchFinished(std::nullopt);
         });

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3502,6 +3502,10 @@ void WebPageProxy::activityStateDidChange(OptionSet<ActivityState> mayHaveChange
     WEBPAGEPROXY_RELEASE_LOG(ActivityState, "activityStateDidChange: mayHaveChanged=%d", mayHaveChanged.toRaw());
 
     RefPtr pageClient = this->pageClient();
+    if (!pageClient) {
+        WEBPAGEPROXY_RELEASE_LOG(ViewState, "activityStateDidChange: Returning early since there is no PageClient");
+        return;
+    }
 
     internals().potentiallyChangedActivityStateFlags.add(mayHaveChanged);
     m_activityStateChangeWantsSynchronousReply = m_activityStateChangeWantsSynchronousReply || replyMode == ActivityStateChangeReplyMode::Synchronous;

--- a/Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp
@@ -63,6 +63,12 @@ TEST(MIMESniffer, WebMSnifferDoesNotReadPastEnd)
     // read in MIMESniffer.cpp under ASan / libc++ hardened mode.
     constexpr std::array<const uint8_t, 7> truncatedWebM = { 0x1A, 0x45, 0xDF, 0xA3, 0x42, 0x82, 0x80 };
     MIMESniffer::getMIMETypeFromContent(std::span { truncatedWebM });
+
+    // EBML magic (4 bytes) followed by a lone 0x42 as the last byte. The loop
+    // guard only ensures iter < length, so the 0x42 0x82 two-byte compare reads
+    // sequence[iter + 1] one byte past the end when iter == length - 1.
+    constexpr std::array<const uint8_t, 5> truncatedWebMAtMagicByte = { 0x1A, 0x45, 0xDF, 0xA3, 0x42 };
+    MIMESniffer::getMIMETypeFromContent(std::span { truncatedWebMAtMagicByte });
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 936571551944468efa6a5e867270ff5a76fa2774
<pre>
Cherry-pick 317758@main (38e3c810c7af). <a href="https://bugs.webkit.org/show_bug.cgi?id=320013">https://bugs.webkit.org/show_bug.cgi?id=320013</a>

    StabilityTracer: Crash in WebKit::WebPageProxy::activityStateDidChange
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320013">https://bugs.webkit.org/show_bug.cgi?id=320013</a>
    <a href="https://rdar.apple.com/182529810">rdar://182529810</a>

    Reviewed by Alex Christensen.

    We crash in WebPageProxy::activityStateDidChange() because WebPageProxy&apos;s
    m_pageClient is null and we attempt to access it. This state is possible
    when the WebViewImpl is being destroyed (it&apos;s the sole owner of PageClient)
    but the WebPageProxy is still alive because something else refs it. Null
    checking m_pageClient is common practice in the WebPageProxy code likely
    for this reason. Since activityStateDidChange() relies on data from the
    PageClient, we can early return if it isn&apos;t alive.

    This is a speculative fix.

    * Source/WebKit/UIProcess/WebPageProxy.cpp:
    (WebKit::WebPageProxy::activityStateDidChange):

    Canonical link: <a href="https://commits.webkit.org/317758@main">https://commits.webkit.org/317758@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.90@webkitglib/2.54">https://commits.webkit.org/317695.90@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### a1ead6db543ef4a4daf22260f6d38b3a60edcd45
<pre>
Cherry-pick 317738@main (637127bb65c1). <a href="https://bugs.webkit.org/show_bug.cgi?id=318828">https://bugs.webkit.org/show_bug.cgi?id=318828</a>

    Remove incorrect `NODELETE` annotation from `cbor/CBORValue.h`
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318828">https://bugs.webkit.org/show_bug.cgi?id=318828</a>
    <a href="https://rdar.apple.com/181641564">rdar://181641564</a>

    Reviewed by Chris Dumez.

    Drop `NODELETE` from a function that destroys objects since it is a lie.

    * Source/WebCore/Modules/webauthn/cbor/CBORValue.h:
    * Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations:

    Canonical link: <a href="https://commits.webkit.org/317738@main">https://commits.webkit.org/317738@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.89@webkitglib/2.54">https://commits.webkit.org/317695.89@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### df743b8e3ece3b1b946304c3d1c066a7d7416a6d
<pre>
Cherry-pick 317834@main (e59b5d3cc487). <a href="https://bugs.webkit.org/show_bug.cgi?id=319610">https://bugs.webkit.org/show_bug.cgi?id=319610</a>

    REGRESSION(283790@main): the touch path didn&apos;t adopt mouseInteraction and no longer works
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319610">https://bugs.webkit.org/show_bug.cgi?id=319610</a>
    <a href="https://rdar.apple.com/182438327">rdar://182438327</a>

    Reviewed by BJ Burg.

    The Touch branch of transitionInputSourceToState never adopted
    283790@main&apos;s change to dispatch off b.mouseInteraction: it still
    infers TouchDown/LiftUp/MoveTo purely from pressedMouseButton edges.
    safaridriver&apos;s paired fix for the same bug stopped clearing
    pressedMouseButton on pointerUp, relying on mouseInteraction alone to
    signal Up, so pressedMouseButton now stays set across the whole
    pointerDown/pointerUp pair. Since the Touch branch only emits LiftUp
    when pressedMouseButton goes from set to unset, no LiftUp is emitted
    for the pointerUp action itself; the touch stays held until the next
    command (or the Release Actions reset keyframe) lifts it late and at
    the wrong coordinate.

    Port 283790@main&apos;s approach to the Touch branch, mirroring the
    Mouse/Pen branch exactly: dispatch off b.mouseInteraction with no
    pressedMouseButton-delta fallback. This makes the Up keyframe&apos;s
    resolveLocation(origin=Pointer, location=(0,0)) resolve to the down
    coordinate, so LiftUp now fires in place during the pointerUp action&apos;s
    own keyframe transition.

    * Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp:
    (WebKit::touchInteractionForMouseInteraction):
    (WebKit::SimulatedInputDispatcher::transitionInputSourceToState):

    Canonical link: <a href="https://commits.webkit.org/317834@main">https://commits.webkit.org/317834@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.88@webkitglib/2.54">https://commits.webkit.org/317695.88@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 8399efaa43f4ea375bc508f38fe0d5890fe1af6b
<pre>
Cherry-pick 317999@main (f67b7993605d). <a href="https://bugs.webkit.org/show_bug.cgi?id=320374">https://bugs.webkit.org/show_bug.cgi?id=320374</a>

    REGRESSION(316238@main): YouTube captions become infinitely tall in iPhone fullscreen
    <a href="https://rdar.apple.com/182808868">rdar://182808868</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320374">https://bugs.webkit.org/show_bug.cgi?id=320374</a>

    Reviewed by Simon Fraser.

    In 316238@main, in order to work around an issue where both YouTube&apos;s custom-rendered
    subtitles and quirk-derived system subtitles were displayed simultanously, YouTube&apos;s
    own subtitle divs were hidden with `display:none`. However this broke their ability to
    detect that subtitles have grown too tall inside the video viewport, and they fail to
    remove those generated subtitles when adding new ones.

    Switch from `display:none` to `visibility:hidden` so that size detection works the way
    YouTube expects, even though the subtitles are not displayed.

    * Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js:
    (CaptionMirror.prototype._handlePresentationModeChanged):

    Canonical link: <a href="https://commits.webkit.org/317999@main">https://commits.webkit.org/317999@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.87@webkitglib/2.54">https://commits.webkit.org/317695.87@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 63350dd0d8ee79bbcdc650fc5a41301332549f6d
<pre>
Cherry-pick 318095@main (3b267afd25f0). <a href="https://bugs.webkit.org/show_bug.cgi?id=320473">https://bugs.webkit.org/show_bug.cgi?id=320473</a>

Unreviewed backport.

    REGRESSION(314501@main): On flights.google.com, can&apos;t use backspace to delete airport from box
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320473">https://bugs.webkit.org/show_bug.cgi?id=320473</a>
    <a href="https://rdar.apple.com/183391399">rdar://183391399</a>

    Unreviewed, reverting 314501@main (a8c7730a75ef)

    Reverted change:

        GitHub.com: emoji reaction touches code box in comment.
        <a href="https://bugs.webkit.org/show_bug.cgi?id=312152">https://bugs.webkit.org/show_bug.cgi?id=312152</a>
        <a href="https://rdar.apple.com/174652842">rdar://174652842</a>
        314501@main (a8c7730a75ef)

    Canonical link: <a href="https://commits.webkit.org/318095@main">https://commits.webkit.org/318095@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.86@webkitglib/2.54">https://commits.webkit.org/317695.86@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### b7b814a80b65c13decc47efc9b6ee6629835977f
<pre>
Cherry-pick 318243@main (ef325e63cb21). <a href="https://bugs.webkit.org/show_bug.cgi?id=320634">https://bugs.webkit.org/show_bug.cgi?id=320634</a>

    Out-of-bounds read in WebM MIME sniffer at the 0x42 0x82 DocType check
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320634">https://bugs.webkit.org/show_bug.cgi?id=320634</a>

    Reviewed by Youenn Fablet.

    314498@main guarded the inner skip-NUL loop in hasSignatureForWebM(),
    but a second unguarded iter + 1 read remains at the top of the loop:
    ```
        while (iter &lt; length &amp;&amp; iter &lt; 38) {
            if (sequence[iter] == 0x42 &amp;&amp; sequence[iter + 1] == 0x82) {
    ```
    The loop guard only guarantees iter &lt; length, not iter + 1 &lt; length. When
    iter == length - 1 and sequence[iter] == 0x42, the short-circuit &amp;&amp; goes on
    to evaluate sequence[iter + 1], reading one byte past the end of the span.
    This is reachable before the skip-NUL path 314498@main fixed: a 5-byte
    input of EBML magic + a trailing 0x42 (0x1A 0x45 0xDF 0xA3 0x42) enters the
    loop at iter == 4 == length - 1 and reads sequence[5]. getMIMETypeFromContent()
    is called on attacker-controlled response bytes via MediaResourceSniffer with
    a span sized to the exact number of received bytes, so this is a remotely
    reachable crash. WebKit builds with hardened libc++, so std::span&apos;s bounds
    check turns it into a safe abort on every build.

    Guard the two-byte compare with iter + 1 &lt; length so the bounds check
    short-circuits the dereference, matching the guarded reads later in the
    function, and extend the regression test with the truncated 5-byte input.

    Test: MIMESniffer.WebMSnifferDoesNotReadPastEnd

    * Source/WebCore/platform/graphics/MIMESniffer.cpp:
    (WebCore::MIMESniffer::hasSignatureForWebM):
    * Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp:
    (TestWebKitAPI::TEST(MIMESniffer, WebMSnifferDoesNotReadPastEnd)):

    Canonical link: <a href="https://commits.webkit.org/318243@main">https://commits.webkit.org/318243@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.85@webkitglib/2.54">https://commits.webkit.org/317695.85@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af08c556f79f39fc39119421bb01ced13965609f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179794 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53733 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47532 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189627 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144105 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181657 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/55027 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53445 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140249 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144105 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182751 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/55027 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47532 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120699 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/55027 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53445 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47532 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/55027 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47532 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1080 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46339 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53445 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191848 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53403 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47532 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149527 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/54084 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47532 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149261 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27301 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/54084 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126356 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121393 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52601 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47532 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/51986 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52227 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52047 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->