### PR TITLE
[site-isolation] media/audio-session-category-unmute-mute.html is a permanent failure

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -323,6 +323,8 @@ void MediaSessionManagerCocoa::removeSession(PlatformMediaSessionInterface& sess
         if (m_nowPlayingManager)
             m_nowPlayingManager->removeClient(*this);
         m_audioHardwareListener = nullptr;
+        m_delayCategoryChangeTimer.stop();
+        m_previousCategory = AudioSession::CategoryType::None;
     }
 
     scheduleSessionStatusUpdate();


### PR DESCRIPTION
#### dabf122e6804336f528546dc2bbb9f382e92f971
<pre>
[site-isolation] media/audio-session-category-unmute-mute.html is a permanent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=321479">https://bugs.webkit.org/show_bug.cgi?id=321479</a>
<a href="https://rdar.apple.com/184569176">rdar://184569176</a>

Reviewed by Eric Carlson.

The test plays a muted element and expects the audio session category to be None. With site isolation
enabled it read MediaPlayback, on every run, and only when another test had run before it in the same
UI process.

updateSessionState() does not drop straight to None: when the computed category is None and the previous
one was neither None nor PlayAndRecord, it starts a two second timer and reports the previous category
instead. That previous category and the timer belong to the manager instance. Without site isolation
that instance is the page&apos;s own MediaSessionManagerCocoa, which starts out at None for each test. With
site isolation the category is computed by RemoteMediaSessionManagerProxy, one instance for the whole UI
process, so MediaPlayback left behind by media/audio-session-category-at-most-recent-playback.html was
still the previous category when this test&apos;s page computed None, and the hold outlasted the gap between
the two tests. The proxy&apos;s session counts confirm no session was leaking across: it saw one session at a
time and dropped to none between the tests, while every computation reported &quot;setting category =
MediaPlayback, previous category = MediaPlayback&quot;.

removeSession() clears the previous category and stops the timer once the last session is gone, so the
hold only covers transitions while a session exists.

Covered by existing tests.

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::removeSession): Clear the delayed category change when the last
session goes away.

Canonical link: <a href="https://commits.webkit.org/318968@main">https://commits.webkit.org/318968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38c4f7c8ec407061ba288ee2a5acbe4e32d793f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190156 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144263 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12d95c09-3298-416c-ba7c-44952969e18a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140321 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/360112e6-50e3-46f8-be43-a6be99e68682) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120772 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a0e740f-93c4-4b6b-920a-a401cc9d2978) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42650 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40964 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153052 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.WindowClientNavigate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40628 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1313 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192088 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53556 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149659 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40104 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54243 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149389 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44036 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126506 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121563 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52760 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15615 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52142 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52380 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52206 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->