### PR TITLE
[Navigation API] SourceElement is the element responsible for the navigation, not the deepest element that was clicked

### DIFF
--- a/LayoutTests/navigation-api/navigate-event-source-element-is-initiating-anchor-expected.txt
+++ b/LayoutTests/navigation-api/navigate-event-source-element-is-initiating-anchor-expected.txt
@@ -1,0 +1,15 @@
+Tests that NavigateEvent.sourceElement is the anchor responsible for the navigation, not the deepest clicked node.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Clicking the anchor itself
+PASS sourceElement is plainAnchor
+Clicking a SPAN inside the anchor
+PASS sourceElement is spanAnchor
+Clicking an I nested two levels inside the anchor
+PASS sourceElement is deepAnchor
+PASS successfullyParsed is true
+
+TEST COMPLETE
+plain anchor text inside a span text nested two levels deep

--- a/LayoutTests/navigation-api/navigate-event-source-element-is-initiating-anchor.html
+++ b/LayoutTests/navigation-api/navigate-event-source-element-is-initiating-anchor.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<body>
+<a id="plainAnchor" href="#plain">plain anchor</a>
+<a id="spanAnchor" href="#span"><span id="spanChild">text inside a span</span></a>
+<a id="deepAnchor" href="#deep"><b><i id="deepChild">text nested two levels deep</i></b></a>
+<script>
+description("Tests that NavigateEvent.sourceElement is the anchor responsible for the navigation, not the deepest clicked node.");
+
+jsTestIsAsync = true;
+
+var plainAnchor = document.getElementById("plainAnchor");
+var spanAnchor = document.getElementById("spanAnchor");
+var deepAnchor = document.getElementById("deepAnchor");
+
+var sourceElement = null;
+var notifyNavigateEvent = () => { };
+
+navigation.addEventListener("navigate", event => {
+    // Cancel so the document stays put and each case can be tested in turn.
+    event.preventDefault();
+    sourceElement = event.sourceElement;
+    notifyNavigateEvent();
+});
+
+// Dispatch on the element being "clicked" so that event.target is that element;
+// calling anchor.click() would instead make the anchor its own target.
+function clickAndAwaitNavigateEvent(element)
+{
+    sourceElement = null;
+    return new Promise(resolve => {
+        notifyNavigateEvent = resolve;
+        setTimeout(resolve, 500); // Do not hang the test if no navigate event fires.
+        element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+    });
+}
+
+window.onload = async () => {
+    debug("Clicking the anchor itself");
+    await clickAndAwaitNavigateEvent(plainAnchor);
+    shouldBe("sourceElement", "plainAnchor");
+
+    debug("Clicking a SPAN inside the anchor");
+    await clickAndAwaitNavigateEvent(document.getElementById("spanChild"));
+    shouldBe("sourceElement", "spanAnchor");
+
+    debug("Clicking an I nested two levels inside the anchor");
+    await clickAndAwaitNavigateEvent(document.getElementById("deepChild"));
+    shouldBe("sourceElement", "deepAnchor");
+
+    finishJSTest();
+};
+</script>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4584,7 +4584,9 @@ bool FrameLoader::dispatchNavigateEvent(FrameLoadType loadType, const FrameLoadR
     if (navigationType == NavigationNavigationType::Traverse)
         return true;
 
-    RefPtr sourceElement = event ? dynamicDowncast<Element>(event->target()) : nullptr;
+    RefPtr sourceElement = request.sourceElement();
+    if (!sourceElement && event)
+        sourceElement = dynamicDowncast<Element>(event->target());
 
     return protect(window->navigation())->dispatchPushReplaceReloadNavigateEvent(newURL, navigationType, isSameDocument, formState, classicHistoryAPIState, sourceElement.get());
 }


### PR DESCRIPTION
#### d4093dea3b7cfce7d9f43f7d8c79438f2f7046e9
<pre>
[Navigation API] SourceElement is the element responsible for the navigation, not the deepest element that was clicked
<a href="https://bugs.webkit.org/show_bug.cgi?id=321490">https://bugs.webkit.org/show_bug.cgi?id=321490</a>
<a href="https://rdar.apple.com/184581613">rdar://184581613</a>

Reviewed by Jessica Lee.

The HTML spec (<a href="https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks)">https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks)</a>
says that sourceElement is the element responsible for the navigation (e.g. the &lt;a&gt;),
not the deepest node that happened to be clicked. This is already correctly set on the
FrameLoadRequest, so we reuse it. Fall back to the event target for callers that don&apos;t
supply an initiating element since that is the current behavior so these callers aren&apos;t
broken.

This makes us match Chrome and is covered by a new layout test:
navigate-event-source-element-is-initiating-anchor.html

* LayoutTests/navigation-api/navigate-event-source-element-is-initiating-anchor-expected.txt: Added.
* LayoutTests/navigation-api/navigate-event-source-element-is-initiating-anchor.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::dispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/319005@main">https://commits.webkit.org/319005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91e807a6d23efcab1a8b5cb8d4106d91a674ebc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144288 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d025ed4c-858d-4090-a8fd-cd272dabee49) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140345 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ac182d9-7797-408f-908d-44c024493436) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120796 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eaa52a13-17f2-4471-a9e8-233db80e15f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42680 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40990 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40657 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1338 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192113 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149682 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54268 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149412 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27356 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44063 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126531 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121603 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52785 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15645 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52167 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52405 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52231 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->