### PR TITLE
[JSC] Reland: cache FastStringifier's buffer pointer and length across property-name emission

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1529,29 +1529,53 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                 recordBufferFull();
                 return false;
             }
-            if (needComma)
-                buffer()[m_length++] = ',';
-            if constexpr (hasGap == HasGap::Yes)
-                appendNewLineAndIndentUnchecked();
-            buffer()[m_length] = '"';
 
-            if constexpr (std::same_as<CharType, char16_t>) {
-                if (stringCopyUpconvert(span, buffer() + m_length + 1)) [[unlikely]] {
-                    recordFailure("property name character needs escaping"_s);
-                    return false;
+            {
+                // m_dynamicBuffer has inline capacity, so buffer() can point inside this object
+                // next to m_length: stores through it may-alias the members, forcing the compiler
+                // to reload both after every store. Cache them instead. Scoped because the pointer
+                // dies at the next hasRemainingCapacity(), which can reallocate.
+                CharType* out = buffer();
+                unsigned length = m_length;
+
+                if (needComma)
+                    out[length++] = ',';
+
+                if constexpr (hasGap == HasGap::Yes) {
+                    // The callee reads m_length and advances it.
+                    m_length = length;
+                    appendNewLineAndIndentUnchecked();
+                    out = buffer();
+                    length = m_length;
                 }
-            } else {
-                if (stringCopySameType(span, buffer() + m_length + 1)) [[unlikely]] {
-                    recordFailure("property name character needs escaping"_s);
-                    return false;
+
+                out[length] = '"';
+
+                // Publish m_length before every bail-out.
+                if constexpr (std::same_as<CharType, char16_t>) {
+                    if (stringCopyUpconvert(span, out + length + 1)) [[unlikely]] {
+                        m_length = length;
+                        recordFailure("property name character needs escaping"_s);
+                        return false;
+                    }
+                } else {
+                    if (stringCopySameType(span, out + length + 1)) [[unlikely]] {
+                        m_length = length;
+                        recordFailure("property name character needs escaping"_s);
+                        return false;
+                    }
                 }
+
+                out[length + 1 + span.size()] = '"';
+                out[length + 1 + span.size() + 1] = ':';
+                length += 1 + span.size() + 2;
+                if constexpr (hasGap == HasGap::Yes)
+                    out[length++] = ' ';
+
+                // Mandatory, not bookkeeping: the next hasRemainingCapacity() sizes itself from
+                // m_length, so leaving a stale value here would under-count the space needed.
+                m_length = length;
             }
-
-            buffer()[m_length + 1 + span.size()] = '"';
-            buffer()[m_length + 1 + span.size() + 1] = ':';
-            m_length += 1 + span.size() + 2;
-            if constexpr (hasGap == HasGap::Yes)
-                buffer()[m_length++] = ' ';
 
             if constexpr (std::same_as<CharType, Latin1Character>) {
                 // Inlining String case here since it is too common.


### PR DESCRIPTION
#### 8b5e6ebb64e65a4aefd8c9de48916c7da5438841
<pre>
[JSC] Reland: cache FastStringifier&apos;s buffer pointer and length across property-name emission
<a href="https://bugs.webkit.org/show_bug.cgi?id=321518">https://bugs.webkit.org/show_bug.cgi?id=321518</a>
<a href="https://rdar.apple.com/184628273">rdar://184628273</a>

Reviewed by Yusuke Suzuki.

Relands 318944@main (ea3fbb33caa5), reverted in 318969@main (ba1d526398de) for a
perf regression, with the property-value half dropped.

ea3fbb3 cached buffer() and m_length in two places: the property-name block and
the inlined string-value block. Dropping the value block is what recovers the
regression. That block is also the half that grew the hot lambda&apos;s frame from
0x50 to 0x60, which is the suspicious part: in DynamicBuffer mode append()
recurses once per nesting level behind a softStackLimit() check, and crossing that
check abandons the whole fast path for the generic Stringifier instead of
degrading gradually.

This reland keeps only the property-name block, which is where the reloads are
concentrated (19 for 9 stores). The frame is back to 0x50 and stack traffic
matches baseline. The discipline is unchanged: locals are captured after
hasRemainingCapacity(), which can reallocate; m_length is published before
appendNewLineAndIndentUnchecked(), which reads and advances it, and before every
bail-out.

Hot instantiation (Latin1, DynamicBuffer, HasGap::No): 1712 -&gt; 1660 bytes, loads
70 -&gt; 61, member reloads 26 -&gt; 17.

Note the reverted version was better on every one of those counters -- 1648
bytes, 56 loads, 12 reloads -- and still regressed. Reload count is a proxy, not
the objective.

Canonical link: <a href="https://commits.webkit.org/318990@main">https://commits.webkit.org/318990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1096b087ec65a1ead2c5057954e30258c4ac69c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144371 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ff88682-f62d-4b4e-b148-0d9107110e45) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140413 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120864 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14ce3546-9b09-44c0-a72a-afc8ed242e07) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41058 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2832 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9682 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40724 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1421 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41326 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192196 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53664 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149758 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54351 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149489 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27345 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44131 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126614 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121721 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52868 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15712 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52251 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52488 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52314 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->