### PR TITLE
Add an expected-failure test for fullscreen state surviving a cross-site frame unload

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7609,6 +7609,7 @@ http/tests/ipc/write-web-archive-frame-ancestry-check.html [ Skip ]
 http/tests/site-isolation/touch-events [ Skip ]
 http/tests/site-isolation/ios [ Skip ]
 http/tests/site-isolation/iframe-dark-mode-print.html [ ImageOnlyFailure ]
+webkit.org/b/321255 http/tests/site-isolation/fullscreen-cross-site-navigation.html [ Failure ]
 
 # CSS syntax
 imported/w3c/web-platform-tests/css/css-scoping/scoped-reference-animation-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/http/tests/site-isolation/fullscreen-cross-site-navigation-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-cross-site-navigation-expected.txt
@@ -1,0 +1,5 @@
+
+after enter: fullscreenElement = IFRAME
+after cross-site self-navigation: fullscreenElement = null
+iframe size: 300x100
+matches :fullscreen: false

--- a/LayoutTests/http/tests/site-isolation/fullscreen-cross-site-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-cross-site-navigation.html
@@ -1,0 +1,55 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!--
+  A fullscreen frame that navigates itself cross-site is unloaded in another process
+  under site isolation, so neither of the hooks that clear the embedder runs and the
+  <iframe> is left fullscreen and viewport-sized. Expected failure, webkit.org/b/321255.
+  The same test passes with SiteIsolationEnabled=false, which is where this baseline
+  came from.
+-->
+<style>
+  iframe { width: 300px; height: 100px; border: 0; }
+</style>
+<iframe id="frame" allowfullscreen src="http://localhost:8000/site-isolation/resources/fullscreen-navigate-away.html"></iframe>
+<pre id="out"></pre>
+<script>
+function log(message) {
+    document.getElementById("out").textContent += message + "\n";
+}
+
+function fullscreenElementDescription() {
+    return document.fullscreenElement ? document.fullscreenElement.tagName : "null";
+}
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.addEventListener("message", async (event) => {
+    if (event.data !== "entered") {
+        log("unexpected message from the frame: " + event.data);
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+
+    log("after enter: fullscreenElement = " + fullscreenElementDescription());
+
+    const frame = document.getElementById("frame");
+    // The navigation commits in another process, so wait for the embedder's own load
+    // event for the replacement document rather than guessing at a delay.
+    const navigated = new Promise((resolve) => frame.addEventListener("load", resolve, { once: true }));
+    frame.contentWindow.postMessage("navigate", "*");
+    await navigated;
+    if (window.testRunner)
+        await testRunner.updatePresentation();
+
+    log("after cross-site self-navigation: fullscreenElement = " + fullscreenElementDescription());
+    const rect = frame.getBoundingClientRect();
+    log("iframe size: " + Math.round(rect.width) + "x" + Math.round(rect.height));
+    log("matches :fullscreen: " + frame.matches(":fullscreen"));
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/fullscreen-navigate-away.html
+++ b/LayoutTests/http/tests/site-isolation/resources/fullscreen-navigate-away.html
@@ -1,0 +1,34 @@
+<style>
+  html { height: 80px; margin: 0; }
+</style>
+cross-site child
+<script>
+async function enterFullscreenThenReport() {
+    // internals.withUserGesture returns undefined rather than the callback's promise,
+    // so the promise has to be captured inside the callback.
+    let requestPromise;
+    internals.withUserGesture(() => {
+        requestPromise = document.documentElement.requestFullscreen();
+    });
+    try {
+        await requestPromise;
+    } catch (error) {
+        window.parent.postMessage("error " + error.name, "*");
+        return;
+    }
+    if (window.testRunner)
+        await testRunner.updatePresentation();
+    window.parent.postMessage("entered", "*");
+}
+
+window.addEventListener("message", (event) => {
+    // Navigating to the parent's site moves this frame out of its own process.
+    if (event.data === "navigate")
+        location = "http://127.0.0.1:8000/site-isolation/resources/access-parent.html";
+});
+
+if (window.internals)
+    enterFullscreenThenReport();
+else
+    window.parent.postMessage("error internals-unavailable", "*");
+</script>


### PR DESCRIPTION
#### de653a6969d2f9e5b8a93ab9c485dce1a2961fec
<pre>
Add an expected-failure test for fullscreen state surviving a cross-site frame unload
<a href="https://bugs.webkit.org/show_bug.cgi?id=321255">https://bugs.webkit.org/show_bug.cgi?id=321255</a>

Reviewed by NOBODY (OOPS!).

Nothing covered this: with site isolation enabled, a fullscreen frame that navigates itself
cross-site is unloaded in another process, so the hooks that would clear the embedding
document never run and its &lt;iframe&gt; is left flagged fullscreen and viewport-sized, taking
every hit test. The baseline records what should happen, so the expectation can be deleted
when 321255 is fixed rather than the test needing a rewrite.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/site-isolation/fullscreen-cross-site-navigation-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/fullscreen-cross-site-navigation.html: Added.
* LayoutTests/http/tests/site-isolation/resources/fullscreen-navigate-away.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de653a6969d2f9e5b8a93ab9c485dce1a2961fec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144325 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b363b0c-5f88-4f6b-b719-a9c4f47e9a15) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140378 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97198 "2 flakes 5 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f6b896f-00ec-4dfd-9f6f-5fc18f099887) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161160 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120829 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90ed4abe-521a-4e9e-b6e8-bbe1c6cc346f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42707 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41020 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40687 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1375 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192150 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149719 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54305 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149450 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44092 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121653 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52822 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15675 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52204 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52442 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52268 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->