### PR TITLE
[site-isolation] media/video-concurrent-playback.html is an intermittent failure

### DIFF
--- a/LayoutTests/media/video-concurrent-playback-expected.txt
+++ b/LayoutTests/media/video-concurrent-playback-expected.txt
@@ -12,7 +12,7 @@ EVENT(playing)
 
 ** Starting the second video, the first one should pause.
 RUN(videos[1].play())
-EVENT(playing)
+EVENT(pause)
 
 EXPECTED (videos[0].paused == 'true') OK
 EXPECTED (videos[1].paused == 'false') OK

--- a/LayoutTests/media/video-concurrent-playback.html
+++ b/LayoutTests/media/video-concurrent-playback.html
@@ -3,35 +3,54 @@
         <script src=media-file.js></script>
         <script src=video-test.js></script>
         <script>
-            var playCount = 0;
             var playThroughCount = 0;
             var videos = [];
+            var secondPlaying = false;
+            var firstPaused = false;
 
             function logEvent(evt)
             {
                 consoleWrite("EVENT(" + evt.type + ")");
             }
 
+            function maybeFinish()
+            {
+                if (!secondPlaying || !firstPaused)
+                    return;
+
+                testExpected("videos[0].paused", true);
+                testExpected("videos[1].paused", false);
+
+                consoleWrite("");
+                endTest();
+            }
+
             function playing(evt)
+            {
+                // The second video's 'playing' is required but not logged: whether it is at
+                // HAVE_FUTURE_DATA when play() is called decides whether the event is queued then or
+                // from a later readyState change, so its order against the first video's pause varies.
+                if (evt.target == videos[1]) {
+                    secondPlaying = true;
+                    maybeFinish();
+                    return;
+                }
+
+                logEvent(evt);
+                consoleWrite("");
+
+                consoleWrite("** Starting the second video, the first one should pause.");
+                run("videos[1].play()");
+                failTestIn(500);
+            }
+
+            function pause(evt)
             {
                 logEvent(evt);
                 consoleWrite("");
 
-                switch (++playCount)
-                {
-                case 1:
-                    consoleWrite("** Starting the second video, the first one should pause.");
-                    run("videos[1].play()");
-                    setTimeout(endTest, 100);
-                    break;
-                case 2:
-                    testExpected("videos[0].paused", true);
-                    testExpected("videos[1].paused", false);
-
-                    consoleWrite("");
-                    endTest();
-                    break;
-                }
+                firstPaused = true;
+                maybeFinish();
             }
 
             function canplaythrough(evt)
@@ -57,6 +76,7 @@
                     video = videos[i];
                     video.addEventListener("canplaythrough", canplaythrough);
                     video.addEventListener('playing', playing);
+                    video.addEventListener('pause', pause);
                     video.src = findMediaFile("video", "content/test");
                 }
                 run("internals.setMediaSessionRestrictions('videoaudio', 'ConcurrentPlaybackNotPermitted')");


### PR DESCRIPTION
#### 9589e0808401278e9602cabd0cd575c7cc903e13
<pre>
[site-isolation] media/video-concurrent-playback.html is an intermittent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=321503">https://bugs.webkit.org/show_bug.cgi?id=321503</a>
<a href="https://rdar.apple.com/184607025">rdar://184607025</a>

Reviewed by Eric Carlson.

The test starts a second video while a first one is playing, with
ConcurrentPlaybackNotPermitted set, and expects the first to be paused. It
asserted that from the second element&apos;s &apos;playing&apos; handler. With site isolation
enabled it read videos[0].paused as false: the &apos;playing&apos; event is queued during
play(), while enforceConcurrentPlaybackRestriction() runs in the UI process and
the pause reaches the web process as ClientShouldSuspendPlayback, at least one
IPC round trip later. Without site isolation the enforcement ran inside play()
itself, before the queued event, so the assertion held.

Asserting from the first element&apos;s &apos;pause&apos; handler instead was not enough: the
second element&apos;s &apos;playing&apos; is only queued during play() when its readyState is
at least HAVE_FUTURE_DATA, and otherwise arrives from a later readyState change,
so its order against that pause varies. On a stress bot the event came after the
pause, and endTest() had already ended the test, so the logged output lost the
line.

The test now records the second element&apos;s &apos;playing&apos; and the first element&apos;s
&apos;pause&apos; as they arrive and asserts once it has both, in either order. That event
is required but no longer logged, so the output is the same whichever order they
come in, and a &apos;playing&apos; that never arrives fails through failTestIn(500) rather
than passing unnoticed. The handler keys off evt.target rather than counting
events, so it identifies the second element rather than &quot;not the first&quot;. The
100ms setTimeout(endTest) is gone with it: it used to end the test with no
assertions at all when the pause was late, reporting success.

* LayoutTests/media/video-concurrent-playback-expected.txt:
* LayoutTests/media/video-concurrent-playback.html:

Canonical link: <a href="https://commits.webkit.org/319001@main">https://commits.webkit.org/319001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b67fe8a453c8843251d77d26a8e515879e449d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144338 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf978584-790f-4faf-bac5-80abfeebb14d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140387 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3783a6c3-28c5-4580-9fb1-7dcb6e53732d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120838 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d2a66e8-67fc-4156-96ab-729d90348edb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42714 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41027 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40693 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1388 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192163 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149728 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40123 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54318 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149458 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44099 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121682 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52835 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15681 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52217 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52455 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52281 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->