### PR TITLE
Site Isolation: copying and pasting text as attributed strings skips content in nested cross-origin subframes

### DIFF
--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -76,9 +76,12 @@
 #import "WebContentReader.h"
 #import "markup.h"
 #import <pal/spi/cocoa/NSAttributedStringSPI.h>
+#import <ranges>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/HashSet.h>
 #import <wtf/cocoa/NSURLExtras.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -150,22 +153,57 @@ static RetainPtr<NSAttributedString> selectionInImageOverlayAsAttributedString(c
 #endif
 }
 
-static RetainPtr<NSAttributedString> selectionAsAttributedString(const Document& document, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent)
+static RetainPtr<NSAttributedString> selectionAsAttributedString(const Document& document)
 {
     auto selection = document.selection().selection();
     if (ImageOverlay::isInsideOverlay(selection))
         return selectionInImageOverlayAsAttributedString(selection);
     auto range = selection.firstRange();
-    return range ? attributedString(*range, IgnoreUserSelectNone::Yes, WTF::move(remoteFrameContent)).nsAttributedString() : adoptNS([NSAttributedString new]);
+    return range ? attributedString(*range, IgnoreUserSelectNone::Yes, MarkRemoteFrameContentPositions::Yes).nsAttributedString() : adoptNS([NSAttributedString new]);
+}
+
+static RetainPtr<NSAttributedString> attributedStringByReplacingRemoteFrameMarkers(RetainPtr<NSAttributedString>&& string, const HashMap<FrameIdentifier, AttributedString>& remoteFrameContent)
+{
+    HashMap<String, AttributedString> contentByFrameIdentifier;
+    for (auto& [frameIdentifier, content] : remoteFrameContent)
+        contentByFrameIdentifier.set(makeString(frameIdentifier.toUInt64()), content);
+
+    RetainPtr result = adoptNS([[NSMutableAttributedString alloc] initWithAttributedString:string]);
+    HashSet<String> replacedFrameIdentifiers;
+    while (true) {
+        Vector<std::pair<NSRange, String>> markers;
+        [result enumerateAttribute:protect(remoteFrameIdentifierAttributeName()) inRange:NSMakeRange(0, [result length]) options:0 usingBlock:[&](id value, NSRange range, BOOL *) {
+            if (RetainPtr identifier = dynamic_objc_cast<NSString>(value))
+                markers.append({ range, identifier.get() });
+        }];
+
+        if (markers.isEmpty())
+            break;
+
+        // Replace back to front so that each range stays valid as earlier ones are substituted.
+        for (auto& [range, frameIdentifier] : markers | std::views::reverse) {
+            RetainPtr<NSAttributedString> content;
+            if (replacedFrameIdentifiers.add(frameIdentifier).isNewEntry) {
+                if (auto it = contentByFrameIdentifier.find(frameIdentifier); it != contentByFrameIdentifier.end())
+                    content = it->value.nsAttributedString();
+            }
+
+            if (content)
+                [result replaceCharactersInRange:range withAttributedString:content];
+            else
+                [result deleteCharactersInRange:range];
+        }
+    }
+    return result;
 }
 
 template<typename PasteboardContent>
-void populateRichTextDataIfNeeded(PasteboardContent& content, const Document& document, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent = { })
+void populateRichTextDataIfNeeded(PasteboardContent& content, const Document& document, const HashMap<FrameIdentifier, AttributedString>& remoteFrameContent = { })
 {
     if (!document.settings().writeRichTextDataWhenCopyingOrDragging())
         return;
 
-    auto string = selectionAsAttributedString(document, WTF::move(remoteFrameContent));
+    auto string = attributedStringByReplacingRemoteFrameMarkers(selectionAsAttributedString(document), remoteFrameContent);
     content.dataInRTFDFormat = [string containsAttachments] ? Editor::dataInRTFDFormat(string.get()) : nullptr;
     content.dataInRTFFormat = Editor::dataInRTFFormat(string.get());
     content.dataInAttributedStringFormat = AttributedString::fromNSAttributedString(string.get());
@@ -187,21 +225,14 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
             HashMap<FrameIdentifier, AttributedString> remoteFrameContent;
             if (document->settings().siteIsolationEnabled()) {
                 content.webArchive = LegacyWebArchive::createFromSelection(protect(document->frame()), WTF::move(options));
-                if (content.webArchive) {
-                    Vector<FrameIdentifier> remoteFrameIdentifiers;
-                    RefPtr localFrame = document->frame();
-                    if (localFrame) {
-                        auto subframeIdentifiers = protect(content.webArchive)->subframeIdentifiers();
-                        for (RefPtr frame = localFrame->tree().traverseNext(localFrame.get()); frame; frame = frame->tree().traverseNext(localFrame.get())) {
-                            if (is<RemoteFrame>(*frame) && subframeIdentifiers.contains(frame->frameID()))
-                                remoteFrameIdentifiers.append(frame->frameID());
-                        }
-                    }
-                    if (localFrame && !remoteFrameIdentifiers.isEmpty())
-                        remoteFrameContent = client()->collectAttributedStringsForRemoteFrames(localFrame->frameID(), remoteFrameIdentifiers);
+                RefPtr localFrame = document->frame();
+                if (content.webArchive && localFrame) {
+                    auto selectedSubframeIdentifiers = protect(content.webArchive)->subframeIdentifiers();
+                    if (!selectedSubframeIdentifiers.isEmpty() && localFrame->tree().containsRemoteFrame())
+                        remoteFrameContent = client()->collectAttributedStringsForRemoteFrames(localFrame->frameID(), selectedSubframeIdentifiers);
                 }
             }
-            populateRichTextDataIfNeeded(content, document, WTF::move(remoteFrameContent));
+            populateRichTextDataIfNeeded(content, document, remoteFrameContent);
         }
         client()->getClientPasteboardData(selectedRange(), content.clientTypesAndData);
     }
@@ -287,6 +318,8 @@ RefPtr<SharedBuffer> Editor::dataInRTFDFormat(NSAttributedString *string)
     if (!length)
         return nullptr;
 
+    ASSERT(!containsRemoteFrameContentMarkers(string));
+
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     return SharedBuffer::create(retainPtr([string RTFDFromRange:NSMakeRange(0, length) documentAttributes:@{ }]).get());
     END_BLOCK_OBJC_EXCEPTIONS
@@ -299,6 +332,8 @@ RefPtr<SharedBuffer> Editor::dataInRTFFormat(NSAttributedString *string)
     NSUInteger length = string.length;
     if (!length)
         return nullptr;
+
+    ASSERT(!containsRemoteFrameContentMarkers(string));
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     return SharedBuffer::create(retainPtr([string RTFFromRange:NSMakeRange(0, length) documentAttributes:@{ }]).get());

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.h
@@ -24,14 +24,21 @@
  */
 
 #import <WebCore/AttributedString.h>
-#import <WebCore/FrameIdentifier.h>
 #import <WebCore/SimpleRange.h>
-#import <wtf/HashMap.h>
 
 namespace WebCore {
 
 enum class IgnoreUserSelectNone : bool;
 
-WEBCORE_EXPORT AttributedString attributedString(const SimpleRange&, IgnoreUserSelectNone, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent = { });
+// Marks a placeholder for the contents of a remote frame.
+WEBCORE_EXPORT NSString *remoteFrameIdentifierAttributeName();
+
+enum class MarkRemoteFrameContentPositions : bool { No, Yes };
+
+#if ASSERT_ENABLED
+WEBCORE_EXPORT bool containsRemoteFrameContentMarkers(NSAttributedString *);
+#endif
+
+WEBCORE_EXPORT AttributedString attributedString(const SimpleRange&, IgnoreUserSelectNone, MarkRemoteFrameContentPositions = MarkRemoteFrameContentPositions::No);
 
 } // namespace WebCore

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -52,6 +52,7 @@
 #import "FontAttributes.h"
 #import "FontCascadeInlines.h"
 #import "FrameDestructionObserverInlines.h"
+#import "FrameIdentifier.h"
 #import "FrameLoader.h"
 #import "HTMLAttachmentElement.h"
 #import "HTMLConverter.h"
@@ -94,6 +95,7 @@
 #import <wtf/text/ParsingUtilities.h>
 #import <wtf/text/StringBuilder.h>
 #import <wtf/text/StringToIntegerConversion.h>
+#import <wtf/unicode/CharacterNames.h>
 
 #if ENABLE(DATA_DETECTION)
 #import "DataDetection.h"
@@ -176,7 +178,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLConverterCaches);
 
 class HTMLConverter {
 public:
-    explicit HTMLConverter(const SimpleRange&, IgnoreUserSelectNone, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent);
+    explicit HTMLConverter(const SimpleRange&, IgnoreUserSelectNone, MarkRemoteFrameContentPositions);
     ~HTMLConverter();
 
     AttributedString convert();
@@ -185,7 +187,7 @@ private:
     Position m_start;
     Position m_end;
     SingleThreadWeakPtr<DocumentLoader> m_dataSource;
-    const HashMap<FrameIdentifier, AttributedString> m_remoteFrameContent;
+    const MarkRemoteFrameContentPositions m_markRemoteFrameContentPositions;
 
     HashMap<Ref<Element>, RetainPtr<NSDictionary>> m_attributesForElements;
     HashMap<RetainPtr<CFTypeRef>, Ref<Element>> m_textTableFooters;
@@ -243,6 +245,7 @@ private:
     void _newLineForElement(Element&);
     void _newTabForElement(Element&);
     BOOL _addAttachmentForElement(Element&, NSURL *url, BOOL needsParagraph, BOOL usePlaceholder);
+    void _addRemoteFrameMarker(FrameIdentifier);
     void _addQuoteForElement(Element&, BOOL opening, NSInteger level);
     void _addValue(NSString *value, Element&);
     void _fillInBlock(NSTextBlock *block, Element&, PlatformColor *backgroundColor, CGFloat extraMargin, CGFloat extraPadding, BOOL isTable);
@@ -264,10 +267,10 @@ private:
     void _adjustTrailingNewline();
 };
 
-HTMLConverter::HTMLConverter(const SimpleRange& range, IgnoreUserSelectNone treatment, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent)
+HTMLConverter::HTMLConverter(const SimpleRange& range, IgnoreUserSelectNone treatment, MarkRemoteFrameContentPositions markRemoteFrameContentPositions)
     : m_start(makeContainerOffsetPosition(range.start))
     , m_end(makeContainerOffsetPosition(range.end))
-    , m_remoteFrameContent(WTF::move(remoteFrameContent))
+    , m_markRemoteFrameContentPositions(markRemoteFrameContentPositions)
     , m_userSelectNoneStateCache(ComposedTree)
     , m_ignoreUserSelectNoneContent(treatment == IgnoreUserSelectNone::Yes && !protect(range.start.document())->quirks().needsToCopyUserSelectNoneQuirk())
 {
@@ -1220,6 +1223,21 @@ BOOL HTMLConverter::_addMultiRepresentationHEICAttachmentForImageElement(HTMLIma
 }
 #endif // ENABLE(MULTI_REPRESENTATION_HEIC)
 
+void HTMLConverter::_addRemoteFrameMarker(FrameIdentifier frameIdentifier)
+{
+    RetainPtr string = adoptNS([[NSString alloc] initWithFormat:@"%C", static_cast<unichar>(objectReplacementCharacter)]);
+    NSRange rangeToReplace = NSMakeRange([_attrStr length], 0);
+
+    [_attrStr replaceCharactersInRange:rangeToReplace withString:string];
+    rangeToReplace.length = [string length];
+    if (rangeToReplace.location < _domRangeStartIndex)
+        _domRangeStartIndex += rangeToReplace.length;
+
+    [_attrStr addAttribute:remoteFrameIdentifierAttributeName() value:makeString(frameIdentifier.toUInt64()).createNSString() range:rangeToReplace];
+
+    _flags.isSoft = NO;
+}
+
 BOOL HTMLConverter::_addAttachmentForElement(Element& element, NSURL *url, BOOL needsParagraph, BOOL usePlaceholder)
 {
     BOOL retval = NO;
@@ -1828,10 +1846,8 @@ BOOL HTMLConverter::_processElement(Element& element, NSInteger depth)
             _traverseNode(*contentDocument, depth + 1, true /* embedded */);
             retval = NO;
         } else if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(frameElement->contentFrame())) {
-            if (auto it = m_remoteFrameContent.find(remoteFrame->frameID()); it != m_remoteFrameContent.end()) {
-                if (RetainPtr subframeAttrString = it->value.nsAttributedString())
-                    [_attrStr appendAttributedString:subframeAttrString];
-            }
+            if (m_markRemoteFrameContentPositions == MarkRemoteFrameContentPositions::Yes)
+                _addRemoteFrameMarker(remoteFrame->frameID());
             retval = NO;
         }
     } else if (element.hasTagName(brTag)) {
@@ -2309,9 +2325,31 @@ Node* HTMLConverterCaches::cacheAncestorsOfStartToBeConverted(const Position& st
 namespace WebCore {
 
 // This function supports more HTML features than the editing variant below, such as tables.
-AttributedString attributedString(const SimpleRange& range, IgnoreUserSelectNone treatment, HashMap<FrameIdentifier, AttributedString>&& remoteFrameContent)
+NSString *remoteFrameIdentifierAttributeName()
 {
-    return HTMLConverter { range, treatment, WTF::move(remoteFrameContent) }.convert();
+    return @"WebKitRemoteFrameIdentifier";
+}
+
+#if ASSERT_ENABLED
+
+bool containsRemoteFrameContentMarkers(NSAttributedString *string)
+{
+    __block bool foundMarker = false;
+    [string enumerateAttribute:remoteFrameIdentifierAttributeName() inRange:NSMakeRange(0, string.length) options:0 usingBlock:^(id value, NSRange, BOOL *stop) {
+        if (!value)
+            return;
+
+        foundMarker = true;
+        *stop = YES;
+    }];
+    return foundMarker;
+}
+
+#endif // ASSERT_ENABLED
+
+AttributedString attributedString(const SimpleRange& range, IgnoreUserSelectNone treatment, MarkRemoteFrameContentPositions markRemoteFrameContentPositions)
+{
+    return HTMLConverter { range, treatment, markRemoteFrameContentPositions }.convert();
 }
 
 }

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -361,6 +361,24 @@ bool NODELETE FrameTree::isDescendantOf(const Frame* ancestor) const
     return false;
 }
 
+bool FrameTree::containsRemoteFrame() const
+{
+    for (RefPtr frame = m_thisFrame.ptr(); frame; frame = frame->tree().traverseNext(m_thisFrame.ptr())) {
+        if (is<RemoteFrame>(*frame))
+            return true;
+    }
+    return false;
+}
+
+bool FrameTree::hasRemoteFrameAncestor() const
+{
+    for (RefPtr ancestor = parent(); ancestor; ancestor = ancestor->tree().parent()) {
+        if (is<RemoteFrame>(*ancestor))
+            return true;
+    }
+    return false;
+}
+
 Frame* FrameTree::traverseNext(const Frame* stayWithin) const
 {
     auto* child = firstChild();

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -60,6 +60,9 @@ public:
     LocalFrame* NODELETE nextLocalSibling() const;
 
     WEBCORE_EXPORT bool NODELETE isDescendantOf(const Frame* ancestor) const;
+
+    bool containsRemoteFrame() const;
+    WEBCORE_EXPORT bool hasRemoteFrameAncestor() const;
     
     WEBCORE_EXPORT Frame* NODELETE traverseNext(const Frame* stayWithin = nullptr) const;
     Frame* NODELETE traverseNextSkippingChildren(const Frame* stayWithin = nullptr) const;

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -2054,15 +2054,37 @@ void WebPageProxy::getAttributedStringsForRemoteFrames(IPC::Connection& connecti
     MESSAGE_CHECK_COMPLETION(rootFrame && rootFrame->page() == this && &rootFrame->process() == WebProcessProxy::fromConnection(connection).ptr(), connection, completionHandler({ }));
     MESSAGE_CHECK_COMPLETION(validateFrameIdentifiersForAttributedStringCollection(rootFrameIdentifier, frameIdentifiers), connection, completionHandler({ }));
 
+    Ref senderProcess = WebProcessProxy::fromConnection(connection);
+
+    unsigned frameCountInRootSubtree = 1;
+    for (RefPtr frame = rootFrame->traverseNext(rootFrame.get()); frame; frame = frame->traverseNext(rootFrame.get()))
+        ++frameCountInRootSubtree;
+
     HashMap<Ref<WebProcessProxy>, Vector<FrameIdentifier>> processFrames;
+    HashSet<FrameIdentifier> expandedSubframes;
+    HashSet<FrameIdentifier> collectedFrames;
     for (auto frameIdentifier : frameIdentifiers) {
-        RefPtr frame = WebFrameProxy::webFrame(frameIdentifier);
-        if (!frame)
+        RefPtr selectedSubframe = WebFrameProxy::webFrame(frameIdentifier);
+        if (!selectedSubframe || selectedSubframe->page() != this)
             continue;
 
-        processFrames.ensure(protect(frame->process()), [] {
-            return Vector<FrameIdentifier> { };
-        }).iterator->value.append(frameIdentifier);
+        if (!expandedSubframes.add(frameIdentifier).isNewEntry)
+            continue;
+
+        if (expandedSubframes.size() > frameCountInRootSubtree)
+            break;
+
+        for (RefPtr frame = selectedSubframe; frame; frame = frame->traverseNext(selectedSubframe.get())) {
+            if (&frame->process() == senderProcess.ptr())
+                continue;
+
+            if (!collectedFrames.add(frame->frameID()).isNewEntry)
+                continue;
+
+            processFrames.ensure(protect(frame->process()), [] {
+                return Vector<FrameIdentifier> { };
+            }).iterator->value.append(frame->frameID());
+        }
     }
 
     if (processFrames.isEmpty()) {

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -821,13 +821,32 @@ void WebPage::getContentsAsAttributedString(CompletionHandler<void(const WebCore
     completionHandler(localFrame ? attributedString(makeRangeSelectingNodeContents(*protect(localFrame->document())), IgnoreUserSelectNone::No) : AttributedString { });
 }
 
-HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> WebPage::attributedStringsForRemoteFrames(WebCore::FrameIdentifier rootFrameIdentifier, const Vector<WebCore::FrameIdentifier>& frameIdentifiers)
+HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> WebPage::attributedStringsForRemoteFrames(WebCore::FrameIdentifier rootFrameIdentifier, const Vector<WebCore::FrameIdentifier>& selectedSubframeIdentifiers)
 {
-    if (frameIdentifiers.isEmpty())
+    if (selectedSubframeIdentifiers.isEmpty())
         return { };
 
-    auto sendResult = sendSync(Messages::WebPageProxy::GetAttributedStringsForRemoteFrames(rootFrameIdentifier, frameIdentifiers));
+    auto sendResult = sendSync(Messages::WebPageProxy::GetAttributedStringsForRemoteFrames(rootFrameIdentifier, selectedSubframeIdentifiers));
     auto [result] = sendResult.takeReplyOr(HashMap<WebCore::FrameIdentifier, WebCore::AttributedString> { });
+
+    // Skip frames in our own process to avoid deadlock.
+    RefPtr rootFrame = WebProcess::singleton().webFrame(rootFrameIdentifier);
+    RefPtr rootCoreFrame = rootFrame ? rootFrame->coreLocalFrame() : nullptr;
+    if (!rootCoreFrame)
+        return result;
+
+    for (RefPtr frame = rootCoreFrame->tree().traverseNext(rootCoreFrame.get()); frame; frame = frame->tree().traverseNext(rootCoreFrame.get())) {
+        RefPtr localFrame = dynamicDowncast<WebCore::LocalFrame>(frame.get());
+        if (!localFrame)
+            continue;
+
+        if (!localFrame->tree().hasRemoteFrameAncestor())
+            continue;
+
+        if (RefPtr document = localFrame->document())
+            result.add(localFrame->frameID(), attributedString(makeRangeSelectingNodeContents(*document), IgnoreUserSelectNone::No, WebCore::MarkRemoteFrameContentPositions::Yes));
+    }
+
     return result;
 }
 
@@ -1788,7 +1807,9 @@ void WebPage::getContentsAsAttributedStringForFrames(const Vector<FrameIdentifie
         if (!document)
             continue;
 
-        result.add(frameIdentifier, attributedString(makeRangeSelectingNodeContents(*document), IgnoreUserSelectNone::No));
+        result.ensure(frameIdentifier, [&] {
+            return attributedString(makeRangeSelectingNodeContents(*document), IgnoreUserSelectNone::No, WebCore::MarkRemoteFrameContentPositions::Yes);
+        });
     }
     completionHandler(WTF::move(result));
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -7461,6 +7461,25 @@ TEST(SiteIsolation, CreateWebArchiveNestedFrameForCopy)
 
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
 
+static RetainPtr<NSAttributedString> attributedStringFromGeneralPasteboard()
+{
+#if PLATFORM(MAC)
+    RetainPtr objects = [NSPasteboard.generalPasteboard readObjectsForClasses:@[NSAttributedString.class] options:@{ }];
+    EXPECT_EQ([objects count], 1u);
+    return [objects firstObject];
+#else
+    RetainPtr itemProvider = [[UIPasteboard.generalPasteboard itemProviders] firstObject];
+    __block bool doneLoading = false;
+    __block RetainPtr<NSAttributedString> result;
+    [itemProvider loadObjectOfClass:NSAttributedString.class completionHandler:^(NSAttributedString *string, NSError *) {
+        result = string;
+        doneLoading = true;
+    }];
+    Util::run(&doneLoading);
+    return result;
+#endif
+}
+
 TEST(SiteIsolation, ReadAttributedStringFromPasteboardAfterCopyWithCrossSiteIframe)
 {
     static constexpr auto mainframeBytes = R"TESTRESOURCE(
@@ -7518,23 +7537,86 @@ TEST(SiteIsolation, ReadAttributedStringFromPasteboardAfterCopyWithCrossSiteIfra
     [webView evaluateJavaScript:@"alertSubframe()" completionHandler:nil];
     Util::run(&alerted);
 
-#if PLATFORM(MAC)
-    RetainPtr objects = [NSPasteboard.generalPasteboard readObjectsForClasses:@[NSAttributedString.class] options:@{ }];
-    EXPECT_EQ([objects count], 1u);
-    RetainPtr result = [objects firstObject];
-#elif PLATFORM(IOS_FAMILY)
-    RetainPtr itemProvider = [[UIPasteboard.generalPasteboard itemProviders] firstObject];
-    __block bool doneLoading = false;
-    __block RetainPtr<NSAttributedString> result;
-    [itemProvider loadObjectOfClass:NSAttributedString.class completionHandler:^(NSAttributedString *string, NSError *) {
-        result = string;
-        doneLoading = true;
-    }];
-    Util::run(&doneLoading);
-#endif
-
+    RetainPtr result = attributedStringFromGeneralPasteboard();
     EXPECT_TRUE([[result string] containsString:@"mainframecontent"]);
     EXPECT_TRUE([[result string] containsString:@"subframecontent"]);
+}
+
+TEST(SiteIsolation, ReadAttributedStringFromPasteboardAfterCopyWithNestedCrossSiteIframes)
+{
+    static constexpr auto mainframeBytes = R"TESTRESOURCE(
+    <!DOCTYPE html>
+    mainframecontent
+    <iframe id='subframe' src='https://example2.com/subframe'></iframe>
+    <iframe src='https://example.com/samesiteframe'></iframe>
+    <script>
+        function alertSubframe() { document.getElementById('subframe').contentWindow.postMessage('alert', '*'); }
+    </script>
+    )TESTRESOURCE"_s;
+
+    static constexpr auto subframeBytes = R"TESTRESOURCE(
+    <!DOCTYPE html>
+    subframecontent
+    <iframe src='https://example3.com/nestedframe'></iframe>
+    <iframe src='https://example.com/nestedframeinmainframeprocess'></iframe>
+    <script>
+        window.addEventListener('message', function(event) {
+            alert('hi');
+        });
+    </script>
+    )TESTRESOURCE"_s;
+
+    static constexpr auto samesiteframeBytes = R"TESTRESOURCE(
+    <!DOCTYPE html>
+    samesiteframecontent
+    <iframe src='https://example4.com/nestedframeundersamesiteframe'></iframe>
+    )TESTRESOURCE"_s;
+
+    HTTPServer server({
+        { "/mainframe"_s, { mainframeBytes } },
+        { "/subframe"_s, { subframeBytes } },
+        { "/samesiteframe"_s, { samesiteframeBytes } },
+        { "/nestedframe"_s, { "nestedframecontent"_s } },
+        { "/nestedframeinmainframeprocess"_s, { "nestedframeinmainframeprocesscontent"_s } },
+        { "/nestedframeundersamesiteframe"_s, { "nestedframeundersamesiteframecontent"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webViewAndDelegates = makeWebViewAndDelegates(server);
+    RetainPtr webView = webViewAndDelegates.webView;
+    RetainPtr navigationDelegate = webViewAndDelegates.navigationDelegate;
+    RetainPtr uiDelegate = webViewAndDelegates.uiDelegate;
+    WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging((__bridge WKPreferencesRef)[[webView configuration] preferences], true);
+    static bool alerted = false;
+    [uiDelegate setRunJavaScriptAlertPanelWithMessage:^(WKWebView *, NSString *message, WKFrameInfo *, void (^completionHandler)()) {
+        alerted = true;
+        completionHandler();
+    }];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView stringByEvaluatingJavaScript:@"getSelection().selectAllChildren(document.body)"];
+    [webView waitForNextPresentationUpdate];
+
+    [webView copy:nil];
+    [webView waitForNextPresentationUpdate];
+
+    [webView evaluateJavaScript:@"alertSubframe()" completionHandler:nil];
+    Util::run(&alerted);
+
+    RetainPtr result = attributedStringFromGeneralPasteboard();
+    EXPECT_TRUE([[result string] containsString:@"mainframecontent"]);
+    EXPECT_TRUE([[result string] containsString:@"subframecontent"]);
+
+    // Nested inside a cross-site frame, in a third process.
+    EXPECT_TRUE([[result string] containsString:@"nestedframecontent"]);
+
+    // Nested inside a same-site frame, which the copying process converts inline.
+    EXPECT_TRUE([[result string] containsString:@"samesiteframecontent"]);
+    EXPECT_TRUE([[result string] containsString:@"nestedframeundersamesiteframecontent"]);
+
+    // Nested inside a cross-site frame, but back in the main frame's process.
+    EXPECT_TRUE([[result string] containsString:@"nestedframeinmainframeprocesscontent"]);
 }
 
 #endif // !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)


### PR DESCRIPTION
#### a764f514974feefcceb1f2d05fd95dd1af8f68ea
<pre>
Site Isolation: copying and pasting text as attributed strings skips content in nested cross-origin subframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=321486">https://bugs.webkit.org/show_bug.cgi?id=321486</a>
<a href="https://rdar.apple.com/168703870">rdar://168703870</a>

Reviewed by Ryosuke Niwa and Abrar Rahman Protyasha.

After the changes in 317283@main, we now include content from cross-origin frames under the top
frame when serializing attributed string data to the pasteboard. However, this logic is broken in
the case where there are same-origin frames nested underneath cross-origin frames, since our current
approach of descending into RemoteFrames and asking for their contents as attributed string doesn&apos;t
handle the case where we might need to later descend **back** into a subframe hosted in the same
process as the main frame.

To fix this, we refactor the way in which this attributed string serialization works to handle all
possible ways of nesting same- or cross-origin frames:

1.  Serialize the selected DOM content into an attributed string. Whenever we encounter a
    `RemoteFrame`, append an object replacement character to the string, marked with an internal
    attribute representing the contents of that remote frame
    (`remoteFrameIdentifierAttributeName`).

2.  Serialize the contents of those remote frames. The UI process walks the frame tree to find all
    remote frames in the selection (including nested descendants) and asks each web process for the
    ones it hosts, since only the UI process knows which process hosts which frame. The web process
    containing the selection is blocked waiting on this reply, so it cannot be asked for anything;
    it serializes the frames it hosts underneath a remote frame itself.

3.  Collate the attributed strings from [1] and [2] into a final, flattened attributed string by
    iteratively replacing each remote frame placeholder with its corresponding subframe contents.

Tests:  SiteIsolation.ReadAttributedStringFromPasteboardAfterCopyWithCrossSiteIframe
        SiteIsolation.ReadAttributedStringFromPasteboardAfterCopyWithNestedCrossSiteIframes

* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::selectionAsAttributedString):
(WebCore::attributedStringByReplacingRemoteFrameMarkers):
(WebCore::populateRichTextDataIfNeeded):
(WebCore::Editor::writeSelectionToPasteboard):
(WebCore::Editor::dataInRTFDFormat):
(WebCore::Editor::dataInRTFFormat):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.h:
(WebCore::attributedString): Deleted.
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(HTMLConverter::HTMLConverter):
(HTMLConverter::_addRemoteFrameMarker):
(HTMLConverter::_processElement):

Add placeholders to represent the contents of remote frames embedded in the attributed string, which
are later removed (and replaced with attributed string data taken from their respective subframes,
if we got data from them).

(WebCore::remoteFrameIdentifierAttributeName):
(WebCore::containsRemoteFrameContentMarkers):
(WebCore::attributedString):

Add an option to extract cross-origin frames as placeholders in the attributed string (see above).

* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::containsRemoteFrame const):
(WebCore::FrameTree::hasRemoteFrameAncestor const):
* Source/WebCore/page/FrameTree.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::getAttributedStringsForRemoteFrames):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::attributedStringsForRemoteFrames):
(WebKit::WebPage::getContentsAsAttributedStringForFrames):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, ReadAttributedStringFromPasteboardAfterCopyWithCrossSiteIframe)):
(TestWebKitAPI::(SiteIsolation, ReadAttributedStringFromPasteboardAfterCopyWithNestedCrossSiteIframes)):

Canonical link: <a href="https://commits.webkit.org/319010@main">https://commits.webkit.org/319010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/379a1d9b697c4c9686de5c058ee2723ff238fe04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180100 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144418 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b79590b5-1a3b-4791-ba74-0ba4b0798986) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140466 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b66ef037-c14e-427b-8dcb-040250e82ee9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120918 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18f3af1c-e335-4e46-a5d0-c7d91c123475) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41098 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40773 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1470 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46644 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45350 "Found 1 new test failure: imported/w3c/web-platform-tests/payment-request/show-consume-activation.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192254 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53711 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149812 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54399 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37386 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149538 "Passed tests") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44173 "Failed to checkout and rebase branch from PR 71360") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126662 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121773 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52915 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15760 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52535 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52363 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->