### PR TITLE
Manage an offscreen web view when implementing the browser.offscreen extension API

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm
@@ -32,6 +32,9 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
 
+#import "WKNavigationDelegate.h"
+#import "WKUIDelegate.h"
+#import "WKWebViewInternal.h"
 #import "WebExtensionOffscreenDocumentParameters.h"
 
 namespace WebKit {
@@ -41,19 +44,85 @@ bool WebExtensionContext::isOffscreenMessageAllowed(IPC::Decoder& message)
     return isLoadedAndPrivilegedMessage(message) && hasPermission(WebExtensionPermission::offscreen());
 }
 
-void WebExtensionContext::offscreenCreateDocument(const WebExtensionOffscreenDocumentParameters&, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
+void WebExtensionContext::offscreenCreateDocument(const WebExtensionOffscreenDocumentParameters& parameters, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
-    completionHandler({ });
+    static constexpr auto apiName = "offscreen.createDocument()"_s;
+
+    if (m_offscreenWebView) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"only a single offscreen document may be created"));
+        return;
+    }
+
+    URL documentURL { m_baseURL, parameters.url };
+    if (!isURLForThisExtension(documentURL)) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"url must be a resource within the extension"));
+        return;
+    }
+
+    RefPtr extensionController = this->extensionController();
+    if (!extensionController) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"the extension is not loaded"));
+        return;
+    }
+
+    m_offscreenWebView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration(WebViewPurpose::Offscreen)];
+
+    // The _WKWebExtensionContextDelegate class interface, which declares conformance to WKUIDelegate and WKNavigationDelegate,
+    // is private to WebExtensionContextCocoa.mm, so the protocol conformances aren't visible here and require explicit casts.
+    m_offscreenWebView.get().UIDelegate = static_cast<id<WKUIDelegate>>(m_delegate.get());
+    m_offscreenWebView.get().navigationDelegate = static_cast<id<WKNavigationDelegate>>(m_delegate.get());
+
+    m_offscreenWebView.get().inspectable = m_inspectable;
+
+    Ref offscreenPage = *m_offscreenWebView.get()._page;
+    Ref offscreenProcess = offscreenPage->siteIsolatedProcess();
+
+    constexpr ASCIILiteral activityName = "Web Extension offscreen document"_s;
+    if (protect(offscreenPage->preferences())->siteIsolationEnabled())
+        m_offscreenWebViewActivity = protect(offscreenPage->activityGroupContext())->foregroundProcessActivityGroup(activityName);
+    else
+        m_offscreenWebViewActivity = protect(offscreenProcess->throttler())->foregroundActivity(activityName);
+
+    [m_offscreenWebView loadRequest:[NSURLRequest requestWithURL:documentURL.createNSURL().get()]];
+
+    m_offscreenDocumentLoadCompletionHandlers.append(WTF::move(completionHandler));
 }
 
 void WebExtensionContext::offscreenCloseDocument(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static constexpr auto apiName = "offscreen.closeDocument()"_s;
+
+    if (!m_offscreenWebView) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"no offscreen document is open"));
+        return;
+    }
+
+    unloadOffscreenWebView();
+
     completionHandler({ });
 }
 
 void WebExtensionContext::offscreenHasDocument(CompletionHandler<void(Expected<bool, WebExtensionError>&&)>&& completionHandler)
 {
-    completionHandler(false);
+    completionHandler(!!m_offscreenWebView);
+}
+
+void WebExtensionContext::unloadOffscreenWebView()
+{
+    static constexpr auto completionHandlerAPIName = "offscreen.createDocument()"_s;
+    for (auto& completionHandler : std::exchange(m_offscreenDocumentLoadCompletionHandlers, { }))
+        completionHandler(toWebExtensionError(completionHandlerAPIName, nullString(), @"offscreen document was closed"));
+
+    m_offscreenWebViewActivity = { };
+
+    [m_offscreenWebView _close];
+    m_offscreenWebView = nil;
+}
+
+void WebExtensionContext::performTasksAfterOffscreenContentLoads()
+{
+    for (auto& completionHandler : std::exchange(m_offscreenDocumentLoadCompletionHandlers, { }))
+        completionHandler({ });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -173,6 +173,11 @@ static constexpr NSInteger currentDeclarativeNetRequestRuleTranslatorVersion = 6
     extensionContext->didFinishDocumentLoad(webView, navigation);
 }
 
+- (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error
+{
+    [self webView:webView didFailNavigation:navigation withError:error];
+}
+
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error
 {
     RefPtr extensionContext = _webExtensionContext.get();
@@ -344,6 +349,10 @@ Expected<bool, RefPtr<API::Error>> WebExtensionContext::unload()
     writeStateToStorage();
 
     unloadBackgroundWebView();
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    unloadOffscreenWebView();
+#endif
+
     removeInjectedContent();
 
     invalidateStorage();
@@ -2866,10 +2875,16 @@ void WebExtensionContext::reportWebViewConfigurationErrorIfNeeded(const WebExten
 
 bool WebExtensionContext::decidePolicyForNavigationAction(WKWebView *webView, WKNavigationAction *navigationAction)
 {
+#ifndef NDEBUG
+    bool isValidWebView = (webView == m_backgroundWebView);
 #if ENABLE(INSPECTOR_EXTENSIONS)
-    ASSERT(webView == m_backgroundWebView || isInspectorBackgroundPage(webView));
-#else
-    ASSERT(webView == m_backgroundWebView);
+    isValidWebView |= isInspectorBackgroundPage(webView);
+#endif
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    isValidWebView |= isOffscreenWebView(webView);
+#endif
+
+    ASSERT(isValidWebView);
 #endif
 
     NSURL *url = navigationAction.request.URL;
@@ -2881,6 +2896,13 @@ bool WebExtensionContext::decidePolicyForNavigationAction(WKWebView *webView, WK
 
 void WebExtensionContext::didFinishDocumentLoad(WKWebView *webView, WKNavigation *)
 {
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    if (isOffscreenWebView(webView)) {
+        performTasksAfterOffscreenContentLoads();
+        return;
+    }
+#endif
+
     if (webView != m_backgroundWebView)
         return;
 
@@ -2893,6 +2915,13 @@ void WebExtensionContext::didFinishDocumentLoad(WKWebView *webView, WKNavigation
 
 void WebExtensionContext::didFailNavigation(WKWebView *webView, WKNavigation *, RefPtr<API::Error> error)
 {
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    if (isOffscreenWebView(webView)) {
+        unloadOffscreenWebView();
+        return;
+    }
+#endif
+
     if (webView != m_backgroundWebView)
         return;
 
@@ -2916,6 +2945,13 @@ void WebExtensionContext::webViewWebContentProcessDidTerminate(WKWebView *webVie
 #if ENABLE(INSPECTOR_EXTENSIONS)
     if (isInspectorBackgroundPage(webView)) {
         [webView loadRequest:[NSURLRequest requestWithURL:inspectorBackgroundPageURL().createNSURL().get()]];
+        return;
+    }
+#endif
+
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    if (isOffscreenWebView(webView)) {
+        unloadOffscreenWebView();
         return;
     }
 #endif

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -329,6 +329,9 @@ public:
         Popup,
         Sidebar,
         Tab,
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+        Offscreen,
+#endif
     };
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
@@ -596,6 +599,12 @@ public:
     URL backgroundContentURL();
 #if PLATFORM(COCOA)
     WKWebView *backgroundWebView() const { return m_backgroundWebView.get(); }
+
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    WKWebView *offscreenWebView() const { return m_offscreenWebView.get(); }
+    bool isOffscreenWebView(WKWebView *webView) const { return webView == m_offscreenWebView; }
+#endif
+
 #endif
     bool safeToLoadBackgroundContent() const { return m_safeToLoadBackgroundContent; }
 
@@ -733,6 +742,11 @@ private:
     void unloadBackgroundWebView();
     void scheduleBackgroundContentToUnload();
     void unloadBackgroundContentIfPossible();
+
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    void unloadOffscreenWebView();
+    void performTasksAfterOffscreenContentLoads();
+#endif
 
     uint64_t loadBackgroundPageListenersVersionNumberFromStorage();
     void loadBackgroundPageListenersFromStorage();
@@ -1121,6 +1135,13 @@ private:
 #if PLATFORM(COCOA)
     RetainPtr<WKWebView> m_backgroundWebView;
     Variant<std::monostate, Ref<ProcessThrottlerActivity>, Ref<ProcessActivityGroup>> m_backgroundWebViewActivity;
+
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    RetainPtr<WKWebView> m_offscreenWebView;
+    Variant<std::monostate, Ref<ProcessThrottlerActivity>, Ref<ProcessActivityGroup>> m_offscreenWebViewActivity;
+    Vector<CompletionHandler<void(Expected<void, WebExtensionError>&&)>> m_offscreenDocumentLoadCompletionHandlers;
+#endif
+
     RetainPtr<_WKWebExtensionContextDelegate> m_delegate;
 #elif ENABLE(2022_GLIB_API)
     GWeakPtr<WebKitWebExtensionContext> m_delegate;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm
@@ -44,6 +44,7 @@ static auto *offscreenManifest = @{
     @"permissions": @[ @"offscreen" ],
     @"background": @{
         @"service_worker": @"background.js",
+        @"type": @"module"
     },
 };
 
@@ -56,6 +57,7 @@ static auto *noOffscreenManifest = @{
     @"permissions": @[],
     @"background": @{
         @"service_worker": @"background.js",
+        @"type": @"module"
     },
 };
 
@@ -154,6 +156,120 @@ TEST_F(WKWebExtensionAPIOffscreen, OffscreenCreateDocumentArgumentValidation)
     ];
 
     Util::loadAndRunExtension(offscreenManifest, @{ @"background.js": Util::constructScript(script) }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, CreateAndHasDocument)
+{
+    auto *script = @[
+        @"browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' }).then(async () => {",
+        @"  browser.test.assertTrue(await browser.offscreen.hasDocument())",
+        @"  browser.test.notifyPass()",
+        @"})",
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{
+        @"background.js": Util::constructScript(script),
+        @"offscreen.html": @"<!DOCTYPE html><html></html>",
+    }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, CreateDocumentFails)
+{
+    auto *script = @[
+        @"await browser.test.assertRejects(browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' }), /Offscreen document was closed/)",
+        @"browser.test.assertFalse(await browser.offscreen.hasDocument())",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{ @"background.js": Util::constructScript(script) }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, CreateDocumentTwiceFails)
+{
+    auto *script = @[
+        @"await browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' })",
+        @"await browser.test.assertRejects(browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' }), /Only a single offscreen document/)",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{
+        @"background.js": Util::constructScript(script),
+        @"offscreen.html": @"<!DOCTYPE html><html></html>",
+    }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, CloseDocument)
+{
+    auto *script = @[
+        @"await browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' })",
+        @"browser.test.assertTrue(await browser.offscreen.hasDocument())",
+        @"await browser.offscreen.closeDocument()",
+        @"browser.test.assertFalse(await browser.offscreen.hasDocument())",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{
+        @"background.js": Util::constructScript(script),
+        @"offscreen.html": @"<!DOCTYPE html><html></html>",
+    }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, CloseDocumentWithoutOneOpenFails)
+{
+    auto *script = @[
+        @"await browser.test.assertRejects(browser.offscreen.closeDocument(), /No offscreen document is open/)",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{ @"background.js": Util::constructScript(script) }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, HasDocumentFalseByDefault)
+{
+    auto *script = @[
+        @"browser.test.assertFalse(await browser.offscreen.hasDocument())",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{ @"background.js": Util::constructScript(script) }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, DocumentContentLoads)
+{
+    auto *script = @[
+        @"browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' })",
+    ];
+
+    auto *offscreenScript = @[
+        @"browser.test.notifyPass()"
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{
+        @"background.js": Util::constructScript(script),
+        @"offscreen.html": @"<script type='module' src='offscreen.js'></script>",
+        @"offscreen.js": Util::constructScript(offscreenScript),
+    }, offscreenConfig);
+}
+
+TEST_F(WKWebExtensionAPIOffscreen, SendMessageToDocument)
+{
+    auto *backgroundScript = @[
+        @"await browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' })",
+        @"browser.runtime.sendMessage('Hello from background')",
+    ];
+
+    auto *offscreenScript = @[
+        @"browser.runtime.onMessage.addListener((message) => {",
+        @"  browser.test.assertEq(message, 'Hello from background', 'Should receive the expected message from the background page')",
+        @"  browser.test.notifyPass()",
+        @"})",
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{
+        @"background.js": Util::constructScript(backgroundScript),
+        @"offscreen.html": @"<script type='module' src='offscreen.js'></script>",
+        @"offscreen.js": Util::constructScript(offscreenScript),
+    }, offscreenConfig);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 1efe7e2360c84d4f08a75df6e33010839fb5e3f7
<pre>
Manage an offscreen web view when implementing the browser.offscreen extension API
<a href="https://bugs.webkit.org/show_bug.cgi?id=321513">https://bugs.webkit.org/show_bug.cgi?id=321513</a>
<a href="https://rdar.apple.com/184269255">rdar://184269255</a>

Reviewed by Kiara Rose.

This PR does a lot of hooking up the actual offscreen WKWebView with the offscreen extension API.

When an offscreen document is created, the corresponding web view is instantiated (if one doesn&apos;t exist already). One
behavior to note is that the promise isn&apos;t fulfilled until the page has finished loading. This matches Chrome and
allows messages dispatched immediately after awaiting the creation of the offscreen web view to be delivered successfully.

When an offscreen document is closed, the corresponding web view is unloaded (if it exists).

offscreen.hasDocument just checks for the presence of the offscreen web view ivar.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm:
(WebKit::WebExtensionContext::offscreenCreateDocument): Create a web view, and save the completion handler for when the load finishes.
(WebKit::WebExtensionContext::offscreenCloseDocument): Unload the web view and call the completion handler.
(WebKit::WebExtensionContext::offscreenHasDocument): Call the completion handler with the presence of the offscreen web view.
(WebKit::WebExtensionContext::unloadOffscreenWebView): Unloads the offscreen web view.
(WebKit::WebExtensionContext::performTasksAfterOffscreenContentLoads): Calls all the queued completion handlers.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(-[_WKWebExtensionContextDelegate webView:didFailProvisionalNavigation:withError:]): Forward this call to didFailNavigation.
(WebKit::WebExtensionContext::unload): Call unloadOffscreenWebView.
(WebKit::WebExtensionContext::decidePolicyForNavigationAction): Update for the offscreen web view.
(WebKit::WebExtensionContext::didFinishDocumentLoad): Ditto.
(WebKit::WebExtensionContext::didFailNavigation): Ditto.
(WebKit::WebExtensionContext::webViewWebContentProcessDidTerminate): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::offscreenWebView const):
(WebKit::WebExtensionContext::isOffscreenWebView const):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm:
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, CreateAndHasDocument)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, CreateDocumentFails)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, CreateDocumentTwiceFails)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, CloseDocument)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, CloseDocumentWithoutOneOpenFails)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, HasDocumentFalseByDefault)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, DocumentContentLoads)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, SendMessageToDocument)):

Canonical link: <a href="https://commits.webkit.org/318996@main">https://commits.webkit.org/318996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de907a3d2402013fd72029d4a46358ca1cebe0a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144410 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1eb360b2-7be1-4d04-9f03-c7c3bc262c30) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53753 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140451 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Running run-layout-tests-in-stress-mode; 7 flakes 2 failures; Uploaded test results; 1 flakes; Passed layout tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f560f3c6-fb04-4515-bbc3-5a656ec06c62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120902 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef416449-9fe6-4ba9-bd5d-c3aa7f8a0ec2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40761 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1462 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46636 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192235 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53703 "Built successfully") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149802 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; 10 flakes 2 failures; Uploaded test results") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40119 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54391 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149524 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44163 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126653 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121763 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52907 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15748 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52290 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52355 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->