### PR TITLE
Cherry-pick 318931@main (717e0fa52336). https://bugs.webkit.org/show_bug.cgi?id=321314

### DIFF
--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -190,12 +190,17 @@ int WebDriverService::run(int argc, char** argv)
     }
 
 #if ENABLE(WEBDRIVER_BIDI)
-    auto bidiPort = parseInteger<uint16_t>(bidiPortString);
-    if (!bidiPort) {
-        const int16_t bidiPortIncrement = *port == std::numeric_limits<uint16_t>::max() ? -1 : 1;
-        bidiPort = { *port + bidiPortIncrement };
-        RELEASE_LOG_INFO(WebDriverBiDi, "Invalid WebSocket BiDi port %s provided. Defaulting to %d.", bidiPortString.utf8().data(), *bidiPort);
-        fprintf(stderr, "Invalid WebSocket BiDi port %s provided. Defaulting to %d.\n", bidiPortString.utf8().data(), *bidiPort);
+    std::optional<uint16_t> bidiPort;
+    if (!bidiPortString.isNull()) {
+        bidiPort = parseInteger<uint16_t>(bidiPortString);
+        if (!bidiPort) {
+            RELEASE_LOG_ERROR(WebDriverBiDi, "Invalid WebSocket BiDi port %s explicitly provided. Aborting.", bidiPortString.utf8().data());
+            SAFE_FPRINTF(stderr, "Invalid WebSocket BiDi port %s explicitly provided. Aborting.\n", bidiPortString.utf8());
+            return EXIT_FAILURE;
+        }
+    } else {
+        RELEASE_LOG_INFO(WebDriverBiDi, "No explicit WebSocket BiDi port requested. Defaulting to an OS-provided one.");
+        bidiPort = 0;
     }
 #endif
 
@@ -219,20 +224,21 @@ int WebDriverService::run(int argc, char** argv)
         RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d target=%s:%d", programNameStr.data(), hostStr.data(), *port, m_targetAddress.utf8().data(), m_targetPort);
 #endif
 
-#if ENABLE(WEBDRIVER_BIDI)
-    if (!m_bidiServer->listen(host ? *host : nullString(), *bidiPort)) {
-        RELEASE_LOG_ERROR(WebDriverBiDi, "Unable to listen for WebSocket BiDi server at host %s and port %d", hostStr.data(), *bidiPort);
-        fprintf(stderr, "FATAL: Unable to listen for WebSocket BiDi server at host %s and port %d.\n", hostStr.data(), *bidiPort);
-        return EXIT_FAILURE;
-    }
-    RELEASE_LOG_INFO(WebDriverBiDi, "Started WebSocket BiDi server with host %s and port %d", hostStr.data(), *bidiPort);
-#endif // ENABLE(WEBDRIVER_BIDI)
     if (!m_server.listen(host, *port)) {
         RELEASE_LOG_ERROR(WebDriverClassic, "Unable to listen for HTTP server at host %s and port %d", hostStr.data(), *port);
         fprintf(stderr, "FATAL: Unable to listen for HTTP server at host %s and port %d.\n", hostStr.data(), *port);
         return EXIT_FAILURE;
     }
     RELEASE_LOG_INFO(WebDriverClassic, "Started HTTP server with host %s and port %d", hostStr.data(), *port);
+#if ENABLE(WEBDRIVER_BIDI)
+    auto bidiServerURL = m_bidiServer->listen(host ? *host : nullString(), *bidiPort);
+    if (!bidiServerURL) {
+        RELEASE_LOG_ERROR(WebDriverBiDi, "Unable to listen for WebSocket BiDi server at host %s and port %d", hostStr.data(), *bidiPort);
+        fprintf(stderr, "FATAL: Unable to listen for WebSocket BiDi server at host %s and port %d.\n", hostStr.data(), *bidiPort);
+        return EXIT_FAILURE;
+    }
+    RELEASE_LOG_INFO(WebDriverBiDi, "Started WebSocket BiDi server at %s", bidiServerURL->utf8().data());
+#endif // ENABLE(WEBDRIVER_BIDI)
 
     RunLoop::run();
 

--- a/Source/WebDriver/soup/WebSocketServerSoup.cpp
+++ b/Source/WebDriver/soup/WebSocketServerSoup.cpp
@@ -144,6 +144,21 @@ std::optional<String> WebSocketServer::listen(const String& host, unsigned port)
         return std::nullopt;
     }
 
+    unsigned boundPort = port;
+    if (!boundPort) {
+        if (GSList* uris = soup_server_get_uris(m_soupServer.get())) {
+            int effectivePort = g_uri_get_port(static_cast<GUri*>(uris->data));
+            if (effectivePort > 0)
+                boundPort = effectivePort;
+            g_slist_free_full(uris, reinterpret_cast<GDestroyNotify>(g_uri_unref));
+        }
+        ASSERT_WITH_MESSAGE(boundPort, "Failed to find actual WebSocket listening port");
+        if (!boundPort) {
+            soup_server_disconnect(m_soupServer.get());
+            return std::nullopt;
+        }
+    }
+
     // Callback for handling incoming WebSocket handshake requests
     soup_server_add_handler(m_soupServer.get(), nullptr, handleIncomingHandshake, this, nullptr);
 
@@ -153,7 +168,7 @@ std::optional<String> WebSocketServer::listen(const String& host, unsigned port)
     // "/session" is the default resource to start bidi-only sessions
     m_listener = WebSocketListener::create(
         host.isNull() ? "localhost"_s : host,
-        port,
+        boundPort,
         false,
         { "/session"_s }
     );

--- a/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
@@ -110,7 +110,10 @@ class SubtestResultRecorder(object):
         return hasattr(report.longrepr, 'reprcrash') and report.longrepr.reprcrash.message.startswith('Failed: Timeout >')
 
     def record_pass(self, report):
-        if hasattr(report, 'wasxfail'):
+        expected = dict(report.user_properties).get("expectations", [])
+        # Avoid expected flaky passes from being reported as XPASS, distracting from
+        # true XPASS tests.
+        if hasattr(report, 'wasxfail') and 'PASS' not in expected:
             if report.wasxfail == 'Timeout':
                 self.record(report.nodeid, 'XPASS_TIMEOUT')
             else:
@@ -131,8 +134,11 @@ class SubtestResultRecorder(object):
         self.record(report.nodeid, 'ERROR', message, report.longrepr)
 
     def record_skip(self, report):
+        expected = dict(report.user_properties).get("expectations", [])
         if hasattr(report, 'wasxfail'):
-            if self._was_timeout(report) and report.wasxfail != 'Timeout':
+            # Avoid expected flaky fail/timeouts from being reported as unexpected TIMEOUT,
+            # distracting from true TIMEOUT regressions.
+            if self._was_timeout(report) and report.wasxfail != 'Timeout' and 'TIMEOUT' not in expected:
                 self.record(report.nodeid, 'TIMEOUT', stack=report.longrepr)
             else:
                 self.record(report.nodeid, 'XFAIL')
@@ -160,13 +166,17 @@ class TestExpectationsMarker(object):
             item_name = get_item_name(item, self._ignore_param)
             if self._expectations.is_slow(test, item_name):
                 item.add_marker(pytest.mark.timeout(self._timeout * 5))
-            expected = self._expectations.get_expectation(test, item_name)[0]
-            if expected == 'FAIL':
+            expected = self._expectations.get_expectation(test, item_name)
+            if 'FAIL' in expected:
+                # Adding a "flaky" reason would overwrite the actual reason the test failed,
+                # making it harder to identify the actual reason
                 item.add_marker(pytest.mark.xfail)
-            elif expected == 'TIMEOUT':
+            elif 'TIMEOUT' in expected:
                 item.add_marker(pytest.mark.xfail(reason="Timeout"))
-            elif expected == 'SKIP':
+            elif 'SKIP' in expected:
                 item.add_marker(pytest.mark.skip)
+
+            item.user_properties.append(("expectations", expected))
 
 
 def collect(directory, args, ignore_param=None):

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -195,7 +195,7 @@
     "imported/selenium/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py": {
         "subtests": {
             "test_add_event_handler_context_created": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}, "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303207"}}
             },
             "test_add_event_handler_dom_content_loaded": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/302058"}, "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/302058"}}
@@ -222,7 +222,7 @@
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288342"}}
             },
             "test_add_event_handler_user_prompt_closed": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288343"}}
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288343"}, "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/288343"}}
             },
             "test_add_event_handler_with_specific_contexts": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
@@ -1093,28 +1093,28 @@
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
             },
             "test_printable_key_sends_correct_events[@-Digit2]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279342"}}
             },
             "test_printable_key_sends_correct_events[\"-Quote]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279342"}}
             },
             "test_printable_key_sends_correct_events[\\u0416-]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303836"}}
             },
             "test_printable_key_sends_correct_events[\\u2603-]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303836"}}
             },
             "test_printable_key_sends_correct_events[\\uf6c2-]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303836"}}
             },
             "test_printable_key_sends_correct_events[\\xe0-]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303836"}}
             },
             "test_special_key_sends_keydown[ADD-expected0]": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
             },
             "test_special_key_sends_keydown[DECIMAL-expected6]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321114"}}
             },
             "test_special_key_sends_keydown[DIVIDE-expected8]": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
@@ -1126,34 +1126,34 @@
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
             },
             "test_special_key_sends_keydown[NUMPAD0-expected33]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321114"}}
             },
             "test_special_key_sends_keydown[NUMPAD1-expected34]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321114"}}
             },
             "test_special_key_sends_keydown[NUMPAD2-expected35]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321114"}}
             },
             "test_special_key_sends_keydown[NUMPAD3-expected36]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321114"}}
             },
             "test_special_key_sends_keydown[NUMPAD4-expected37]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321114"}}
             },
             "test_special_key_sends_keydown[NUMPAD5-expected38]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321114"}}
             },
             "test_special_key_sends_keydown[NUMPAD6-expected39]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321114"}}
             },
             "test_special_key_sends_keydown[NUMPAD7-expected40]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321114"}}
             },
             "test_special_key_sends_keydown[NUMPAD8-expected41]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321114"}}
             },
             "test_special_key_sends_keydown[NUMPAD9-expected42]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321114"}}
             },
             "test_special_key_sends_keydown[SPACE-expected65]": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
@@ -2489,10 +2489,10 @@
     "imported/w3c/webdriver/tests/classic/element_send_keys/events.py": {
         "subtests": {
             "test_form_control_send_text[input]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321115"}}
             },
             "test_form_control_send_text[textarea]": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/321115"}}
             },
             "test_not_blurred[input]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/188118"}}
@@ -2973,7 +2973,8 @@
         "subtests": {
             "test_no_top_browsing_context": {
                 "expected": {
-                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/230612"},
+                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}
                 }
             }
         ,
@@ -4331,8 +4332,8 @@
     "imported/w3c/webdriver/tests/bidi/browsing_context/user_prompt_opened/handler.py": {
         "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/288344"}},
         "subtests": {
-            "test_accept": {"expected": {"all": {"status": ["PASS"]}}},
-            "test_accept_and_notify": {"expected": {"all": {"status": ["PASS"]}}}
+            "test_accept": {"expected": {"all": {"status": ["SKIP"], "bug": "webkit.org/b/321148"}}},
+            "test_accept_and_notify": {"expected": {"all": {"status": ["SKIP"], "bug": "webkit.org/b/321148"}}}
         }
     },
 
@@ -5644,6 +5645,18 @@
     "imported/w3c/webdriver/tests/bidi/script/realm_destroyed/realm_destroyed.py": {
         "expected": { "all": { "status": ["PASS"]}},
         "subtests": {
+            "test_subscribe_to_one_context": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288067"}}
+            },
+            "test_close_context[tab]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/321148"}}
+            },
+            "test_close_context[window]": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/321148"}}
+            },
+            "test_navigate": {
+                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/321148"}}
+            },
             "test_sandbox[evaluate]": {
                 "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288067"}}
             },
@@ -5855,7 +5868,7 @@
             "test_params_events_value_invalid_event_name[]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_value_invalid_event_name[foo]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_value_invalid_event_name[foo.bar]": {"expected": {"all": {"status": ["PASS"]}}},
-            "test_params_events_value_valid_and_invalid_event_name": {"expected": {"all": {"status": ["PASS"]}}},
+            "test_params_events_value_valid_and_invalid_event_name": {"expected": {"all": {"status": ["SKIP"], "bug": "webkit.org/b/321148"}}},
             "test_params_contexts_invalid_type[True]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_contexts_invalid_type[foo]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_contexts_invalid_type[42]": {"expected": {"all": {"status": ["PASS"]}}},

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -507,6 +507,13 @@
     "imported/selenium/py/test/selenium/webdriver/common/print_pdf_tests.py": {
         "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/217173"}}
     },
+    "imported/selenium/py/test/selenium/webdriver/common/quit_tests.py": {
+        "subtests": {
+            "test_quit": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/321475"}}
+            }
+        }
+    },
     "imported/selenium/py/test/selenium/webdriver/common/select_class_tests.py": {
         "subtests": {
             "test_select_by_index_multiple": {

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -194,6 +194,15 @@
 
     "imported/selenium/py/test/selenium/webdriver/common/bidi_browsing_context_tests.py": {
         "subtests": {
+            "test_get_tree_with_child": {
+                "expected": {"all": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
+            },
+            "test_reload_browsing_context": {
+                "expected": {"all": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
+            },
+            "test_reload_with_readiness_state": {
+                "expected": {"wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
+            },
             "test_add_event_handler_context_created": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}, "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303207"}}
             },
@@ -228,7 +237,7 @@
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
             },
             "test_concurrent_event_handler_registration": {
-                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}
+                "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}, "wpe": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/310506"}}
             },
             "test_event_callback_data_consistency": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/288335"}}


### PR DESCRIPTION
#### 31d773a961136e45cf2ea21b885cc98620f8ed3f
<pre>
Cherry-pick 318931@main (717e0fa52336). <a href="https://bugs.webkit.org/show_bug.cgi?id=321314">https://bugs.webkit.org/show_bug.cgi?id=321314</a>

Unreviewed backport.

    [WebDriver][BiDi] Use OS-provided free port instead of guessing based on the http port
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321314">https://bugs.webkit.org/show_bug.cgi?id=321314</a>

    Reviewed by Carlos Alberto Lopez Perez.

    Currently, the WebDriver service chooses the WebDriverBiDi WebSockets
    port based on the HTTP server port if the latter is not explicitly
    defined by the user.

    While this works fine in low churn scenarios, this does not guarantee
    that the server will pick a free port, potentially leading to fatal
    startup errors and test failures.

    This commit makes the WebDriverBiDi server let the OS provide a free
    port if the user does not provide one, reporting that port back through
    the `webSocketURL` capability. Also, to ensure the os-provided port does
    not clash with the explicit port requested for the HTTP server, the
    WebSocket server is now started after it.

    For bidi-only connections (not yet supported, though), the user can just
    provide the port explicitly.

    * Source/WebDriver/WebDriverService.cpp:
    (WebDriver::WebDriverService::run):
    * Source/WebDriver/soup/WebSocketServerSoup.cpp:
    (WebDriver::WebSocketServer::listen):

    Canonical link: <a href="https://commits.webkit.org/318931@main">https://commits.webkit.org/318931@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.101@webkitglib/2.54">https://commits.webkit.org/317695.101@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### ac4b42d61b4b5425524a8d9af3df80dce71ba66c
<pre>
Cherry-pick 318945@main (05b150a7ff4d). <a href="https://bugs.webkit.org/show_bug.cgi?id=321475">https://bugs.webkit.org/show_bug.cgi?id=321475</a>

    [WebDriver][GLIB] imported/selenium/py/test/selenium/webdriver/common/quit_tests.py::test_quit is failing
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321475">https://bugs.webkit.org/show_bug.cgi?id=321475</a>

    Unreviewed test gardening.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/318945@main">https://commits.webkit.org/318945@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.100@webkitglib/2.54">https://commits.webkit.org/317695.100@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 8e1e5e131a592f877509fb628cc32d2a9e7316a8
<pre>
Cherry-pick 318761@main (906e60b3d829). <a href="https://bugs.webkit.org/show_bug.cgi?id=321175">https://bugs.webkit.org/show_bug.cgi?id=321175</a>

    [WebDriver][Tools] Fix pytest_collection_modifyitems to support proper flaky expectations
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321175">https://bugs.webkit.org/show_bug.cgi?id=321175</a>

    Reviewed by Carlos Alberto Lopez Perez.

    Ensure we check the whole expectation list when installing the pytest
    markers. Previously, only the first item was checked, effectively
    ignoring flaky expectations, which have multiple expected outcomes.

    As pytest has no natural flaky test marker, flakies are marked as xfail,
    which, in the case of a pass, currently are reported as XPASS. To avoid
    polluting the final report and hiding true XPASS cases, we also report
    the flaky passes as regular PASS in the outer harness and resulting
    json. The same approach is used for FAIL/TIMEOUT, to avoid the empty
    xfail to mark an expected flaky timeout as a true timeout.

    * Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py:
    (SubtestResultRecorder.record_pass):
    (TestExpectationsMarker.pytest_collection_modifyitems):

    Canonical link: <a href="https://commits.webkit.org/318761@main">https://commits.webkit.org/318761@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.99@webkitglib/2.54">https://commits.webkit.org/317695.99@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### e601b925b14804abda9b338fefc85a4d2187711f
<pre>
Cherry-pick 318766@main (f261a909c8d9). <a href="https://bugs.webkit.org/show_bug.cgi?id=321152">https://bugs.webkit.org/show_bug.cgi?id=321152</a>

    [WebDriver][WPE] Gardening W32 2026 edition
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321152">https://bugs.webkit.org/show_bug.cgi?id=321152</a>

    Unreviewed test gardening.

    Gardening the most persistent flakies.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/318766@main">https://commits.webkit.org/318766@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.98@webkitglib/2.54">https://commits.webkit.org/317695.98@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 6fd0e3f5c5bb59eb4ff7ce09902c589fa8d39a8a
<pre>
Cherry-pick 318683@main (8e51fe62a2a3). <a href="https://bugs.webkit.org/show_bug.cgi?id=321152">https://bugs.webkit.org/show_bug.cgi?id=321152</a>

    [WebDriver][WPE] Gardening W32 2026 edition
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321152">https://bugs.webkit.org/show_bug.cgi?id=321152</a>

    Unreviewed test gardening.

    Includes a few skips related to bidi tests using the event_loop
    pytest-asyncio fixture, which is deprecated on the currently
    autoinstalled version 1.1.1. It&apos;ll be fixed in bug321148.

    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/318683@main">https://commits.webkit.org/318683@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.97@webkitglib/2.54">https://commits.webkit.org/317695.97@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7860cf0c51a4b85ad9992aaaf3f61531dd3d2dba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180065 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/54011 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47807 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190277 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144384 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181927 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/55308 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53727 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144384 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183021 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/55308 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47807 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/120878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/179390 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/55308 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53727 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47807 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/55308 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47807 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1434 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46610 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53727 "The change is no longer eligible for processing.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192209 "Failed to checkout and rebase branch from PR 71356") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53677 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47807 "The change is no longer eligible for processing.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/192209 "Failed to checkout and rebase branch from PR 71356") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/54365 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47807 "The change is no longer eligible for processing.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/192209 "Failed to checkout and rebase branch from PR 71356") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27341 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/54365 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126627 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121736 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52881 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47807 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52264 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52501 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52328 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->