### PR TITLE
[WebTransport] Escape WebTransportOptions.protocols according to RFC 8941

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any-expected.txt
@@ -6,6 +6,8 @@ PASS WebTransport session establishment with status code 401
 PASS WebTransport session establishment fails with status code 404
 PASS Echo back request headers
 PASS Validate subprotocol headers sent
+PASS Protocol with double-quote is escaped in wt-available-protocols header
+PASS Protocol with backslash is escaped in wt-available-protocols header
 PASS Validate subprotocol response header received
 PASS Validate subprotocol response header received with parameters handled correctly
 PASS Validate subprotocol response header with non-offered protocol gets ignored

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.js
@@ -84,6 +84,38 @@ promise_test(async t => {
 }, 'Validate subprotocol headers sent');
 
 promise_test(async t => {
+  const options = { protocols: ['a"b'] };
+  const wt = new WebTransport(webtransport_url('echo-request-headers.py'), options);
+  await wt.ready;
+
+  const streams = await wt.incomingUnidirectionalStreams;
+  const stream_reader = streams.getReader();
+  const { value: recv_stream } = await stream_reader.read();
+  stream_reader.releaseLock();
+
+  const request_headers = await read_stream_as_json(recv_stream);
+  check_and_remove_standard_headers(request_headers);
+  // '"' inside a protocol name must be escaped as '\"' in the SF string.
+  assert_equals(request_headers['wt-available-protocols'], '"a\\"b"');
+}, 'Protocol with double-quote is escaped in wt-available-protocols header');
+
+promise_test(async t => {
+  const options = { protocols: ['a\\b'] };
+  const wt = new WebTransport(webtransport_url('echo-request-headers.py'), options);
+  await wt.ready;
+
+  const streams = await wt.incomingUnidirectionalStreams;
+  const stream_reader = streams.getReader();
+  const { value: recv_stream } = await stream_reader.read();
+  stream_reader.releaseLock();
+
+  const request_headers = await read_stream_as_json(recv_stream);
+  check_and_remove_standard_headers(request_headers);
+  // '\' inside a protocol name must be escaped as '\\' in the SF string.
+  assert_equals(request_headers['wt-available-protocols'], '"a\\\\b"');
+}, 'Protocol with backslash is escaped in wt-available-protocols header');
+
+promise_test(async t => {
   const options = { protocols: ["a", "b", "c"] };
   const wt = new WebTransport(webtransport_url('custom-response.py?wt-protocol="b"'), options);
   await wt.ready;

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.serviceworker-expected.txt
@@ -6,6 +6,8 @@ PASS WebTransport session establishment with status code 401
 PASS WebTransport session establishment fails with status code 404
 PASS Echo back request headers
 PASS Validate subprotocol headers sent
+PASS Protocol with double-quote is escaped in wt-available-protocols header
+PASS Protocol with backslash is escaped in wt-available-protocols header
 PASS Validate subprotocol response header received
 PASS Validate subprotocol response header received with parameters handled correctly
 PASS Validate subprotocol response header with non-offered protocol gets ignored

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.sharedworker-expected.txt
@@ -6,6 +6,8 @@ PASS WebTransport session establishment with status code 401
 PASS WebTransport session establishment fails with status code 404
 PASS Echo back request headers
 PASS Validate subprotocol headers sent
+PASS Protocol with double-quote is escaped in wt-available-protocols header
+PASS Protocol with backslash is escaped in wt-available-protocols header
 PASS Validate subprotocol response header received
 PASS Validate subprotocol response header received with parameters handled correctly
 PASS Validate subprotocol response header with non-offered protocol gets ignored

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.worker-expected.txt
@@ -6,6 +6,8 @@ PASS WebTransport session establishment with status code 401
 PASS WebTransport session establishment fails with status code 404
 PASS Echo back request headers
 PASS Validate subprotocol headers sent
+PASS Protocol with double-quote is escaped in wt-available-protocols header
+PASS Protocol with backslash is escaped in wt-available-protocols header
 PASS Validate subprotocol response header received
 PASS Validate subprotocol response header received with parameters handled correctly
 PASS Validate subprotocol response header with non-offered protocol gets ignored

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any-expected.txt
@@ -11,6 +11,15 @@ PASS WebTransport constructor should reject protocol list ''
 PASS WebTransport constructor should reject protocol list '誤'
 PASS WebTransport constructor should reject protocol list 'test,test'
 PASS WebTransport constructor should reject protocol list 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+PASS WebTransport constructor should reject protocol list '\r'
+PASS WebTransport constructor should reject protocol list '
+'
+PASS WebTransport constructor should reject protocol list 'a\rb'
+PASS WebTransport constructor should reject protocol list 'a
+b'
+PASS WebTransport constructor should reject protocol list '\0'
+PASS WebTransport constructor should reject protocol list ''
+PASS WebTransport constructor should reject protocol list ''
 PASS WebTransport constructor should allow options {"allowPooling":true}
 PASS WebTransport constructor should allow options {"requireUnreliable":true}
 PASS WebTransport constructor should allow options {"allowPooling":true,"requireUnreliable":true}

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.js
@@ -25,6 +25,15 @@ const BAD_PROTOCOL_LISTS = [
   ['\u8AA4'],
   ['test', 'test'],
   ['a'.repeat(513)],
+  // Control characters are not valid in HTTP header fields and cannot appear
+  // in Structured Fields strings (RFC 8941).
+  ['\r'],
+  ['\n'],
+  ['a\rb'],
+  ['a\nb'],
+  ['\x00'],
+  ['\x01'],
+  ['\x7f'],
 ];
 
 for (const protocols of BAD_PROTOCOL_LISTS) {

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.serviceworker-expected.txt
@@ -11,6 +11,15 @@ PASS WebTransport constructor should reject protocol list ''
 PASS WebTransport constructor should reject protocol list '誤'
 PASS WebTransport constructor should reject protocol list 'test,test'
 PASS WebTransport constructor should reject protocol list 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+PASS WebTransport constructor should reject protocol list '\r'
+PASS WebTransport constructor should reject protocol list '
+'
+PASS WebTransport constructor should reject protocol list 'a\rb'
+PASS WebTransport constructor should reject protocol list 'a
+b'
+PASS WebTransport constructor should reject protocol list '\0'
+PASS WebTransport constructor should reject protocol list ''
+PASS WebTransport constructor should reject protocol list ''
 PASS WebTransport constructor should allow options {"allowPooling":true}
 PASS WebTransport constructor should allow options {"requireUnreliable":true}
 PASS WebTransport constructor should allow options {"allowPooling":true,"requireUnreliable":true}

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.sharedworker-expected.txt
@@ -11,6 +11,15 @@ PASS WebTransport constructor should reject protocol list ''
 PASS WebTransport constructor should reject protocol list '誤'
 PASS WebTransport constructor should reject protocol list 'test,test'
 PASS WebTransport constructor should reject protocol list 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+PASS WebTransport constructor should reject protocol list '\r'
+PASS WebTransport constructor should reject protocol list '
+'
+PASS WebTransport constructor should reject protocol list 'a\rb'
+PASS WebTransport constructor should reject protocol list 'a
+b'
+PASS WebTransport constructor should reject protocol list '\0'
+PASS WebTransport constructor should reject protocol list ''
+PASS WebTransport constructor should reject protocol list ''
 PASS WebTransport constructor should allow options {"allowPooling":true}
 PASS WebTransport constructor should allow options {"requireUnreliable":true}
 PASS WebTransport constructor should allow options {"allowPooling":true,"requireUnreliable":true}

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.worker-expected.txt
@@ -11,6 +11,15 @@ PASS WebTransport constructor should reject protocol list ''
 PASS WebTransport constructor should reject protocol list '誤'
 PASS WebTransport constructor should reject protocol list 'test,test'
 PASS WebTransport constructor should reject protocol list 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+PASS WebTransport constructor should reject protocol list '\r'
+PASS WebTransport constructor should reject protocol list '
+'
+PASS WebTransport constructor should reject protocol list 'a\rb'
+PASS WebTransport constructor should reject protocol list 'a
+b'
+PASS WebTransport constructor should reject protocol list '\0'
+PASS WebTransport constructor should reject protocol list ''
+PASS WebTransport constructor should reject protocol list ''
 PASS WebTransport constructor should allow options {"allowPooling":true}
 PASS WebTransport constructor should allow options {"requireUnreliable":true}
 PASS WebTransport constructor should allow options {"allowPooling":true,"requireUnreliable":true}

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -45,6 +45,7 @@
 #include "JSWebTransportCloseInfo.h"
 #include "JSWebTransportConnectionStats.h"
 #include "JSWebTransportSendStream.h"
+#include "RFC8941.h"
 #include "ReadableStream.h"
 #include "ScriptExecutionContextInlines.h"
 #include "SocketProvider.h"
@@ -86,17 +87,18 @@ ExceptionOr<Ref<WebTransport>> WebTransport::create(ScriptExecutionContext& cont
         return Exception { ExceptionCode::NotSupportedError };
 
     HashSet<String> uniqueProtocols;
+    Vector<String> escapedProtocols;
+    escapedProtocols.reserveInitialCapacity(options.protocols.size());
     for (auto& protocol : options.protocols) {
-        if (!isValidHTTPToken(protocol))
+        auto escapedProtocol = RFC8941::escapeString(protocol);
+        if (!escapedProtocol || escapedProtocol->isEmpty() || escapedProtocol->length() > 512)
             return Exception { ExceptionCode::SyntaxError };
 
-        auto utf8 = protocol.utf8();
-        if (utf8.isEmpty() || utf8.length() > 512)
+        if (!uniqueProtocols.add(*escapedProtocol).isNewEntry)
             return Exception { ExceptionCode::SyntaxError };
-
-        if (!uniqueProtocols.add(protocol).isNewEntry)
-            return Exception { ExceptionCode::SyntaxError };
+        escapedProtocols.append(WTF::move(*escapedProtocol));
     }
+    options.protocols = WTF::move(escapedProtocols);
 
     auto* globalObject = context.globalObject();
     if (!globalObject) {

--- a/Source/WebCore/platform/network/RFC8941.cpp
+++ b/Source/WebCore/platform/network/RFC8941.cpp
@@ -378,4 +378,22 @@ std::optional<HashMap<String, std::pair<ItemOrInnerList, Parameters>>> parseDict
     });
 }
 
+std::optional<String> escapeString(StringView input)
+{
+    // https://datatracker.ietf.org/doc/html/rfc8941#section-3.3.3
+    StringBuilder builder;
+    builder.reserveCapacity(input.length());
+    for (char16_t codeUnit : input.codeUnits()) {
+        if (codeUnit < 0x20 || codeUnit > 0x7E)
+            return std::nullopt;
+        if (codeUnit == '"')
+            builder.append("\\\""_s);
+        else if (codeUnit == '\\')
+            builder.append("\\\\"_s);
+        else
+            builder.append(static_cast<Latin1Character>(codeUnit));
+    }
+    return builder.toString();
+};
+
 } // namespace RFC8941

--- a/Source/WebCore/platform/network/RFC8941.h
+++ b/Source/WebCore/platform/network/RFC8941.h
@@ -67,6 +67,7 @@ using ItemOrInnerList = Variant<BareItem, InnerList>;
 WEBCORE_EXPORT std::optional<std::pair<BareItem, Parameters>> parseItemStructuredFieldValue(StringView header);
 WEBCORE_EXPORT std::optional<Vector<std::pair<ItemOrInnerList, Parameters>>> parseListStructuredFieldValue(StringView header);
 WEBCORE_EXPORT std::optional<HashMap<String, std::pair<ItemOrInnerList, Parameters>>> parseDictionaryStructuredFieldValue(StringView header);
+std::optional<String> escapeString(StringView);
 
 } // namespace RFC8941
 


### PR DESCRIPTION
#### 55d163721de6165adedc733fdf0ed90295df84a9
<pre>
[WebTransport] Escape WebTransportOptions.protocols according to RFC 8941
<a href="https://bugs.webkit.org/show_bug.cgi?id=321445">https://bugs.webkit.org/show_bug.cgi?id=321445</a>
<a href="https://rdar.apple.com/184538329">rdar://184538329</a>

Reviewed by Basuke Suzuki.

My initial implementation used isValidHTTPToken, which checks characters according to RFC 7230, Section 3.2.6.
Chrome and Firefox both behave like RFC 8941 Section 3.3.3, which allows all characters from U+0020 to U+007E
with escapes for &quot; and \.  Though the specification doesn&apos;t seem very clear to me, let&apos;s match behavior of
other browsers.  This will make us pass new tests from <a href="https://github.com/web-platform-tests/wpt/pull/61598">https://github.com/web-platform-tests/wpt/pull/61598</a>

* LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/connect.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/constructor.https.sub.any.worker-expected.txt:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::create):
* Source/WebCore/platform/network/RFC8941.cpp:
(RFC8941::escapeString):
* Source/WebCore/platform/network/RFC8941.h:

Canonical link: <a href="https://commits.webkit.org/318984@main">https://commits.webkit.org/318984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c03d856de2fe7b05525e17d34770608cf6e88f50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190058 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144173 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140280 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a743a71-0425-41c6-96c8-884fe2eeaa7b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120731 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42568 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40889 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40552 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1222 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191996 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53466 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149577 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54153 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149309 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43955 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126416 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121468 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52670 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15540 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52052 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52290 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52116 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->