### PR TITLE
[JSC] Quick pattern matching for byte-copy loop in OMG

### DIFF
--- a/JSTests/wasm/stress/byte-loop-idiom-loop-osr.js
+++ b/JSTests/wasm/stress/byte-loop-idiom-loop-osr.js
@@ -1,0 +1,195 @@
+//@ runDefaultWasm("-m", "--useConcurrentJIT=0")
+
+// A byte-at-a-time copy or fill loop can be entered by OSR part way through its run, with the
+// pointers and the counter already advanced. What is left of the run then has to come out the same
+// whether it is finished by the loop or by the bulk memory operation that replaces it, so each
+// function here runs a count long enough to tier up in the middle of the loop.
+
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const PAGE = 65536;
+const COUNT = 30000;
+
+const golden = new Uint8Array(PAGE);
+for (let i = 0; i < PAGE; ++i)
+    golden[i] = (i * 31 + 7) & 0xff;
+
+let wat = `
+(module
+    (memory (export "mem") 1)
+    (global $d (mut i32) (i32.const 0))
+    (global $s (mut i32) (i32.const 0))
+    (global $n (mut i32) (i32.const 0))
+
+    ;; for (; n; --n) mem[d++] = mem[s++];
+    (func (export "copyForward") (param i32 i32 i32)
+        (local i32)
+        local.get 2
+        if
+            local.get 0
+            local.set 3
+            loop
+                local.get 3
+                local.get 1
+                i32.load8_u
+                i32.store8
+                local.get 3
+                i32.const 1
+                i32.add
+                local.set 3
+                local.get 1
+                i32.const 1
+                i32.add
+                local.set 1
+                local.get 2
+                i32.const 1
+                i32.sub
+                local.tee 2
+                br_if 0
+            end
+        end
+        local.get 3
+        global.set $d
+        local.get 1
+        global.set $s
+        local.get 2
+        global.set $n)
+
+    ;; for (; n; --n) mem[--d] = mem[--s];  -- the caller passes the ends of the regions.
+    (func (export "copyBackward") (param i32 i32 i32)
+        (local i32)
+        local.get 2
+        if
+            local.get 0
+            local.set 3
+            loop
+                local.get 3
+                i32.const 1
+                i32.sub
+                local.tee 3
+                local.get 1
+                i32.const 1
+                i32.sub
+                local.tee 1
+                i32.load8_u
+                i32.store8
+                local.get 2
+                i32.const 1
+                i32.sub
+                local.tee 2
+                br_if 0
+            end
+        end
+        local.get 3
+        global.set $d
+        local.get 1
+        global.set $s
+        local.get 2
+        global.set $n)
+
+    ;; for (; n; --n) mem[d++] = v;
+    (func (export "fill") (param i32 i32 i32)
+        (local i32)
+        local.get 2
+        if
+            local.get 0
+            local.set 3
+            loop
+                local.get 3
+                local.get 1
+                i32.store8
+                local.get 3
+                i32.const 1
+                i32.add
+                local.set 3
+                local.get 2
+                i32.const 1
+                i32.sub
+                local.tee 2
+                br_if 0
+            end
+        end
+        local.get 3
+        global.set $d
+        local.get 2
+        global.set $n)
+
+    (func (export "readD") (result i32) global.get $d)
+    (func (export "readS") (result i32) global.get $s)
+    (func (export "readN") (result i32) global.get $n)
+)
+`;
+
+async function test()
+{
+    const instance = await instantiate(wat, {}, {});
+    const { copyForward, copyBackward, fill, readD, readS, readN, mem } = instance.exports;
+    const memory = new Uint8Array(mem.buffer);
+    const expected = new Uint8Array(PAGE);
+
+    function seed()
+    {
+        memory.set(golden);
+        expected.set(golden);
+    }
+
+    function assertMemoryMatches()
+    {
+        let i = 0;
+        while (i < PAGE && memory[i] === expected[i])
+            ++i;
+        assert.eq(i, PAGE, "memory differs at index " + i);
+    }
+
+    // Overlapping with the destination below the source, which a bulk copy performs faithfully.
+    function copyMemmoveLike()
+    {
+        seed();
+        copyForward(0, 20000, COUNT);
+        expected.copyWithin(0, 20000, 20000 + COUNT);
+        assert.eq([readD(), readS(), readN()], [COUNT, 20000 + COUNT, 0]);
+        assertMemoryMatches();
+    }
+
+    // Overlapping the other way, which replicates a byte across the destination rather than moving
+    // the region, so the loop has to keep running after the OSR entry.
+    function copyReplicating()
+    {
+        seed();
+        copyForward(20000, 19999, COUNT);
+        for (let i = 0; i < COUNT; ++i)
+            expected[20000 + i] = expected[19999 + i];
+        assert.eq([readD(), readS(), readN()], [20000 + COUNT, 19999 + COUNT, 0]);
+        assertMemoryMatches();
+    }
+
+    function copyDownwards()
+    {
+        seed();
+        copyBackward(PAGE, PAGE - COUNT, COUNT);
+        expected.copyWithin(PAGE - COUNT, PAGE - 2 * COUNT, PAGE - COUNT);
+        assert.eq([readD(), readS(), readN()], [PAGE - COUNT, PAGE - 2 * COUNT, 0]);
+        assertMemoryMatches();
+    }
+
+    function fillRegion()
+    {
+        seed();
+        fill(1000, 0x5a, COUNT);
+        expected.fill(0x5a, 1000, 1000 + COUNT);
+        assert.eq([readD(), readN()], [1000 + COUNT, 0]);
+        assertMemoryMatches();
+    }
+
+    // The OSR entry happens on the run where the loop's own back edges tier the function up, which
+    // takes more than one run of a loop this long.
+    for (let repeat = 0; repeat < 4; ++repeat) {
+        copyMemmoveLike();
+        copyReplicating();
+        copyDownwards();
+        fillRegion();
+    }
+}
+
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/byte-loop-idiom-recognition.js
+++ b/JSTests/wasm/stress/byte-loop-idiom-recognition.js
@@ -1,0 +1,260 @@
+// Exercises the recognition of loops that copy or fill linear memory one byte per iteration,
+// which OMG compiles as a bulk memory operation instead. The bulk form is only faithful to the
+// loop for some inputs, so every case here is checked against a JavaScript model of the loop
+// itself: copies that overlap the wrong way replicate bytes rather than move them, a copy that
+// runs off the end of memory traps, and the loop leaves its pointer and counter locals at
+// specific values.
+
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const PAGE = 65536;
+
+// Every case in the matrix below touches memory inside this window, which leaves room on both sides
+// for a bulk operation that wrote outside the loop's range to show up as a difference.
+const WINDOW_BEGIN = 512;
+const WINDOW_END = 3072;
+
+const golden = new Uint8Array(PAGE);
+for (let i = 0; i < PAGE; ++i)
+    golden[i] = (i * 31 + 7) & 0xff;
+
+let wat = `
+(module
+    (memory (export "mem") 1)
+    (global $d (mut i32) (i32.const 0))
+    (global $s (mut i32) (i32.const 0))
+    (global $n (mut i32) (i32.const 0))
+
+    ;; for (; n; --n) mem[d++] = mem[s++];
+    (func (export "copyForward") (param i32 i32 i32)
+        (local i32)
+        local.get 2
+        if
+            local.get 0
+            local.set 3
+            loop
+                local.get 3
+                local.get 1
+                i32.load8_u
+                i32.store8
+                local.get 3
+                i32.const 1
+                i32.add
+                local.set 3
+                local.get 1
+                i32.const 1
+                i32.add
+                local.set 1
+                local.get 2
+                i32.const 1
+                i32.sub
+                local.tee 2
+                br_if 0
+            end
+        end
+        local.get 3
+        global.set $d
+        local.get 1
+        global.set $s
+        local.get 2
+        global.set $n)
+
+    ;; for (; n; --n) mem[--d] = mem[--s];  -- the caller passes the ends of the regions.
+    (func (export "copyBackward") (param i32 i32 i32)
+        (local i32)
+        local.get 2
+        if
+            local.get 0
+            local.set 3
+            loop
+                local.get 3
+                i32.const 1
+                i32.sub
+                local.tee 3
+                local.get 1
+                i32.const 1
+                i32.sub
+                local.tee 1
+                i32.load8_u
+                i32.store8
+                local.get 2
+                i32.const 1
+                i32.sub
+                local.tee 2
+                br_if 0
+            end
+        end
+        local.get 3
+        global.set $d
+        local.get 1
+        global.set $s
+        local.get 2
+        global.set $n)
+
+    ;; for (; n; --n) mem[d++] = v;
+    (func (export "fill") (param i32 i32 i32)
+        (local i32)
+        local.get 2
+        if
+            local.get 0
+            local.set 3
+            loop
+                local.get 3
+                local.get 1
+                i32.store8
+                local.get 3
+                i32.const 1
+                i32.add
+                local.set 3
+                local.get 2
+                i32.const 1
+                i32.sub
+                local.tee 2
+                br_if 0
+            end
+        end
+        local.get 3
+        global.set $d
+        local.get 2
+        global.set $n)
+
+    (func (export "readD") (result i32) global.get $d)
+    (func (export "readS") (result i32) global.get $s)
+    (func (export "readN") (result i32) global.get $n)
+)
+`;
+
+// The models throw where the wasm loop would trap, so the same function serves both the in-bounds
+// cases and the out-of-bounds ones.
+function access(i)
+{
+    if (i < 0 || i >= PAGE)
+        throw new RangeError("out of bounds");
+    return i;
+}
+
+function modelCopyForward(memory, d, s, n)
+{
+    if (n) {
+        do {
+            memory[access(d)] = memory[access(s)];
+            d = (d + 1) | 0;
+            s = (s + 1) | 0;
+        } while (--n);
+    }
+    return [d, s, n];
+}
+
+function modelCopyBackward(memory, d, s, n)
+{
+    if (n) {
+        do {
+            d = (d - 1) | 0;
+            s = (s - 1) | 0;
+            memory[access(d)] = memory[access(s)];
+        } while (--n);
+    }
+    return [d, s, n];
+}
+
+function modelFill(memory, d, v, n)
+{
+    if (n) {
+        do {
+            memory[access(d)] = v & 0xff;
+            d = (d + 1) | 0;
+        } while (--n);
+    }
+    return [d, n];
+}
+
+// Lengths bracket the sizes at which a bulk copy switches between vector, 64-bit, 32-bit and
+// byte moves, and the addresses cover overlap in both directions at several distances.
+const lengths = [1, 2, 3, 7, 8, 15, 16, 17, 31, 63, 127, 128, 129, 300];
+const addressPairs = [[1000, 2000], [2000, 1000], [1000, 1001], [1001, 1000], [1000, 1003], [1003, 1000], [1000, 1000]];
+
+async function test()
+{
+    const instance = await instantiate(wat, {}, {});
+    const { copyForward, copyBackward, fill, readD, readS, readN, mem } = instance.exports;
+    const memory = new Uint8Array(mem.buffer);
+    const expected = new Uint8Array(PAGE);
+
+    const goldenWindow = golden.subarray(WINDOW_BEGIN, WINDOW_END);
+
+    function seedWindow()
+    {
+        memory.set(goldenWindow, WINDOW_BEGIN);
+        expected.set(goldenWindow, WINDOW_BEGIN);
+    }
+
+    function seedEverything()
+    {
+        memory.set(golden);
+        expected.set(golden);
+    }
+
+    function assertMemoryMatches(begin, end)
+    {
+        let i = begin;
+        while (i < end && memory[i] === expected[i])
+            ++i;
+        assert.eq(i, end, "memory differs at index " + i);
+    }
+
+    function checkEveryCase()
+    {
+        for (const n of lengths) {
+            for (const [d, s] of addressPairs.concat([[1000, 1000 + n], [1000 + n, 1000]])) {
+                seedWindow();
+                copyForward(d, s, n);
+                assert.eq(modelCopyForward(expected, d, s, n), [readD(), readS(), readN()]);
+                assertMemoryMatches(WINDOW_BEGIN, WINDOW_END);
+
+                seedWindow();
+                copyBackward(d, s, n);
+                assert.eq(modelCopyBackward(expected, d, s, n), [readD(), readS(), readN()]);
+                assertMemoryMatches(WINDOW_BEGIN, WINDOW_END);
+
+                seedWindow();
+                fill(d, s, n);
+                assert.eq(modelFill(expected, d, s, n), [readD(), readN()]);
+                assertMemoryMatches(WINDOW_BEGIN, WINDOW_END);
+            }
+        }
+    }
+
+    // Check every case below OMG, then warm the functions up until OMG compiles them and check every
+    // case again there, since only OMG replaces the loops with a bulk operation.
+    for (let repeat = 0; repeat < 2; ++repeat) {
+        checkEveryCase();
+        for (let i = 0; i < wasmTestLoopCount; ++i) {
+            copyForward(1000, 2000, 64);
+            copyBackward(1500, 2500, 64);
+            fill(1000, 0x5a, 64);
+        }
+    }
+    checkEveryCase();
+
+    // A copy that runs off the end of memory must trap. How far it got before trapping is left
+    // unchecked, since the bulk operation and the loop need not agree on that.
+    function assertTraps(copy, model, d, s, n)
+    {
+        seedEverything();
+        assert.throws(() => model(expected, d, s, n), RangeError, "out of bounds");
+        assert.throws(() => copy(d, s, n), WebAssembly.RuntimeError, "Out of bounds memory access");
+    }
+    assertTraps(copyForward, modelCopyForward, PAGE - 10, 0, 40);
+    assertTraps(copyForward, modelCopyForward, 0, PAGE - 10, 40);
+    assertTraps(copyBackward, modelCopyBackward, 10, 4000, 40);
+    assertTraps(copyBackward, modelCopyBackward, 4000, 10, 40);
+
+    // Right up against the end of memory is in bounds and must not trap.
+    seedEverything();
+    copyForward(PAGE - 40, 0, 40);
+    modelCopyForward(expected, PAGE - 40, 0, 40);
+    assertMemoryMatches(0, PAGE);
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1279,6 +1279,7 @@
 		53F11F41209138D700E411A7 /* JSCellButterfly.h in Headers */ = {isa = PBXBuildFile; fileRef = 53F11F40209138D700E411A7 /* JSCellButterfly.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53F40E851D58F9770099A1B6 /* WasmSections.h in Headers */ = {isa = PBXBuildFile; fileRef = 53F40E841D58F9770099A1B6 /* WasmSections.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53F40E8B1D5901BB0099A1B6 /* WasmFunctionParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 53F40E8A1D5901BB0099A1B6 /* WasmFunctionParser.h */; };
+		E0EA80DE450D471DB60067AE /* WasmByteLoopIdiom.h in Headers */ = {isa = PBXBuildFile; fileRef = 59599FF72E2E412795C8979D /* WasmByteLoopIdiom.h */; };
 		53F40E8D1D5901F20099A1B6 /* WasmParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 53F40E8C1D5901F20099A1B6 /* WasmParser.h */; };
 		53F40E931D5A4AB30099A1B6 /* WasmOMGIRGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 53F40E921D5A4AB30099A1B6 /* WasmOMGIRGenerator.h */; };
 		53F6BF6D1C3F060A00F41E5D /* InternalFunctionAllocationProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 53F6BF6C1C3F060A00F41E5D /* InternalFunctionAllocationProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4703,6 +4704,7 @@
 		53F256E11B87E28000B4B768 /* JSTypedArrayViewPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSTypedArrayViewPrototype.cpp; sourceTree = "<group>"; };
 		53F40E841D58F9770099A1B6 /* WasmSections.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmSections.h; sourceTree = "<group>"; };
 		53F40E8A1D5901BB0099A1B6 /* WasmFunctionParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmFunctionParser.h; sourceTree = "<group>"; };
+		59599FF72E2E412795C8979D /* WasmByteLoopIdiom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmByteLoopIdiom.h; sourceTree = "<group>"; };
 		53F40E8C1D5901F20099A1B6 /* WasmParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmParser.h; sourceTree = "<group>"; };
 		53F40E8E1D5902820099A1B6 /* WasmOMGIRGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmOMGIRGenerator.cpp; sourceTree = "<group>"; };
 		53F40E921D5A4AB30099A1B6 /* WasmOMGIRGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmOMGIRGenerator.h; sourceTree = "<group>"; };
@@ -8374,6 +8376,7 @@
 				37AAC091279F124200D64842 /* WasmBranchHints.h */,
 				37AAC090279F124100D64842 /* WasmBranchHintsSectionParser.cpp */,
 				37AAC092279F124200D64842 /* WasmBranchHintsSectionParser.h */,
+				59599FF72E2E412795C8979D /* WasmByteLoopIdiom.h */,
 				525C0DD71E935847002184CD /* WasmCallee.cpp */,
 				525C0DD81E935847002184CD /* WasmCallee.h */,
 				526AC4B41E977C5D003500E1 /* WasmCalleeGroup.cpp */,
@@ -12826,6 +12829,7 @@
 				37AAC094279F1C0500D64842 /* WasmBranchHints.h in Headers */,
 				37AAC093279F1BFC00D64842 /* WasmBranchHintsSectionParser.h in Headers */,
 				FFB963922E38302B0069A70F /* WasmBreakpointManager.h in Headers */,
+				E0EA80DE450D471DB60067AE /* WasmByteLoopIdiom.h in Headers */,
 				525C0DDA1E935847002184CD /* WasmCallee.h in Headers */,
 				526AC4B71E977C5D003500E1 /* WasmCalleeGroup.h in Headers */,
 				53FD04D41D7AB291003287D3 /* WasmCallingConvention.h in Headers */,

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -565,6 +565,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Size, wasmSmallPartialCompileLimit, 5000, Normal, "Limit on the number of bytes a Wasm::Plan::compile should attempt for small wasm binary before checking for other work."_s) \
     v(Size, wasmLargePartialCompileLimit, 20000, Normal, "Limit on the number of bytes a Wasm::Plan::compile should attempt for large wasm binary before checking for other work."_s) \
     v(Unsigned, wasmOMGOptimizationLevel, Options::defaultB3OptLevel(), Normal, "B3 Optimization level for OMG Web Assembly module compilations."_s) \
+    v(Bool, useWasmByteLoopReplacement, true, Normal, "If true, OMG replaces a loop that copies or fills linear memory one byte per iteration with the equivalent bulk memory operation."_s) \
     \
     v(Bool, useBBQTierUpChecks, true, Normal, "Enables tier up checks for our BBQ code."_s) \
     v(Bool, useWasmOSR, true, Normal, nullptr) \

--- a/Source/JavaScriptCore/wasm/WasmByteLoopIdiom.h
+++ b/Source/JavaScriptCore/wasm/WasmByteLoopIdiom.h
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "Options.h"
+#include "WasmOps.h"
+#include "WasmParser.h"
+
+namespace JSC { namespace Wasm {
+
+// Pattern matches the byte-at-a-time copy and fill loops that a toolchain without the bulk memory
+// instructions emits for memcpy, memmove and memset, so that they can run as a single memory.copy or
+// memory.fill instead of roughly six instructions per byte.
+//
+// Matching is on raw bytecode rather than on IR, which covers an inlined callee just as well and is
+// cheap enough to run at every loop. Only memory 0 at a zero static offset matches, never a
+// multi-memory access, and only the three shapes below, exactly; anything else is left alone.
+class ByteLoopIdiom {
+public:
+    enum class Kind : uint8_t {
+        // for (; n; --n) mem[d++] = mem[s++];
+        CopyForward,
+        // for (; n; --n) mem[--d] = mem[--s];
+        CopyBackward,
+        // for (; n; --n) mem[d++] = v;
+        Fill,
+    };
+
+    Kind kind;
+    uint32_t destinationLocal { 0 };
+    // sourceLocal for a copy, the byte to store for a fill.
+    uint32_t operandLocal { 0 };
+    uint32_t countLocal { 0 };
+
+    bool isFill() const { return kind == Kind::Fill; }
+    bool isBackward() const { return kind == Kind::CopyBackward; }
+
+    static std::optional<ByteLoopIdiom> match(std::span<const uint8_t> source, size_t bodyOffset)
+    {
+        if (!Options::useWasmByteLoopReplacement()) [[unlikely]]
+            return std::nullopt;
+        if (auto idiom = matchCopyForward(source, bodyOffset))
+            return idiom;
+        if (auto idiom = matchCopyBackward(source, bodyOffset))
+            return idiom;
+        return matchFill(source, bodyOffset);
+    }
+
+private:
+    class Cursor final : public Parser<void> {
+    public:
+        Cursor(std::span<const uint8_t> source, size_t offset)
+            : Parser<void>(source)
+        {
+            m_offset = offset;
+        }
+
+        bool opcode(OpType expected)
+        {
+            uint8_t byte;
+            return parseUInt8(byte) && byte == expected;
+        }
+
+        bool opcodeWithImmediate(OpType expected, uint32_t& result)
+        {
+            return opcode(expected) && parseVarUInt32(result);
+        }
+
+        bool constantOne()
+        {
+            int32_t value;
+            return opcode(OpType::I32Const) && parseVarInt32(value) && value == 1;
+        }
+
+        // Only a plain access to memory 0 at offset 0 is matched; a memory index follows the
+        // alignment when its bit 6 is set.
+        bool byteAccess(OpType expected)
+        {
+            uint32_t alignment;
+            uint64_t offset;
+            return opcode(expected)
+                && parseVarUInt32(alignment)
+                && !(alignment & (1 << 6))
+                && parseVarUInt64(offset)
+                && !offset;
+        }
+
+        // local.get x; i32.const 1; <arithmetic>; local.set x  (or local.tee x)
+        bool updateLocalByOne(OpType arithmetic, OpType write, uint32_t& local)
+        {
+            uint32_t read;
+            uint32_t written;
+            if (!opcodeWithImmediate(OpType::GetLocal, read)
+                || !constantOne()
+                || !opcode(arithmetic)
+                || !opcodeWithImmediate(write, written)
+                || read != written)
+                return false;
+            local = read;
+            return true;
+        }
+
+        // The loop body must end right here, so that nothing else in it can have an effect.
+        bool continueThenEndOfBody()
+        {
+            uint32_t target;
+            return opcodeWithImmediate(OpType::BrIf, target) && !target && opcode(OpType::End);
+        }
+    };
+
+    bool localsAreDistinct() const
+    {
+        return destinationLocal != operandLocal && countLocal != destinationLocal && countLocal != operandLocal;
+    }
+
+    static std::optional<ByteLoopIdiom> matchCopyForward(std::span<const uint8_t> source, size_t bodyOffset)
+    {
+        Cursor cursor(source, bodyOffset);
+        ByteLoopIdiom idiom { Kind::CopyForward };
+        uint32_t firstAdvanced;
+        uint32_t secondAdvanced;
+        if (!cursor.opcodeWithImmediate(OpType::GetLocal, idiom.destinationLocal)
+            || !cursor.opcodeWithImmediate(OpType::GetLocal, idiom.operandLocal)
+            || !cursor.byteAccess(OpType::I32Load8U)
+            || !cursor.byteAccess(OpType::I32Store8)
+            || !cursor.updateLocalByOne(OpType::I32Add, OpType::SetLocal, firstAdvanced)
+            || !cursor.updateLocalByOne(OpType::I32Add, OpType::SetLocal, secondAdvanced)
+            || !cursor.updateLocalByOne(OpType::I32Sub, OpType::TeeLocal, idiom.countLocal)
+            || !cursor.continueThenEndOfBody())
+            return std::nullopt;
+        // The two pointers may be advanced in either order.
+        if (std::minmax(firstAdvanced, secondAdvanced) != std::minmax(idiom.destinationLocal, idiom.operandLocal))
+            return std::nullopt;
+        if (!idiom.localsAreDistinct())
+            return std::nullopt;
+        return idiom;
+    }
+
+    static std::optional<ByteLoopIdiom> matchCopyBackward(std::span<const uint8_t> source, size_t bodyOffset)
+    {
+        Cursor cursor(source, bodyOffset);
+        ByteLoopIdiom idiom { Kind::CopyBackward };
+        if (!cursor.updateLocalByOne(OpType::I32Sub, OpType::TeeLocal, idiom.destinationLocal)
+            || !cursor.updateLocalByOne(OpType::I32Sub, OpType::TeeLocal, idiom.operandLocal)
+            || !cursor.byteAccess(OpType::I32Load8U)
+            || !cursor.byteAccess(OpType::I32Store8)
+            || !cursor.updateLocalByOne(OpType::I32Sub, OpType::TeeLocal, idiom.countLocal)
+            || !cursor.continueThenEndOfBody()
+            || !idiom.localsAreDistinct())
+            return std::nullopt;
+        return idiom;
+    }
+
+    static std::optional<ByteLoopIdiom> matchFill(std::span<const uint8_t> source, size_t bodyOffset)
+    {
+        Cursor cursor(source, bodyOffset);
+        ByteLoopIdiom idiom { Kind::Fill };
+        uint32_t advanced;
+        if (!cursor.opcodeWithImmediate(OpType::GetLocal, idiom.destinationLocal)
+            || !cursor.opcodeWithImmediate(OpType::GetLocal, idiom.operandLocal)
+            || !cursor.byteAccess(OpType::I32Store8)
+            || !cursor.updateLocalByOne(OpType::I32Add, OpType::SetLocal, advanced)
+            || !cursor.updateLocalByOne(OpType::I32Sub, OpType::TeeLocal, idiom.countLocal)
+            || !cursor.continueThenEndOfBody()
+            || advanced != idiom.destinationLocal
+            || !idiom.localsAreDistinct())
+            return std::nullopt;
+        return idiom;
+    }
+};
+
+} } // namespace JSC::Wasm
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -71,6 +71,7 @@
 #include "ScratchRegisterAllocator.h"
 #include "WasmBaselineData.h"
 #include "WasmBranchHints.h"
+#include "WasmByteLoopIdiom.h"
 #include "WasmCallProfile.h"
 #include "WasmCallingConvention.h"
 #include "WasmContext.h"
@@ -758,6 +759,8 @@ public:
     [[nodiscard]] PartialResult addCurrentMemory(ExpressionType& result, uint8_t memoryIndex);
     [[nodiscard]] PartialResult addMemoryFill(ExpressionType dstAddress, ExpressionType targetValue, ExpressionType count, uint8_t memoryIndex);
     [[nodiscard]] PartialResult addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex);
+    void emitMemoryFill(Value* dstAddress, Value* targetValue, Value* count, uint8_t memoryIndex);
+    void emitMemoryCopy(Value* dstAddress, Value* srcAddress, Value* count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex);
     [[nodiscard]] PartialResult addMemoryInit(unsigned, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length, uint8_t memoryIndex);
     [[nodiscard]] PartialResult addDataDrop(unsigned);
 
@@ -822,6 +825,8 @@ public:
     [[nodiscard]] ControlData addTopLevel(BlockSignature&&);
     [[nodiscard]] PartialResult addBlock(BlockSignature&&, std::span<TypedExpression> args, ControlType& newBlock);
     [[nodiscard]] PartialResult addLoop(BlockSignature&&, std::span<TypedExpression> args, ControlType& block, uint32_t loopIndex);
+    std::optional<ByteLoopIdiom> matchByteLoopIdiom(const BlockSignature&);
+    void emitByteLoopIdiom(const ByteLoopIdiom&, ControlType& loop, BasicBlock* body);
     [[nodiscard]] PartialResult addIf(ExpressionType condition, BlockSignature&&, std::span<TypedExpression> args, ControlType& result);
     [[nodiscard]] PartialResult addElse(ControlData&, std::span<const TypedExpression>);
     [[nodiscard]] PartialResult addElseToUnreachable(ControlData&);
@@ -2114,10 +2119,13 @@ auto OMGIRGenerator::addCurrentMemory(ExpressionType& result, uint8_t memoryInde
 
 auto OMGIRGenerator::addMemoryFill(ExpressionType dstAddress, ExpressionType target, ExpressionType count, uint8_t memoryIndex) -> PartialResult
 {
-    auto* dstAddressValue = addressOperand(m_info.memory(memoryIndex).isMemory64(), dstAddress);
-    auto* targetValue = get(target);
-    auto* countValue = addressOperand(m_info.memory(memoryIndex).isMemory64(), count);
+    bool is64Bit = m_info.memory(memoryIndex).isMemory64();
+    emitMemoryFill(addressOperand(is64Bit, dstAddress), get(target), addressOperand(is64Bit, count), memoryIndex);
+    return { };
+}
 
+void OMGIRGenerator::emitMemoryFill(Value* dstAddressValue, Value* targetValue, Value* countValue, uint8_t memoryIndex)
+{
     if (!memoryIndex) {
         auto* memorySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfCachedMemory0Size()));
         m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_cachedMemory0Size, memorySize);
@@ -2148,8 +2156,6 @@ auto OMGIRGenerator::addMemoryFill(ExpressionType dstAddress, ExpressionType tar
             });
         }
     }
-
-    return { };
 }
 
 auto OMGIRGenerator::addMemoryInit(unsigned dataSegmentIndex, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length, uint8_t memoryIndex) -> PartialResult
@@ -2178,7 +2184,12 @@ auto OMGIRGenerator::addMemoryCopy(ExpressionType dstAddress, ExpressionType src
     auto* dstAddressValue = addressOperand(m_info.memory(dstMemoryIndex).isMemory64(), dstAddress);
     auto* srcAddressValue = addressOperand(m_info.memory(srcMemoryIndex).isMemory64(), srcAddress);
     auto* countValue = addressOperand(m_info.memory(srcMemoryIndex).isMemory64() && m_info.memory(dstMemoryIndex).isMemory64(), count);
+    emitMemoryCopy(dstAddressValue, srcAddressValue, countValue, dstMemoryIndex, srcMemoryIndex);
+    return { };
+}
 
+void OMGIRGenerator::emitMemoryCopy(Value* dstAddressValue, Value* srcAddressValue, Value* countValue, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex)
+{
     if (!dstMemoryIndex && !srcMemoryIndex) {
         auto* memorySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfCachedMemory0Size()));
         m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_cachedMemory0Size, memorySize);
@@ -2220,8 +2231,6 @@ auto OMGIRGenerator::addMemoryCopy(ExpressionType dstAddress, ExpressionType src
             });
         }
     }
-
-    return { };
 }
 
 auto OMGIRGenerator::addDataDrop(unsigned dataSegmentIndex) -> PartialResult
@@ -4541,12 +4550,136 @@ void OMGIRGenerator::connectValuesAtEntrypoint(unsigned& indexInBuffer, Value* p
     }
 };
 
+std::optional<ByteLoopIdiom> OMGIRGenerator::matchByteLoopIdiom(const BlockSignature& signature)
+{
+    // An empty signature keeps the loop's continuation free of phis, so the bulk path can jump
+    // straight to it.
+    if (signature.argumentCount() || signature.returnCount())
+        return std::nullopt;
+    if (!m_info.memoryCount() || m_info.memory(0).isMemory64())
+        return std::nullopt;
+
+    auto idiom = ByteLoopIdiom::match(m_parser->source(), m_parser->offset());
+    if (!idiom)
+        return std::nullopt;
+
+    // The matcher reads local indices straight out of the bytecode, ahead of the validation that
+    // would reject them.
+    for (uint32_t local : { idiom->destinationLocal, idiom->operandLocal, idiom->countLocal }) {
+        if (local >= m_locals.size() || !m_parser->typeOfLocal(local).isI32())
+            return std::nullopt;
+    }
+    return idiom;
+}
+
+// Emits the equivalent bulk memory operation for a recognized byte-at-a-time loop, guarded so that
+// the loop itself still runs whenever the bulk form would not be faithful to it. This is emitted
+// into a block that every edge into the loop passes through, so the guard costs one test per entry
+// rather than one per iteration; a loop whose guard fails then runs at exactly its original speed.
+//
+// Only the overlap term can change as the loop runs, and only in the direction that a copy which
+// deliberately replicates bytes forwards eventually stops overlapping. Testing for that would mean
+// paying for the test on every one of the iterations that replicate, so entry is the only place
+// worth asking.
+void OMGIRGenerator::emitByteLoopIdiom(const ByteLoopIdiom& idiom, ControlType& loop, BasicBlock* body)
+{
+    bool isFill = idiom.isFill();
+    bool isBackward = idiom.isBackward();
+
+    Value* destination = get(m_locals[idiom.destinationLocal]);
+    Value* operand = get(m_locals[idiom.operandLocal]);
+    Value* count = get(m_locals[idiom.countLocal]);
+
+    auto* memorySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfCachedMemory0Size()));
+    m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_cachedMemory0Size, memorySize);
+
+    // Widen to 64 bits so that adding a length to an address cannot wrap.
+    Value* wideDestination = pointerOfInt32(destination);
+    Value* wideCount = pointerOfInt32(count);
+    Value* wideSource = isFill ? nullptr : pointerOfInt32(operand);
+
+    auto binary = [&](B3::Opcode opcode, Value* left, Value* right) {
+        return m_currentBlock->appendNew<Value>(m_proc, opcode, origin(), left, right);
+    };
+    auto all = [&](Value* condition, auto... rest) {
+        ((condition = binary(BitAnd, condition, rest)), ...);
+        return condition;
+    };
+
+    Value* nonEmpty = binary(NotEqual, count, constant(Int32, 0));
+    Value* guard = nullptr;
+    if (isBackward) {
+        // count != 0
+        // && destination >= count && source >= count
+        // && destination <= memorySize && source <= memorySize
+        // && (destination >= source || (destination + count) <= source)
+        //
+        // Copying downwards matches a memmove when the destination is above the source, and either
+        // direction works when the regions do not overlap at all.
+        guard = all(nonEmpty,
+            binary(AboveEqual, wideDestination, wideCount),
+            binary(AboveEqual, wideSource, wideCount),
+            binary(BelowEqual, wideDestination, memorySize),
+            binary(BelowEqual, wideSource, memorySize),
+            binary(BitOr,
+                binary(AboveEqual, wideDestination, wideSource),
+                binary(BelowEqual, binary(Add, wideDestination, wideCount), wideSource)));
+    } else if (isFill) {
+        // count != 0 && (destination + count) <= memorySize
+        guard = all(nonEmpty,
+            binary(BelowEqual, binary(Add, wideDestination, wideCount), memorySize));
+    } else {
+        // count != 0
+        // && (destination + count) <= memorySize && (source + count) <= memorySize
+        // && (destination <= source || destination >= (source + count))
+        //
+        // Copying upwards matches a memmove when the destination is below the source, and either
+        // direction works when the regions do not overlap at all.
+        guard = all(nonEmpty,
+            binary(BelowEqual, binary(Add, wideDestination, wideCount), memorySize),
+            binary(BelowEqual, binary(Add, wideSource, wideCount), memorySize),
+            binary(BitOr,
+                binary(BelowEqual, wideDestination, wideSource),
+                binary(AboveEqual, wideDestination, binary(Add, wideSource, wideCount))));
+    }
+
+    BasicBlock* bulkPath = m_proc.addBlock();
+    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(), guard, FrequentedBlock(bulkPath), FrequentedBlock(body, FrequencyClass::Rare));
+    bulkPath->addPredecessor(m_currentBlock);
+    body->addPredecessor(m_currentBlock);
+
+    m_currentBlock = bulkPath;
+    auto* startOfDestination = isBackward ? binary(Sub, destination, count) : destination;
+    if (isFill)
+        emitMemoryFill(pointerOfInt32(startOfDestination), operand, wideCount, 0);
+    else {
+        auto* startOfSource = isBackward ? binary(Sub, operand, count) : operand;
+        emitMemoryCopy(pointerOfInt32(startOfDestination), pointerOfInt32(startOfSource), wideCount, 0, 0);
+    }
+
+    // Leave the locals holding exactly what the loop would have left in them.
+    B3::Opcode advance = isBackward ? Sub : Add;
+    set(m_locals[idiom.destinationLocal], binary(advance, destination, count));
+    if (!isFill)
+        set(m_locals[idiom.operandLocal], binary(advance, operand, count));
+    set(m_locals[idiom.countLocal], constant(Int32, 0));
+    m_currentBlock->appendNewControlValue(m_proc, B3::Jump, origin(), loop.continuation);
+    loop.continuation->addPredecessor(m_currentBlock);
+}
+
 auto OMGIRGenerator::addLoop(BlockSignature&& signature, std::span<TypedExpression> args, ControlType& block, uint32_t loopIndex) -> PartialResult
 {
     auto enclosingStack = m_parser->expressionStack();
     TRACE_CF("LOOP: entering loop index: ", loopIndex, " signature: ", signature);
     BasicBlock* body = m_proc.addBlock();
     BasicBlock* continuation = m_proc.addBlock();
+
+    auto idiom = matchByteLoopIdiom(signature);
+
+    // Every edge into the loop goes through this block, so a recognized idiom can test its guard
+    // once per entry there instead of once per iteration. Without an idiom it stays empty and the
+    // jump through it folds away.
+    BasicBlock* entry = idiom ? m_proc.addBlock() : body;
 
     block = ControlData(m_proc, origin(), WTF::move(signature), BlockType::Loop, continuation, body);
 
@@ -4559,7 +4692,7 @@ auto OMGIRGenerator::addLoop(BlockSignature&& signature, std::span<TypedExpressi
         args[i] = TypedExpression(block.signature().argumentType(i), phi);
     }
 
-    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), body);
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), entry);
     if (loopIndex == m_loopIndexForOSREntry) {
         // This must be kept in sync with BBQJIT::makeStackMap.
         dataLogLnIf(WasmOMGIRGeneratorInternal::verbose, "Setting up for OSR entry");
@@ -4599,11 +4732,17 @@ auto OMGIRGenerator::addLoop(BlockSignature&& signature, std::span<TypedExpressi
 
         ASSERT(!m_proc.usesSIMD() || m_compilationMode == CompilationMode::OMGForOSREntryMode);
         *m_osrEntryScratchBufferSize = indexInBuffer;
-        m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), body);
-        body->addPredecessor(m_currentBlock);
+        m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), entry);
+        entry->addPredecessor(m_currentBlock);
+    }
+
+    if (idiom) {
+        m_currentBlock = entry;
+        emitByteLoopIdiom(*idiom, block, body);
     }
 
     m_currentBlock = body;
+
     return { };
 }
 


### PR DESCRIPTION
#### 0c51f43daa3b812261b117b60bdfeeeb8aee1b7d
<pre>
[JSC] Quick pattern matching for byte-copy loop in OMG
<a href="https://bugs.webkit.org/show_bug.cgi?id=321468">https://bugs.webkit.org/show_bug.cgi?id=321468</a>
<a href="https://rdar.apple.com/184557364">rdar://184557364</a>

Reviewed by Keith Miller.

Depending on toolchain, options etc., very naive byte-copy loop is
generated instead of wasm bulk-memory operations like memory.copy /
memory.fill. This patch does quick pattern matching, detecting it and
spreading MemoryCopy / MemoryFill operation with guards before the
actual naive loop. We just prepend the fast path with MemoryCopy
and MemoryFill since we do not know whether src and destination are
overlapping or not at runtime easily. So we need to check them, and we
need to fall back to the normal loop when it is overlapping badly.

The replacement can be turned off with the useWasmByteLoopReplacement
option.

Tests: JSTests/wasm/stress/byte-loop-idiom-recognition.js
       JSTests/wasm/stress/byte-loop-idiom-loop-osr.js

* JSTests/wasm/stress/byte-loop-idiom-loop-osr.js: Added.
(async test.seed):
(async test.assertMemoryMatches):
(async test.copyMemmoveLike):
(async test.copyReplicating):
(async test.copyDownwards):
(async test.fillRegion):
(async test):
* JSTests/wasm/stress/byte-loop-idiom-recognition.js: Added.
(access):
(modelCopyForward):
(modelCopyBackward):
(modelFill):
(async test.seedWindow):
(async test.seedEverything):
(async test.assertMemoryMatches):
(async test.checkEveryCase):
(async test.assertTraps):
(async test):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmByteLoopIdiom.h: Added.
(JSC::Wasm::ByteLoopIdiom::isFill const):
(JSC::Wasm::ByteLoopIdiom::isBackward const):
(JSC::Wasm::ByteLoopIdiom::match):
(JSC::Wasm::ByteLoopIdiom::localsAreDistinct const):
(JSC::Wasm::ByteLoopIdiom::matchCopyForward):
(JSC::Wasm::ByteLoopIdiom::matchCopyBackward):
(JSC::Wasm::ByteLoopIdiom::matchFill):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addMemoryFill):
(JSC::Wasm::OMGIRGenerator::emitMemoryFill):
(JSC::Wasm::OMGIRGenerator::addMemoryCopy):
(JSC::Wasm::OMGIRGenerator::emitMemoryCopy):
(JSC::Wasm::OMGIRGenerator::matchByteLoopIdiom):
(JSC::Wasm::OMGIRGenerator::emitByteLoopIdiom):
(JSC::Wasm::OMGIRGenerator::addLoop):

Canonical link: <a href="https://commits.webkit.org/319065@main">https://commits.webkit.org/319065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3711540eb9bb303d9c38d0e59da0d10d533ebb4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190524 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144634 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/87c796ab-9ed2-46cd-892b-7d073a710115) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140670 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e8c70a23-72ff-4d52-b0fb-8c19555ff8d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121122 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41272 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/3089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9911 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40955 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1683 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41587 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46857 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45525 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192459 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53924 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150001 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54612 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149723 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27371 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44358 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126875 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122036 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53129 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15944 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52511 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52576 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->