### PR TITLE
Same-frame fragment navigation that starts after a download attribute click, in the same task, cancels the download

### DIFF
--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-in-detached-frame-expected.txt
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-in-detached-frame-expected.txt
@@ -1,0 +1,5 @@
+Test that detaching a frame that just clicked a link with a download attribute does not crash. The download's policy check outlives the navigation that started it, so it can be answered after the frame is gone; it must be discarded rather than applied to a frame that is no longer in a page.
+
+This test passes if it does not crash and no download callbacks are logged.
+
+

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-in-detached-frame.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-in-detached-frame.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.setShouldLogDownloadCallbacks(true);
+  testRunner.waitUntilDone();
+}
+</script>
+</head>
+<body>
+<p>Test that detaching a frame that just clicked a link with a download attribute does not crash. The
+download's policy check outlives the navigation that started it, so it can be answered after the frame is
+gone; it must be discarded rather than applied to a frame that is no longer in a page.</p>
+<p>This test passes if it does not crash and no download callbacks are logged.</p>
+<iframe id="testFrame" srcdoc="<a id='download' download='test.html' href='data:text/html,HelloWorld!'>download</a>"></iframe>
+<script>
+onload = function() {
+    var frame = document.getElementById("testFrame");
+    frame.contentDocument.getElementById("download").click();
+    // Detaches the frame while the download's policy decision is still outstanding.
+    frame.remove();
+    if (window.testRunner) {
+        setTimeout(function() { testRunner.notifyDone(); }, 0);
+    }
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-cross-document-navigation-expected.txt
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-cross-document-navigation-expected.txt
@@ -1,0 +1,13 @@
+Download started.
+Downloading URL with suggested filename "test.html"
+Download completed.
+Test that a subframe navigating to another document right after clicking a link with a download attribute neither cancels the download nor disturbs the new navigation.
+
+This test passes if you see a 'Download started' message above.
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Navigated.

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-cross-document-navigation.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-cross-document-navigation.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.dumpChildFramesAsText();
+  testRunner.setShouldLogDownloadCallbacks(true);
+  testRunner.waitUntilDownloadFinished();
+}
+</script>
+</head>
+<body>
+<p>Test that a subframe navigating to another document right after clicking a link with a download
+attribute neither cancels the download nor disturbs the new navigation.</p>
+<p>This test passes if you see a 'Download started' message above.</p>
+<iframe id="testFrame" src="resources/anchor-download-then-navigate-frame.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-fragment-navigation-expected.txt
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-fragment-navigation-expected.txt
@@ -1,0 +1,6 @@
+Download started.
+Downloading URL with suggested filename "test.html"
+Download completed.
+Test that a same-document navigation started right after clicking a link with a download attribute does not cancel the download. Activating an element with a download attribute runs "download the hyperlink", whose steps run in parallel with the navigable, so a later navigation must not cancel it.
+
+This test passes if you see a 'Download started' message above.

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-fragment-navigation.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-fragment-navigation.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.setShouldLogDownloadCallbacks(true);
+  testRunner.waitUntilDownloadFinished();
+}
+</script>
+</head>
+<body>
+<p>Test that a same-document navigation started right after clicking a link with a download attribute
+does not cancel the download. Activating an element with a download attribute runs "download the
+hyperlink", whose steps run in parallel with the navigable, so a later navigation must not cancel it.</p>
+<p>This test passes if you see a 'Download started' message above.</p>
+<script>
+var link = document.createElement("a");
+link.href = "data:text/html,HelloWorld!";
+link.download = "test.html";
+link.click();
+
+// Toggling between two values keeps this a real fragment navigation whatever fragment the document was
+// loaded with, so the test behaves the same when repeated.
+location.hash = location.hash === "#a" ? "#b" : "#a";
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-nested-click-expected.txt
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-nested-click-expected.txt
@@ -1,0 +1,8 @@
+Download started.
+Downloading URL with suggested filename "test.csv"
+Download completed.
+Test that a link with a download attribute clicked from another link's click handler starts a download. The outer link's default action performs a fragment navigation once the handler returns, which must not cancel the download. This is the form the bug was originally reported in.
+
+This test passes if you see a 'Download started' message above.
+
+Download CSV

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-nested-click.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-nested-click.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.setShouldLogDownloadCallbacks(true);
+  testRunner.waitUntilDownloadFinished();
+}
+</script>
+</head>
+<body>
+<p>Test that a link with a download attribute clicked from another link's click handler starts a download.
+The outer link's default action performs a fragment navigation once the handler returns, which must not
+cancel the download. This is the form the bug was originally reported in.</p>
+<p>This test passes if you see a 'Download started' message above.</p>
+<a id="outerLink" href="#" onclick="downloadCSV()">Download CSV</a>
+<script>
+function downloadCSV()
+{
+    var link = document.createElement("a");
+    link.href = "data:text/csv;charset=utf-8,Name,Age%0AJohn,30";
+    link.target = "_blank";
+    link.download = "test.csv";
+    link.click();
+}
+document.getElementById("outerLink").click();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/resources/anchor-download-then-navigate-frame-2.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/resources/anchor-download-then-navigate-frame-2.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+<body>Navigated.</body>
+</html>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/resources/anchor-download-then-navigate-frame.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/resources/anchor-download-then-navigate-frame.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<body>
+<a id="next" href="anchor-download-then-navigate-frame-2.html">next</a>
+<script>
+var link = document.createElement("a");
+link.href = "data:text/html,HelloWorld!";
+link.download = "test.html";
+link.click();
+// Activating a link navigates synchronously, unlike assigning location.href, so this newer
+// navigation owns the frame's policy document loader before the download's decision arrives.
+document.getElementById("next").click();
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2024,7 +2024,22 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
 
     auto policyDecisionMode = loader->triggeringAction().isFromNavigationAPI() ? PolicyDecisionMode::Synchronous : PolicyDecisionMode::Asynchronous;
     RELEASE_ASSERT(!isBackForwardLoadType(policyChecker().loadType()) || history().provisionalItem());
-    policyChecker().checkNavigationPolicy(ResourceRequest(loader->request()), ResourceResponse { } /* redirectResponse */, loader, WTF::move(formSubmission), [this, protectedThis = Ref { *this }, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache, completionHandler = completionHandlerCaller.release()] (const ResourceRequest& request, WeakPtr<const FormSubmission>&& weakFormSubmission, NavigationPolicyDecision navigationPolicyDecision) mutable {
+    policyChecker().checkNavigationPolicy(ResourceRequest(loader->request()), ResourceResponse { } /* redirectResponse */, loader, WTF::move(formSubmission), [
+        this,
+        protectedThis = Ref { *this },
+        allowNavigationToInvalidURL,
+        shouldRestoreFromBackForwardCache,
+        expectedPolicyDocumentLoader = RefPtr { loader },
+        completionHandler = completionHandlerCaller.release()
+    ] (const ResourceRequest& request, WeakPtr<const FormSubmission>&& weakFormSubmission, NavigationPolicyDecision navigationPolicyDecision) mutable {
+        // A download attribute check is not cancelled by the navigation that follows it, so it can be
+        // answered once a newer navigation owns m_policyDocumentLoader. Continuing would tear that
+        // newer navigation down; the download, if any, has already started.
+        if (m_policyDocumentLoader != expectedPolicyDocumentLoader) {
+            FRAMELOADER_RELEASE_LOG(ResourceLoading, "loadWithDocumentLoader: not continuing because a newer navigation owns the policy document loader");
+            completionHandler();
+            return;
+        }
         continueLoadAfterNavigationPolicy(request, RefPtr { weakFormSubmission.get() }.get(), navigationPolicyDecision, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache);
         completionHandler();
     }, IsSameDocumentNavigation::No, policyDecisionMode, determineNavigationType(type, NavigationHistoryBehavior::Auto));

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -225,6 +225,11 @@ void WebFrameProxy::webProcessWillShutDown()
         m_activeListener = nullptr;
     }
 
+    // Download checks survive navigation, but not the frame itself.
+    auto activeDownloadListeners = std::exchange(m_activeDownloadListeners, { });
+    for (Ref downloadListener : activeDownloadListeners.values())
+        downloadListener->ignore();
+
     if (m_navigateCallback)
         m_navigateCallback({ }, { });
 }
@@ -396,17 +401,40 @@ void WebFrameProxy::didChangeTitle(String&& title)
     m_title = WTF::move(title);
 }
 
-WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck)
+WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck, IsDownloadPolicyCheck isDownloadPolicyCheck)
 {
-    if (RefPtr previousListener = m_activeListener)
-        previousListener->ignore();
-    m_activeListener = WebFramePolicyListenerProxy::create([this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (PolicyAction action, API::WebsitePolicies* policies, ProcessSwapRequestedByClient processSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, WasNavigationIntercepted wasNavigationIntercepted) mutable {
+    bool isDownload = isDownloadPolicyCheck == IsDownloadPolicyCheck::Yes;
+    auto downloadListenerID = isDownload ? ++m_nextDownloadListenerID : 0;
+
+    if (!isDownload) {
+        if (RefPtr previousListener = m_activeListener)
+            previousListener->ignore();
+    }
+
+    auto reply = [
+        this,
+        protectedThis = Ref { *this },
+        completionHandler = WTF::move(completionHandler),
+        isDownload,
+        downloadListenerID
+    ] (PolicyAction action, API::WebsitePolicies* policies, ProcessSwapRequestedByClient processSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, WasNavigationIntercepted wasNavigationIntercepted) mutable {
         if (action != PolicyAction::Use && m_navigateCallback)
             m_navigateCallback(pageIdentifier(), frameID());
 
         completionHandler(action, policies, processSwapRequestedByClient, isNavigatingToAppBoundDomain, wasNavigationIntercepted);
-        m_activeListener = nullptr;
-    }, expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck);
+
+        if (isDownload)
+            m_activeDownloadListeners.remove(downloadListenerID);
+        else
+            m_activeListener = nullptr;
+    };
+
+    if (isDownload) {
+        m_activeDownloadListeners.add(downloadListenerID, WebFramePolicyListenerProxy::create(WTF::move(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck));
+        return *m_activeDownloadListeners.get(downloadListenerID);
+    }
+
+    m_activeListener = WebFramePolicyListenerProxy::create(WTF::move(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck);
     return *m_activeListener;
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -211,7 +211,10 @@ public:
     void didSameDocumentNavigation(URL&&); // eg. anchor navigation, session state change.
     void didChangeTitle(String&&);
 
-    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck);
+    // Only one navigation policy check can be outstanding per frame, so a new one displaces the
+    // previous. A download is not a navigation, so it neither displaces nor is displaced.
+    enum class IsDownloadPolicyCheck : bool { No, Yes };
+    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck, IsDownloadPolicyCheck);
 
 #if ENABLE(CONTENT_FILTERING)
     void contentFilterDidBlockLoad(WebCore::ContentFilterUnblockHandler contentFilterUnblockHandler) { m_contentFilterUnblockHandler = WTF::move(contentFilterUnblockHandler); }
@@ -369,6 +372,8 @@ private:
     WebCore::CertificateInfo m_certificateInfo;
     HashMap<String, WebCore::CertificateInfo> m_hostAndPortToCertificateInfo;
     RefPtr<WebFramePolicyListenerProxy> m_activeListener;
+    HashMap<uint64_t, Ref<WebFramePolicyListenerProxy>> m_activeDownloadListeners;
+    uint64_t m_nextDownloadListenerID { 0 };
     WebCore::FrameIdentifier m_frameID;
     ListHashSet<Ref<WebFrameProxy>> m_childFrames;
     WeakPtr<WebFrameProxy> m_parentFrame;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9967,7 +9967,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         }
         completionHandlerWrapper(policyAction);
 
-    }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLink);
+    }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLink, navigationAction->shouldPerformDownload() ? WebFrameProxy::IsDownloadPolicyCheck::Yes : WebFrameProxy::IsDownloadPolicyCheck::No);
     if (shouldExpectSafeBrowsingResult == ShouldExpectSafeBrowsingResult::Yes)
         beginSafeBrowsingCheck(request.url(), *navigation, frame.isMainFrame());
     if (shouldWaitForInitialLinkDecorationFilteringData == ShouldWaitForInitialLinkDecorationFilteringData::Yes)
@@ -10146,7 +10146,7 @@ void WebPageProxy::decidePolicyForNewWindowAction(IPC::Connection& connection, N
         RELEASE_ASSERT(processSwapRequestedByClient == ProcessSwapRequestedByClient::No);
 
         receivedPolicyDecision(policyAction, nullptr, std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, std::nullopt, WTF::move(completionHandler));
-    }, ShouldExpectSafeBrowsingResult::No, ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No);
+    }, ShouldExpectSafeBrowsingResult::No, ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No, WebFrameProxy::IsDownloadPolicyCheck::No);
 
     if (m_policyClient)
         m_policyClient->decidePolicyForNewWindowAction(*this, *frame, navigationAction.get(), request, frameName, WTF::move(listener));
@@ -10327,7 +10327,7 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
         }
 #endif
         completionHandlerWrapper(policyAction);
-    }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No);
+    }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No, WebFrameProxy::IsDownloadPolicyCheck::No);
     if (expectSafeBrowsing == ShouldExpectSafeBrowsingResult::Yes && navigation) {
         navigation->whenSafeBrowsingCheckCompletes([listener] mutable {
             listener->didReceiveSafeBrowsingResults();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -199,7 +199,14 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
 
     RefPtr webPage = m_frame->page();
 
-    uint64_t listenerID = m_frame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::Yes);
+    Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument;
+    if (!navigationAction.downloadAttribute().isNull()) {
+        if (RefPtr localFrame = m_frame->coreLocalFrame()) {
+            if (RefPtr document = localFrame->document())
+                downloadAttributeInitiatingDocument = document->identifier();
+        }
+    }
+    uint64_t listenerID = m_frame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::Yes, downloadAttributeInitiatingDocument);
 
     // Notify the UIProcess.
     if (policyDecisionMode == PolicyDecisionMode::Synchronous) {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -375,6 +375,12 @@ FrameTreeNodeData WebFrame::frameTreeData() const
 void WebFrame::invalidate()
 {
     ASSERT(!WebProcess::singleton().webFrame(m_frameID) || WebProcess::singleton().webFrame(m_frameID) == this);
+
+    // A download check survives navigation, including the navigation that tears this frame down.
+    auto pendingPolicyChecks = std::exchange(m_pendingPolicyChecks, { });
+    for (auto& policyCheck : pendingPolicyChecks.values())
+        policyCheck.policyFunction(PolicyAction::Ignore);
+
     RefPtr page = m_page.get();
     WebProcess::singleton().removeWebFrame(frameID(), page.get());
     m_coreFrame = nullptr;
@@ -387,15 +393,30 @@ ScopeExit<Function<void()>> WebFrame::makeInvalidator()
     });
 }
 
-uint64_t WebFrame::setUpPolicyListener(WebCore::FramePolicyFunction&& policyFunction, ForNavigationAction forNavigationAction)
+uint64_t WebFrame::setUpPolicyListener(WebCore::FramePolicyFunction&& policyFunction, ForNavigationAction forNavigationAction, Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument)
 {
     auto policyListenerID = generateListenerID();
     m_pendingPolicyChecks.add(policyListenerID, PolicyCheck {
         forNavigationAction,
+        downloadAttributeInitiatingDocument,
         WTF::move(policyFunction)
     });
 
     return policyListenerID;
+}
+
+// Unlike a navigation check, a download check is not cancelled by what this frame does next, so it can be
+// answered once the frame is no longer in a page - which startDownload() requires - or once another
+// document has committed. The document matters because PolicyChecker::checkNavigationPolicy() decides
+// against live frame state, including the sandbox allow-downloads flag that
+// LocalFrame::effectiveSandboxFlags() takes from the current document.
+bool WebFrame::shouldHonorDownloadAttributePolicyCheck(const PolicyCheck& policyCheck) const
+{
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
+    if (!localFrame || !localFrame->page())
+        return false;
+    RefPtr document = localFrame->document();
+    return document && document->identifier() == policyCheck.downloadAttributeInitiatingDocument;
 }
 
 void WebFrame::loadDidCommitInAnotherProcess(WebCore::ProcessIdentifier hostingProcessID, std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier)
@@ -627,10 +648,20 @@ void WebFrame::invalidatePolicyListeners()
 {
     Ref protectedThis { *this };
 
+    // "Download the hyperlink" runs in parallel with the navigable, so a later navigation must not cancel a
+    // download: https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks
     m_policyDownloadID = { };
 
-    auto pendingPolicyChecks = std::exchange(m_pendingPolicyChecks, { });
-    for (auto& policyCheck : pendingPolicyChecks.values())
+    HashMap<uint64_t, PolicyCheck> policyChecksToCancel;
+    for (auto& [listenerID, policyCheck] : std::exchange(m_pendingPolicyChecks, { })) {
+        if (policyCheck.downloadAttributeInitiatingDocument && shouldHonorDownloadAttributePolicyCheck(policyCheck))
+            m_pendingPolicyChecks.add(listenerID, WTF::move(policyCheck));
+        else
+            policyChecksToCancel.add(listenerID, WTF::move(policyCheck));
+    }
+
+    // Survivors go back before this point because cancelling can start a load, adding new checks.
+    for (auto& policyCheck : policyChecksToCancel.values())
         policyCheck.policyFunction(PolicyAction::Ignore);
 }
 
@@ -644,8 +675,12 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
             page->addConsoleMessage(m_frameID, message->messageSource, message->messageLevel, message->message);
     }
 
-    if (!m_coreFrame)
+    if (!m_coreFrame) {
+        // Answer rather than drop the check: FramePolicyFunction is a CompletionHandler.
+        if (auto policyCheck = m_pendingPolicyChecks.take(listenerID); policyCheck.policyFunction)
+            policyCheck.policyFunction(PolicyAction::Ignore);
         return;
+    }
     setIsSafeBrowsingCheckOngoing(policyDecision.isSafeBrowsingCheckOngoing);
 
     auto policyCheck = m_pendingPolicyChecks.take(listenerID);
@@ -655,6 +690,9 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
     FramePolicyFunction function = WTF::move(policyCheck.policyFunction);
     bool forNavigationAction = policyCheck.forNavigationAction == ForNavigationAction::Yes;
 
+    if (policyCheck.downloadAttributeInitiatingDocument && !shouldHonorDownloadAttributePolicyCheck(policyCheck))
+        return function(PolicyAction::Ignore);
+
     if (forNavigationAction && localFrameLoaderClient() && policyDecision.websitePoliciesData) {
         ASSERT(page());
         if (page())
@@ -663,14 +701,18 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
     }
 
     m_policyDownloadID = policyDecision.downloadID;
-    if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get())) {
-        auto& loader = localFrame->loader();
-        if (RefPtr policyDocumentLoader = loader.policyDocumentLoader()) {
-            if (policyDecision.navigationID)
-                policyDocumentLoader->setNavigationID(*policyDecision.navigationID);
-            policyDocumentLoader->setIsOriginKeyedFromUIProcess(policyDecision.isOriginKeyed);
-        } else if (RefPtr provisionalDocumentLoader = loader.provisionalDocumentLoader())
-            provisionalDocumentLoader->setIsOriginKeyedFromUIProcess(policyDecision.isOriginKeyed);
+    // Only a download skips this: a download attribute link the client answered Use for is a
+    // navigation like any other, and m_policyDocumentLoader is its own.
+    if (policyDecision.policyAction != PolicyAction::Download) {
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get())) {
+            auto& loader = localFrame->loader();
+            if (RefPtr policyDocumentLoader = loader.policyDocumentLoader()) {
+                if (policyDecision.navigationID)
+                    policyDocumentLoader->setNavigationID(*policyDecision.navigationID);
+                policyDocumentLoader->setIsOriginKeyedFromUIProcess(policyDecision.isOriginKeyed);
+            } else if (RefPtr provisionalDocumentLoader = loader.provisionalDocumentLoader())
+                provisionalDocumentLoader->setIsOriginKeyedFromUIProcess(policyDecision.isOriginKeyed);
+        }
     }
 
     if (policyDecision.backForwardFrameState) {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -44,9 +44,11 @@
 #include <WebCore/LocalFrameLoaderClient.h>
 #include <WebCore/MarkupExclusionRule.h>
 #include <WebCore/ProcessIdentifier.h>
+#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/ShareableBitmap.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/Markable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/WeakPtr.h>
@@ -153,7 +155,8 @@ public:
     WebCore::FrameIdentifier frameID() const { return m_frameID; }
 
     enum class ForNavigationAction : bool { No, Yes };
-    uint64_t setUpPolicyListener(WebCore::FramePolicyFunction&&, ForNavigationAction);
+    // A non-null initiating document marks this as a download attribute check.
+    uint64_t setUpPolicyListener(WebCore::FramePolicyFunction&&, ForNavigationAction, Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument = { });
     void invalidatePolicyListeners();
     void didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&&);
 
@@ -333,9 +336,12 @@ private:
 
     struct PolicyCheck {
         ForNavigationAction forNavigationAction { ForNavigationAction::No };
+        Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument;
         WebCore::FramePolicyFunction policyFunction;
     };
     HashMap<uint64_t, PolicyCheck> m_pendingPolicyChecks;
+
+    bool shouldHonorDownloadAttributePolicyCheck(const PolicyCheck&) const;
 
     std::optional<DownloadID> m_policyDownloadID;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Download.mm
@@ -44,6 +44,8 @@
 #import <WebKit/WKNavigationResponsePrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKUIDelegatePrivate.h>
+#import <WebKit/WKURLSchemeHandler.h>
+#import <WebKit/WKURLSchemeTask.h>
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewConfiguration.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
@@ -1464,6 +1466,29 @@ TEST(_WKDownload, SubframeSecurityOrigin)
     TestWebKitAPI::Util::run(&isDone);
 }
 
+@interface DownloadAttributeAllowedSchemeHandler : NSObject <WKURLSchemeHandler>
+@end
+
+@implementation DownloadAttributeAllowedSchemeHandler
+
+- (void)webView:(WKWebView *)webView startURLSchemeTask:(id<WKURLSchemeTask>)task
+{
+    // Same scheme and host for both, so the download attribute is not dropped as cross origin.
+    NSString *html = [task.request.URL.absoluteString containsString:@"target"]
+        ? @"<body>target</body>"
+        : @"<a id='dl' download='name.html' href='download-attribute-allowed://host/target'>dl</a>";
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:task.request.URL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Content-Type": @"text/html" }]);
+    [task didReceiveResponse:response.get()];
+    [task didReceiveData:[html dataUsingEncoding:NSUTF8StringEncoding]];
+    [task didFinish];
+}
+
+- (void)webView:(WKWebView *)webView stopURLSchemeTask:(id<WKURLSchemeTask>)task
+{
+}
+
+@end
+
 namespace TestWebKitAPI {
 
 static void checkCallbackRecord(TestDownloadDelegate *delegate, Vector<DownloadCallback> expectedCallbacks)
@@ -2785,6 +2810,113 @@ TEST(WKDownload, BlobResponse)
 #endif
         DownloadCallback::DidFinish
     });
+}
+
+// A download attribute link the client answers Use for is an ordinary navigation, so the navigation
+// identifier the UI process assigned still has to reach the document loader. Without it the UI process
+// cannot match the load to its API::Navigation and the client sees a null WKNavigation.
+TEST(WKDownload, DownloadAttributeAllowedByClientIsANavigation)
+{
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr schemeHandler = adoptNS([DownloadAttributeAllowedSchemeHandler new]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"download-attribute-allowed"];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    __block bool sawDownloadAttributeAction = false;
+    delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
+        if (action.shouldPerformDownload)
+            sawDownloadAttributeAction = true;
+        completionHandler(WKNavigationActionPolicyAllow);
+    };
+    delegate.get().decidePolicyForNavigationResponse = ^(WKNavigationResponse *, void (^completionHandler)(WKNavigationResponsePolicy)) {
+        completionHandler(WKNavigationResponsePolicyAllow);
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"download-attribute-allowed://host/main"]]];
+    [delegate waitForDidFinishNavigation];
+
+    __block RetainPtr<WKNavigation> startedNavigation;
+    __block RetainPtr<WKNavigation> finishedNavigation;
+    __block bool done = false;
+    delegate.get().didStartProvisionalNavigation = ^(WKWebView *, WKNavigation *navigation) {
+        startedNavigation = navigation;
+    };
+    delegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *navigation) {
+        finishedNavigation = navigation;
+        done = true;
+    };
+
+    [webView evaluateJavaScript:@"document.getElementById('dl').click()" completionHandler:nil];
+    Util::run(&done);
+
+    EXPECT_TRUE(sawDownloadAttributeAction);
+    EXPECT_NOT_NULL(startedNavigation.get());
+    EXPECT_NOT_NULL(finishedNavigation.get());
+    EXPECT_EQ(startedNavigation.get(), finishedNavigation.get());
+}
+
+TEST(WKDownload, DownloadAttributeSurvivesLaterNavigation)
+{
+    // A link with a download attribute does not navigate:
+    // https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks runs its fetch in
+    // parallel with the navigable. So navigating the frame afterwards must not cancel the download.
+    //
+    // The navigation delegate here does not answer the download decision when it is asked; it holds it
+    // until a later navigation has come through. That is what a real browser's asynchronous delegate
+    // does. A delegate that answers immediately never leaves the decision outstanding long enough to be
+    // cancelled, which is why WebKitTestRunner, and so any layout test, cannot cover this.
+    NSString *html = @"<script>"
+    "function downloadThenNavigate() {"
+    "    var a = document.createElement('a');"
+    "    var b = new Blob([1,2,3]);"
+    "    a.href = URL.createObjectURL(b);"
+    "    a.download = 'downloadFilename';"
+    "    a.click();"
+    "    location.href = 'about:blank';"
+    "}"
+    "</script><body onload='downloadThenNavigate()'></body>";
+
+    RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    __block RetainPtr<id> heldDownloadDecision;
+    __block bool answeredDownloadAfterNavigation = false;
+    delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
+        if (action.shouldPerformDownload) {
+            EXPECT_WK_STREQ(action.request.URL.scheme, "blob");
+            heldDownloadDecision = adoptNS([completionHandler copy]);
+            return;
+        }
+
+        completionHandler(WKNavigationActionPolicyAllow);
+
+        if (heldDownloadDecision && !answeredDownloadAfterNavigation) {
+            answeredDownloadAfterNavigation = true;
+            ((void (^)(WKNavigationActionPolicy))heldDownloadDecision.get())(WKNavigationActionPolicyDownload);
+        }
+    };
+    delegate.get().navigationActionDidBecomeDownload = ^(WKWebView *, WKNavigationAction *, WKDownload *download) {
+        download.delegate = delegate.get();
+    };
+    delegate.get().decideDestinationUsingResponse = ^(WKDownload *, NSURLResponse *, NSString *suggestedFilename, void (^completionHandler)(NSURL *)) {
+        EXPECT_WK_STREQ(suggestedFilename, "downloadFilename");
+        completionHandler(expectedDownloadFile.get());
+    };
+    __block bool done = false;
+    delegate.get().downloadDidFinish = ^(WKDownload *) {
+        done = true;
+    };
+
+    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
+    Util::run(&done);
+
+    EXPECT_TRUE(answeredDownloadAfterNavigation);
+    checkFileContents(expectedDownloadFile.get(), "123"_s);
 }
 
 TEST(WKDownload, BlobResponseNoFilename)


### PR DESCRIPTION
#### f3f75e999f1ddd211c21e69c3af81b978e4b92a0
<pre>
Same-frame fragment navigation that starts after a download attribute click, in the same task, cancels the download
<a href="https://bugs.webkit.org/show_bug.cgi?id=302895">https://bugs.webkit.org/show_bug.cgi?id=302895</a>
<a href="https://rdar.apple.com/165498647">rdar://165498647</a>

Reviewed by Brady Eidson and Alex Christensen.

Activating a link with a download attribute runs &quot;download the hyperlink&quot; [1], not &quot;navigate&quot;, and its
steps run in parallel with the navigable. WebKit instead routed it through the frame&apos;s single navigation
policy slot, so the fragment navigation in FrameLoader::loadURL() called PolicyChecker::stopCheck(), which
answered every outstanding check with PolicyAction::Ignore. The download&apos;s decision then never arrived as
PolicyAction::Download, so startDownload() was never called and nothing happened.

There are two such cancellations, in both processes, and both have to go. In the web process
PolicyChecker::stopCheck() answers every outstanding check with Ignore. In the UI process WebFrameProxy
keeps one policy listener per frame and setUpPolicyListenerProxy() resolves the previous one with
ignore(), so the navigation&apos;s check displaces the download&apos;s there regardless of what the web process
does. Download checks are now kept out of both.

A download check therefore outlives the navigation that started it, so record the document that
initiated it and only honor it while that document is still the one in this frame and the frame is
still in a page.

The frame check avoids a crash: detaching a frame starts no navigation, so nothing else answers the check
and the decision arrives for a frame that has left its page. The document check matters because
PolicyChecker decides against the frame&apos;s live state, including the sandbox allow-downloads flag that
LocalFrame::effectiveSandboxFlags() takes from the current document. Keeping the check out of the UI
process cancellation is what makes that reachable: a decision can now arrive after another document has
committed, and would otherwise be evaluated against it.

Also stop a late decision from tearing down a newer navigation.

The policy delegate is still consulted for these loads: WKNavigationAction&apos;s shouldPerformDownload is
unchanged, and both Download and Allow are still honored. Allow is honored in one case where it was
previously dropped, since the check it belongs to is no longer cancelled.

WebKitLegacy is left unfixed: its WebFrameLoaderClient::cancelPolicyCheck() invalidates a single
policy listener and cannot tell a download check apart.

[1] <a href="https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks">https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks</a>

Tests: TestWebKitAPI.WKDownload.DownloadAttributeAllowedByClientIsANavigation
       TestWebKitAPI.WKDownload.DownloadAttributeSurvivesLaterNavigation
       fast/dom/HTMLAnchorElement/anchor-download-in-detached-frame.html
       fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-cross-document-navigation.html
       fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-fragment-navigation.html
       fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-nested-click.html

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadWithDocumentLoader): Don&apos;t continue once a newer navigation owns the policy
document loader, which hits the entry assertion in continueLoadAfterNavigationPolicy() and tears down that
newer navigation. Only a check that survived cancellation can get there.

* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction): Record the document initiating a
download attribute check.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::webProcessWillShutDown): Answer download checks, which navigation no longer
cancels, so their replies are not lost with the frame.
(WebKit::WebFrameProxy::setUpPolicyListenerProxy): Keep download checks in their own list so they neither
displace the navigation check nor are displaced by it.
* Source/WebKit/UIProcess/WebFrameProxy.h: Added IsDownloadPolicyCheck and the list of outstanding download
listeners. They are keyed by an ID rather than held in a single member because, unlike navigation checks,
several can be outstanding at once now that none of them displaces another.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationAction): Mark a check for an action with a download
attribute.
(WebKit::WebPageProxy::decidePolicyForNewWindowAction): Neither of these can be a download attribute
check, so both pass No.
(WebKit::WebPageProxy::decidePolicyForResponseShared): Ditto.

* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::invalidate): Answer any check still outstanding, rather than destroying its
CompletionHandler. Navigation used to have cancelled them all by this point. No test: for frame detach the
page condition above already cancels the check first, and I could not find another path that reaches here
with one outstanding.
(WebKit::WebFrame::setUpPolicyListener): Store it.
(WebKit::WebFrame::shouldHonorDownloadAttributePolicyCheck): Added.
(WebKit::WebFrame::invalidatePolicyListeners): Leave still-valid download attribute checks outstanding
rather than ignoring them. Reinstate them before cancelling the rest, as cancelling can add checks back.
(WebKit::WebFrame::didReceivePolicyDecision): Ignore a download attribute check that should no longer be
honored, and skip navigationID and origin-keying only when the decision is actually Download - answering
Use for such a link makes it an ordinary navigation. Answer rather than drop a check for a frame whose
core frame is gone, which previously left an uncalled CompletionHandler behind.

* Source/WebKit/WebProcess/WebPage/WebFrame.h: Added the initiating document to PolicyCheck and to
setUpPolicyListener(). It is a Markable rather than a separate flag plus an identifier so that a download
attribute check cannot exist without the document it has to be validated against, and so that its presence
is what tells such a check apart from a navigation one. Declared
shouldHonorDownloadAttributePolicyCheck().

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Download.mm:
(TEST(WKDownload, DownloadAttributeAllowedByClientIsANavigation)): Added. Clicks a download attribute link
that the navigation delegate answers Use for, and checks the client is given the same non-null WKNavigation
on didStartProvisionalNavigation and didFinishNavigation. Skipping navigationID for such a check leaves the
UI process unable to match the load to its API::Navigation, and both are null. Serves both documents from
one custom scheme so the attribute is not dropped as cross origin, and as displayable HTML so the load
commits rather than becoming a download at the response stage.
(TEST(WKDownload, DownloadAttributeSurvivesLaterNavigation)): Added. The delegate does not answer the
download decision when asked: it holds it until a later navigation of the same frame has been decided, then
answers Download, and the test checks the file is written. Holding it is what leaves the decision
outstanding while the frame navigates, which is the state both cancellations destroy. A delegate that
answers immediately never reaches that state, which is also why WebKitTestRunner, and so any layout test,
cannot cover the UI process half.

* LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-in-detached-frame-expected.txt: Added.
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-in-detached-frame.html: Added. Clicks a download
attribute link in a subframe and then removes the subframe, and checks that nothing crashes and no download
callbacks are logged. The decision arrives for a frame that has left its page, which is the one thing
navigation no longer does for us.

* LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-cross-document-navigation-expected.txt: Added.
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-cross-document-navigation.html: Added.
A subframe clicks a download attribute link and then activates a link to another document. Child frames are
dumped, so this checks both that the download completes and that the subframe reaches the second document.
Activating a link navigates synchronously, unlike assigning location.href, so the newer navigation owns the
policy document loader before the decision arrives; without the FrameLoader change that decision tears the
newer navigation down and trips the assertion at the top of continueLoadAfterNavigationPolicy().

* LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-fragment-navigation-expected.txt: Added.
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-fragment-navigation.html: Added.
Clicks a download attribute link and then sets location.hash, and checks the download still starts and
finishes. This is the reduced form of the bug: no nesting is involved. The hash toggles between two values
so it stays a real fragment navigation whatever fragment the document was loaded with, which keeps the test
working when it is repeated.

* LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-nested-click-expected.txt: Added.
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-not-cancelled-by-nested-click.html: Added. The form
the bug was reported in: a link with href=&quot;#&quot; whose click handler clicks a download attribute link, so the
fragment navigation comes from the outer link&apos;s default action once the handler returns.

* LayoutTests/fast/dom/HTMLAnchorElement/resources/anchor-download-then-navigate-frame-2.html: Added.
* LayoutTests/fast/dom/HTMLAnchorElement/resources/anchor-download-then-navigate-frame.html: Added.

Canonical link: <a href="https://commits.webkit.org/319105@main">https://commits.webkit.org/319105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5388e18217eb148948ebbb0a41a3aa4c23b59be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190550 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144660 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0b2cae7-b443-41de-ad06-631107b70320) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140662 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8d3c79e-ca08-43f8-8e11-4159910679e6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121114 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/022e24e6-5945-485e-91e7-0165e0b1f27e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42994 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41290 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40968 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1709 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192485 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53950 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150016 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40196 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54638 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149738 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44376 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126901 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122063 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53155 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15957 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52537 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52774 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52602 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->