### PR TITLE
[JSC][Wasm] Treat missing Global value setter argument as undefined

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-get-set.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-get-set.any-expected.txt
@@ -65,6 +65,6 @@ PASS Mutable f64 (one)
 PASS Mutable f64 (string)
 PASS Mutable f64 (true on prototype)
 PASS i64 mutability
-FAIL Calling setter without argument Not enough arguments
+PASS Calling setter without argument
 PASS Stray argument
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-get-set.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-get-set.any.worker-expected.txt
@@ -65,6 +65,6 @@ PASS Mutable f64 (one)
 PASS Mutable f64 (string)
 PASS Mutable f64 (true on prototype)
 PASS i64 mutability
-FAIL Calling setter without argument Not enough arguments
+PASS Calling setter without argument
 PASS Stray argument
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
@@ -107,9 +107,6 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyGlobalProtoSetterFuncValue, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    if (callFrame->argumentCount() < 1) [[unlikely]]
-        return JSValue::encode(throwException(globalObject, throwScope, createNotEnoughArgumentsError(globalObject)));
-
     JSWebAssemblyGlobal* global = getGlobal(globalObject, vm, callFrame->thisValue());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 


### PR DESCRIPTION
#### 9b3637884b68bfd82fc35fa2f59647d0f717d13a
<pre>
[JSC][Wasm] Treat missing Global value setter argument as undefined
<a href="https://bugs.webkit.org/show_bug.cgi?id=321493">https://bugs.webkit.org/show_bug.cgi?id=321493</a>

Reviewed by Keith Miller.

WebAssembly.Global.prototype.value&apos;s setter threw NotEnoughArguments
when invoked with no argument. The JS API and the WPT treat a missing
argument as undefined, same as a normal JS setter.

* Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp:
(webAssemblyGlobalProtoSetterFuncValue):
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-get-set.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-get-set.any.worker-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318967@main">https://commits.webkit.org/318967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a28336bcd6aadf575705f606e1b3c3748d16a52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144303 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140357 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120808 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42690 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41005 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2776 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9631 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40673 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1353 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41258 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192128 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53596 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149699 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40102 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54283 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149430 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44077 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126546 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121622 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52800 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15661 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52182 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52420 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->