### PR TITLE
[Navigation API] navigation.activation.from should be null when navigating away from the initial about:blank

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-initial-about-blank-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-initial-about-blank-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation interaction with initial about:blank assert_equals: expected null but got object "[object NavigationHistoryEntry]"
+PASS navigation.activation interaction with initial about:blank
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -300,7 +300,7 @@ void Navigation::setActivation(HistoryItem* previousItem, std::optional<Navigati
         previousEntry = m_entries.at(previousEntryIndex.value()).ptr();
     if (type == NavigationNavigationType::Reload)
         previousEntry = currentEntry();
-    else if (type == NavigationNavigationType::Replace && (isSameOrigin || wasAboutBlank))
+    else if (type == NavigationNavigationType::Replace && isSameOrigin && !wasAboutBlank)
         previousEntry = NavigationHistoryEntry::create(*this, *previousItem);
 
     m_activation = NavigationActivation::create(*type, *currentEntry(), WTF::move(previousEntry));


### PR DESCRIPTION
#### e147bdb27a590c121311316be163ef3bbcb8a24d
<pre>
[Navigation API] navigation.activation.from should be null when navigating away from the initial about:blank
<a href="https://bugs.webkit.org/show_bug.cgi?id=321514">https://bugs.webkit.org/show_bug.cgi?id=321514</a>
<a href="https://rdar.apple.com/184624752">rdar://184624752</a>

Reviewed by Rupin Mittal.

The initial about:blank document has entries and events disabled, so it has no
NavigationHistoryEntry, and the activation for the replace navigation that
leaves it must therefore expose a null from entry.

We instead synthesized a NavigationHistoryEntry out of the about:blank history
item. That used to be what the spec asked for, and
navigation-api/navigation-activation/activation-initial-about-blank.html
asserted `activation.from.url === &quot;about:blank&quot;` with `from.index === -1`. The
test was changed upstream to assert `activation.from === null`, and it has been
failing since it was resynced in 316724@main.

&quot;Update document for history step application&quot; [1] only sets the activation&apos;s
old entry when all three of the following hold: navigationType is &quot;replace&quot;,
previousEntryForActivation&apos;s document state&apos;s origin is same origin with the
document&apos;s origin, and previousEntryForActivation&apos;s initial about:blank is
false. We were missing that third condition, so add it. The about:blank history
item already has an opaque origin and so fails the same-origin check on its
own, but spelling the condition out keeps the code aligned with the spec and
does not rely on that.

wasAboutBlank is also still used to force the navigation type to &quot;replace&quot;.

[1] <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-document-for-history-step-application">https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-document-for-history-step-application</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-initial-about-blank-expected.txt: Progression
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::setActivation):

Canonical link: <a href="https://commits.webkit.org/319217@main">https://commits.webkit.org/319217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8518227ab8a0d33e4b562eeb5f0e5694bd7af85f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145113 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69587a73-b9eb-4747-b3dc-ba8b6f5d1054) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141026 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f03695e-ffe6-4981-b213-22007a6cd272) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44692 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121491 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bcbd0e6-2424-42a3-81e2-e85a157a8d49) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41644 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41312 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2164 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192938 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54401 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150410 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40262 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55089 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150128 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44719 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127355 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122641 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53606 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16305 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52988 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53225 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53053 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->