### PR TITLE
Declare the four macOS spellcheck editing actions on WKWebView

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -975,6 +975,13 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)_setSmartListsEnabled:(BOOL)flag WK_API_AVAILABLE(macos(26.4));
 - (void)_toggleSmartLists:(id)sender WK_API_AVAILABLE(macos(26.4));
 
+// These are deliberately not underscore-prefixed: they must match the AppKit responder chain
+// selectors exactly, and they mirror the equivalent declarations in WebKitLegacy's WebView.
+- (IBAction)checkSpelling:(id)sender WK_API_AVAILABLE(macos(27.0));
+- (IBAction)toggleContinuousSpellChecking:(id)sender WK_API_AVAILABLE(macos(27.0));
+- (IBAction)toggleGrammarChecking:(id)sender WK_API_AVAILABLE(macos(27.0));
+- (IBAction)toggleAutomaticSpellingCorrection:(id)sender WK_API_AVAILABLE(macos(27.0));
+
 - (void)_storePrivateClickMeasurementWithSourceID:(uint8_t)sourceID destinationURL:(NSURL *)destinationURL reportEndpoint:(NSURL *)reportEndpoint WK_API_AVAILABLE(macos(26.4));
 - (void)_storeSimulatedPrivateClickMeasurementConversionWithPriority:(uint8_t)priority triggerData:(uint8_t)triggerData sourceURL:(NSURL *)sourceURL destinationURL:(NSURL *)destinationURL WK_API_AVAILABLE(macos(26.4));
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -424,19 +424,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     _impl->showGuessPanel(sender);
 }
 
-- (IBAction)checkSpelling:(id)sender
-{
-    _impl->checkSpelling();
-}
-
 - (void)changeSpelling:(id)sender
 {
     _impl->changeSpelling(sender);
-}
-
-- (IBAction)toggleContinuousSpellChecking:(id)sender
-{
-    _impl->toggleContinuousSpellChecking();
 }
 
 - (BOOL)isGrammarCheckingEnabled
@@ -447,16 +437,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (void)setGrammarCheckingEnabled:(BOOL)flag
 {
     _impl->setGrammarCheckingEnabled(flag);
-}
-
-- (IBAction)toggleGrammarChecking:(id)sender
-{
-    _impl->toggleGrammarChecking();
-}
-
-- (IBAction)toggleAutomaticSpellingCorrection:(id)sender
-{
-    _impl->toggleAutomaticSpellingCorrection();
 }
 
 - (void)orderFrontSubstitutionsPanel:(id)sender
@@ -2259,6 +2239,30 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_toggleSmartLists:(id)sender
 {
     _impl->toggleSmartLists();
+}
+
+#pragma mark - Spell checking
+
+// These are not underscore-prefixed because they must match the AppKit responder chain selectors exactly.
+
+- (IBAction)checkSpelling:(id)sender
+{
+    _impl->checkSpelling();
+}
+
+- (IBAction)toggleContinuousSpellChecking:(id)sender
+{
+    _impl->toggleContinuousSpellChecking();
+}
+
+- (IBAction)toggleGrammarChecking:(id)sender
+{
+    _impl->toggleGrammarChecking();
+}
+
+- (IBAction)toggleAutomaticSpellingCorrection:(id)sender
+{
+    _impl->toggleAutomaticSpellingCorrection();
 }
 
 - (void)_storePrivateClickMeasurementWithSourceID:(uint8_t)sourceID destinationURL:(NSURL *)destinationURL reportEndpoint:(NSURL *)reportEndpoint


### PR DESCRIPTION
#### 30c68bb0b49a6fbb81919d5df7d97ea60a2f8588
<pre>
Declare the four macOS spellcheck editing actions on WKWebView
rdar://184422182

`checkSpelling:`, `toggleContinuousSpellChecking:`, `toggleGrammarChecking:` and
`toggleAutomaticSpellingCorrection:` have been implemented on WKWebView for years and are
validated by `WebViewImpl::validateUserInterfaceItem`, but no WKWebView header declares
them, so a client that wires them into a menu or the responder chain has no declaration to
compile against.

Declare all four in the `WKPrivateMac` category. They are deliberately not underscore
prefixed: they must match the AppKit responder chain selectors exactly, and they mirror the
equivalent declarations in WebKitLegacy&apos;s WebView (`WebView.h`, `WebViewPrivate.h`).

Declaring them in `WKPrivateMac` requires their implementations to live in that category
too, otherwise `-Wincomplete-implementation` fires, so move the four bodies out of the
file-local `WKImplementationMac` category. This is a move only; no behaviour changes.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView checkSpelling:]):
(-[WKWebView toggleContinuousSpellChecking:]):
(-[WKWebView toggleGrammarChecking:]):
(-[WKWebView toggleAutomaticSpellingCorrection:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30c68bb0b49a6fbb81919d5df7d97ea60a2f8588

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47644 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53564 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182858 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/43940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1270 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192045 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53514 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/160584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54201 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/149350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/43997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121520 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52718 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/15580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52100 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->