### PR TITLE
Tools/CISupport/run-tests fails due to missing AutoInstall registrations

### DIFF
--- a/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
@@ -54,6 +54,10 @@ AutoInstall.install(Package('Mako', Version(1, 3, 10)))
 AutoInstall.install(Package('croniter', Version(6, 0, 0)))
 AutoInstall.install(Package('pytz', Version(2025, 2)))
 
+AutoInstall.install(Package('boto3', Version(1, 33, 10), wheel=True))
+AutoInstall.install(Package('botocore', Version(1, 34, 5), wheel=True))
+AutoInstall.install(Package('jmespath', Version(1, 0, 1), wheel=True))
+
 AutoInstall.install(Package('buildbot', Version(4, 3, 0)))
 AutoInstall.install(Package('buildbot_worker', Version(4, 3, 0), pypi_name='buildbot-worker'))
 


### PR DESCRIPTION
#### f2a021692661459a1b5164e260211ae0a5fcf7be
<pre>
Tools/CISupport/run-tests fails due to missing AutoInstall registrations
<a href="https://bugs.webkit.org/show_bug.cgi?id=321340">https://bugs.webkit.org/show_bug.cgi?id=321340</a>

Reviewed by Aakash Jain.

Tools/CISupport/Shared/generate_s3_url.py imports boto3, but this is
not registered with AutoInstall when running
Tools/CISupport/run-tests.

The only existing registration is in
Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py, and it is
because of this that the Services EWS bot mostly succeeds in running
these tests: it only fails on first run (with no autoinstalled
packages).

* Tools/Scripts/webkitpy/autoinstalled/buildbot.py:
Add these to the end, given there is no clear order.

Canonical link: <a href="https://commits.webkit.org/319124@main">https://commits.webkit.org/319124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a81fc2fa81e4181f9ad89f6de456239ac5a5822f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144146 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79a0f2a1-dd68-4016-9af0-b0eb520f4425) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140271 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97085 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2cb057eb-26ac-4fd3-8c79-4bf014188b45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120721 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8efd61b6-4b4a-4719-84fb-c5007b422621) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/179151 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42547 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40867 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40532 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1193 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191969 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/179229 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53439 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149553 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54126 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37145 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149286 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27399 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43936 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121436 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52643 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15520 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52025 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52262 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52089 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->