### PR TITLE
[JSC] Fix repeated OSR exit via VarargsOverflow

### DIFF
--- a/JSTests/stress/varargs-overflow-exit-site-checkpoint.js
+++ b/JSTests/stress/varargs-overflow-exit-site-checkpoint.js
@@ -1,0 +1,49 @@
+// A varargs call whose argument count grows past the profiled maximum makes the LoadVarargs
+// speculation fail. That exit is recorded against the makeCall checkpoint of the call bytecode
+// rather than the instruction start, so the parser has to consult every checkpoint of the index
+// before inlining the call again. Otherwise it re-inlines with the same too-small limit and exits
+// again, relearning the same lesson on every recompile.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("expected " + expected + " but got " + actual);
+}
+
+function callee() {
+    let total = 0;
+    for (let i = 0; i < arguments.length; ++i)
+        total += arguments[i];
+    return total;
+}
+
+function caller(args) {
+    return callee.apply(null, args);
+}
+noInline(caller);
+
+// Grow the argument count in stages. Each stage runs long enough to be optimized with a limit that
+// the next stage then exceeds.
+let args = [1, 2, 3];
+for (let stage = 0; stage < 6; ++stage) {
+    let expected = 0;
+    for (const value of args)
+        expected += value;
+
+    for (let i = 0; i < 20000; ++i)
+        shouldBe(caller(args), expected);
+
+    const grown = args.slice();
+    for (let i = 0; i < 8; ++i)
+        grown.push(stage * 8 + i);
+    args = grown;
+}
+
+// Alternating between a short and a long argument list must still produce correct results.
+const short = [1, 2, 3];
+let longExpected = 0;
+for (const value of args)
+    longExpected += value;
+for (let i = 0; i < 20000; ++i) {
+    shouldBe(caller(short), 6);
+    shouldBe(caller(args), longExpected);
+}

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2186,6 +2186,16 @@ bool ByteCodeParser::handleVarargsInlining(Node* callTargetNode, Operand result,
         VERBOSE_LOG("Bailing inlining: too many arguments for varargs inlining.\n");
         return false;
     }
+
+    auto hasVarargsOverflowExit = [&] {
+        for (unsigned checkpoint = 0; checkpoint < BytecodeIndex::numberOfCheckpoints; ++checkpoint) {
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex.withCheckpoint(checkpoint), VarargsOverflow))
+                return true;
+        }
+        return false;
+    };
+    if (hasVarargsOverflowExit())
+        return false;
     if (callLinkStatus.couldTakeSlowPath() || callLinkStatus.size() != 1) {
         VERBOSE_LOG("Bailing inlining: polymorphic inlining is not yet supported for varargs.\n");
         return false;


### PR DESCRIPTION
#### 7600ab4bec971aa283a234db6ba4ff6b3d5df212
<pre>
[JSC] Fix repeated OSR exit via VarargsOverflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=321512">https://bugs.webkit.org/show_bug.cgi?id=321512</a>
<a href="https://rdar.apple.com/184624051">rdar://184624051</a>

Reviewed by Yijia Huang and Dan Hecht.

This patch fixes a bug that we are getting repeated VarargsOverflow,
by suppressing Varargs inlining when we repeatedly encounter the
VarargsOverflow OSR exits.

Test: JSTests/stress/varargs-overflow-exit-site-checkpoint.js

* JSTests/stress/varargs-overflow-exit-site-checkpoint.js: Added.
(shouldBe):
(callee):
(caller):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleVarargsInlining):

Canonical link: <a href="https://commits.webkit.org/318989@main">https://commits.webkit.org/318989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b26fac83081f7be35312ba25eac3eabec4aa18df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144354 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a2c503f-0ae1-4072-b21d-80d351f06ae7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53697 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140398 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/323ef31d-8654-4978-bc87-8d03556dda87) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120849 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/447a3ab1-6ccb-42a6-b173-fd3b46fce025) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42725 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41041 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2817 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9663 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40705 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1404 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41309 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192179 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53647 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149740 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54334 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37318 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149471 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27344 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44111 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126597 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121704 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52851 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15693 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52233 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52471 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52297 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->