### PR TITLE
[JSC] Cache FastStringifier's buffer pointer and length across property emission

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1529,29 +1529,53 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                 recordBufferFull();
                 return false;
             }
-            if (needComma)
-                buffer()[m_length++] = ',';
-            if constexpr (hasGap == HasGap::Yes)
-                appendNewLineAndIndentUnchecked();
-            buffer()[m_length] = '"';
 
-            if constexpr (std::same_as<CharType, char16_t>) {
-                if (stringCopyUpconvert(span, buffer() + m_length + 1)) [[unlikely]] {
-                    recordFailure("property name character needs escaping"_s);
-                    return false;
+            {
+                // m_dynamicBuffer has inline capacity, so buffer() can point inside this object
+                // next to m_length: stores through it may-alias the members, forcing the compiler
+                // to reload both after every store. Cache them instead. Scoped because the pointer
+                // dies at the next hasRemainingCapacity(), which can reallocate.
+                CharType* out = buffer();
+                unsigned length = m_length;
+
+                if (needComma)
+                    out[length++] = ',';
+
+                if constexpr (hasGap == HasGap::Yes) {
+                    // The callee reads m_length and advances it.
+                    m_length = length;
+                    appendNewLineAndIndentUnchecked();
+                    out = buffer();
+                    length = m_length;
                 }
-            } else {
-                if (stringCopySameType(span, buffer() + m_length + 1)) [[unlikely]] {
-                    recordFailure("property name character needs escaping"_s);
-                    return false;
+
+                out[length] = '"';
+
+                // Publish m_length before every bail-out.
+                if constexpr (std::same_as<CharType, char16_t>) {
+                    if (stringCopyUpconvert(span, out + length + 1)) [[unlikely]] {
+                        m_length = length;
+                        recordFailure("property name character needs escaping"_s);
+                        return false;
+                    }
+                } else {
+                    if (stringCopySameType(span, out + length + 1)) [[unlikely]] {
+                        m_length = length;
+                        recordFailure("property name character needs escaping"_s);
+                        return false;
+                    }
                 }
+
+                out[length + 1 + span.size()] = '"';
+                out[length + 1 + span.size() + 1] = ':';
+                length += 1 + span.size() + 2;
+                if constexpr (hasGap == HasGap::Yes)
+                    out[length++] = ' ';
+
+                // Mandatory, not bookkeeping: the next hasRemainingCapacity() sizes itself from
+                // m_length, so leaving a stale value here would under-count the space needed.
+                m_length = length;
             }
-
-            buffer()[m_length + 1 + span.size()] = '"';
-            buffer()[m_length + 1 + span.size() + 1] = ':';
-            m_length += 1 + span.size() + 2;
-            if constexpr (hasGap == HasGap::Yes)
-                buffer()[m_length++] = ' ';
 
             if constexpr (std::same_as<CharType, Latin1Character>) {
                 // Inlining String case here since it is too common.
@@ -1563,11 +1587,17 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                             recordBufferFull();
                             return false;
                         }
-                        buffer()[m_length] = '"';
-                        if (!stringCopySameType(valueString.data.span8(), buffer() + m_length + 1)) [[likely]] {
-                            buffer()[m_length + 1 + valueLength] = '"';
-                            m_length += 1 + valueLength + 1;
-                            return true;
+
+                        {
+                            // Same reason as the property name above; cache after the capacity check.
+                            CharType* out = buffer();
+                            unsigned length = m_length;
+                            out[length] = '"';
+                            if (!stringCopySameType(valueString.data.span8(), out + length + 1)) [[likely]] {
+                                out[length + 1 + valueLength] = '"';
+                                m_length = length + 1 + valueLength + 1;
+                                return true;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
#### ea3fbb33caa535e1284ece06efc997479ffe5896
<pre>
[JSC] Cache FastStringifier&apos;s buffer pointer and length across property emission
<a href="https://bugs.webkit.org/show_bug.cgi?id=321452">https://bugs.webkit.org/show_bug.cgi?id=321452</a>
<a href="https://rdar.apple.com/184544084">rdar://184544084</a>

Reviewed by Yusuke Suzuki.

append() writes the property name as buffer()[m_length] one character at a time,
and every store forces a reload of both members: m_dynamicBuffer has inline
capacity, so buffer() can point inside the object next to m_length, and a store
through it may alias them. The property-name block pays 19 reloads for 9 stores.

Cache both in locals for the two runs of writes that sit between capacity checks,
and publish m_length once at the end. The locals are captured after
hasRemainingCapacity(), which can reallocate, and m_length is published before
every exit -- hasRemainingCapacity() computes m_capacity - m_length, so a stale
value there would over-report free space and skip a needed grow.

Hot instantiation (Latin1, DynamicBuffer, HasGap::No): 1712 -&gt; 1648 bytes, loads
70 -&gt; 56, member reloads 26 -&gt; 12.

Canonical link: <a href="https://commits.webkit.org/318944@main">https://commits.webkit.org/318944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d2d37426471002d779c40748652bfee93e3362b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47608 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144185 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ee42c5e-3d17-401c-82b1-59fdbc4fb51e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53528 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/724a2118-0b6c-4dae-8fef-c598ccd79012) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161037 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/85bba984-6555-4a9f-9cde-959df0c66cc1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40899 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9522 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152982 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40563 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1234 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41140 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192008 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53478 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149588 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54165 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37175 "Too many flaky failures: http/tests/media/now-playing-info-default-artwork-favicon.html, http/tests/navigation/post-308-response.html, http/tests/privateClickMeasurement/store-private-click-measurement.html, http/tests/resourceLoadStatistics/grandfathering.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/iframe-srcdoc-external-script.html, http/tests/security/mixedContent/secure-page-navigates-to-basic-auth-insecure-page.https.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html, http/tests/websocket/tests/hybi/closed-port-delay.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149319 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27319 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43966 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126428 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121480 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52682 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15550 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52064 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52302 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52128 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->