### PR TITLE
NavigationHistoryEntry url/key/id should return the empty string, not null, when the document is not fully active

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entry-after-detach-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entry-after-detach-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL NavigationHistoryEntry properties after detach assert_equals: expected (string) "" but got (object) null
+PASS NavigationHistoryEntry properties after detach
 

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -98,30 +98,34 @@ void NavigationHistoryEntry::eventListenersDidChange()
 const String& NavigationHistoryEntry::url() const
 {
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    // https://html.spec.whatwg.org/#dom-navigationhistoryentry-url (Step 2)
     if (!document || !document->isFullyActive())
-        return nullString();
+        return emptyString();
     // https://html.spec.whatwg.org/#dom-navigationhistoryentry-url (Step 4)
     if (document->identifier() != m_originalDocumentState.identifier && (m_originalDocumentState.referrerPolicy == ReferrerPolicy::NoReferrer || m_originalDocumentState.referrerPolicy == ReferrerPolicy::Origin))
         return nullString();
     return m_urlString;
 }
 
+// https://html.spec.whatwg.org/#concept-navigationhistoryentry-key
 String NavigationHistoryEntry::key() const
 {
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->isFullyActive())
-        return nullString();
+        return emptyString();
     return m_associatedHistoryItem->navigationAPIKey().toString();
 }
 
+// https://html.spec.whatwg.org/#concept-navigationhistoryentry-id
 String NavigationHistoryEntry::id() const
 {
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->isFullyActive())
-        return nullString();
+        return emptyString();
     return m_id.toString();
 }
 
+// https://html.spec.whatwg.org/#concept-navigationhistoryentry-index
 uint64_t NavigationHistoryEntry::index() const
 {
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());


### PR DESCRIPTION
#### 99285ff92cc38dad904802141efe17f2885ba157
<pre>
NavigationHistoryEntry url/key/id should return the empty string, not null, when the document is not fully active
<a href="https://bugs.webkit.org/show_bug.cgi?id=321494">https://bugs.webkit.org/show_bug.cgi?id=321494</a>
<a href="https://rdar.apple.com/184590003">rdar://184590003</a>

Reviewed by Rupin Mittal.

Each of the url [1], key [2] and ID [3] concepts opens with the same step:

   If ... Document is not fully active, then return the empty string.

All three returned nullString() instead. Return emptyString() from each.

For url this is web-facing. It is declared `USVString?` [4], so a null String
marshals to JS null while an empty String marshals to &quot;&quot;, and an entry whose
document had been detached reported `null` where &quot;&quot; is required.

key and ID are declared `DOMString`, and jsStringWithCache() maps any zero-length
String - null included - onto jsEmptyString(), so those two already reached script
as &quot;&quot;. The distinction is not observable internally either: key()&apos;s only callers
go through Navigation::entryIndexOfKey(), which rejects the lookup with isEmpty()
before comparing anything, and that covers null and empty alike. So there is
nothing separately testable for them; entry-after-detach.html already asserts key
and id are &quot;&quot; after detach and already passed those two assertions. Fix them
anyway, so the getters say what the spec says instead of leaning on a
binding-layer coincidence.

The index concept [5] already returned -1 as required and is unchanged. Cite the
spec algorithm inline in all four getters while here.

[1] <a href="https://html.spec.whatwg.org/#dom-navigationhistoryentry-url">https://html.spec.whatwg.org/#dom-navigationhistoryentry-url</a>
[2] <a href="https://html.spec.whatwg.org/#concept-navigationhistoryentry-key">https://html.spec.whatwg.org/#concept-navigationhistoryentry-key</a>
[3] <a href="https://html.spec.whatwg.org/#concept-navigationhistoryentry-id">https://html.spec.whatwg.org/#concept-navigationhistoryentry-id</a>
[4] <a href="https://html.spec.whatwg.org/#the-navigationhistoryentry-interface">https://html.spec.whatwg.org/#the-navigationhistoryentry-interface</a>
[5] <a href="https://html.spec.whatwg.org/#concept-navigationhistoryentry-index">https://html.spec.whatwg.org/#concept-navigationhistoryentry-index</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entry-after-detach-expected.txt: Progression
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::url const):
(WebCore::NavigationHistoryEntry::key const):
(WebCore::NavigationHistoryEntry::id const):
(WebCore::NavigationHistoryEntry::index const):

Canonical link: <a href="https://commits.webkit.org/319007@main">https://commits.webkit.org/319007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d703c9deb13858800a2fe2bbc395bf8ea5b1a7ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190339 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144446 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f87a534-f04d-4bf0-81e2-f737006f880a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140482 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0321df2c-b3a5-4a78-bde2-d91272f6b439) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120934 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0eaf122a-1e61-4cee-a30d-36775cc1fe9c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40791 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1498 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46672 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192273 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53739 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149826 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40126 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54427 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149553 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44195 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126690 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121807 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52944 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15779 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52326 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52563 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52391 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->