### PR TITLE
[ Do not merge ] Stacked on top of previous change.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/inheritance-expected.txt
@@ -25,6 +25,6 @@ PASS Property outline-width has initial value 3px
 PASS Property outline-width does not inherit
 PASS Property resize has initial value none
 PASS Property resize does not inherit
-FAIL Property user-select has initial value auto assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select does not inherit assert_true: expected true got false
+PASS Property user-select has initial value auto
+PASS Property user-select does not inherit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-computed-contain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-computed-contain-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Property user-select value 'contain' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
+FAIL Property user-select value 'contain' assert_true: 'contain' is a supported value for user-select. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-computed-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Property user-select value 'auto' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select value 'text' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select value 'none' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select value 'all' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
+PASS Property user-select value 'auto'
+PASS Property user-select value 'text'
+PASS Property user-select value 'none'
+PASS Property user-select value 'all'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-valid-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL e.style['user-select'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['user-select'] = "text" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['user-select'] = "none" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['user-select'] = "all" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['user-select'] = "auto" should set the property value
+PASS e.style['user-select'] = "text" should set the property value
+PASS e.style['user-select'] = "none" should set the property value
+PASS e.style['user-select'] = "all" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-inheritance-expected.txt
@@ -2,9 +2,9 @@ abc
 xyz
 def
 
-FAIL user-select:all should not be inherited. assert_equals: user-select:all should be supported. expected (string) "all" but got (undefined) undefined
-FAIL user-select:auto should not be inherited. assert_equals: user-select:auto should be supported. expected (string) "auto" but got (undefined) undefined
-FAIL user-select:contain should not be inherited. assert_equals: user-select:contain should be supported. expected (string) "contain" but got (undefined) undefined
-FAIL user-select:none should not be inherited. assert_equals: user-select:none should be supported. expected (string) "none" but got (undefined) undefined
-FAIL user-select:text should not be inherited. assert_equals: user-select:text should be supported. expected (string) "text" but got (undefined) undefined
+PASS user-select:all should not be inherited.
+PASS user-select:auto should not be inherited.
+FAIL user-select:contain should not be inherited. assert_equals: user-select:contain should be supported. expected "contain" but got "auto"
+PASS user-select:none should not be inherited.
+PASS user-select:text should not be inherited.
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1831,7 +1831,7 @@ CSSUnprefixedBackdropFilterEnabled:
 
 CSSUnprefixedUserSelectEnabled:
   type: bool
-  status: internal
+  status: testable
   category: css
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   humanReadableName: "CSS Unprefixed User Select"

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1829,6 +1829,21 @@ CSSUnprefixedBackdropFilterEnabled:
       "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
       default: false
 
+CSSUnprefixedUserSelectEnabled:
+  type: bool
+  status: internal
+  category: css
+  webcoreOnChange: setNeedsRecalcStyleInAllFrames
+  humanReadableName: "CSS Unprefixed User Select"
+  humanReadableDescription: "Enable the unprefixed user-select CSS property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSWhiteSpaceTrimEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12499,7 +12499,7 @@
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "UserSelect",
                 "parser-grammar": "<<values>>",
-                "comment": "Not an alias of 'user-select': this property is inherited, it overrides 'user-select' whenever it has been specified (hence the has-explicitly-set flag)."
+                "comment": "Not an alias of 'user-select': this property is inherited and, when present, overrides 'user-select' for the entire subtree (see the has-explicitly-set flag)."
             },
             "status": "non-standard"
         },

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12481,11 +12481,33 @@
             "status": "non-standard"
         },
         "-webkit-user-select": {
-            "animation-type": "not animatable (needs triage)",
-            "animation-type-comment": "Current spec for standard 'user-select' animation type is 'discrete'",
+            "animation-type": "not animatable (legacy)",
             "inherited": true,
             "initial": "text",
-            "initial-comment": "Current spec for standard 'user-select' initial is 'auto'",
+            "initial-comment": "Legacy behavior - 'auto' is folded into 'text'",
+            "values": [
+                "auto",
+                "text",
+                "none",
+                "all"
+            ],
+            "codegen-properties": {
+                "computed-style-has-explicitly-set-policy": "value-only",
+                "computed-style-has-explicitly-set-storage-path": ["m_inheritedRareData"],
+                "computed-style-name-for-methods": "WebkitUserSelect",
+                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-kind": "enum",
+                "computed-style-type": "UserSelect",
+                "parser-grammar": "<<values>>",
+                "comment": "Not an alias of 'user-select': this property is inherited, it overrides 'user-select' whenever it has been specified (hence the has-explicitly-set flag)."
+            },
+            "status": "non-standard"
+        },
+        "user-select": {
+            "animation-type": "not animatable (needs triage)",
+            "animation-type-comment": "Current spec animation type is 'discrete'",
+            "inherited": false,
+            "initial": "auto",
             "values": [
                 "auto",
                 "text",
@@ -12497,10 +12519,11 @@
                 "all"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_inheritedRareData"],
+                "computed-style-storage-path": ["m_nonInheritedData", "miscData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "UserSelect",
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "settings-flag": "cssUnprefixedUserSelectEnabled"
             },
             "status": {
                 "status": "experimental"

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -858,9 +858,9 @@ static Node::Editability NODELETE computeEditabilityFromComputedStyle(const Styl
     // ContainerNode::setFocus() calls invalidateStyleForSubtree(), so the assertion
     // would fire in the middle of Document::setFocusedElement().
 
-    // Elements with user-select: all style are considered atomic
+    // Elements with -webkit-user-select: all are considered atomic
     // therefore non editable.
-    if (treatment == Node::UserSelectAllTreatment::NotEditable && style.usedUserSelect() == UserSelect::All)
+    if (treatment == Node::UserSelectAllTreatment::NotEditable && style.usedUserSelect() == UserSelect::All && style.hasExplicitlySetWebkitUserSelect())
         return Node::Editability::ReadOnly;
 
     if (pageIsEditable == PageIsEditable::Yes)

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1286,6 +1286,7 @@ TextStream& operator<<(TextStream& ts, UserModify userModify)
 TextStream& operator<<(TextStream& ts, UserSelect userSelect)
 {
     switch (userSelect) {
+    case UserSelect::Auto: ts << "auto"_s; break;
     case UserSelect::None: ts << "none"_s; break;
     case UserSelect::Text: ts << "text"_s; break;
     case UserSelect::All: ts << "all"_s; break;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -494,7 +494,8 @@ enum class UserDrag : uint8_t {
 enum class UserSelect : uint8_t {
     None,
     Text,
-    All
+    All,
+    Auto
 };
 
 // CSS3 Image Values

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -638,12 +638,13 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
 #if ENABLE(IMAGE_ANALYSIS)
         // Don't allow selecting individual glyphs on text recognized inside an image:
         if (m_element->isInUserAgentShadowTree() && m_element->userAgentPart() == UserAgentParts::internalImageOverlayText()) {
-            switch (style.userSelect()) {
+            switch (style.webkitUserSelect()) {
             case UserSelect::All:
             case UserSelect::None:
                 break;
+            case UserSelect::Auto:
             case UserSelect::Text:
-                style.setUserSelect(UserSelect::All);
+                style.setWebkitUserSelect(UserSelect::All);
                 break;
             }
         }
@@ -1089,7 +1090,7 @@ void Adjuster::adjustForSiteSpecificQuirks(Style::ComputedStyle& style) const
     if (documentQuirks.needsPrimeVideoUserSelectNoneQuirk()) {
         static MainThreadNeverDestroyed<const AtomString> className("webPlayerSDKUiContainer"_s);
         if (m_element->hasClassName(className))
-            style.setUserSelect(UserSelect::None);
+            style.setWebkitUserSelect(UserSelect::None);
     }
 
     if (auto tikTokOverflowingContentQuery = documentQuirks.needsTikTokOverflowingContentQuirk(protect(*m_element), m_parentStyle)) {

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -638,15 +638,8 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
 #if ENABLE(IMAGE_ANALYSIS)
         // Don't allow selecting individual glyphs on text recognized inside an image:
         if (m_element->isInUserAgentShadowTree() && m_element->userAgentPart() == UserAgentParts::internalImageOverlayText()) {
-            switch (style.webkitUserSelect()) {
-            case UserSelect::All:
-            case UserSelect::None:
-                break;
-            case UserSelect::Auto:
-            case UserSelect::Text:
-                style.setWebkitUserSelect(UserSelect::All);
-                break;
-            }
+            style.setWebkitUserSelect(style.webkitUserSelect() == UserSelect::None ? UserSelect::None : UserSelect::All);
+            style.setUserSelect(style.userSelect() == UserSelect::None ? UserSelect::None : UserSelect::All);
         }
 #endif
 
@@ -826,6 +819,32 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
 #endif
 
     adjustForSiteSpecificQuirks(style);
+
+    // The hasExplicitlySetWebkitUserSelect flag is inherited along with -webkit-user-select, so legacy behavior propagates to children:
+    if (!m_document->settings().cssUnprefixedUserSelectEnabled() || style.hasExplicitlySetWebkitUserSelect()) {
+        auto value = style.webkitUserSelect();
+
+        // Legacy behavior: on editable, non-draggable content, we override None to Text
+        if (style.userModify() != UserModify::ReadOnly && style.userDrag() != UserDrag::Element && value == UserSelect::None)
+            value = UserSelect::Text;
+
+        // Legacy behavior: prefixed user-select treats Auto as Text since this
+        // implies the parent is not All / None
+        if (value == UserSelect::Auto)
+            value = UserSelect::Text;
+
+        style.setUsedUserSelect(value);
+    } else {
+        auto value = style.userSelect();
+        if (value == UserSelect::Auto)
+            value = m_parentStyle.usedUserSelectIgnoringEffectivelyInert();
+
+        // FIXME: should be overridden to UserSelect::Contain (already behaves as such)
+        if (style.userModify() != UserModify::ReadOnly)
+            value = UserSelect::Text;
+
+        style.setUsedUserSelect(value);
+    }
 }
 
 static bool NODELETE hasEffectiveDisplayNoneForDisplayContents(const Element& element)
@@ -1089,8 +1108,10 @@ void Adjuster::adjustForSiteSpecificQuirks(Style::ComputedStyle& style) const
 
     if (documentQuirks.needsPrimeVideoUserSelectNoneQuirk()) {
         static MainThreadNeverDestroyed<const AtomString> className("webPlayerSDKUiContainer"_s);
-        if (m_element->hasClassName(className))
+        if (m_element->hasClassName(className)) {
+            style.setUserSelect(UserSelect::None);
             style.setWebkitUserSelect(UserSelect::None);
+        }
     }
 
     if (auto tikTokOverflowingContentQuery = documentQuirks.needsTikTokOverflowingContentQuirk(protect(*m_element), m_parentStyle)) {

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -800,7 +800,7 @@ public:
     {
         return a.effectiveInert != b.effectiveInert
             || a.userModify != b.userModify
-            || a.userSelect != b.userSelect
+            || a.webkitUserSelect != b.webkitUserSelect
             || a.appleColorFilter != b.appleColorFilter
             || a.imageRendering != b.imageRendering
             || a.accentColor != b.accentColor

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -801,6 +801,7 @@ public:
         return a.effectiveInert != b.effectiveInert
             || a.userModify != b.userModify
             || a.webkitUserSelect != b.webkitUserSelect
+            || a.usedUserSelect != b.usedUserSelect
             || a.appleColorFilter != b.appleColorFilter
             || a.imageRendering != b.imageRendering
             || a.accentColor != b.accentColor

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -528,7 +528,7 @@ UserSelect ComputedStyle::usedUserSelect() const
     if (effectiveInert())
         return UserSelect::None;
 
-    auto value = userSelect();
+    auto value = webkitUserSelect();
     if (userModify() != UserModify::ReadOnly && userDrag() != UserDrag::Element)
         return value == UserSelect::None ? UserSelect::Text : value;
 

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -528,11 +528,7 @@ UserSelect ComputedStyle::usedUserSelect() const
     if (effectiveInert())
         return UserSelect::None;
 
-    auto value = webkitUserSelect();
-    if (userModify() != UserModify::ReadOnly && userDrag() != UserDrag::Element)
-        return value == UserSelect::None ? UserSelect::Text : value;
-
-    return value;
+    return static_cast<UserSelect>(m_inheritedRareData->usedUserSelect);
 }
 
 WebCore::Color ComputedStyle::usedScrollbarThumbColor() const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -244,6 +244,11 @@ inline ContentVisibility ComputedStyleBase::usedContentVisibility() const
     return static_cast<ContentVisibility>(m_inheritedRareData->usedContentVisibility);
 }
 
+inline UserSelect ComputedStyleBase::usedUserSelectIgnoringEffectivelyInert() const
+{
+    return static_cast<UserSelect>(m_inheritedRareData->usedUserSelect);
+}
+
 inline TouchAction ComputedStyleBase::usedTouchAction() const
 {
     return m_inheritedRareData->usedTouchAction;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -193,6 +193,11 @@ inline void ComputedStyleBase::setUsedAppearance(StyleAppearance a)
     SET_NESTED(m_nonInheritedData, miscData, usedAppearance, static_cast<unsigned>(a));
 }
 
+inline void ComputedStyleBase::setUsedUserSelect(UserSelect userSelect)
+{
+    SET(m_inheritedRareData, usedUserSelect, static_cast<unsigned>(userSelect));
+}
+
 inline void ComputedStyleBase::setUsedContentVisibility(ContentVisibility usedContentVisibility)
 {
     SET(m_inheritedRareData, usedContentVisibility, static_cast<unsigned>(usedContentVisibility));

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -555,6 +555,9 @@ public:
     inline StyleAppearance usedAppearance() const;
     inline void setUsedAppearance(StyleAppearance);
 
+    inline UserSelect usedUserSelectIgnoringEffectivelyInert() const;
+    inline void setUsedUserSelect(UserSelect);
+
     // usedContentVisibility will return ContentVisibility::Hidden in a content-visibility: hidden subtree (overriding
     // content-visibility: auto at all times), ContentVisibility::Auto in a content-visibility: auto subtree (when the
     // content is not user relevant and thus skipped), and ContentVisibility::Visible otherwise.

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
@@ -91,7 +91,7 @@ InheritedRareData::InheritedRareData()
     , overflowWrap(static_cast<unsigned>(ComputedStyle::initialOverflowWrap()))
     , nbspMode(static_cast<unsigned>(NBSPMode::Normal))
     , lineBreak(static_cast<unsigned>(LineBreak::Auto))
-    , userSelect(static_cast<unsigned>(ComputedStyle::initialUserSelect()))
+    , webkitUserSelect(static_cast<unsigned>(ComputedStyle::initialWebkitUserSelect()))
     , speakAs(ComputedStyle::initialSpeakAs().toRaw())
     , hyphens(static_cast<unsigned>(Hyphens::Manual))
     , textCombine(static_cast<unsigned>(ComputedStyle::initialTextCombine()))
@@ -123,6 +123,7 @@ InheritedRareData::InheritedRareData()
     , joinStyle(static_cast<unsigned>(ComputedStyle::initialJoinStyle()))
     , hasExplicitlySetStrokeWidth(false)
     , hasExplicitlySetStrokeColor(false)
+    , hasExplicitlySetWebkitUserSelect(false)
     , effectiveInert(false)
     , effectivelyTransparent(false)
     , effectiveWrapInsideAvoid(false)
@@ -197,7 +198,7 @@ inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     , overflowWrap(o.overflowWrap)
     , nbspMode(o.nbspMode)
     , lineBreak(o.lineBreak)
-    , userSelect(o.userSelect)
+    , webkitUserSelect(o.webkitUserSelect)
     , speakAs(o.speakAs)
     , hyphens(o.hyphens)
     , textCombine(o.textCombine)
@@ -229,6 +230,7 @@ inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     , joinStyle(o.joinStyle)
     , hasExplicitlySetStrokeWidth(o.hasExplicitlySetStrokeWidth)
     , hasExplicitlySetStrokeColor(o.hasExplicitlySetStrokeColor)
+    , hasExplicitlySetWebkitUserSelect(o.hasExplicitlySetWebkitUserSelect)
     , effectiveInert(o.effectiveInert)
     , effectivelyTransparent(o.effectivelyTransparent)
     , effectiveWrapInsideAvoid(o.effectiveWrapInsideAvoid)
@@ -293,7 +295,7 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
 #if ENABLE(TEXT_AUTOSIZING)
         && textSizeAdjust == o.textSizeAdjust
 #endif
-        && userSelect == o.userSelect
+        && webkitUserSelect == o.webkitUserSelect
         && speakAs == o.speakAs
         && hyphens == o.hyphens
         && hyphenateLimitBefore == o.hyphenateLimitBefore
@@ -331,6 +333,7 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
         && joinStyle == o.joinStyle
         && hasExplicitlySetStrokeWidth == o.hasExplicitlySetStrokeWidth
         && hasExplicitlySetStrokeColor == o.hasExplicitlySetStrokeColor
+        && hasExplicitlySetWebkitUserSelect == o.hasExplicitlySetWebkitUserSelect
         && mathShift == o.mathShift
         && mathStyle == o.mathStyle
         && isInSubtreeWithBlendMode == o.isInSubtreeWithBlendMode
@@ -409,7 +412,7 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
     LOG_IF_DIFFERENT_WITH_CAST(OverflowWrap, overflowWrap);
     LOG_IF_DIFFERENT_WITH_CAST(NBSPMode, nbspMode);
     LOG_IF_DIFFERENT_WITH_CAST(LineBreak, lineBreak);
-    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, userSelect);
+    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, webkitUserSelect);
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(SpeakAs, speakAs);
 
@@ -451,6 +454,7 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetStrokeWidth);
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetStrokeColor);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetWebkitUserSelect);
 
     LOG_IF_DIFFERENT_WITH_CAST(MathShift, mathShift);
     LOG_IF_DIFFERENT_WITH_CAST(MathStyle, mathStyle);

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
@@ -92,6 +92,7 @@ InheritedRareData::InheritedRareData()
     , nbspMode(static_cast<unsigned>(NBSPMode::Normal))
     , lineBreak(static_cast<unsigned>(LineBreak::Auto))
     , webkitUserSelect(static_cast<unsigned>(ComputedStyle::initialWebkitUserSelect()))
+    , usedUserSelect(static_cast<unsigned>(UserSelect::Text))
     , speakAs(ComputedStyle::initialSpeakAs().toRaw())
     , hyphens(static_cast<unsigned>(Hyphens::Manual))
     , textCombine(static_cast<unsigned>(ComputedStyle::initialTextCombine()))
@@ -199,6 +200,7 @@ inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     , nbspMode(o.nbspMode)
     , lineBreak(o.lineBreak)
     , webkitUserSelect(o.webkitUserSelect)
+    , usedUserSelect(o.usedUserSelect)
     , speakAs(o.speakAs)
     , hyphens(o.hyphens)
     , textCombine(o.textCombine)
@@ -296,6 +298,7 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
         && textSizeAdjust == o.textSizeAdjust
 #endif
         && webkitUserSelect == o.webkitUserSelect
+        && usedUserSelect == o.usedUserSelect
         && speakAs == o.speakAs
         && hyphens == o.hyphens
         && hyphenateLimitBefore == o.hyphenateLimitBefore
@@ -413,6 +416,7 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
     LOG_IF_DIFFERENT_WITH_CAST(NBSPMode, nbspMode);
     LOG_IF_DIFFERENT_WITH_CAST(LineBreak, lineBreak);
     LOG_IF_DIFFERENT_WITH_CAST(UserSelect, webkitUserSelect);
+    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, usedUserSelect);
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(SpeakAs, speakAs);
 

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -183,7 +183,7 @@ public:
     PREFERRED_TYPE(OverflowWrap) unsigned overflowWrap : 2;
     PREFERRED_TYPE(NBSPMode) unsigned nbspMode : 1;
     PREFERRED_TYPE(LineBreak) unsigned lineBreak : 3;
-    PREFERRED_TYPE(UserSelect) unsigned userSelect : 2;
+    PREFERRED_TYPE(UserSelect) unsigned webkitUserSelect : 2;
     PREFERRED_TYPE(SpeakAs) unsigned speakAs : 4;
     PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
     PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;
@@ -215,6 +215,7 @@ public:
     PREFERRED_TYPE(LineJoin) unsigned joinStyle : 2;
     PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeWidth : 1;
     PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeColor : 1;
+    PREFERRED_TYPE(bool) unsigned hasExplicitlySetWebkitUserSelect : 1;
     PREFERRED_TYPE(bool) unsigned effectiveInert : 1;
     PREFERRED_TYPE(bool) unsigned effectivelyTransparent : 1;
     PREFERRED_TYPE(bool) unsigned effectiveWrapInsideAvoid : 1; // This box or an ancestor has wrap-inside: avoid.

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -184,6 +184,7 @@ public:
     PREFERRED_TYPE(NBSPMode) unsigned nbspMode : 1;
     PREFERRED_TYPE(LineBreak) unsigned lineBreak : 3;
     PREFERRED_TYPE(UserSelect) unsigned webkitUserSelect : 2;
+    PREFERRED_TYPE(UserSelect) unsigned usedUserSelect : 2;
     PREFERRED_TYPE(SpeakAs) unsigned speakAs : 4;
     PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
     PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;

--- a/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.cpp
@@ -63,6 +63,7 @@ NonInheritedMiscData::NonInheritedMiscData()
     , tableLayout(static_cast<unsigned>(ComputedStyle::initialTableLayout()))
     , appearance(static_cast<unsigned>(ComputedStyle::initialAppearance()))
     , usedAppearance(static_cast<unsigned>(ComputedStyle::initialAppearance()))
+    , userSelect(static_cast<unsigned>(ComputedStyle::initialUserSelect()))
     , textOverflow(static_cast<unsigned>(ComputedStyle::initialTextOverflow()))
     , userDrag(static_cast<unsigned>(ComputedStyle::initialUserDrag()))
     , objectFit(static_cast<unsigned>(ComputedStyle::initialObjectFit()))
@@ -104,6 +105,7 @@ NonInheritedMiscData::NonInheritedMiscData(const NonInheritedMiscData& o)
     , tableLayout(o.tableLayout)
     , appearance(o.appearance)
     , usedAppearance(o.usedAppearance)
+    , userSelect(o.userSelect)
     , textOverflow(o.textOverflow)
     , userDrag(o.userDrag)
     , objectFit(o.objectFit)
@@ -152,6 +154,7 @@ bool NonInheritedMiscData::operator==(const NonInheritedMiscData& o) const
         && tableLayout == o.tableLayout
         && appearance == o.appearance
         && usedAppearance == o.usedAppearance
+        && userSelect == o.userSelect
         && textOverflow == o.textOverflow
         && userDrag == o.userDrag
         && objectFit == o.objectFit
@@ -209,6 +212,8 @@ void NonInheritedMiscData::dumpDifferences(TextStream& ts, const NonInheritedMis
     LOG_IF_DIFFERENT_WITH_CAST(TableLayoutType, tableLayout);
     LOG_IF_DIFFERENT_WITH_CAST(StyleAppearance, appearance);
     LOG_IF_DIFFERENT_WITH_CAST(StyleAppearance, usedAppearance);
+
+    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, userSelect);
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, textOverflow);
 

--- a/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h
@@ -112,6 +112,7 @@ public:
     PREFERRED_TYPE(TableLayoutType) unsigned tableLayout : 1;
     PREFERRED_TYPE(StyleAppearance) unsigned appearance : appearanceBitWidth;
     PREFERRED_TYPE(StyleAppearance) unsigned usedAppearance : appearanceBitWidth;
+    PREFERRED_TYPE(UserSelect) unsigned userSelect : 2;
     PREFERRED_TYPE(bool) unsigned textOverflow : 1; // Whether or not lines that spill out should be truncated with "..."
     PREFERRED_TYPE(UserDrag) unsigned userDrag : 2;
     PREFERRED_TYPE(ObjectFit) unsigned objectFit : 3;

--- a/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
+++ b/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
@@ -1228,6 +1228,8 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 constexpr CSSValueID toCSSValueID(UserSelect e)
 {
     switch (e) {
+    case UserSelect::Auto:
+        return CSSValueAuto;
     case UserSelect::None:
         return CSSValueNone;
     case UserSelect::Text:
@@ -1243,7 +1245,7 @@ template<> constexpr UserSelect fromCSSValueID(CSSValueID valueID)
 {
     switch (valueID) {
     case CSSValueAuto:
-        return UserSelect::Text;
+        return UserSelect::Auto;
     case CSSValueNone:
         return UserSelect::None;
     case CSSValueText:


### PR DESCRIPTION
#### 0c7186b014dbfbb37d9b10a2b57cdfa849399c7e
<pre>
[ Do not merge ] Stacked on top of previous change.

Sets CSSUnprefixedUserSelectEnabled to testable and adds support for
user-select, while keeping -webkit-user-select as a legacy override.

If the flag is off, no changes in behavior are expected. With the flag on, elements using or inheriting -webkit-user-select should keep the legacy behavior, so only elements that exclusively use the unprefixed version should behave differently. This is not the
specced behavior - -webkit-user-select is supposed to be an alias of user-select, not
a legacy alternative.

Here&apos;s a breakdown of differences between -webkit-user-select and user-select:
- Editable elements are made selectable. However, for -webkit-user-select, this does not apply for draggable elements
- webkit-user-select: all forces content to not be editable
- webkit-user-select: auto behaves as Text, not as &quot;resolve from parent&quot;
- user-select does not use inheritance, so getComputedStyle() does not resolve user-select: auto
</pre>
----------------------------------------------------------------------
#### e9505cfdc6b50298ff0347aa5c01d7e05f8b07e1
<pre>
Add unprefixed user-select (and feature flag)
<a href="https://bugs.webkit.org/show_bug.cgi?id=321119">https://bugs.webkit.org/show_bug.cgi?id=321119</a>
<a href="https://rdar.apple.com/184152184">rdar://184152184</a>

Reviewed by NOBODY (OOPS!).

Adds the (unprefixed) user-select property, gated by a new feature
flag (CSSUnprefixedUserSelectEnabled). The property is completely
inert - this only adds the plumbing, not any behavior. The
prefixed `-webkit-user-select` is still the source of truth.

No changes in behavior expected.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c7186b014dbfbb37d9b10a2b57cdfa849399c7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144143 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc55eb51-4f0e-497d-899b-28040d7b015c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53486 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140273 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97084 "6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37f6415d-cfaa-4f0e-8847-8644fe95e17f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120723 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b99e61b1-ae6e-4f3e-aa66-a8bc7fc09862) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42549 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40864 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2692 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9489 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152949 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40529 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select.html imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1190 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41098 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46368 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45112 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select.html imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191966 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53436 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149554 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54123 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37142 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select.html imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149287 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43935 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126385 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121433 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52640 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15517 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52022 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52259 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52086 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->