### PR TITLE
[JSC][Temporal] Give the ICU paths an error channel instead of plausible values

### DIFF
--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -510,13 +510,16 @@ ISO8601::PlainDate calendarDateAdd(JSGlobalObject* globalObject, CalendarID cale
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil
-ISO8601::Duration calendarDateUntil(CalendarID calendarId, const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
+ISO8601::Duration calendarDateUntil(JSGlobalObject* globalObject, CalendarID calendarId, const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
 {
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     if (calendarId == iso8601CalendarID())
         return TemporalCore::calendarDateUntil(one, two, largestUnit);
     auto result = TemporalCore::calendarDateUntil(calendarId, one, two, largestUnit);
-    if (!result) [[unlikely]]
+    if (!result) [[unlikely]] {
+        throwTemporalError(globalObject, scope, result.error());
         return { };
+    }
     return *result;
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.h
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.h
@@ -49,7 +49,7 @@ ISO8601::PlainDateTime interpretTemporalDateTimeFields(JSGlobalObject*, Calendar
 
 ISO8601::PlainDate isoDateAdd(JSGlobalObject*, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
 ISO8601::PlainDate calendarDateAdd(JSGlobalObject*, CalendarID, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
-ISO8601::Duration calendarDateUntil(CalendarID, const ISO8601::PlainDate&, const ISO8601::PlainDate&, TemporalUnit);
+ISO8601::Duration calendarDateUntil(JSGlobalObject*, CalendarID, const ISO8601::PlainDate&, const ISO8601::PlainDate&, TemporalUnit);
 
 enum class FieldSetType { Date, YearMonth, MonthDay, DateTime };
 template<FieldSetType type = FieldSetType::Date>

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -429,9 +429,10 @@ ISO8601::Duration TemporalPlainDate::differenceTemporalPlainDate(JSGlobalObject*
 
     // Step 6: dateDifference = CalendarDateUntil(calendar, this, other, largestUnit).
     ISO8601::Duration dateDiff;
-    if (!TemporalCore::calendarIsISO(m_calendarID))
-        dateDiff = calendarDateUntil(m_calendarID, plainDate(), other->plainDate(), largestUnit);
-    else
+    if (!TemporalCore::calendarIsISO(m_calendarID)) {
+        dateDiff = calendarDateUntil(globalObject, m_calendarID, plainDate(), other->plainDate(), largestUnit);
+        RETURN_IF_EXCEPTION(scope, { });
+    } else
         dateDiff = TemporalCore::calendarDateUntil(plainDate(), other->plainDate(), largestUnit);
 
     // Step 7: duration = CombineDateAndTimeDuration(dateDifference, 0).

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -816,7 +816,9 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterEra, (JSGlobalObject* g
 
     // Step 3: Return CalendarISOToDate(calendar, isoDate).[[Era]].
     auto result = TemporalCore::calendarEra(plainDate->calendarID(), plainDate->plainDate());
-    if (!result || !*result)
+    if (!result) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, result.error().message);
+    if (!*result)
         return JSValue::encode(jsUndefined());
     return JSValue::encode(jsString(vm, **result));
 }
@@ -833,7 +835,9 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterEraYear, (JSGlobalObjec
 
     // Steps 3-5: Return CalendarISOToDate(calendar, isoDate).[[EraYear]], or undefined.
     auto result = TemporalCore::calendarEraYear(plainDate->calendarID(), plainDate->plainDate());
-    if (!result || !*result)
+    if (!result) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, result.error().message);
+    if (!*result)
         return JSValue::encode(jsUndefined());
     return JSValue::encode(jsNumber(**result));
 }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -933,7 +933,9 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterEra, (JSGlobalObjec
 
     // Step 3: Return CalendarISOToDate(calendar, isoDate).[[Era]].
     auto result = TemporalCore::calendarEra(plainDateTime->calendarID(), plainDateTime->plainDate());
-    if (!result || !*result)
+    if (!result) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, result.error().message);
+    if (!*result)
         return JSValue::encode(jsUndefined());
     return JSValue::encode(jsString(vm, **result));
 }
@@ -950,7 +952,9 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterEraYear, (JSGlobalO
 
     // Steps 3-5: Return CalendarISOToDate(calendar, isoDate).[[EraYear]], or undefined.
     auto result = TemporalCore::calendarEraYear(plainDateTime->calendarID(), plainDateTime->plainDate());
-    if (!result || !*result)
+    if (!result) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, result.error().message);
+    if (!*result)
         return JSValue::encode(jsUndefined());
     return JSValue::encode(jsNumber(**result));
 }

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
@@ -299,16 +299,13 @@ static JSC::EncodedJSValue differenceTemporalPlainYearMonth(JSGlobalObject* glob
 
     // Steps 7-13: thisFields/otherFields with day=1 → thisDate/otherDate → dateDifference.
     //   TemporalCore::differenceYearMonth fuses the fields+day=1+dateFromFields for both endpoints
-    //   before invoking CalendarDateUntil. Fallback to direct calendarDateUntil on failure.
-    ISO8601::Duration dateDifference;
+    //   before invoking CalendarDateUntil.
     auto dateDiffResult = TemporalCore::differenceYearMonth(calendarId, thisIsoDate, otherIsoDate, largestUnit);
-    if (!dateDiffResult) {
-        if (calendarId != iso8601CalendarID())
-            dateDifference = calendarDateUntil(calendarId, thisIsoDate, otherIsoDate, largestUnit);
-        else
-            dateDifference = TemporalCore::calendarDateUntil(thisIsoDate, otherIsoDate, largestUnit);
-    } else
-        dateDifference = *dateDiffResult;
+    if (!dateDiffResult) [[unlikely]] {
+        throwTemporalError(globalObject, scope, dateDiffResult.error());
+        return { };
+    }
+    ISO8601::Duration dateDifference = *dateDiffResult;
 
     // Steps 14-15: yearsMonthsDifference = ! AdjustDateDurationRecord(dateDifference, 0, 0)  — zero weeks and days;
     //              duration = CombineDateAndTimeDuration(yearsMonthsDifference, 0).
@@ -688,7 +685,9 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainYearMonthPrototypeGetterEra, (JSGlobalObje
 
     // Steps 3-4: result = CalendarISOToDate(calendar, isoDate).[[Era]]; if undefined, return undefined.
     auto result = TemporalCore::calendarEra(yearMonth->calendarID(), yearMonth->plainYearMonth().isoPlainDate());
-    if (!result || !*result)
+    if (!result) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, result.error().message);
+    if (!*result)
         return JSValue::encode(jsUndefined());
     // Step 5: Return result.
     return JSValue::encode(jsString(vm, **result));
@@ -707,7 +706,9 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainYearMonthPrototypeGetterEraYear, (JSGlobal
 
     // Steps 3-4: result = CalendarISOToDate(calendar, isoDate).[[EraYear]]; if undefined, return undefined.
     auto result = TemporalCore::calendarEraYear(yearMonth->calendarID(), yearMonth->plainYearMonth().isoPlainDate());
-    if (!result || !*result)
+    if (!result) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, result.error().message);
+    if (!*result)
         return JSValue::encode(jsUndefined());
     // Step 5: Return 𝔽(result).
     return JSValue::encode(jsNumber(**result));

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
@@ -195,12 +195,21 @@ TemporalResult<void> nonISOResolveFields(CalendarID calendarId, CalendarFieldsIn
             if (!calendarIsLunisolar(calendarId))
                 ordinal = static_cast<uint8_t>(mc.monthNumber);
             else {
-                // ~constrain~ is spec-pinned here → can't throw, .value() safe.
-                auto constrained = yearContainsMonthCode(calendarId, *fields.year, mc)
-                    ? mc
-                    : constrainMonthCode(calendarId, *fields.year, mc, TemporalOverflow::Constrain).value();
+                auto contained = yearContainsMonthCode(calendarId, *fields.year, mc);
+                if (!contained) [[unlikely]]
+                    return makeUnexpected(contained.error());
+                auto constrained = mc;
+                if (!*contained) {
+                    auto constrainResult = constrainMonthCode(calendarId, *fields.year, mc, TemporalOverflow::Constrain);
+                    if (!constrainResult) [[unlikely]]
+                        return makeUnexpected(constrainResult.error());
+                    constrained = *constrainResult;
+                }
                 // Step 18.b.ii: MonthCodeToOrdinal (precondition guaranteed by constrain above).
-                ordinal = static_cast<uint8_t>(monthCodeOrdinalInYear(calendarId, constrained, *fields.year));
+                auto ordinalResult = monthCodeOrdinalInYear(calendarId, constrained, *fields.year);
+                if (!ordinalResult) [[unlikely]]
+                    return makeUnexpected(ordinalResult.error());
+                ordinal = static_cast<uint8_t>(*ordinalResult);
             }
             if (ordinal) {
                 // Step 18.b.iii: consistency.
@@ -425,32 +434,37 @@ TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, c
 
         // Re-resolve: get monthCode+day from first resolution, then use ecmaReferenceYear.
         auto resolvedFields = isoToCalendarFields(calendarId, *result);
-        if (resolvedFields && !resolvedFields->monthCode.isEmpty()) {
-            auto resolvedMonthCode = ISO8601::parseMonthCode(resolvedFields->monthCode);
-            if (resolvedMonthCode) {
-                auto refYearOr = ecmaReferenceYear(calendarId, resolvedMonthCode->monthNumber, resolvedMonthCode->isLeapMonth, resolvedFields->day);
-                int32_t refYear;
-                std::optional<ParsedMonthCode> effectiveRefMonthCode = resolvedMonthCode;
-                if (!refYearOr) {
-                    switch (refYearOr.error()) {
-                    case EcmaReferenceYearError::MonthNotInCalendar:
-                        return makeUnexpected(rangeError("This month code does not exist in this calendar"_s));
-                    case EcmaReferenceYearError::UseRegularIfConstrain:
-                        if (overflow == TemporalOverflow::Reject)
-                            return makeUnexpected(rangeError("Leap month does not exist near the reference year"_s));
-                        auto fallback = ecmaReferenceYear(calendarId, resolvedMonthCode->monthNumber, /* isLeapMonth */ false, resolvedFields->day);
-                        RELEASE_ASSERT(fallback);
-                        refYear = *fallback;
-                        effectiveRefMonthCode = ParsedMonthCode { resolvedMonthCode->monthNumber, /* isLeapMonth */ false };
-                        break;
-                    }
-                } else
-                    refYear = *refYearOr;
-                auto refResult = nonISOCalendarDateToISO(calendarId, std::optional<int32_t>(refYear), resolvedFields->month, resolvedFields->day, effectiveRefMonthCode, TemporalOverflow::Constrain);
-                if (refResult)
-                    return ResolvedCalendarDate { *refResult, calendarId };
+        if (!resolvedFields)
+            return makeUnexpected(resolvedFields.error());
+        if (resolvedFields->monthCode.isEmpty())
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        auto resolvedMonthCode = ISO8601::parseMonthCode(resolvedFields->monthCode);
+        if (!resolvedMonthCode)
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+
+        auto refYearOr = ecmaReferenceYear(calendarId, resolvedMonthCode->monthNumber, resolvedMonthCode->isLeapMonth, resolvedFields->day);
+        int32_t refYear = 0;
+        std::optional<ParsedMonthCode> effectiveRefMonthCode = resolvedMonthCode;
+        if (!refYearOr) {
+            switch (refYearOr.error()) {
+            case EcmaReferenceYearError::MonthNotInCalendar:
+                return makeUnexpected(rangeError("This month code does not exist in this calendar"_s));
+            case EcmaReferenceYearError::UseRegularIfConstrain: {
+                if (overflow == TemporalOverflow::Reject)
+                    return makeUnexpected(rangeError("Leap month does not exist near the reference year"_s));
+                auto fallback = ecmaReferenceYear(calendarId, resolvedMonthCode->monthNumber, /* isLeapMonth */ false, resolvedFields->day);
+                RELEASE_ASSERT(fallback);
+                refYear = *fallback;
+                effectiveRefMonthCode = ParsedMonthCode { resolvedMonthCode->monthNumber, /* isLeapMonth */ false };
+                break;
             }
-        }
+            }
+        } else
+            refYear = *refYearOr;
+        auto refResult = nonISOCalendarDateToISO(calendarId, std::optional<int32_t>(refYear), resolvedFields->month, resolvedFields->day, effectiveRefMonthCode, TemporalOverflow::Constrain);
+        if (!refResult)
+            return makeUnexpected(refResult.error());
+        return ResolvedCalendarDate { *refResult, calendarId };
     }
 
     // Step 3: Assert: ISODateWithinLimits(result) — reference year is always within limits.

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -724,35 +724,45 @@ static bool addLunisolarCalendarDays(UCalendar* cal, CalendarID calendarId, int3
 // FIXME: only relabels the single Tevet D1 slot; doesn't shift the rest of the year, so
 // dayOfYear under-counts from there on (see temporal-hebrew-year0-kislev.js skipped block).
 // Wait for ICU to fix the classification rather than patching further (icu-issues/01).
-static bool isHebrewYear0(UCalendar* cal, CalendarID calendarId)
+static std::optional<bool> isHebrewYear0(UCalendar* cal, CalendarID calendarId)
 {
     if (calendarId != hebrewCalendarID())
         return false;
     UErrorCode status = U_ZERO_ERROR;
     int32_t year = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-    return !U_FAILURE(status) && !year;
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    return !year;
 }
-static bool isHebrewYear0ExtraKislevDay(UCalendar* cal, CalendarID calendarId)
+static std::optional<bool> isHebrewYear0ExtraKislevDay(UCalendar* cal, CalendarID calendarId)
 {
-    if (!isHebrewYear0(cal, calendarId))
+    auto isYear0 = isHebrewYear0(cal, calendarId);
+    if (!isYear0) [[unlikely]]
+        return std::nullopt;
+    if (!*isYear0)
         return false;
     UErrorCode status = U_ZERO_ERROR;
     int32_t day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-    if (U_FAILURE(status) || day != 1) [[unlikely]]
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    if (day != 1)
         return false;
     int32_t ucalMonth = ucal_get(cal, UCAL_MONTH, &status);
     if (U_FAILURE(status)) [[unlikely]]
-        return false;
+        return std::nullopt;
     return ucalMonth == 3; // Tevet slot in Hebrew (0-indexed): Tishri=0, Cheshvan=1, Kislev=2, Tevet=3.
 }
-static bool isHebrewYear0Kislev(UCalendar* cal, CalendarID calendarId)
+static std::optional<bool> isHebrewYear0Kislev(UCalendar* cal, CalendarID calendarId)
 {
-    if (!isHebrewYear0(cal, calendarId))
+    auto isYear0 = isHebrewYear0(cal, calendarId);
+    if (!isYear0) [[unlikely]]
+        return std::nullopt;
+    if (!*isYear0)
         return false;
     UErrorCode status = U_ZERO_ERROR;
     int32_t ucalMonth = ucal_get(cal, UCAL_MONTH, &status);
     if (U_FAILURE(status)) [[unlikely]]
-        return false;
+        return std::nullopt;
     return ucalMonth == 2; // Kislev slot.
 }
 
@@ -1048,7 +1058,10 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
             // ICU4C-WORKAROUND: rdar://182958553 - re-label y0 M04 D1 as y0 M03 D30.
             if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
                 return makeUnexpected(rangeError(icuSetCalendarFailed));
-            if (isHebrewYear0ExtraKislevDay(cal, calendarId)) {
+            auto extraKislev = isHebrewYear0ExtraKislevDay(cal, calendarId);
+            if (!extraKislev) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            if (*extraKislev) {
                 raw.day = 30;
                 raw.ordinalMonth = 3;
                 raw.monthCode = String("M03"_s);
@@ -1137,7 +1150,10 @@ TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::Plai
     return withCalendarSetToDate(calendarId, isoDate, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
         {
             // ICU4C-WORKAROUND: rdar://182958553 - re-label y0 M04 as ordinal 3.
-            if (isHebrewYear0ExtraKislevDay(cal, calendarId))
+            auto extraKislev = isHebrewYear0ExtraKislevDay(cal, calendarId);
+            if (!extraKislev) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            if (*extraKislev)
                 return static_cast<uint8_t>(3);
         }
         auto ordinal = computeFieldResolutionOrdinalMonth(cal, calendarId);
@@ -1162,7 +1178,10 @@ TemporalResult<String> calendarMonthCode(CalendarID calendarId, const ISO8601::P
     return withCalendarSetToDate(calendarId, isoDate, [&](UCalendar* cal) -> TemporalResult<String> {
         {
             // ICU4C-WORKAROUND: rdar://182958553 - re-label y0 M04 as monthCode M03.
-            if (isHebrewYear0ExtraKislevDay(cal, calendarId))
+            auto extraKislev = isHebrewYear0ExtraKislevDay(cal, calendarId);
+            if (!extraKislev) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            if (*extraKislev)
                 return String("M03"_s);
         }
         auto code = getMonthCode(cal, calendarId);
@@ -1187,7 +1206,10 @@ TemporalResult<uint8_t> calendarDay(CalendarID calendarId, const ISO8601::PlainD
     return withCalendarSetToDate(calendarId, isoDate, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
         {
             // ICU4C-WORKAROUND: rdar://182958553 - Kislev has 30 days in y0 per icu4x.
-            if (isHebrewYear0ExtraKislevDay(cal, calendarId))
+            auto extraKislev = isHebrewYear0ExtraKislevDay(cal, calendarId);
+            if (!extraKislev) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            if (*extraKislev)
                 return static_cast<uint8_t>(30);
         }
         auto day = readICUField(cal, UCAL_DAY_OF_MONTH);
@@ -1309,7 +1331,13 @@ TemporalResult<int32_t> calendarDaysInMonth(CalendarID calendarId, const ISO8601
         return ISO8601::daysInMonth(isoDate.year(), isoDate.month());
     return withCalendarSetToDate(gregorianArithmeticCalendarFor(calendarId), isoDate, [&](UCalendar* cal) -> TemporalResult<int32_t> {
         // ICU4C-WORKAROUND: rdar://182958553 - ICU says 29 (Deficient leap); icu4x says 30.
-        if (isHebrewYear0Kislev(cal, calendarId) || isHebrewYear0ExtraKislevDay(cal, calendarId))
+        auto y0Kislev = isHebrewYear0Kislev(cal, calendarId);
+        if (!y0Kislev) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        auto y0ExtraKislev = isHebrewYear0ExtraKislevDay(cal, calendarId);
+        if (!y0ExtraKislev) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        if (*y0Kislev || *y0ExtraKislev)
             return 30;
         if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) {
             auto result = actualLunisolarMonthLength(cal, calendarId);
@@ -1515,17 +1543,17 @@ static bool positionCalendarToYearStart(UCalendar* cal, CalendarID calendarId, i
 }
 
 // resolveMonthCodeToOrdinal — internal: resolves a monthCode to its 1-based ordinal position in the given year
-static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& monthCode, int32_t year)
+static std::optional<int32_t> resolveMonthCodeToOrdinal(CalendarID calendarId, const String& monthCode, int32_t year)
 {
-    return withCalendar(calendarId, [&](UCalendar* cal) -> int32_t {
+    return withCalendar(calendarId, [&](UCalendar* cal) -> std::optional<int32_t> {
         if (!cal) [[unlikely]]
-            return 1;
+            return std::nullopt;
         UErrorCode status = U_ZERO_ERROR;
         if (!positionCalendarToYearStart(cal, calendarId, year, status)) [[unlikely]]
-            return 1;
+            return std::nullopt;
         auto found = searchYearForMonthCode(cal, calendarId, monthCode);
         if (!found) [[unlikely]]
-            return 1;
+            return std::nullopt;
         if (found->exact)
             return found->ordinal;
         // Hebrew M05L keeps the stopped-on ordinal (icu4x hebrew.rs ordinal_from_month: -> 6 under
@@ -1559,7 +1587,7 @@ bool isValidMonthCodeForCalendar(CalendarID calendarId, ParsedMonthCode monthCod
 }
 
 // https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-yearcontainsmonthcode
-static bool yearContainsMonthCodeInternal(UCalendar* cal, CalendarID calendarId, int32_t year, ParsedMonthCode monthCode)
+static std::optional<bool> yearContainsMonthCodeInternal(UCalendar* cal, CalendarID calendarId, int32_t year, ParsedMonthCode monthCode)
 {
     // Step 1: Assert IsValidMonthCodeForCalendar.
     ASSERT(isValidMonthCodeForCalendar(calendarId, monthCode));
@@ -1569,18 +1597,25 @@ static bool yearContainsMonthCodeInternal(UCalendar* cal, CalendarID calendarId,
     // Step 3 (calendar-dependent): leap month exists iff ICU can position on the exact monthCode.
     UErrorCode status = U_ZERO_ERROR;
     if (!positionCalendarToYearStart(cal, calendarId, year, status)) [[unlikely]]
-        return false;
+        return std::nullopt;
     String mcStr = makeString("M"_s, monthCode.monthNumber < 10 ? "0"_s : ""_s, monthCode.monthNumber, "L"_s);
     auto probe = setCalendarToMonthCode(cal, calendarId, mcStr);
-    return probe && *probe == 1;
+    if (!probe) [[unlikely]]
+        return std::nullopt;
+    return *probe == 1;
 }
 
-// Public wrapper: opens ICU via withCalendar for one-shot callers.
-bool yearContainsMonthCode(CalendarID calendarId, int32_t year, ParsedMonthCode monthCode)
+// Public wrapper: takes a cached ICU calendar via withCalendar for one-shot callers.
+TemporalResult<bool> yearContainsMonthCode(CalendarID calendarId, int32_t year, ParsedMonthCode monthCode)
 {
-    return withCalendar(calendarId, [&](UCalendar* cal) -> bool {
-        return cal && yearContainsMonthCodeInternal(cal, calendarId, year, monthCode);
+    auto contained = withCalendar(calendarId, [&](UCalendar* cal) -> std::optional<bool> {
+        if (!cal) [[unlikely]]
+            return std::nullopt;
+        return yearContainsMonthCodeInternal(cal, calendarId, year, monthCode);
     });
+    if (!contained) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return *contained;
 }
 
 // https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-constrainmonthcode
@@ -1606,7 +1641,10 @@ TemporalResult<ParsedMonthCode> constrainMonthCode(CalendarID calendarId, int32_
     // Step 1: Assert IsValidMonthCodeForCalendar.
     ASSERT(isValidMonthCodeForCalendar(calendarId, monthCode));
     // Steps 2-8: delegate to algorithm extract with cursor-computed containment.
-    return constrainMonthCodeGivenContainment(calendarId, monthCode, yearContainsMonthCode(calendarId, year, monthCode), overflow);
+    auto contained = yearContainsMonthCode(calendarId, year, monthCode);
+    if (!contained) [[unlikely]]
+        return makeUnexpected(contained.error());
+    return constrainMonthCodeGivenContainment(calendarId, monthCode, *contained, overflow);
 }
 static TemporalResult<ParsedMonthCode> constrainMonthCodeInternal(UCalendar* cal, CalendarID calendarId, ParsedMonthCode monthCode, TemporalOverflow overflow)
 {
@@ -1617,42 +1655,52 @@ static TemporalResult<ParsedMonthCode> constrainMonthCodeInternal(UCalendar* cal
     if (U_FAILURE(status)) [[unlikely]]
         return makeUnexpected(rangeError(icuReadCalendarFailed));
     // Steps 2-8: delegate to algorithm extract with cursor-computed containment.
-    return constrainMonthCodeGivenContainment(calendarId, monthCode, yearContainsMonthCodeInternal(cal, calendarId, year, monthCode), overflow);
+    auto contained = yearContainsMonthCodeInternal(cal, calendarId, year, monthCode);
+    if (!contained) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return constrainMonthCodeGivenContainment(calendarId, monthCode, *contained, overflow);
 }
 
 // https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-monthcodetoordinal
-int32_t monthCodeOrdinalInYear(CalendarID calendarId, ParsedMonthCode monthCode, int32_t year)
+TemporalResult<int32_t> monthCodeOrdinalInYear(CalendarID calendarId, ParsedMonthCode monthCode, int32_t year)
 {
     ASSERT(isValidMonthCodeForCalendar(calendarId, monthCode));
-    ASSERT(yearContainsMonthCode(calendarId, year, monthCode));
 
     // Step 6 (extended to non-table calendars): no leap months -> ordinal == monthNumber.
     if (!calendarIsLunisolar(calendarId))
         return monthCode.monthNumber;
 
     // Steps 2-4 init + steps 8-9 loop: M01, M01L, M02, M02L, ..., M12, M12L.
-    return withCalendar(calendarId, [&](UCalendar* cal) -> int32_t {
+    auto ordinal = withCalendar(calendarId, [&](UCalendar* cal) -> std::optional<int32_t> {
         if (!cal) [[unlikely]]
-            return monthCode.monthNumber; // fallback: ignore leap-month index shift
+            return std::nullopt;
         int32_t monthsBefore = 0;
         for (uint8_t number = 1; number <= 12; number++) {
             for (bool isLeap : { false, true }) {
                 ParsedMonthCode candidate { number, isLeap };
-                if (isValidMonthCodeForCalendar(calendarId, candidate)
-                    && yearContainsMonthCodeInternal(cal, calendarId, year, candidate))
-                    monthsBefore++; // Step 9.b
+                if (isValidMonthCodeForCalendar(calendarId, candidate)) {
+                    auto contained = yearContainsMonthCodeInternal(cal, calendarId, year, candidate);
+                    if (!contained) [[unlikely]]
+                        return std::nullopt;
+                    if (*contained)
+                        monthsBefore++; // Step 9.b
+                }
                 if (number == monthCode.monthNumber && isLeap == monthCode.isLeapMonth) // Step 9.c
                     return monthsBefore;
             }
         }
         RELEASE_ASSERT_NOT_REACHED(); // Precondition ensures target is visited.
     });
+    if (!ordinal) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return *ordinal;
 }
 
 // nonISODateSurpasses — icu4x: surpasses() (components/calendar/src/calendar_arithmetic.rs) — two-phase lexicographic + ordinal check
 // sourceRelatedYear is the same instant as sourceYear in resolveMonthCodeToOrdinal's domain. Not
 // interchangeable: for chinese/dangi the two differ on some ICU versions.
-static bool nonISODateSurpasses(
+// nullopt means ICU could not resolve the source monthCode in the candidate year.
+static std::optional<bool> nonISODateSurpasses(
     CalendarID calendarId,
     int32_t sign,
     int32_t sourceYear,
@@ -1668,8 +1716,10 @@ static bool nonISODateSurpasses(
     int32_t y0 = sourceYear + candidateYears; // Phase 1: lexicographic check (year, monthCode, day).
     if (compareSurpassesLexicographic(sign, y0, sourceMonthCode, sourceDay, targetYear, targetMonthCode, targetDay))
         return true; // Phase 2: constrain source monthCode to year y0, compare ordinally.
-    int32_t m0 = resolveMonthCodeToOrdinal(calendarId, sourceMonthCode, sourceRelatedYear + candidateYears);
-    return compareSurpassesOrdinally(sign, y0, m0, sourceDay, targetYear, targetOrdinalMonth, targetDay);
+    auto m0 = resolveMonthCodeToOrdinal(calendarId, sourceMonthCode, sourceRelatedYear + candidateYears);
+    if (!m0) [[unlikely]]
+        return std::nullopt;
+    return compareSurpassesOrdinally(sign, y0, *m0, sourceDay, targetYear, targetOrdinalMonth, targetDay);
 }
 
 static bool calendarIsNonISOSolar(CalendarID calendarId)
@@ -1858,7 +1908,10 @@ TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const 
 
         // ICU4C-WORKAROUND: rdar://182958553 - y0 Kislev D30 sits at ICU's Tevet D1; step back
         // one day so ucal_add(MONTH) advances from Kislev, and treat the snapshot as M03 D30.
-        bool hebrewY0Kislev = isHebrewYear0ExtraKislevDay(cal, calendarId);
+        auto hebrewY0KislevOpt = isHebrewYear0ExtraKislevDay(cal, calendarId);
+        if (!hebrewY0KislevOpt) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        bool hebrewY0Kislev = *hebrewY0KislevOpt;
         if (hebrewY0Kislev) {
             UErrorCode s = U_ZERO_ERROR;
             ucal_add(cal, UCAL_DAY_OF_MONTH, -1, &s);
@@ -2064,7 +2117,10 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
             // ICU4C-WORKAROUND: rdar://182958553 - relabel ICU's Tevet D1 as Kislev D30 for diff snapshots.
-            bool hebrewY0Kislev = isHebrewYear0ExtraKislevDay(cal, calendarId);
+            auto hebrewY0KislevOpt = isHebrewYear0ExtraKislevDay(cal, calendarId);
+            if (!hebrewY0KislevOpt) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            bool hebrewY0Kislev = *hebrewY0KislevOpt;
             snapshot.year = ucal_get(cal, calendarArithmeticYearField(calendarId), &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -2155,10 +2211,12 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
     // Count full years by fast-forward + surpass probe.
     if (largestUnit == TemporalUnit::Year) {
         int64_t candidateYears = minYears ? minYears : sign;
-        auto yearDoesNotSurpass = [&] {
-            return !nonISODateSurpasses(calendarId, sign, source.year, *source.relatedYear, source.monthCode, source.day, static_cast<int32_t>(candidateYears), target.year, target.monthCode, target.ordinalMonth, target.day);
-        };
-        while (yearDoesNotSurpass()) {
+        while (true) {
+            auto surpasses = nonISODateSurpasses(calendarId, sign, source.year, *source.relatedYear, source.monthCode, source.day, static_cast<int32_t>(candidateYears), target.year, target.monthCode, target.ordinalMonth, target.day);
+            if (!surpasses) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            if (*surpasses)
+                break;
             years = static_cast<int32_t>(candidateYears);
             candidateYears += sign;
         }
@@ -2536,8 +2594,13 @@ static TemporalResult<void> validateRejectMode(UCalendar* cal, CalendarID calend
         // gives UCAL_MONTH+1=6, and ICU4C never sets IS_LEAP_MONTH). constrainMonthCode
         // already positioned the calendar at the target month; verify only the day.
         // ICU4C-WORKAROUND: rdar://182958553 - y0 Kislev D30 rolls to ICU's M04 D1 (see maxDay override).
-        bool hebrewYear0KislevD30 = calendarId == hebrewCalendarID()
-            && monthCode->monthNumber == 3 && !monthCode->isLeapMonth && day == 30 && isHebrewYear0ExtraKislevDay(cal, calendarId);
+        bool hebrewYear0KislevD30 = false;
+        if (calendarId == hebrewCalendarID() && monthCode->monthNumber == 3 && !monthCode->isLeapMonth && day == 30) {
+            auto extraKislev = isHebrewYear0ExtraKislevDay(cal, calendarId);
+            if (!extraKislev) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            hebrewYear0KislevD30 = *extraKislev;
+        }
         if (!hebrewYear0KislevD30 && resolvedDay != static_cast<int32_t>(day)) [[unlikely]]
             return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
         return { };
@@ -2758,7 +2821,10 @@ TemporalResult<ISO8601::PlainDate> nonISOCalendarDateToISO(CalendarID calendarId
 
         {
             // ICU4C-WORKAROUND: rdar://182958553 - force maxDay = 30 for Hebrew y0 Kislev.
-            if (isHebrewYear0Kislev(cal, calendarId))
+            auto y0Kislev = isHebrewYear0Kislev(cal, calendarId);
+            if (!y0Kislev) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            if (*y0Kislev)
                 maxDay = 30;
         }
 

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
@@ -99,11 +99,11 @@ JS_EXPORT_PRIVATE std::optional<int32_t> calendarYearOfWeek(CalendarID, const IS
 
 JS_EXPORT_PRIVATE bool isValidMonthCodeForCalendar(CalendarID, ParsedMonthCode);
 
-JS_EXPORT_PRIVATE bool yearContainsMonthCode(CalendarID, int32_t year, ParsedMonthCode);
+JS_EXPORT_PRIVATE TemporalResult<bool> yearContainsMonthCode(CalendarID, int32_t year, ParsedMonthCode);
 
 JS_EXPORT_PRIVATE TemporalResult<ParsedMonthCode> constrainMonthCode(CalendarID, int32_t year, ParsedMonthCode, TemporalOverflow);
 
-JS_EXPORT_PRIVATE int32_t monthCodeOrdinalInYear(CalendarID, ParsedMonthCode, int32_t year);
+JS_EXPORT_PRIVATE TemporalResult<int32_t> monthCodeOrdinalInYear(CalendarID, ParsedMonthCode, int32_t year);
 
 JS_EXPORT_PRIVATE TemporalResult<std::optional<String>> calendarEra(CalendarID, const ISO8601::PlainDate& isoDate);
 

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -371,16 +371,16 @@ TemporalResult<std::optional<ISO8601::ExactTime>> getTimeZoneTransition(const Ti
 
             // Check if offset actually changed at this transition by querying before/after on cal directly.
             double beforeMs = transitionMs - 1.0;
-            double afterMs = transitionMs;
-            ucal_setMillis(cal, beforeMs, &status);
-            int32_t offsetBefore = ucal_get(cal, UCAL_ZONE_OFFSET, &status) + ucal_get(cal, UCAL_DST_OFFSET, &status);
-            ucal_setMillis(cal, afterMs, &status);
-            int32_t offsetAfter = ucal_get(cal, UCAL_ZONE_OFFSET, &status) + ucal_get(cal, UCAL_DST_OFFSET, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return std::optional<ISO8601::ExactTime> { transition };
-            if (offsetBefore != offsetAfter)
+            auto offsetBefore = getOffsetMsAtEpoch(cal, beforeMs);
+            if (!offsetBefore) [[unlikely]]
+                return makeUnexpected(rangeError(icuTransitionFailed));
+            auto offsetAfter = getOffsetMsAtEpoch(cal, transitionMs);
+            if (!offsetAfter) [[unlikely]]
+                return makeUnexpected(rangeError(icuTransitionFailed));
+            if (*offsetBefore != *offsetAfter)
                 return std::optional<ISO8601::ExactTime> { transition };
 
+            status = U_ZERO_ERROR;
             ucal_setMillis(cal, direction == TransitionDirection::Previous ? beforeMs : transitionMs + 1.0, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuTransitionFailed));


### PR DESCRIPTION
#### 642d9211add2a4e20dbe7be9a2012d0de1916b2c
<pre>
[JSC][Temporal] Give the ICU paths an error channel instead of plausible values
<a href="https://bugs.webkit.org/show_bug.cgi?id=321477">https://bugs.webkit.org/show_bug.cgi?id=321477</a>
<a href="https://rdar.apple.com/184567556">rdar://184567556</a>

Reviewed by Yusuke Suzuki.

Sites across the calendar and time zone bridges folded an ICU failure into a
legitimate-looking answer. No test: none of it is reachable while ICU is healthy -- extreme
years on all eight non-ISO calendars, hebrew year 0, PlainYearMonth diffs at both range ends
and far-future transitions behave identically before and after.

yearContainsMonthCode short-circuited on `cal &amp;&amp;`, so a failed calendar open read as &quot;this
year has no such month&quot; and constrainMonthCodeGivenContainment rewrote the month -- for
hebrew a valid M05L became M06, bypassing overflow: &quot;reject&quot;. monthCodeOrdinalInYear fell
back to monthCode.monthNumber, losing the leap-month shift, and resolveMonthCodeToOrdinal
had three failure paths returning 1, which fed the year count in calendarDateUntil. The
isHebrewYear0 trio folded a read failure into false, so callers skipped the hebrew
year-0 Kislev correction. All return optional or TemporalResult now; the genuine
constrain-backward exits stay distinct from the failure exits, and monthCodeOrdinalInYear&apos;s
ASSERT goes with the type change.

getTimeZoneTransition&apos;s offset check reused the UErrorCode ucal_getTimeZoneTransitionDate
had written, and ICU is sticky, so after any upstream failure all six calls no-oped to zero
and it returned the transition regardless. It reuses getOffsetMsAtEpoch now. PlainYearMonth
until/since and monthDayFromFields no longer fall back to a value on failure.

Canonical link: <a href="https://commits.webkit.org/318953@main">https://commits.webkit.org/318953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25b09d8ce9157b8bfbd7003657ed477294c7f8bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144255 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d9214b2-2a7b-4686-b43f-e1cf3688e67b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53598 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0acabcc-48e7-4a0a-b50d-209fa1ead0f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120764 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41cdf72a-0b5c-4cf4-98fc-e69a2fd33416) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/40956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2732 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9581 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40623 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1305 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41210 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192079 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53548 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149655 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54235 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149385 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27325 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44028 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126498 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121555 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52752 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15610 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52134 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52372 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52198 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->