### PR TITLE
[JSC][Wasm] Elide BBQ null checks on non-nullable refs

### DIFF
--- a/JSTests/wasm/gc/elide-null-checks.js
+++ b/JSTests/wasm/gc/elide-null-checks.js
@@ -1,0 +1,68 @@
+import * as assert from "../assert.js";
+import { instantiate } from "./wast-wrapper.js";
+
+function testRefAsNonNull() {
+  let m = instantiate(`
+    (module
+      (type $t (func (result i32)))
+      (elem declare func $f)
+      (func $f (type $t) (i32.const 42))
+      (func (export "nonnull") (result i32)
+        (call_ref $t (ref.as_non_null (ref.func $f))))
+      (func (export "null") (result i32)
+        (call_ref $t (ref.as_non_null (ref.null $t))))
+    )
+  `);
+  for (let i = 0; i < wasmTestLoopCount; i++) {
+    assert.eq(m.exports.nonnull(), 42);
+    assert.throws(() => m.exports.null(), WebAssembly.RuntimeError, "ref.as_non_null to a null reference");
+  }
+}
+
+function testCallRef() {
+  let m = instantiate(`
+    (module
+      (type $t (func (result i32)))
+      (func $f (type $t) (i32.const 7))
+      (global $g (ref $t) (ref.func $f))
+      (func (export "nonnull") (result i32)
+        (call_ref $t (global.get $g)))
+      (func (export "null") (result i32)
+        (call_ref $t (ref.null $t)))
+    )
+  `);
+  for (let i = 0; i < wasmTestLoopCount; i++) {
+    assert.eq(m.exports.nonnull(), 7);
+    assert.throws(() => m.exports.null(), WebAssembly.RuntimeError, "null reference");
+  }
+}
+
+function testThrowRef() {
+  // Binary: wast-wrapper and in-tree wabt cannot encode (ref exn).
+  // (module
+  //   (tag $e)
+  //   (func (export "nonnull")
+  //     (block $caught (result (ref exn))
+  //       (try_table (result (ref exn)) (catch_ref $e $caught)
+  //         (throw $e)
+  //         (unreachable)))
+  //     (throw_ref))
+  //   (func (export "null")
+  //     (throw_ref (ref.null exn))))
+  let m = new WebAssembly.Instance(new WebAssembly.Module(new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+    0x03, 0x03, 0x02, 0x00, 0x00, 0x0d, 0x03, 0x01, 0x00, 0x00, 0x07, 0x12, 0x02, 0x07,
+    0x6e, 0x6f, 0x6e, 0x6e, 0x75, 0x6c, 0x6c, 0x00, 0x00, 0x04, 0x6e, 0x75, 0x6c, 0x6c,
+    0x00, 0x01, 0x0a, 0x1a, 0x02, 0x12, 0x00, 0x02, 0x64, 0x69, 0x1f, 0x64, 0x69, 0x01,
+    0x01, 0x00, 0x00, 0x08, 0x00, 0x00, 0x0b, 0x0b, 0x0a, 0x0b, 0x05, 0x00, 0xd0, 0x69,
+    0x0a, 0x0b
+  ])));
+  for (let i = 0; i < wasmTestLoopCount; i++) {
+    assert.throws(() => m.exports.nonnull(), WebAssembly.Exception, "");
+    assert.throws(() => m.exports.null(), WebAssembly.RuntimeError, "throw_ref on a null reference");
+  }
+}
+
+testRefAsNonNull();
+testCallRef();
+testThrowRef();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1926,7 +1926,7 @@ public:
 
     [[nodiscard]] PartialResult addRefIsNull(Value operand, Value& result);
 
-    [[nodiscard]] PartialResult addRefAsNonNull(Value value, Value& result);
+    [[nodiscard]] PartialResult addRefAsNonNull(TypedExpression value, Value& result);
 
     [[nodiscard]] PartialResult addRefEq(Value ref0, Value ref1, Value& result);
 
@@ -1987,7 +1987,7 @@ public:
 
     [[nodiscard]] PartialResult addRethrow(unsigned, ControlType& data);
 
-    [[nodiscard]] PartialResult addThrowRef(ExpressionType exception, std::span<TypedExpression>);
+    [[nodiscard]] PartialResult addThrowRef(TypedExpression exception, std::span<TypedExpression>);
 
     void prepareForExceptions();
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3165,8 +3165,9 @@ PartialResult BBQJIT::addI32WrapI64(Value operand, Value& result)
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addRefAsNonNull(Value value, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addRefAsNonNull(TypedExpression typedValue, Value& result)
 {
+    auto value = typedValue.value();
     Location valueLocation;
     if (value.isConst()) {
         valueLocation = Location::fromGPR(wasmScratchGPR);
@@ -3179,7 +3180,8 @@ PartialResult BBQJIT::addI32WrapI64(Value operand, Value& result)
     result = topValue(TypeKind::Ref);
     Location resultLocation = allocate(result);
     ASSERT(JSValue::encode(jsNull()) >= 0 && JSValue::encode(jsNull()) <= INT32_MAX);
-    emitThrowOnNullReference(ExceptionType::NullRefAsNonNull, valueLocation);
+    if (typedValue.type().isNullable())
+        emitThrowOnNullReference(ExceptionType::NullRefAsNonNull, valueLocation);
     emitMove(TypeKind::Ref, valueLocation, resultLocation);
 
     return { };
@@ -3367,8 +3369,9 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
     targetControl.addBranch(m_jit.jump());
 }
 
-[[nodiscard]] PartialResult BBQJIT::addThrowRef(Value exception, std::span<TypedExpression>)
+[[nodiscard]] PartialResult BBQJIT::addThrowRef(TypedExpression typedException, std::span<TypedExpression>)
 {
+    auto exception = typedException.value();
     LOG_INSTRUCTION("ThrowRef", exception);
 
     emitMove(exception, Location::fromGPR(GPRInfo::argumentGPR1));
@@ -3380,16 +3383,20 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
         flushRegisters();
     }
 
-    // Check for a null exception
-    m_jit.move(CCallHelpers::TrustedImmPtr(JSValue::encode(jsNull())), wasmScratchGPR);
-    auto noexnref = m_jit.branchPtr(CCallHelpers::Equal, GPRInfo::argumentGPR1, wasmScratchGPR);
+    if (typedException.type().isNullable()) {
+        m_jit.move(CCallHelpers::TrustedImmPtr(JSValue::encode(jsNull())), wasmScratchGPR);
+        auto noexnref = m_jit.branchPtr(CCallHelpers::Equal, GPRInfo::argumentGPR1, wasmScratchGPR);
 
-    m_jit.move(GPRInfo::wasmContextInstancePointer, GPRInfo::argumentGPR0);
-    emitThrowRefImpl(m_jit);
+        m_jit.move(GPRInfo::wasmContextInstancePointer, GPRInfo::argumentGPR0);
+        emitThrowRefImpl(m_jit);
 
-    noexnref.linkTo(m_jit.label(), &m_jit);
+        noexnref.linkTo(m_jit.label(), &m_jit);
 
-    emitThrowException(ExceptionType::NullExnrefReference);
+        emitThrowException(ExceptionType::NullExnrefReference);
+    } else {
+        m_jit.move(GPRInfo::wasmContextInstancePointer, GPRInfo::argumentGPR0);
+        emitThrowRefImpl(m_jit);
+    }
 
     return { };
 }
@@ -5138,7 +5145,8 @@ void BBQJIT::emitMove(StorageType type, Value src, Address dst)
 [[nodiscard]] PartialResult BBQJIT::addCallRef(unsigned callProfileIndex, const RTT& signature, ArgumentList& args, ResultList& results, CallType callType)
 {
     emitIncrementCallProfileCount(callProfileIndex);
-    Value callee = args.takeLast();
+    TypedExpression typedCallee = args.takeLast();
+    Value callee = typedCallee.value();
     ASSERT(signature.argumentCount() == args.size());
 
     CallInformation callInfo = wasmCallingConvention().callInformationFor(signature, CallRole::Caller);
@@ -5162,7 +5170,8 @@ void BBQJIT::emitMove(StorageType type, Value src, Address dst)
             } else
                 calleeLocation = loadIfNecessary(callee);
             consume(callee);
-            emitThrowOnNullReferenceBeforeAccess(calleeLocation, WebAssemblyFunctionBase::offsetOfTargetInstance());
+            if (typedCallee.type().isNullable())
+                emitThrowOnNullReferenceBeforeAccess(calleeLocation, WebAssemblyFunctionBase::offsetOfTargetInstance());
 
             GPRReg calleePtr = calleeLocation.asGPR();
             m_jit.addPtr(TrustedImm32(WebAssemblyFunctionBase::offsetOfImportableFunction()), calleePtr, importableFunction);


### PR DESCRIPTION
#### 4687d7ecfefad54c517d4af8e238e556ff4eefb3
<pre>
[JSC][Wasm] Elide BBQ null checks on non-nullable refs
<a href="https://bugs.webkit.org/show_bug.cgi?id=321439">https://bugs.webkit.org/show_bug.cgi?id=321439</a>
Reviewed by Yusuke Suzuki.

OMG already skips the null check when the reference type is
non-nullable. BBQ still always emitted it for ref.as_non_null,
call_ref, and throw_ref because those emitters discarded the wasm
type. Keep TypedExpression and skip the check when !isNullable(),
matching array/struct and OMG.

* JSTests/wasm/gc/elide-null-checks.js: Added.
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefAsNonNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addThrowRef):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefAsNonNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallRef):
(JSC::Wasm::BBQJITImpl::BBQJIT::addThrowRef):

Canonical link: <a href="https://commits.webkit.org/318951@main">https://commits.webkit.org/318951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e65e132595cc50ea9b7bb9dd9bcae9d6ef667c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144144 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140272 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120722 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42548 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40865 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2691 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9487 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152948 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40527 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1191 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41099 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191967 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53437 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149551 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54124 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149284 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27324 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43934 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126386 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121434 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52641 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15515 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52023 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->