### PR TITLE
[site-isolation] platform/mac/media/audio-session-category-video-track-change.html is an intermittent failure

### DIFF
--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -202,7 +202,7 @@ RemoteMediaSessionManagerProxy::~RemoteMediaSessionManagerProxy()
 {
 }
 
-void RemoteMediaSessionManagerProxy::addMediaSession(IPC::Connection& connection, RemoteMediaSessionState&& state)
+void RemoteMediaSessionManagerProxy::addMediaSession(IPC::Connection& connection, RemoteMediaSessionState&& state, CompletionHandler<void(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&& completionHandler)
 {
     Ref process = WebProcessProxy::fromConnection(connection);
 
@@ -215,6 +215,12 @@ void RemoteMediaSessionManagerProxy::addMediaSession(IPC::Connection& connection
         session->updateState(state);
 
     REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::addSession(session);
+
+#if USE(AUDIO_SESSION)
+    completionHandler(m_category, m_mode, m_routeSharingPolicy);
+#else
+    completionHandler(WebCore::AudioSessionCategory::None, WebCore::AudioSessionMode::Default, WebCore::RouteSharingPolicy::Default);
+#endif
 }
 
 void RemoteMediaSessionManagerProxy::removeMediaSession(IPC::Connection& connection, RemoteMediaSessionState&& state)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -100,7 +100,7 @@ private:
     RemoteMediaSessionManagerProxy();
 
     // Messages
-    void addMediaSession(IPC::Connection&, RemoteMediaSessionState&&);
+    void addMediaSession(IPC::Connection&, RemoteMediaSessionState&&, CompletionHandler<void(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&&);
     void removeMediaSession(IPC::Connection&, RemoteMediaSessionState&&);
     void setCurrentMediaSession(IPC::Connection&, RemoteMediaSessionState&&);
     void updateMediaSessionStates(IPC::Connection&, WebCore::PageIdentifier, Vector<RemoteMediaSessionState>&&, uint64_t audioCaptureSourceCount, WebCore::AudioSessionCategory categoryOverride, CompletionHandler<void(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&&);

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
@@ -30,7 +30,7 @@
 ]
 messages -> RemoteMediaSessionManagerProxy {
     UpdateMediaSessionStates(WebCore::PageIdentifier pageIdentifier, Vector<WebKit::RemoteMediaSessionState> sessions, uint64_t audioCaptureSourceCount, enum:uint8_t WebCore::AudioSessionCategory categoryOverride) -> (enum:uint8_t WebCore::AudioSessionCategory category, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
-    void AddMediaSession(struct WebKit::RemoteMediaSessionState session);
+    AddMediaSession(struct WebKit::RemoteMediaSessionState session) -> (enum:uint8_t WebCore::AudioSessionCategory category, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
     void RemoveMediaSession(struct WebKit::RemoteMediaSessionState session);
     void SetCurrentMediaSession(struct WebKit::RemoteMediaSessionState session);
     void MediaSessionStateChanged(struct WebKit::RemoteMediaSessionState session);

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
@@ -86,7 +86,16 @@ RemoteMediaSessionManager::~RemoteMediaSessionManager()
 void RemoteMediaSessionManager::addSession(WebCore::PlatformMediaSessionInterface& session)
 {
     REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::addSession(session);
-    send(Messages::RemoteMediaSessionManagerProxy::AddMediaSession(currentSessionState(session)));
+    sendWithAsyncReply(Messages::RemoteMediaSessionManagerProxy::AddMediaSession(currentSessionState(session)),
+        [](WebCore::AudioSessionCategory category, WebCore::AudioSessionMode mode, WebCore::RouteSharingPolicy policy) {
+#if USE(AUDIO_SESSION)
+            WebCore::AudioSession::singleton().setCategory(category, mode, policy);
+#else
+            UNUSED_PARAM(category);
+            UNUSED_PARAM(mode);
+            UNUSED_PARAM(policy);
+#endif
+        });
 }
 
 void RemoteMediaSessionManager::removeSession(WebCore::PlatformMediaSessionInterface& session)


### PR DESCRIPTION
#### 3e5ac6f71459be18c1d617357a2406171b419292
<pre>
[site-isolation] platform/mac/media/audio-session-category-video-track-change.html is an intermittent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=321492">https://bugs.webkit.org/show_bug.cgi?id=321492</a>
<a href="https://rdar.apple.com/184587691">rdar://184587691</a>

Reviewed by Eric Carlson.

The test enables a video&apos;s audio track while it plays and expects the audio
session category to become MediaPlayback. With site isolation enabled it read
None. internals.audioSessionCategory() reads the category cached in the web
process by RemoteAudioSession, and in that pass the web process never applied a
category at all: the UI process computed MediaPlayback and the GPU process
applied it to the audio session, while the web process hosting the page logged no
setCategory.

AddMediaSession replies with the current category, mode and route sharing policy,
and the web process applies the reply, so a session&apos;s process knows the category
from the moment the session registers. This follows UpdateMediaSessionStates and
MediaSessionWillBeginPlayback, which already reply with it.

The test remains intermittent for a separate reason: webkit.org/b/184609 makes the
non-isolated run miss the same category change, and the comparison fails whenever
that happens.

* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxy::addMediaSession): Reply with the current
category.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in:
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp:
(WebKit::RemoteMediaSessionManager::addSession): Apply the category the reply
carries.

Canonical link: <a href="https://commits.webkit.org/319003@main">https://commits.webkit.org/319003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/469f1f68923f4186778e9f6cead20470ecbfd625

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144340 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fc2286f-6d0b-4a0c-bbc1-c6bc2e5dced7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140390 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120841 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c34bf825-227e-4b4d-9484-0ea2e5cea319) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42716 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41029 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153118 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40696 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1390 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192165 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53633 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149730 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40124 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54320 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149460 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44101 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126583 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121684 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52837 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15684 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52219 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52457 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52283 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->