### PR TITLE
AX: live and isolated tree don't agree on several attributes when a textarea ends in a line break

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/textarea-line-range-with-trailing-newline-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/textarea-line-range-with-trailing-newline-expected.txt
@@ -1,0 +1,60 @@
+Asserts the caret's line range for text control values that end in a line break.
+
+no trailing newline: value "one two ", caret at 8
+PASS: axField.numberOfCharacters === 8
+PASS: axField.stringForTextMarkerRange(lineRange) === "one two "
+PASS: axField.textMarkerRangeLength(lineRange) === 8
+
+trailing newline, caret on the blank final line: value "one two \n", caret at 9
+PASS: axField.numberOfCharacters === 9
+PASS: axField.stringForTextMarkerRange(lineRange) === ""
+PASS: axField.textMarkerRangeLength(lineRange) === 0
+PASS: lineEnd.isEqual(caret) === true
+
+trailing newline, caret on the first line: value "one two \n", caret at 4
+PASS: axField.numberOfCharacters === 9
+PASS: axField.stringForTextMarkerRange(lineRange) === "one two \n"
+PASS: axField.textMarkerRangeLength(lineRange) === 9
+
+two lines, caret starting the second: value "one two \nthree", caret at 9
+PASS: axField.numberOfCharacters === 14
+PASS: axField.stringForTextMarkerRange(lineRange) === "three"
+PASS: axField.textMarkerRangeLength(lineRange) === 5
+
+leading newline: value "one \ntwo three", caret at 5
+PASS: axField.numberOfCharacters === 14
+PASS: axField.stringForTextMarkerRange(lineRange) === "two three"
+PASS: axField.textMarkerRangeLength(lineRange) === 9
+
+only a newline, caret after it: value "\n", caret at 1
+PASS: axField.numberOfCharacters === 1
+PASS: axField.stringForTextMarkerRange(lineRange) === ""
+PASS: axField.textMarkerRangeLength(lineRange) === 0
+PASS: lineEnd.isEqual(caret) === true
+
+only a newline, caret before it: value "\n", caret at 0
+PASS: axField.numberOfCharacters === 1
+PASS: axField.stringForTextMarkerRange(lineRange) === "\n"
+PASS: axField.textMarkerRangeLength(lineRange) === 1
+
+two trailing newlines, caret on the blank final line: value "a\n\n", caret at 3
+PASS: axField.numberOfCharacters === 3
+PASS: axField.stringForTextMarkerRange(lineRange) === ""
+PASS: axField.textMarkerRangeLength(lineRange) === 0
+PASS: lineEnd.isEqual(caret) === true
+
+two trailing newlines, caret on the blank middle line: value "a\n\n", caret at 2
+PASS: axField.numberOfCharacters === 3
+PASS: axField.stringForTextMarkerRange(lineRange) === "\n"
+PASS: axField.textMarkerRangeLength(lineRange) === 1
+
+whitespace either side of a newline: value "  \n  ", caret at 5
+PASS: axField.numberOfCharacters === 5
+PASS: axField.stringForTextMarkerRange(lineRange) === "  "
+PASS: axField.textMarkerRangeLength(lineRange) === 2
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/textarea-line-range-with-trailing-newline.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/textarea-line-range-with-trailing-newline.html
@@ -1,0 +1,136 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- A text control whose value ends in a line break renders an empty final line, which
+     HTMLTextFormControlElement::setInnerTextValue gives a line box by appending a placeholder <br>.
+     That <br>'s newline is not a character of the value — innerTextValueFrom() strips one trailing
+     newline "that's collapsed out by rendering" — so the control's character count and its line
+     ranges must not count it. The isolated tree builds these answers from text runs, which model
+     rendered text and so do include that newline; these cases would then be one character long. -->
+<!-- The caret's line range is checked here rather than in the cross-platform character-count test
+     because it needs AXSelectedTextMarkerRange, which the iOS test runner doesn't implement (see
+     AccessibilityUIElement::selectedTextMarkerRange, which only mac overrides). -->
+<textarea id="warmup" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta0" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta1" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta2" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta3" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta4" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta5" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta6" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta7" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta8" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta9" style="width: 200px; height: 60px"></textarea>
+
+<script>
+var output = "Asserts the caret's line range for text control values that end in a line break.\n\n";
+
+// Every value is set before the accessibility tree is first built, so no case depends on the
+// isolated tree observing a mutation.
+var cases = [
+    { id: "ta0", label: "no trailing newline", value: "one two ", caret: 8, lineString: "one two ", lineLength: 8 },
+    { id: "ta1", label: "trailing newline, caret on the blank final line", value: "one two \n", caret: 9, lineString: "", lineLength: 0 },
+    { id: "ta2", label: "trailing newline, caret on the first line", value: "one two \n", caret: 4, lineString: "one two \n", lineLength: 9 },
+    { id: "ta3", label: "two lines, caret starting the second", value: "one two \nthree", caret: 9, lineString: "three", lineLength: 5 },
+    { id: "ta4", label: "leading newline", value: "one \ntwo three", caret: 5, lineString: "two three", lineLength: 9 },
+    { id: "ta5", label: "only a newline, caret after it", value: "\n", caret: 1, lineString: "", lineLength: 0 },
+    { id: "ta6", label: "only a newline, caret before it", value: "\n", caret: 0, lineString: "\n", lineLength: 1 },
+    { id: "ta7", label: "two trailing newlines, caret on the blank final line", value: "a\n\n", caret: 3, lineString: "", lineLength: 0 },
+    { id: "ta8", label: "two trailing newlines, caret on the blank middle line", value: "a\n\n", caret: 2, lineString: "\n", lineLength: 1 },
+    { id: "ta9", label: "whitespace either side of a newline", value: "  \n  ", caret: 5, lineString: "  ", lineLength: 2 },
+];
+
+for (var testCase of cases) {
+    var field = document.getElementById(testCase.id);
+    if (field.isContentEditable)
+        field.textContent = testCase.value;
+    else
+        field.value = testCase.value;
+    // Force layout so the value is laid out before the accessibility tree is built.
+    field.offsetHeight;
+}
+
+// expect() evaluates its expressions in its own scope, so the values it reads are globals.
+var axField, caret, lineRange, lineEnd, webArea;
+
+// The id of the text control the document's accessibility selection currently sits in, or null.
+function idOfFieldHoldingAccessibilitySelection() {
+    var selection = axField.selectedTextMarkerRange();
+    if (!selection)
+        return null;
+    var element = axField.accessibilityElementForTextMarker(axField.startTextMarkerForTextMarkerRange(selection));
+    // The marker points into the control's inner text, so walk out to the control itself.
+    while (element && !element.domIdentifier)
+        element = element.parentElement();
+    return element ? element.domIdentifier : null;
+}
+
+async function checkCase(testCase) {
+    var field = document.getElementById(testCase.id);
+    axField = await waitForElementById(testCase.id);
+    if (!axField) {
+        output += `FAIL: ${testCase.label}: no accessibility element for #${testCase.id}\n`;
+        return;
+    }
+
+    // The accessibility layer learns of the selection through a notification, so place the caret
+    // inside waitForNotification: that notification is the point at which the accessibility
+    // selection — which the text marker below is read from — has caught up. Waiting on this field's
+    // AXSelectedTextRange instead would be too weak, because that reflects the control's own
+    // selection, which setSelectionRange updates synchronously, so it can be satisfied while the
+    // accessibility selection still points into the field measured before this one.
+    await waitForNotification(webArea, "AXSelectedTextChanged", () => {
+        field.focus();
+        field.setSelectionRange(testCase.caret, testCase.caret);
+    });
+    var selectionFieldId = idOfFieldHoldingAccessibilitySelection();
+    if (selectionFieldId !== testCase.id) {
+        output += `FAIL: ${testCase.label}: the accessibility selection reached #${selectionFieldId}, not #${testCase.id}\n`;
+        return;
+    }
+
+    caret = axField.startTextMarkerForTextMarkerRange(axField.selectedTextMarkerRange());
+    lineRange = axField.lineTextMarkerRangeForTextMarker(caret);
+    lineEnd = axField.endTextMarkerForTextMarkerRange(lineRange);
+
+    output += `${testCase.label}: value ${JSON.stringify(testCase.value)}, caret at ${testCase.caret}\n`;
+    output += expect("axField.numberOfCharacters", `${testCase.value.length}`);
+    output += expect("axField.stringForTextMarkerRange(lineRange)", JSON.stringify(testCase.lineString));
+    output += expect("axField.textMarkerRangeLength(lineRange)", `${testCase.lineLength}`);
+    // A caret on the blank final line has nothing after it, so the line it reports must end where
+    // the caret is. Otherwise the line names a character past the end of the value.
+    if (!testCase.lineLength)
+        output += expect("lineEnd.isEqual(caret)", "true");
+    output += "\n";
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        webArea = accessibilityController.rootElement.childAtIndex(0);
+
+        // Warm up the selection machinery on a field this test doesn't measure, so that the first
+        // measured case doesn't race the accessibility tree's first selection update.
+        var warmUpField = document.getElementById("warmup");
+        await waitForElementById("warmup");
+        await waitForNotification(webArea, "AXSelectedTextChanged", () => {
+            warmUpField.focus();
+            warmUpField.setSelectionRange(0, 0);
+        });
+
+        for (var testCase of cases)
+            await checkCase(testCase);
+
+        debugEscaped(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/textarea-line-range-with-trailing-newline-expected.txt
+++ b/LayoutTests/accessibility/mac/textarea-line-range-with-trailing-newline-expected.txt
@@ -1,0 +1,60 @@
+Asserts the caret's line range for text control values that end in a line break.
+
+no trailing newline: value "one two ", caret at 8
+PASS: axField.numberOfCharacters === 8
+PASS: axField.stringForTextMarkerRange(lineRange) === "one two "
+PASS: axField.textMarkerRangeLength(lineRange) === 8
+
+trailing newline, caret on the blank final line: value "one two \n", caret at 9
+PASS: axField.numberOfCharacters === 9
+PASS: axField.stringForTextMarkerRange(lineRange) === ""
+PASS: axField.textMarkerRangeLength(lineRange) === 0
+PASS: lineEnd.isEqual(caret) === true
+
+trailing newline, caret on the first line: value "one two \n", caret at 4
+PASS: axField.numberOfCharacters === 9
+PASS: axField.stringForTextMarkerRange(lineRange) === "one two \n"
+PASS: axField.textMarkerRangeLength(lineRange) === 9
+
+two lines, caret starting the second: value "one two \nthree", caret at 9
+PASS: axField.numberOfCharacters === 14
+PASS: axField.stringForTextMarkerRange(lineRange) === "three"
+PASS: axField.textMarkerRangeLength(lineRange) === 5
+
+leading newline: value "one \ntwo three", caret at 5
+PASS: axField.numberOfCharacters === 14
+PASS: axField.stringForTextMarkerRange(lineRange) === "two three"
+PASS: axField.textMarkerRangeLength(lineRange) === 9
+
+only a newline, caret after it: value "\n", caret at 1
+PASS: axField.numberOfCharacters === 1
+PASS: axField.stringForTextMarkerRange(lineRange) === ""
+PASS: axField.textMarkerRangeLength(lineRange) === 0
+PASS: lineEnd.isEqual(caret) === true
+
+only a newline, caret before it: value "\n", caret at 0
+PASS: axField.numberOfCharacters === 1
+PASS: axField.stringForTextMarkerRange(lineRange) === "\n"
+PASS: axField.textMarkerRangeLength(lineRange) === 1
+
+two trailing newlines, caret on the blank final line: value "a\n\n", caret at 3
+PASS: axField.numberOfCharacters === 3
+PASS: axField.stringForTextMarkerRange(lineRange) === ""
+PASS: axField.textMarkerRangeLength(lineRange) === 0
+PASS: lineEnd.isEqual(caret) === true
+
+two trailing newlines, caret on the blank middle line: value "a\n\n", caret at 2
+PASS: axField.numberOfCharacters === 3
+PASS: axField.stringForTextMarkerRange(lineRange) === "\n"
+PASS: axField.textMarkerRangeLength(lineRange) === 1
+
+whitespace either side of a newline: value "  \n  ", caret at 5
+PASS: axField.numberOfCharacters === 5
+PASS: axField.stringForTextMarkerRange(lineRange) === "  "
+PASS: axField.textMarkerRangeLength(lineRange) === 2
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/textarea-line-range-with-trailing-newline.html
+++ b/LayoutTests/accessibility/mac/textarea-line-range-with-trailing-newline.html
@@ -1,0 +1,136 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- A text control whose value ends in a line break renders an empty final line, which
+     HTMLTextFormControlElement::setInnerTextValue gives a line box by appending a placeholder <br>.
+     That <br>'s newline is not a character of the value — innerTextValueFrom() strips one trailing
+     newline "that's collapsed out by rendering" — so the control's character count and its line
+     ranges must not count it. The isolated tree builds these answers from text runs, which model
+     rendered text and so do include that newline; these cases would then be one character long. -->
+<!-- The caret's line range is checked here rather than in the cross-platform character-count test
+     because it needs AXSelectedTextMarkerRange, which the iOS test runner doesn't implement (see
+     AccessibilityUIElement::selectedTextMarkerRange, which only mac overrides). -->
+<textarea id="warmup" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta0" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta1" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta2" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta3" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta4" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta5" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta6" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta7" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta8" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta9" style="width: 200px; height: 60px"></textarea>
+
+<script>
+var output = "Asserts the caret's line range for text control values that end in a line break.\n\n";
+
+// Every value is set before the accessibility tree is first built, so no case depends on the
+// isolated tree observing a mutation.
+var cases = [
+    { id: "ta0", label: "no trailing newline", value: "one two ", caret: 8, lineString: "one two ", lineLength: 8 },
+    { id: "ta1", label: "trailing newline, caret on the blank final line", value: "one two \n", caret: 9, lineString: "", lineLength: 0 },
+    { id: "ta2", label: "trailing newline, caret on the first line", value: "one two \n", caret: 4, lineString: "one two \n", lineLength: 9 },
+    { id: "ta3", label: "two lines, caret starting the second", value: "one two \nthree", caret: 9, lineString: "three", lineLength: 5 },
+    { id: "ta4", label: "leading newline", value: "one \ntwo three", caret: 5, lineString: "two three", lineLength: 9 },
+    { id: "ta5", label: "only a newline, caret after it", value: "\n", caret: 1, lineString: "", lineLength: 0 },
+    { id: "ta6", label: "only a newline, caret before it", value: "\n", caret: 0, lineString: "\n", lineLength: 1 },
+    { id: "ta7", label: "two trailing newlines, caret on the blank final line", value: "a\n\n", caret: 3, lineString: "", lineLength: 0 },
+    { id: "ta8", label: "two trailing newlines, caret on the blank middle line", value: "a\n\n", caret: 2, lineString: "\n", lineLength: 1 },
+    { id: "ta9", label: "whitespace either side of a newline", value: "  \n  ", caret: 5, lineString: "  ", lineLength: 2 },
+];
+
+for (var testCase of cases) {
+    var field = document.getElementById(testCase.id);
+    if (field.isContentEditable)
+        field.textContent = testCase.value;
+    else
+        field.value = testCase.value;
+    // Force layout so the value is laid out before the accessibility tree is built.
+    field.offsetHeight;
+}
+
+// expect() evaluates its expressions in its own scope, so the values it reads are globals.
+var axField, caret, lineRange, lineEnd, webArea;
+
+// The id of the text control the document's accessibility selection currently sits in, or null.
+function idOfFieldHoldingAccessibilitySelection() {
+    var selection = axField.selectedTextMarkerRange();
+    if (!selection)
+        return null;
+    var element = axField.accessibilityElementForTextMarker(axField.startTextMarkerForTextMarkerRange(selection));
+    // The marker points into the control's inner text, so walk out to the control itself.
+    while (element && !element.domIdentifier)
+        element = element.parentElement();
+    return element ? element.domIdentifier : null;
+}
+
+async function checkCase(testCase) {
+    var field = document.getElementById(testCase.id);
+    axField = await waitForElementById(testCase.id);
+    if (!axField) {
+        output += `FAIL: ${testCase.label}: no accessibility element for #${testCase.id}\n`;
+        return;
+    }
+
+    // The accessibility layer learns of the selection through a notification, so place the caret
+    // inside waitForNotification: that notification is the point at which the accessibility
+    // selection — which the text marker below is read from — has caught up. Waiting on this field's
+    // AXSelectedTextRange instead would be too weak, because that reflects the control's own
+    // selection, which setSelectionRange updates synchronously, so it can be satisfied while the
+    // accessibility selection still points into the field measured before this one.
+    await waitForNotification(webArea, "AXSelectedTextChanged", () => {
+        field.focus();
+        field.setSelectionRange(testCase.caret, testCase.caret);
+    });
+    var selectionFieldId = idOfFieldHoldingAccessibilitySelection();
+    if (selectionFieldId !== testCase.id) {
+        output += `FAIL: ${testCase.label}: the accessibility selection reached #${selectionFieldId}, not #${testCase.id}\n`;
+        return;
+    }
+
+    caret = axField.startTextMarkerForTextMarkerRange(axField.selectedTextMarkerRange());
+    lineRange = axField.lineTextMarkerRangeForTextMarker(caret);
+    lineEnd = axField.endTextMarkerForTextMarkerRange(lineRange);
+
+    output += `${testCase.label}: value ${JSON.stringify(testCase.value)}, caret at ${testCase.caret}\n`;
+    output += expect("axField.numberOfCharacters", `${testCase.value.length}`);
+    output += expect("axField.stringForTextMarkerRange(lineRange)", JSON.stringify(testCase.lineString));
+    output += expect("axField.textMarkerRangeLength(lineRange)", `${testCase.lineLength}`);
+    // A caret on the blank final line has nothing after it, so the line it reports must end where
+    // the caret is. Otherwise the line names a character past the end of the value.
+    if (!testCase.lineLength)
+        output += expect("lineEnd.isEqual(caret)", "true");
+    output += "\n";
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        webArea = accessibilityController.rootElement.childAtIndex(0);
+
+        // Warm up the selection machinery on a field this test doesn't measure, so that the first
+        // measured case doesn't race the accessibility tree's first selection update.
+        var warmUpField = document.getElementById("warmup");
+        await waitForElementById("warmup");
+        await waitForNotification(webArea, "AXSelectedTextChanged", () => {
+            warmUpField.focus();
+            warmUpField.setSelectionRange(0, 0);
+        });
+
+        for (var testCase of cases)
+            await checkCase(testCase);
+
+        debugEscaped(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/text-marker/textarea-character-count-with-trailing-newline-expected.txt
+++ b/LayoutTests/accessibility/text-marker/textarea-character-count-with-trailing-newline-expected.txt
@@ -1,0 +1,28 @@
+Asserts the character count of text control values that end in a line break.
+
+no trailing newline: value "one two "
+PASS: axField.numberOfCharacters === 8
+
+trailing newline: value "one two \n"
+PASS: axField.numberOfCharacters === 9
+
+two lines, no trailing newline: value "one two \nthree"
+PASS: axField.numberOfCharacters === 14
+
+only a newline: value "\n"
+PASS: axField.numberOfCharacters === 1
+
+two trailing newlines: value "a\n\n"
+PASS: axField.numberOfCharacters === 3
+
+whitespace either side of a newline: value "  \n  "
+PASS: axField.numberOfCharacters === 5
+
+ARIA textbox, trailing newline: value "one two \n"
+PASS: axField.numberOfCharacters === 9
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/text-marker/textarea-character-count-with-trailing-newline.html
+++ b/LayoutTests/accessibility/text-marker/textarea-character-count-with-trailing-newline.html
@@ -1,0 +1,83 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- A text control whose value ends in a line break renders an empty final line, which
+     HTMLTextFormControlElement::setInnerTextValue gives a line box by appending a placeholder <br>.
+     That <br>'s newline is not a character of the value — innerTextValueFrom() strips one trailing
+     newline that's collapsed out by rendering — so the control's character count must not count it.
+     The isolated tree builds its answer from text runs, which model rendered text and so do include
+     that newline; these values would then be one character too long. -->
+<div id="content">
+<textarea id="ta0" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta1" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta2" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta3" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta4" style="width: 200px; height: 60px"></textarea>
+<textarea id="ta5" style="width: 200px; height: 60px"></textarea>
+<!-- An ARIA textbox is not a native text control: its text has no collapsed trailing line break, so
+     a trailing newline in it *is* a character and must still be counted. -->
+<div id="ce0" contenteditable role="textbox" style="width: 200px; white-space: pre-wrap"></div>
+</div>
+
+<script>
+var output = "Asserts the character count of text control values that end in a line break.\n\n";
+
+// Every value is set before the accessibility tree is first built, so no case depends on the
+// isolated tree observing a mutation.
+var cases = [
+    { id: "ta0", label: "no trailing newline", value: "one two " },
+    { id: "ta1", label: "trailing newline", value: "one two \n" },
+    { id: "ta2", label: "two lines, no trailing newline", value: "one two \nthree" },
+    { id: "ta3", label: "only a newline", value: "\n" },
+    { id: "ta4", label: "two trailing newlines", value: "a\n\n" },
+    { id: "ta5", label: "whitespace either side of a newline", value: "  \n  " },
+    { id: "ce0", label: "ARIA textbox, trailing newline", value: "one two \n" },
+];
+
+for (var testCase of cases) {
+    var field = document.getElementById(testCase.id);
+    if (field.isContentEditable)
+        field.textContent = testCase.value;
+    else
+        field.value = testCase.value;
+    // Force layout so the value is laid out before the accessibility tree is built.
+    field.offsetHeight;
+}
+
+// expect() evaluates its expressions in its own scope, so the values it reads are globals.
+var axField;
+
+async function checkCase(testCase) {
+    axField = await waitForElementById(testCase.id);
+    if (!axField) {
+        output += `FAIL: ${testCase.label}: no accessibility element for #${testCase.id}\n`;
+        return;
+    }
+
+    output += `${testCase.label}: value ${JSON.stringify(testCase.value)}\n`;
+    output += expect("axField.numberOfCharacters", `${testCase.value.length}`);
+    output += "\n";
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        for (var testCase of cases)
+            await checkCase(testCase);
+
+        // Hide the test content so the output is just the assertions above, with no page text dump.
+        document.getElementById("content").hidden = true;
+
+        debugEscaped(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2559,6 +2559,9 @@ accessibility/text-marker/text-marker-bidi-element-hebrew.html [ Skip ]
 # TextMarkerDebugDescription not implemented on iOS:
 accessibility/text-marker/text-marker-debug-description.html [ Skip ]
 
+# numberOfCharacters not implemented on iOS
+accessibility/text-marker/textarea-character-count-with-trailing-newline.html [ Skip ]
+
 # More flaky tests (Sept 18, 2015)
 
 fast/forms/select-element-focus-ring.html [ Failure Pass ]

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -972,6 +972,10 @@ public:
     // text field or the controls of a <video>. TextIterator walks the light DOM and so never emits
     // this text, and neither do the text-marker walks over document text.
     virtual bool isInUserAgentShadowTree() const = 0;
+    // True for the <br> a text control keeps at the end of its inner text when its value ends in a
+    // line break. It renders the empty final line but is not a character of the control's value,
+    // which strips it (see AccessibilityObject::isCollapsedTrailingLineBreak).
+    virtual bool isCollapsedTrailingLineBreak() const = 0;
     virtual AXTextRunLineID listMarkerLineID() const = 0;
     virtual String listMarkerText() const = 0;
     virtual FontOrientation fontOrientation() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -932,6 +932,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::IsColumnHeader:
         stream << "IsColumnHeader";
         break;
+    case AXProperty::IsCollapsedTrailingLineBreak:
+        stream << "IsCollapsedTrailingLineBreak";
+        break;
     case AXProperty::IsEnabled:
         stream << "IsEnabled";
         break;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -4330,7 +4330,14 @@ VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarker
     if (node->isPseudoElement())
         return { };
 
-    auto visiblePosition = VisiblePosition({ node.get(), textMarkerData.offset, textMarkerData.anchorType }, textMarkerData.affinity);
+    // Only the offset-in-anchor constructor takes an offset. A marker can be anchored before or
+    // after its node instead — the caret on the empty final line of a text control is anchored
+    // before the placeholder <br>, for instance — and those anchor types have their own constructor,
+    // which derives the offset from the node.
+    auto position = textMarkerData.anchorType == Position::PositionIsOffsetInAnchor
+        ? Position { node.get(), textMarkerData.offset, textMarkerData.anchorType }
+        : Position { node.get(), textMarkerData.anchorType };
+    auto visiblePosition = VisiblePosition(position, textMarkerData.affinity);
     auto deepPosition = visiblePosition.deepEquivalent();
     if (deepPosition.isNull())
         return { };

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -558,6 +558,79 @@ String listMarkerTextOnSameLine(const AXTextMarker& marker)
     }
     return { };
 }
+
+// Traverses from m_start to m_end, collecting all text along the way. See the declaration.
+template<typename AppendFunction>
+void AXTextMarkerRange::forEachTextPiece(IncludeListMarkerText includeListMarkerText, IncludeImageAltText includeImageAltText, NOESCAPE const AppendFunction& append) const
+{
+    auto markers = toValidTextRunMarkers();
+    if (!markers)
+        return;
+    auto& [start, end] = *markers;
+
+    // auxiliaryTextForObject needs the most recently emitted character to avoid doubling newlines.
+    char16_t lastEmittedCharacter = 0;
+    auto emit = [&] (StringView text) {
+        if (text.isEmpty())
+            return;
+        lastEmittedCharacter = text[text.length() - 1];
+        append(text);
+    };
+
+    if (includeListMarkerText == IncludeListMarkerText::Yes) {
+        String listMarkerText = listMarkerTextOnSameLine(start);
+        emit(listMarkerText);
+    }
+
+    if (start.isolatedObject() == end.isolatedObject()) {
+        size_t minOffset = std::min(start.offset(), end.offset());
+        size_t maxOffset = std::max(start.offset(), end.offset());
+        emit(start.runs()->substring(minOffset, maxOffset - minOffset));
+        return;
+    }
+
+    auto emitAuxiliaryText = [&] (AXIsolatedObject& object, TraversalPoint traversalPoint) {
+        if (traversalPoint == TraversalPoint::ReachedInPreOrder && includeImageAltText == IncludeImageAltText::Yes && object.isImage()) {
+            // This is an image, so add alt text (if it has any).
+            String description = object.description();
+            emit(description);
+            return;
+        }
+
+        emit(auxiliaryTextForObject(object, traversalPoint, lastEmittedCharacter).text);
+    };
+
+    emit(start.runs()->substring(start.offset()));
+
+    // FIXME: If we've been given reversed markers, i.e. the end marker actually comes before the start marker,
+    // we may want to detect this and try searching AXDirection::Previous?
+    RefPtr current = findObjectWithRuns(*start.isolatedObject(), AXDirection::Next, std::nullopt, emitAuxiliaryText, EnterUserAgentShadowContent::No);
+    while (current && current->objectID() != end.objectID()) {
+        emit(current->textRuns()->toStringView());
+        RefPtr next = findObjectWithRuns(*current, AXDirection::Next, std::nullopt, emitAuxiliaryText, EnterUserAgentShadowContent::No);
+        if (next == current) [[unlikely]] {
+            // findObjectWithRuns returned its input. Would loop forever.
+            AX_ASSERT_NOT_REACHED();
+            break;
+        }
+        current = WTF::move(next);
+    }
+    emit(end.runs()->substring(0, end.offset()));
+}
+
+// The length of what toString would return, without building the string. Text markers are queried
+// for lengths far more often than for text — AXNumberOfCharacters and AXLengthForTextMarkerRange ask
+// for nothing else, and the line walks below ask once per line — so those paths go through here.
+unsigned AXTextMarkerRange::length(IncludeListMarkerText includeListMarkerText) const
+{
+    AX_ASSERT(!isMainThread());
+
+    unsigned length = 0;
+    forEachTextPiece(includeListMarkerText, IncludeImageAltText::No, [&] (StringView piece) {
+        length += piece.length();
+    });
+    return length;
+}
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
 String AXTextMarkerRange::toString(IncludeListMarkerText includeListMarkerText, IncludeImageAltText includeImageAltText) const
@@ -568,50 +641,10 @@ String AXTextMarkerRange::toString(IncludeListMarkerText includeListMarkerText, 
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (!isMainThread()) {
-        // Traverses from m_start to m_end, collecting all text along the way.
-        auto markers = toValidTextRunMarkers();
-        if (!markers)
-            return emptyString();
-        auto& [start, end] = *markers;
-
         StringBuilder result;
-        if (includeListMarkerText == IncludeListMarkerText::Yes)
-            result.append(listMarkerTextOnSameLine(start));
-
-        if (start.isolatedObject() == end.isolatedObject()) {
-            size_t minOffset = std::min(start.offset(), end.offset());
-            size_t maxOffset = std::max(start.offset(), end.offset());
-            result.append(start.runs()->substring(minOffset, maxOffset - minOffset));
-            return result.toString();
-        }
-
-        auto emitAuxiliaryText = [&] (AXIsolatedObject& object, TraversalPoint traversalPoint) {
-            if (traversalPoint == TraversalPoint::ReachedInPreOrder && includeImageAltText == IncludeImageAltText::Yes && object.isImage()) {
-                // This is an image, so add alt text (if it has any).
-                result.append(object.description());
-                return;
-            }
-
-            char16_t lastEmittedCharacter = result.length() ? result[result.length() - 1] : 0;
-            result.append(auxiliaryTextForObject(object, traversalPoint, lastEmittedCharacter).text);
-        };
-
-        result.append(start.runs()->substring(start.offset()));
-
-        // FIXME: If we've been given reversed markers, i.e. the end marker actually comes before the start marker,
-        // we may want to detect this and try searching AXDirection::Previous?
-        RefPtr current = findObjectWithRuns(*start.isolatedObject(), AXDirection::Next, std::nullopt, emitAuxiliaryText, EnterUserAgentShadowContent::No);
-        while (current && current->objectID() != end.objectID()) {
-            result.append(current->textRuns()->toStringView());
-            RefPtr next = findObjectWithRuns(*current, AXDirection::Next, std::nullopt, emitAuxiliaryText, EnterUserAgentShadowContent::No);
-            if (next == current) [[unlikely]] {
-                // findObjectWithRuns returned its input. Would loop forever.
-                AX_ASSERT_NOT_REACHED();
-                break;
-            }
-            current = WTF::move(next);
-        }
-        result.append(end.runs()->substring(0, end.offset()));
+        forEachTextPiece(includeListMarkerText, includeImageAltText, [&] (StringView piece) {
+            result.append(piece);
+        });
         return result.toString();
     }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -833,7 +866,7 @@ CharacterRange AXTextMarker::characterRangeForLine(unsigned lineIndex) const
     // meaning we will compute a different length between these two APIs for the same logical range.
     auto currentLineRange = textRunMarker.lineRange(LineRangeType::Current, IncludeTrailingLineBreak::Yes);
     while (lineIndex && currentLineRange) {
-        precedingLength += currentLineRange.toString().length();
+        precedingLength += currentLineRange.length();
         currentLineRange = nextLineRange(currentLineRange, IncludeTrailingLineBreak::Yes, stopAtID);
         --lineIndex;
     }
@@ -841,7 +874,7 @@ CharacterRange AXTextMarker::characterRangeForLine(unsigned lineIndex) const
         return { };
     // Report the trailing blank line of a value ending in a line break as an empty range at the
     // document end, so it reads as an empty line rather than a line whose content is a newline.
-    unsigned lineLength = currentLineRange.toString().length();
+    unsigned lineLength = currentLineRange.length();
     if (isOnTrailingPlaceholderBlankLine(currentLineRange, lineLength, stopAtID))
         return CharacterRange(precedingLength, 0);
     return CharacterRange(precedingLength, lineLength);
@@ -883,7 +916,7 @@ int AXTextMarker::lineNumberForIndex(unsigned index) const
     unsigned lineNumber = 0;
     auto currentLineRange = textRunMarker.lineRange(LineRangeType::Current, IncludeTrailingLineBreak::Yes);
     while (currentLineRange) {
-        unsigned lineLength = currentLineRange.toString().length();
+        unsigned lineLength = currentLineRange.length();
         if (index < lineStart + lineLength) {
             // Report an index on the trailing blank line of a value ending in a line break as
             // out of range, matching the non-isolated AccessibilityRenderObject path: that line
@@ -919,6 +952,11 @@ bool AXTextMarker::atLineBoundaryForDirection(AXDirection direction) const
 
 bool AXTextMarker::atLineBoundaryForDirection(AXDirection direction, const AXTextRuns* runs, size_t runIndex) const
 {
+    // The empty final line of a text control holds no text (see isCollapsedTrailingLineBreak), so
+    // its only position is both its start and its end.
+    if (RefPtr object = isolatedObject(); object && object->isCollapsedTrailingLineBreak())
+        return true;
+
     RefPtr nextObjectWithRuns = findObjectWithRuns(*isolatedObject(), direction);
     // If the next object is a line break, it will often have the same line index as the previous static text
     // (even though it is a newline). In this case, advance one object to check the next line index.
@@ -1344,6 +1382,11 @@ AXTextMarker AXTextMarker::findLine(AXDirection direction, AXTextUnitBoundary bo
     const auto* currentRuns = currentObject->textRuns();
     auto origin = boundary == AXTextUnitBoundary::Start && direction == AXDirection::Previous ? TextMarkerOrigin::PreviousLineStart : TextMarkerOrigin::NextLineEnd;
 
+    // Both boundaries of that empty final line are the position before its newline (see
+    // isCollapsedTrailingLineBreak), which is as far as the main thread ever goes.
+    if (currentObject->isCollapsedTrailingLineBreak())
+        return { *currentObject, 0, origin };
+
     // If, for example, we are asked to find the next line end, and are at the very end of a line already,
     // we need the end position of the next line instead. Determine this by checking the next or previous marker.
     if (atLineBoundaryForDirection(direction, currentRuns, runIndex)) {
@@ -1419,7 +1462,13 @@ AXTextMarker AXTextMarker::findLine(AXDirection direction, AXTextUnitBoundary bo
         }
         currentObject = findObjectWithRuns(*currentObject, direction, stopAtID);
         if (currentObject) {
-            if (includeTrailingLineBreak == IncludeTrailingLineBreak::No && currentObject->role() == AccessibilityRole::LineBreak)
+            // Stop before a line break that ends the line we're measuring: with
+            // IncludeTrailingLineBreak::No because the caller doesn't want it, and always for a
+            // collapsed trailing line break (see isCollapsedTrailingLineBreak). Stopping rather than
+            // stepping into the latter leaves the empty final line to be reported as its own
+            // zero-length line by the walks in characterRangeForLine and lineNumberForIndex.
+            if (currentObject->role() == AccessibilityRole::LineBreak
+                && (includeTrailingLineBreak == IncludeTrailingLineBreak::No || currentObject->isCollapsedTrailingLineBreak()))
                 break;
             currentRuns = currentObject->textRuns();
             // Reset the runIndex to 0 or the maximum, since we should start iterating from the very beginning/end of the next object's runs, depending on the direction.

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -421,6 +421,8 @@ public:
     String toString(IncludeListMarkerText = IncludeListMarkerText::Yes, IncludeImageAltText = IncludeImageAltText::No) const;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    // The length of what toString returns, computed without building the string. AX-thread only.
+    unsigned length(IncludeListMarkerText = IncludeListMarkerText::Yes) const;
     std::optional<std::pair<AXTextMarker, AXTextMarker>> toValidTextRunMarkers() const;
     // Returns the bounds (frame) of the text in this range relative to the viewport.
     // Analagous to AXCoreObject::relativeFrame().
@@ -434,6 +436,16 @@ public:
     String description() const;
     String debugDescription() const;
 private:
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    // Hands each piece of this range's text to |append| in document order: the text of every run the
+    // range spans, plus the characters emitted between them (see auxiliaryTextForObject). toString
+    // and length both walk a range through here, so a string and its length can never disagree, and
+    // length never has to build the string. Each piece is a StringView into storage that outlives
+    // the |append| call.
+    template<typename AppendFunction>
+    void forEachTextPiece(IncludeListMarkerText, IncludeImageAltText, NOESCAPE const AppendFunction&) const;
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
     AXTextMarker m_start;
     AXTextMarker m_end;
 };

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -118,6 +118,7 @@
 #include "SharedBuffer.h"
 #include "TextCheckerClient.h"
 #include "TextCheckingHelper.h"
+#include "TextControlInnerElements.h"
 #include "TextIterator.h"
 #include "UserGestureIndicator.h"
 #include "VisibleUnits.h"
@@ -2127,6 +2128,25 @@ bool AccessibilityObject::isInUserAgentShadowTree() const
 {
     RefPtr node = this->node();
     return node && node->isInUserAgentShadowTree();
+}
+
+bool AccessibilityObject::isCollapsedTrailingLineBreak() const
+{
+    // True for the <br> that HTMLTextFormControlElement::setInnerTextValue appends to a text
+    // control's inner text when its value ends in a line break, so that the empty final line gets a
+    // line box.
+    //
+    // This <br> is rendered but is not part of the value: innerTextValueFrom() strips one trailing
+    // newline, which stripTrailingNewline() in HTMLTextFormControlElement.cpp explains is always
+    // collapsed out by rendering. So no main-thread position lies past it, and the value's character
+    // count and line ranges don't count it. Text runs model rendered text instead, so this <br> does
+    // carry a "\n" run — which is why the AX-thread implementations of those answers must not count
+    // it or step over it.
+    RefPtr node = this->node();
+    if (!node || !node->hasTagName(brTag))
+        return false;
+    RefPtr parent = node->parentNode();
+    return is<TextControlInnerTextElement>(parent) && parent->lastChild() == node;
 }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -441,6 +441,7 @@ public:
     TextEmissionBehavior textEmissionBehavior() const override { return TextEmissionBehavior::None; }
     bool isReplacedElementForTextEmission() const final;
     bool isInUserAgentShadowTree() const final;
+    bool isCollapsedTrailingLineBreak() const final;
     AXTextRunLineID listMarkerLineID() const override { return { }; }
     String listMarkerText() const override { return { }; }
     FontOrientation fontOrientation() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -111,6 +111,7 @@ public:
     TextEmissionBehavior textEmissionBehavior() const final;
     bool isReplacedElementForTextEmission() const final { return boolAttributeValue(AXProperty::IsReplacedElementForTextEmission); }
     bool isInUserAgentShadowTree() const final { return boolAttributeValue(AXProperty::IsInUserAgentShadowTree); }
+    bool isCollapsedTrailingLineBreak() const final { return boolAttributeValue(AXProperty::IsCollapsedTrailingLineBreak); }
     AXTextRunLineID listMarkerLineID() const final { return propertyValue<AXTextRunLineID>(AXProperty::ListMarkerLineID); };
     String listMarkerText() const final { return stringAttributeValue(AXProperty::ListMarkerText); }
     FontOrientation fontOrientation() const final { return propertyValue<FontOrientation>(AXProperty::FontOrientation); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -2269,6 +2269,8 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         setProperty(AXProperty::TextRuns, WTF::makeUnique<AXTextRuns>(object.textRuns()));
         setProperty(AXProperty::IsReplacedElementForTextEmission, object.isReplacedElementForTextEmission());
         setProperty(AXProperty::IsInUserAgentShadowTree, object.isInUserAgentShadowTree());
+        if (object.role() == AccessibilityRole::LineBreak)
+            setProperty(AXProperty::IsCollapsedTrailingLineBreak, object.isCollapsedTrailingLineBreak());
         switch (object.textEmissionBehavior()) {
         case TextEmissionBehavior::DoubleNewline:
             propertyFlags.add(AXPropertyFlag::IsTextEmissionBehaviorDoubleNewline);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -210,6 +210,7 @@ enum class AXProperty : uint16_t {
     IsBusy,
     IsChecked,
     IsColumnHeader,
+    IsCollapsedTrailingLineBreak,
     IsExpanded,
     IsExposableTable,
     IsFieldset,

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -206,7 +206,7 @@ std::optional<NSRange> AXIsolatedObject::visibleCharacterRange() const
         auto markerRange = textMarkerRange();
         if (!markerRange)
             return { };
-        return NSMakeRange(0, markerRange.toString().length());
+        return NSMakeRange(0, markerRange.length());
     }
 
     RefPtr current = const_cast<AXIsolatedObject*>(this);
@@ -249,7 +249,7 @@ std::optional<NSRange> AXIsolatedObject::visibleCharacterRange() const
 
                 // Points to the last text position of the text belonging to this object that *was not* painted.
                 markerPriorToPaintedText = AXTextMarker { *current, renderedCharactersPriorToStartLine };
-                finalRange.location = AXTextMarkerRange { WTF::move(thisFirstMarker), *markerPriorToPaintedText }.toString().length();
+                finalRange.location = AXTextMarkerRange { WTF::move(thisFirstMarker), *markerPriorToPaintedText }.length();
             }
             unsigned visibleCharactersUpToEndLine = currentRuns->runLengthSumTo(range.endLineIndex);
             lastVisibleMarker = AXTextMarker { *current, visibleCharactersUpToEndLine };
@@ -264,7 +264,7 @@ std::optional<NSRange> AXIsolatedObject::visibleCharacterRange() const
     }
 
     AXTextMarkerRange visibleTextRange = AXTextMarkerRange { WTF::move(*markerPriorToPaintedText), WTF::move(*lastVisibleMarker) };
-    finalRange.length = visibleTextRange.toString().length();
+    finalRange.length = visibleTextRange.length();
     return finalRange;
 }
 
@@ -350,7 +350,7 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRangeForNSRange(const NSRange& ran
     }
 
     if (std::optional markerRange = Accessibility::markerRangeFrom(range, *this)) {
-        if (range.length > markerRange->toString().length())
+        if (range.length > markerRange->length())
             return { };
         return WTF::move(*markerRange);
     }
@@ -368,7 +368,20 @@ unsigned AXIsolatedObject::textLength() const
     AX_ASSERT(isTextControl());
     AX_ASSERT(!isMainThread());
 
-    return textMarkerRange().toString().length();
+    // The marker range spans this control's rendered inner text, which is one character longer than
+    // its value when the value ends in a line break: rendering adds a placeholder <br> for the empty
+    // final line, and the text walks emit its newline. The main-thread implementation measures the
+    // value, so leave that newline out. See isCollapsedTrailingLineBreak().
+    auto range = textMarkerRange();
+    auto lastMarker = range.end().toTextRunMarker();
+    RefPtr lastObject = lastMarker.isolatedObject();
+    // Ask the range's last object rather than testing the text for a trailing newline: a control
+    // that isn't a native text control (an ARIA textbox, say) has no placeholder, so a newline
+    // ending its text is a character of it.
+    bool endsWithPlaceholderNewline = lastObject && lastObject->isCollapsedTrailingLineBreak() && lastMarker.offset();
+    unsigned length = range.length();
+    AX_ASSERT(!endsWithPlaceholderNewline || length);
+    return endsWithPlaceholderNewline && length ? length - 1 : length;
 }
 
 RetainPtr<id> AXIsolatedObject::remoteFramePlatformElement() const

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -4230,7 +4230,7 @@ static id handleLengthForTextMarkerRangeAttribute(WebAccessibilityObjectWrapper*
 {
     if (!isMainThread()) {
         AXTextMarkerRange range = { context.textMarkerRange };
-        return @(range.toString().length());
+        return @(range.length());
     }
 
     RefPtr<AXCoreObject> backingObject = wrapper.axBackingObject;

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -1412,6 +1412,9 @@ void AccessibilityUIElementIOS::removeSelection()
 // Text markers
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementIOS::lineTextMarkerRangeForTextMarker(AccessibilityTextMarker* textMarker)
 {
+    if (!textMarker)
+        return nullptr;
+
     id startTextMarker = [m_element lineStartMarkerForMarker:textMarker->platformTextMarker()];
     id endTextMarker = [m_element lineEndMarkerForMarker:textMarker->platformTextMarker()];
     if (!startTextMarker || !endTextMarker)
@@ -1430,6 +1433,9 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementIOS::textMarkerRangeF
 
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementIOS::misspellingTextMarkerRange(AccessibilityTextMarkerRange* start, bool forward)
 {
+    if (!start)
+        return nullptr;
+
     id misspellingRange = [m_element misspellingTextMarkerRange:start->platformTextMarkerRange() forward:forward];
     return AccessibilityTextMarkerRange::create(misspellingRange);
 }
@@ -1445,23 +1451,35 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementIOS::textMarkerRangeF
 
 int AccessibilityUIElementIOS::textMarkerRangeLength(AccessibilityTextMarkerRange* range)
 {
+    if (!range)
+        return -1;
+
     return [m_element lengthForTextMarkers:range->platformTextMarkerRange()];
 }
 
 RefPtr<AccessibilityTextMarker> AccessibilityUIElementIOS::previousTextMarker(AccessibilityTextMarker* textMarker)
 {
+    if (!textMarker)
+        return nullptr;
+
     id previousMarker = [m_element previousMarkerForMarker:textMarker->platformTextMarker()];
     return AccessibilityTextMarker::create(previousMarker);
 }
 
 RefPtr<AccessibilityTextMarker> AccessibilityUIElementIOS::nextTextMarker(AccessibilityTextMarker* textMarker)
 {
+    if (!textMarker)
+        return nullptr;
+
     id nextMarker = [m_element nextMarkerForMarker:textMarker->platformTextMarker()];
     return AccessibilityTextMarker::create(nextMarker);
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElementIOS::stringForTextMarkerRange(AccessibilityTextMarkerRange* markerRange)
 {
+    if (!markerRange)
+        return nullptr;
+
     id textMarkers = markerRange->platformTextMarkerRange();
     if (![textMarkers isKindOfClass:[NSArray class]])
         return createJSString();
@@ -1470,6 +1488,9 @@ JSRetainPtr<JSStringRef> AccessibilityUIElementIOS::stringForTextMarkerRange(Acc
 
 JSRetainPtr<JSStringRef> AccessibilityUIElementIOS::rectsForTextMarkerRange(AccessibilityTextMarkerRange* markerRange, JSStringRef text)
 {
+    if (!markerRange)
+        return nullptr;
+
     id textMarkers = markerRange->platformTextMarkerRange();
     if (![textMarkers isKindOfClass:[NSArray class]])
         return createJSString();
@@ -1478,6 +1499,9 @@ JSRetainPtr<JSStringRef> AccessibilityUIElementIOS::rectsForTextMarkerRange(Acce
 
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementIOS::textMarkerRangeForMarkers(AccessibilityTextMarker* startMarker, AccessibilityTextMarker* endMarker)
 {
+    if (!startMarker || !endMarker)
+        return nullptr;
+
     NSArray *textMarkers = @[startMarker->platformTextMarker(), endMarker->platformTextMarker()];
     id textMarkerRange = [m_element textMarkerRangeForMarkers:textMarkers];
     return AccessibilityTextMarkerRange::create(textMarkerRange);
@@ -1490,6 +1514,9 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementIOS::intersectTextMar
 
 RefPtr<AccessibilityTextMarker> AccessibilityUIElementIOS::startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange* range)
 {
+    if (!range)
+        return nullptr;
+
     id textMarkers = range->platformTextMarkerRange();
     id textMarker = [m_element startOrEndTextMarkerForTextMarkers:textMarkers isStart:YES];
     return AccessibilityTextMarker::create(textMarker);
@@ -1497,6 +1524,9 @@ RefPtr<AccessibilityTextMarker> AccessibilityUIElementIOS::startTextMarkerForTex
 
 RefPtr<AccessibilityTextMarker> AccessibilityUIElementIOS::endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange* range)
 {
+    if (!range)
+        return nullptr;
+
     id textMarkers = range->platformTextMarkerRange();
     id textMarker = [m_element startOrEndTextMarkerForTextMarkers:textMarkers isStart:NO];
     return AccessibilityTextMarker::create(textMarker);
@@ -1529,6 +1559,9 @@ RefPtr<AccessibilityTextMarker> AccessibilityUIElementIOS::textMarkerForPoint(in
 
 RefPtr<AccessibilityUIElement> AccessibilityUIElementIOS::accessibilityElementForTextMarker(AccessibilityTextMarker* marker)
 {
+    if (!marker)
+        return nullptr;
+
     id obj = [m_element accessibilityObjectForTextMarker:marker->platformTextMarker()];
     if (obj)
         return AccessibilityUIElement::create(obj);
@@ -1561,6 +1594,9 @@ bool AccessibilityUIElementIOS::attributedStringForTextMarkerRangeContainsAttrib
 
 int AccessibilityUIElementIOS::indexForTextMarker(AccessibilityTextMarker* marker)
 {
+    if (!marker)
+        return -1;
+
     return [m_element positionForTextMarker:(__bridge id)marker->platformTextMarker()];
 }
 
@@ -1636,6 +1672,9 @@ RefPtr<AccessibilityTextMarker> AccessibilityUIElementIOS::previousSentenceStart
 
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementIOS::textMarkerRangeMatchesTextNearMarkers(JSStringRef text, AccessibilityTextMarker* startMarker, AccessibilityTextMarker* endMarker)
 {
+    if (!startMarker || !endMarker)
+        return nullptr;
+
     NSArray *textMarkers = nil;
     if (startMarker->platformTextMarker() && endMarker->platformTextMarker())
         textMarkers = @[startMarker->platformTextMarker(), endMarker->platformTextMarker()];


### PR DESCRIPTION
#### ef1d7119a4db5d2a8bd38b5ec902625a2cd9322d
<pre>
AX: live and isolated tree don&apos;t agree on several attributes when a textarea ends in a line break
<a href="https://bugs.webkit.org/show_bug.cgi?id=321454">https://bugs.webkit.org/show_bug.cgi?id=321454</a>
<a href="https://rdar.apple.com/184544371">rdar://184544371</a>

Reviewed by Tyler Wilcock.

The character count and text marker range weren&apos;t consistent between the live tree and
isolated tree, for a textarea engine with a line break. Fix it by introducing a new
isCollapsedTrailingLineBreak() method and corresponding isolated node property, so
that it can be detected and stripped from the isolated tree.

Tests: accessibility/isolated-tree/mac/textarea-line-range-with-trailing-newline.html
       accessibility/mac/textarea-line-range-with-trailing-newline.html
       accessibility/text-marker/textarea-character-count-with-trailing-newline.html

* LayoutTests/accessibility/isolated-tree/mac/textarea-line-range-with-trailing-newline-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/textarea-line-range-with-trailing-newline.html: Added.
* LayoutTests/accessibility/mac/textarea-line-range-with-trailing-newline-expected.txt: Added.
* LayoutTests/accessibility/mac/textarea-line-range-with-trailing-newline.html: Added.
* LayoutTests/accessibility/text-marker/textarea-character-count-with-trailing-newline-expected.txt: Added.
* LayoutTests/accessibility/text-marker/textarea-character-count-with-trailing-newline.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::visiblePositionForTextMarkerData):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::forEachTextPiece const):
(WebCore::AXTextMarkerRange::length const):
(WebCore::AXTextMarkerRange::toString const):
(WebCore::AXTextMarker::characterRangeForLine const):
(WebCore::AXTextMarker::lineNumberForIndex const):
(WebCore::AXTextMarker::atLineBoundaryForDirection const):
(WebCore::AXTextMarker::findLine const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isCollapsedTrailingLineBreak const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::visibleCharacterRange const):
(WebCore::AXIsolatedObject::textMarkerRangeForNSRange const):
(WebCore::AXIsolatedObject::textLength const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(handleLengthForTextMarkerRangeAttribute):
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElementIOS::lineTextMarkerRangeForTextMarker):
(WTR::AccessibilityUIElementIOS::misspellingTextMarkerRange):
(WTR::AccessibilityUIElementIOS::textMarkerRangeLength):
(WTR::AccessibilityUIElementIOS::previousTextMarker):
(WTR::AccessibilityUIElementIOS::nextTextMarker):
(WTR::AccessibilityUIElementIOS::stringForTextMarkerRange):
(WTR::AccessibilityUIElementIOS::rectsForTextMarkerRange):
(WTR::AccessibilityUIElementIOS::textMarkerRangeForMarkers):
(WTR::AccessibilityUIElementIOS::startTextMarkerForTextMarkerRange):
(WTR::AccessibilityUIElementIOS::endTextMarkerForTextMarkerRange):
(WTR::AccessibilityUIElementIOS::accessibilityElementForTextMarker):
(WTR::AccessibilityUIElementIOS::indexForTextMarker):
(WTR::AccessibilityUIElementIOS::textMarkerRangeMatchesTextNearMarkers):

Canonical link: <a href="https://commits.webkit.org/319133@main">https://commits.webkit.org/319133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0a2fc2c094aac9251e1edc8844bc0fb452abec7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144442 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2d824f5-e01f-46e8-a89a-71059fd66307) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181986 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140478 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97284 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad89a2eb-5d5d-4c37-a364-e2402c51e7e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120930 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bed0cfcb-4eb1-4621-9a9a-c6b94a20e6e2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42805 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41116 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40789 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1494 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192269 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149830 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40213 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54423 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149552 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44193 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126686 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121803 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52940 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15775 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52322 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52559 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->