### PR TITLE
[GFC] Parameterize resolveIntrinsicTrackSizesWithSpanningItems() by intrinsic sizing phase

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -57,7 +57,7 @@ struct FlexTrack {
 
 enum class ExtraSpaceDistributionTarget : bool { BaseSizes, GrowthLimits };
 
-// Content and flexible tracks are resolved in separete phases.
+// Content and flexible tracks are resolved in separate phases.
 enum class ResolveIntrinsicTrackSizesPhase : bool { ContentSizedTracks, FlexibleTracks };
 
 // The min track sizing functions a base-size pass of https://drafts.csswg.org/css-grid-1/#algo-spanning-items
@@ -226,6 +226,19 @@ static GridItemIndexes itemsSpanningFlexibleTracks(const UnsizedTracks& unsizedT
             spanningItems.append(gridItemIndex);
     }
     return spanningItems;
+}
+
+// https://drafts.csswg.org/css-grid-1/#algo-content
+static GridItemIndexes itemsToAccommodate(const UnsizedTracks& unsizedTracks, const PlacedGridItemSpanList& gridItemSpanList, ResolveIntrinsicTrackSizesPhase phase)
+{
+    if (phase == ResolveIntrinsicTrackSizesPhase::ContentSizedTracks) {
+        // https://drafts.csswg.org/css-grid-1/#algo-spanning-items
+        notImplemented();
+        return { };
+    }
+
+    // https://drafts.csswg.org/css-grid-1/#algo-spanning-flex-items
+    return itemsSpanningFlexibleTracks(unsizedTracks, gridItemSpanList);
 }
 
 using TrackIndexes = Vector<size_t>;
@@ -586,11 +599,10 @@ static void distributeExtraSpace(ExtraSpaceDistributionTarget spaceDistributionT
     }
 }
 
-// Collects the flexible tracks whose min track sizing function the given base-size pass distributes
-// space to.
-static TrackIndexes affectedFlexibleTracksMatchingMinSizeFunction(const UnsizedTracks& unsizedTracks, MinTrackSizingFunctionType minTrackSizingFunctionType)
+// Collects the tracks whose min track sizing function the given base-size pass distributes space to.
+static TrackIndexes affectedTracksMatchingMinSizeFunction(const UnsizedTracks& unsizedTracks, MinTrackSizingFunctionType minTrackSizingFunctionType, ResolveIntrinsicTrackSizesPhase phase)
 {
-    auto minSizingFunctionForType = [&](const auto& minTrackSizingFunction) {
+    auto isMinTrackSizingFunctionValidForType = [&](const auto& minTrackSizingFunction) {
         switch (minTrackSizingFunctionType) {
         case MinTrackSizingFunctionType::Intrinsic:
             return minTrackSizingFunction.isContentSized();
@@ -605,32 +617,35 @@ static TrackIndexes affectedFlexibleTracksMatchingMinSizeFunction(const UnsizedT
         return false;
     };
 
+    auto isMaxTrackSizingFunctionValidForPhase = [&](const auto& maxTrackSizingFunction) {
+        switch (phase) {
+        case ResolveIntrinsicTrackSizesPhase::ContentSizedTracks:
+            return !maxTrackSizingFunction.isFlex();
+        case ResolveIntrinsicTrackSizesPhase::FlexibleTracks:
+            return maxTrackSizingFunction.isFlex();
+        }
+        ASSERT_NOT_REACHED();
+        return false;
+    };
+
     TrackIndexes trackIndexes;
     for (auto [trackIndex, track] : WTF::indexedRange(unsizedTracks)) {
-        if (track.trackSizingFunction.max.isFlex() && minSizingFunctionForType(track.trackSizingFunction.min))
+        if (isMinTrackSizingFunctionValidForType(track.trackSizingFunction.min) && isMaxTrackSizingFunctionValidForPhase(track.trackSizingFunction.max))
             trackIndexes.append(trackIndex);
     }
     return trackIndexes;
 }
 
 // https://drafts.csswg.org/css-grid-1/#algo-spanning-items
-static void increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks(const ResolveIntrinsicTrackSizesContext& resolveIntrinsicTrackSizesContext,
-    UnsizedTracks& unsizedTracks)
-{
-    UNUSED_PARAM(resolveIntrinsicTrackSizesContext);
-    UNUSED_PARAM(unsizedTracks);
-    notImplemented();
-}
-
 // https://drafts.csswg.org/css-grid-1/#algo-spanning-flex-items
-// Increase sizes to accommodate spanning items crossing flexible tracks: repeat the previous step
-// (https://drafts.csswg.org/css-grid-1/#algo-spanning-items) considering, together, all items that
-// span a track with a flexible sizing function, while distributing space only to flexible tracks.
-static void increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(const ResolveIntrinsicTrackSizesContext& resolveIntrinsicTrackSizesContext,
-    UnsizedTracks& unsizedTracks)
+// The flexible phase is specified as repeating the content sized phase's steps, differing only in the
+// items it accommodates, the tracks it distributes space to, and in items 4-6 being vacuous for it.
+static void resolveIntrinsicTrackSizesWithSpanningItems(const ResolveIntrinsicTrackSizesContext& resolveIntrinsicTrackSizesContext,
+    UnsizedTracks& unsizedTracks, ResolveIntrinsicTrackSizesPhase phase)
 {
     auto gridItemSpanList = spannedLinesList(resolveIntrinsicTrackSizesContext.trackSizingItems);
-    auto spanningItems = itemsSpanningFlexibleTracks(unsizedTracks, gridItemSpanList);
+
+    auto spanningItems = itemsToAccommodate(unsizedTracks, gridItemSpanList, phase);
     if (spanningItems.isEmpty())
         return;
 
@@ -653,32 +668,32 @@ static void increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(const 
     // min track sizing function, to accommodate these items' minimum contributions. If the grid
     // container is being sized under a min-/max-content constraint, use the items' limited min-content
     // contributions instead.
-    auto flexibleTracksWithIntrinsicMinimums = affectedFlexibleTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::Intrinsic);
+    auto tracksWithIntrinsicMinimums = affectedTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::Intrinsic, phase);
     auto minimumSizeContributions = isSizedUnderMinOrMaxContentConstraint(resolveIntrinsicTrackSizesContext.axisConstraint)
         ? limitedContentContributions(minContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions), fixedMaxTrackSizingFunctionSums, minimumContributionsList)
         : minimumContributionsList;
-    distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithIntrinsicMinimums, minimumSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
+    distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, tracksWithIntrinsicMinimums, minimumSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
 
     // 2. For content-based minimums: continue to distribute extra space to the base sizes of tracks with
     // a min track sizing function of min-content or max-content, to accommodate the items' min-content
     // contributions.
     auto minContentSizeContributions = minContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions);
-    auto flexibleTracksWithContentBasedMinimums = affectedFlexibleTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::MinContentOrMaxContent);
-    distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithContentBasedMinimums, minContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
+    auto tracksWithContentBasedMinimums = affectedTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::MinContentOrMaxContent, phase);
+    distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, tracksWithContentBasedMinimums, minContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
 
     // 3. For max-content minimums: if the grid container is being sized under a max-content constraint
     if (scenario == AxisConstraint::FreeSpaceScenario::MaxContent) {
         // continue to distribute extra space to the base sizes of tracks with a min track sizing function
         // of auto or max-content, to accommodate the items' limited max-content contributions...
-        auto flexibleTracksWithAutoOrMaxContentMinimums = affectedFlexibleTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::AutoOrMaxContent);
+        auto tracksWithAutoOrMaxContentMinimums = affectedTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::AutoOrMaxContent, phase);
         auto limitedMaxContentSizeContributions = limitedContentContributions(maxContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions), fixedMaxTrackSizingFunctionSums, minimumContributionsList);
-        distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithAutoOrMaxContentMinimums, limitedMaxContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
+        distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, tracksWithAutoOrMaxContentMinimums, limitedMaxContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
     }
     // ...In all cases, distribute to tracks with a max-content min track sizing function
     // to accommodate the items' max-content contributions.
-    auto flexibleTracksWithMaxContentMinimums = affectedFlexibleTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::MaxContent);
+    auto tracksWithMaxContentMinimums = affectedTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::MaxContent, phase);
     auto maxContentSizeContributions = maxContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions);
-    distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, flexibleTracksWithMaxContentMinimums, maxContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
+    distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, tracksWithMaxContentMinimums, maxContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
 
     // 4. If at this point any track's growth limit is now less than its base size, increase its
     //    growth limit to match its base size.
@@ -698,14 +713,6 @@ static void increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(const 
     //    max-content max track sizing function, to accommodate these items' max-content contributions.
     //    Not applicable: a flexible track's max track sizing function is <flex>, not max-content, so no
     //    flexible track is affected.
-}
-
-static void resolveIntrinsicTrackSizesWithSpanningItems(const ResolveIntrinsicTrackSizesContext& resolveIntrinsicTrackSizesContext, UnsizedTracks& unsizedTracks, ResolveIntrinsicTrackSizesPhase phase)
-{
-    if (phase == ResolveIntrinsicTrackSizesPhase::ContentSizedTracks)
-        increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks(resolveIntrinsicTrackSizesContext, unsizedTracks);
-    else
-        increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks(resolveIntrinsicTrackSizesContext, unsizedTracks);
 }
 
 // https://drafts.csswg.org/css-grid-1/#algo-content


### PR DESCRIPTION
#### 98a5bbe21fd107e71f4cffbafd8eadc6ae55a51f
<pre>
[GFC] Parameterize resolveIntrinsicTrackSizesWithSpanningItems() by intrinsic sizing phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=321474">https://bugs.webkit.org/show_bug.cgi?id=321474</a>
&lt;<a href="https://rdar.apple.com/184566237">rdar://184566237</a>&gt;

Reviewed by Sammy Gill.

We should parameterize resolveIntrinsicTrackSizesWithSpanningItems()
and all the helper functions it uses instead of splitting it into two
pieces for flex and content sized tracks.

This PR removes affectedFlexibleTracksMatchingMinSizeFunction and replaces with
affectedTracksMatchingMinSizeFunction which takes the ResolveIntrinsicTrackSizesPhase
as a parameter, allowing it to support flex and content sized tracks.

A helper function itemsToAccommodate() was added to collect the items that we need to
size the grid tracks for during a given phase, which currently only wraps
itemsSpanningFlexibleTracks and does not yet support the content sizing phases.

No behavior change

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::itemsToAccommodate):
(WebCore::Layout::affectedTracksMatchingMinSizeFunction):
(WebCore::Layout::resolveIntrinsicTrackSizesWithSpanningItems):
(WebCore::Layout::affectedFlexibleTracksMatchingMinSizeFunction): Deleted.
(WebCore::Layout::increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks): Deleted.
(WebCore::Layout::increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks): Deleted.

Canonical link: <a href="https://commits.webkit.org/318977@main">https://commits.webkit.org/318977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/995fa279d4accb8b48cf549cf616a8c875a3e759

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144267 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181810 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140322 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120773 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd13e648-170f-4a57-81c3-fc79219b5944) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42659 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40967 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40634 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1317 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192092 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53560 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149664 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54247 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37315 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149394 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27335 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44040 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126510 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121569 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52764 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15621 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52146 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52384 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52210 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->