### PR TITLE
GPUQueue.copyExternalImageToTexture() does not upload indexed PNG correctly

### DIFF
--- a/LayoutTests/fast/webgpu/copy-indexed-png-palette-expected.txt
+++ b/LayoutTests/fast/webgpu/copy-indexed-png-palette-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: PASS: indexed PNG palette was resolved to colors, not uploaded as raw indices
+This test passes if it prints PASS: the palette of an indexed PNG must be resolved when copied to a WebGPU texture.

--- a/LayoutTests/fast/webgpu/copy-indexed-png-palette.html
+++ b/LayoutTests/fast/webgpu/copy-indexed-png-palette.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) { testRunner.dumpAsText(); testRunner.waitUntilDone(); }
+
+// Verifies that copyExternalImageToTexture resolves the palette of an indexed (color-type 3)
+// PNG instead of uploading the raw palette indices.
+//
+// The 2x2 source PNG is indexed with a palette whose indices (0,1,2,3) map to saturated,
+// distinct colors:
+//     index 0 -> red    (255,   0,   0)
+//     index 1 -> green  (  0, 255,   0)
+//     index 2 -> blue   (  0,   0, 255)
+//     index 3 -> yellow (255, 255,   0)
+// If the palette is (incorrectly) ignored, each pixel uploads its raw index (<= 3) into all
+// channels, i.e. every pixel is essentially black -- which this test detects and reports FAIL.
+
+// 2x2 indexed PNG, palette [red, green, blue, yellow], pixels [[0,1],[2,3]].
+const indexedPNG = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAMAAABFaP0WAAAADFBMVEX/AAAA/wAAAP///wDWAo97AAAADklEQVR42mNgYGRgYgYAABEAB4PKZGQAAAAASUVORK5CYII=";
+
+function loadImage(src) {
+    return new Promise((resolve, reject) => {
+        const image = new Image();
+        image.onload = () => resolve(image);
+        image.onerror = reject;
+        image.src = src;
+    });
+}
+
+// Classify a pixel into a color name using generous thresholds. The buggy (raw-index) path
+// produces channel values <= 3, so it can never be classified as a saturated color.
+function classify(r, g, b) {
+    const hi = 200, lo = 60;
+    if (r > hi && g < lo && b < lo) return "red";
+    if (r < lo && g > hi && b < lo) return "green";
+    if (r < lo && g < lo && b > hi) return "blue";
+    if (r > hi && g > hi && b < lo) return "yellow";
+    return `unclassified(${r},${g},${b})`;
+}
+
+onload = async () => {
+    try {
+        const adapter = await navigator.gpu?.requestAdapter();
+        const device = await adapter?.requestDevice();
+        if (!device) {
+            console.log("FAIL: No WebGPU device available");
+            if (window.testRunner) testRunner.notifyDone();
+            return;
+        }
+
+        const image = await loadImage(indexedPNG);
+
+        const width = 2, height = 2;
+        const texture = device.createTexture({
+            size: [width, height],
+            format: "rgba8unorm",
+            usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+        });
+
+        device.queue.copyExternalImageToTexture({ source: image }, { texture }, [width, height]);
+
+        // Read the texture back. copyTextureToBuffer requires bytesPerRow to be a multiple of 256.
+        const bytesPerRow = 256;
+        const readbackBuffer = device.createBuffer({
+            size: bytesPerRow * height,
+            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+        });
+
+        const encoder = device.createCommandEncoder();
+        encoder.copyTextureToBuffer(
+            { texture },
+            { buffer: readbackBuffer, bytesPerRow, rowsPerImage: height },
+            [width, height]
+        );
+        device.queue.submit([encoder.finish()]);
+
+        await readbackBuffer.mapAsync(GPUMapMode.READ);
+        const bytes = new Uint8Array(readbackBuffer.getMappedRange());
+
+        // Pixel (col, row) starts at row * bytesPerRow + col * 4.
+        const pixel = (col, row) => {
+            const o = row * bytesPerRow + col * 4;
+            return [bytes[o], bytes[o + 1], bytes[o + 2]];
+        };
+
+        const expected = [
+            { col: 0, row: 0, name: "red" },
+            { col: 1, row: 0, name: "green" },
+            { col: 0, row: 1, name: "blue" },
+            { col: 1, row: 1, name: "yellow" },
+        ];
+
+        let allPass = true;
+        for (const e of expected) {
+            const [r, g, b] = pixel(e.col, e.row);
+            const got = classify(r, g, b);
+            if (got !== e.name) {
+                allPass = false;
+                console.log(`FAIL: pixel (${e.col},${e.row}) expected ${e.name} but got ${got} — palette was not applied`);
+            }
+        }
+
+        readbackBuffer.unmap();
+
+        if (allPass)
+            console.log("PASS: indexed PNG palette was resolved to colors, not uploaded as raw indices");
+
+    } catch (e) {
+        console.log("FAIL: " + e);
+    }
+
+    if (window.testRunner) testRunner.notifyDone();
+};
+</script>
+This test passes if it prints PASS: the palette of an indexed PNG must be resolved when copied to a WebGPU texture.

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -52,6 +52,7 @@
 #include <wtf/MallocSpan.h>
 
 #if PLATFORM(COCOA)
+#include "ColorSpaceCG.h"
 #include <Accelerate/Accelerate.h>
 #include <wtf/cf/VectorCF.h>
 
@@ -521,6 +522,23 @@ static void imageBytesForSource(WebGPU::Queue& backing, const GPUImageCopyExtern
             RetainPtr platformImage = nativeImage->platformImage();
             if (!platformImage)
                 return callback({ }, 0, 0);
+
+            if (CGColorSpaceGetModel(CGImageGetColorSpace(platformImage.get())) == kCGColorSpaceModelIndexed) {
+                auto indexedWidth = CGImageGetWidth(platformImage.get());
+                auto indexedHeight = CGImageGetHeight(platformImage.get());
+                RetainPtr bitmapContext = adoptCF(CGBitmapContextCreate(nullptr, indexedWidth, indexedHeight, 8, indexedWidth * 4, sRGBColorSpaceSingleton(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+                if (!bitmapContext)
+                    return callback({ }, 0, 0);
+
+                CGContextSetBlendMode(bitmapContext.get(), kCGBlendModeCopy);
+                CGContextSetInterpolationQuality(bitmapContext.get(), kCGInterpolationNone);
+                CGContextDrawImage(bitmapContext.get(), CGRectMake(0, 0, indexedWidth, indexedHeight), platformImage.get());
+
+                platformImage = adoptCF(CGBitmapContextCreateImage(bitmapContext.get()));
+                if (!platformImage)
+                    return callback({ }, 0, 0);
+            }
+
             RetainPtr pixelDataCfData = adoptCF(CGDataProviderCopyData(RetainPtr { CGImageGetDataProvider(platformImage.get()) }.get()));
             if (!pixelDataCfData)
                 return callback({ }, 0, 0);


### PR DESCRIPTION
#### 09c8c53713588fea24ef7208937b2695da950cdc
<pre>
GPUQueue.copyExternalImageToTexture() does not upload indexed PNG correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=321430">https://bugs.webkit.org/show_bug.cgi?id=321430</a>
<a href="https://rdar.apple.com/184529653">rdar://184529653</a>

Reviewed by Dan Glastonbury.

Indexed images were previously not supported correctly in the image
upload path from GPUQueue.

Test: fast/webgpu/copy-indexed-png-palette.html

* LayoutTests/fast/webgpu/copy-indexed-png-palette-expected.txt: Added.
* LayoutTests/fast/webgpu/copy-indexed-png-palette.html: Added.
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::imageBytesForSource):

Canonical link: <a href="https://commits.webkit.org/318952@main">https://commits.webkit.org/318952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/345d4641ebdc6cdf6d40a3abf65c6cfdda802554

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144166 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd18eea5-cf40-4868-8a39-45880ab8a87b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140281 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b85804f9-20c6-49cb-ad94-2f6415954347) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120732 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/551c34ee-d6af-4458-951b-4edc058a9b9d) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42565 "Found 1 new test failure: imported/w3c/web-platform-tests/background-fetch/match.https.window.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40884 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40547 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1215 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191989 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149569 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40087 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54146 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149301 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43949 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126408 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121460 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52663 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15535 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52045 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52282 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52109 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->