### PR TITLE
[css-variables-2] var() should be an arbitrary substitution function

### DIFF
--- a/LayoutTests/fast/css/css-typed-om/var-name-argument-unparsed-expected.txt
+++ b/LayoutTests/fast/css/css-typed-om/var-name-argument-unparsed-expected.txt
@@ -1,0 +1,17 @@
+var() with a name argument that is not a literal <custom-property-name> reifies as text in Typed OM.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS unparsedValue("width: var(20px)").toString() is "var(20px)"
+PASS unparsedValue("width: var(not-a-name)").toString() is "var(not-a-name)"
+PASS unparsedValue("width: var(--x ())").toString() is "var(--x ())"
+PASS unparsedValue("width: var({--x})").toString() is "var({--x})"
+PASS unparsedValue("width: var(attr(data-name type(*)))").toString() is "var(attr(data-name type(*)))"
+PASS unparsedValue("width: var(--x)")[0].variable is "--x"
+PASS unparsedValue("width: var(--x, 10px)")[0].variable is "--x"
+PASS unparsedValue("width: var(var(--name))")[1].variable is "--name"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/css-typed-om/var-name-argument-unparsed.html
+++ b/LayoutTests/fast/css/css-typed-om/var-name-argument-unparsed.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="target" data-name="--x"></div>
+<script>
+description("var() with a name argument that is not a literal &lt;custom-property-name&gt; reifies as text in Typed OM.");
+
+// The name argument is a <declaration-value> that is parsed as a <custom-property-name> only at
+// computed-value time, so these have no variable reference to reify.
+// https://drafts.csswg.org/css-variables-2/#funcdef-var
+
+var target = document.getElementById("target");
+
+function unparsedValue(declaration)
+{
+    target.setAttribute("style", declaration);
+    var value = target.attributeStyleMap.get("width");
+    target.removeAttribute("style");
+    return value;
+}
+
+shouldBeEqualToString('unparsedValue("width: var(20px)").toString()', "var(20px)");
+shouldBeEqualToString('unparsedValue("width: var(not-a-name)").toString()', "var(not-a-name)");
+shouldBeEqualToString('unparsedValue("width: var(--x ())").toString()', "var(--x ())");
+shouldBeEqualToString('unparsedValue("width: var({--x})").toString()', "var({--x})");
+shouldBeEqualToString('unparsedValue("width: var(attr(data-name type(*)))").toString()', "var(attr(data-name type(*)))");
+
+// A literal name still reifies as a CSSVariableReferenceValue, with or without a fallback.
+shouldBeEqualToString('unparsedValue("width: var(--x)")[0].variable', "--x");
+shouldBeEqualToString('unparsedValue("width: var(--x, 10px)")[0].variable', "--x");
+shouldBeEqualToString('unparsedValue("width: var(var(--name))")[1].variable', "--name");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/variables/env/env-name-argument-not-substituted-expected.txt
+++ b/LayoutTests/fast/css/variables/env/env-name-argument-not-substituted-expected.txt
@@ -1,0 +1,11 @@
+env() does not substitute its name argument. This is a WebKit limitation: env()'s argument grammar is env( <declaration-value>, <declaration-value>? ), so env(var(--name)) should be valid at parse time and resolve the name at computed-value time.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS CSS.supports("width", "env(var(--myvar))") is false
+PASS computedWidth("--myvar: safe-area-inset-top; width: env(var(--myvar), 150px);") is initialWidth
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/variables/env/env-name-argument-not-substituted.html
+++ b/LayoutTests/fast/css/variables/env/env-name-argument-not-substituted.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+description("env() does not substitute its name argument. This is a WebKit limitation: env()'s argument grammar is env( &lt;declaration-value&gt;, &lt;declaration-value&gt;? ), so env(var(--name)) should be valid at parse time and resolve the name at computed-value time.");
+
+var target = document.getElementById("target");
+
+function computedWidth(declaration)
+{
+    target.setAttribute("style", declaration);
+    var value = getComputedStyle(target).width;
+    target.removeAttribute("style");
+    return value;
+}
+
+var initialWidth = computedWidth("width: initial;");
+
+shouldBeFalse('CSS.supports("width", "env(var(--myvar))")');
+shouldBe('computedWidth("--myvar: safe-area-inset-top; width: env(var(--myvar), 150px);")', 'initialWidth');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/var-ident-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/var-ident-function-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Referencing a custom property with ident() assert_equals: expected "PASS" but got "FAIL1"
+FAIL Referencing a custom property with ident() assert_equals: expected "PASS" but got "FAIL2"
 PASS ident() remains unresolved on custom properties
 PASS ident() causing lookup of invalid custom property
-FAIL ident() causing lookup of invalid custom property, fallback assert_equals: expected "PASS" but got ""
-FAIL ident() causing lookup of invalid custom property, fallback, CSS-wide keyword assert_equals: expected "PASS" but got "FAIL"
+PASS ident() causing lookup of invalid custom property, fallback
+PASS ident() causing lookup of invalid custom property, fallback, CSS-wide keyword
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/var-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/var-parsing-expected.txt
@@ -2,9 +2,19 @@
 PASS e.style['width'] = "var(--x)" should set the property value
 PASS e.style['width'] = "var(--x,)" should set the property value
 PASS e.style['width'] = "var(--x, )" should set the property value
-PASS e.style['width'] = "var(--x ())" should not set the property value
-PASS e.style['width'] = "var(--x () )" should not set the property value
-PASS e.style['width'] = "var(--x() )" should not set the property value
-PASS e.style['width'] = "var(--x (),)" should not set the property value
-PASS e.style['width'] = "var(--x(),)" should not set the property value
+PASS e.style['width'] = "var(--x ())" should set the property value
+PASS e.style['width'] = "var(--x () )" should set the property value
+PASS e.style['width'] = "var(--x() )" should set the property value
+PASS e.style['width'] = "var(--x (),)" should set the property value
+PASS e.style['width'] = "var(--x(),)" should set the property value
+PASS e.style['width'] = "var({--x})" should set the property value
+PASS e.style['width'] = "var({--x}, 10px)" should set the property value
+PASS e.style['width'] = "var({--x, --y})" should set the property value
+PASS e.style['width'] = "var(--x {--y})" should not set the property value
+PASS e.style['width'] = "var({--x} --y)" should not set the property value
+PASS e.style['width'] = "var(--x {--y}, 10px)" should not set the property value
+PASS e.style['width'] = "var()" should not set the property value
+PASS e.style['width'] = "var({})" should not set the property value
+PASS e.style['width'] = "var({}, 10px)" should not set the property value
+PASS e.style['width'] = "var(, 10px)" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/var-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/var-parsing.html
@@ -12,10 +12,34 @@ test_valid_value('width', 'var(--x)');
 test_valid_value('width', 'var(--x,)');
 test_valid_value('width', 'var(--x, )');
 
-test_invalid_value('width', 'var(--x ())');
-test_invalid_value('width', 'var(--x () )');
-test_invalid_value('width', 'var(--x() )');
-test_invalid_value('width', 'var(--x (),)');
-test_invalid_value('width', 'var(--x(),)');
+// var()'s name argument is a <declaration-value> that is substituted and only then parsed as a
+// <custom-property-name>, so these are valid at parse time and round-trip as pending-substitution
+// values. They become invalid at computed-value time when the name fails to parse.
+// https://drafts.csswg.org/css-variables-2/#funcdef-var
+test_valid_value('width', 'var(--x ())');
+test_valid_value('width', 'var(--x () )');
+test_valid_value('width', 'var(--x() )');
+test_valid_value('width', 'var(--x (),)');
+test_valid_value('width', 'var(--x(),)');
+
+// The name argument is a free-form production, so it may be {}-wrapped: the braces are syntactic and
+// the argument is the block's contents.
+// https://drafts.csswg.org/css-values-5/#component-function-commas
+test_valid_value('width', 'var({--x})');
+test_valid_value('width', 'var({--x}, 10px)');
+test_valid_value('width', 'var({--x, --y})');
+
+// A free-form production that does not start with "{" matches neither top-level commas nor {} blocks,
+// so a {} block may not be mixed with other values in the name argument.
+test_invalid_value('width', 'var(--x {--y})');
+test_invalid_value('width', 'var({--x} --y)');
+test_invalid_value('width', 'var(--x {--y}, 10px)');
+
+// <declaration-value> is one or more tokens, so an empty name argument is invalid whether or not it
+// is {}-wrapped.
+test_invalid_value('width', 'var()');
+test_invalid_value('width', 'var({})');
+test_invalid_value('width', 'var({}, 10px)');
+test_invalid_value('width', 'var(, 10px)');
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-declaration-29.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-declaration-29.html
@@ -3,15 +3,18 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <!DOCTYPE html>
-<title>CSS Test: Test declaring a variable with an invalid custom property name "--".</title>
+<title>CSS Test: An invalid custom property name "--" as a var() name argument triggers the fallback.</title>
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="http://www.w3.org/TR/css-variables-1/#defining-variables">
 <link rel="match" href="support/color-green-ref.html">
 <style>
+/* "--" is not a valid <custom-property-name>, so "--: red" is dropped and the var() name argument
+   substitutes to "--", which fails to parse as a name. The reference is guaranteed-invalid, so the
+   fallback is used. https://drafts.csswg.org/css-variables-2/#funcdef-var */
 p {
-  color: green;
+  color: red;
   --: red;
-  color: var(--,crimson);
+  color: var(--, green);
 }
 </style>
 <p>This text must be green.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution-attr-taint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution-attr-taint-expected.txt
@@ -1,0 +1,11 @@
+
+PASS attr()-tainted name argument makes an image-set() declaration invalid at computed-value time
+PASS attr()-tainted name argument taints a url() value
+PASS attr()-taint reaches the name argument through another custom property
+PASS attr()-tainted name argument taints the fallback
+PASS attr()-tainted name argument taints a registered <url> property
+PASS attr()-tainted name argument does not invalidate values that are not URLs
+PASS attr()-tainted name argument substitutes normally into a custom property
+PASS attr()-tainted name argument taints the value even when an earlier value was already tainted
+PASS untainted substituted name argument does not taint the value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution-attr-taint.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution-attr-taint.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>attr()-taint propagates through the var() name argument</title>
+    <link rel="help" href="https://drafts.csswg.org/css-values-5/#attr-security">
+    <link rel="help" href="https://drafts.csswg.org/css-variables-2/#replace-a-var-function">
+    <link rel="author" title="Apple Inc." href="https://apple.com">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style>
+        @property --registered-url {
+            syntax: "<url>";
+            inherits: false;
+            initial-value: url("https://does-not-exist.test/initial.png");
+        }
+    </style>
+</head>
+<body>
+<div id="target" data-image-name="--image" data-length-name="--length" data-not-a-name="10px" data-none="none"></div>
+<script>
+    "use strict";
+
+    // The substitution value of an arbitrary substitution function is attr()-tainted as a whole if any
+    // attr()-tainted values were involved in creating it, and using an attr()-tainted value as or in a
+    // <url> makes a declaration invalid at computed-value time. Resolving a var() name argument from an
+    // attribute therefore taints the substituted value, even though the value itself comes from a
+    // custom property rather than from the attribute.
+
+    const target = document.getElementById("target");
+    const url = "https://does-not-exist.test/404.png";
+    const initialURL = "https://does-not-exist.test/initial.png";
+
+    function computed(declaration, property) {
+        target.setAttribute("style", declaration);
+        const value = getComputedStyle(target).getPropertyValue(property);
+        target.removeAttribute("style");
+        return value;
+    }
+
+    test(() => {
+        assert_equals(computed(`--image: image-set("${url}"); background-image: var(attr(data-image-name type(*)));`,
+                              "background-image"), "none");
+    }, "attr()-tainted name argument makes an image-set() declaration invalid at computed-value time");
+
+    test(() => {
+        assert_equals(computed(`--image: url("${url}"); background-image: var(attr(data-image-name type(*)));`,
+                              "background-image"), "none");
+    }, "attr()-tainted name argument taints a url() value");
+
+    test(() => {
+        assert_equals(computed(`--name: attr(data-image-name type(*)); --image: url("${url}"); background-image: var(var(--name));`,
+                              "background-image"), "none");
+    }, "attr()-taint reaches the name argument through another custom property");
+
+    // The name is tainted and does not parse, so the taint carries into the fallback that gets used.
+    test(() => {
+        assert_equals(computed(`background-image: var(attr(data-not-a-name type(*)), url("${url}"));`,
+                              "background-image"), "none");
+    }, "attr()-tainted name argument taints the fallback");
+
+    // A registered property with <url> syntax resolved from tainted data is invalid at computed-value
+    // time, so it computes to its initial value.
+    test(() => {
+        assert_equals(computed(`--image: url("${url}"); --registered-url: var(attr(data-image-name type(*)));`,
+                              "--registered-url"), `url("${initialURL}")`);
+    }, "attr()-tainted name argument taints a registered <url> property");
+
+    // Taint only matters for URLs.
+    test(() => {
+        assert_equals(computed("--length: 10px; width: var(attr(data-length-name type(*)));", "width"), "10px");
+    }, "attr()-tainted name argument does not invalidate values that are not URLs");
+
+    // Custom properties are not URL contexts, so the tainted value is still observable there.
+    test(() => {
+        assert_equals(computed(`--image: url("${url}"); --result: var(attr(data-image-name type(*)));`, "--result"),
+                      `url("${url}")`);
+    }, "attr()-tainted name argument substitutes normally into a custom property");
+
+    // Taint from the name argument must be detected per var(), not from the state of the value so far.
+    test(() => {
+        assert_equals(computed(`--image: url("${url}"); --name: attr(data-image-name type(*)); --tainted-none: attr(data-none type(*)); background-image: var(--tainted-none), var(var(--name));`,
+                              "background-image"), "none");
+    }, "attr()-tainted name argument taints the value even when an earlier value was already tainted");
+
+    // A name argument with no attr() involved is not tainted.
+    test(() => {
+        assert_equals(computed(`--image: image-set("${url}"); --name: --image; background-image: var(var(--name));`,
+                              "background-image"), `image-set(url("${url}") 1dppx)`);
+    }, "untainted substituted name argument does not taint the value");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution-expected.txt
@@ -1,0 +1,26 @@
+
+PASS var() name comes from another var()
+PASS var() name comes from a chain of var()s
+PASS invalid substituted name falls back
+PASS unset name-providing var() falls back
+PASS whitespace around substituted name
+PASS invalid substituted name without fallback is invalid at computed-value time
+PASS name argument substituting to nothing falls back
+PASS multi-token substituted name falls back
+PASS dimension-token substituted name falls back
+PASS string substituted name falls back
+PASS -- as substituted name falls back
+PASS {}-wrapped literal name argument
+PASS {}-wrapped substituted name argument
+PASS {}-wrapped name argument with whitespace
+PASS {}-wrapped name argument with fallback
+PASS var() name comes from attr()
+PASS var() name from attr() that is not a name falls back
+PASS var() name comes from if()
+PASS var() name comes from random-item()
+PASS direct cycle through the name argument
+PASS indirect cycle through the name argument
+PASS substituted name resolves a registered property
+PASS substituted name of a guaranteed-invalid registered property uses the fallback
+PASS fallback of an unparsed name is not syntax checked
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>var() name argument is an arbitrary substitution value</title>
+    <link rel="help" href="https://drafts.csswg.org/css-variables-2/#replace-a-var-function">
+    <link rel="help" href="https://drafts.csswg.org/css-values-5/#component-function-commas">
+    <link rel="author" title="Apple Inc." href="https://apple.com">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style>
+        #target { --other: 10px; }
+        @property --registered-length {
+            syntax: "<length>";
+            inherits: false;
+            initial-value: 7px;
+        }
+        @property --registered-universal {
+            syntax: "*";
+            inherits: false;
+        }
+    </style>
+</head>
+<body>
+<div id="target" data-name="--other" data-not-a-name="10px"></div>
+<script>
+    "use strict";
+
+    const target = document.getElementById("target");
+
+    function computed(declaration, property) {
+        target.setAttribute("style", declaration);
+        const value = getComputedStyle(target).getPropertyValue(property || "width");
+        target.removeAttribute("style");
+        return value;
+    }
+
+    const initialWidth = computed("width: initial;");
+
+    // The inner var() resolves to `--other`, which becomes the name looked up by the outer var().
+    // https://drafts.csswg.org/css-variables-2/#replace-a-var-function example.
+    test(() => {
+        assert_equals(computed("--myvar: --other; width: var(var(--myvar));"), "10px");
+    }, "var() name comes from another var()");
+
+    test(() => {
+        assert_equals(computed("--myvar: --other; --indirect: --myvar; width: var(var(var(--indirect)));"), "10px");
+    }, "var() name comes from a chain of var()s");
+
+    // A substituted name that does not parse as a <custom-property-name> makes the reference
+    // guaranteed-invalid, so the fallback is used.
+    test(() => {
+        assert_equals(computed("--myvar: not-a-custom-prop; width: var(var(--myvar), 20px);"), "20px");
+    }, "invalid substituted name falls back");
+
+    // The name-providing var() is itself unset, so the name is guaranteed-invalid: fallback is used.
+    test(() => {
+        assert_equals(computed("width: var(var(--unset), 30px);"), "30px");
+    }, "unset name-providing var() falls back");
+
+    // Whitespace around the substituted name is allowed.
+    test(() => {
+        assert_equals(computed("--myvar: --other; width: var( var(--myvar) );"), "10px");
+    }, "whitespace around substituted name");
+
+    // A substituted name that is not itself a custom-property name (bad prefix) and no fallback:
+    // the property is invalid at computed-value time and falls back to initial (auto).
+    test(() => {
+        assert_equals(computed("--myvar: other; width: var(var(--myvar));"), initialWidth);
+    }, "invalid substituted name without fallback is invalid at computed-value time");
+
+    // A name argument that substitutes to nothing does not parse as a <custom-property-name>.
+    test(() => {
+        assert_equals(computed("--empty: ; width: var(var(--empty), 40px);"), "40px");
+    }, "name argument substituting to nothing falls back");
+
+    // A <custom-property-name> is a single ident, so a multi-token name never parses.
+    test(() => {
+        assert_equals(computed("--two: --other --other; width: var(var(--two), 50px);"), "50px");
+    }, "multi-token substituted name falls back");
+
+    test(() => {
+        assert_equals(computed("--dimension: 10px; width: var(var(--dimension), 60px);"), "60px");
+    }, "dimension-token substituted name falls back");
+
+    test(() => {
+        assert_equals(computed('--string: "--other"; width: var(var(--string), 70px);'), "70px");
+    }, "string substituted name falls back");
+
+    // "--" is not a valid <custom-property-name>.
+    test(() => {
+        assert_equals(computed("--dashes: --; width: var(var(--dashes), 80px);"), "80px");
+    }, "-- as substituted name falls back");
+
+    // https://drafts.csswg.org/css-values-5/#component-function-commas
+    // A {}-wrapped free-form production represents the contents of the block, so the braces are
+    // stripped before the name is parsed. They are allowed even when not required.
+    test(() => {
+        assert_equals(computed("width: var({--other});"), "10px");
+    }, "{}-wrapped literal name argument");
+
+    test(() => {
+        assert_equals(computed("--myvar: --other; width: var({var(--myvar)});"), "10px");
+    }, "{}-wrapped substituted name argument");
+
+    test(() => {
+        assert_equals(computed("width: var( { --other } );"), "10px");
+    }, "{}-wrapped name argument with whitespace");
+
+    test(() => {
+        assert_equals(computed("width: var({--unset}, 90px);"), "90px");
+    }, "{}-wrapped name argument with fallback");
+
+    // Other arbitrary substitution functions can produce the name.
+    test(() => {
+        assert_equals(computed("width: var(attr(data-name type(*)));"), "10px");
+    }, "var() name comes from attr()");
+
+    test(() => {
+        assert_equals(computed("width: var(attr(data-not-a-name type(*)), 100px);"), "100px");
+    }, "var() name from attr() that is not a name falls back");
+
+    test(() => {
+        assert_equals(computed("width: var(if(style(--other: 10px): --other; else: --unset));"), "10px");
+    }, "var() name comes from if()");
+
+    test(() => {
+        assert_equals(computed("width: var(random-item(--key, --other, --other));"), "10px");
+    }, "var() name comes from random-item()");
+
+    // Cycles are detected through the name argument, since looking up the referenced property
+    // implies property replacement. https://drafts.csswg.org/css-variables-2/#replace-a-var-function
+    test(() => {
+        assert_equals(computed("--self: var(var(--self)); width: var(--self, 110px);"), "110px");
+    }, "direct cycle through the name argument");
+
+    test(() => {
+        assert_equals(computed("--name: --cyclic; --cyclic: var(var(--name)); width: var(--cyclic, 120px);"), "120px");
+    }, "indirect cycle through the name argument");
+
+    // Registered properties: a substituted name resolves them like a literal name does.
+    test(() => {
+        assert_equals(computed("--name: --registered-length; width: var(var(--name));"), "7px");
+    }, "substituted name resolves a registered property");
+
+    // A universal registration without an initial value is guaranteed-invalid, so the fallback is used.
+    test(() => {
+        assert_equals(computed("--name: --registered-universal; width: var(var(--name), 130px);"), "130px");
+    }, "substituted name of a guaranteed-invalid registered property uses the fallback");
+
+    // A name that does not parse has no referenced property, so there is no registered syntax to
+    // check the fallback against.
+    // https://drafts.css-houdini.org/css-properties-values-api/#fallbacks-in-var-references
+    test(() => {
+        assert_equals(computed("--name: not-a-name; width: var(var(--name), 140px);"), "140px");
+    }, "fallback of an unparsed name is not syntax checked");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference.html
@@ -37,13 +37,13 @@
         { cssText: "width: var(--prop,);",                  expectedPropertyValue: "var(--prop,)" },
 
         { cssText: "width: var();",                         expectedPropertyValue: "" },
-        { cssText: "width: var(prop);",                     expectedPropertyValue: "" },
-        { cssText: "width: var(-prop);",                    expectedPropertyValue: "" },
-        { cssText: "width: var(--prop 20px);",              expectedPropertyValue: "" },
-        { cssText: "width: var(--prop, var(prop));",        expectedPropertyValue: "" },
-        { cssText: "width: var(--prop, var(-prop));",       expectedPropertyValue: "" },
-        { cssText: "width: var(20px);",                     expectedPropertyValue: "" },
-        { cssText: "width: var(var(--prop));",              expectedPropertyValue: "" },
+        { cssText: "width: var(prop);",                     expectedPropertyValue: "var(prop)" },
+        { cssText: "width: var(-prop);",                    expectedPropertyValue: "var(-prop)" },
+        { cssText: "width: var(--prop 20px);",              expectedPropertyValue: "var(--prop 20px)" },
+        { cssText: "width: var(--prop, var(prop));",        expectedPropertyValue: "var(--prop, var(prop))" },
+        { cssText: "width: var(--prop, var(-prop));",       expectedPropertyValue: "var(--prop, var(-prop))" },
+        { cssText: "width: var(20px);",                     expectedPropertyValue: "var(20px)" },
+        { cssText: "width: var(var(--prop));",              expectedPropertyValue: "var(var(--prop))" },
     ];
 
     testcases.forEach(function (testcase) {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-supports-30.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-supports-30.html
@@ -3,13 +3,16 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <!DOCTYPE html>
-<title>CSS Test: Test a passing non-custom property declaration in an @supports rule whose value contains a variable reference with a dimension token as the variable name.</title>
+<title>CSS Test: A non-custom property declaration in an @supports rule whose value is a var() reference with a dimension token as the name argument is supported.</title>
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="http://www.w3.org/TR/css-variables-1/#using-variables">
 <link rel="match" href="support/color-green-ref.html">
 <style>
 body { color: red; }
-@supports (color: var(--a)) and (not (color: var(1px))) {
+/* var()'s name argument is a <declaration-value>, so var(1px) is valid at parse time; the name
+   fails to parse as a <custom-property-name> only at computed-value time, so the declaration is
+   supported. https://drafts.csswg.org/css-variables-2/#funcdef-var */
+@supports (color: var(--a)) and (color: var(1px)) {
   p { color: green; }
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-supports-64.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-supports-64.html
@@ -3,13 +3,16 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <!DOCTYPE html>
-<title>CSS Test: Test a failing custom property declaration in an @supports rule whose value is a variable reference with a dimension token as the variable name.</title>
+<title>CSS Test: A custom property declaration in an @supports rule whose value is a var() reference with a dimension token as the name argument is supported.</title>
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="http://www.w3.org/TR/css-variables-1/#using-variables">
 <link rel="match" href="support/color-green-ref.html">
 <style>
 body { color: red; }
-@supports (--a: a) and (not (--a: var(1px))) {
+/* var()'s name argument is a <declaration-value>, so var(1px) is valid at parse time; the name
+   fails to parse as a <custom-property-name> only at computed-value time, so the declaration is
+   supported. https://drafts.csswg.org/css-variables-2/#funcdef-var */
+@supports (--a: a) and (--a: var(1px)) {
   p { color: green; }
 }
 </style>

--- a/Source/WebCore/css/CSSSubstitutionValue.cpp
+++ b/Source/WebCore/css/CSSSubstitutionValue.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "CSSSubstitutionValue.h"
 
+#include "CSSSubstitutionParser.h"
 #include "CSSVariableData.h"
 
 namespace WebCore {
@@ -93,13 +94,19 @@ void CSSSubstitutionValue::cacheSimpleReference()
 
     variableRange.consumeWhitespace();
 
-    auto variableName = variableRange.consumeIncludingWhitespace().value().toAtomString();
+    // var() names a <custom-property-name> and env() an <ident>. Anything else takes the full
+    // substitution path, since var()'s name argument may be any <declaration-value>.
+    auto& nameToken = variableRange.consumeIncludingWhitespace();
+    if (nameToken.type() != IdentToken)
+        return;
+    if (functionId == CSSValueVar && !CSSSubstitutionParser::isValidCustomPropertyName(nameToken))
+        return;
 
     // No fallback support on this path.
     if (!variableRange.atEnd())
         return;
 
-    m_simpleReference = SimpleReference { variableName, functionId };
+    m_simpleReference = SimpleReference { nameToken.value().toAtomString(), functionId };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
+++ b/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
@@ -201,17 +201,40 @@ static std::optional<ClassifyBlockResult> classifyBlock(CSSParserTokenRange rang
     return result;
 }
 
+// Validates a single comma-separated argument that is a <declaration-value> subject to the
+// comma-containing-production rules: a {}-wrapped block groups internal commas, but may not be
+// mixed with other values, and a bare {} is not a valid value.
+// https://drafts.csswg.org/css-values-5/#component-function-commas
+// `allowEmpty` distinguishes <declaration-value># (dashed functions) from <declaration-value>?#
+// (random-item() items, where an item may be empty).
+static bool isValidDeclarationValueArgument(CSSParserTokenRange argumentRange, const CSSParserContext& parserContext, bool allowEmpty)
+{
+    if (argumentRange.atEnd())
+        return allowEmpty;
+
+    auto result = classifyBlock(argumentRange, parserContext);
+    return result && !result->hasTopLevelBraceBlockMixedWithOtherValues && !result->hasEmptyTopLevelBraceBlock;
+}
+
+// https://drafts.csswg.org/css-variables-2/#funcdef-var
+// <var-args> = var( <declaration-value> , <declaration-value>? )
+// The name argument is a <declaration-value>. It is substituted and then parsed as a
+// <custom-property-name> at substitution time, so parse-time validity only requires a
+// <declaration-value> here.
 bool isValidVariableReference(CSSParserTokenRange range, const CSSParserContext& parserContext)
 {
     range.consumeWhitespace();
-    if (!CSSSubstitutionParser::isValidCustomPropertyName(range.consumeIncludingWhitespace()))
-        return false;
-    if (range.atEnd())
-        return true;
 
-    if (!CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range))
+    // Split at the first literal comma into the name argument and optional fallback.
+    auto nameArgStart = range;
+    while (!range.atEnd() && range.peek().type() != CommaToken)
+        range.consumeComponentValue();
+
+    if (!isValidDeclarationValueArgument(nameArgStart.rangeUntil(range), parserContext, /* allowEmpty */ false))
         return false;
-    if (range.atEnd())
+
+    // The split stopped at a literal comma or at the end, so this covers both a missing and an empty fallback.
+    if (!CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range) || range.atEnd())
         return true;
 
     return !!classifyBlock(range, parserContext);
@@ -231,21 +254,6 @@ bool isValidConstantReference(CSSParserTokenRange range, const CSSParserContext&
         return true;
 
     return !!classifyBlock(range, parserContext);
-}
-
-// Validates a single comma-separated argument that is a <declaration-value> subject to the
-// comma-containing-production rules: a {}-wrapped block groups internal commas, but may not be
-// mixed with other values, and a bare {} is not a valid value.
-// https://drafts.csswg.org/css-values-5/#component-function-commas
-// `allowEmpty` distinguishes <declaration-value># (dashed functions) from <declaration-value>?#
-// (random-item() items, where an item may be empty).
-static bool isValidDeclarationValueArgument(CSSParserTokenRange argumentRange, const CSSParserContext& parserContext, bool allowEmpty)
-{
-    if (argumentRange.atEnd())
-        return allowEmpty;
-
-    auto result = classifyBlock(argumentRange, parserContext);
-    return result && !result->hasTopLevelBraceBlockMixedWithOtherValues && !result->hasEmptyTopLevelBraceBlock;
 }
 
 bool isValidDashedFunction(CSSParserTokenRange range, const CSSParserContext& parserContext)

--- a/Source/WebCore/css/query/ContainerQuery.cpp
+++ b/Source/WebCore/css/query/ContainerQuery.cpp
@@ -65,6 +65,8 @@ void collectCustomPropertyNames(const MQ::Feature& feature, HashSet<AtomString>&
             names.add(name);
 
         // var() references, at any nesting depth.
+        // FIXME: This only sees literal names. A name that comes from substitution, e.g.
+        // var(var(--name)), leaves the indirectly named property uncollected and so unwatched.
         for (size_t i = 0; i < tokens.size(); ++i) {
             if (tokens[i].type() != FunctionToken || tokens[i].functionId() != CSSValueVar)
                 continue;

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -33,6 +33,7 @@
 #include "CSSOMVariableReferenceValue.h"
 #include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
+#include "CSSSubstitutionParser.h"
 #include "CSSSubstitutionValue.h"
 #include "CSSTokenizer.h"
 #include "ExceptionOr.h"
@@ -65,28 +66,40 @@ Ref<CSSUnparsedValue> CSSUnparsedValue::create(CSSParserTokenRange tokens)
         
         if (currentToken.type() == FunctionToken || currentToken.type() == LeftParenthesisToken) {
             if (currentToken.functionId() == CSSValueVar) {
+                // https://drafts.csswg.org/css-variables-2/#funcdef-var
+                // The name argument is a <declaration-value> that is only parsed as a
+                // <custom-property-name> at computed-value time, so there is a reference to reify here
+                // only when it is a literal one. Anything else is kept as text.
+                auto argumentsRange = tokens;
+                argumentsRange.consumeWhitespace();
+                auto& nameToken = argumentsRange.consumeIncludingWhitespace();
+                auto isLiteralName = CSSSubstitutionParser::isValidCustomPropertyName(nameToken)
+                    && (argumentsRange.peek().type() == CommaToken || argumentsRange.peek().type() == RightParenthesisToken);
+
+                if (!isLiteralName) {
+                    currentToken.serialize(builder);
+                    identifiers.append(std::nullopt);
+                    continue;
+                }
+
                 if (!builder.isEmpty()) {
                     segmentStack.last().append(builder.toString());
                     builder.clear();
                 }
-                tokens.consumeWhitespace();
-                auto identToken = tokens.consumeIncludingWhitespace();
-                // Token after whitespace consumption must be variable reference identifier
-                ASSERT(identToken.type() == IdentToken);
+                tokens = argumentsRange;
+
                 if (tokens.peek().type() == CommaToken) {
                     // Fallback present
-                    identifiers.append(StringView(identToken.value()));
+                    identifiers.append(StringView(nameToken.value()));
                     segmentStack.append({ });
                     tokens.consume();
-                } else if (tokens.peek().type() == RightParenthesisToken) {
+                } else {
                     // No fallback
-                    auto variableReference = CSSOMVariableReferenceValue::create(identToken.value().toString());
+                    auto variableReference = CSSOMVariableReferenceValue::create(nameToken.value().toString());
                     ASSERT(!variableReference.hasException());
                     segmentStack.last().append(CSSUnparsedSegment { variableReference.releaseReturnValue() });
                     tokens.consume();
-                } else
-                    ASSERT_NOT_REACHED();
-                
+                }
             } else {
                 currentToken.serialize(builder);
                 identifiers.append(std::nullopt);

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -40,6 +40,7 @@
 #include "CSSSelectorParser.h"
 #include "CSSSerializationContext.h"
 #include "CSSShorthandSubstitutionValue.h"
+#include "CSSSubstitutionParser.h"
 #include "CSSSubstitutionValue.h"
 #include "CSSTokenizer.h"
 #include "CSSUnits.h"
@@ -144,17 +145,82 @@ RefPtr<const CustomProperty> SubstitutionResolver::propertyValueForVariableName(
     return protect(m_styleBuilder.state().style())->customPropertyValue(variableName);
 }
 
-bool SubstitutionResolver::substituteVariableFunction(CSSParserTokenRange range, CSSValueID functionId, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+auto SubstitutionResolver::substituteVarArgumentGrammar(CSSParserTokenRange range, const CSSParserContext& context) -> VarArgumentGrammarSubstitution
 {
-    ASSERT(functionId == CSSValueVar || functionId == CSSValueEnv);
+    // https://drafts.csswg.org/css-values-5/#argument-grammars
+    // <var-args> = var( <declaration-value> , <declaration-value>? )
+    // Splits at the first literal comma and substitutes the name argument, which is then parsed as a
+    // <custom-property-name>. The name may itself come from other substitution functions, e.g.
+    // var(var(--name)). A name that does not parse is left unset rather than failing the function, so
+    // that the fallback still gets used.
 
+    range.consumeWhitespace();
+
+    auto nameArgStart = range;
+    while (!range.atEnd() && range.peek().type() != CommaToken)
+        range.consumeComponentValue();
+    auto nameArgRange = unwrapArgumentBraces(nameArgStart.rangeUntil(range));
+
+    std::optional<CSSParserTokenRange> fallbackRange;
+    if (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range)) {
+        range.trimTrailingWhitespace();
+        fallbackRange = range;
+    }
+
+    auto parseName = [](CSSParserTokenRange nameRange) -> std::optional<AtomString> {
+        nameRange.consumeWhitespace();
+        auto& nameToken = nameRange.consumeIncludingWhitespace();
+        if (!CSSSubstitutionParser::isValidCustomPropertyName(nameToken) || !nameRange.atEnd())
+            return { };
+        return nameToken.value().toAtomString();
+    };
+
+    // Fast path: a name argument that is already a literal <custom-property-name> needs no substitution.
+    if (auto name = parseName(nameArgRange))
+        return { name, fallbackRange };
+
+    // https://drafts.csswg.org/css-values-5/#attr-security
+    // Isolate the flag to see whether resolving the name itself involved attr()-tainted values. Diffing
+    // it would miss the taint when something earlier in the same value had already set it.
+    auto wasAttrTainted = std::exchange(m_isAttrTainted, false);
+    auto substitutedName = substituteTokenRange(nameArgRange, context);
+    auto isNameAttrTainted = m_isAttrTainted ? IsAttrTainted::Yes : IsAttrTainted::No;
+    m_isAttrTainted |= wasAttrTainted;
+
+    if (!substitutedName)
+        return { { }, fallbackRange, isNameAttrTainted };
+
+    return { parseName(CSSParserTokenRange { *substitutedName }), fallbackRange, isNameAttrTainted };
+}
+
+bool SubstitutionResolver::substituteVarFunction(CSSParserTokenRange range, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+{
+    // https://drafts.csswg.org/css-variables-2/#replace-a-var-function
+    auto arguments = substituteVarArgumentGrammar(range, context);
+
+    auto startIndex = tokens.size();
+    if (!substituteNamedValueOrFallback(arguments.name, arguments.fallbackRange, CSSValueVar, tokens, context))
+        return false;
+
+    // https://drafts.csswg.org/css-values-5/#attr-security
+    // A name argument resolved from attr()-tainted values taints the whole substitution value. The
+    // URL to catch is in the substituted tokens, not in the name.
+    propagateAttrTaint(arguments.isNameAttrTainted, std::span(tokens).subspan(startIndex));
+
+    return true;
+}
+
+bool SubstitutionResolver::substituteEnvFunction(CSSParserTokenRange range, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+{
+    // https://drafts.csswg.org/css-env-1/#env-function
+    // FIXME: env()'s argument grammar is env( <declaration-value>, <declaration-value>? ) like var()'s,
+    // so the name argument should be substituted and only then parsed as <custom-ident> <integer>*.
+    // Only a literal <ident> name is supported here, the same limitation as the unsupported indices.
     range.consumeWhitespace();
     if (range.peek().type() != IdentToken)
         return false;
-    auto variableName = range.consumeIncludingWhitespace().value().toAtomString();
+    auto name = range.consumeIncludingWhitespace().value().toAtomString();
 
-    // Substitute the optional `, <fallback>` only when the referenced value is guaranteed-invalid.
-    // https://drafts.csswg.org/css-variables-2/#replace-a-var-function
     std::optional<CSSParserTokenRange> fallbackRange;
     if (!range.atEnd()) {
         if (range.peek().type() != CommaToken)
@@ -164,7 +230,15 @@ bool SubstitutionResolver::substituteVariableFunction(CSSParserTokenRange range,
         fallbackRange = range;
     }
 
-    RefPtr property = propertyValueForVariableName(variableName, functionId);
+    return substituteNamedValueOrFallback(name, fallbackRange, CSSValueEnv, tokens, context);
+}
+
+bool SubstitutionResolver::substituteNamedValueOrFallback(const std::optional<AtomString>& name, const std::optional<CSSParserTokenRange>& fallbackRange, CSSValueID functionId, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+{
+    ASSERT(functionId == CSSValueVar || functionId == CSSValueEnv);
+
+    // A name that failed to parse leaves the reference guaranteed-invalid, which still permits the fallback.
+    RefPtr property = name ? propertyValueForVariableName(*name, functionId) : nullptr;
 
     if (property && !property->isGuaranteedInvalid()) {
         if (property->tokens().size() > maxSubstitutionTokens)
@@ -178,25 +252,24 @@ bool SubstitutionResolver::substituteVariableFunction(CSSParserTokenRange range,
         return true;
     }
 
-    if (fallbackRange) {
-        auto fallbackTokens = substituteTokenRange(*fallbackRange, context);
-        if (!fallbackTokens || fallbackTokens->size() > maxSubstitutionTokens)
+    if (!fallbackRange)
+        return false;
+
+    auto fallbackTokens = substituteTokenRange(*fallbackRange, context);
+    if (!fallbackTokens || fallbackTokens->size() > maxSubstitutionTokens)
+        return false;
+
+    if (functionId == CSSValueVar && name) {
+        auto* registered = m_styleBuilder.state().registeredProperty(*name);
+        // https://drafts.css-houdini.org/css-properties-values-api/#fallbacks-in-var-references
+        // A used fallback must match the referenced registered property's syntax.
+        if (registered && !registered->syntax.isUniversal()
+            && !CSSPropertyParser::isValidCustomPropertyValueForSyntax(registered->syntax, *fallbackTokens, context))
             return false;
-
-        if (functionId == CSSValueVar) {
-            auto* registered = m_styleBuilder.state().registeredProperty(variableName);
-            // https://drafts.css-houdini.org/css-properties-values-api/#fallbacks-in-var-references
-            // A used fallback must match the referenced registered property's syntax.
-            if (registered && !registered->syntax.isUniversal()
-                && !CSSPropertyParser::isValidCustomPropertyValueForSyntax(registered->syntax, *fallbackTokens, context))
-                return false;
-        }
-
-        tokens.appendVector(*fallbackTokens);
-        return true;
     }
 
-    return false;
+    tokens.appendVector(*fallbackTokens);
+    return true;
 }
 
 // https://drafts.csswg.org/css-values-5/#first-valid
@@ -1002,8 +1075,13 @@ std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange
         auto token = range.peek();
         if (token.type() == FunctionToken) {
             auto functionId = token.functionId();
-            if (functionId == CSSValueVar || functionId == CSSValueEnv) {
-                if (!substituteVariableFunction(range.consumeBlock(), functionId, tokens, context))
+            if (functionId == CSSValueVar) {
+                if (!substituteVarFunction(range.consumeBlock(), tokens, context))
+                    success = false;
+                continue;
+            }
+            if (functionId == CSSValueEnv) {
+                if (!substituteEnvFunction(range.consumeBlock(), tokens, context))
                     success = false;
                 continue;
             }

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -64,7 +64,9 @@ public:
 private:
     std::optional<Vector<CSSParserToken>> substituteTokenRange(CSSParserTokenRange, const CSSParserContext&);
 
-    bool substituteVariableFunction(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, const CSSParserContext&);
+    bool substituteVarFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
+    bool substituteEnvFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
+    bool substituteNamedValueOrFallback(const std::optional<AtomString>& name, const std::optional<CSSParserTokenRange>& fallbackRange, CSSValueID, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteFirstValid(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteDashedFunction(StringView functionName, CSSParserTokenRange, Vector<CSSParserToken>&);
     RefPtr<MutableStyleProperties> resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>&, const Vector<Vector<CSSParserToken>>&, LocalPropertyRegistry&, ScopeOrdinal definitionScope);
@@ -73,6 +75,15 @@ private:
     bool substituteInternalAutoBaseFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteRandomItemFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     std::optional<double> randomItemBaseValue(Vector<CSSParserToken> randomKey);
+
+    struct VarArgumentGrammarSubstitution {
+        // An unset name failed to parse as a <custom-property-name> after substitution.
+        std::optional<AtomString> name;
+        std::optional<CSSParserTokenRange> fallbackRange;
+        // Whether resolving the name argument involved attr()-tainted values.
+        IsAttrTainted isNameAttrTainted { IsAttrTainted::No };
+    };
+    VarArgumentGrammarSubstitution substituteVarArgumentGrammar(CSSParserTokenRange, const CSSParserContext&);
 
     struct AttrArgumentGrammarSubstitution {
         Vector<CSSParserToken> firstArg;


### PR DESCRIPTION
#### 8ce7ca092057b07052d0c88e5e3e940970cc75d3
<pre>
[css-variables-2] var() should be an arbitrary substitution function
<a href="https://bugs.webkit.org/show_bug.cgi?id=320896">https://bugs.webkit.org/show_bug.cgi?id=320896</a>
<a href="https://rdar.apple.com/183913427">rdar://183913427</a>

Reviewed by Sam Weinig.

var() function is an arbitrary substitution function, and its argument grammar is:

&lt;var-args&gt; = var( &lt;declaration-value&gt; , &lt;declaration-value&gt;? )

<a href="https://drafts.csswg.org/css-variables-2/#using-variables">https://drafts.csswg.org/css-variables-2/#using-variables</a>

This moves the argument validation to computed-value time and allows using other substitution functions
inside var() (assuming there was ident() implementation):

color: var(ident(--foo-color- attr(bar-attr)))

Tests: fast/css/css-typed-om/var-name-argument-unparsed.html
       fast/css/variables/env/env-name-argument-not-substituted.html
       imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution-attr-taint.html
       imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution.html
* LayoutTests/fast/css/css-typed-om/var-name-argument-unparsed-expected.txt: Added.
* LayoutTests/fast/css/css-typed-om/var-name-argument-unparsed.html: Added.

A var() that no longer has a name to reify must round-trip as text through Typed OM.

* LayoutTests/fast/css/variables/env/env-name-argument-not-substituted-expected.txt: Added.
* LayoutTests/fast/css/variables/env/env-name-argument-not-substituted.html: Added.

Covers the env() limitation. Not in the imported tree, since the spec allows what this asserts is invalid.

* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/var-ident-function-expected.txt:

Fallback subtests pass now that a bad substituted name triggers the fallback.

* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/var-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/var-parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference.html:

Malformed name arguments are valid at parse time and round-trip.

* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-declaration-29.html:

An invalid substituted name (--) triggers the fallback rather than dropping the declaration.

* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-supports-30.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-supports-64.html:

var() with a dimension-token name argument is valid at parse time, so the declaration is supported.

* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution-attr-taint-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution-attr-taint.html: Added.

A name resolved from an attribute must not sneak a URL past the taint check, including when an
earlier value in the same declaration was already tainted.

* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-name-substitution.html: Added.

Names from other substitution functions, names that don&apos;t parse as &lt;custom-property-name&gt;,
{}-wrapped names, cycles through the name argument, and registered properties.

* Source/WebCore/css/CSSSubstitutionValue.cpp:
(WebCore::CSSSubstitutionValue::cacheSimpleReference):

Only cache a name that var() or env() could actually name. Taking the first token whatever it was
made var(20px) cache a reference to &quot;px&quot;, so every resolution did a futile custom property lookup
first.

* Source/WebCore/css/parser/CSSSubstitutionParser.cpp:
(WebCore::isValidDeclarationValueArgument):
(WebCore::isValidVariableReference):

Validate the name argument as a &lt;declaration-value&gt; split at the first literal comma. It is a
free-form production, so isValidDeclarationValueArgument() applies the {}-wrapping rules to it.

* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteVarArgumentGrammar):

Substitute the name argument and parse it as a &lt;custom-property-name&gt;. A name that does not parse is
an unset optional, leaving the reference guaranteed-invalid while still permitting the fallback.
m_isAttrTainted is a sticky resolver-wide flag, so it is isolated across the name substitution:
diffing it would miss the taint whenever an earlier value had already set it, letting a tainted name
reach a URL.

(WebCore::Style::SubstitutionResolver::substituteVarFunction):
(WebCore::Style::SubstitutionResolver::substituteEnvFunction):

One entry point each. env() names a literal &lt;ident&gt; with nothing to substitute, so sharing meant
branching on the function id. Its argument grammar is the same as var()&apos;s per css-env-1, so the
ident-only name is a WebKit limitation and now says so.

(WebCore::Style::SubstitutionResolver::substituteNamedValueOrFallback):

The tail they do share: look up the name, fall back when the result is guaranteed-invalid.

(WebCore::Style::SubstitutionResolver::substituteTokenRange):
(WebCore::Style::SubstitutionResolver::substituteVariableFunction): Deleted.
* Source/WebCore/style/StyleSubstitutionResolver.h:
* Source/WebCore/css/typedom/CSSUnparsedValue.cpp:
(WebCore::CSSUnparsedValue::create):

The assumption that a parsed var() has a literal &lt;ident&gt; name no longer holds. var(20px) hit the
ASSERT and then aborted in release on the CSSOMVariableReferenceValue::create() exception, reachable
from attributeStyleMap.get() and CSSStyleValue.parse(). Reify a variable reference only for a
literal name and keep anything else as text.

* Source/WebCore/css/query/ContainerQuery.cpp:
(WebCore::Style::collectCustomPropertyNames):

FIXME for the names that only exist after substitution, which this cannot see.

Canonical link: <a href="https://commits.webkit.org/318912@main">https://commits.webkit.org/318912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39b6e926690bdc92ce354bbd7ecb4d97964e214c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144132 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/632db867-d5e8-47e5-944c-9c89dcf5c49d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140259 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f900e4b-6c66-45df-b467-daf2eef4530a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120709 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4c608af-79b9-4081-bbaa-80e9ad9bd79f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40854 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152940 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40515 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1177 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191955 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40063 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54112 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149276 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43927 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126374 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121417 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52629 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15505 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52011 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52248 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52075 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->