### PR TITLE
MessagePorts + SharedWorkers have a bad time with recently added message checks

### DIFF
--- a/Source/WebCore/dom/messageports/MessagePortChannel.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.cpp
@@ -85,6 +85,10 @@ void MessagePortChannel::entanglePortWithProcess(const MessagePortIdentifier& po
 
     ASSERT(!m_processes[i] || *m_processes[i] == process);
     m_processes[i] = process;
+
+    if (m_status[i] == MessagePortStatus::Unclaimed)
+        m_status[i] = MessagePortStatus::Open;
+
     m_entangledToProcessProtectors[i] = this;
     m_pendingMessagePortTransfers[i].remove(*this);
 }
@@ -98,7 +102,7 @@ void MessagePortChannel::disentanglePort(const MessagePortIdentifier& port)
     ASSERT(port == m_ports[0] || port == m_ports[1]);
     size_t i = port == m_ports[0] ? 0 : 1;
 
-    ASSERT(m_processes[i] || m_isClosed[i]);
+    ASSERT(m_processes[i] || m_status[i] != MessagePortStatus::Open);
     m_processes[i] = std::nullopt;
     m_pendingMessagePortTransfers[i].add(*this);
 
@@ -107,15 +111,17 @@ void MessagePortChannel::disentanglePort(const MessagePortIdentifier& port)
     auto protectedThis = WTF::move(m_entangledToProcessProtectors[i]);
 }
 
-void MessagePortChannel::closePort(const MessagePortIdentifier& port)
+void MessagePortChannel::closePort(const MessagePortIdentifier& port, MessagePortStatus status)
 {
     ASSERT(isMainThread());
+    ASSERT(status != MessagePortStatus::Open);
 
     ASSERT(port == m_ports[0] || port == m_ports[1]);
     size_t i = port == m_ports[0] ? 0 : 1;
 
     m_processes[i] = std::nullopt;
-    m_isClosed[i] = true;
+    if (m_status[i] != MessagePortStatus::Closed)
+        m_status[i] = status;
 
     m_pendingMessages[i].clear();
     m_pendingMessagePortTransfers[i].clear();
@@ -130,7 +136,7 @@ bool MessagePortChannel::postMessageToRemote(MessageWithMessagePorts&& message, 
     ASSERT(remoteTarget == m_ports[0] || remoteTarget == m_ports[1]);
     size_t i = remoteTarget == m_ports[0] ? 0 : 1;
 
-    if (m_isClosed[i])
+    if (m_status[i] != MessagePortStatus::Open)
         return false;
 
     m_pendingMessages[i].append(WTF::move(message));

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -39,6 +39,8 @@ namespace WebCore {
 
 class MessagePortChannelRegistry;
 
+enum class MessagePortStatus : uint8_t { Open, Unclaimed, Closed };
+
 class MessagePortChannel : public RefCountedAndCanMakeWeakPtr<MessagePortChannel> {
 public:
     static Ref<MessagePortChannel> create(MessagePortChannelRegistry&, const MessagePortIdentifier& port1, const MessagePortIdentifier& port2);
@@ -52,7 +54,7 @@ public:
     WEBCORE_EXPORT bool NODELETE includesPort(const MessagePortIdentifier&);
     void entanglePortWithProcess(const MessagePortIdentifier&, ProcessIdentifier);
     void disentanglePort(const MessagePortIdentifier&);
-    void closePort(const MessagePortIdentifier&);
+    void closePort(const MessagePortIdentifier&, MessagePortStatus);
     bool postMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget);
 
     void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&);
@@ -69,7 +71,7 @@ private:
     MessagePortChannel(MessagePortChannelRegistry&, const MessagePortIdentifier& port1, const MessagePortIdentifier& port2);
 
     std::array<MessagePortIdentifier, 2> m_ports;
-    std::array<bool, 2> m_isClosed { false, false };
+    std::array<MessagePortStatus, 2> m_status { MessagePortStatus::Open, MessagePortStatus::Open };
     std::array<std::optional<ProcessIdentifier>, 2> m_processes;
     std::array<RefPtr<MessagePortChannel>, 2> m_entangledToProcessProtectors;
     std::array<Vector<MessageWithMessagePorts>, 2> m_pendingMessages;

--- a/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp
@@ -72,7 +72,7 @@ void MessagePortChannelProviderImpl::messagePortClosed(const MessagePortIdentifi
 {
     ensureOnMainThread([weakRegistry = WeakPtr { m_registry }, local] {
         if (CheckedPtr registry = weakRegistry.get())
-            registry->didCloseMessagePort(local);
+            registry->didCloseMessagePort(local, MessagePortStatus::Closed);
     });
 }
 

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp
@@ -102,7 +102,7 @@ void MessagePortChannelRegistry::didDisentangleMessagePort(const MessagePortIden
         channel->disentanglePort(port);
 }
 
-void MessagePortChannelRegistry::didCloseMessagePort(const MessagePortIdentifier& port)
+void MessagePortChannelRegistry::didCloseMessagePort(const MessagePortIdentifier& port, MessagePortStatus status)
 {
     ASSERT(isMainThread());
 
@@ -117,7 +117,7 @@ void MessagePortChannelRegistry::didCloseMessagePort(const MessagePortIdentifier
         LOG(MessagePorts, "Registry: (Note) The channel closed for port %s had messages pending or in flight", port.logString().utf8().data());
 #endif
 
-    channel->closePort(port);
+    channel->closePort(port, status);
 
     // FIXME: When making message ports be multi-process, this should probably push a notification
     // to the remaining port to tell it this port closed.

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
@@ -47,7 +47,7 @@ public:
     WEBCORE_EXPORT void didCreateMessagePortChannel(const MessagePortIdentifier& port1, const MessagePortIdentifier& port2);
     WEBCORE_EXPORT void didEntangleLocalToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote, ProcessIdentifier);
     WEBCORE_EXPORT void didDisentangleMessagePort(const MessagePortIdentifier& local);
-    WEBCORE_EXPORT void didCloseMessagePort(const MessagePortIdentifier& local);
+    WEBCORE_EXPORT void didCloseMessagePort(const MessagePortIdentifier& local, MessagePortStatus);
     WEBCORE_EXPORT bool didPostMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget);
     WEBCORE_EXPORT void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&);
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -197,8 +197,7 @@ NetworkConnectionToWebProcess::~NetworkConnectionToWebProcess()
     // This may call hasUploadStateChanged().
     m_networkResourceLoaders.clear();
 
-    for (auto& port : m_processEntangledPorts)
-        protect(m_networkProcess->messagePortChannelRegistry())->didCloseMessagePort(port);
+    closeAllEntangledMessagePorts();
 
     auto completionHandlers = std::exchange(m_messageBatchDeliveryCompletionHandlers, { });
     for (auto& completionHandler : completionHandlers.values())
@@ -460,8 +459,16 @@ bool NetworkConnectionToWebProcess::dispatchSyncMessage(IPC::Connection& connect
     return false;
 }
 
+void NetworkConnectionToWebProcess::closeAllEntangledMessagePorts()
+{
+    for (auto& port : std::exchange(m_processEntangledPorts, { }))
+        protect(m_networkProcess->messagePortChannelRegistry())->didCloseMessagePort(port, MessagePortStatus::Unclaimed);
+}
+
 void NetworkConnectionToWebProcess::didClose(IPC::Connection& connection)
 {
+    closeAllEntangledMessagePorts();
+
     if (RefPtr connection = std::exchange(m_swContextConnection, nullptr))
         connection->stop();
 
@@ -1805,7 +1812,8 @@ void NetworkConnectionToWebProcess::messagePortClosed(const MessagePortIdentifie
     if (RefPtr channel = registry->existingChannelContainingPort(port))
         MESSAGE_CHECK(channel->processForPort(port) == m_webProcessIdentifier);
 
-    registry->didCloseMessagePort(port);
+    m_processEntangledPorts.remove(port);
+    registry->didCloseMessagePort(port, MessagePortStatus::Closed);
 }
 
 MessageBatchIdentifier NetworkConnectionToWebProcess::nextMessageBatchIdentifier(CompletionHandler<void()>&& deliveryCallback)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -377,6 +377,8 @@ private:
     void postMessageToRemote(WebCore::MessageWithMessagePorts&&, const WebCore::MessagePortIdentifier&);
     void didDeliverMessagePortMessages(MessageBatchIdentifier);
 
+    void closeAllEntangledMessagePorts();
+
 #if PLATFORM(MAC)
     void updateActivePages(String&& name, const Vector<String>& activePagesOrigins, CoreIPCAuditToken&&);
     void getProcessDisplayName(CoreIPCAuditToken&&, CompletionHandler<void(const String&)>&&);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -93,6 +93,8 @@ void WebSharedWorkerServerConnection::requestSharedWorker(WebCore::SharedWorkerK
 {
     MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, WebCore::RegistrableDomain::uncheckedCreateFromHost(sharedWorkerKey.origin.topOrigin.host())) != NetworkProcess::AllowCookieAccess::Terminate);
     MESSAGE_CHECK(sharedWorkerObjectIdentifier.processIdentifier() == m_webProcessIdentifier);
+    MESSAGE_CHECK(port.first.processIdentifier == m_webProcessIdentifier);
+    MESSAGE_CHECK(port.second.processIdentifier == m_webProcessIdentifier);
     MESSAGE_CHECK(sharedWorkerKey.name == workerOptions.name);
     CONNECTION_RELEASE_LOG("requestSharedWorker: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING, sharedWorkerObjectIdentifier.toString().utf8().data());
     if (CheckedPtr session = this->session())

--- a/Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm
+++ b/Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm
@@ -737,3 +737,130 @@ TEST(MessagePortSecurity, WorkerMessagePortsSurviveNetworkProcessRestart)
     EXPECT_FALSE(webContentTerminated);
     EXPECT_EQ(initialWebProcessPID, [webView _webProcessIdentifier]);
 }
+
+template<typename Predicate> static bool messagePortWaitUntilTrue(Predicate&& predicate, unsigned maxTimeout = 100)
+{
+    for (unsigned i = 0; i < maxTimeout; ++i) {
+        if (predicate())
+            return true;
+        TestWebKitAPI::Util::runFor(0.1_s);
+    }
+    return false;
+}
+
+static pid_t sharedWorkerHostProcessIdentifier()
+{
+    for (_WKWebContentProcessInfo *info in [WKProcessPool _webContentProcessInfoForTesting]) {
+        if (info.runningSharedWorkers)
+            return info.pid;
+    }
+    return 0;
+}
+
+static constexpr auto echoSharedWorkerBytes = R"PORTRESOURCE(
+onconnect = function(e) {
+    var port = e.ports[0];
+    port.onmessage = function(event) {
+        port.postMessage('echo:' + event.data);
+    };
+    port.start();
+    port.postMessage('connected');
+};
+)PORTRESOURCE"_s;
+
+static constexpr auto echoClientBytes = R"PORTRESOURCE(
+<!doctype html>
+<script>
+window.replies = [];
+window.worker = new SharedWorker('/echo-worker.js');
+window.worker.port.onmessage = function(e) { window.replies.push(e.data); };
+window.worker.port.start();
+window.worker.port.postMessage('hello');
+</script>
+)PORTRESOURCE"_s;
+
+// When a SharedWorker's context process dies while one of its clients is in the back/forward cache, the
+// cached client keeps the worker alive, so it is relaunched and its connect port is re-entangled using the
+// same MessagePortIdentifier. The client should still be able to talk to it afterwards.
+TEST(MessagePortSecurity, SharedWorkerPortStillWorksAfterContextProcessDiesWithCachedClient)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/client"_s, { echoClientBytes } },
+        { "/away"_s, { "<!doctype html><body>away</body>"_s } },
+        { "/echo-worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, echoSharedWorkerBytes } },
+    });
+
+    auto repliesContain = [](TestWKWebView *webView, NSString *reply) {
+        return [[webView stringByEvaluatingJavaScript:@"window.replies ? window.replies.join(',') : ''"] containsString:reply];
+    };
+
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    // `webViewA` establishes the SharedWorker, so its process is the one the worker is launched into.
+    RetainPtr navDelegateA = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webViewA = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewA setNavigationDelegate:navDelegateA.get()];
+    [webViewA loadRequest:server.request("/client"_s)];
+    [navDelegateA waitForDidFinishNavigation];
+    EXPECT_TRUE(messagePortWaitUntilTrue([&] { return repliesContain(webViewA.get(), @"echo:hello"); }));
+
+    // `webViewB` is a second client of that same SharedWorker, in its own process.
+    RetainPtr navDelegateB = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webViewB = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewB setNavigationDelegate:navDelegateB.get()];
+    [webViewB loadRequest:server.request("/client"_s)];
+    [navDelegateB waitForDidFinishNavigation];
+    EXPECT_TRUE(messagePortWaitUntilTrue([&] { return repliesContain(webViewB.get(), @"echo:hello"); }));
+
+    pid_t webProcessPIDB = [webViewB _webProcessIdentifier];
+    EXPECT_NE([webViewA _webProcessIdentifier], webProcessPIDB);
+
+    __block bool webContentTerminatedB = false;
+    navDelegateB.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        webContentTerminatedB = true;
+    };
+
+    // The worker must be hosted outside `webViewB`'s process, otherwise killing it below would take the
+    // cached client with it and there would be nothing left to relaunch for.
+    pid_t originalSharedWorkerPID = 0;
+    EXPECT_TRUE(messagePortWaitUntilTrue([&] {
+        originalSharedWorkerPID = sharedWorkerHostProcessIdentifier();
+        return !!originalSharedWorkerPID;
+    }));
+    EXPECT_NE(originalSharedWorkerPID, webProcessPIDB);
+
+    // Lets us tell a back/forward cache restore from a reload.
+    [webViewB evaluateJavaScript:@"window.documentInstanceMarker = 'first-instance';" completionHandler:nil];
+
+    [webViewB loadRequest:server.request("/away"_s)];
+    [navDelegateB waitForDidFinishNavigation];
+
+    // This also takes `webViewA`'s page with it. The relaunch may land in `webViewB`'s own process, since it
+    // is now the only remaining client.
+    kill(originalSharedWorkerPID, SIGKILL);
+
+    pid_t relaunchedSharedWorkerPID = 0;
+    EXPECT_TRUE(messagePortWaitUntilTrue([&] {
+        relaunchedSharedWorkerPID = sharedWorkerHostProcessIdentifier();
+        return relaunchedSharedWorkerPID && relaunchedSharedWorkerPID != originalSharedWorkerPID;
+    }));
+
+    // Re-entangling must not be mistaken for a misbehaving WebContent process.
+    EXPECT_FALSE(webContentTerminatedB);
+    EXPECT_EQ(webProcessPIDB, [webViewB _webProcessIdentifier]);
+
+    [webViewB goBack];
+    [navDelegateB waitForDidFinishNavigation];
+
+    // If this fails the page was reloaded rather than restored, and the rest proves nothing.
+    EXPECT_WK_STREQ([webViewB stringByEvaluatingJavaScript:@"window.documentInstanceMarker || 'reloaded'"], "first-instance");
+
+    EXPECT_TRUE(messagePortWaitUntilTrue([&] { return repliesContain(webViewB.get(), @"connected"); }));
+
+    [webViewB evaluateJavaScript:@"window.replies = []; window.worker.port.postMessage('after-relaunch');" completionHandler:nil];
+    EXPECT_TRUE(messagePortWaitUntilTrue([&] { return repliesContain(webViewB.get(), @"echo:after-relaunch"); }));
+
+    EXPECT_FALSE(webContentTerminatedB);
+    EXPECT_EQ(webProcessPIDB, [webViewB _webProcessIdentifier]);
+}
+


### PR DESCRIPTION
#### 900818e2cde3c693a0bfa07a2732cd6ccbd21647
<pre>
MessagePorts + SharedWorkers have a bad time with recently added message checks
<a href="https://rdar.apple.com/184338230">rdar://184338230</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321471">https://bugs.webkit.org/show_bug.cgi?id=321471</a>

Reviewed by Chris Dumez.

If a SharedWorker&apos;s web content process dies while one of its clients is in the back/forward cache,
it is relaunched for the sake of that client. Any message ports are then re-entangled.

The networking process only releases message port ownership in ~NetworkConnectionToWebProcess, which
can run long after ::didClose() starts the relaunch. This causes the re-entanglement for ports &quot;owned&quot;
by the dead process to be message checked against the new process.

We can release port ownership in didClose() instead, and treat a port owned by a process with no live
connection as &quot;unreleased&quot; instead of a misbehaving sender.

MessagePortChannel::closePort() also latched m_isClosed with nothing to clear it, so once the worker
relaunches every message the client sent it was silently dropped; entanglePortWithProcess() now clears it.

New test: MessagePortSecurity.SharedWorkerPortStillWorksAfterContextProcessDiesWithCachedClient

* Source/WebCore/dom/messageports/MessagePortChannel.cpp:
(WebCore::MessagePortChannel::entanglePortWithProcess):
(WebCore::MessagePortChannel::disentanglePort):
(WebCore::MessagePortChannel::closePort):
(WebCore::MessagePortChannel::postMessageToRemote):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::~NetworkConnectionToWebProcess):
(WebKit::NetworkConnectionToWebProcess::closeAllEntangledMessagePorts):
(WebKit::NetworkConnectionToWebProcess::didClose):
(WebKit::NetworkConnectionToWebProcess::entangleLocalPortInThisProcessToRemote):
(WebKit::NetworkConnectionToWebProcess::takeAllMessagesForPort):
(WebKit::NetworkConnectionToWebProcess::messagePortClosed):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm:
((MessagePortSecurity, SharedWorkerPortStillWorksAfterContextProcessDiesWithCachedClient)):
* Source/WebCore/dom/messageports/MessagePortChannel.h:
* Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp:
(WebCore::MessagePortChannelProviderImpl::messagePortClosed):
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp:
(WebCore::MessagePortChannelRegistry::didCloseMessagePort):
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.h:

Canonical link: <a href="https://commits.webkit.org/319041@main">https://commits.webkit.org/319041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e84dd6709c9efa787483693bcd963d4f9dbbddd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180038 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144357 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2c10cc2-dc47-4a53-b8ae-7ba8e4e0cc44) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140402 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a860f25-f924-4b41-a278-94a7a28e3ad2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120853 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f75219d-0fb0-46a1-acec-74d9ced0160f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42731 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41045 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153133 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40709 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1407 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192182 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53650 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149744 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40153 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54337 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149475 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44115 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126600 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121707 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52854 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15697 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52236 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52474 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52300 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->