### PR TITLE
Potential use-after-move in `Document::processCaptureStateDidChange()`

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6199,7 +6199,8 @@ void Document::processCaptureStateDidChange(Function<bool(const Page&)>&& isPage
     if (!hasRealtimeMediaSource(m_captureSources, filterSource))
         return;
 
-    eventLoop().queueTask(TaskSource::MediaElement, [weakDocument = WeakPtr { *this }, weakSession = WeakPtr { *mediaSession }, isPageMuted = isPageMutedCallback(*page), filterSource = WTF::move(filterSource), isPageMutedCallback = WTF::move(isPageMutedCallback), action] {
+    bool isPageMuted = isPageMutedCallback(*page);
+    eventLoop().queueTask(TaskSource::MediaElement, [weakDocument = WeakPtr { *this }, weakSession = WeakPtr { *mediaSession }, isPageMuted, filterSource = WTF::move(filterSource), isPageMutedCallback = WTF::move(isPageMutedCallback), action] {
         RefPtr protecteDocument = weakDocument.get();
         if (!protecteDocument)
             return;


### PR DESCRIPTION
#### 78dfedf6e4f023154e5680322dbb5637591bacbd
<pre>
Potential use-after-move in `Document::processCaptureStateDidChange()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=321483">https://bugs.webkit.org/show_bug.cgi?id=321483</a>
<a href="https://rdar.apple.com/184571470">rdar://184571470</a>

Reviewed by Chris Dumez.

ISO C++23 does not guarantee the initialization order of lambda captures.
The lambda capture list here both used `isPageMutedCallback` and moved it,
so the use and the move were unsequenced.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processCaptureStateDidChange):

Canonical link: <a href="https://commits.webkit.org/318966@main">https://commits.webkit.org/318966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc4c124200de7c3f61690d897a8f5aff405bc8e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144271 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140326 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42660 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40973 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40640 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1321 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192096 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53564 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149668 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40101 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54251 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149398 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44046 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126514 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121573 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52768 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15627 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52150 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52388 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->