### PR TITLE
Cherry-pick 315022@main (52cacff4c9e7). https://bugs.webkit.org/show_bug.cgi?id=316827

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/encode_api_test.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/encode_api_test.cc
@@ -795,6 +795,74 @@ TEST(EncodeAPI, MultiResEncode) {
   }
 }
 
+#if CONFIG_VP8_ENCODER && CONFIG_MULTI_RES_ENCODING
+// Regression test for an off-by-one in vpx_codec_encode()'s multi-resolution
+// loop: when the *first* iteration (highest-index encoder, smallest stream)
+// returns non-OK, `break` skips `ctx--`, the post-loop `ctx++` advances ctx to
+// one past the caller's array, and SAVE_STATUS(ctx, res) writes ctx->err out of
+// bounds. With a heap-allocated 3-element array (matching WebRTC's
+// std::vector<vpx_codec_ctx_t> encoders_), ASan reports a 4-byte
+// heap-buffer-overflow WRITE at +16 past a 168-byte region.
+// Bug: 513405023.
+TEST(EncodeAPI, MultiResEncodeFirstIterFailOOB) {
+  constexpr int kNumEnc = 3;
+  // Heap-allocate exactly kNumEnc contexts, mirroring WebRTC's
+  // encoders_.reserve(3); encoders_.resize(3);
+  std::vector<vpx_codec_ctx_t> enc;
+  enc.reserve(kNumEnc);
+  enc.resize(kNumEnc);
+  memset(enc.data(), 0, sizeof(vpx_codec_ctx_t) * kNumEnc);
+
+  vpx_codec_enc_cfg_t cfg[kNumEnc];
+  vpx_rational_t dsf[kNumEnc] = { { 2, 1 }, { 2, 1 }, { 1, 1 } };
+  const int w[kNumEnc] = { 320, 160, 80 };
+  const int h[kNumEnc] = { 240, 120, 60 };
+
+  for (int i = 0; i < kNumEnc; ++i) {
+    ASSERT_EQ(vpx_codec_enc_config_default(&vpx_codec_vp8_cx_algo, &cfg[i], 0),
+              VPX_CODEC_OK);
+    cfg[i].g_w = w[i];
+    cfg[i].g_h = h[i];
+    cfg[i].g_lag_in_frames = 0;
+    cfg[i].rc_end_usage = VPX_CBR;
+    cfg[i].rc_resize_allowed = 0;
+    cfg[i].rc_target_bitrate = 300 >> i;
+    cfg[i].g_timebase.num = 1;
+    cfg[i].g_timebase.den = 30;
+  }
+
+  ASSERT_EQ(vpx_codec_enc_init_multi(enc.data(), &vpx_codec_vp8_cx_algo, cfg,
+                                     kNumEnc, 0, dsf),
+            VPX_CODEC_OK);
+
+  // Contiguous image array; vpx_codec_encode walks img += num_enc-1.
+  vpx_image_t imgs[kNumEnc];
+  for (int i = 0; i < kNumEnc; ++i) {
+    ASSERT_NE(vpx_img_alloc(&imgs[i], VPX_IMG_FMT_I420, w[i], h[i], 1),
+              nullptr);
+    memset(imgs[i].img_data, 128, imgs[i].stride[0] * h[i] * 3 / 2);
+  }
+
+  // Force the FIRST loop iteration (i = num_enc-1, ctx = &enc[2]) to fail in
+  // validate_img() before any ctx-- runs: set an unsupported format on the
+  // highest-index image. validate_img returns VPX_CODEC_INVALID_PARAM, the
+  // loop breaks, ctx++ advances to &enc[3], and SAVE_STATUS writes
+  // (&enc[3])->err — a 4-byte heap OOB write at offset 16 past the vector's
+  // 168-byte backing store.
+  imgs[kNumEnc - 1].fmt = VPX_IMG_FMT_I444;
+
+  // Under ASan this line reports:
+  //   heap-buffer-overflow WRITE of size 4 ... in vpx_codec_encode
+  //   0 bytes to the right of (or 16 past) 168-byte region.
+  EXPECT_EQ(vpx_codec_encode(enc.data(), imgs, /*pts=*/0, /*duration=*/1,
+                             /*flags=*/0, VPX_DL_REALTIME),
+            VPX_CODEC_INVALID_PARAM);
+
+  for (int i = 0; i < kNumEnc; ++i) vpx_img_free(&imgs[i]);
+  for (int i = kNumEnc - 1; i >= 0; --i) vpx_codec_destroy(&enc[i]);
+}
+#endif  // CONFIG_VP8_ENCODER && CONFIG_MULTI_RES_ENCODING
+
 TEST(EncodeAPI, SetRoi) {
   static struct {
     vpx_codec_iface_t *iface;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx/src/vpx_encoder.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx/src/vpx_encoder.c
@@ -236,7 +236,10 @@ vpx_codec_err_t vpx_codec_encode(vpx_codec_ctx_t *ctx, const vpx_image_t *img,
         ctx--;
         if (img) img--;
       }
-      ctx++;
+      // Only restore ctx to &ctx[0] when the loop ran to completion. If an
+      // iteration failed, ctx already points at the failing element; advancing
+      // it would point past the array when the first iteration failed.
+      if (i < 0) ctx++;
     }
 
     FLOATING_POINT_RESTORE();

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -58,6 +58,7 @@
 #include "SourceBufferPrivate.h"
 #include "TextTrackList.h"
 #include "TimeRanges.h"
+#include "TrackOpaqueRoot.h"
 #include "VideoTrack.h"
 #include "VideoTrackList.h"
 #include "VideoTrackPrivate.h"
@@ -179,7 +180,7 @@ SourceBuffer::SourceBuffer(Ref<SourceBufferPrivate>&& sourceBufferPrivate, Media
     , m_private(WTF::move(sourceBufferPrivate))
     , m_client(SourceBufferClientImpl::create(*this))
     , m_source(&source)
-    , m_opaqueRootProvider(Observer<WebCoreOpaqueRoot()>::create([opaqueRoot = WebCoreOpaqueRoot { this }] { return opaqueRoot; }))
+    , m_trackOpaqueRoot(TrackOpaqueRoot::create(opaqueRoot()))
     , m_appendWindowStart(MediaTime::zeroTime())
     , m_appendWindowEnd(MediaTime::positiveInfiniteTime())
     , m_appendState(WaitingForSegment)
@@ -199,6 +200,7 @@ SourceBuffer::~SourceBuffer()
 {
     ASSERT(isRemoved());
     ALWAYS_LOG(LOGIDENTIFIER);
+    m_trackOpaqueRoot->clear();
 }
 
 ExceptionOr<Ref<TimeRanges>> SourceBuffer::buffered()
@@ -758,7 +760,7 @@ VideoTrackList& SourceBuffer::videoTracks()
     if (!m_videoTracks) {
         Ref videoTracks = VideoTrackList::create(protectedScriptExecutionContext().get());
         m_videoTracks = videoTracks.copyRef();
-        videoTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        videoTracks->setOpaqueRoot(m_trackOpaqueRoot);
     }
     return *m_videoTracks;
 }
@@ -768,7 +770,7 @@ AudioTrackList& SourceBuffer::audioTracks()
     if (!m_audioTracks) {
         Ref audioTracks = AudioTrackList::create(protectedScriptExecutionContext().get());
         m_audioTracks = audioTracks.copyRef();
-        audioTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        audioTracks->setOpaqueRoot(m_trackOpaqueRoot);
     }
     return *m_audioTracks;
 }
@@ -778,7 +780,7 @@ TextTrackList& SourceBuffer::textTracks()
     if (!m_textTracks) {
         Ref textTracks = TextTrackList::create(protectedScriptExecutionContext().get());
         m_textTracks = textTracks.copyRef();
-        textTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        textTracks->setOpaqueRoot(m_trackOpaqueRoot);
     }
     return *m_textTracks;
 }

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -56,6 +56,7 @@ class PlatformTimeRanges;
 class SourceBufferPrivate;
 class TextTrackList;
 class TimeRanges;
+class TrackOpaqueRoot;
 class VideoTrackList;
 class WebCoreOpaqueRoot;
 template<typename> class ExceptionOr;
@@ -234,7 +235,7 @@ private:
     WeakPtr<MediaSource> m_source;
     AppendMode m_mode { AppendMode::Segments };
 
-    const Ref<WTF::Observer<WebCoreOpaqueRoot()>> m_opaqueRootProvider;
+    const Ref<TrackOpaqueRoot> m_trackOpaqueRoot;
 
     RefPtr<SharedBuffer> m_pendingAppendData;
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -716,6 +716,7 @@ bindings/js/JSFetchEventCustom.cpp
 bindings/js/JSHTMLAllCollectionCustom.cpp
 bindings/js/JSHTMLCanvasElementCustom.cpp
 bindings/js/JSHTMLElementCustom.cpp
+bindings/js/JSHTMLMediaElementCustom.cpp
 bindings/js/JSHTMLTemplateElementCustom.cpp
 bindings/js/JSHistoryCustom.cpp
 bindings/js/JSIDBCursorCustom.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -16482,6 +16482,8 @@
 		9B56C9A81C89312800C456DF /* CustomElementReactionQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomElementReactionQueue.h; sourceTree = "<group>"; };
 		9B56C9A91C89329A00C456DF /* CustomElementReactionQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CustomElementReactionQueue.cpp; sourceTree = "<group>"; };
 		9B6116491F6A593300E923B8 /* WebContentReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebContentReader.cpp; sourceTree = "<group>"; };
+		9B672EC52FDC971500D9F683 /* JSHTMLMediaElementCustom.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSHTMLMediaElementCustom.cpp; sourceTree = "<group>"; };
+		9B672EC62FDC98BF00D9F683 /* TrackOpaqueRoot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackOpaqueRoot.h; sourceTree = "<group>"; };
 		9B69D3B11B98FF0A00E3512B /* HTMLSlotElement.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = HTMLSlotElement.idl; sourceTree = "<group>"; };
 		9B69D3B21B98FFE900E3512B /* HTMLSlotElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTMLSlotElement.cpp; sourceTree = "<group>"; };
 		9B69D3B31B98FFE900E3512B /* HTMLSlotElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTMLSlotElement.h; sourceTree = "<group>"; };
@@ -31287,6 +31289,7 @@
 				4131F3B11F9552810059995A /* JSFetchEventCustom.cpp */,
 				84BBE5482597E7F100AA8F28 /* JSHTMLAllCollectionCustom.cpp */,
 				6E576BC324EB509C0094D4AA /* JSHTMLCanvasElementCustom.cpp */,
+				9B672EC52FDC971500D9F683 /* JSHTMLMediaElementCustom.cpp */,
 				D6F7960C166FFECE0076DD18 /* JSHTMLTemplateElementCustom.cpp */,
 				511EF2CE17F0FDF100E4FA16 /* JSIDBObjectStoreCustom.cpp */,
 				51E269321DD3BC43006B6A58 /* JSIDBTransactionCustom.cpp */,
@@ -34908,6 +34911,7 @@
 				070334D21459FFAC008D8D45 /* TrackEvent.idl */,
 				BE88E0BF1715CE2600658D98 /* TrackListBase.cpp */,
 				BE88E0C01715CE2600658D98 /* TrackListBase.h */,
+				9B672EC62FDC98BF00D9F683 /* TrackOpaqueRoot.h */,
 				BE88E0D21715D2A200658D98 /* VideoTrack.cpp */,
 				BE88E0D31715D2A200658D98 /* VideoTrack.h */,
 				BE88E0D41715D2A200658D98 /* VideoTrack.idl */,

--- a/Source/WebCore/bindings/js/JSHTMLMediaElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLMediaElementCustom.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSHTMLMediaElement.h"
+
+#include "TrackOpaqueRoot.h"
+#include "WebCoreOpaqueRootInlines.h"
+
+namespace WebCore {
+
+template<typename Visitor>
+void JSHTMLMediaElement::visitAdditionalChildren(Visitor& visitor)
+{
+    addWebCoreOpaqueRoot(visitor, wrapped().trackOpaqueRoot().opaqueRoot());
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSHTMLMediaElement);
+
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -141,6 +141,7 @@
 #include "TextTrackRepresentation.h"
 #include "ThreadableBlobRegistry.h"
 #include "TimeRanges.h"
+#include "TrackOpaqueRoot.h"
 #include "UserContentController.h"
 #include "UserGestureIndicator.h"
 #include "VideoPlaybackQuality.h"
@@ -645,10 +646,7 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
     , m_haveVisibleTextTrack(false)
     , m_processingPreferenceChange(false)
     , m_volumeLocked(defaultVolumeLocked())
-    , m_opaqueRootProvider(WTF::Observer<WebCoreOpaqueRoot()>::create([weakThis = WeakPtr { *this }] {
-        // This gets called on the GC thread so we cannot ref `this`.
-        return weakThis->opaqueRoot();
-    }))
+    , m_trackOpaqueRoot(TrackOpaqueRoot::create(WebCoreOpaqueRoot { this }))
 #if USE(AUDIO_SESSION)
     , m_categoryAtMostRecentPlayback(AudioSessionCategory::None)
     , m_modeAtMostRecentPlayback(AudioSessionMode::Default)
@@ -768,6 +766,8 @@ HTMLMediaElement::~HTMLMediaElement()
     invalidateBufferingStopwatch();
 
     beginIgnoringTrackDisplayUpdateRequests();
+
+    m_trackOpaqueRoot->clear();
 
     if (m_textTracks) {
         for (unsigned i = 0; i < m_textTracks->length(); ++i) {
@@ -5307,7 +5307,7 @@ AudioTrackList& HTMLMediaElement::ensureAudioTracks()
 {
     if (!m_audioTracks) {
         lazyInitialize(m_audioTracks, AudioTrackList::create(ActiveDOMObject::protectedScriptExecutionContext().get()));
-        m_audioTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        m_audioTracks->setOpaqueRoot(m_trackOpaqueRoot);
     }
 
     return *m_audioTracks;
@@ -5317,7 +5317,7 @@ TextTrackList& HTMLMediaElement::ensureTextTracks()
 {
     if (!m_textTracks) {
         lazyInitialize(m_textTracks, TextTrackList::create(ActiveDOMObject::protectedScriptExecutionContext().get()));
-        m_textTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        m_textTracks->setOpaqueRoot(m_trackOpaqueRoot);
         m_textTracks->setDuration(durationMediaTime());
     }
 
@@ -5328,7 +5328,7 @@ VideoTrackList& HTMLMediaElement::ensureVideoTracks()
 {
     if (!m_videoTracks) {
         lazyInitialize(m_videoTracks, VideoTrackList::create(ActiveDOMObject::protectedScriptExecutionContext().get()));
-        m_videoTracks->setOpaqueRootObserver(m_opaqueRootProvider);
+        m_videoTracks->setOpaqueRoot(m_trackOpaqueRoot);
     }
 
     return *m_videoTracks;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -116,6 +116,7 @@ class SleepDisabler;
 class SourceBuffer;
 class SpeechSynthesis;
 class TextTrackList;
+class TrackOpaqueRoot;
 class TimeRanges;
 class VideoPlaybackQuality;
 class VideoTrackList;
@@ -194,6 +195,8 @@ public:
     void ref() const final { HTMLElement::ref(); }
     void deref() const final { HTMLElement::deref(); }
     using HTMLElement::protectedScriptExecutionContext;
+
+    TrackOpaqueRoot& trackOpaqueRoot() { return m_trackOpaqueRoot; }
 
     MediaPlayer* player() const { return m_player.get(); }
     RefPtr<MediaPlayer> protectedPlayer() const { return m_player; }
@@ -1360,6 +1363,7 @@ private:
 
     std::optional<CaptionUserPreferences::CaptionDisplayMode> m_captionDisplayMode;
 
+    Ref<TrackOpaqueRoot> m_trackOpaqueRoot;
     const RefPtr<AudioTrackList> m_audioTracks;
     const RefPtr<TextTrackList> m_textTracks;
     const RefPtr<VideoTrackList> m_videoTracks;
@@ -1395,7 +1399,6 @@ private:
     RefPtr<Blob> m_blob;
     URLKeepingBlobAlive m_blobURLForReading;
     MediaProvider m_mediaProvider;
-    const Ref<WTF::Observer<WebCoreOpaqueRoot()>> m_opaqueRootProvider;
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     bool m_hasNeedkeyListener { false };

--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -43,6 +43,7 @@ typedef (
     ActiveDOMObject,
     Conditional=VIDEO,
     ExportMacro=WEBCORE_EXPORT,
+    JSCustomMarkFunction,
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface HTMLMediaElement : HTMLElement {

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -46,6 +46,15 @@ TextTrackList::TextTrackList(ScriptExecutionContext* context)
 
 TextTrackList::~TextTrackList() = default;
 
+void TextTrackList::setOpaqueRoot(TrackOpaqueRoot& trackOpaqueRoot)
+{
+    TrackListBase::setOpaqueRoot(trackOpaqueRoot);
+    for (Ref track : m_addTrackTracks)
+        track->setOpaqueRoot(trackOpaqueRoot);
+    for (Ref track : m_elementTracks)
+        track->setOpaqueRoot(trackOpaqueRoot);
+}
+
 unsigned TextTrackList::length() const
 {
     return m_addTrackTracks.size() + m_elementTracks.size() + m_inbandTracks.size();

--- a/Source/WebCore/html/track/TextTrackList.h
+++ b/Source/WebCore/html/track/TextTrackList.h
@@ -46,6 +46,8 @@ public:
     }
     virtual ~TextTrackList();
 
+    void setOpaqueRoot(TrackOpaqueRoot&) final;
+
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
     unsigned length() const final;
     int getTrackIndex(TextTrack&);

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "Logging.h"
 #include "TrackListBase.h"
+#include "TrackOpaqueRoot.h"
 #include "TrackPrivateBase.h"
 #include "TrackPrivateBaseClient.h"
 #include <JavaScriptCore/ConsoleTypes.h>
@@ -92,6 +93,18 @@ void TrackBase::didMoveToNewDocument(Document& newDocument)
     observeContext(newDocument.protectedContextDocument().ptr());
 }
 
+void TrackBase::setOpaqueRoot(TrackOpaqueRoot& opaqueRoot)
+{
+    m_trackOpaqueRoot = opaqueRoot;
+}
+
+WebCoreOpaqueRoot TrackBase::opaqueRoot()
+{
+    if (RefPtr trackOpaqueRoot = m_trackOpaqueRoot)
+        return trackOpaqueRoot->opaqueRoot();
+    return WebCoreOpaqueRoot { const_cast<TrackBase*>(this) };
+}
+
 #if ENABLE(MEDIA_SOURCE)
 SourceBuffer* TrackBase::sourceBuffer() const
 {
@@ -107,26 +120,18 @@ void TrackBase::setSourceBuffer(SourceBuffer* buffer)
 void TrackBase::setTrackList(TrackListBase& trackList)
 {
     m_trackList = trackList;
-    m_opaqueRoot = WebCoreOpaqueRoot { &trackList };
+    m_trackOpaqueRoot = trackList.trackOpaqueRoot();
 }
 
 void TrackBase::clearTrackList()
 {
     m_trackList = nullptr;
-    m_opaqueRoot = WebCoreOpaqueRoot { this };
+    m_trackOpaqueRoot = nullptr;
 }
 
 TrackListBase* TrackBase::trackList() const
 {
     return m_trackList.get();
-}
-
-WebCoreOpaqueRoot TrackBase::opaqueRoot() const
-{
-    // Runs on GC thread.
-    if (SUPPRESS_UNCOUNTED_LOCAL auto* trackList = this->trackList())
-        return trackList->opaqueRoot();
-    return WebCoreOpaqueRoot { const_cast<TrackBase*>(this) };
 }
 
 // See: https://tools.ietf.org/html/bcp47#section-2.1

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -39,6 +39,7 @@ namespace WebCore {
 
 class SourceBuffer;
 class TrackListBase;
+class TrackOpaqueRoot;
 class TrackPrivateBase;
 class TrackPrivateBaseClient;
 using TrackID = uint64_t;
@@ -79,7 +80,9 @@ public:
     void setTrackList(TrackListBase&);
     void clearTrackList();
     TrackListBase* trackList() const;
-    WebCoreOpaqueRoot opaqueRoot() const;
+
+    void setOpaqueRoot(TrackOpaqueRoot&);
+    WebCoreOpaqueRoot opaqueRoot();
 
     virtual bool enabled() const = 0;
 
@@ -122,7 +125,7 @@ private:
     uint64_t m_logIdentifier { 0 };
 #endif
     WeakPtr<TrackListBase, WeakPtrImplWithEventTargetData> m_trackList;
-    std::atomic<WebCoreOpaqueRoot> m_opaqueRoot { WebCoreOpaqueRoot { this } };
+    RefPtr<TrackOpaqueRoot> m_trackOpaqueRoot;
     size_t m_clientRegistrationId;
 };
 

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -33,6 +33,7 @@
 #include "EventNames.h"
 #include "ScriptExecutionContext.h"
 #include "TrackEvent.h"
+#include "TrackOpaqueRoot.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -58,11 +59,17 @@ void TrackListBase::didMoveToNewDocument(Document& newDocument)
         track->didMoveToNewDocument(newDocument);
 }
 
+void TrackListBase::setOpaqueRoot(TrackOpaqueRoot& trackOpaqueRoot)
+{
+    m_trackOpaqueRoot = &trackOpaqueRoot;
+    for (Ref track : m_inbandTracks)
+        track->setOpaqueRoot(trackOpaqueRoot);
+}
+
 WebCoreOpaqueRoot TrackListBase::opaqueRoot()
 {
-    // Cannot ref the observer as this gets called on the GC thread.
-    SUPPRESS_UNCOUNTED_LOCAL if (auto* rootObserver = m_opaqueRootObserver.get())
-        return (*rootObserver)();
+    if (RefPtr trackOpaqueRoot = m_trackOpaqueRoot)
+        return trackOpaqueRoot->opaqueRoot();
     return WebCoreOpaqueRoot { this };
 }
 

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -38,6 +38,7 @@
 namespace WebCore {
 
 class TrackBase;
+class TrackOpaqueRoot;
 using TrackID = uint64_t;
 
 class TrackListBase : public RefCounted<TrackListBase>, public EventTarget, public ActiveDOMObject {
@@ -65,8 +66,8 @@ public:
 
     WebCoreOpaqueRoot opaqueRoot();
 
-    using OpaqueRootObserver = WTF::Observer<WebCoreOpaqueRoot()>;
-    void setOpaqueRootObserver(const OpaqueRootObserver& observer) { m_opaqueRootObserver = observer; };
+    TrackOpaqueRoot* trackOpaqueRoot() { return m_trackOpaqueRoot.get(); }
+    virtual void setOpaqueRoot(TrackOpaqueRoot&);
 
     // Needs to be public so tracks can call it
     void scheduleChangeEvent();
@@ -89,7 +90,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    WeakPtr<OpaqueRootObserver> m_opaqueRootObserver;
+    RefPtr<TrackOpaqueRoot> m_trackOpaqueRoot;
     bool m_isChangeEventScheduled { false };
 };
 

--- a/Source/WebCore/html/track/TrackOpaqueRoot.h
+++ b/Source/WebCore/html/track/TrackOpaqueRoot.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebCoreOpaqueRoot.h"
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+class TrackOpaqueRoot : public ThreadSafeRefCounted<TrackOpaqueRoot> {
+public:
+    static Ref<TrackOpaqueRoot> create(const WebCoreOpaqueRoot& root)
+    {
+        return adoptRef(*new TrackOpaqueRoot(root));
+    }
+
+    WebCoreOpaqueRoot opaqueRoot() const { return m_opaqueRoot; }
+    void clear() { m_opaqueRoot = nullptr; }
+
+private:
+    TrackOpaqueRoot(const WebCoreOpaqueRoot& root)
+        : m_opaqueRoot(root)
+    { }
+
+    WebCoreOpaqueRoot m_opaqueRoot;
+};
+
+}

--- a/Source/WebCore/page/LargestContentfulPaintData.cpp
+++ b/Source/WebCore/page/LargestContentfulPaintData.cpp
@@ -198,12 +198,20 @@ void LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry(Eleme
         pendingEntry->setURLString(image->url().string());
         auto loadTimestamp = window->protectedPerformance()->relativeTimeFromTimeOriginInReducedResolution(loadTime);
         pendingEntry->setLoadTime(loadTimestamp);
-    }
+
+        // FIXME: Adopt ReducedResolutionSeconds: webkit.org/b/316824.
+        auto reduceResolution = [](Seconds value, Seconds resolution) {
+            return Seconds(std::floor(value.value() / resolution.value()) * resolution.value());
+        };
+
+        // https://w3c.github.io/largest-contentful-paint/#sec-report-largest-contentful-paint coarsens renderTime to 4ms for images.
+        static constexpr auto renderTimeSecondsResolution = 4_ms;
+        pendingEntry->setRenderTime(reduceResolution(Seconds::fromMilliseconds(paintTimestamp), renderTimeSecondsResolution).milliseconds());
+    } else
+        pendingEntry->setRenderTime(paintTimestamp);
 
     if (element.hasID())
         pendingEntry->setID(element.getIdAttribute().string());
-
-    pendingEntry->setRenderTime(paintTimestamp);
 
     LOG_WITH_STREAM(LargestContentfulPaint, stream << " making new entry for " << element << " image " << (image ? image->url().string() : emptyString()) << " id " << pendingEntry->id() <<
         ": entry size " << pendingEntry->size() << ", loadTime " << pendingEntry->loadTime() << ", renderTime " << pendingEntry->renderTime());


### PR DESCRIPTION
#### 786415d2064a36aea7a26677990e0949cac5245e
<pre>
Cherry-pick 315022@main (52cacff4c9e7). <a href="https://bugs.webkit.org/show_bug.cgi?id=316827">https://bugs.webkit.org/show_bug.cgi?id=316827</a>

Unreviewed backport.

    LCP `renderTime` should have 4ms granularity
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316827">https://bugs.webkit.org/show_bug.cgi?id=316827</a>
    <a href="https://rdar.apple.com/173015796">rdar://173015796</a>

    Reviewed by Matthew Finkel.

    Follow Blink in coarsening `renderTime` for images in LCP to 4ms:

    <a href="https://chromestatus.com/feature/5128261284397056">https://chromestatus.com/feature/5128261284397056</a>
    <a href="https://docs.google.com/document/d/1VxgMf1wlWzB4ViAW4ohkOe3AT0wQZKk7hC3IVq-cuw0/">https://docs.google.com/document/d/1VxgMf1wlWzB4ViAW4ohkOe3AT0wQZKk7hC3IVq-cuw0/</a>

    A future change will adopt ReducedResolutionSeconds here (webkit.org/b/316824).

    * Source/WebCore/page/LargestContentfulPaintData.cpp:
    (WebCore::LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry):

    Canonical link: <a href="https://commits.webkit.org/315022@main">https://commits.webkit.org/315022@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1086@webkitglib/2.52">https://commits.webkit.org/305877.1086@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e4dda9dc223c446ce50432f17b9b117fa46e3281
<pre>
Cherry-pick 305413.951@safari-7624.4-branch (3cbf2f5adfe0). <a href="https://bugs.webkit.org/show_bug.cgi?id=311800">https://bugs.webkit.org/show_bug.cgi?id=311800</a>

    Data race in TrackBase::opaqueRoot during GC leading to use-after-free
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311800">https://bugs.webkit.org/show_bug.cgi?id=311800</a>
    <a href="https://rdar.apple.com/176058579">rdar://176058579</a>

    Reviewed by Geoffrey Garen.

    To fix the data race, we introduce SourceBuffer and HTMLMediaElement as opaque roots for Track* classes
    and *TrackList classes instead of using the root node of HTMLMediaElement which can change over time.

    We introduce TrackOpaqueRoot, which is a thin ThreadSafeRefCounted wrapper around WebCoreOpaqueRoot,
    and initialize it with WebCoreOpaqueRoot pointing to SourceBuffer or HTMLMediaElement.

    Each Track and TrackList class will have RefPtr&lt;TrackOpaqueRoot&gt; and reads the opaque root directly
    from a GC thread without relying on any pointer indirections.

    No new tests since there is no reliable way to test this data race.

    * Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
    (WebCore::SourceBuffer::SourceBuffer):
    (WebCore::SourceBuffer::~SourceBuffer):
    (WebCore::SourceBuffer::videoTracks):
    (WebCore::SourceBuffer::audioTracks):
    (WebCore::SourceBuffer::textTracks):
    (WebCore::m_logIdentifier): Deleted.
    * Source/WebCore/Modules/mediasource/SourceBuffer.h:
    * Source/WebCore/Sources.txt:
    * Source/WebCore/WebCore.xcodeproj/project.pbxproj:
    * Source/WebCore/bindings/js/JSHTMLMediaElementCustom.cpp: Added.
    (WebCore::JSHTMLMediaElement::visitAdditionalChildren):
    * Source/WebCore/html/HTMLMediaElement.cpp:
    (WebCore::m_trackOpaqueRoot):
    (WebCore::HTMLMediaElement::~HTMLMediaElement):
    (WebCore::HTMLMediaElement::ensureAudioTracks):
    (WebCore::HTMLMediaElement::ensureTextTracks):
    (WebCore::HTMLMediaElement::ensureVideoTracks):
    (WebCore::m_opaqueRootProvider): Deleted.
    * Source/WebCore/html/HTMLMediaElement.h:
    (WebCore::HTMLMediaElement::trackOpaqueRoot):
    * Source/WebCore/html/HTMLMediaElement.idl:
    * Source/WebCore/html/track/TextTrackList.cpp:
    (WebCore::TextTrackList::setOpaqueRoot):
    * Source/WebCore/html/track/TextTrackList.h:
    * Source/WebCore/html/track/TrackBase.cpp:
    (WebCore::TrackBase::setOpaqueRoot):
    (WebCore::TrackBase::opaqueRoot):
    (WebCore::TrackBase::setTrackList):
    (WebCore::TrackBase::clearTrackList):
    * Source/WebCore/html/track/TrackBase.h:
    * Source/WebCore/html/track/TrackListBase.cpp:
    (WebCore::TrackListBase::setOpaqueRoot):
    (WebCore::TrackListBase::opaqueRoot):
    * Source/WebCore/html/track/TrackListBase.h:
    (WebCore::TrackListBase::trackOpaqueRoot):
    (WebCore::TrackListBase::setOpaqueRootObserver): Deleted.
    * Source/WebCore/html/track/TrackOpaqueRoot.h: Added.
    (WebCore::TrackOpaqueRoot::create):
    (WebCore::TrackOpaqueRoot::opaqueRoot const):
    (WebCore::TrackOpaqueRoot::clear):
    (WebCore::TrackOpaqueRoot::TrackOpaqueRoot):

    Identifier: 305413.951@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.1085@webkitglib/2.52">https://commits.webkit.org/305877.1085@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 605a2257bdee33195d47f23a61eefb610118f519
<pre>
Cherry-pick 305413.883@safari-7624.4-branch (5256fb491a2b). <a href="https://bugs.webkit.org/show_bug.cgi?id=316410">https://bugs.webkit.org/show_bug.cgi?id=316410</a>

    Potential &apos;out-of-bounds&apos; issue committed to upstream libwebrtc
    <a href="https://rdar.apple.com/177498569">rdar://177498569</a>

    Reviewed by Jean-Yves Avenard.

    Cherry-pick of <a href="https://github.com/webmproject/libvpx/commit/63aad2761655ab788be64966ad462c98e2bce327.">https://github.com/webmproject/libvpx/commit/63aad2761655ab788be64966ad462c98e2bce327.</a>

    * test/encode_api_test.cc:
    * vpx/src/vpx_encoder.c:
    (vpx_codec_encode):

    Identifier: 305413.883@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.1084@webkitglib/2.52">https://commits.webkit.org/305877.1084@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99e128d0e4ccfbf1563076bbc1f9e742c20e9c33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179838 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53785 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47581 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189822 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144158 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181701 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/55082 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53501 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140275 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144158 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182795 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/55082 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47581 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120726 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/55082 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53501 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47581 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/55082 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47581 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1205 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46383 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53501 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191981 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53451 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47581 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149568 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/54138 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47581 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149335 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27314 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/54138 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126400 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121450 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52655 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47581 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52037 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52274 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52101 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->