### PR TITLE
<animateMotion> ignores a zero-length motion path

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-moveto-only-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-moveto-only-expected.txt
@@ -1,0 +1,7 @@
+
+
+PASS path="M 100 100" translates to the initial point of the path
+PASS <mpath> referencing d="M 100 100" translates to the initial point of the path
+PASS accumulate="sum" on a single-moveto path adds the end of the path per repeat
+PASS path="M 200 100" with rotate="auto" uses a 0 degree angle, not the position vector
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-moveto-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-moveto-only.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>&lt;animateMotion> with a motion path that is a single moveto</title>
+<link rel="help" href="https://svgwg.org/specs/animations/#AnimateMotionElement">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- "M 100 100" is a legal path: a path data segment must begin with a moveto,
+     and nothing requires a second command. Because it is legal, the SMIL rule
+     that an illegal value makes the animation have no effect does not apply.
+     Its total length is 0, so t/dur distance along it is 0 at every t and the
+     computed coordinate is its initial point, (100, 100) -- exactly as for the
+     other zero-length spellings in animateMotion-path-zero-length-subpaths.html. -->
+
+<svg id="svg-path" width="300" height="300">
+  <rect id="rect-path" width="10" height="10" fill="green">
+    <animateMotion path="M 100 100" rotate="auto" dur="2s" fill="freeze"/>
+  </rect>
+</svg>
+
+<svg id="svg-mpath" width="300" height="300">
+  <defs><path id="motion-path" d="M 100 100"/></defs>
+  <rect id="rect-mpath" width="10" height="10" fill="green">
+    <animateMotion rotate="auto" dur="2s" fill="freeze">
+      <mpath href="#motion-path"/>
+    </animateMotion>
+  </rect>
+</svg>
+
+<svg id="svg-accumulate" width="300" height="300">
+  <rect id="rect-accumulate" width="10" height="10" fill="green">
+    <animateMotion path="M 100 100" dur="2s"
+                   repeatCount="2" accumulate="sum" fill="freeze"/>
+  </rect>
+</svg>
+
+<!-- (200,100) is not on the x==y diagonal, so an angle taken from the position
+     vector (26.57 degrees here) is distinguishable from one taken from the
+     undefined tangent (0 degrees). -->
+<svg id="svg-off-diagonal" width="400" height="300">
+  <rect id="rect-off-diagonal" width="10" height="10" fill="green">
+    <animateMotion path="M 200 100" rotate="auto" dur="2s" fill="freeze"/>
+  </rect>
+</svg>
+
+<script>
+for (const svg of document.querySelectorAll('svg'))
+  svg.pauseAnimations();
+
+function sampleAt(svg, t) {
+  svg.setCurrentTime(t);
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+function assertTransform(rect, x, y, angle, description) {
+  const m = rect.getCTM();
+  assert_not_equals(m, null, `${description}: getCTM()`);
+  const epsilon = 0.01;
+  assert_approx_equals(m.e, x, epsilon, `${description}: translate x`);
+  assert_approx_equals(m.f, y, epsilon, `${description}: translate y`);
+  const degrees = Math.atan2(m.b, m.a) * 180 / Math.PI;
+  assert_approx_equals(degrees, angle, epsilon, `${description}: rotation angle`);
+}
+
+promise_test(async t => {
+  const svg = document.getElementById('svg-path');
+  const rect = document.getElementById('rect-path');
+  for (const time of [0, 1, 2, 4]) {
+    await sampleAt(svg, time);
+    assertTransform(rect, 100, 100, 0, `t=${time}`);
+  }
+}, 'path="M 100 100" translates to the initial point of the path');
+
+promise_test(async t => {
+  const svg = document.getElementById('svg-mpath');
+  const rect = document.getElementById('rect-mpath');
+  for (const time of [0, 1, 2, 4]) {
+    await sampleAt(svg, time);
+    assertTransform(rect, 100, 100, 0, `t=${time}`);
+  }
+}, '<mpath> referencing d="M 100 100" translates to the initial point of the path');
+
+promise_test(async t => {
+  const svg = document.getElementById('svg-accumulate');
+  const rect = document.getElementById('rect-accumulate');
+  await sampleAt(svg, 1);
+  assertTransform(rect, 100, 100, 0, 't=1, first iteration');
+  await sampleAt(svg, 2);
+  assertTransform(rect, 200, 200, 0, 't=2, second iteration accumulates');
+  await sampleAt(svg, 4);
+  assertTransform(rect, 200, 200, 0, 't=4, frozen');
+}, 'accumulate="sum" on a single-moveto path adds the end of the path per repeat');
+
+promise_test(async t => {
+  // The tangent of a zero-length path is undefined, so rotate="auto" must not
+  // fall back to the angle of the position vector, which would be 26.57 degrees.
+  const svg = document.getElementById('svg-off-diagonal');
+  const rect = document.getElementById('rect-off-diagonal');
+  for (const time of [0, 1, 2, 4]) {
+    await sampleAt(svg, time);
+    assertTransform(rect, 200, 100, 0, `t=${time}`);
+  }
+}, 'path="M 200 100" with rotate="auto" uses a 0 degree angle, not the position vector');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-zero-length-subpaths-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-zero-length-subpaths-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS path="M 100 100 L 100 100" stays at the initial point, with a 0 degree angle
+PASS path="M 100 100 Z" stays at the initial point, with a 0 degree angle
+PASS accumulate="sum" on a zero-length path adds the end of the path per repeat
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-zero-length-subpaths.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-zero-length-subpaths.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>&lt;animateMotion> with a zero-length motion path made of several path elements</title>
+<link rel="help" href="https://svgwg.org/specs/animations/#AnimateMotionElement">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- Every path below has a total length of 0, so t/dur distance along the path is
+     0 at every t, and the computed coordinate is the path's initial point. -->
+
+<svg id="svg-line" width="300" height="300">
+  <rect id="rect-line" width="10" height="10" fill="green">
+    <animateMotion path="M 100 100 L 100 100" rotate="auto" dur="2s" fill="freeze"/>
+  </rect>
+</svg>
+
+<svg id="svg-close" width="300" height="300">
+  <rect id="rect-close" width="10" height="10" fill="green">
+    <animateMotion path="M 100 100 Z" rotate="auto" dur="2s" fill="freeze"/>
+  </rect>
+</svg>
+
+<!-- Deliberately not tested here: path="M 100 100 M 200 200". Which of the two
+     zero-length subpaths a distance of 0 lands on is not resolved -- SVG 2 says
+     "the point which is t/dur distance along the motion path", while SMIL says a
+     moveto happens instantaneously, which argues for the second one. WebKit uses
+     the first moveto; Chrome and Firefox use the last. Needs a spec answer before
+     it is worth asserting either way. -->
+
+<svg id="svg-accumulate" width="300" height="300">
+  <rect id="rect-accumulate" width="10" height="10" fill="green">
+    <animateMotion path="M 100 100 L 100 100" dur="2s"
+                   repeatCount="2" accumulate="sum" fill="freeze"/>
+  </rect>
+</svg>
+
+<script>
+// Drive the timelines by hand rather than waiting on wall-clock time.
+for (const svg of document.querySelectorAll('svg'))
+  svg.pauseAnimations();
+
+function sampleAt(svg, t) {
+  svg.setCurrentTime(t);
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+// The supplemental transform is translate(x, y) * rotate(angle), so the CTM of a
+// rect in an untransformed viewport is [cos, sin, -sin, cos, x, y].
+function assertTransform(rect, x, y, angle, description) {
+  const m = rect.getCTM();
+  assert_not_equals(m, null, `${description}: getCTM()`);
+  const epsilon = 0.01;
+  assert_approx_equals(m.e, x, epsilon, `${description}: translate x`);
+  assert_approx_equals(m.f, y, epsilon, `${description}: translate y`);
+  // An undefined tangent must not leak a NaN angle into the matrix; the
+  // approx_equals below would fail on NaN, which is the point.
+  const degrees = Math.atan2(m.b, m.a) * 180 / Math.PI;
+  assert_approx_equals(degrees, angle, epsilon, `${description}: rotation angle`);
+}
+
+promise_test(async t => {
+  const svg = document.getElementById('svg-line');
+  const rect = document.getElementById('rect-line');
+  for (const time of [0, 1, 2, 4]) {
+    await sampleAt(svg, time);
+    assertTransform(rect, 100, 100, 0, `t=${time}`);
+  }
+}, 'path="M 100 100 L 100 100" stays at the initial point, with a 0 degree angle');
+
+promise_test(async t => {
+  const svg = document.getElementById('svg-close');
+  const rect = document.getElementById('rect-close');
+  for (const time of [0, 1, 2, 4]) {
+    await sampleAt(svg, time);
+    assertTransform(rect, 100, 100, 0, `t=${time}`);
+  }
+}, 'path="M 100 100 Z" stays at the initial point, with a 0 degree angle');
+
+promise_test(async t => {
+  const svg = document.getElementById('svg-accumulate');
+  const rect = document.getElementById('rect-accumulate');
+  await sampleAt(svg, 1);
+  assertTransform(rect, 100, 100, 0, 't=1, first iteration');
+  await sampleAt(svg, 2);
+  assertTransform(rect, 200, 200, 0, 't=2, second iteration accumulates');
+  await sampleAt(svg, 4);
+  assertTransform(rect, 200, 200, 0, 't=4, frozen');
+}, 'accumulate="sum" on a zero-length path adds the end of the path per repeat');
+</script>

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -227,17 +227,14 @@ void SVGAnimateMotionElement::calculateAnimatedValue(float percentage, unsigned 
         // its normal angle, and at most once more for the accumulated repeats.
         float pathLength = m_animationPath.length();
 
+        // A zero-length path never reports success(), but current() is still its initial point.
         auto traversalState = m_animationPath.traversalStateAtLength(pathLength * percentage);
-        if (traversalState.success())
-            transform->translate(traversalState.current());
+        transform->translate(traversalState.current());
 
         if (isAccumulated() && repeatCount) {
-            auto endOfPathState = m_animationPath.traversalStateAtLength(pathLength);
-            if (endOfPathState.success()) {
-                auto endOfPath = endOfPathState.current();
-                for (unsigned i = 0; i < repeatCount; ++i)
-                    transform->translate(endOfPath);
-            }
+            auto endOfPath = m_animationPath.traversalStateAtLength(pathLength).current();
+            for (unsigned i = 0; i < repeatCount; ++i)
+                transform->translate(endOfPath);
         }
 
         angle = traversalState.normalAngle();


### PR DESCRIPTION
#### ea32b77b2786ebbe88c58a70fe96072b47a405da
<pre>
&lt;animateMotion&gt; ignores a zero-length motion path
<a href="https://bugs.webkit.org/show_bug.cgi?id=321478">https://bugs.webkit.org/show_bug.cgi?id=321478</a>
<a href="https://rdar.apple.com/184569273">rdar://184569273</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

path=&quot;M 100 100&quot; is a legal motion path of length 0, so every t/dur distance
along it resolves to its initial point and the element should sit at (100,100)
for the whole animation. Instead it never moves.

calculateAnimatedValue() translated only when PathTraversalState::success() was
set, and a zero-length path never sets it: the traversal marks a zero vector on
the first element and waits for a second one to resolve it, which a lone moveto
never provides. Both the position and the accumulated repeats were skipped, so
the result depended on spelling -- &quot;M 100 100 L 100 100&quot; and &quot;M 100 100 Z&quot; have
a second element and do translate to (100,100).

Translate by current() unconditionally. It already holds the initial point in
the failing case, and it is what successful traversals were reading anyway, so
those are unaffected. The angle does not change either: normalAngle() is 0 here,
which is what rotate=&quot;auto&quot; already resolved to.

Chrome and Firefox both place the element at the initial point, and
accumulate=&quot;sum&quot; now steps (100,100) -&gt; (200,200), as all three engines already
do for the two-element spelling.

Tests: imported/w3c/web-platform-tests/svg/animations/animateMotion-path-moveto-only.html
 imported/w3c/web-platform-tests/svg/animations/animateMotion-path-zero-length-subpaths.html

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-moveto-only-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-moveto-only.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-zero-length-subpaths-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-path-zero-length-subpaths.html: Added.
* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::calculateAnimatedValue):

Canonical link: <a href="https://commits.webkit.org/318963@main">https://commits.webkit.org/318963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2320f9dff4445cae611c560a8a2d8963f1b0b5e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190151 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144258 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ca9f9f1-55be-435f-a737-b0233cfdd822) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140319 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/760dd586-685d-4b36-a2a6-fd8974d8046b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120770 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7775b4e6-7408-4fec-8c60-f5b17a57b337) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42647 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40960 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40630 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1308 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192083 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149656 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40099 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54238 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149386 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44034 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126501 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121558 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52755 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15617 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52137 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52375 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52201 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->