### PR TITLE
[JSC] `SourceProviderCacheItem::create` over-allocates the trailing `PackedPtr` array

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -69,7 +69,6 @@ llint/LLIntEntrypoint.cpp
 parser/Lexer.h
 parser/Parser.cpp
 parser/Parser.h
-parser/SourceProviderCacheItem.h
 parser/SourceTaintedOrigin.cpp
 profiler/ProfilerDatabase.cpp
 runtime/CachedTypes.cpp

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -877,8 +877,8 @@ public:
         m_needsFullActivation = info->needsFullActivation;
         m_needsSuperBinding = info->needsSuperBinding;
         UniquedStringImplPtrSet& destSet = m_usedVariables.last();
-        for (unsigned i = 0; i < info->usedVariablesCount; ++i)
-            destSet.add(info->usedVariables()[i].get());
+        for (auto& variable : info->usedVariables())
+            destSet.add(variable.get());
     }
 
     class MaybeParseAsGeneratorFunctionForScope;

--- a/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
+++ b/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
@@ -29,11 +29,11 @@
 #include <JavaScriptCore/ImplementationVisibility.h>
 #include <JavaScriptCore/ParserModes.h>
 #include <JavaScriptCore/ParserTokens.h>
+#include <wtf/PackedRefPtr.h>
+#include <wtf/TrailingArray.h>
 #include <wtf/Vector.h>
 #include <wtf/text/UniquedStringImpl.h>
 #include <wtf/text/WTFString.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
@@ -59,11 +59,12 @@ struct SourceProviderCacheItemCreationParameters {
 };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SourceProviderCacheItem);
-class SourceProviderCacheItem {
+class SourceProviderCacheItem final : public TrailingArray<SourceProviderCacheItem, PackedRefPtr<UniquedStringImpl>> {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SourceProviderCacheItem, SourceProviderCacheItem);
 public:
+    using Base = TrailingArray<SourceProviderCacheItem, PackedRefPtr<UniquedStringImpl>>;
+
     static std::unique_ptr<SourceProviderCacheItem> create(const SourceProviderCacheItemCreationParameters&);
-    ~SourceProviderCacheItem();
 
     JSToken endFunctionToken() const 
     {
@@ -102,37 +103,27 @@ public:
     bool taintedByWithScope : 1;
     unsigned lastTokenLineStartOffset : 31;
     bool isBodyArrowExpression : 1;
-    unsigned usedVariablesCount;
     unsigned tokenType : 24; // JSTokenType
     unsigned innerArrowFunctionFeatures : 6; // InnerArrowFunctionCodeFeatures
     unsigned constructorKind : 2; // ConstructorKind
     unsigned implementationVisibility : 2; // ImplementationVisibility
     bool usesImportMeta : 1 { false };
 
-    PackedPtr<UniquedStringImpl>* usedVariables() const { return const_cast<PackedPtr<UniquedStringImpl>*>(m_variables); }
+    std::span<const PackedRefPtr<UniquedStringImpl>> usedVariables() const LIFETIME_BOUND { return span(); }
 
 private:
     SourceProviderCacheItem(const SourceProviderCacheItemCreationParameters&);
-
-    PackedPtr<UniquedStringImpl> m_variables[0];
 };
-
-inline SourceProviderCacheItem::~SourceProviderCacheItem()
-{
-    for (unsigned i = 0; i < usedVariablesCount; ++i)
-        m_variables[i]->deref();
-}
 
 inline std::unique_ptr<SourceProviderCacheItem> SourceProviderCacheItem::create(const SourceProviderCacheItemCreationParameters& parameters)
 {
-    size_t variableCount = parameters.usedVariables.size();
-    size_t objectSize = sizeof(SourceProviderCacheItem) + sizeof(UniquedStringImpl*) * variableCount;
-    void* slot = SourceProviderCacheItemMalloc::malloc(objectSize);
-    return std::unique_ptr<SourceProviderCacheItem>(new (slot) SourceProviderCacheItem(parameters));
+    void* slot = SourceProviderCacheItemMalloc::malloc(Base::allocationSize(parameters.usedVariables.size()));
+    return std::unique_ptr<SourceProviderCacheItem>(new (NotNull, slot) SourceProviderCacheItem(parameters));
 }
 
 inline SourceProviderCacheItem::SourceProviderCacheItem(const SourceProviderCacheItemCreationParameters& parameters)
-    : needsFullActivation(parameters.needsFullActivation)
+    : Base(parameters.usedVariables.span())
+    , needsFullActivation(parameters.needsFullActivation)
     , endFunctionOffset(parameters.endFunctionOffset)
     , usesEval(parameters.usesEval)
     , lastTokenLine(parameters.lastTokenLine)
@@ -145,7 +136,6 @@ inline SourceProviderCacheItem::SourceProviderCacheItem(const SourceProviderCach
     , taintedByWithScope(parameters.lexicallyScopedFeatures & TaintedByWithScopeLexicallyScopedFeature)
     , lastTokenLineStartOffset(parameters.lastTokenLineStartOffset)
     , isBodyArrowExpression(parameters.isBodyArrowExpression)
-    , usedVariablesCount(parameters.usedVariables.size())
     , tokenType(static_cast<unsigned>(parameters.tokenType))
     , innerArrowFunctionFeatures(static_cast<unsigned>(parameters.innerArrowFunctionFeatures))
     , constructorKind(static_cast<unsigned>(parameters.constructorKind))
@@ -157,13 +147,6 @@ inline SourceProviderCacheItem::SourceProviderCacheItem(const SourceProviderCach
     ASSERT(constructorKind == static_cast<unsigned>(parameters.constructorKind));
     ASSERT(implementationVisibility == static_cast<unsigned>(parameters.implementationVisibility));
     ASSERT(expectedSuperBinding == static_cast<unsigned>(parameters.expectedSuperBinding));
-    for (unsigned i = 0; i < usedVariablesCount; ++i) {
-        auto* pointer = parameters.usedVariables[i];
-        pointer->ref();
-        m_variables[i] = pointer;
-    }
 }
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 69b336c0ac0539338e0d764beba3da19bc58af3c
<pre>
[JSC] `SourceProviderCacheItem::create` over-allocates the trailing `PackedPtr` array
<a href="https://bugs.webkit.org/show_bug.cgi?id=321488">https://bugs.webkit.org/show_bug.cgi?id=321488</a>

Reviewed by Yusuke Suzuki.

SourceProviderCacheItem stores its used-variable names in a trailing
PackedPtr&lt;UniquedStringImpl&gt; array, whose element is 6 bytes on 64-bit
macOS/Linux, but create() sized the allocation with
sizeof(UniquedStringImpl*) (8 bytes) per element, so every item carried 2
unused bytes per used variable. These items are created for each function
longer than 16 characters in a parsed source and live in the VM&apos;s
SourceProviderCache until the next full GC, so the slack accumulates.

Make SourceProviderCacheItem a TrailingArray of PackedRefPtr&lt;UniquedStringImpl&gt;
so that the allocation size, element construction and ref/deref all derive
from the declared element type instead of being hand-written. Moving the
element count into TrailingArray::m_size also lets isBodyArrowExpression share
a word with tokenType, shrinking the fixed part from 40 to 36 bytes on
macOS/Linux. Parsing a 17.8 MB bundle (64,830 items, 3.56 used variables per
item on average) goes from 4.80 MB to 4.22 MB of malloc&apos;d
SourceProviderCacheItem storage after size-class rounding (4.46 MB with the
element size fix alone).

* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::restoreFromSourceProviderCache):
* Source/JavaScriptCore/parser/SourceProviderCacheItem.h:
(JSC::SourceProviderCacheItem::create):
(JSC::SourceProviderCacheItem::SourceProviderCacheItem):
(JSC::SourceProviderCacheItem::endFunctionToken const): Deleted.
(JSC::SourceProviderCacheItem::lexicallyScopedFeatures const): Deleted.
(JSC::SourceProviderCacheItem::usedVariables const): Deleted.
(JSC::SourceProviderCacheItem::~SourceProviderCacheItem): Deleted.

Canonical link: <a href="https://commits.webkit.org/319014@main">https://commits.webkit.org/319014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e9e7344a04bf31b74e756adc9aabb8dbee11e74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190205 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144312 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140365 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120816 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42698 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41014 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2784 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9638 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40680 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1362 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41267 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192137 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53605 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149704 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40133 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54292 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149435 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44086 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126555 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121631 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52809 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15668 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52191 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->