### PR TITLE
[WebKit Networking] Client certificate authentication challenge is never completed when the SecKeyProxy identity cannot be created, hanging the page load

### DIFF
--- a/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
@@ -40,6 +40,43 @@
 
 namespace WebKit {
 
+static std::optional<WebCore::Credential> credentialFromClientCertificateMessage(xpc_object_t message)
+{
+    OSObjectPtr<xpc_object_t> xpcEndPoint = xpc_dictionary_get_value(message, ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey);
+    if (!xpcEndPoint || xpc_get_type(xpcEndPoint.get()) != XPC_TYPE_ENDPOINT)
+        return std::nullopt;
+    RetainPtr endPoint = adoptNS([[NSXPCListenerEndpoint alloc] init]);
+    [endPoint _setEndpoint:xpcEndPoint.get()];
+    NSError *error = nil;
+    RetainPtr identity = adoptCF([SecKeyProxy createIdentityFromEndpoint:endPoint.get() error:&error]);
+    if (!identity || error) {
+        LOG_ERROR("Couldn't create identity from end point: %@", error);
+        return std::nullopt;
+    }
+
+    OSObjectPtr<xpc_object_t> certificateDataArray = xpc_dictionary_get_array(message, ClientCertificateAuthentication::XPCCertificatesKey);
+    if (!certificateDataArray)
+        return std::nullopt;
+    RetainPtr<NSMutableArray> certificates;
+    if (auto total = xpc_array_get_count(certificateDataArray.get())) {
+        certificates = [NSMutableArray arrayWithCapacity:total];
+        for (size_t i = 0; i < total; i++) {
+            OSObjectPtr<xpc_object_t> certificateData = xpc_array_get_value(certificateDataArray.get(), i);
+            RetainPtr cfData = adoptCF(CFDataCreate(nullptr, static_cast<const UInt8*>(xpc_data_get_bytes_ptr(certificateData.get())), xpc_data_get_length(certificateData.get())));
+            RetainPtr certificate = adoptCF(SecCertificateCreateWithData(nullptr, cfData.get()));
+            if (!certificate)
+                return std::nullopt;
+            [certificates addObject:(__bridge id)certificate.get()];
+        }
+    }
+
+    auto persistence = xpc_dictionary_get_uint64(message, ClientCertificateAuthentication::XPCPersistenceKey);
+    if (persistence > static_cast<uint64_t>(NSURLCredentialPersistenceSynchronizable))
+        return std::nullopt;
+
+    return WebCore::Credential(adoptNS([[NSURLCredential alloc] initWithIdentity:identity.get() certificates:certificates.get() persistence:(NSURLCredentialPersistence)persistence]).get());
+}
+
 void AuthenticationManager::initializeConnection(IPC::Connection* connection)
 {
     RELEASE_ASSERT(isMainRunLoop());
@@ -66,42 +103,20 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
             }
 
             auto challengeID = xpc_dictionary_get_uint64(event.get(), ClientCertificateAuthentication::XPCChallengeIDKey);
-            if (!challengeID)
+            if (!ObjectIdentifier<AuthenticationChallengeIdentifierType>::isValidIdentifier(challengeID)) {
+                ASSERT_NOT_REACHED();
                 return;
+            }
+            auto challengeIdentifier = ObjectIdentifier<AuthenticationChallengeIdentifierType>(challengeID);
 
-            OSObjectPtr<xpc_object_t> xpcEndPoint = xpc_dictionary_get_value(event.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey);
-            if (!xpcEndPoint || xpc_get_type(xpcEndPoint.get()) != XPC_TYPE_ENDPOINT)
-                return;
-            auto endPoint = adoptNS([[NSXPCListenerEndpoint alloc] init]);
-            [endPoint _setEndpoint:xpcEndPoint.get()];
-            NSError *error = nil;
-            auto identity = adoptCF([SecKeyProxy createIdentityFromEndpoint:endPoint.get() error:&error]);
-            if (!identity || error) {
-                LOG_ERROR("Couldn't create identity from end point: %@", error);
+            // CFNetwork owns the challenge's completion handler and never times out, so failing to complete it hangs the load forever.
+            auto credential = credentialFromClientCertificateMessage(event.get());
+            if (!credential) {
+                weakThis->completeAuthenticationChallenge(challengeIdentifier, AuthenticationChallengeDisposition::PerformDefaultHandling, { });
                 return;
             }
 
-            OSObjectPtr<xpc_object_t> certificateDataArray = xpc_dictionary_get_array(event.get(), ClientCertificateAuthentication::XPCCertificatesKey);
-            if (!certificateDataArray)
-                return;
-            RetainPtr<NSMutableArray> certificates;
-            if (auto total = xpc_array_get_count(certificateDataArray.get())) {
-                certificates = [NSMutableArray arrayWithCapacity:total];
-                for (size_t i = 0; i < total; i++) {
-                    OSObjectPtr<xpc_object_t> certificateData = xpc_array_get_value(certificateDataArray.get(), i);
-                    RetainPtr cfData = adoptCF(CFDataCreate(nullptr, static_cast<const UInt8*>(xpc_data_get_bytes_ptr(certificateData.get())), xpc_data_get_length(certificateData.get())));
-                    RetainPtr certificate = adoptCF(SecCertificateCreateWithData(nullptr, cfData.get()));
-                    if (!certificate)
-                        return;
-                    [certificates addObject:(__bridge id)certificate.get()];
-                }
-            }
-
-            auto persistence = xpc_dictionary_get_uint64(event.get(), ClientCertificateAuthentication::XPCPersistenceKey);
-            if (persistence > static_cast<uint64_t>(NSURLCredentialPersistenceSynchronizable))
-                return;
-
-            weakThis->completeAuthenticationChallenge(ObjectIdentifier<AuthenticationChallengeIdentifierType>(challengeID), AuthenticationChallengeDisposition::UseCredential, WebCore::Credential(adoptNS([[NSURLCredential alloc] initWithIdentity:identity.get() certificates:certificates.get() persistence:(NSURLCredentialPersistence)persistence]).get()));
+            weakThis->completeAuthenticationChallenge(challengeIdentifier, AuthenticationChallengeDisposition::UseCredential, WTF::move(*credential));
         });
     });
 }


### PR DESCRIPTION
#### fc7c2fa58bb93ead23f03d5120ded2fac488bb66
<pre>
[WebKit Networking] Client certificate authentication challenge is never completed when the SecKeyProxy identity cannot be created, hanging the page load
<a href="https://bugs.webkit.org/show_bug.cgi?id=321435">https://bugs.webkit.org/show_bug.cgi?id=321435</a>
<a href="https://rdar.apple.com/182381982">rdar://182381982</a>

Reviewed by Alex Christensen.

WebKit does not move a client certificate&apos;s private key between processes. The UI process wraps the
chosen SecIdentity in a SecKeyProxy and sends only the XPC endpoint plus the certificate chain to the
network process, which rebuilds the identity with -[SecKeyProxy createIdentityFromEndpoint:error:].
That call round-trips back to the UI process, so it fails whenever the private key&apos;s Keychain ACL
denies access - for instance a certificate provisioned by a third-party application whose ACL is bound
to that application&apos;s Team ID.

On failure the XPC handler only logged and returned, without completing the challenge. The same was
true of every other early return in the handler: a missing or non-endpoint XPC endpoint, a missing
certificate data array, a certificate that fails SecCertificateCreateWithData, and an out-of-range
persistence value. Abandoning the challenge leaves the Challenge object, which owns CFNetwork&apos;s
challenge completion handler, in AuthenticationManager::m_challenges forever. There is no timeout and
no fallback, so the TLS handshake keeps waiting for a client certificate and the page load stalls
indefinitely with no error shown to the user.

Move the credential reconstruction into credentialFromClientCertificateMessage() so that all of those
failures collapse into a single std::nullopt, and complete the challenge with PerformDefaultHandling
when it returns nothing. That matches the fallback NetworkProcessProxy::processAuthenticationChallenge
already uses for non-server-trust schemes, and turns the hang into a reportable load failure.

The remaining early return has to stay: there is no identifier to complete, and constructing one anyway
would hit the RELEASE_ASSERT in ObjectIdentifier&apos;s constructor and crash the network process. Validate
with ObjectIdentifier::isValidIdentifier() so the guard rejects exactly what that constructor rejects,
which includes the hash table deleted value as well as zero. It only gets an ASSERT_NOT_REACHED,
matching the message name check above it, since an invalid identifier means a malformed message rather
than a challenge we could fail.

This does not make client certificate authentication succeed when the ACL denies access; that denial
is by design and needs the certificate to be provisioned with an ACL that permits the requesting
applications.

No new tests (the failure path needs a Keychain ACL denial, which cannot be simulated in the test
harness). The unchanged success path stays covered by TestWebKitAPI.Challenge.ClientCertificate.

* Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm:
(WebKit::credentialFromClientCertificateMessage):
(WebKit::AuthenticationManager::initializeConnection):

Canonical link: <a href="https://commits.webkit.org/318936@main">https://commits.webkit.org/318936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58ee1001d597259b04c8c0dfb6988bfc6c1675da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47630 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c2df6b4-d3ec-4c87-b7c8-83bb75c536f7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53550 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0de5bc15-1378-4050-be2f-41d18aaabd97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182844 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161053 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f66e88d5-fe5d-4383-a883-7ad0bf456b53) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40580 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1256 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46433 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192030 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53500 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149608 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40076 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54187 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149339 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43987 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121502 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52704 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15566 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52086 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52324 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52150 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->