### PR TITLE
[JSC] Implement op_switch_string fast path in baseline JIT

### DIFF
--- a/JSTests/stress/switch-string-inline-atom-dispatch.js
+++ b/JSTests/stress/switch-string-inline-atom-dispatch.js
@@ -1,0 +1,112 @@
+// Coverage for the baseline JIT's inline atom-pointer dispatch of op_switch_string and the
+// reachability of the slow path for other shapes.
+
+function shouldBe(actual, expected, tag, detail) {
+    if (actual !== expected) {
+        let where = detail === undefined ? tag : `${tag} [${String(detail)}]`;
+        throw new Error(`${where}: expected ${String(expected)} but got ${String(actual)}`);
+    }
+}
+
+function nonAtomCopyOf(string) {
+    return string.split("").join("");
+}
+
+function nonAtomWideCopyOf(string) {
+    return $vm.make16BitStringIfPossible(string);
+}
+
+function unresolvedRope(left, right) {
+    return left + right;
+}
+
+const scrutineesThatMustTakeDefault = [
+    42, -0, 1.5, NaN, Infinity, true, false, null, undefined, 0n,
+    Symbol("alpha"), { toString() { return "alpha"; } }, ["alpha"], () => "alpha",
+];
+
+function switchOnMixedLengthKeys(scrutinee) {
+    switch (scrutinee) {
+    case "": return "empty";
+    case "a": return "a";
+    case "alpha": return "alpha";
+    case "alphabet": return "alphabet";
+    default: return "default";
+    }
+}
+noInline(switchOnMixedLengthKeys);
+
+function switchOnNonLatin1Keys(scrutinee) {
+    switch (scrutinee) {
+    case "café": return "cafe";
+    case "日本": return "japan";
+    case "plain": return "plain";
+    default: return "default";
+    }
+}
+noInline(switchOnNonLatin1Keys);
+
+const minimumTableSwitchCaseCount = 3;
+const defaultInlineCaseCap = 64;
+const caseCountsStraddlingInlineCap = [
+    minimumTableSwitchCaseCount,
+    defaultInlineCaseCap - 1,
+    defaultInlineCaseCap,
+    defaultInlineCaseCap + 1,
+    100,
+];
+
+const generatedSwitches = caseCountsStraddlingInlineCap.map(caseCount => {
+    let clauses = "";
+    let keyLiterals = [];
+    for (let i = 0; i < caseCount; ++i) {
+        clauses += `case "key${i}": return ${i};`;
+        keyLiterals.push(`"key${i}"`);
+    }
+    let { switchFunction, atomKeys } = new Function(`
+        const switchFunction = function (scrutinee) {
+            switch (scrutinee) { ${clauses} default: return -1; }
+        };
+        return { switchFunction, atomKeys: [${keyLiterals.join(",")}] };
+    `)();
+    noInline(switchFunction);
+    return { caseCount, switchFunction, atomKeys };
+});
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(switchOnMixedLengthKeys(""), "empty", "empty atom key");
+    shouldBe(switchOnMixedLengthKeys("a"), "a", "one-character atom key");
+    shouldBe(switchOnMixedLengthKeys("alpha"), "alpha", "atom key");
+    shouldBe(switchOnMixedLengthKeys("alphabet"), "alphabet", "longest atom key");
+    shouldBe(switchOnMixedLengthKeys("beta"), "default", "atom miss");
+    shouldBe(switchOnMixedLengthKeys(nonAtomCopyOf("alpha")), "alpha", "non-atom hit");
+    shouldBe(switchOnMixedLengthKeys(nonAtomCopyOf("beta")), "default", "non-atom miss");
+    shouldBe(switchOnMixedLengthKeys(nonAtomWideCopyOf("alpha")), "alpha", "wide copy of 8-bit key");
+    shouldBe(switchOnMixedLengthKeys(unresolvedRope("alph", "abet")), "alphabet", "rope hit");
+    shouldBe(switchOnMixedLengthKeys(unresolvedRope("bet", "a")), "default", "rope miss");
+    shouldBe(switchOnMixedLengthKeys(unresolvedRope("alphabet", "s")), "default", "rope longer than every key");
+
+    shouldBe(switchOnNonLatin1Keys("café"), "cafe", "16-bit atom key");
+    shouldBe(switchOnNonLatin1Keys("日本"), "japan", "non-Latin1 atom key");
+    shouldBe(switchOnNonLatin1Keys(nonAtomCopyOf("café")), "cafe", "non-atom 16-bit hit");
+    shouldBe(switchOnNonLatin1Keys(unresolvedRope("caf", "é")), "cafe", "16-bit rope hit");
+    shouldBe(switchOnNonLatin1Keys("plain"), "plain", "8-bit key among 16-bit keys");
+
+    for (const scrutinee of scrutineesThatMustTakeDefault) {
+        shouldBe(switchOnMixedLengthKeys(scrutinee), "default", "non-string scrutinee", scrutinee);
+        shouldBe(switchOnNonLatin1Keys(scrutinee), "default", "non-string scrutinee, 16-bit keys", scrutinee);
+    }
+
+    for (const { caseCount, switchFunction, atomKeys } of generatedSwitches) {
+        shouldBe(switchFunction(atomKeys[0]), 0, "first key", caseCount);
+        shouldBe(switchFunction(atomKeys[caseCount >> 1]), caseCount >> 1, "middle key", caseCount);
+        shouldBe(switchFunction(atomKeys[caseCount - 1]), caseCount - 1, "last key", caseCount);
+        shouldBe(switchFunction("nope"), -1, "miss", caseCount);
+        shouldBe(switchFunction(nonAtomCopyOf(atomKeys[caseCount - 1])), caseCount - 1, "non-atom hit", caseCount);
+        shouldBe(switchFunction(nonAtomWideCopyOf(atomKeys[0])), 0, "wide copy hit", caseCount);
+        shouldBe(switchFunction(unresolvedRope("key", "0")), 0, "rope hit", caseCount);
+        shouldBe(switchFunction(unresolvedRope("key", "nope")), -1, "rope miss", caseCount);
+        for (const scrutinee of scrutineesThatMustTakeDefault)
+            shouldBe(switchFunction(scrutinee), -1, "non-string scrutinee", caseCount);
+    }
+}

--- a/Source/JavaScriptCore/jit/BaselineJITRegisters.h
+++ b/Source/JavaScriptCore/jit/BaselineJITRegisters.h
@@ -112,7 +112,8 @@ namespace SwitchString {
 
     static constexpr GPRReg globalObjectGPR { preferredArgumentGPR<SlowOperation, 0>() };
     static constexpr JSValueRegs scrutineeJSR { preferredArgumentJSR<SlowOperation, 1>() };
-    static_assert(noOverlap(globalObjectGPR, scrutineeJSR), "Required for call to slow operation");
+    static constexpr GPRReg scratch1GPR { GPRInfo::regT5 };
+    static_assert(noOverlap(globalObjectGPR, scrutineeJSR, scratch1GPR), "Required for call to slow operation, and the scrutinee must survive the inline fast path");
 }
 
 namespace ResolveScope {

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -1331,8 +1331,37 @@ void JIT::emit_op_switch_string(const JSInstruction* currentInstruction)
 
     using BaselineJITRegisters::SwitchString::globalObjectGPR;
     using BaselineJITRegisters::SwitchString::scrutineeJSR;
+    using BaselineJITRegisters::SwitchString::scratch1GPR;
 
     emitGetVirtualRegister(scrutinee, scrutineeJSR);
+
+    // Fast path: if the scrutinee is an atom, dispatch inline using pointer comparison.
+    // Switch keys are always atoms as asserted in BytecodeGenerator::endSwitch, and also here.
+    unsigned caseCount = unlinkedTable.m_offsetTable.size();
+    if (caseCount && caseCount <= Options::maximumInlineStringSwitchCaseCount()) {
+        Vector<int64_t, 16> caseKeys;
+        Vector<int32_t, 16> caseTargets;
+        caseKeys.reserveInitialCapacity(caseCount);
+        caseTargets.reserveInitialCapacity(caseCount);
+        for (auto& entry : unlinkedTable.m_offsetTable) {
+            ASSERT(entry.key->isAtom());
+            caseKeys.append(static_cast<int64_t>(std::bit_cast<intptr_t>(entry.key.get())));
+            caseTargets.append(entry.value.m_branchOffset);
+        }
+
+        JumpList slowCases;
+        slowCases.append(branchIfNotCell(scrutineeJSR));
+        slowCases.append(branchIfNotString(scrutineeJSR.payloadGPR()));
+        slowCases.append(loadCacheableIdentifierImpl(scrutineeJSR.payloadGPR(), scratch1GPR, /* propertyIsString */ true, /* propertyIsSymbol */ false));
+
+        BinarySwitch binarySwitch(scratch1GPR, caseKeys.span(), BinarySwitch::IntPtr);
+        while (binarySwitch.advance(*this))
+            addJump(jump(), caseTargets[binarySwitch.caseIndex()]);
+        addJump(binarySwitch.fallThrough(), defaultOffset);
+
+        slowCases.link(this);
+    }
+
     loadGlobalObject(globalObjectGPR);
     callOperation(operationSwitchStringWithUnknownKeyType, globalObjectGPR, scrutineeJSR, tableIndex);
     farJump(returnValueGPR, JSSwitchPtrTag);

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -333,6 +333,7 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Unsigned, maximumBinaryStringSwitchCaseLength, 50, Normal, nullptr) \
     v(Unsigned, maximumBinaryStringSwitchTotalLength, 2000, Normal, nullptr) \
+    v(Unsigned, maximumInlineStringSwitchCaseCount, 64, Normal, "Maximum number of cases for which the baseline JIT dispatches op_switch_string inline instead of calling out."_s) \
     v(Unsigned, maximumRegExpTestInlineCodesize, 500, Normal, "Maximum code size in bytes for inlined RegExp.test JIT code."_s) \
     v(Unsigned, maximumRegExpJITCodeSize, 16 * MB, Normal, "Maximum generated code size in bytes for RegExp JIT compilation before falling back to the interpreter."_s) \
     \


### PR DESCRIPTION
#### c00fd8a9713c5c2ab4a542ea533d00cd205ec8f2
<pre>
[JSC] Implement op_switch_string fast path in baseline JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=321476">https://bugs.webkit.org/show_bug.cgi?id=321476</a>
<a href="https://rdar.apple.com/184566236">rdar://184566236</a>

Reviewed by Yusuke Suzuki.

Higher JIT tiers generate a fast path for op_switch_string to perform pointer
identity-based inline dispatch if the scrutinee is an atom. Baseline JIT does not do that,
so dispatch is always handled by the slow case operationSwitchStringWithUnknownKeyType,
which hashes the scrutinee&apos;s characters and probes the jump table.

This patch adds support to generate a fast path in the baseline JIT tier to handle an
atomic scrutinee.

Testing: added JSTests/stress/switch-string-inline-atom-dispatch.js to ensure correctness
Canonical link: <a href="https://commits.webkit.org/318959@main">https://commits.webkit.org/318959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccf8f2943fbcf9b5799b18e5a31d0ced1af6d658

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190144 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144251 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1ad74695-97dd-4c33-b532-132784f16971) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140334 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/512f011b-4da1-45e4-98e8-c4c4ea5ff549) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43975 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120785 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/397d37cc-8856-4cef-97c5-90ac9226e87e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40957 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2753 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9584 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40626 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1301 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41206 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192075 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53544 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149651 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40095 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54231 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149381 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44030 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126494 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121551 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52748 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15613 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52130 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52368 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52194 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->