### PR TITLE
[GLib] Fix documentation warnings

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtension.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtension.cpp
@@ -559,7 +559,7 @@ const char* webkit_web_extension_get_path(WebKitWebExtension* extension)
  * Get the parsed manifest version, or `0` if there is no
  * version specified in the manifest.
  *
- * A [error@WebKit.WebExtensionError.UNSUPPORTED_MANIFEST_VERSION] error will be
+ * A [error@WebExtensionError.UNSUPPORTED_MANIFEST_VERSION] error will be
  * reported if the manifest version isn't specified.
  * 
  * Returns: the parsed manifest version.

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -77,9 +77,9 @@ void webkitWebViewRestoreWindow(WebKitWebView*, CompletionHandler<void()>&& comp
  * The new view will use the default [class@WebContext] and will not
  * have an associated [class@UserContentManager].
  *
- * See also [id@webkit_web_view_new_with_context],
- * [id@webkit_web_view_new_with_user_content_manager]), and
- * [id@webkit_web_view_new_with_settings].
+ * Set the [property@WebView:web-context],
+ * [property@WebView:user-content-manager] or [property@WebView:settings]
+ * properties at construction to use a different configuration.
  *
  * Returns: The newly created web view.
  */
@@ -109,8 +109,8 @@ WebKitWebView* webkit_web_view_new(WebKitWebViewBackend* backend)
  * The new web view will use the given [class@WebContext] and will not have
  * an associated [class@UserContentManager].
  *
- * See also [id@webkit_web_view_new_with_user_content_manager] and
- * [id@webkit_web_view_new_with_settings].
+ * See also [ctor@WebView.new_with_user_content_manager] and
+ * [ctor@WebView.new_with_settings].
  *
  * Returns: The newly created web view.
  */
@@ -169,8 +169,8 @@ WebKitWebView* webkit_web_view_new_with_related_view(WebKitWebViewBackend* backe
  *
  * Creates a new web view with the given settings.
  *
- * See also [id@webkit_web_view_new_with_context], and
- * [id@webkit_web_view_new_with_user_content_manager].
+ * See also [ctor@WebView.new_with_context] and
+ * [ctor@WebView.new_with_user_content_manager].
  *
  * Returns: (transfer full): The newly created web view.
  *

--- a/Source/WebKit/WPEPlatform/docs/overview.md
+++ b/Source/WebKit/WPEPlatform/docs/overview.md
@@ -109,7 +109,7 @@ lifecycles you can rely on.
 
 The minimum viable usage looks like this:
 
-1. Create a [class@WebKit.WebView] without specifying a display or a
+1. Create a `WebKitWebView` without specifying a display or a
    backend. WebKit then uses the default display automatically — it is
    obtained by iterating the registered platform modules in priority
    order and connecting to the first one that succeeds.


### PR DESCRIPTION
#### bf034981129cc532f756837d94f9a4ba60fd13e3
<pre>
[GLib] Fix documentation warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=321516">https://bugs.webkit.org/show_bug.cgi?id=321516</a>

Reviewed by Adrian Perez de Castro.

This fixes some simple warnings.

* Source/WebKit/UIProcess/API/glib/WebKitWebExtension.cpp:

This required an upstream fix: <a href="https://gitlab.gnome.org/GNOME/gi-docgen/-/merge_requests/272">https://gitlab.gnome.org/GNOME/gi-docgen/-/merge_requests/272</a>

* Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp:
* Source/WebKit/WPEPlatform/docs/overview.md:

WPEPlatform can&apos;t link to WebKit easily, since the dependency is
the reverse of that.

Canonical link: <a href="https://commits.webkit.org/318988@main">https://commits.webkit.org/318988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/974f82098ded2c713701950c3b02b09de4fcb014

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144355 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140400 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120851 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41043 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40708 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1405 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192180 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53648 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149741 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40116 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54335 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149472 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44112 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126598 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121705 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52852 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15696 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52234 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52472 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->