### PR TITLE
Add Swift dependencies on C++ headers

### DIFF
--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -825,6 +825,7 @@ function(WEBKIT_COPY_FILES target_name)
         list(APPEND dst_files ${dst_file})
     endforeach ()
     add_custom_target(${target_name} ALL DEPENDS ${dst_files})
+    set_property(GLOBAL PROPERTY ${target_name}_STAGED_FILES "${dst_files}")
 endfunction()
 
 function(WEBKIT_SYMLINK_FILES target_name)
@@ -1502,6 +1503,18 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         elseif (NOT _skip_swift_cxx_header)
             list(APPEND _trigger_deps "${_header_stamp_path}")
         endif ()
+        # Swift imports the C++ modules of the frameworks it depends on, so their
+        # staged headers are inputs too. Swift does emit a .d file containing these,
+        # but cmake currently ignores it - this works around it.
+        foreach (_lib IN ITEMS WTF ${${_target}_FRAMEWORKS})
+            foreach (_suffix IN ITEMS _CopyHeaders _CopyPrivateHeaders)
+                get_property(_staged GLOBAL PROPERTY ${_lib}${_suffix}_STAGED_FILES)
+                if (_staged)
+                    list(APPEND _trigger_deps ${_staged})
+                endif ()
+            endforeach ()
+        endforeach ()
+        list(REMOVE_DUPLICATES _trigger_deps)
         add_custom_command(
             OUTPUT "${_trigger_path}"
             DEPENDS ${_trigger_deps}


### PR DESCRIPTION
#### adbf766c9d9359aebed132b1570d8941d3139ee8
<pre>
Add Swift dependencies on C++ headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321505">https://bugs.webkit.org/show_bug.cgi?id=321505</a>
<a href="https://rdar.apple.com/184611931">rdar://184611931</a>

Reviewed by NOBODY (OOPS!).

This fixes a missing set of dependency edges in the cmake build. Swift targets
frequently import and depend upon C++ headers, but were not rebuilding when
those headers changed.

Ideally this would be fixed by cmake asking swiftc to emit a dependency file
and then using that to add extra ninja dependency edges - discussions in
progress. Meanwhile, add cmake rules to add these dependency edges for WebKit
projects specifically, to avoid outdated builds.

This change will likely cause some Swift targets to rebuild more often, as
it means Swift targets depend upon all the headers copied into place for the
C++ targets on which they depend.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adbf766c9d9359aebed132b1570d8941d3139ee8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190224 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144331 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/667c1a67-9fb1-4c9f-a5fb-79a4e6d44c9b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140383 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97202 "4 flakes 7 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07d84bbc-f971-4c63-918c-7fbaa86efab9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120834 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71a6106b-82fa-4526-91f6-199fa6df1c41) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42711 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41024 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2802 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9649 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40691 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1381 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41286 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192156 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53624 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149724 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54311 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149454 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44096 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121665 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52828 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15679 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52210 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52448 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52274 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->