### PR TITLE
REGRESSION(318890@main): [GTK][WPE] Build broken due to name clash at VectorBorrow.cpp

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/VectorBorrow.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/VectorBorrow.cpp
@@ -31,7 +31,7 @@
 
 namespace TestWebKitAPI {
 
-TEST(WTF_Borrow, ReadWhileBorrowedThenInteriorDestroyAfter)
+TEST(WTF_VectorBorrow, ReadWhileBorrowedThenInteriorDestroyAfter)
 {
     Vector<uint8_t> vector { 1, 2, 3 };
     {
@@ -45,7 +45,7 @@ TEST(WTF_Borrow, ReadWhileBorrowedThenInteriorDestroyAfter)
     EXPECT_EQ(vector.size(), 4u);
 }
 
-TEST(WTF_Borrow, NestedBorrows)
+TEST(WTF_VectorBorrow, NestedBorrows)
 {
     Vector<uint8_t> vector { 1, 2, 3 };
     {
@@ -62,7 +62,7 @@ TEST(WTF_Borrow, NestedBorrows)
     EXPECT_EQ(vector.size(), 4u);
 }
 
-TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(ReallocateWhileBorrowedCrashes))
+TEST(WTF_VectorBorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(ReallocateWhileBorrowedCrashes))
 {
     auto shouldCrash = [] {
         Vector<uint8_t> vector { 1, 2, 3 };
@@ -72,7 +72,7 @@ TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(ReallocateWhileBorrowe
     ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
 }
 
-TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(DestroyWhileBorrowedCrashes))
+TEST(WTF_VectorBorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(DestroyWhileBorrowedCrashes))
 {
     auto shouldCrash = [] {
         auto* vector = new Vector<uint8_t> { 1, 2, 3 };
@@ -82,7 +82,7 @@ TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(DestroyWhileBorrowedCr
     ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
 }
 
-TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(SwapWhileBorrowedCrashes))
+TEST(WTF_VectorBorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(SwapWhileBorrowedCrashes))
 {
     auto shouldCrash = [] {
         Vector<uint8_t> vector { 1, 2, 3 };
@@ -93,7 +93,7 @@ TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(SwapWhileBorrowedCrash
     ASSERT_DEATH_IF_SUPPORTED(shouldCrash(), "");
 }
 
-TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(MoveWhileBorrowedCrashes))
+TEST(WTF_VectorBorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(MoveWhileBorrowedCrashes))
 {
     auto shouldCrash = [] {
         Vector<uint8_t> vector { 1, 2, 3 };


### PR DESCRIPTION
#### 405321bdf6d52e64555138205b8d026889004547
<pre>
REGRESSION(<a href="https://commits.webkit.org/318890@main">318890@main</a>): [GTK][WPE] Build broken due to name clash at VectorBorrow.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=321434">https://bugs.webkit.org/show_bug.cgi?id=321434</a>

Reviewed by NOBODY (OOPS!).

On <a href="https://commits.webkit.org/318890@main">318890@main</a> VectorBorrow.cpp reused the test prefix from Borrow.cpp and duplicated
the test DestroyWhileBorrowedCrashes causing a name clash.

Fix that by changing the prefixes of the tests in the VectorBorrow file.

* Tools/TestWebKitAPI/Tests/WTF/VectorBorrow.cpp:
(TestWebKitAPI::TEST(WTF_VectorBorrow, ReadWhileBorrowedThenInteriorDestroyAfter)):
(TestWebKitAPI::TEST(WTF_VectorBorrow, NestedBorrows)):
(TestWebKitAPI::TEST(WTF_VectorBorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(ReallocateWhileBorrowedCrashes)):
(TestWebKitAPI::TEST(WTF_VectorBorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(DestroyWhileBorrowedCrashes)):
(TestWebKitAPI::TEST(WTF_VectorBorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(SwapWhileBorrowedCrashes)):
(TestWebKitAPI::TEST(WTF_VectorBorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(MoveWhileBorrowedCrashes)):
(TestWebKitAPI::TEST(WTF_Borrow, ReadWhileBorrowedThenInteriorDestroyAfter)): Deleted.
(TestWebKitAPI::TEST(WTF_Borrow, NestedBorrows)): Deleted.
(TestWebKitAPI::TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(ReallocateWhileBorrowedCrashes)): Deleted.
(TestWebKitAPI::TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(DestroyWhileBorrowedCrashes)): Deleted.
(TestWebKitAPI::TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(SwapWhileBorrowedCrashes)): Deleted.
(TestWebKitAPI::TEST(WTF_BorrowDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(MoveWhileBorrowedCrashes)): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/405321bdf6d52e64555138205b8d026889004547

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179806 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189706 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181669 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55045 "Failed to checkout and rebase branch from PR 71288") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182763 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/55045 "Failed to checkout and rebase branch from PR 71288") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/120705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/55045 "Failed to checkout and rebase branch from PR 71288") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/55045 "Failed to checkout and rebase branch from PR 71288") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/1171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/191949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/191949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/54104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/191949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/54104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121409 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->