### PR TITLE
[WPE][cross-toolchain-helper] serial-getty@ttyS0 restarts in a loop on the RPi bots

### DIFF
--- a/Tools/yocto/rpi/local-rpi3-32bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi3-32bits-mesa.conf
@@ -37,6 +37,11 @@ CONF_VERSION = "2"
 # Machine selection
 MACHINE = "raspberrypi3"
 
+# Disable the serial getty. The default console here is the mini UART (ttyS0), but the
+# firmware does not enable that port, so agetty fails with "not a tty" and systemd keeps
+# restarting it every 10 seconds forever.
+SERIAL_CONSOLES = ""
+
 # WPE Backend selection
 PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
 

--- a/Tools/yocto/rpi/local-rpi3-32bits-userland.conf
+++ b/Tools/yocto/rpi/local-rpi3-32bits-userland.conf
@@ -38,6 +38,11 @@ CONF_VERSION = "2"
 MACHINE = "raspberrypi3"
 DISABLE_VC4GRAPHICS = "1"
 
+# Disable the serial getty. The default console here is the mini UART (ttyS0), but the
+# firmware does not enable that port, so agetty fails with "not a tty" and systemd keeps
+# restarting it every 10 seconds forever.
+SERIAL_CONSOLES = ""
+
 # WPE Backend selection
 PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-rdk"
 PACKAGECONFIG:pn-wpebackend-rdk = "rpi input-libinput input-udev"

--- a/Tools/yocto/rpi/local-rpi3-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi3-64bits-mesa.conf
@@ -37,6 +37,11 @@ CONF_VERSION = "2"
 # Machine selection
 MACHINE = "raspberrypi3-64"
 
+# Disable the serial getty. The default console here is the mini UART (ttyS0), but the
+# firmware does not enable that port, so agetty fails with "not a tty" and systemd keeps
+# restarting it every 10 seconds forever.
+SERIAL_CONSOLES = ""
+
 # WPE Backend selection
 PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
 

--- a/Tools/yocto/rpi/local-rpi4-32bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi4-32bits-mesa.conf
@@ -37,6 +37,11 @@ CONF_VERSION = "2"
 # Machine selection
 MACHINE = "raspberrypi4"
 
+# Disable the serial getty. The default console here is the mini UART (ttyS0), but the
+# firmware does not enable that port, so agetty fails with "not a tty" and systemd keeps
+# restarting it every 10 seconds forever.
+SERIAL_CONSOLES = ""
+
 # WPE Backend selection
 PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
 

--- a/Tools/yocto/rpi/local-rpi4-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi4-64bits-mesa.conf
@@ -37,6 +37,11 @@ CONF_VERSION = "2"
 # Machine selection
 MACHINE = "raspberrypi4-64"
 
+# Disable the serial getty. The default console here is the mini UART (ttyS0), but the
+# firmware does not enable that port, so agetty fails with "not a tty" and systemd keeps
+# restarting it every 10 seconds forever.
+SERIAL_CONSOLES = ""
+
 # WPE Backend selection
 PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
 


### PR DESCRIPTION
#### 5863d45bdf1a85cb74d8e32b714984d5c2f5f93c
<pre>
[WPE][cross-toolchain-helper] serial-getty@ttyS0 restarts in a loop on the RPi bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=321449">https://bugs.webkit.org/show_bug.cgi?id=321449</a>

Reviewed by Carlos Alberto Lopez Perez.

meta-raspberrypi defaults SERIAL_CONSOLES to the mini UART (ttyS0) and the image
ships with serial-getty@ttyS0.service enabled. The firmware only powers up that
port when enable_uart=1 is set in config.txt, which we never set, so agetty fails.
However systemd will try to restart it every 10s, flooding the journal.

Nobody attaches a serial cable to these machines, so stop installing the getty.

* Tools/yocto/rpi/local-rpi3-32bits-mesa.conf:
* Tools/yocto/rpi/local-rpi3-32bits-userland.conf:
* Tools/yocto/rpi/local-rpi3-64bits-mesa.conf:
* Tools/yocto/rpi/local-rpi4-32bits-mesa.conf:
* Tools/yocto/rpi/local-rpi4-64bits-mesa.conf:

Canonical link: <a href="https://commits.webkit.org/319147@main">https://commits.webkit.org/319147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b5f21c8e10139c35359ba13be4a8a3386bbc937

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190071 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140283 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97106 "3 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120734 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42576 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40897 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40560 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1229 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192003 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53473 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149584 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54160 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149315 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27413 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43962 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121475 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52677 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15547 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->