### PR TITLE
Cherry-pick 318964@main (848a9b915e9b). https://bugs.webkit.org/show_bug.cgi?id=311225

### DIFF
--- a/LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update-expected.html
+++ b/LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>foreignObject: SVG DOM 'x' property update repositions the element</title>
+<style>* { margin: 0; padding: 0; }</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <foreignObject x="100" y="50" width="150" height="100">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="background-color: green; width: 150px; height: 100px;"></div>
+  </foreignObject>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update.html
+++ b/LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>foreignObject: SVG DOM 'x' property update repositions the element</title>
+<link rel="match" href="foreignobject-svgdom-x-property-update-expected.html">
+<!-- Setting SVGForeignObjectElement.x.baseVal.value must reposition the foreignObject.
+     layout() derives the viewport from the resolved style, so the x/y presentation
+     hint style has to be invalidated when the SVG DOM property changes. This green
+     block must end up at x=100, exactly overlapping the reference. -->
+<style>* { margin: 0; padding: 0; }</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <foreignObject id="fo" x="-100" y="50" width="150" height="100">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="background-color: green; width: 150px; height: 100px;"></div>
+  </foreignObject>
+</svg>
+<script>
+  var fo = document.getElementById("fo");
+  // Force an initial layout at the wrong position, then move via the SVG DOM property.
+  document.body.offsetTop;
+  fo.x.baseVal.value = 100;
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update-expected.html
+++ b/LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>foreignObject: SVG DOM 'y' property update repositions the element</title>
+<style>* { margin: 0; padding: 0; }</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <foreignObject x="50" y="100" width="150" height="100">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="background-color: green; width: 150px; height: 100px;"></div>
+  </foreignObject>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update.html
+++ b/LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>foreignObject: SVG DOM 'y' property update repositions the element</title>
+<link rel="match" href="foreignobject-svgdom-y-property-update-expected.html">
+<!-- Setting SVGForeignObjectElement.y.baseVal.value must reposition the foreignObject.
+     layout() derives the viewport from the resolved style, so the x/y presentation
+     hint style has to be invalidated when the SVG DOM property changes. This green
+     block must end up at y=100, exactly overlapping the reference. -->
+<style>* { margin: 0; padding: 0; }</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <foreignObject id="fo" x="50" y="-100" width="150" height="100">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="background-color: green; width: 150px; height: 100px;"></div>
+  </foreignObject>
+</svg>
+<script>
+  var fo = document.getElementById("fo");
+  // Force an initial layout at the wrong position, then move via the SVG DOM property.
+  document.body.offsetTop;
+  fo.y.baseVal.value = 100;
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/notifications/NotificationPayload.h
+++ b/Source/WebCore/Modules/notifications/NotificationPayload.h
@@ -59,7 +59,7 @@ struct NotificationPayload {
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     WEBCORE_EXPORT static bool hasDeclarativeMessageHeader(const String& message);
     WEBCORE_EXPORT static ExceptionOr<NotificationPayload> parseJSON(const String&);
-    NotificationPayload static NODELETE fromNotificationData(const NotificationData&);
+    NotificationPayload static fromNotificationData(const NotificationData&);
 
     WEBCORE_EXPORT NotificationData toNotificationData() const;
 

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -73,7 +73,7 @@ public:
 
     void runCancelSteps(JSDOMGlobalObject&, JSC::JSValue, Function<void(std::optional<JSC::JSValue>&&)>&&);
     void runPullSteps(JSDOMGlobalObject&, Ref<ReadableStreamReadRequest>&&);
-    void NODELETE runReleaseSteps();
+    void runReleaseSteps();
 
     void storeError(JSDOMGlobalObject&, JSC::JSValue);
     JSC::JSValue NODELETE storedError() const;
@@ -142,7 +142,7 @@ private:
     void invalidateByobRequest();
     Vector<PullIntoDescriptor> processPullIntoDescriptorsUsingQueue();
     void enqueueDetachedPullIntoToQueue(JSDOMGlobalObject&, PullIntoDescriptor&);
-    PullIntoDescriptor NODELETE shiftPendingPullInto();
+    PullIntoDescriptor shiftPendingPullInto();
     void enqueueChunkToQueue(Ref<JSC::ArrayBuffer>&&, size_t byteOffset, size_t byteLength);
     void enqueueClonedChunkToQueue(JSDOMGlobalObject&, JSC::ArrayBuffer&, size_t byteOffset, size_t byteLength);
     void callPullIfNeeded(JSDOMGlobalObject&);

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
@@ -76,7 +76,7 @@ public:
 
     void read(JSDOMGlobalObject&, JSC::ArrayBufferView&, uint64_t, Ref<ReadableStreamReadIntoRequest>&&);
 
-    bool NODELETE isReachableFromOpaqueRoots() const;
+    bool isReachableFromOpaqueRoots() const;
     template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
 
 private:

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -198,9 +198,9 @@ void BaseAudioContext::clear()
 
     // Audio thread is dead. Nobody will schedule node deletion action. Let's do it ourselves.
     do {
-        m_nodesToDelete = std::exchange(m_nodesMarkedForDeletion, { });
+        m_nodesToDelete.appendVector(std::exchange(m_nodesMarkedForDeletion, { }));
         deleteMarkedNodes();
-    } while (!m_nodesToDelete.isEmpty());
+    } while (!m_nodesMarkedForDeletion.isEmpty());
 }
 
 void BaseAudioContext::uninitialize()

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.h
@@ -41,7 +41,7 @@ public:
     ~WebTransportDatagramsWritable();
 
     const RefPtr<WebTransportSendGroup>& NODELETE sendGroup();
-    void NODELETE setSendGroup(WebTransportSendGroup*);
+    void setSendGroup(WebTransportSendGroup*);
 
     int64_t NODELETE sendOrder();
     void NODELETE setSendOrder(int64_t);

--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,9 +1,5 @@
 Modules/indexeddb/server/IndexValueStore.cpp
-Modules/notifications/NotificationPayload.cpp
-Modules/streams/ReadableByteStreamController.cpp
-Modules/streams/ReadableStreamBYOBReader.cpp
 Modules/websockets/WebSocketChannelInspector.cpp
-Modules/webtransport/WebTransportDatagramsWritable.cpp
 css/DOMMatrixReadOnly.cpp
 css/SelectorChecker.cpp
 dom/ContainerNode.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -4,12 +4,8 @@ Modules/streams/ReadableByteStreamController.cpp
 Modules/streams/ReadableStreamBYOBReader.cpp
 Modules/websockets/WebSocketChannelInspector.cpp
 Modules/webtransport/WebTransportDatagramsWritable.cpp
-css/CSSComputedStyleDeclaration.cpp
-css/CSSPropertyInitialValues.cpp
 css/DOMMatrixReadOnly.cpp
 css/SelectorChecker.cpp
-css/StyleSheetList.cpp
-css/parser/CSSPropertyParserConsumer+String.cpp
 dom/ContainerNode.cpp
 dom/Document.cpp
 dom/Element.cpp

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.h
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.h
@@ -65,12 +65,12 @@ private:
     String NODELETE getPropertyPriority(const String& propertyName) final;
     String NODELETE getPropertyShorthand(const String& propertyName) final;
     bool NODELETE isPropertyImplicit(const String& propertyName) final;
-    ExceptionOr<void> NODELETE setProperty(const String& propertyName, const String& value, const String& priority) final;
+    ExceptionOr<void> setProperty(const String& propertyName, const String& value, const String& priority) final;
     ExceptionOr<String> removeProperty(const String& propertyName) final;
     String NODELETE cssText() const final;
-    ExceptionOr<void> NODELETE setCssText(const String&) final;
+    ExceptionOr<void> setCssText(const String&) final;
     String getPropertyValueInternal(CSSPropertyID) final;
-    ExceptionOr<void> NODELETE setPropertyInternal(CSSPropertyID, const String& value, IsImportant) final;
+    ExceptionOr<void> setPropertyInternal(CSSPropertyID, const String& value, IsImportant) final;
     Ref<MutableStyleProperties> copyProperties() const final;
 
     Element& element() const { return m_element; }

--- a/Source/WebCore/css/CSSPropertyInitialValues.cpp
+++ b/Source/WebCore/css/CSSPropertyInitialValues.cpp
@@ -55,7 +55,8 @@ static bool NODELETE isValueIDPair(const CSSValue& value, CSSValueID valueID)
     return value.isPair() && isValueID(value.first(), valueID) && isValueID(value.second(), valueID);
 }
 
-static bool NODELETE isNumber(const CSSPrimitiveValue& value, CSSPrimitiveValue::Raw number)
+// FIXME: SUPPRESS_NODELETE shouldn't be necessary.
+SUPPRESS_NODELETE static bool NODELETE isNumber(const CSSPrimitiveValue& value, CSSPrimitiveValue::Raw number)
 {
     return WTF::switchOn(value,
         [&](const CSSPrimitiveValue::Calc&) {
@@ -67,8 +68,9 @@ static bool NODELETE isNumber(const CSSPrimitiveValue& value, CSSPrimitiveValue:
     );
 }
 
+// FIXME: SUPPRESS_NODELETE shouldn't be necessary.
 template<auto unit>
-static bool NODELETE isNumber(const CSSPrimitiveValue& value, CSS::ValueLiteral<unit> literal)
+SUPPRESS_NODELETE static bool NODELETE isNumber(const CSSPrimitiveValue& value, CSS::ValueLiteral<unit> literal)
 {
     return WTF::switchOn(value,
         [&](const CSSPrimitiveValue::Calc&) {

--- a/Source/WebCore/css/DOMMatrixReadOnly.h
+++ b/Source/WebCore/css/DOMMatrixReadOnly.h
@@ -51,6 +51,11 @@ public:
     ~DOMMatrixReadOnly();
 
     enum class Is2D : bool { No, Yes };
+
+    struct AbstractMatrix {
+        TransformationMatrix matrix;
+        bool is2D { true };
+    };
     static Ref<DOMMatrixReadOnly> create(const TransformationMatrix& matrix, Is2D is2D)
     {
         return adoptRef(*new DOMMatrixReadOnly(matrix, is2D));
@@ -121,17 +126,12 @@ public:
 
     const TransformationMatrix& transformationMatrix() const LIFETIME_BOUND { return m_matrix; }
     
-    Ref<DOMMatrix> NODELETE cloneAsDOMMatrix() const;
+    Ref<DOMMatrix> cloneAsDOMMatrix() const;
 
 protected:
     DOMMatrixReadOnly() = default;
     DOMMatrixReadOnly(const TransformationMatrix&, Is2D);
     DOMMatrixReadOnly(TransformationMatrix&&, Is2D);
-
-    struct AbstractMatrix {
-        TransformationMatrix matrix;
-        bool is2D { true };
-    };
 
     static ExceptionOr<AbstractMatrix> parseStringIntoAbstractMatrix(Document&, const String&);
 

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -309,7 +309,7 @@ inline static bool hasScrollbarPseudoElement(EnumSet<PseudoElementType> collecte
     return collectedPseudoElements.contains(PseudoElementType::WebKitResizer);
 }
 
-static SelectorChecker::LocalContext NODELETE localContextForParent(const SelectorChecker::LocalContext& context)
+static SelectorChecker::LocalContext localContextForParent(const SelectorChecker::LocalContext& context)
 {
     SelectorChecker::LocalContext updatedContext(context);
     // Disable :visited matching when we see the first link.

--- a/Source/WebCore/css/StyleSheetList.h
+++ b/Source/WebCore/css/StyleSheetList.h
@@ -47,7 +47,7 @@ public:
 
     CSSStyleSheet* namedItem(const AtomString&) const;
     bool isSupportedPropertyName(const AtomString&) const;
-    Vector<AtomString> NODELETE supportedPropertyNames();
+    Vector<AtomString> supportedPropertyNames();
 
     Node* NODELETE ownerNode() const;
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+String.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+String.h
@@ -41,7 +41,7 @@ namespace CSSPropertyParserHelpers {
 // https://drafts.csswg.org/css-values/#strings
 
 StringView NODELETE consumeStringRaw(CSSParserTokenRange&);
-std::optional<CSS::String> NODELETE consumeUnresolvedString(CSSParserTokenRange&);
+std::optional<CSS::String> consumeUnresolvedString(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeString(CSSParserTokenRange&);
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/values/color/CSSKeywordColor.cpp
+++ b/Source/WebCore/css/values/color/CSSKeywordColor.cpp
@@ -72,7 +72,7 @@ bool isSystemColorKeyword(CSSValueID id)
     return (id >= CSSValueCanvas && id <= CSSValueInternalDocumentTextColor) || isDeprecatedSystemColorKeyword(id);
 }
 
-bool isDeprecatedSystemColorKeyword(CSSValueID id)
+SUPPRESS_NODELETE bool isDeprecatedSystemColorKeyword(CSSValueID id)
 {
     if (id == CSSValueText)
 #if PLATFORM(COCOA)

--- a/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -89,13 +89,9 @@ void SVGForeignObjectElement::svgAttributeChanged(const QualifiedName& attrName)
 {
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         InstanceInvalidationGuard guard(*this);
-        if (attrName == SVGNames::widthAttr || attrName == SVGNames::heightAttr)
-            setPresentationalHintStyleIsDirty();
-        else {
-            ASSERT(attrName == SVGNames::xAttr || attrName == SVGNames::yAttr);
+        setPresentationalHintStyleIsDirty();
+        if (attrName == SVGNames::xAttr || attrName == SVGNames::yAttr)
             updateRelativeLengthsInformation();
-            updateSVGRendererForElementChange();
-        }
         return;
     }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -85,23 +85,16 @@ WEBKIT_DEFINE_FINAL_TYPE(WebKitFaviconDatabase, webkit_favicon_database, G_TYPE_
 static void webkit_favicon_database_class_init(WebKitFaviconDatabaseClass* faviconDatabaseClass)
 {
 #if PLATFORM(GTK)
-    /**
-     * WebKitFaviconDatabase::favicon-changed:
-     * @database: the object on which the signal is emitted
-     * @page_uri: the URI of the Web page containing the icon
-     * @favicon_uri: the URI of the favicon
-     *
-     * This signal is emitted when the favicon URI of @page_uri has
-     * been changed to @favicon_uri in the database. You can connect
-     * to this signal and call webkit_favicon_database_get_favicon()
-     * to get the favicon. If you are interested in the favicon of a
-     * #WebKitWebView it's easier to use the #WebKitWebView:favicon
-     * property. See webkit_web_view_get_favicon() for more details.
-     */
+#if USE(GTK4)
+    static constexpr auto faviconChangedSignalFlags =
+        static_cast<GSignalFlags>(G_SIGNAL_RUN_LAST | G_SIGNAL_DEPRECATED);
+#else
+    static constexpr auto faviconChangedSignalFlags = G_SIGNAL_RUN_LAST;
+#endif // USE(GTK4)
     signals[FAVICON_CHANGED] = g_signal_new(
         "favicon-changed",
         G_TYPE_FROM_CLASS(faviconDatabaseClass),
-        G_SIGNAL_RUN_LAST,
+        faviconChangedSignalFlags,
         0, nullptr, nullptr,
         g_cclosure_marshal_generic,
         G_TYPE_NONE, 2,
@@ -221,25 +214,6 @@ void webkitFaviconDatabaseGetFaviconInternal(WebKitFaviconDatabase* database, co
         });
 }
 
-/**
- * webkit_favicon_database_get_favicon:
- * @database: a #WebKitFaviconDatabase
- * @page_uri: URI of the page for which we want to retrieve the favicon
- * @cancellable: (allow-none): A #GCancellable or %NULL.
- * @callback: (scope async) (nullable): A #GAsyncReadyCallback to call when the request is
- *            satisfied or %NULL if you don't care about the result.
- * @user_data: The data to pass to @callback.
- *
- * Asynchronously obtains a favicon image.
- *
- * Asynchronously obtains an image of the favicon for the
- * given page URI. It returns the cached icon if it's in the database
- * asynchronously waiting for the icon to be read from the database.
- *
- * This is an asynchronous method. When the operation is finished, callback will
- * be invoked. You can then call webkit_favicon_database_get_favicon_finish()
- * to get the result of the operation.
- */
 void webkit_favicon_database_get_favicon(WebKitFaviconDatabase* database, const gchar* pageURI, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
 {
     g_return_if_fail(WEBKIT_IS_FAVICON_DATABASE(database));
@@ -248,16 +222,6 @@ void webkit_favicon_database_get_favicon(WebKitFaviconDatabase* database, const 
     webkitFaviconDatabaseGetFaviconInternal(database, pageURI, false, cancellable, callback, userData);
 }
 
-/**
- * webkit_favicon_database_get_favicon_finish:
- * @database: a #WebKitFaviconDatabase
- * @result: A #GAsyncResult obtained from the #GAsyncReadyCallback passed to webkit_favicon_database_get_favicon()
- * @error: (allow-none): Return location for error or %NULL.
- *
- * Finishes an operation started with webkit_favicon_database_get_favicon().
- *
- * Returns: (transfer full): a new favicon image, or %NULL in case of error.
- */
 #if USE(GTK4)
 GdkTexture* webkit_favicon_database_get_favicon_finish(WebKitFaviconDatabase* database, GAsyncResult* result, GError** error)
 #else
@@ -283,16 +247,6 @@ cairo_surface_t* webkit_favicon_database_get_favicon_finish(WebKitFaviconDatabas
 #endif
 }
 
-/**
- * webkit_favicon_database_get_favicon_uri:
- * @database: a #WebKitFaviconDatabase
- * @page_uri: URI of the page containing the icon
- *
- * Obtains the URI of the favicon for the given @page_uri.
- *
- * Returns: a newly allocated URI for the favicon, or %NULL if the
- * database doesn't have a favicon for @page_uri.
- */
 gchar* webkit_favicon_database_get_favicon_uri(WebKitFaviconDatabase* database, const gchar* pageURL)
 {
     g_return_val_if_fail(WEBKIT_IS_FAVICON_DATABASE(database), nullptr);

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
@@ -124,4 +124,132 @@ webkit_favicon_database_clear              (WebKitFaviconDatabase *database);
 
 G_END_DECLS
 
+#if USE(GTK4)
+/**
+ * WebKitFaviconDatabase::favicon-changed:
+ * @database: the object on which the signal is emitted
+ * @page_uri: the URI of the Web page containing the icon
+ * @favicon_uri: the URI of the favicon
+ *
+ * This signal is emitted when the favicon URI of @page_uri has
+ * been changed to @favicon_uri in the database. You can connect
+ * to this signal and call webkit_favicon_database_get_favicon()
+ * to get the favicon. If you are interested in the favicon of a
+ * #WebKitWebView it's easier to use the #WebKitWebView:favicon
+ * property. See webkit_web_view_get_favicon() for more details.
+ *
+ * Deprecated: 2.54
+ */
+
+/**
+ * webkit_favicon_database_get_favicon:
+ * @database: a #WebKitFaviconDatabase
+ * @page_uri: URI of the page for which we want to retrieve the favicon
+ * @cancellable: (allow-none): A #GCancellable or %NULL.
+ * @callback: (scope async) (nullable): A #GAsyncReadyCallback to call when the request is
+ *            satisfied or %NULL if you don't care about the result.
+ * @user_data: The data to pass to @callback.
+ *
+ * Asynchronously obtains a favicon image.
+ *
+ * Asynchronously obtains an image of the favicon for the
+ * given page URI. It returns the cached icon if it's in the database
+ * asynchronously waiting for the icon to be read from the database.
+ *
+ * This is an asynchronous method. When the operation is finished, callback will
+ * be invoked. You can then call webkit_favicon_database_get_favicon_finish()
+ * to get the result of the operation.
+ *
+ * New applications should use [method@FaviconDatabase.get_page_icons] and
+ * [method@FaviconDatabase.get_page_icons_finish] instead.
+ *
+ * Deprecated: 2.54
+ */
+
+/**
+ * webkit_favicon_database_get_favicon_finish:
+ * @database: a #WebKitFaviconDatabase
+ * @result: A #GAsyncResult obtained from the #GAsyncReadyCallback passed to webkit_favicon_database_get_favicon()
+ * @error: (allow-none): Return location for error or %NULL.
+ *
+ * Finishes an operation started with webkit_favicon_database_get_favicon().
+ *
+ * New applications should use [method@FaviconDatabase.get_page_icons] and
+ * [method@FaviconDatabase.get_page_icons_finish] instead.
+ *
+ * Returns: (transfer full): a new favicon image, or %NULL in case of error.
+ *
+ * Deprecated: 2.54
+ */
+
+/**
+ * webkit_favicon_database_get_favicon_uri:
+ * @database: a #WebKitFaviconDatabase
+ * @page_uri: URI of the page containing the icon
+ *
+ * Obtains the URI of the favicon for the given @page_uri.
+ *
+ * Returns: a newly allocated URI for the favicon, or %NULL if the
+ * database doesn't have a favicon for @page_uri.
+ *
+ * Deprecated: 2.54
+ */
+#else
+/**
+ * WebKitFaviconDatabase::favicon-changed:
+ * @database: the object on which the signal is emitted
+ * @page_uri: the URI of the Web page containing the icon
+ * @favicon_uri: the URI of the favicon
+ *
+ * This signal is emitted when the favicon URI of @page_uri has
+ * been changed to @favicon_uri in the database. You can connect
+ * to this signal and call webkit_favicon_database_get_favicon()
+ * to get the favicon. If you are interested in the favicon of a
+ * #WebKitWebView it's easier to use the #WebKitWebView:favicon
+ * property. See webkit_web_view_get_favicon() for more details.
+ */
+
+/**
+ * webkit_favicon_database_get_favicon:
+ * @database: a #WebKitFaviconDatabase
+ * @page_uri: URI of the page for which we want to retrieve the favicon
+ * @cancellable: (allow-none): A #GCancellable or %NULL.
+ * @callback: (scope async) (nullable): A #GAsyncReadyCallback to call when the request is
+ *            satisfied or %NULL if you don't care about the result.
+ * @user_data: The data to pass to @callback.
+ *
+ * Asynchronously obtains a favicon image.
+ *
+ * Asynchronously obtains an image of the favicon for the
+ * given page URI. It returns the cached icon if it's in the database
+ * asynchronously waiting for the icon to be read from the database.
+ *
+ * This is an asynchronous method. When the operation is finished, callback will
+ * be invoked. You can then call webkit_favicon_database_get_favicon_finish()
+ * to get the result of the operation.
+ */
+
+/**
+ * webkit_favicon_database_get_favicon_finish:
+ * @database: a #WebKitFaviconDatabase
+ * @result: A #GAsyncResult obtained from the #GAsyncReadyCallback passed to webkit_favicon_database_get_favicon()
+ * @error: (allow-none): Return location for error or %NULL.
+ *
+ * Finishes an operation started with webkit_favicon_database_get_favicon().
+ *
+ * Returns: (transfer full): a new favicon image, or %NULL in case of error.
+ */
+
+/**
+ * webkit_favicon_database_get_favicon_uri:
+ * @database: a #WebKitFaviconDatabase
+ * @page_uri: URI of the page containing the icon
+ *
+ * Obtains the URI of the favicon for the given @page_uri.
+ *
+ * Returns: a newly allocated URI for the favicon, or %NULL if the
+ * database doesn't have a favicon for @page_uri.
+ */
+#endif // USE(GTK4)
+
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -1477,12 +1477,6 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
             WEBKIT_PARAM_READABLE);
 
 #if PLATFORM(GTK)
-    /**
-     * WebKitWebView:favicon:
-     *
-     * The favicon currently associated to the #WebKitWebView.
-     * See webkit_web_view_get_favicon() for more details.
-     */
     sObjProperties[PROP_FAVICON] =
 #if USE(GTK4)
         g_param_spec_object(
@@ -4016,19 +4010,6 @@ const gchar* webkit_web_view_get_uri(WebKitWebView* webView)
 }
 
 #if PLATFORM(GTK)
-/**
- * webkit_web_view_get_favicon:
- * @web_view: a #WebKitWebView
- *
- * Returns favicon currently associated to @web_view.
- *
- * Returns favicon currently associated to @web_view, if any. You can
- * connect to notify::favicon signal of @web_view to be notified when
- * the favicon is available.
- *
- * Returns: (transfer none): the favicon image or %NULL if there's no
- *    icon associated with @web_view.
- */
 #if USE(GTK4)
 GdkTexture* webkit_web_view_get_favicon(WebKitWebView* webView)
 #else

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -1091,6 +1091,60 @@ webkit_web_view_leave_immersive_mode                 (WebKitWebView             
  */
 #endif
 
+#if PLATFORM(GTK)
+#if USE(GTK4)
+/**
+ * WebKitWebView:favicon:
+ *
+ * The favicon currently associated to the #WebKitWebView.
+ * See webkit_web_view_get_favicon() for more details.
+ *
+ * New applications should use [property@WebView:page-icons] instead.
+ *
+ * Deprecated: 2.54
+ */
+
+/**
+ * webkit_web_view_get_favicon:
+ * @web_view: a #WebKitWebView
+ *
+ * Returns favicon currently associated to @web_view.
+ *
+ * Returns favicon currently associated to @web_view, if any. You can
+ * connect to notify::favicon signal of @web_view to be notified when
+ * the favicon is available.
+ *
+ * New applications should use [method@WebView.get_page_icons] instead.
+ *
+ * Returns: (transfer none): the favicon image or %NULL if there's no
+ *    icon associated with @web_view.
+ *
+ * Deprecated: 2.54
+ */
+#else
+/**
+ * WebKitWebView:favicon:
+ *
+ * The favicon currently associated to the #WebKitWebView.
+ * See webkit_web_view_get_favicon() for more details.
+ */
+
+/**
+ * webkit_web_view_get_favicon:
+ * @web_view: a #WebKitWebView
+ *
+ * Returns favicon currently associated to @web_view.
+ *
+ * Returns favicon currently associated to @web_view, if any. You can
+ * connect to notify::favicon signal of @web_view to be notified when
+ * the favicon is available.
+ *
+ * Returns: (transfer none): the favicon image or %NULL if there's no
+ *    icon associated with @web_view.
+ */
+#endif // USE(GTK4)
+#endif // PLATFORM(GTK)
+
 G_END_DECLS
 
 #endif

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -249,8 +249,11 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
         MemoryPressureHandler::singleton().setConfiguration(WTF::move(*parameters.memoryPressureHandlerConfiguration));
 
 #if ENABLE(REMOTE_INSPECTOR)
-    if (!parameters.inspectorServerAddress.isNull())
+    if (!parameters.inspectorServerAddress.isNull()) {
         Inspector::RemoteInspector::setInspectorServerAddress(WTF::move(parameters.inspectorServerAddress));
+        // pre-warm the inspector for the potentially early BiDi-related events like script.realmCreated
+        Inspector::RemoteInspector::singleton();
+    }
 #endif
 
 #if USE(ATSPI)

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -198,7 +198,7 @@
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
             },
             "test_add_event_handler_dom_content_loaded": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/302058"}}
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/302058"}, "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/302058"}}
             },
             "test_add_event_handler_download_will_begin": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288338"}}
@@ -210,7 +210,7 @@
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/287936"}}
             },
             "test_add_event_handler_load": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288340"}}
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288340"}, "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/288340"}}
             },
             "test_add_event_handler_navigation_committed": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/287934"}}


### PR DESCRIPTION
#### 7a1ca6a85456b695bdd07eb18142a89186d850d8
<pre>
Cherry-pick 318964@main (848a9b915e9b). <a href="https://bugs.webkit.org/show_bug.cgi?id=311225">https://bugs.webkit.org/show_bug.cgi?id=311225</a>

    [GTK4] Mark old favicon API as deprecated
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311225">https://bugs.webkit.org/show_bug.cgi?id=311225</a>

    Reviewed by Patrick Griffis.

    Deprecate the old favicon public API, and edit the documentation
    comments to refer to the new functions that may be used instead.

    * Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
    (webkit_favicon_database_class_init):
    * Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in:
    * Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
    (webkit_web_view_class_init):
    * Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:

    Canonical link: <a href="https://commits.webkit.org/318964@main">https://commits.webkit.org/318964@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.96@webkitglib/2.54">https://commits.webkit.org/317695.96@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### ea86346f1e002d3b36fc767fb624af30ada2b331
<pre>
Cherry-pick 318669@main (27a59f0ec20e). <a href="https://bugs.webkit.org/show_bug.cgi?id=321122">https://bugs.webkit.org/show_bug.cgi?id=321122</a>

Unreviewed backport.

    REGRESSION(313859@main): SVGForeignObjectElement dynamic x/y take no effect
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321122">https://bugs.webkit.org/show_bug.cgi?id=321122</a>

    Reviewed by Sam Weinig.

    Since 313859@main, LegacyRenderSVGForeignObject::layout() (and the LBSE
    RenderSVGForeignObject::layout()) derive the viewport geometry from the
    resolved style instead of the SVG animated properties. The x/y/width/height
    attributes are presentation attributes mapped to the CSS x/y/width/height
    properties, so the resolved style must be invalidated when they change.

    SVGForeignObjectElement::svgAttributeChanged() only marked the presentational
    hint style dirty for width/height. For x/y it invalidated the renderer without
    refreshing the presentation style, so a style recalc never happened and layout
    kept reading the stale x/y. Updating x/y via the SVG DOM property
    (x.baseVal.value = ...) therefore left the foreignObject at its old position.

    Mark the presentational hint style dirty for all four geometry attributes,
    matching how SVGRectElement handles its geometry attributes, and keep updating
    the relative-lengths information for x/y.

    Added new reftests to verify this functionality instead of relying on
    svg/dynamic-updates/SVGForeignObjectElement-svgdom-x-prop.html which only
    verify the logic through pixel testing, which isn&apos;t executed by default.

    * LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update-expected.html: Added.
    * LayoutTests/svg/foreignObject/foreignobject-svgdom-x-property-update.html: Added.
    * LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update-expected.html: Added.
    * LayoutTests/svg/foreignObject/foreignobject-svgdom-y-property-update.html: Added.
    * Source/WebCore/svg/SVGForeignObjectElement.cpp:
    (WebCore::SVGForeignObjectElement::svgAttributeChanged):

    Canonical link: <a href="https://commits.webkit.org/318669@main">https://commits.webkit.org/318669@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.95@webkitglib/2.54">https://commits.webkit.org/317695.95@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 1b52066fd9dc37aedb06d69bd5dfb094eea07f3d
<pre>
Cherry-pick 318136@main (8862b90b0bd7). <a href="https://bugs.webkit.org/show_bug.cgi?id=320512">https://bugs.webkit.org/show_bug.cgi?id=320512</a>

    Remove incorrect NODELETE annotations from Source/WebCore/Modules
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320512">https://bugs.webkit.org/show_bug.cgi?id=320512</a>

    Reviewed by Chris Dumez.

    Removed NODELETE annotations from various functions in Source/WebCore/Modules.

    * Source/WebCore/Modules/notifications/NotificationPayload.h:
    * Source/WebCore/Modules/streams/ReadableByteStreamController.h:
    * Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h:
    * Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.h:
    * Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations:

    Canonical link: <a href="https://commits.webkit.org/318136@main">https://commits.webkit.org/318136@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.94@webkitglib/2.54">https://commits.webkit.org/317695.94@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 942924a2391051ed647e457055173235b32c115e
<pre>
Cherry-pick 318810@main (65b1821f100e). <a href="https://bugs.webkit.org/show_bug.cgi?id=320518">https://bugs.webkit.org/show_bug.cgi?id=320518</a>

    Remove incorrect NODELETE annotations from Source/WebCore/css
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320518">https://bugs.webkit.org/show_bug.cgi?id=320518</a>

    Reviewed by Geoffrey Garen.

    Removed NODELETE annotations from a bunch of functions in Source/WebCore/css.

    * Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations:
    * Source/WebCore/css/CSSComputedStyleDeclaration.h:
    * Source/WebCore/css/CSSPropertyInitialValues.cpp:
    (WebCore::isNumber):
    * Source/WebCore/css/DOMMatrixReadOnly.h:
    * Source/WebCore/css/SelectorChecker.cpp:
    (WebCore::localContextForParent):
    * Source/WebCore/css/StyleSheetList.h:
    * Source/WebCore/css/parser/CSSPropertyParserConsumer+String.h:
    * Source/WebCore/css/values/color/CSSKeywordColor.cpp:
    (WebCore::CSS::isDeprecatedSystemColorKeyword):

    Canonical link: <a href="https://commits.webkit.org/318810@main">https://commits.webkit.org/318810@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.93@webkitglib/2.54">https://commits.webkit.org/317695.93@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 03cfb775f8e972d5d608ec74d18bde8bebdba0c0
<pre>
Cherry-pick 318867@main (9f39c1d4c9b0). <a href="https://bugs.webkit.org/show_bug.cgi?id=321367">https://bugs.webkit.org/show_bug.cgi?id=321367</a>

    BaseAudioContext::clear() leaks AudioNodes marked for deletion during uninitialize()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321367">https://bugs.webkit.org/show_bug.cgi?id=321367</a>
    <a href="https://rdar.apple.com/184421456">rdar://184421456</a>

    Reviewed by Chris Dumez.

    clear() assigned m_nodesMarkedForDeletion over m_nodesToDelete instead of appending
    to it. m_nodesToDelete is not necessarily empty on entry: uninitialize() sets
    m_isAudioThreadFinished before calling handleDeferredDecrementConnectionCounts() and
    handleDeferredDerefs(), and those reach markForDeletion(), which appends straight to
    m_nodesToDelete once the audio thread is finished, without the deleteMarkedNodes()
    call that the public deref() / decrementConnectionCount() wrappers make. Those nodes
    were dropped by the assignment. They are deleted by hand, and each holds a Ref to its
    context, so a single dropped node leaks the whole BaseAudioContext and its graph.

    The loop was dead too: deleteMarkedNodes() drains m_nodesToDelete, so the condition
    was always false and nodes marked while deleting other nodes were never collected.

    Append instead of assign and loop on m_nodesMarkedForDeletion, restoring the behavior
    from before 6eceb6d922f3, which drained before moving.

    No test: the deferred lists are only populated when the audio thread failed a
    tryLock() on the graph lock, so this cannot be triggered deterministically.

    * Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
    (WebCore::BaseAudioContext::clear):

    Canonical link: <a href="https://commits.webkit.org/318867@main">https://commits.webkit.org/318867@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.92@webkitglib/2.54">https://commits.webkit.org/317695.92@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### d6105d03c475000432040b7fe22fc35e8df848ab
<pre>
Cherry-pick 318898@main (2865d793ebdc). <a href="https://bugs.webkit.org/show_bug.cgi?id=321277">https://bugs.webkit.org/show_bug.cgi?id=321277</a>

    [WebDriver][GLIB] Flaky WPEWebProcess portal crashes in eager JSWindowProxy creation
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321277">https://bugs.webkit.org/show_bug.cgi?id=321277</a>

    Reviewed by Carlos Alberto Lopez Perez.

    Since 310527@main, WebAutomationSession::createBrowsingContext calls
    WebAutomationSessionProxy::ensureRealmForInitialEmptyDocument, which in
    turn tries to create an early JSWindowProxy for the realm. This can lead
    to a race in the RemoteInspector initialization, resulting in dbus
    critical messages in the portal negotiation.

    While this eager JSWindowProxy eager initialization is properly handled
    within bug310506, this commit works around this issue by pre-warming the
    RemoteInspector on the WebProcess when its address is set (e.g.
    automated pages), allowing the configuration to settle before
    ensureRealmForInitialEmptyDocument is called.

    Also, drive-by gardening of some related issues mistakenly attributed to
    this issue.

    * Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
    (WebKit::WebProcess::platformInitializeWebProcess):
    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/318898@main">https://commits.webkit.org/318898@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.91@webkitglib/2.54">https://commits.webkit.org/317695.91@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9a07022690f9252d87840deab5a8cf1722c0f7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180002 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/53948 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47744 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190214 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144321 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181864 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/55245 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53664 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140374 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144321 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182958 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/55245 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47744 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120825 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/55245 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53664 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47744 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/55245 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47744 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1371 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46547 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53664 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192146 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53614 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47744 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149714 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/54301 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47744 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149445 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27330 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/54301 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126564 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121645 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52818 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47744 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52200 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52438 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52264 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->