### PR TITLE
[Navigation API] navigateEvent.scroll() does not scroll to the beginning of the document when the fragment does not exist

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-fragment-does-not-exist-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-fragment-does-not-exist-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scroll: scroll() should clear the CSS :target element when the fragment does not exist
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-fragment-does-not-exist.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-fragment-does-not-exist.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<div style="height: 200vh; width: 200vw;"></div>
+<div id="frag"></div>
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  await navigation.navigate("#frag").finished;
+  assert_equals(document.querySelector(":target"), document.getElementById("frag"),
+                "target element after navigating to #frag");
+
+  let intercept_resolve;
+  let navigate_event;
+  navigation.onnavigate = e => {
+    navigate_event = e;
+    e.intercept({ handler: () => new Promise(r => intercept_resolve = r),
+                  scroll: "manual" });
+  };
+  let promises = navigation.navigate("#does-not-exist");
+  await promises.committed;
+  assert_equals(document.querySelector(":target"), document.getElementById("frag"),
+                "target element before scroll()");
+  navigate_event.scroll();
+  assert_equals(document.querySelector(":target"), null, "target element after scroll()");
+  intercept_resolve();
+  await promises.finished;
+  assert_equals(document.querySelector(":target"), null, "target element after finished");
+}, "scroll: scroll() should clear the CSS :target element when the fragment does not exist");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-no-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-no-fragment-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scroll: scroll() should clear the CSS :target element when the destination url contains no fragment
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-no-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-no-fragment.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<div style="height: 200vh; width: 200vw;"></div>
+<div id="frag"></div>
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  let start_url = location.href;
+  await navigation.navigate("#frag").finished;
+  assert_equals(document.querySelector(":target"), document.getElementById("frag"),
+                "target element after navigating to #frag");
+
+  let intercept_resolve;
+  let navigate_event;
+  navigation.onnavigate = e => {
+    navigate_event = e;
+    e.intercept({ handler: () => new Promise(r => intercept_resolve = r),
+                  scroll: "manual" });
+  };
+  let promises = navigation.navigate(start_url);
+  await promises.committed;
+  assert_equals(document.querySelector(":target"), document.getElementById("frag"),
+                "target element before scroll()");
+  navigate_event.scroll();
+  assert_equals(document.querySelector(":target"), null, "target element after scroll()");
+  intercept_resolve();
+  await promises.finished;
+  assert_equals(document.querySelector(":target"), null, "target element after finished");
+}, "scroll: scroll() should clear the CSS :target element when the destination url contains no fragment");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-fragment-does-not-exist-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-fragment-does-not-exist-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL scroll: scroll() should scroll to beginning of document when the fragment does not exist assert_equals: expected 0 but got 631
+PASS scroll: scroll() should scroll to beginning of document when the fragment does not exist
 

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -157,26 +157,26 @@ void NavigateEvent::processScrollBehavior(Document& document)
         return;
     }
 
-    if (!document.url().hasFragmentIdentifier()) {
-        if (m_navigationType == NavigationNavigationType::Reload)
-            document.frame()->loader().history().restoreScrollPositionAndViewState();
-        else
-            protect(protect(document)->frame()->view())->setScrollPosition({ 0, 0 });
-        return;
+    if (document.url().hasFragmentIdentifier()) {
+        if (!document.haveStylesheetsLoaded()) {
+            document.setGotoAnchorNeededAfterStylesheetsLoad(true);
+            return;
+        }
+
+        // LocalFrameView::scrollToFragment() only fails when the document's indicated part
+        // is null, and it clears the CSS :target element itself in that case.
+        if (protect(protect(document)->frame()->view())->scrollToFragment(document.url()))
+            return;
     }
 
-    // LocalFrameView::scrollToFragment() will fail only when anchor is not found
-    // if the url has fragment and the fragment is not text fragment.
-    if (!document.findAnchor(document.url().fragmentIdentifier())) {
-        if (m_navigationType == NavigationNavigationType::Reload)
-            document.frame()->loader().history().restoreScrollPositionAndViewState();
-        return;
-    }
+    // The document's indicated part is null, so clear the CSS :target element and scroll
+    // to the beginning of the document.
+    document.setCSSTarget(nullptr);
 
-    if (!document.haveStylesheetsLoaded())
-        document.setGotoAnchorNeededAfterStylesheetsLoad(true);
+    if (m_navigationType == NavigationNavigationType::Reload)
+        document.frame()->loader().history().restoreScrollPositionAndViewState();
     else
-        protect(protect(document)->frame()->view())->scrollToFragment(document.url());
+        protect(protect(document)->frame()->view())->setScrollPosition({ 0, 0 });
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-scroll


### PR DESCRIPTION
#### 4cb75e05600d142f19d71730baafbe0b7455d8f3
<pre>
[Navigation API] navigateEvent.scroll() does not scroll to the beginning of the document when the fragment does not exist
<a href="https://bugs.webkit.org/show_bug.cgi?id=321498">https://bugs.webkit.org/show_bug.cgi?id=321498</a>
<a href="https://rdar.apple.com/184595100">rdar://184595100</a>

Reviewed by Basuke Suzuki.

Step 4.2 of &quot;process scroll behavior&quot; says that if the document&apos;s indicated part
is null, we must scroll to the beginning of the document:
<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#process-scroll-behavior">https://html.spec.whatwg.org/multipage/nav-history-apis.html#process-scroll-behavior</a>

We already handled the case where the destination URL has no fragment identifier
at all, but when the URL had a fragment that matched no anchor we returned
without scrolling, leaving the scroll position untouched.

Instead of duplicating the &quot;is there an anchor?&quot; check, rely on
LocalFrameView::scrollToFragment(), which fails exactly when the document&apos;s
indicated part is null, and scroll to the beginning of the document in that case,
keeping the existing behavior of restoring the saved scroll position for a
reload. Deferring to scrollToFragment() also stops us from missing an anchor
whose id matches only the percent-decoded fragment, since it tries both forms,
and a fragment holding just a text directive that matched nothing now scrolls to
the beginning of the document as well, matching the spec&apos;s behavior of stripping
the directive from the fragment.

Step 1 of &quot;scroll to the fragment&quot; also requires the document&apos;s target element to
be null when the indicated part is null, otherwise the :target pseudo class stays
on the element matched by an earlier fragment. scrollToFragment() takes care of
that via resetScrollAnchor(), so only a destination URL without a fragment
identifier needs to clear it explicitly. This matches Chrome.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-fragment-does-not-exist-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-fragment-does-not-exist.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-no-fragment-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-clears-target-when-no-fragment.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/manual-scroll-fragment-does-not-exist-expected.txt: Progression
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::processScrollBehavior):

Canonical link: <a href="https://commits.webkit.org/319068@main">https://commits.webkit.org/319068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/847467a69ae6144cea1366bab2ce89a5ddaa66c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144505 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0fa7906c-3e32-49c5-8e6a-c75e0b95da4c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140532 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/20d1cbc7-c413-4cc8-a01e-eb609f0d9d9b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161312 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120984 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f91db82-3b74-419e-91c0-f10c5f859d0c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42861 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41167 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153265 "Failed to checkout and rebase branch from PR 71348") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40841 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1557 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192332 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149880 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40174 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54486 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37453 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149607 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44247 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126749 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121884 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53003 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15830 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52385 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52622 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52450 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->