### PR TITLE
[JSC] Move `m_parentScopeTDZVariables` into `UnlinkedFunctionExecutable` itself

### DIFF
--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -117,11 +117,13 @@ UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* struct
     , m_derivedContextType(static_cast<unsigned>(derivedContextType))
     , m_inlineAttribute(static_cast<unsigned>(inlineAttribute))
     , m_evalContextType(static_cast<unsigned>(evalContextType))
+    , m_hasName(!node->ident().isNull())
     , m_unlinkedCodeBlockForCall()
     , m_unlinkedCodeBlockForConstruct()
-    , m_name(node->ident())
     , m_ecmaName(node->ecmaName())
+    , m_parentScopeTDZVariables(WTF::move(parentScopeTDZVariables))
 {
+    ASSERT(node->ident().isNull() || node->ident() == node->ecmaName());
     // Make sure these bitfields are adequately wide.
     ASSERT(m_implementationVisibility == static_cast<unsigned>(node->implementationVisibility()));
     ASSERT(m_constructAbility == static_cast<unsigned>(constructAbility));
@@ -137,12 +139,17 @@ UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* struct
     ASSERT(!m_needsClassFieldInitializer || (isClassConstructorFunction() || derivedContextType == DerivedContextType::DerivedConstructorContext));
     if (!node->classSource().isNull())
         setClassSource(node->classSource());
-    if (parentScopeTDZVariables)
-        ensureRareData().m_parentScopeTDZVariables = WTF::move(parentScopeTDZVariables);
     if (generatorOrAsyncWrapperFunctionParameterNames)
         ensureRareData().m_generatorOrAsyncWrapperFunctionParameterNames = FixedVector<Identifier>(WTF::move(generatorOrAsyncWrapperFunctionParameterNames.value()));
     if (parentPrivateNameEnvironment)
         ensureRareData().m_parentPrivateNameEnvironment = WTF::move(*parentPrivateNameEnvironment);
+}
+
+const Identifier& UnlinkedFunctionExecutable::name() const
+{
+    if (m_hasName)
+        return m_ecmaName;
+    return vm().propertyNames->nullIdentifier;
 }
 
 UnlinkedFunctionExecutable::~UnlinkedFunctionExecutable()

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -83,9 +83,13 @@ public:
 
     ~UnlinkedFunctionExecutable();
 
-    const Identifier& name() const { return m_name; }
+    const Identifier& name() const;
     const Identifier& ecmaName() const { return m_ecmaName; }
-    void setEcmaName(const Identifier& name) { m_ecmaName = name; }
+    void setEcmaName(const Identifier& name)
+    {
+        ASSERT(!m_hasName || name == m_ecmaName);
+        m_ecmaName = name;
+    }
     unsigned parameterCount() const { return m_parameterCount; }; // Excluding 'this'!
     SourceParseMode parseMode() const { return static_cast<SourceParseMode>(m_sourceParseMode); };
 
@@ -176,12 +180,7 @@ public:
     }
     bool isBuiltinDefaultClassConstructor() const { return m_isBuiltinDefaultClassConstructor; }
 
-    RefPtr<TDZEnvironmentLink> parentScopeTDZVariables() const
-    {
-        if (!m_rareData)
-            return nullptr;
-        return m_rareData->m_parentScopeTDZVariables;
-    }
+    RefPtr<TDZEnvironmentLink> parentScopeTDZVariables() const { return m_parentScopeTDZVariables; }
 
     const FixedVector<Identifier>* generatorOrAsyncWrapperFunctionParameterNames() const
     {
@@ -252,7 +251,6 @@ public:
         SourceCode m_classSource;
         String m_sourceURLDirective;
         String m_sourceMappingURLDirective;
-        RefPtr<TDZEnvironmentLink> m_parentScopeTDZVariables;
         FixedVector<Identifier> m_generatorOrAsyncWrapperFunctionParameterNames;
         FixedVector<ClassElementDefinition> m_classElementDefinitions;
         PrivateNameEnvironment m_parentPrivateNameEnvironment;
@@ -319,6 +317,7 @@ private:
     uint8_t m_derivedContextType : 2;
     uint8_t m_inlineAttribute : 1;
     uint8_t m_evalContextType : 2;
+    uint8_t m_hasName : 1;
 
     union {
         WriteBarrier<UnlinkedFunctionCodeBlock> m_unlinkedCodeBlockForCall;
@@ -333,8 +332,8 @@ private:
         };
     };
 
-    Identifier m_name;
     Identifier m_ecmaName;
+    RefPtr<TDZEnvironmentLink> m_parentScopeTDZVariables;
 
     RareData& ensureRareData()
     {

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -1873,7 +1873,6 @@ public:
     void encode(Encoder& encoder, const UnlinkedFunctionExecutable::RareData& rareData)
     {
         m_classSource.encode(encoder, rareData.m_classSource);
-        m_parentScopeTDZVariables.encode(encoder, rareData.m_parentScopeTDZVariables);
         m_generatorOrAsyncWrapperFunctionParameterNames.encode(encoder, rareData.m_generatorOrAsyncWrapperFunctionParameterNames);
         m_classElementDefinitions.encode(encoder, rareData.m_classElementDefinitions);
         m_parentPrivateNameEnvironment.encode(encoder, rareData.m_parentPrivateNameEnvironment);
@@ -1883,7 +1882,6 @@ public:
     {
         UnlinkedFunctionExecutable::RareData* rareData = new UnlinkedFunctionExecutable::RareData { };
         m_classSource.decode(decoder, rareData->m_classSource);
-        m_parentScopeTDZVariables.decode(decoder, rareData->m_parentScopeTDZVariables);
         m_generatorOrAsyncWrapperFunctionParameterNames.decode(decoder, rareData->m_generatorOrAsyncWrapperFunctionParameterNames);
         m_classElementDefinitions.decode(decoder, rareData->m_classElementDefinitions);
         m_parentPrivateNameEnvironment.decode(decoder, rareData->m_parentPrivateNameEnvironment);
@@ -1892,7 +1890,6 @@ public:
 
 private:
     CachedSourceCodeWithoutProvider m_classSource;
-    CachedRefPtr<CachedTDZEnvironmentLink> m_parentScopeTDZVariables;
     CachedVector<CachedIdentifier> m_generatorOrAsyncWrapperFunctionParameterNames;
     CachedVector<CachedClassElementDefinition> m_classElementDefinitions;
     CachedPrivateNameEnvironment m_parentPrivateNameEnvironment;
@@ -1934,9 +1931,10 @@ public:
     unsigned NODELETE inlineAttribute() const { return m_inlineAttribute; }
     unsigned NODELETE needsClassFieldInitializer() const { return m_needsClassFieldInitializer; }
     unsigned NODELETE privateBrandRequirement() const { return m_privateBrandRequirement; }
+    unsigned NODELETE hasName() const { return m_hasName; }
 
-    Identifier name(Decoder& decoder) const { return m_name.decode(decoder); }
     Identifier ecmaName(Decoder& decoder) const { return m_ecmaName.decode(decoder); }
+    RefPtr<TDZEnvironmentLink> parentScopeTDZVariables(Decoder& decoder) const { return m_parentScopeTDZVariables.decode(decoder); }
 
     UnlinkedFunctionExecutable::RareData* rareData(Decoder& decoder) const { return m_rareData.decode(decoder); }
 
@@ -1970,11 +1968,12 @@ private:
     unsigned m_inlineAttribute : 1;
     unsigned m_needsClassFieldInitializer : 1;
     unsigned m_implementationVisibility : bitWidthOfImplementationVisibility;
+    unsigned m_hasName : 1;
 
     CachedPtr<CachedFunctionExecutableRareData> m_rareData;
 
-    CachedIdentifier m_name;
     CachedIdentifier m_ecmaName;
+    CachedRefPtr<CachedTDZEnvironmentLink> m_parentScopeTDZVariables;
 
     CachedWriteBarrier<CachedFunctionCodeBlock, UnlinkedFunctionCodeBlock> m_unlinkedCodeBlockForCall;
     CachedWriteBarrier<CachedFunctionCodeBlock, UnlinkedFunctionCodeBlock> m_unlinkedCodeBlockForConstruct;
@@ -2355,11 +2354,12 @@ ALWAYS_INLINE void CachedFunctionExecutable::encode(Encoder& encoder, const Unli
     m_needsClassFieldInitializer = executable.m_needsClassFieldInitializer;
     m_implementationVisibility = executable.m_implementationVisibility;
     m_privateBrandRequirement = executable.m_privateBrandRequirement;
+    m_hasName = executable.m_hasName;
 
     m_rareData.encode(encoder, executable.m_rareData.get());
 
-    m_name.encode(encoder, executable.name());
     m_ecmaName.encode(encoder, executable.ecmaName());
+    m_parentScopeTDZVariables.encode(encoder, executable.m_parentScopeTDZVariables);
 
     m_unlinkedCodeBlockForCall.encode(encoder, executable.m_unlinkedCodeBlockForCall);
     m_unlinkedCodeBlockForConstruct.encode(encoder, executable.m_unlinkedCodeBlockForConstruct);
@@ -2407,11 +2407,12 @@ ALWAYS_INLINE UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(Decoder& de
     , m_derivedContextType(cachedExecutable.derivedContextType())
     , m_inlineAttribute(cachedExecutable.inlineAttribute())
     , m_evalContextType(cachedExecutable.evalContextType())
+    , m_hasName(cachedExecutable.hasName())
     , m_unlinkedCodeBlockForCall()
     , m_unlinkedCodeBlockForConstruct()
 
-    , m_name(cachedExecutable.name(decoder))
     , m_ecmaName(cachedExecutable.ecmaName(decoder))
+    , m_parentScopeTDZVariables(cachedExecutable.parentScopeTDZVariables(decoder))
 
     , m_rareData(cachedExecutable.rareData(decoder))
 {


### PR DESCRIPTION
#### 8d33a8ff591daa32c3d2f441d3cfd82197f296c1
<pre>
[JSC] Move `m_parentScopeTDZVariables` into `UnlinkedFunctionExecutable` itself
<a href="https://bugs.webkit.org/show_bug.cgi?id=321497">https://bugs.webkit.org/show_bug.cgi?id=321497</a>

Reviewed by Yusuke Suzuki.

210869@main moved m_parentScopeTDZVariables into UnlinkedFunctionExecutable::RareData
because it was non-empty for only ~1% of executables at the time. That no longer holds:
since 230994@main, BytecodeGenerator::getVariablesUnderTDZ() returns a non-null
TDZEnvironmentLink whenever the enclosing TDZ stack is non-empty, and in
let/const/class-heavy code most closures are created while some lexical binding of an
enclosing scope is still in its TDZ (the binding being initialized in
`const f = () =&gt; ...`, the class name for every method of a named class, any const/class
declared later in the scope). As a result the 80-byte RareData is malloc&apos;ed for a large
fraction of the 96-byte executables just to hold this one pointer.

This patch stores m_parentScopeTDZVariables in the cell again without growing it. The 8
bytes come from m_name/m_ecmaName: FunctionMetadataNode::ecmaName() is ident() whenever
ident() is non-null, so the two Identifiers only differ for anonymous functions. Keep a
single m_ecmaName plus an m_hasName bit, which fits in the existing bit-field padding, and
make name() return vm().propertyNames-&gt;nullIdentifier (what the parser already uses as the
ident of anonymous functions) when the bit is unset. sizeof(UnlinkedFunctionExecutable)
stays at 96 bytes and RareData goes back to being rare (class constructors, private name
environments, generator/async body wrapper parameter names, source URL directives).

RareData allocations, counted at UnlinkedFunctionExecutable::ensureRareDataSlow():

                                             non-builtin      RareData
                                             executables   before   after

    typescript.js 5.9 load + transpileModule       15979     5553      49
    JetStream2 chai-wtb                            13544     4149     197
    JetStream2 prepack-wtb                         13622     4061     197
    JetStream2 uglify-js-wtb                       13434     4061     197
    JetStream2 coffeescript-wtb                    13192     3817     197
    JetStream2 acorn-wtb                           13078     3702     197
    JetStream2 WSL                                  2197     1476     136
    JetStream2 pdfjs                                 986      897      17
    JetStream2 ML                                    564      543      30
    JetStream2 Air                                   386      333      30
    JetStream2 Babylon                               397      376      28
    JetStream2 FlightPlanner                         223      191      37
    JetStream2 Basic                                 228      162      32
    JetStream2 UniPoker                              135      111      21
    JetStream2 async-fs                              138      110      27
    JetStream2 driver only (cdjs, gbemu, ...)       ~170       88      17

JetStream2 scores are neutral. Per-benchmark Score, patched/baseline over 8 alternating
runs of cli.js: acorn-wtb 1.003, babylon-wtb 1.010, chai-wtb 0.994, coffeescript-wtb
0.999, espree-wtb 1.006, jshint-wtb 1.002, lebab-wtb 0.994, prepack-wtb 1.000,
uglify-js-wtb 1.006, typescript 1.001, pdfjs 0.997, first-inspector-code-load 1.012,
multi-inspector-code-load 1.037, WSL 1.035, Air 0.991, ML 1.053, Basic 0.997,
async-fs 1.028, UniPoker 1.028; all within the run-to-run confidence intervals.

* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::UnlinkedFunctionExecutable::UnlinkedFunctionExecutable):
(JSC::UnlinkedFunctionExecutable::name const):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedFunctionExecutableRareData::encode):
(JSC::CachedFunctionExecutableRareData::decode const):
(JSC::CachedFunctionExecutable::hasName const):
(JSC::CachedFunctionExecutable::parentScopeTDZVariables const):
(JSC::CachedFunctionExecutable::encode):
(JSC::UnlinkedFunctionExecutable::UnlinkedFunctionExecutable):
(JSC::CachedFunctionExecutable::name const): Deleted.

Canonical link: <a href="https://commits.webkit.org/319021@main">https://commits.webkit.org/319021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6032420eb3d8ad59454fc028bf0b05df94d9eefe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190204 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144311 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140370 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120821 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42702 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41013 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2789 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9639 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153104 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40681 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1361 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41266 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46537 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45263 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-values/random-computed.tentative.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192136 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53604 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149705 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40138 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54291 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149436 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44085 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126554 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121630 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52808 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15669 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52190 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->