### PR TITLE
[Web Automation] WebDriver commands hang for elements in cross-origin iframes under Site Isolation

### DIFF
--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -818,10 +818,17 @@ void WebAutomationSessionProxy::computeElementLayout(WebCore::PageIdentifier pag
         // FIXME: Wait in an implementation-specific way up to the session implicit wait timeout for the element to become in view.
     }
 
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->coreFrame()->mainFrame());
-    if (!localFrame)
+    // Convert through this frame's local root rather than the page's main frame.
+    // Under site isolation, an out-of-process iframe's main frame is a RemoteFrame in this process
+    // and has no LocalFrameView, so the local root is the deepest frame reachable here.
+    // Without site isolation the local root is the main frame, so this preserves behavior.
+    Ref localRootFrame = coreLocalFrame->rootFrame();
+    RefPtr rootView = localRootFrame->view();
+    if (!rootView) {
+        String windowNotFoundErrorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::WindowNotFound);
+        completionHandler(windowNotFoundErrorType, { }, std::nullopt, false);
         return;
-    RefPtr mainView = localFrame->view();
+    }
 
     WebCore::FloatRect resultElementBounds;
     std::optional<WebCore::IntPoint> resultInViewCenterPoint;
@@ -833,7 +840,7 @@ void WebAutomationSessionProxy::computeElementLayout(WebCore::PageIdentifier pag
         break;
     case CoordinateSystem::LayoutViewport: {
         auto elementBoundsInRootCoordinates = convertRectFromFrameClientToRootView(frameView.get(), coreElement->boundingClientRect());
-        resultElementBounds = mainView->absoluteToLayoutViewportRect(mainView->rootViewToContents(elementBoundsInRootCoordinates));
+        resultElementBounds = rootView->absoluteToLayoutViewportRect(rootView->rootViewToContents(elementBoundsInRootCoordinates));
         break;
     }
     }
@@ -893,7 +900,7 @@ void WebAutomationSessionProxy::computeElementLayout(WebCore::PageIdentifier pag
         break;
     case CoordinateSystem::LayoutViewport: {
         auto inViewCenterPointInRootCoordinates = convertPointFromFrameClientToRootView(frameView.get(), elementInViewCenterPoint);
-        resultInViewCenterPoint = flooredIntPoint(mainView->absoluteToLayoutViewportPoint(mainView->rootViewToContents(inViewCenterPointInRootCoordinates)));
+        resultInViewCenterPoint = flooredIntPoint(rootView->absoluteToLayoutViewportPoint(rootView->rootViewToContents(inViewCenterPointInRootCoordinates)));
         break;
     }
     }
@@ -1064,10 +1071,13 @@ void WebAutomationSessionProxy::takeScreenshot(WebCore::PageIdentifier pageID, s
         ASSERT(page);
         RefPtr frame = frameID ? WebProcess::singleton().webFrame(*frameID) : &page->mainWebFrame();
         ASSERT(frame && frame->coreLocalFrame());
-        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(frame->coreFrame()->mainFrame());
-        if (!localMainFrame)
-            return;
-        auto snapshotRect = WebCore::IntRect(protect(localMainFrame->view())->clientToDocumentRect(rect));
+        // Convert through this frame's local root rather than the page's main frame, which is a
+        // RemoteFrame with no LocalFrameView in this process under site isolation.
+        RefPtr localRootFrame = frame ? frame->coreLocalFrame() : nullptr;
+        RefPtr localRootView = localRootFrame ? localRootFrame->rootFrame().view() : nullptr;
+        if (!localRootView)
+            return completionHandler(std::nullopt, Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::InternalError));
+        auto snapshotRect = WebCore::IntRect(localRootView->clientToDocumentRect(rect));
         RefPtr<WebImage> image = page->scaledSnapshotWithOptions(snapshotRect, 1, SnapshotOption::Shareable);
         if (!image)
             return completionHandler(std::nullopt, Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::ScreenshotError));


### PR DESCRIPTION
#### b0da4c18f786cf60aa8ee4b0a2d02f091627c526
<pre>
[Web Automation] WebDriver commands hang for elements in cross-origin iframes under Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=321440">https://bugs.webkit.org/show_bug.cgi?id=321440</a>
<a href="https://rdar.apple.com/184526544">rdar://184526544</a>

Reviewed by BJ Burg.

Element Send Keys, Element Clear, Get Element Rect, and Element Click commands hang
in cross-origin iframes under Site Isolation.

`WebAutomationSessionProxy::computeElementLayout()` and `takeScreenshot()` reached to the page&apos;s
main frame to convert position coordinates, via `dynamicDowncast&lt;LocalFrame&gt;(mainFrame())`.

When Site Isolation is enabled, the main frame of an out-of-process iframe is a RemoteFrame,
so the downcast produces `null` and both functions early return, destroying their completion
handler without calling it. This prevents an IPC reply from ever being, so the automation command
never completes and the WebDriver client hangs until it times out.

This affects every command that computes an element&apos;s layout for an element inside a cross-origin iframe:
Element Send Keys, Element Clear, Element Click and Get Element Rect.

This patch introduces a change to convert through the frame&apos;s local root instead of the page&apos;s main frame.

This is not a new approximation: `LocalFrameView::contentsToRootView()` already stops at the local root,
so the existing conversion helpers produce local-root coordinates and pairing them with the local
root&apos;s view is consistent. Without Site Isolation the local root is the main frame, so behavior there is unchanged.

When the local root has no view, reply with an error instead of dropping the completion handler,
so that any future failure surfaces as a WebDriver error rather than as a hang.

* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::computeElementLayout):
(WebKit::WebAutomationSessionProxy::takeScreenshot):

Canonical link: <a href="https://commits.webkit.org/319026@main">https://commits.webkit.org/319026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/045aab494143f124d17d360a7700e0f86d3047f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190432 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25872da6-6173-4f99-a7f5-25c06842d166) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53882 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/053d92a0-d72f-426d-ac40-42b0ce2a19d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44220 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161346 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121017 "Build is in progress. Recent messages:") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66e2f792-90bb-472f-a85b-8972e9b7460f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40875 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1591 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192367 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53832 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40143 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54520 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149638 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44278 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126783 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121930 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53037 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15864 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52419 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52656 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52484 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->