### PR TITLE
[YARR] Compile lookbehinds in the JIT

### DIFF
--- a/JSTests/microbenchmarks/regexp-lookbehind-fixed.js
+++ b/JSTests/microbenchmarks/regexp-lookbehind-fixed.js
@@ -1,0 +1,7 @@
+let text = "The quick brown fox jumps over the lazy dog. ".repeat(80) + "price: $42";
+let re = /(?<=\$)\d+/;
+let result = 0;
+for (let i = 0; i < 1e4; ++i)
+    result += re.exec(text).index;
+if (result !== 3608 * 1e4)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/regexp-lookbehind-negative-alternation.js
+++ b/JSTests/microbenchmarks/regexp-lookbehind-negative-alternation.js
@@ -1,0 +1,16 @@
+let agents = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15",
+    "curl/8.4.0",
+    "Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots) yasearch",
+    "libhttp/1.0 a cubot",
+];
+let re = /(?<! cu)bot|(?<!lib)http|(?<! ya(?:yandex)?)search|crawler|spider|curl/i;
+let result = 0;
+for (let i = 0; i < 3e4; ++i) {
+    for (let agent of agents)
+        result += re.test(agent);
+}
+if (result !== 3 * 3e4)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/regexp-lookbehind-replace.js
+++ b/JSTests/microbenchmarks/regexp-lookbehind-replace.js
@@ -1,0 +1,7 @@
+let text = "1234567890".repeat(30);
+let re = /(?<=\d)(?=(?:\d{3})+$)/g;
+let result = 0;
+for (let i = 0; i < 2e3; ++i)
+    result += text.replace(re, ",").length;
+if (result !== 399 * 2e3)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/regexp-lookbehind-variable.js
+++ b/JSTests/microbenchmarks/regexp-lookbehind-variable.js
@@ -1,0 +1,10 @@
+let text = "key1 = value1; key22 = value22; key333 = value333; ".repeat(40);
+let re = /(?<=key\d+ = )\w+/g;
+let result = 0;
+for (let i = 0; i < 1e4; ++i) {
+    re.lastIndex = 0;
+    while (re.exec(text))
+        result++;
+}
+if (result !== 120 * 1e4)
+    throw new Error("Bad result: " + result);

--- a/JSTests/stress/regexp-lookbehind-jit-alternatives.js
+++ b/JSTests/stress/regexp-lookbehind-jit-alternatives.js
@@ -1,0 +1,53 @@
+function shouldBe(actual, expected) {
+    actual = JSON.stringify(actual, (key, value) => value === undefined ? "<undefined>" : value);
+    expected = JSON.stringify(expected, (key, value) => value === undefined ? "<undefined>" : value);
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function matchOf(re, string) {
+    let match = re.exec(string);
+    return match ? [match.index, ...match] : null;
+}
+
+shouldBe(matchOf(/(?<=abc|a|)x/, "x"), [0, "x"]);
+shouldBe(matchOf(/(?<=abc|a|)x/, "ax"), [1, "x"]);
+shouldBe(matchOf(/(?<=|a)(x)/, "ax"), [1, "x", "x"]);
+shouldBe(matchOf(/(?<!abc|a|)x/, "zx"), null);
+shouldBe(matchOf(/(?<=abcd|bc)x/, "abcx"), [3, "x"]);
+shouldBe(matchOf(/(?<=abcd|bc)x/, "abcdx"), [4, "x"]);
+shouldBe(matchOf(/(?<=bc|abcd)x/, "abcdx"), [4, "x"]);
+shouldBe(matchOf(/(?<=(abcd|bc))x/, "abcdx"), [4, "x", "abcd"]);
+shouldBe(matchOf(/(?<=(bc|abcd))x/, "abcdx"), [4, "x", "abcd"]);
+shouldBe(matchOf(/(?<=a(?:bcd|c)|zz)x/, "acx"), [2, "x"]);
+shouldBe(matchOf(/(?<=x[ab]c)d/, "xbcd"), [3, "d"]);
+shouldBe(matchOf(/(?<=x[ab]c)d/, "ybcd"), null);
+shouldBe(matchOf(/(?<=\dx[ab])c/, "1xac"), [3, "c"]);
+shouldBe(matchOf(/(?<=(?<=(?<=a)b)c)d/, "abcd"), [3, "d"]);
+shouldBe(matchOf(/(?<=(?<=(?<=x)b)c)d/, "abcd"), null);
+shouldBe(matchOf(/(?<=(?<!(?<=a)b)c)d/, "abcd"), null);
+shouldBe(matchOf(/(?<=(?<!(?<=a)b)c)d/, "xbcd"), [3, "d"]);
+shouldBe(matchOf(/(?=(?<=(?=(?<=a)b)b)b)./, "abb"), [2, "b"]);
+shouldBe(matchOf(/(?<=a)bcde|(?<=x)yzwv/, "..xyzwv..abcde"), [3, "yzwv"]);
+shouldBe(matchOf(/abcd(?<=d)|wxyz(?<!q...)/i, "...WXYZ"), [3, "WXYZ"]);
+shouldBe(matchOf(/.*(?<=x)abc.*/, "11xabc22\nxabc"), [0, "11xabc22"]);
+shouldBe(matchOf(/.*(?<!x)abc.*/, "11xabc22\nyabc3"), [9, "yabc3"]);
+shouldBe(matchOf(/(?<=a)b$/, "ab".repeat(3) + "cab"), [8, "b"]);
+shouldBe(matchOf(/(?<=a+)b$/, "b" + "a".repeat(50) + "b"), [51, "b"]);
+shouldBe(matchOf(/(?<=^a+)b$/, "a".repeat(50) + "b"), [50, "b"]);
+shouldBe(matchOf(/(?<=^a+)b$/, "ba".repeat(25) + "b"), null);
+shouldBe(matchOf(/^(?<=)abc/, "abc"), [0, "abc"]);
+shouldBe(matchOf(/^abc(?<=c)/, "abc"), [0, "abc"]);
+shouldBe(matchOf(/(?<=\u00e9)x/i, "\u00c9x"), [1, "x"]);
+shouldBe(matchOf(/(?<=[\u00e0-\u00ff]{2})x/i, "\u00c9\u00c0x"), [2, "x"]);
+shouldBe(matchOf(/(?<=k)x/i, "Kx"), [1, "x"]);
+shouldBe(matchOf(/(?<=k)x/i, "\u212ax"), null);
+shouldBe(matchOf(/(?<=a.b)x/, "a\u0100bx"), [3, "x"]);
+shouldBe(matchOf(/(?<=a[^b]b)x/, "a\u0100bx"), [3, "x"]);
+shouldBe(matchOf(new RegExp("(?<=\u0100{2})x"), "q\u0100\u0100x"), [3, "x"]);
+shouldBe(matchOf(/(?<=\s{2})x/, "a  x"), [3, "x"]);
+shouldBe(matchOf(/(?<=^\s*)x/m, "a\n  x"), [4, "x"]);
+shouldBe(matchOf(/(?<=(?:ab){0}c)x/, "cx"), [1, "x"]);
+shouldBe(matchOf(/(?<=a{0}c)x/, "cx"), [1, "x"]);
+shouldBe(matchOf(/(?<=b(?:){5}c)x/, "bcx"), [2, "x"]);
+shouldBe(matchOf(/(?<=(?=)c)x/, "cx"), [1, "x"]);

--- a/JSTests/stress/regexp-lookbehind-jit-captures.js
+++ b/JSTests/stress/regexp-lookbehind-jit-captures.js
@@ -1,0 +1,32 @@
+function shouldBe(actual, expected) {
+    actual = JSON.stringify(actual, (key, value) => value === undefined ? "<undefined>" : value);
+    expected = JSON.stringify(expected, (key, value) => value === undefined ? "<undefined>" : value);
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function matchOf(re, string) {
+    let match = re.exec(string);
+    return match ? [match.index, ...match] : null;
+}
+
+shouldBe(matchOf(/(?<=(ab))\1/, "abab"), [2, "ab", "ab"]);
+shouldBe(matchOf(/(?<=(a+))\1/, "xaaaa"), [2, "a", "a"]);
+shouldBe(matchOf(/(?<=(a+?))\1/, "xaaaa"), [2, "a", "a"]);
+shouldBe(matchOf(/(?<=(a)|(b))(?:\1|\2)c/, "bbc"), [1, "bc", undefined, "b"]);
+shouldBe(matchOf(/(?<=(?<n>a)b)\k<n>/, "aba"), [2, "a", "a"]);
+shouldBe(matchOf(/(?<=(?<n>ab)|(?<n>cd))x/, "cdx"), [2, "x", undefined, "cd"]);
+shouldBe(/(?<=(?<n>ab)|(?<n>cd))x/.exec("cdx").groups.n, "cd");
+shouldBe(matchOf(/(?<=(a+)(b+))c/d, "xaabbc"), [5, "c", "aa", "bb"]);
+shouldBe(/(?<=(a+)(b+))c/d.exec("xaabbc").indices.slice(1), [[1, 3], [3, 5]]);
+shouldBe(/(?<=(?<n>a+))c/d.exec("aac").indices.groups.n, [0, 2]);
+shouldBe(/(?<=(a))\1/.test("aa"), true);
+shouldBe(/(?<=(a))\1/.test("ab"), false);
+shouldBe(matchOf(/(?:(?<=(a))b(\1))+/, "abaaba"), [1, "ba", "a", "a"]);
+shouldBe(matchOf(/((?<=(\w))x)+/, "axbx"), [1, "x", "x", "a"]);
+shouldBe(matchOf(/(?:(?<=(a)|(b))c){2}/, "acbc"), null);
+shouldBe(matchOf(/(?:(?<=(a)|(b))c){2}/, "acac"), null);
+shouldBe(matchOf(/(x(?<=(x))y)*z/, "xyxyz"), [0, "xyxyz", "xy", "x"]);
+shouldBe(matchOf(/(?<=([ab])+)c/, "abc"), [2, "c", "a"]);
+shouldBe("abcabd".replace(/(?<=(b))[cd]/g, "[$1]"), "ab[b]ab[b]");
+shouldBe("aXbXc".split(/(?<=([abc]))X/), ["a", "a", "b", "b", "c"]);

--- a/JSTests/stress/regexp-lookbehind-jit-hot-loop.js
+++ b/JSTests/stress/regexp-lookbehind-jit-hot-loop.js
@@ -1,0 +1,39 @@
+function shouldBe(actual, expected) {
+    actual = JSON.stringify(actual, (key, value) => value === undefined ? "<undefined>" : value);
+    expected = JSON.stringify(expected, (key, value) => value === undefined ? "<undefined>" : value);
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function execConstant() {
+    return /(?<=(a+))b(?<!c)/.exec("xaab");
+}
+noInline(execConstant);
+
+function testVarying(string) {
+    return /(?<! cu)bot|(?<=[/ ])curl/i.test(string);
+}
+noInline(testVarying);
+
+function replaceAll(string) {
+    return string.replace(/(?<=\d)(?=(?:\d{3})+$)/g, ",");
+}
+noInline(replaceAll);
+
+function searchSticky(re, string, lastIndex) {
+    re.lastIndex = lastIndex;
+    return re.exec(string);
+}
+noInline(searchSticky);
+
+let sticky = /(?<=a(b*))c/y;
+let subjects = ["Googlebot", "a cubot", "get curl/8", "libcurl", "abbc"];
+for (let i = 0; i < testLoopCount; ++i) {
+    let match = execConstant();
+    shouldBe([match.index, ...match], [3, "b", "aa"]);
+    shouldBe(testVarying(subjects[i % subjects.length]), [true, false, true, false, false][i % subjects.length]);
+    shouldBe(replaceAll("1234567"), "1,234,567");
+    let stickyMatch = searchSticky(sticky, "xabbcabc", i % 2 ? 7 : 4);
+    shouldBe([stickyMatch.index, ...stickyMatch], i % 2 ? [7, "c", "b"] : [4, "c", "bb"]);
+    shouldBe(searchSticky(sticky, "xabbcabc", 5), null);
+}

--- a/JSTests/stress/regexp-lookbehind-jit-large-offset.js
+++ b/JSTests/stress/regexp-lookbehind-jit-large-offset.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    actual = JSON.stringify(actual, (key, value) => value === undefined ? "<undefined>" : value);
+    expected = JSON.stringify(expected, (key, value) => value === undefined ? "<undefined>" : value);
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function matchOf(re, string) {
+    let match = re.exec(string);
+    return match ? [match.index, ...match] : null;
+}
+
+shouldBe(matchOf(new RegExp("(?<=a{1073741824}x)b"), "xb"), null);
+shouldBe(matchOf(new RegExp("(?<=a{1073741824}x)b"), "\u0100xb"), null);
+shouldBe(matchOf(new RegExp("(?<=xa{1073741824})b"), "xb"), null);
+shouldBe(matchOf(new RegExp("(?<=(?:a{536870912}){2}x)b"), "xb"), null);
+shouldBe(matchOf(new RegExp("(?<=a{2147483647})b"), "ab"), null);
+shouldBe(matchOf(new RegExp("(?<=.{300}x)y"), "q".repeat(300) + "xy"), [301, "y"]);
+shouldBe(matchOf(new RegExp("(?<=x.{300})y"), "x" + "q".repeat(300) + "y"), [301, "y"]);
+shouldBe(matchOf(new RegExp("(?<=x.{300})y"), "z" + "q".repeat(300) + "y"), null);
+shouldBe(matchOf(new RegExp("(?<=x.{300})y"), "\u0100x" + "q".repeat(300) + "y"), [302, "y"]);

--- a/JSTests/stress/regexp-lookbehind-jit.js
+++ b/JSTests/stress/regexp-lookbehind-jit.js
@@ -1,0 +1,225 @@
+function shouldBe(actual, expected) {
+    actual = JSON.stringify(actual, (key, value) => value === undefined ? "<undefined>" : value);
+    expected = JSON.stringify(expected, (key, value) => value === undefined ? "<undefined>" : value);
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function matchOf(re, string) {
+    let match = re.exec(string);
+    return match ? [match.index, ...match] : null;
+}
+
+shouldBe(matchOf(/(?<=x)a/, "xa"), [1, "a"]);
+shouldBe(matchOf(/(?<=x)a/, "ya"), null);
+shouldBe(matchOf(/(?<=x)a/, "a"), null);
+shouldBe(matchOf(/(?<!x)a/, "ya"), [1, "a"]);
+shouldBe(matchOf(/(?<!x)a/, "xa"), null);
+shouldBe(matchOf(/(?<!x)a/, "a"), [0, "a"]);
+shouldBe(matchOf(/(?<=abc)d/, "abcd"), [3, "d"]);
+shouldBe(matchOf(/(?<=abc)d/, "xbcd"), null);
+shouldBe(matchOf(/(?<=abc)d/, "bcd"), null);
+shouldBe(matchOf(/(?<=)a/, "a"), [0, "a"]);
+shouldBe(matchOf(/(?<!)a/, "a"), null);
+shouldBe(matchOf(/a(?<=a)/, "a"), [0, "a"]);
+shouldBe(matchOf(/a(?<=b)/, "a"), null);
+shouldBe(matchOf(/a(?<=xa)b/, "xab"), [1, "ab"]);
+shouldBe(matchOf(/a(?<=xa)b/, "yab"), null);
+shouldBe(matchOf(/ab(?<=xab)/, "xab"), [1, "ab"]);
+shouldBe(matchOf(/(?<=a{3})b/, "aaab"), [3, "b"]);
+shouldBe(matchOf(/(?<=a{3})b/, "aab"), null);
+shouldBe(matchOf(/(?<=xa{2})b/, "xaab"), [3, "b"]);
+shouldBe(matchOf(/(?<=xa{2})b/, "yaab"), null);
+shouldBe(matchOf(/(?<=\d{3})x/, "123x"), [3, "x"]);
+shouldBe(matchOf(/(?<=\d{3})x/, "12x"), null);
+shouldBe(matchOf(/(?<=[ab][cd])x/, "adx"), [2, "x"]);
+shouldBe(matchOf(/(?<=[ab][cd])x/, "dax"), null);
+shouldBe(matchOf(/(?<=\bfoo)bar/, "foobar"), [3, "bar"]);
+shouldBe(matchOf(/(?<=\bfoo)bar/, "xfoobar"), null);
+shouldBe(matchOf(/(?<=\Bfoo)bar/, "xfoobar"), [4, "bar"]);
+shouldBe(matchOf(/(?<=o\b)bar/, "foo bar"), null);
+shouldBe(matchOf(/(?<=o\b.)bar/, "foo bar"), [4, "bar"]);
+shouldBe(matchOf(/(?<=\b)bar/, " bar"), [1, "bar"]);
+shouldBe(matchOf(/(?<=\B)ar/, "bar"), [1, "ar"]);
+shouldBe(matchOf(/(?<=\b)ar/, "bar"), null);
+shouldBe(matchOf(/(?<!\b)bar/, " bar"), null);
+
+shouldBe(matchOf(/(?<=ab|xyz)q/, "abq"), [2, "q"]);
+shouldBe(matchOf(/(?<=ab|xyz)q/, "xyzq"), [3, "q"]);
+shouldBe(matchOf(/(?<=ab|xyz)q/, "yzq"), null);
+shouldBe(matchOf(/(?<=xyz|ab)q/, "abq"), [2, "q"]);
+shouldBe(matchOf(/(?<=xyz|ab)q/, "xyzq"), [3, "q"]);
+shouldBe(matchOf(/(?<=a|bc|def)q/, "defq"), [3, "q"]);
+shouldBe(matchOf(/(?<=a|bc|def)q/, "efq"), null);
+shouldBe(matchOf(/(?<=(?:ab|x)(?:cd|y))q/, "abyq"), [3, "q"]);
+shouldBe(matchOf(/(?<=(?:ab|x)(?:cd|y))q/, "xcdq"), [3, "q"]);
+shouldBe(matchOf(/(?<=(?:ab|x)(?:cd|y))q/, "acdq"), null);
+shouldBe(matchOf(/(?<=x(?:ab|a)b)q/, "xabq"), [3, "q"]);
+shouldBe(matchOf(/(?<=x(?:a|ab)b)q/, "xabq"), [3, "q"]);
+shouldBe(matchOf(/(?<=x(?:a|ab)b)q/, "xabbq"), [4, "q"]);
+
+shouldBe(matchOf(/(?<=a+)b/, "aaab"), [3, "b"]);
+shouldBe(matchOf(/(?<=a+)b/, "b"), null);
+shouldBe(matchOf(/(?<=ba*)c/, "bc"), [1, "c"]);
+shouldBe(matchOf(/(?<=ba*)c/, "baaac"), [4, "c"]);
+shouldBe(matchOf(/(?<=ba*)c/, "aaac"), null);
+shouldBe(matchOf(/(?<=ba*?)c/, "baaac"), [4, "c"]);
+shouldBe(matchOf(/(?<=ba+?)c/, "bc"), null);
+shouldBe(matchOf(/(?<=ba?)c/, "bac"), [2, "c"]);
+shouldBe(matchOf(/(?<=ba?)c/, "baac"), null);
+shouldBe(matchOf(/(?<=ba??)c/, "bac"), [2, "c"]);
+shouldBe(matchOf(/(?<=b[a-z]*)c/, "bxyc"), [3, "c"]);
+shouldBe(matchOf(/(?<=b[a-z]*?)c/, "bxyc"), [3, "c"]);
+shouldBe(matchOf(/(?<=b\d{2,4})c/, "b12345c"), null);
+shouldBe(matchOf(/(?<=b\d{2,4})c/, "b1234c"), [5, "c"]);
+shouldBe(matchOf(/(?<=b\d{2,4})c/, "b1c"), null);
+shouldBe(matchOf(/(?<=b\d{2,4}?)c/, "b123c"), [4, "c"]);
+shouldBe(matchOf(/(?<=aa+a)b/, "aab"), null);
+shouldBe(matchOf(/(?<=aa+a)b/, "aaab"), [3, "b"]);
+shouldBe(matchOf(/(?<=ba+ab)c/, "baabc"), [4, "c"]);
+shouldBe(matchOf(/(?<=ba+ab)c/, "babc"), null);
+shouldBe(matchOf(/(?<=b.*)c/, "bxxc"), [3, "c"]);
+shouldBe(matchOf(/(?<=b.*)c/, "xxc"), null);
+shouldBe(matchOf(/(?<=^.*b.*)c/, "xbxc"), [3, "c"]);
+shouldBe(matchOf(/(?<!^.*b.*)c/, "xbxc"), null);
+shouldBe(matchOf(/(?<=x(?:ab)?)c/, "xabc"), [3, "c"]);
+shouldBe(matchOf(/(?<=x(?:ab)?)c/, "xc"), [1, "c"]);
+shouldBe(matchOf(/(?<=x(?:ab)?)c/, "xbc"), null);
+shouldBe(matchOf(/(?<=x(?:ab)??)c/, "xabc"), [3, "c"]);
+shouldBe(matchOf(/(?<! ya(?:yandex)?)search/, "yasearch"), [2, "search"]);
+shouldBe(matchOf(/(?<! ya(?:yandex)?)search/, " yasearch"), null);
+shouldBe(matchOf(/(?<! ya(?:yandex)?)search/, " yayandexsearch"), null);
+shouldBe(matchOf(/(?<! ya(?:yandex)?)search/, "search"), [0, "search"]);
+
+shouldBe(matchOf(/(?<=(a)(b))c/, "abc"), [2, "c", "a", "b"]);
+shouldBe(matchOf(/(?<=(a+))b/, "xaaab"), [4, "b", "aaa"]);
+shouldBe(matchOf(/(?<=(a+?))b/, "xaaab"), [4, "b", "a"]);
+shouldBe(matchOf(/(?<=(\d+)(\d+))x/, "1234x"), [4, "x", "1", "234"]);
+shouldBe(matchOf(/(?<=(\d+?)(\d+?))x/, "1234x"), [4, "x", "3", "4"]);
+shouldBe(matchOf(/(?<=x(ab|a)(b?))c/, "xabc"), [3, "c", "a", "b"]);
+shouldBe(matchOf(/(?<=(ab)?x)c/, "abxc"), [3, "c", "ab"]);
+shouldBe(matchOf(/(?<=(ab)?x)c/, "bxc"), [2, "c", undefined]);
+shouldBe(matchOf(/(?<=(ab)??x)c/, "abxc"), [3, "c", undefined]);
+shouldBe(/(?<=(?<n>a)b)c/.exec("abc").groups.n, "a");
+shouldBe(matchOf(/(?<!(a))b/, "cb"), [1, "b", undefined]);
+shouldBe(matchOf(/(?<!(a)c)b/, "acb"), null);
+shouldBe(matchOf(/(a)(?<=(a))b/, "ab"), [0, "ab", "a", "a"]);
+shouldBe(matchOf(/(?<=(a))bz|(?<=(a))b/, "ab"), [1, "b", undefined, "a"]);
+shouldBe(matchOf(/(?:(?<=(a))b)+z|b/, "abb"), [1, "b", undefined]);
+shouldBe(matchOf(/(?<=(a)|(x))b/, "xb"), [1, "b", undefined, "x"]);
+shouldBe(matchOf(/(?<=(a)|(x))b/, "ab"), [1, "b", "a", undefined]);
+
+shouldBe(matchOf(/(?<=(?<=a)b)c/, "abc"), [2, "c"]);
+shouldBe(matchOf(/(?<=(?<=a)b)c/, "xbc"), null);
+shouldBe(matchOf(/(?<=b(?<=ab))c/, "abc"), [2, "c"]);
+shouldBe(matchOf(/(?<=b(?<=ab))c/, "xbc"), null);
+shouldBe(matchOf(/(?<=(?<!a)b)c/, "xbc"), [2, "c"]);
+shouldBe(matchOf(/(?<=(?<!a)b)c/, "abc"), null);
+shouldBe(matchOf(/(?<=x(?<=(x))y)c/, "xyc"), [2, "c", "x"]);
+shouldBe(matchOf(/(?=a(?<=([bx])a))./, "xa"), [1, "a", "x"]);
+shouldBe(matchOf(/(?=.(?<=([bx])a))./, "xa"), [1, "a", "x"]);
+shouldBe(matchOf(/(?=.(?<=([bx])a))./, "ya"), null);
+shouldBe(matchOf(/q(?=ab(?<=q(a)b))/, "qab"), [0, "q", "a"]);
+shouldBe(matchOf(/(?!ab(?<=xab)).b/, "xabyab"), [4, "ab"]);
+
+shouldBe(matchOf(/(?<=^)a/, "a"), [0, "a"]);
+shouldBe(matchOf(/(?<=^)a/, "ba"), null);
+shouldBe(matchOf(/(?<!^)a/, "a"), null);
+shouldBe(matchOf(/(?<!^)a/, "ba"), [1, "a"]);
+shouldBe(matchOf(/(?<=^x)y/, "xy"), [1, "y"]);
+shouldBe(matchOf(/(?<=^x)y/, "axy"), null);
+shouldBe(matchOf(/(?<=^a*)b/, "aab"), [2, "b"]);
+shouldBe(matchOf(/(?<=^a*)b/, "xaab"), null);
+shouldBe(matchOf(/(?<=x^)y/, "xy"), null);
+shouldBe(matchOf(/(?<=x$)/, "x"), [1, ""]);
+shouldBe(matchOf(/(?<=x$)/, "xy"), null);
+shouldBe(matchOf(/(?<=$x)/, "x"), null);
+shouldBe(matchOf(/(?<=a*$)/, "aa"), [2, ""]);
+shouldBe(matchOf(/x(?<=^x$)/, "x"), [0, "x"]);
+shouldBe(matchOf(/x(?<=^x$)/, "xx"), null);
+shouldBe(matchOf(/(?<=^a)b/m, "xa\nab"), [4, "b"]);
+shouldBe(matchOf(/(?<=^a)b/m, "xab"), null);
+shouldBe(matchOf(/(?<=^)a/m, "\na"), [1, "a"]);
+shouldBe(matchOf(/(?<=a$)/m, "a\nb"), [1, ""]);
+shouldBe(matchOf(/(?<=a$\n)b/m, "a\nb"), [2, "b"]);
+shouldBe(matchOf(/(?<=a$.)b/m, "a\nb"), null);
+shouldBe(matchOf(/(?<=a$.)b/ms, "a\nb"), [2, "b"]);
+shouldBe(matchOf(/(?<=$)b/m, "a\nb"), null);
+shouldBe(matchOf(/(?<=^[^]?)b/m, "a\nb"), [2, "b"]);
+
+{
+    let re = /(?<=ab)c/g;
+    let indices = [];
+    let match;
+    while ((match = re.exec("abcabc")) !== null)
+        indices.push(match.index);
+    shouldBe(indices, [2, 5]);
+
+    let sticky = /(?<=ab)c/y;
+    sticky.lastIndex = 2;
+    shouldBe(matchOf(sticky, "abc"), [2, "c"]);
+    sticky.lastIndex = 1;
+    shouldBe(matchOf(sticky, "abc"), null);
+
+    shouldBe("abcabc".replace(/(?<=b)c/g, "X"), "abXabX");
+    shouldBe("aaa".replace(/(?<=a)/g, "-"), "a-a-a-");
+    shouldBe("aaa".replace(/(?<!a)/g, "-"), "-aaa");
+    shouldBe("1234567".replace(/(?<=\d)(?=(?:\d{3})+$)/g, ","), "1,234,567");
+    shouldBe("abcabc".split(/(?<=b)/), ["ab", "cab", "c"]);
+}
+
+shouldBe(matchOf(/(?<=ab)c/i, "ABC"), [2, "C"]);
+shouldBe(matchOf(/(?<=k)c/i, "Kc"), [1, "c"]);
+shouldBe(matchOf(/(?<=a[bx]+)c/i, "ABXc"), [3, "c"]);
+shouldBe(matchOf(/(?<=\u00e9)x/, "\u00e9x"), [1, "x"]);
+shouldBe(matchOf(/(?<=\u0100)x/, "\u0100x"), [1, "x"]);
+shouldBe(matchOf(/(?<=\u0100+)x/, "\u0100\u0100x"), [2, "x"]);
+shouldBe(matchOf(/(?<=ab)c/, "\u0100abc"), [3, "c"]);
+shouldBe(matchOf(/(?<=\u0100)x/, "ax"), null);
+shouldBe(matchOf(/(?<=[\u0100-\u0200]{2})x/, "a\u0100\u0180x"), [3, "x"]);
+shouldBe(matchOf(/(?<=\ud83d)\ude00/, "\ud83d\ude00"), [1, "\ude00"]);
+
+shouldBe(matchOf(/.*(?<=a)/, "xxaxx"), [0, "xxa"]);
+shouldBe(matchOf(/.*(?<=a)x/, "xxaxx"), [0, "xxax"]);
+shouldBe(matchOf(/.+?(?<=a)/, "xxaxa"), [0, "xxa"]);
+shouldBe(matchOf(/[a-z]+(?<!q)!/, "aq!ab!"), [3, "ab!"]);
+shouldBe(matchOf(/(?:ab|a)(?<=a)c/, "abac"), [2, "ac"]);
+shouldBe(matchOf(/(a|ab)(?<=b)c/, "abc"), [0, "abc", "ab"]);
+shouldBe(matchOf(/^(?:foo|bar)(?<=r)$/, "bar"), [0, "bar"]);
+shouldBe(matchOf(/^(?:foo|bar)(?<=r)$/, "foo"), null);
+shouldBe(matchOf(/x*(?<=xx)y/, "xxxy"), [0, "xxxy"]);
+shouldBe(matchOf(/x*(?<=xx)y/, "xy"), null);
+shouldBe(matchOf(/(?<=a.{6})b/, "a123456b"), [7, "b"]);
+shouldBe(matchOf(new RegExp("(?<=a.{200})b"), "a" + "1".repeat(200) + "b"), [201, "b"]);
+shouldBe(matchOf(new RegExp("(?<=a.{200})b"), "1".repeat(201) + "b"), null);
+shouldBe(matchOf(new RegExp("(?<=a" + "\\d".repeat(50) + ")b"), "a" + "1".repeat(50) + "b"), [51, "b"]);
+
+{
+    let re = /(?<! cu)bot|(?<!lib)http|(?<! ya(?:yandex)?)search|crawler|spider/;
+    let lines = ["Googlebot/2.1", "a cubot toy", "libhttp client", "http agent", "yandexsearch", " yasearch", "crawler", "spiderman"];
+    shouldBe(lines.map(line => re.test(line)), [true, false, false, true, true, false, true, true]);
+}
+
+shouldBe(matchOf(/a(?<!x)(^)?$/, "xa"), [1, "a", undefined]);
+shouldBe(matchOf(/(?<=y)a(^)?$/, "ya"), [1, "a", undefined]);
+shouldBe(matchOf(/(?<!q)b(^)*c/, "abc"), [1, "bc", undefined]);
+shouldBe(matchOf(/\w(?<=\d)(^)?/, "a1"), [1, "1", undefined]);
+shouldBe("qxaqxa".split(/a(?<!x)(^)?$/), ["qxaqx", undefined, ""]);
+
+shouldBe(matchOf(/(?<=(a)\1)b/, "aab"), [2, "b", "a"]);
+shouldBe(matchOf(/(?<=(a)\1)b/, "xab"), [2, "b", "a"]);
+shouldBe(matchOf(/(?<=\1(a))b/, "xab"), null);
+shouldBe(matchOf(/(?<=\1(a))b/, "aab"), [2, "b", "a"]);
+shouldBe(matchOf(/(a)x(?<=\1x)b/, "axb"), [0, "axb", "a"]);
+shouldBe(matchOf(/(?<=(?:ab)+)c/, "ababc"), [4, "c"]);
+shouldBe(matchOf(/(?<=(?:ab)+)c/, "xc"), null);
+shouldBe(matchOf(/(?<=(?:ab){2})c/, "ababc"), [4, "c"]);
+shouldBe(matchOf(/(?<=(?:ab){2})c/, "xabc"), null);
+shouldBe(matchOf(/(?<=(?:ab){1,2}x)c/, "abxc"), [3, "c"]);
+shouldBe(matchOf(/(?<=(?=a)a)b/, "ab"), [1, "b"]);
+shouldBe(matchOf(/(?<=(?=a)a)b/, "cb"), null);
+shouldBe(matchOf(/(?<=(?!a).)b/, "cb"), [1, "b"]);
+shouldBe(matchOf(/(?<=(?!a).)b/, "ab"), null);
+shouldBe(matchOf(/(?<=\u{1F600})x/u, "\u{1F600}x"), [2, "x"]);
+shouldBe(matchOf(/(?<=\u{1F600})x/u, "yx"), null);
+shouldBe(matchOf(/(?<=.)x/u, "\u{1F600}x"), [2, "x"]);

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -317,7 +317,7 @@ void RegExp::compile(VM* vm, Yarr::CharSize charSize, std::optional<StringView> 
     }
 
 #if ENABLE(YARR_JIT)
-    if (!pattern.containsUnsignedLengthPattern() && Options::useRegExpJIT() && !pattern.m_containsLookbehinds) {
+    if (!pattern.containsUnsignedLengthPattern() && Options::useRegExpJIT() && !(pattern.m_containsLookbehinds && eitherUnicode())) {
         auto& jitCode = ensureRegExpJITCode();
         Yarr::jitCompile(pattern, m_patternString, charSize, sampleString, vm, jitCode, Yarr::ExecutionMode::IncludeSubpatterns);
         if (!jitCode.failureReason()) {
@@ -400,7 +400,7 @@ void RegExp::compileMatchOnly(VM* vm, Yarr::CharSize charSize, std::optional<Str
     }
 
 #if ENABLE(YARR_JIT)
-    if (!pattern.containsUnsignedLengthPattern() && Options::useRegExpJIT() && !pattern.m_containsLookbehinds) {
+    if (!pattern.containsUnsignedLengthPattern() && Options::useRegExpJIT() && !(pattern.m_containsLookbehinds && eitherUnicode())) {
         auto& jitCode = ensureRegExpJITCode();
         Yarr::jitCompile(pattern, m_patternString, charSize, sampleString, vm, jitCode, Yarr::ExecutionMode::MatchOnly);
         if (!jitCode.failureReason()) {

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1322,38 +1322,79 @@ class YarrGenerator final : public YarrJITInfo {
         }
     }
 
-    // Jumps if input not available; will have (incorrectly) incremented already!
+    template<typename SrcType>
+    void advance(MacroAssembler::RegisterID position, SrcType count)
+    {
+        if (m_direction == Backward)
+            m_jit.sub32(count, position);
+        else
+            m_jit.add32(count, position);
+    }
+
+    template<typename SrcType>
+    void consumeIndex(SrcType count)
+    {
+        advance(m_regs.index, count);
+    }
+
+    template<typename SrcType>
+    void rewindIndex(SrcType count)
+    {
+        if (m_direction == Backward)
+            m_jit.add32(count, m_regs.index);
+        else
+            m_jit.sub32(count, m_regs.index);
+    }
+
+    void positionFromIndex(unsigned negativeOffset, MacroAssembler::RegisterID dest)
+    {
+        if (m_direction == Backward)
+            m_jit.add32(MacroAssembler::Imm32(negativeOffset), m_regs.index, dest);
+        else
+            m_jit.sub32(m_regs.index, MacroAssembler::Imm32(negativeOffset), dest);
+    }
+
+    // Jumps if input not available; will have (incorrectly) consumed it already!
     MacroAssembler::Jump jumpIfNoAvailableInput(unsigned countToCheck = 0)
     {
         if (countToCheck)
-            m_jit.add32(MacroAssembler::Imm32(countToCheck), m_regs.index);
+            consumeIndex(MacroAssembler::Imm32(countToCheck));
+        if (m_direction == Backward)
+            return m_jit.branch32(MacroAssembler::LessThan, m_regs.index, MacroAssembler::TrustedImm32(0));
         return m_jit.branch32(MacroAssembler::Above, m_regs.index, m_regs.length);
     }
 
     MacroAssembler::Jump jumpIfAvailableInput(unsigned countToCheck)
     {
-        m_jit.add32(MacroAssembler::Imm32(countToCheck), m_regs.index);
-        return m_jit.branch32(MacroAssembler::BelowOrEqual, m_regs.index, m_regs.length);
+        consumeIndex(MacroAssembler::Imm32(countToCheck));
+        return checkInput();
     }
 
     MacroAssembler::Jump checkNotEnoughInput(MacroAssembler::RegisterID additionalAmount)
     {
+        ASSERT(m_direction == Forward);
         m_jit.add32(m_regs.index, additionalAmount);
         return m_jit.branch32(MacroAssembler::Above, additionalAmount, m_regs.length);
     }
 
     MacroAssembler::Jump checkInput()
     {
+        if (m_direction == Backward)
+            return m_jit.branch32(MacroAssembler::GreaterThanOrEqual, m_regs.index, MacroAssembler::TrustedImm32(0));
         return m_jit.branch32(MacroAssembler::BelowOrEqual, m_regs.index, m_regs.length);
     }
 
     MacroAssembler::Jump atEndOfInput()
     {
+        if (m_direction == Backward)
+            return m_jit.branchTest32(MacroAssembler::Zero, m_regs.index);
         return m_jit.branch32(MacroAssembler::Equal, m_regs.index, m_regs.length);
     }
 
     MacroAssembler::Jump notAtEndOfInput()
     {
+        if (m_direction == Backward)
+            return m_jit.branchTest32(MacroAssembler::NonZero, m_regs.index);
         return m_jit.branch32(MacroAssembler::NotEqual, m_regs.index, m_regs.length);
     }
 
@@ -1366,31 +1407,36 @@ class YarrGenerator final : public YarrJITInfo {
     {
         MacroAssembler::RegisterID base = m_regs.input;
 
+        int64_t characterOffset = m_direction == Backward ? static_cast<int64_t>(negativeCharacterOffset.value()) - 1 : -static_cast<int64_t>(negativeCharacterOffset.value());
+
         // MacroAssembler::BaseIndex() addressing can take a int32_t offset. Given that we can have a regular
         // expression that has unsigned character offsets, MacroAssembler::BaseIndex's signed offset is insufficient
         // for addressing in extreme cases where we might underflow. Therefore we check to see if
         // negativeCharacterOffset will underflow directly or after converting for 16 bit characters.
         // If so, we do our own address calculating by adjusting the base, using the result register
         // as a temp address register.
-        unsigned maximumNegativeOffsetForCharacterSize = m_charSize == CharSize::Char8 ? 0x7fffffff : 0x3fffffff;
-        unsigned offsetAdjustAmount = 0x40000000;
-        if (negativeCharacterOffset > maximumNegativeOffsetForCharacterSize) {
+        int64_t maximumOffsetForCharacterSize = m_charSize == CharSize::Char8 ? 0x7fffffff : 0x3fffffff;
+        int32_t offsetAdjustAmount = 0x40000000;
+        auto offsetIsTooLarge = [&] {
+            return characterOffset < -maximumOffsetForCharacterSize || characterOffset > maximumOffsetForCharacterSize;
+        };
+        if (offsetIsTooLarge()) {
             base = tempReg;
             m_jit.move(m_regs.input, base);
-            while (negativeCharacterOffset > maximumNegativeOffsetForCharacterSize) {
-                m_jit.subPtr(MacroAssembler::TrustedImm32(offsetAdjustAmount), base);
-                if (m_charSize != CharSize::Char8)
-                    m_jit.subPtr(MacroAssembler::TrustedImm32(offsetAdjustAmount), base);
-                negativeCharacterOffset -= offsetAdjustAmount;
+            while (offsetIsTooLarge()) {
+                for (unsigned i = 0; i < (m_charSize == CharSize::Char8 ? 1 : 2); ++i) {
+                    if (characterOffset < 0)
+                        m_jit.subPtr(MacroAssembler::TrustedImm32(offsetAdjustAmount), base);
+                    else
+                        m_jit.addPtr(MacroAssembler::TrustedImm32(offsetAdjustAmount), base);
+                }
+                characterOffset += characterOffset < 0 ? offsetAdjustAmount : -offsetAdjustAmount;
             }
         }
 
-        Checked<int32_t> characterOffset(-static_cast<int32_t>(negativeCharacterOffset));
-
         if (m_charSize == CharSize::Char8)
-            return MacroAssembler::BaseIndex(base, indexReg, MacroAssembler::TimesOne, characterOffset * static_cast<int32_t>(sizeof(char)));
-
-        return MacroAssembler::BaseIndex(base, indexReg, MacroAssembler::TimesTwo, characterOffset * static_cast<int32_t>(sizeof(char16_t)));
+            return MacroAssembler::BaseIndex(base, indexReg, MacroAssembler::TimesOne, Checked<int32_t>(characterOffset) * static_cast<int32_t>(sizeof(char)));
+        return MacroAssembler::BaseIndex(base, indexReg, MacroAssembler::TimesTwo, Checked<int32_t>(characterOffset) * static_cast<int32_t>(sizeof(char16_t)));
     }
 
     void tryReadUnicodeChar(MacroAssembler::BaseIndex address, MacroAssembler::RegisterID resultReg)
@@ -1787,11 +1833,15 @@ class YarrGenerator final : public YarrJITInfo {
         // FIXME: could avoid offsetting this value in JIT code, apply offsets only afterwards, at the point the results array is being accessed.
         ASSERT(term->capture() && shouldRecordSubpatterns());
         unsigned inputOffset = checkedOffset - term->inputPosition + extraOffset;
+        MacroAssembler::RegisterID positionReg = m_regs.index;
         if (inputOffset) {
-            m_jit.sub32(m_regs.index, MacroAssembler::Imm32(inputOffset), indexTemporary);
-            setSubpatternStart(indexTemporary, term->parentheses.subpatternId);
-        } else
-            setSubpatternStart(m_regs.index, term->parentheses.subpatternId);
+            positionFromIndex(inputOffset, indexTemporary);
+            positionReg = indexTemporary;
+        }
+        if (m_direction == Backward)
+            setSubpatternEnd(positionReg, term->parentheses.subpatternId);
+        else
+            setSubpatternStart(positionReg, term->parentheses.subpatternId);
     }
 
     void emitCaptureEnd(PatternTerm* term, Checked<unsigned> checkedOffset, MacroAssembler::RegisterID indexTemporary)
@@ -1800,11 +1850,15 @@ class YarrGenerator final : public YarrJITInfo {
         ASSERT(term->capture() && shouldRecordSubpatterns());
         auto subpatternId = term->parentheses.subpatternId;
         unsigned inputOffset = checkedOffset - term->inputPosition;
+        MacroAssembler::RegisterID positionReg = m_regs.index;
         if (inputOffset) {
-            m_jit.sub32(m_regs.index, MacroAssembler::Imm32(inputOffset), indexTemporary);
-            setSubpatternEnd(indexTemporary, subpatternId);
-        } else
-            setSubpatternEnd(m_regs.index, subpatternId);
+            positionFromIndex(inputOffset, indexTemporary);
+            positionReg = indexTemporary;
+        }
+        if (m_direction == Backward)
+            setSubpatternStart(positionReg, subpatternId);
+        else
+            setSubpatternEnd(positionReg, subpatternId);
         if (m_pattern.m_numDuplicateNamedCaptureGroups) {
             if (auto duplicateNamedGroupId = m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId])
                 storeDuplicateNamedGroupSubpatternId(duplicateNamedGroupId, subpatternId);
@@ -1939,6 +1993,7 @@ class YarrGenerator final : public YarrJITInfo {
         // The operation, as a YarrOpCode, and also a reference to the PatternTerm.
         PatternTerm* m_term;
         YarrOpCode m_op;
+        MatchDirection m_direction { Forward };
 
         // Used to record a set of Jumps out of the generated code, typically
         // used for jumps out to backtracking code, and a single reentry back
@@ -2148,6 +2203,48 @@ class YarrGenerator final : public YarrJITInfo {
         m_backtrackingState.append(op.m_jumps);
     }
 
+    bool canBeAtStartOfInput(const YarrOp& op)
+    {
+        if (m_direction == Backward)
+            return op.m_term->inputPosition == op.m_checkedOffset;
+        return !op.m_term->inputPosition;
+    }
+
+    MacroAssembler::Jump branchIfAtStartOfInput(const YarrOp& op, MacroAssembler::RelationalCondition condition = MacroAssembler::Equal)
+    {
+        ASSERT(canBeAtStartOfInput(op));
+        if (m_direction == Backward)
+            return m_jit.branch32(condition, m_regs.index, MacroAssembler::TrustedImm32(0));
+        return m_jit.branch32(condition, m_regs.index, MacroAssembler::Imm32(op.m_checkedOffset));
+    }
+
+    bool canBeAtEndOfInput(const YarrOp& op)
+    {
+        if (m_direction == Backward)
+            return !op.m_term->inputPosition;
+        return op.m_term->inputPosition == op.m_checkedOffset;
+    }
+
+    MacroAssembler::Jump branchIfAtEndOfInput(const YarrOp& op, MacroAssembler::RegisterID scratch, MacroAssembler::RelationalCondition condition = MacroAssembler::Equal)
+    {
+        ASSERT(canBeAtEndOfInput(op));
+        if (m_direction == Backward) {
+            m_jit.add32(MacroAssembler::Imm32(op.m_checkedOffset), m_regs.index, scratch);
+            return m_jit.branch32(condition, scratch, m_regs.length);
+        }
+        return m_jit.branch32(condition, m_regs.index, m_regs.length);
+    }
+
+    unsigned offsetOfCharacterBefore(const YarrOp& op)
+    {
+        return (op.m_checkedOffset - op.m_term->inputPosition + (m_direction == Backward ? 0 : 1)).value();
+    }
+
+    unsigned offsetOfCharacterAfter(const YarrOp& op)
+    {
+        return (op.m_checkedOffset - op.m_term->inputPosition + (m_direction == Backward ? 1 : 0)).value();
+    }
+
     void generateAssertionBOL(size_t opIndex)
     {
         YarrOp& op = m_ops[opIndex];
@@ -2158,20 +2255,20 @@ class YarrGenerator final : public YarrJITInfo {
             const MacroAssembler::RegisterID scratch = m_regs.regT1;
 
             MacroAssembler::JumpList matchDest;
-            if (!term->inputPosition)
-                matchDest.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, MacroAssembler::Imm32(op.m_checkedOffset)));
+            if (canBeAtStartOfInput(op))
+                matchDest.append(branchIfAtStartOfInput(op));
 
-            readCharacter(op.m_checkedOffset - term->inputPosition + 1, character);
+            readCharacter(offsetOfCharacterBefore(op), character);
             matchCharacterClass(character, scratch, matchDest, m_pattern.newlineCharacterClass());
             op.m_jumps.append(m_jit.jump());
 
             matchDest.link(&m_jit);
         } else {
             // Erk, really should poison out these alternatives early. :-/
-            if (term->inputPosition)
+            if (!canBeAtStartOfInput(op))
                 op.m_jumps.append(m_jit.jump());
             else
-                op.m_jumps.append(m_jit.branch32(MacroAssembler::NotEqual, m_regs.index, MacroAssembler::Imm32(op.m_checkedOffset)));
+                op.m_jumps.append(branchIfAtStartOfInput(op, MacroAssembler::NotEqual));
         }
     }
     void backtrackAssertionBOL(size_t opIndex)
@@ -2184,22 +2281,22 @@ class YarrGenerator final : public YarrJITInfo {
         YarrOp& op = m_ops[opIndex];
         PatternTerm* term = op.m_term;
 
+        const MacroAssembler::RegisterID character = m_regs.regT0;
+        const MacroAssembler::RegisterID scratch = m_regs.regT1;
+
         if (term->multiline()) {
-            const MacroAssembler::RegisterID character = m_regs.regT0;
-            const MacroAssembler::RegisterID scratch = m_regs.regT1;
-
             MacroAssembler::JumpList matchDest;
-            if (term->inputPosition == op.m_checkedOffset)
-                matchDest.append(atEndOfInput());
+            if (canBeAtEndOfInput(op))
+                matchDest.append(branchIfAtEndOfInput(op, scratch));
 
-            readCharacter(op.m_checkedOffset - term->inputPosition, character);
+            readCharacter(offsetOfCharacterAfter(op), character);
             matchCharacterClass(character, scratch, matchDest, m_pattern.newlineCharacterClass());
             op.m_jumps.append(m_jit.jump());
 
             matchDest.link(&m_jit);
         } else {
-            if (term->inputPosition == op.m_checkedOffset)
-                op.m_jumps.append(notAtEndOfInput());
+            if (canBeAtEndOfInput(op))
+                op.m_jumps.append(branchIfAtEndOfInput(op, scratch, MacroAssembler::NotEqual));
             // Erk, really should poison out these alternatives early. :-/
             else
                 op.m_jumps.append(m_jit.jump());
@@ -2213,12 +2310,11 @@ class YarrGenerator final : public YarrJITInfo {
     void generateAssertionBOI(size_t opIndex)
     {
         YarrOp& op = m_ops[opIndex];
-        PatternTerm* term = op.m_term;
 
-        if (term->inputPosition)
+        if (!canBeAtStartOfInput(op))
             op.m_jumps.append(m_jit.jump());
         else
-            op.m_jumps.append(m_jit.branch32(MacroAssembler::NotEqual, m_regs.index, MacroAssembler::Imm32(op.m_checkedOffset)));
+            op.m_jumps.append(branchIfAtStartOfInput(op, MacroAssembler::NotEqual));
     }
     void backtrackAssertionBOI(size_t opIndex)
     {
@@ -2230,11 +2326,12 @@ class YarrGenerator final : public YarrJITInfo {
         YarrOp& op = m_ops[opIndex];
         PatternTerm* term = op.m_term;
 
+        const MacroAssembler::RegisterID character = m_regs.regT0;
+        const MacroAssembler::RegisterID scratch = m_regs.regT1;
+
         if (term->m_withOptionalLineTerminator) {
             // Equivalent to (?=(?:\r\n|\n|\r|\u2028|\u2029)?(?-m:$))
-
-            const MacroAssembler::RegisterID character = m_regs.regT0;
-            const MacroAssembler::RegisterID scratch = m_regs.regT1;
+            ASSERT(m_direction == Forward);
 
             MacroAssembler::JumpList success;
 
@@ -2285,8 +2382,8 @@ class YarrGenerator final : public YarrJITInfo {
 
             success.link(&m_jit);
         } else {
-            if (term->inputPosition == op.m_checkedOffset)
-                op.m_jumps.append(notAtEndOfInput());
+            if (canBeAtEndOfInput(op))
+                op.m_jumps.append(branchIfAtEndOfInput(op, scratch, MacroAssembler::NotEqual));
             else
                 op.m_jumps.append(m_jit.jump());
         }
@@ -2305,10 +2402,10 @@ class YarrGenerator final : public YarrJITInfo {
         const MacroAssembler::RegisterID character = m_regs.regT0;
         const MacroAssembler::RegisterID scratch = m_regs.regT1;
 
-        if (term->inputPosition == op.m_checkedOffset)
-            nextIsNotWordChar.append(atEndOfInput());
+        if (canBeAtEndOfInput(op))
+            nextIsNotWordChar.append(branchIfAtEndOfInput(op, scratch));
 
-        readCharacter(op.m_checkedOffset - term->inputPosition, character);
+        readCharacter(offsetOfCharacterAfter(op), character);
 
         CharacterClass* wordcharCharacterClass;
 
@@ -2328,12 +2425,11 @@ class YarrGenerator final : public YarrJITInfo {
         const MacroAssembler::RegisterID character = m_regs.regT0;
         const MacroAssembler::RegisterID scratch = m_regs.regT1;
 
-
         MacroAssembler::Jump atBegin;
         MacroAssembler::JumpList matchDest;
-        if (!term->inputPosition)
-            atBegin = m_jit.branch32(MacroAssembler::Equal, m_regs.index, MacroAssembler::Imm32(op.m_checkedOffset));
-        readCharacter(op.m_checkedOffset - term->inputPosition + 1, character);
+        if (canBeAtStartOfInput(op))
+            atBegin = branchIfAtStartOfInput(op);
+        readCharacter(offsetOfCharacterBefore(op), character);
 
         CharacterClass* wordcharCharacterClass;
 
@@ -2343,7 +2439,7 @@ class YarrGenerator final : public YarrJITInfo {
             wordcharCharacterClass = m_pattern.wordcharCharacterClass();
 
         matchCharacterClass(character, scratch, matchDest, wordcharCharacterClass);
-        if (!term->inputPosition)
+        if (canBeAtStartOfInput(op))
             atBegin.link(&m_jit);
 
         // We fall through to here if the last character was not a wordchar.
@@ -2763,8 +2859,8 @@ class YarrGenerator final : public YarrJITInfo {
         // upper & lower case representations are converted to a character class.
         ASSERT(!op.m_term->ignoreCase() || isASCIIAlpha(firstChar) || isCanonicallyUnique(firstChar, m_canonicalMode));
 
-        if (m_decodeSurrogatePairs && (!U_IS_BMP(firstChar) || U16_IS_SURROGATE(firstChar))) {
-            // The first term we are considering is a non-BMP or dangling surrogate char in unicode pattern. Just try matching it and be done.
+        if (m_direction == Backward || (m_decodeSurrogatePairs && (!U_IS_BMP(firstChar) || U16_IS_SURROGATE(firstChar)))) {
+            // The first term we are considering is Backward, or a non-BMP or dangling surrogate char in unicode pattern. Just try matching it and be done.
             uint64_t charToMatch = firstChar;
 
             auto offset = op.m_checkedOffset - op.m_term->inputPosition;
@@ -3130,7 +3226,7 @@ class YarrGenerator final : public YarrJITInfo {
 
         Checked<unsigned> scaledMaxCount = term->quantityMaxCount;
         scaledMaxCount *= U_IS_BMP(ch) ? 1 : 2;
-        m_jit.sub32(m_regs.index, MacroAssembler::Imm32(scaledMaxCount), countRegister);
+        positionFromIndex(scaledMaxCount, countRegister);
 
         MacroAssembler::Label loop(&m_jit);
         readCharacter(op.m_checkedOffset - term->inputPosition - scaledMaxCount, character, countRegister);
@@ -3146,7 +3242,7 @@ class YarrGenerator final : public YarrJITInfo {
         if (m_decodeSurrogatePairs && !U_IS_BMP(ch))
             m_jit.add32(MacroAssembler::TrustedImm32(2), countRegister);
         else
-            m_jit.add32(MacroAssembler::TrustedImm32(1), countRegister);
+            advance(countRegister, MacroAssembler::TrustedImm32(1));
         m_jit.branch32(MacroAssembler::NotEqual, countRegister, m_regs.index).linkTo(loop, &m_jit);
     }
     void backtrackPatternCharacterFixed(size_t opIndex)
@@ -3172,7 +3268,7 @@ class YarrGenerator final : public YarrJITInfo {
             failures.append(atEndOfInput());
             failures.append(jumpIfCharNotEquals(ch, op.m_checkedOffset - term->inputPosition, character, term->ignoreCase()));
 
-            m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
+            consumeIndex(MacroAssembler::TrustedImm32(1));
             if (m_decodeSurrogatePairs && !U_IS_BMP(ch)) {
                 MacroAssembler::Jump surrogatePairOk = notAtEndOfInput();
                 m_jit.sub32(MacroAssembler::TrustedImm32(1), m_regs.index);
@@ -3208,7 +3304,7 @@ class YarrGenerator final : public YarrJITInfo {
             loadFromFrame(term->frameLocation + BackTrackInfoPatternCharacter::matchAmountIndex(), countRegister);
             if (m_decodeSurrogatePairs && !U_IS_BMP(term->patternCharacter))
                 m_jit.lshift32(MacroAssembler::TrustedImm32(1), countRegister);
-            m_jit.sub32(countRegister, m_regs.index);
+            rewindIndex(countRegister);
             m_backtrackingState.fallthrough();
             return;
         }
@@ -3217,7 +3313,7 @@ class YarrGenerator final : public YarrJITInfo {
         m_backtrackingState.append(m_jit.branchTest32(MacroAssembler::Zero, countRegister));
         m_jit.sub32(MacroAssembler::TrustedImm32(1), countRegister);
         if (!m_decodeSurrogatePairs || U_IS_BMP(term->patternCharacter))
-            m_jit.sub32(MacroAssembler::TrustedImm32(1), m_regs.index);
+            rewindIndex(MacroAssembler::TrustedImm32(1));
         else
             m_jit.sub32(MacroAssembler::TrustedImm32(2), m_regs.index);
         m_jit.jump(op.m_reentry);
@@ -3255,7 +3351,7 @@ class YarrGenerator final : public YarrJITInfo {
                 nonGreedyFailures.append(m_jit.branch32(MacroAssembler::Equal, countRegister, MacroAssembler::Imm32(term->quantityMaxCount)));
             nonGreedyFailures.append(jumpIfCharNotEquals(ch, op.m_checkedOffset - term->inputPosition, character, term->ignoreCase()));
 
-            m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
+            consumeIndex(MacroAssembler::TrustedImm32(1));
             if (m_decodeSurrogatePairs && !U_IS_BMP(ch)) {
                 MacroAssembler::Jump surrogatePairOk = notAtEndOfInput();
                 m_jit.sub32(MacroAssembler::TrustedImm32(1), m_regs.index);
@@ -3274,7 +3370,7 @@ class YarrGenerator final : public YarrJITInfo {
             m_jit.lshift32(MacroAssembler::TrustedImm32(1), countRegister);
         }
 
-        m_jit.sub32(countRegister, m_regs.index);
+        rewindIndex(countRegister);
         m_backtrackingState.fallthrough();
     }
 
@@ -3370,7 +3466,7 @@ class YarrGenerator final : public YarrJITInfo {
             }
         }
 
-        m_jit.sub32(m_regs.index, MacroAssembler::Imm32(scaledMaxCount), countRegister);
+        positionFromIndex(scaledMaxCount, countRegister);
 
         MacroAssembler::Label loop(&m_jit);
         readCharacterForCharacterClassTerm(op.m_checkedOffset - term->inputPosition - scaledMaxCount, character, countRegister, term);
@@ -3391,7 +3487,7 @@ class YarrGenerator final : public YarrJITInfo {
                 isBMPChar.link(&m_jit);
             }
         } else
-            m_jit.add32(MacroAssembler::TrustedImm32(1), countRegister);
+            advance(countRegister, MacroAssembler::TrustedImm32(1));
 
         if (nonBMPOnly) {
             done.append(m_jit.branch32(MacroAssembler::Equal, countRegister, m_regs.index));
@@ -3475,7 +3571,7 @@ class YarrGenerator final : public YarrJITInfo {
         if (m_decodeSurrogatePairs)
             advanceIndexAfterCharacterClassTermMatch(term, failuresDecrementIndex, character);
         else
-            m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
+            consumeIndex(MacroAssembler::TrustedImm32(1));
         m_jit.add32(MacroAssembler::TrustedImm32(1), countRegister);
 
         if (term->quantityMaxCount == quantifyInfinite)
@@ -3514,7 +3610,7 @@ class YarrGenerator final : public YarrJITInfo {
             loadFromFrame(term->frameLocation + BackTrackInfoCharacterClass::matchAmountIndex(), countRegister);
             if (m_decodeSurrogatePairs && term->characterClass->hasNonBMPCharacters())
                 m_jit.lshift32(MacroAssembler::TrustedImm32(1), countRegister); // 2 code units per match.
-            m_jit.sub32(countRegister, m_regs.index);
+            rewindIndex(countRegister);
             m_backtrackingState.fallthrough();
             return;
         }
@@ -3524,7 +3620,7 @@ class YarrGenerator final : public YarrJITInfo {
         m_jit.sub32(MacroAssembler::TrustedImm32(1), countRegister);
 
         if (!m_decodeSurrogatePairs)
-            m_jit.sub32(MacroAssembler::TrustedImm32(1), m_regs.index);
+            rewindIndex(MacroAssembler::TrustedImm32(1));
         else if (term->isFixedWidthCharacterClass())
             m_jit.sub32(MacroAssembler::TrustedImm32(term->characterClass->hasNonBMPCharacters() ? 2 : 1), m_regs.index);
         else {
@@ -3591,7 +3687,7 @@ class YarrGenerator final : public YarrJITInfo {
         if (m_decodeSurrogatePairs)
             advanceIndexAfterCharacterClassTermMatch(term, nonGreedyFailuresDecrementIndex, character);
         else
-            m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
+            consumeIndex(MacroAssembler::TrustedImm32(1));
         m_jit.add32(MacroAssembler::TrustedImm32(1), countRegister);
 
         m_jit.jump(op.m_reentry);
@@ -3605,7 +3701,7 @@ class YarrGenerator final : public YarrJITInfo {
         if (m_decodeSurrogatePairs)
             loadFromFrame(term->frameLocation + BackTrackInfoCharacterClass::beginIndex(), m_regs.index);
         else
-            m_jit.sub32(countRegister, m_regs.index);
+            rewindIndex(countRegister);
         m_backtrackingState.fallthrough();
     }
 
@@ -3864,6 +3960,7 @@ class YarrGenerator final : public YarrJITInfo {
                 m_disassembler->setForGenerate(opIndex, m_jit.label());
 
             YarrOp& op = m_ops[opIndex];
+            m_direction = op.m_direction;
             switch (op.m_op) {
 
             case YarrOpCode::Term:
@@ -4615,7 +4712,7 @@ class YarrGenerator final : public YarrJITInfo {
                 storeToFrame(m_regs.index, parenthesesFrameLocation + BackTrackInfoParentheticalAssertion::beginIndex());
 
                 if (op.m_checkAdjust)
-                    m_jit.sub32(MacroAssembler::Imm32(op.m_checkAdjust), m_regs.index);
+                    rewindIndex(MacroAssembler::Imm32(op.m_checkAdjust));
                 break;
             }
             case YarrOpCode::ParentheticalAssertionEnd: {
@@ -4661,6 +4758,7 @@ class YarrGenerator final : public YarrJITInfo {
                 m_disassembler->setForBacktrack(opIndex, m_jit.label());
 
             YarrOp& op = m_ops[opIndex];
+            m_direction = op.m_direction;
             switch (op.m_op) {
 
             case YarrOpCode::Term:
@@ -4979,7 +5077,7 @@ class YarrGenerator final : public YarrJITInfo {
                     if (!m_backtrackingState.isEmpty()) {
                         // Handle the cases where we need to link the backtracks here.
                         m_backtrackingState.link(*this, op);
-                        m_jit.sub32(MacroAssembler::Imm32(op.m_checkAdjust), m_regs.index);
+                        rewindIndex(MacroAssembler::Imm32(op.m_checkAdjust));
                         if (!isLastAlternative) {
                             // An alternative that is not the last should jump to its successor.
                             m_jit.jump(nextOp.m_reentry);
@@ -5408,7 +5506,7 @@ class YarrGenerator final : public YarrJITInfo {
                     m_backtrackingState.link(*this, op);
 
                     if (op.m_checkAdjust)
-                        m_jit.add32(MacroAssembler::Imm32(op.m_checkAdjust), m_regs.index);
+                        consumeIndex(MacroAssembler::Imm32(op.m_checkAdjust));
 
                     // In an inverted assertion failure to match the subpattern
                     // is treated as a successful match - jump to the end of the
@@ -5627,6 +5725,89 @@ class YarrGenerator final : public YarrJITInfo {
         m_ops[parenEnd].m_checkedOffset = checkedOffset;
     }
 
+    std::unique_ptr<PatternDisjunction> reverseDisjunctionForBackward(PatternDisjunction* disjunction, unsigned initialInputPosition)
+    {
+        ASSERT(!m_pattern.eitherUnicode());
+        if (!isSafeToRecurse()) [[unlikely]] {
+            m_failureReason = JITFailureReason::ParenthesisNestedTooDeep;
+            return nullptr;
+        }
+        auto unsupported = [&] {
+            m_failureReason = JITFailureReason::Lookbehind;
+            return nullptr;
+        };
+
+        auto reversedDisjunction = makeUnique<PatternDisjunction>();
+        reversedDisjunction->m_minimumSize = disjunction->m_minimumSize;
+        reversedDisjunction->m_callFrameSize = disjunction->m_callFrameSize;
+        reversedDisjunction->m_hasFixedSize = disjunction->m_hasFixedSize;
+
+        for (auto& alternative : disjunction->m_alternatives) {
+            ASSERT(alternative->matchDirection() == Backward);
+            PatternAlternative* reversedAlternative = reversedDisjunction->addNewAlternative(alternative->m_firstSubpatternId, Backward);
+            reversedAlternative->m_lastSubpatternId = alternative->m_lastSubpatternId;
+            reversedAlternative->m_minimumSize = alternative->m_minimumSize;
+            reversedAlternative->m_hasFixedSize = alternative->m_hasFixedSize;
+            reversedAlternative->m_isLastAlternative = alternative->m_isLastAlternative;
+            reversedAlternative->m_terms.reserveInitialCapacity(alternative->m_terms.size());
+            unsigned inputPosition = initialInputPosition;
+            for (size_t i = alternative->m_terms.size(); i--;) {
+                PatternTerm term = alternative->m_terms[i];
+                switch (term.type) {
+                case PatternTerm::Type::AssertionBOL:
+                case PatternTerm::Type::AssertionEOL:
+                case PatternTerm::Type::AssertionBOI:
+                case PatternTerm::Type::AssertionEOI:
+                case PatternTerm::Type::AssertionWordBoundary:
+                    term.inputPosition = inputPosition;
+                    break;
+
+                case PatternTerm::Type::NumberedForwardReference:
+                case PatternTerm::Type::NamedForwardReference:
+                    break;
+
+                case PatternTerm::Type::PatternCharacter:
+                case PatternTerm::Type::CharacterClass:
+                    term.inputPosition = inputPosition;
+                    if (term.quantityType == QuantifierType::FixedCount)
+                        inputPosition += term.quantityMaxCount.value();
+                    break;
+
+                case PatternTerm::Type::ParenthesesSubpattern:
+                    if (term.quantityMaxCount != 1 || term.parentheses.isCopy)
+                        return unsupported();
+                    ASSERT(!term.parentheses.isStringList && !term.parentheses.isTerminal);
+                    if (auto reversed = reverseDisjunctionForBackward(term.parentheses.disjunction, inputPosition)) {
+                        term.parentheses.disjunction = reversed.get();
+                        m_reversedDisjunctions.append(WTF::move(reversed));
+                    } else
+                        return nullptr;
+                    if (term.quantityType == QuantifierType::FixedCount)
+                        inputPosition += term.parentheses.disjunction->m_minimumSize;
+                    term.inputPosition = inputPosition;
+                    break;
+
+                case PatternTerm::Type::ParentheticalAssertion:
+                    if (term.matchDirection() == Forward)
+                        return unsupported();
+                    term.inputPosition = inputPosition;
+                    break;
+
+                case PatternTerm::Type::NumberedBackReference:
+                case PatternTerm::Type::NamedBackReference:
+                    return unsupported();
+
+                case PatternTerm::Type::DotStarEnclosure:
+                    RELEASE_ASSERT_NOT_REACHED();
+                }
+                reversedAlternative->m_terms.append(term);
+            }
+            ASSERT(inputPosition - initialInputPosition == alternative->m_minimumSize);
+        }
+
+        return reversedDisjunction;
+    }
+
     // opCompileParentheticalAssertion
     // Emits ops for a parenthetical assertion. These consist of an
     // YarrOpCode::SimpleNestedAlternativeBegin/Next/End set of nodes wrapping
@@ -5642,6 +5823,15 @@ class YarrGenerator final : public YarrJITInfo {
             return;
         }
 
+        PatternDisjunction* disjunction = term->parentheses.disjunction;
+        if (term->matchDirection() == Backward) {
+            auto reversed = reverseDisjunctionForBackward(disjunction, 0);
+            if (!reversed)
+                return;
+            disjunction = reversed.get();
+            m_reversedDisjunctions.append(WTF::move(reversed));
+        }
+
         auto originalCheckedOffset = checkedOffset;
         size_t parenBegin = m_ops.size();
         appendOp(YarrOpCode::ParentheticalAssertionBegin);
@@ -5649,10 +5839,13 @@ class YarrGenerator final : public YarrJITInfo {
         checkedOffset -= m_ops.last().m_checkAdjust;
         m_ops.last().m_checkedOffset = checkedOffset;
 
+        MatchDirection previousDirection = std::exchange(m_direction, term->matchDirection());
+        if (m_direction == Backward)
+            checkedOffset = 0;
+
         appendOp(YarrOpCode::SimpleNestedAlternativeBegin);
         m_ops.last().m_previousOp = notFound;
         m_ops.last().m_term = term;
-        PatternDisjunction* disjunction = term->parentheses.disjunction;
         auto& alternatives = disjunction->m_alternatives;
         for (unsigned i = 0; i < alternatives.size(); ++i) {
             size_t lastOpIndex = m_ops.size() - 1;
@@ -5685,6 +5878,8 @@ class YarrGenerator final : public YarrJITInfo {
         lastOp.m_alternative = nullptr;
         lastOp.m_nextOp = notFound;
         lastOp.m_checkedOffset = checkedOffset;
+
+        m_direction = previousDirection;
 
         size_t parenEnd = m_ops.size();
         appendOp(YarrOpCode::ParentheticalAssertionEnd);
@@ -6964,7 +7159,7 @@ public:
     {
         MacroAssembler::Label startOfMainCode;
 
-        if (m_pattern.m_containsLookbehinds) {
+        if (m_pattern.m_containsLookbehinds && m_pattern.eitherUnicode()) {
             codeBlock.setFallBackWithFailureReason(JITFailureReason::Lookbehind);
             return;
         }
@@ -7503,6 +7698,7 @@ public:
         unsigned index = m_ops.size();
         m_ops.constructAndAppend(std::forward<Args>(args)...);
         m_ops.last().m_index = index;
+        m_ops.last().m_direction = m_direction;
     }
 
 private:
@@ -7545,6 +7741,9 @@ private:
     MacroAssembler::JumpList m_hitMatchLimit;
     MacroAssembler::JumpList m_inlinedMatched;
     MacroAssembler::JumpList m_inlinedFailedMatch;
+
+    MatchDirection m_direction { Forward };
+    Vector<std::unique_ptr<PatternDisjunction>> m_reversedDisjunctions;
 
     // The regular expression expressed as a linear sequence of operations.
     Vector<YarrOp, 128> m_ops;
@@ -7665,7 +7864,7 @@ static void dumpCompileFailure(JITFailureReason failure)
 {
     switch (failure) {
     case JITFailureReason::Lookbehind:
-        dataLog("Can't JIT a pattern containing lookbehinds\n");
+        dataLog("Can't JIT a pattern containing this kind of lookbehind\n");
         break;
     case JITFailureReason::ParenthesisNestedTooDeep:
         dataLog("Can't JIT pattern due to parentheses nested too deeply\n");


### PR DESCRIPTION
#### f4f06bc1151fe9f14da9f05774162f39351ed537
<pre>
[YARR] Compile lookbehinds in the JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=321496">https://bugs.webkit.org/show_bug.cgi?id=321496</a>

Reviewed by Daniel Liu.

A pattern containing a lookbehind never reached YarrJIT: RegExp::compile did not call
jitCompile for it and YarrGenerator::compile bailed out on m_containsLookbehinds, so a single
lookbehind sent the whole pattern, including everything around it, to the interpreter.

A lookbehind matches its disjunction backward, ending at the current position, which is the
same as matching the reversed sequence of its terms while consuming input downward. This patch
makes opCompileParentheticalAssertion compile a Backward assertion from a copy of its
disjunction in which each alternative has its terms reversed and its input positions reassigned
the way setupAlternativeOffsets() does (reverseDisjunctionForBackward), so the existing op
compilation, code generation and backtracking are reused as they are. The YarrPattern is left
untouched for the interpreter fallback.

The ops compiled from it are marked Backward, and only the primitives that touch the index
register look at the direction: index is the start of the input consumed so far, so claiming
input subtracts and checks index &gt;= 0, the character `offset` before index is read from
input[index + offset - 1], the end of input is index == 0, greedy terms consume with index -= 1
and give back with index += 1, a capture stores its end when the parenthesis begins and its
start when it ends, and ^ $ \b test the start / end of input and read the surrounding
characters through canBeAtStartOfInput() and friends. The machine code generated for Forward
ops is unchanged.

Unicode patterns with a lookbehind, and lookbehinds containing a backreference, a lookahead,
or a quantified parenthesis still fall back to the interpreter, and Backward ops do not combine
adjacent characters into a wider load yet.

Follow-up patches are planned to (1) JIT the remaining lookbehind shapes above and optimize
Backward ops further, (2) make the interpreter match lookbehinds from a reversed disjunction
in the same way instead of its own backward bookkeeping, and then (3) have YarrPatternConstructor
build the disjunction of a lookbehind in reversed form from the start, so that both tiers share
one representation and this copy goes away.

                                                Baseline                  Patched

regexp-lookbehind-variable                  167.9369+-2.1830     ^     34.5673+-0.2600        ^ definitely 4.8583x faster
regexp-lookbehind-negative-alternation      470.5741+-1.4593     ^     48.5470+-0.2605        ^ definitely 9.6932x faster
regexp-lookbehind-fixed                     233.4527+-4.8987     ^     44.8282+-0.4900        ^ definitely 5.2077x faster
regexp-lookbehind-replace                   651.3264+-5.8342     ^     61.1449+-1.7254        ^ definitely 10.6522x faster
regexp-exec                                  14.5383+-0.1674     ?     14.6957+-0.2200        ? might be 1.0108x slower

Tests: JSTests/microbenchmarks/regexp-lookbehind-fixed.js
       JSTests/microbenchmarks/regexp-lookbehind-negative-alternation.js
       JSTests/microbenchmarks/regexp-lookbehind-replace.js
       JSTests/microbenchmarks/regexp-lookbehind-variable.js
       JSTests/stress/regexp-lookbehind-jit-alternatives.js
       JSTests/stress/regexp-lookbehind-jit-captures.js
       JSTests/stress/regexp-lookbehind-jit-hot-loop.js
       JSTests/stress/regexp-lookbehind-jit-large-offset.js
       JSTests/stress/regexp-lookbehind-jit.js

* JSTests/microbenchmarks/regexp-lookbehind-fixed.js: Added.
* JSTests/microbenchmarks/regexp-lookbehind-negative-alternation.js: Added.
* JSTests/microbenchmarks/regexp-lookbehind-replace.js: Added.
* JSTests/microbenchmarks/regexp-lookbehind-variable.js: Added.
* JSTests/stress/regexp-lookbehind-jit-alternatives.js: Added.
(shouldBe):
(matchOf):
(shouldBe.matchOf):
(shouldBe.matchOf.b):
* JSTests/stress/regexp-lookbehind-jit-captures.js: Added.
(shouldBe):
(matchOf):
(shouldBe.matchOf.a):
* JSTests/stress/regexp-lookbehind-jit-hot-loop.js: Added.
(shouldBe):
(execConstant):
(testVarying):
(replaceAll):
(searchSticky):
* JSTests/stress/regexp-lookbehind-jit-large-offset.js: Added.
(shouldBe):
(matchOf):
* JSTests/stress/regexp-lookbehind-jit.js: Added.
(shouldBe):
(matchOf):
(shouldBe.matchOf):
(string_appeared_here.string_appeared_here.repeat):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::compile):
(JSC::RegExp::compileMatchOnly):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::dumpCompileFailure):

Canonical link: <a href="https://commits.webkit.org/319067@main">https://commits.webkit.org/319067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b4b751608a5e977c32141207c11c2a73a1f495f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144307 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140366 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97187 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; 1 flakes 5 failures; Uploaded test results; layout-tests (failure) (timed out)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42695 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41008 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2785 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9633 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153097 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40675 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1357 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41262 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46533 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192132 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53600 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149706 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40172 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54287 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149437 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44080 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126550 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121626 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52804 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15663 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52186 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->