### PR TITLE
[JSC][Wasm] Split type definitions out of TypeKind

### DIFF
--- a/JSTests/wasm/WASM.js
+++ b/JSTests/wasm/WASM.js
@@ -34,7 +34,8 @@ export const description = JSON.parse(read("wasm.json", "caller relative")); // 
 export const type = Object.keys(description.type);
 const _typeSet = new Set(type);
 export const isValidType = v => _typeSet.has(v);
-export const typeValue = _mapValues(description.type);
+export const definedTypeValue = _mapValues(description.defined_type);
+export const typeValue = { ..._mapValues(description.type), ...definedTypeValue };
 const _valueTypeSet = new Set(description.value_type);
 export const isValidValueType = v => _valueTypeSet.has(v);
 const _blockTypeSet = new Set(description.block_type);

--- a/JSTests/wasm/wasm.json
+++ b/JSTests/wasm/wasm.json
@@ -24,13 +24,15 @@
         "arrayref":      { "type": "varint7", "value":  -22, "b3type": "B3::pointerType()",  "width": 0 },
         "ref":           { "type": "varint7", "value":  -28, "b3type": "B3::pointerType()",  "width": 64 },
         "ref_null":      { "type": "varint7", "value":  -29, "b3type": "B3::pointerType()",  "width": 64 },
-        "func":          { "type": "varint7", "value":  -32, "b3type": "B3::Void",   "width": 0 },
-        "struct":        { "type": "varint7", "value":  -33, "b3type": "B3::Void",   "width": 0 },
-        "array":         { "type": "varint7", "value":  -34, "b3type": "B3::Void",   "width": 0 },
-        "sub":           { "type": "varint7", "value":  -48, "b3type": "B3::Void",   "width": 0 },
-        "subfinal":      { "type": "varint7", "value":  -49, "b3type": "B3::Void",   "width": 0 },
-        "rec":           { "type": "varint7", "value":  -50, "b3type": "B3::Void",   "width": 0 },
         "void":          { "type": "varint7", "value":  -64, "b3type": "B3::Void",   "width": 0 }
+    },
+    "defined_type": {
+        "func":          { "type": "varint7", "value":  -32 },
+        "struct":        { "type": "varint7", "value":  -33 },
+        "array":         { "type": "varint7", "value":  -34 },
+        "sub":           { "type": "varint7", "value":  -48 },
+        "subfinal":      { "type": "varint7", "value":  -49 },
+        "rec":           { "type": "varint7", "value":  -50 }
     },
     "packed_type": {
         "i8":        { "type": "varint7", "value":  -8},

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/wasm-builder.js
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/wasm-builder.js
@@ -471,7 +471,7 @@ const WASM = {};
     const type = WASM.type = Object.keys(description.type);
     const _typeSet = new Set(type);
     WASM.isValidType = v => _typeSet.has(v);
-    WASM.typeValue = _mapValues(description.type);
+    WASM.typeValue = { ..._mapValues(description.type), ..._mapValues(description.defined_type || {}) };
     const _valueTypeSet = new Set(description.value_type);
     WASM.isValidValueType = v => _valueTypeSet.has(v);
     const _blockTypeSet = new Set(description.block_type);

--- a/LayoutTests/resources/wasm-builder.js
+++ b/LayoutTests/resources/wasm-builder.js
@@ -471,7 +471,7 @@ const WASM = {};
     const type = WASM.type = Object.keys(description.type);
     const _typeSet = new Set(type);
     WASM.isValidType = v => _typeSet.has(v);
-    WASM.typeValue = _mapValues(description.type);
+    WASM.typeValue = { ..._mapValues(description.type), ..._mapValues(description.defined_type || {}) };
     const _valueTypeSet = new Set(description.value_type);
     WASM.isValidValueType = v => _valueTypeSet.has(v);
     const _blockTypeSet = new Set(description.block_type);

--- a/LayoutTests/storage/indexeddb/resources/wasm-exceptions.js
+++ b/LayoutTests/storage/indexeddb/resources/wasm-exceptions.js
@@ -471,7 +471,7 @@ const WASM = {};
     const type = WASM.type = Object.keys(description.type);
     const _typeSet = new Set(type);
     WASM.isValidType = v => _typeSet.has(v);
-    WASM.typeValue = _mapValues(description.type);
+    WASM.typeValue = { ..._mapValues(description.type), ..._mapValues(description.defined_type || {}) };
     const _valueTypeSet = new Set(description.value_type);
     WASM.isValidValueType = v => _valueTypeSet.has(v);
     const _blockTypeSet = new Set(description.block_type);

--- a/LayoutTests/workers/wasm-references/test.js
+++ b/LayoutTests/workers/wasm-references/test.js
@@ -493,7 +493,7 @@ const WASM = {};
     const type = WASM.type = Object.keys(description.type);
     const _typeSet = new Set(type);
     WASM.isValidType = v => _typeSet.has(v);
-    WASM.typeValue = _mapValues(description.type);
+    WASM.typeValue = { ..._mapValues(description.type), ..._mapValues(description.defined_type || {}) };
     const _valueTypeSet = new Set(description.value_type);
     WASM.isValidValueType = v => _valueTypeSet.has(v);
     const _blockTypeSet = new Set(description.block_type);

--- a/LayoutTests/workers/wasm-resources/long-compile-worker.js
+++ b/LayoutTests/workers/wasm-resources/long-compile-worker.js
@@ -471,7 +471,7 @@ const WASM = {};
     const type = WASM.type = Object.keys(description.type);
     const _typeSet = new Set(type);
     WASM.isValidType = v => _typeSet.has(v);
-    WASM.typeValue = _mapValues(description.type);
+    WASM.typeValue = { ..._mapValues(description.type), ..._mapValues(description.defined_type || {}) };
     const _valueTypeSet = new Set(description.value_type);
     WASM.isValidValueType = v => _valueTypeSet.has(v);
     const _blockTypeSet = new Set(description.block_type);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -309,19 +309,13 @@ TypeKind BBQJIT::toValueKind(TypeKind kind)
     case TypeKind::F64:
     case TypeKind::V128:
         return kind;
-    case TypeKind::Func:
     case TypeKind::I31ref:
     case TypeKind::Funcref:
     case TypeKind::Exnref:
     case TypeKind::Ref:
     case TypeKind::RefNull:
-    case TypeKind::Rec:
-    case TypeKind::Sub:
-    case TypeKind::Subfinal:
-    case TypeKind::Struct:
     case TypeKind::Structref:
     case TypeKind::Externref:
-    case TypeKind::Array:
     case TypeKind::Arrayref:
     case TypeKind::Eqref:
     case TypeKind::Anyref:
@@ -3366,12 +3360,6 @@ void BBQJIT::emitEntryTierUpCheck()
         case TypeKind::F32:
         case TypeKind::F64:
         case TypeKind::I64:
-        case TypeKind::Struct:
-        case TypeKind::Rec:
-        case TypeKind::Func:
-        case TypeKind::Array:
-        case TypeKind::Sub:
-        case TypeKind::Subfinal:
         case TypeKind::V128:
             clear(ClearMode::Zero, type, m_locals[i]);
             break;

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -104,18 +104,12 @@ uint32_t NODELETE BBQJIT::sizeOfType(TypeKind type)
     case TypeKind::V128:
         return 16;
     case TypeKind::I31ref:
-    case TypeKind::Func:
     case TypeKind::Funcref:
     case TypeKind::Ref:
     case TypeKind::RefNull:
-    case TypeKind::Rec:
-    case TypeKind::Sub:
-    case TypeKind::Subfinal:
-    case TypeKind::Struct:
     case TypeKind::Structref:
     case TypeKind::Exnref:
     case TypeKind::Externref:
-    case TypeKind::Array:
     case TypeKind::Arrayref:
     case TypeKind::Eqref:
     case TypeKind::Anyref:
@@ -217,18 +211,12 @@ Value BBQJIT::instanceValue()
         case TypeKind::V128:
             m_jit.loadVector(Address(wasmScratchGPR), resultLocation.asFPR());
             break;
-        case TypeKind::Func:
         case TypeKind::Funcref:
         case TypeKind::Ref:
         case TypeKind::RefNull:
-        case TypeKind::Rec:
-        case TypeKind::Sub:
-        case TypeKind::Subfinal:
-        case TypeKind::Struct:
         case TypeKind::Structref:
         case TypeKind::Exnref:
         case TypeKind::Externref:
-        case TypeKind::Array:
         case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Eqref:
@@ -300,18 +288,12 @@ Value BBQJIT::instanceValue()
         case TypeKind::V128:
             m_jit.storeVector(valueLocation.asFPR(), Address(wasmScratchGPR));
             break;
-        case TypeKind::Func:
         case TypeKind::Funcref:
         case TypeKind::Ref:
         case TypeKind::RefNull:
-        case TypeKind::Rec:
-        case TypeKind::Sub:
-        case TypeKind::Subfinal:
-        case TypeKind::Struct:
         case TypeKind::Structref:
         case TypeKind::Exnref:
         case TypeKind::Externref:
-        case TypeKind::Array:
         case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Eqref:
@@ -3234,12 +3216,6 @@ void BBQJIT::emitCatchImpl(ControlData& dataCatch, const RTT& exceptionSignature
             case TypeKind::Noneref:
             case TypeKind::Nofuncref:
             case TypeKind::Noexternref:
-            case TypeKind::Rec:
-            case TypeKind::Sub:
-            case TypeKind::Subfinal:
-            case TypeKind::Array:
-            case TypeKind::Struct:
-            case TypeKind::Func:
                 m_jit.transfer64(Address(wasmScratchGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asAddress());
                 break;
             case TypeKind::F32:
@@ -3323,12 +3299,6 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
                 case TypeKind::Noneref:
                 case TypeKind::Nofuncref:
                 case TypeKind::Noexternref:
-                case TypeKind::Rec:
-                case TypeKind::Sub:
-                case TypeKind::Subfinal:
-                case TypeKind::Array:
-                case TypeKind::Struct:
-                case TypeKind::Func:
                     if (slot.isGPR())
                         m_jit.load64(Address(wasmScratchGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asGPR());
                     else

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -629,13 +629,7 @@ void BBQJIT::emitCCall(Func function, std::span<const Value> arguments, Value& r
     case TypeKind::Noexnref:
     case TypeKind::Noneref:
     case TypeKind::Nofuncref:
-    case TypeKind::Noexternref:
-    case TypeKind::Rec:
-    case TypeKind::Sub:
-    case TypeKind::Subfinal:
-    case TypeKind::Array:
-    case TypeKind::Struct:
-    case TypeKind::Func: {
+    case TypeKind::Noexternref: {
         resultLocation = Location::fromGPR(GPRInfo::returnValueGPR);
         ASSERT(validGPRs().contains(GPRInfo::returnValueGPR, IgnoreVectors));
         break;

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -332,10 +332,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, void, (void* sp,
 
         switch (argType.kind()) {
         case TypeKind::Void:
-        case TypeKind::Func:
-        case TypeKind::Struct:
         case TypeKind::Structref:
-        case TypeKind::Array:
         case TypeKind::Arrayref:
         case TypeKind::Eqref:
         case TypeKind::Anyref:
@@ -344,9 +341,6 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, void, (void* sp,
         case TypeKind::Nofuncref:
         case TypeKind::Noexternref:
         case TypeKind::I31ref:
-        case TypeKind::Rec:
-        case TypeKind::Sub:
-        case TypeKind::Subfinal:
         case TypeKind::V128:
             RELEASE_ASSERT_NOT_REACHED();
         case TypeKind::RefNull:

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -70,29 +70,29 @@ auto SectionParser::parseType() -> PartialResult
         // When GC is enabled, recursive references can show up in any of these cases.
         SetForScope<RecursionGroupInformation> recursionGroupInfo(m_typeSection.recursionGroupInformation, RecursionGroupInformation { true, m_info->typeCount(), m_info->typeCount() + 1 });
 
-        switch (static_cast<TypeKind>(typeKind)) {
-        case TypeKind::Func: {
+        switch (static_cast<DefinedTypeKind>(typeKind)) {
+        case DefinedTypeKind::Func: {
             WASM_FAIL_IF_HELPER_FAILS(parseFunctionType(i, signature));
             break;
         }
-        case TypeKind::Struct: {
+        case DefinedTypeKind::Struct: {
             WASM_FAIL_IF_HELPER_FAILS(parseStructType(i, signature));
             break;
         }
-        case TypeKind::Array: {
+        case DefinedTypeKind::Array: {
             WASM_FAIL_IF_HELPER_FAILS(parseArrayType(i, signature));
             break;
         }
-        case TypeKind::Rec: {
+        case DefinedTypeKind::Rec: {
             WASM_FAIL_IF_HELPER_FAILS(parseRecursionGroup(i));
             ++recursionGroupCount;
             WASM_PARSER_FAIL_IF(recursionGroupCount > maxNumberOfRecursionGroups, "number of recursion groups exceeded the limit of "_s, maxNumberOfRecursionGroups);
             continue; // RecursionGroup parsing is done inside parseRecursionGroup.
         }
-        case TypeKind::Sub:
-        case TypeKind::Subfinal: {
+        case DefinedTypeKind::Sub:
+        case DefinedTypeKind::Subfinal: {
             Vector<TypeIndex> noRecursionGroup;
-            WASM_FAIL_IF_HELPER_FAILS(parseSubtype(i, signature, noRecursionGroup, static_cast<TypeKind>(typeKind) == TypeKind::Subfinal));
+            WASM_FAIL_IF_HELPER_FAILS(parseSubtype(i, signature, noRecursionGroup, static_cast<DefinedTypeKind>(typeKind) == DefinedTypeKind::Subfinal));
             break;
         }
         default:
@@ -1038,22 +1038,22 @@ auto SectionParser::parseRecursionGroup(uint32_t position) -> PartialResult
         int8_t typeKind;
         WASM_PARSER_FAIL_IF(!parseInt7(typeKind), "can't get recursion group's "_s, i, "th Type's type"_s);
         ParsedDef signature;
-        switch (static_cast<TypeKind>(typeKind)) {
-        case TypeKind::Func: {
+        switch (static_cast<DefinedTypeKind>(typeKind)) {
+        case DefinedTypeKind::Func: {
             WASM_FAIL_IF_HELPER_FAILS(parseFunctionType(i, signature));
             break;
         }
-        case TypeKind::Struct: {
+        case DefinedTypeKind::Struct: {
             WASM_FAIL_IF_HELPER_FAILS(parseStructType(i, signature));
             break;
         }
-        case TypeKind::Array: {
+        case DefinedTypeKind::Array: {
             WASM_FAIL_IF_HELPER_FAILS(parseArrayType(i, signature));
             break;
         }
-        case TypeKind::Sub:
-        case TypeKind::Subfinal: {
-            WASM_FAIL_IF_HELPER_FAILS(parseSubtype(i, signature, types, static_cast<TypeKind>(typeKind) == TypeKind::Subfinal));
+        case DefinedTypeKind::Sub:
+        case DefinedTypeKind::Subfinal: {
+            WASM_FAIL_IF_HELPER_FAILS(parseSubtype(i, signature, types, static_cast<DefinedTypeKind>(typeKind) == DefinedTypeKind::Subfinal));
             break;
         }
         default:
@@ -1208,16 +1208,16 @@ auto SectionParser::parseSubtype(uint32_t position, ParsedDef& subtype, Vector<T
     int8_t typeKind;
     WASM_PARSER_FAIL_IF(!parseInt7(typeKind), "can't get subtype's underlying Type's type"_s);
     ParsedDef underlyingType;
-    switch (static_cast<TypeKind>(typeKind)) {
-    case TypeKind::Func: {
+    switch (static_cast<DefinedTypeKind>(typeKind)) {
+    case DefinedTypeKind::Func: {
         WASM_FAIL_IF_HELPER_FAILS(parseFunctionType(position, underlyingType));
         break;
     }
-    case TypeKind::Struct: {
+    case DefinedTypeKind::Struct: {
         WASM_FAIL_IF_HELPER_FAILS(parseStructType(position, underlyingType));
         break;
     }
-    case TypeKind::Array: {
+    case DefinedTypeKind::Array: {
         WASM_FAIL_IF_HELPER_FAILS(parseArrayType(position, underlyingType));
         break;
     }

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -332,13 +332,7 @@ constexpr size_t typeKindSizeInBytes(TypeKind kind)
     case TypeKind::RefNull: {
         return sizeof(WriteBarrierBase<Unknown>);
     }
-    case TypeKind::Array:
-    case TypeKind::Func:
-    case TypeKind::Struct:
     case TypeKind::Void:
-    case TypeKind::Sub:
-    case TypeKind::Subfinal:
-    case TypeKind::Rec:
     case TypeKind::Eqref:
     case TypeKind::Anyref:
     case TypeKind::Noexnref:

--- a/Source/JavaScriptCore/wasm/generateWasm.py
+++ b/Source/JavaScriptCore/wasm/generateWasm.py
@@ -40,6 +40,7 @@ class Wasm:
                 self.expectedVersionNumber = str(pre["value"])
         self.preamble = wasm["preamble"]
         self.types = wasm["type"]
+        self.defined_types = wasm["defined_type"]
         self.packed_types = wasm["packed_type"]
         self.opcodes = wasm["opcode"]
         self.header = """/*

--- a/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
@@ -67,13 +67,21 @@ def packedTypeMacroizer():
         yield cppMacroPacked(ty, wasm.packed_types[ty]["value"])
 
 
+def definedTypeMacroizer():
+    for ty in wasm.defined_types:
+        yield cppMacroPacked(ty, wasm.defined_types[ty]["value"])
+
+
 def typeMacroizerFiltered(filter):
     for t in typeMacroizer():
         if not filter(t):
             yield t
 
+
 type_definitions = ["#define FOR_EACH_WASM_TYPE(macro)"]
 type_definitions.extend([t for t in typeMacroizer()])
+type_definitions.extend(["\n\n#define FOR_EACH_WASM_DEFINED_TYPE(macro)"])
+type_definitions.extend([t for t in definedTypeMacroizer()])
 type_definitions.extend(["\n\n#define FOR_EACH_WASM_PACKED_TYPE(macro)"])
 type_definitions.extend([t for t in packedTypeMacroizer()])
 type_definitions = "".join(type_definitions)
@@ -263,6 +271,12 @@ enum class TypeKind : int8_t {
 #define CREATE_ENUM_VALUE(name, id) name = id,
 enum class PackedType: int8_t {
     FOR_EACH_WASM_PACKED_TYPE(CREATE_ENUM_VALUE)
+};
+#undef CREATE_ENUM_VALUE
+
+#define CREATE_ENUM_VALUE(name, id) name = id,
+enum class DefinedTypeKind : int8_t {
+    FOR_EACH_WASM_DEFINED_TYPE(CREATE_ENUM_VALUE)
 };
 #undef CREATE_ENUM_VALUE
 
@@ -515,6 +529,19 @@ inline bool isValidPackedType(Int i)
 }
 #undef CREATE_CASE
 
+#define CREATE_CASE(name, id, ...) case id: return true;
+template <typename Int>
+inline bool isValidDefinedTypeKind(Int i)
+{
+    switch (i) {
+    default: return false;
+    FOR_EACH_WASM_DEFINED_TYPE(CREATE_CASE)
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return false;
+}
+#undef CREATE_CASE
+
 #define CREATE_CASE(name, ...) case TypeKind::name: return #name ## _s;
 inline ASCIILiteral makeString(TypeKind kind)
 {
@@ -531,6 +558,17 @@ inline ASCIILiteral makeString(PackedType packedType)
 {
     switch (packedType) {
     FOR_EACH_WASM_PACKED_TYPE(CREATE_CASE)
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return { };
+}
+#undef CREATE_CASE
+
+#define CREATE_CASE(name, ...) case DefinedTypeKind::name: return #name ## _s;
+inline ASCIILiteral makeString(DefinedTypeKind kind)
+{
+    switch (kind) {
+    FOR_EACH_WASM_DEFINED_TYPE(CREATE_CASE)
     }
     RELEASE_ASSERT_NOT_REACHED();
     return { };

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -151,13 +151,7 @@ void JSWebAssemblyStruct::set(uint32_t fieldIndex, uint64_t argument)
         return;
     }
     case TypeKind::V128:
-    case TypeKind::Func:
-    case TypeKind::Struct:
-    case TypeKind::Array:
     case TypeKind::Void:
-    case TypeKind::Sub:
-    case TypeKind::Subfinal:
-    case TypeKind::Rec:
     case TypeKind::Exnref:
     case TypeKind::Eqref:
     case TypeKind::Anyref:

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -135,10 +135,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
             Type argType = signature.argumentType(argNum);
             switch (argType.kind()) {
             case TypeKind::Void:
-            case TypeKind::Func:
-            case TypeKind::Struct:
             case TypeKind::Structref:
-            case TypeKind::Array:
             case TypeKind::Arrayref:
             case TypeKind::Eqref:
             case TypeKind::Anyref:
@@ -147,9 +144,6 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
             case TypeKind::Nofuncref:
             case TypeKind::Noexternref:
             case TypeKind::I31ref:
-            case TypeKind::Rec:
-            case TypeKind::Sub:
-            case TypeKind::Subfinal:
             case TypeKind::V128:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.
             case TypeKind::RefNull:
@@ -225,10 +219,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
             Type argType = signature.argumentType(argNum);
             switch (argType.kind()) {
             case TypeKind::Void:
-            case TypeKind::Func:
-            case TypeKind::Struct:
             case TypeKind::Structref:
-            case TypeKind::Array:
             case TypeKind::Arrayref:
             case TypeKind::Eqref:
             case TypeKind::Anyref:
@@ -237,9 +228,6 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
             case TypeKind::Nofuncref:
             case TypeKind::Noexternref:
             case TypeKind::I31ref:
-            case TypeKind::Rec:
-            case TypeKind::Sub:
-            case TypeKind::Subfinal:
             case TypeKind::V128:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.
             case TypeKind::RefNull:

--- a/Source/JavaScriptCore/wasm/wasm.json
+++ b/Source/JavaScriptCore/wasm/wasm.json
@@ -26,13 +26,15 @@
         "exnref":        { "type": "varint7", "value":  -23, "b3type": "B3::Int64",  "width": 0 },
         "ref":           { "type": "varint7", "value":  -28, "b3type": "B3::Int64",  "width": 64 },
         "ref_null":      { "type": "varint7", "value":  -29, "b3type": "B3::Int64",  "width": 64 },
-        "func":          { "type": "varint7", "value":  -32, "b3type": "B3::Void",   "width": 0 },
-        "struct":        { "type": "varint7", "value":  -33, "b3type": "B3::Void",   "width": 0 },
-        "array":         { "type": "varint7", "value":  -34, "b3type": "B3::Void",   "width": 0 },
-        "sub":           { "type": "varint7", "value":  -48, "b3type": "B3::Void",   "width": 0 },
-        "subfinal":      { "type": "varint7", "value":  -49, "b3type": "B3::Void",   "width": 0 },
-        "rec":           { "type": "varint7", "value":  -50, "b3type": "B3::Void",   "width": 0 },
         "void":          { "type": "varint7", "value":  -64, "b3type": "B3::Void",   "width": 0 }
+    },
+    "defined_type": {
+        "func":          { "type": "varint7", "value":  -32 },
+        "struct":        { "type": "varint7", "value":  -33 },
+        "array":         { "type": "varint7", "value":  -34 },
+        "sub":           { "type": "varint7", "value":  -48 },
+        "subfinal":      { "type": "varint7", "value":  -49 },
+        "rec":           { "type": "varint7", "value":  -50 }
     },
     "packed_type": {
         "i8":        { "type": "varint7", "value":  -8},


### PR DESCRIPTION
#### 76b474b3225c59cd3c31f39d5eed60a63a084a3d
<pre>
[JSC][Wasm] Split type definitions out of TypeKind
<a href="https://bugs.webkit.org/show_bug.cgi?id=261640">https://bugs.webkit.org/show_bug.cgi?id=261640</a>

Reviewed by Sosuke Suzuki.

TypeKind mixed value types with type-section forms (func, struct, array,
rec, sub, subfinal). Those are not value types, so every TypeKind switch
needed dummy cases for them. Move them to DefinedTypeKind and dispatch
the type section on that enum.

* Source/JavaScriptCore/wasm/wasm.json:
* Source/JavaScriptCore/wasm/generateWasm.py:
* Source/JavaScriptCore/wasm/generateWasmOpsHeader.py:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
* JSTests/wasm/wasm.json:
* JSTests/wasm/WASM.js:
* LayoutTests/resources/wasm-builder.js:
* LayoutTests/http/tests/security/contentSecurityPolicy/resources/wasm-builder.js:
* LayoutTests/storage/indexeddb/resources/wasm-exceptions.js:
* LayoutTests/workers/wasm-references/test.js:
* LayoutTests/workers/wasm-resources/long-compile-worker.js:

Canonical link: <a href="https://commits.webkit.org/319431@main">https://commits.webkit.org/319431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5deddb6c5e70dba304acd33833b599887a69eb2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190988 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145098 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54436 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141015 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97724 "2 flakes 7 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43351 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41630 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3434 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10254 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41298 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2149 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42049 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192923 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54386 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150396 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55074 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150113 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27553 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44706 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127340 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122626 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53591 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16291 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52973 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53210 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->