### PR TITLE
[JSC][Temporal] Adopt three audit tests and remove a dead ICU epoch probe

### DIFF
--- a/JSTests/stress/temporal-monthcode-wrong-type.js
+++ b/JSTests/stress/temporal-monthcode-wrong-type.js
@@ -1,0 +1,57 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${String(expected)} but got ${String(actual)}`);
+}
+function shouldThrow(ctor, fn) {
+    try { fn(); } catch (e) {
+        if (!(e instanceof ctor))
+            throw new Error(`expected ${ctor.name}, got ${e}`);
+        return;
+    }
+    throw new Error(`expected ${ctor.name} but no exception thrown`);
+}
+
+const notStrings = [5, 0, true, false, null, 12n, Symbol('M03')];
+
+// from() and with() across every type that reads a monthCode field.
+for (const monthCode of notStrings) {
+    shouldThrow(TypeError, () => Temporal.PlainDate.from({ year: 2024, month: 3, day: 5, monthCode }));
+    shouldThrow(TypeError, () => Temporal.PlainYearMonth.from({ year: 2024, month: 3, monthCode }));
+    shouldThrow(TypeError, () => Temporal.PlainMonthDay.from({ month: 3, day: 5, monthCode }));
+    shouldThrow(TypeError, () => Temporal.PlainDateTime.from({ year: 2024, month: 3, day: 5, monthCode }));
+    shouldThrow(TypeError, () => Temporal.PlainDate.from('2024-03-05').with({ monthCode }));
+    shouldThrow(TypeError, () => Temporal.PlainDateTime.from('2024-03-05T00:00').with({ monthCode }));
+    shouldThrow(TypeError, () => Temporal.PlainYearMonth.from('2024-03').with({ monthCode }));
+    shouldThrow(TypeError, () => Temporal.PlainMonthDay.from('03-05').with({ monthCode }));
+    shouldThrow(TypeError, () => Temporal.PlainDate.from('2024-03-05[u-ca=hebrew]').with({ monthCode, day: 3 }));
+}
+
+// A malformed String is still a RangeError, and a well-formed one still works.
+{
+    shouldThrow(RangeError, () => Temporal.PlainDate.from({ year: 2024, day: 5, monthCode: 'bogus' }));
+    shouldThrow(RangeError, () => Temporal.PlainDateTime.from('2024-03-05T00:00').with({ monthCode: 'bogus' }));
+    shouldThrow(RangeError, () => Temporal.PlainDate.from({ year: 2024, month: 3, day: 5, monthCode: 'M05' }));
+    shouldBe(Temporal.PlainDate.from({ year: 2024, month: 3, day: 5, monthCode: 'M03' }).toString(), '2024-03-05');
+    shouldBe(Temporal.PlainDateTime.from('2024-03-05T00:00').with({ monthCode: 'M05' }).toString(), '2024-05-05T00:00:00');
+}
+
+// ToPrimitive is applied, so an object that stringifies to a valid monthCode is accepted and one
+// that stringifies to garbage is a RangeError rather than a TypeError.
+{
+    shouldBe(Temporal.PlainDate.from({ year: 2024, day: 5, monthCode: { toString: () => 'M07' } }).toString(), '2024-07-05');
+    shouldThrow(RangeError, () => Temporal.PlainDate.from({ year: 2024, day: 5, monthCode: { toString: () => 'nope' } }));
+
+    let calls = 0;
+    const counted = { toString() { calls++; return 'M07'; } };
+    shouldBe(Temporal.PlainDate.from({ year: 2024, day: 5, monthCode: counted }).toString(), '2024-07-05');
+    shouldBe(calls, 1);
+}
+
+// Grammar is checked as monthCode is read, before year's type is validated; suitability for the
+// calendar is checked after. Both orderings are already pinned by test262 and must not regress.
+{
+    shouldThrow(RangeError, () => Temporal.PlainDateTime.from({ day: 1, monthCode: 'L99M', year: Symbol() }));
+    shouldThrow(TypeError, () => Temporal.PlainDateTime.from({ day: 1, monthCode: 'M99L', year: Symbol() }));
+}

--- a/JSTests/stress/temporal-plaindate-with-option-order.js
+++ b/JSTests/stress/temporal-plaindate-with-option-order.js
@@ -1,0 +1,59 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${String(expected)} but got ${String(actual)}`);
+}
+function shouldThrow(ctor, fn) {
+    try { fn(); } catch (e) {
+        if (!(e instanceof ctor))
+            throw new Error(`expected ${ctor.name}, got ${e}`);
+        return;
+    }
+    throw new Error(`expected ${ctor.name} but no exception thrown`);
+}
+
+const date = Temporal.PlainDate.from('2025-07-31');
+
+// A month/monthCode conflict must read overflow first.
+{
+    const log = [];
+    shouldThrow(RangeError, () => date.with({ month: 3, monthCode: 'M04' }, { get overflow() { log.push('overflow'); return 'constrain'; } }));
+    shouldBe(log.join(','), 'overflow');
+
+    // So a throwing overflow getter wins over the conflict.
+    shouldThrow(EvalError, () => date.with({ month: 3, monthCode: 'M04' }, { get overflow() { throw new EvalError('x'); } }));
+    // And an invalid overflow value is reported before the conflict.
+    shouldThrow(RangeError, () => date.with({ month: 3, monthCode: 'M04' }, { overflow: 'bogus' }));
+}
+
+// An empty bag must throw before overflow is read at all.
+{
+    const log = [];
+    shouldThrow(TypeError, () => date.with({}, { get overflow() { log.push('overflow'); return 'constrain'; } }));
+    shouldBe(log.join(','), '');
+
+    // So the TypeError wins over a throwing overflow getter.
+    shouldThrow(TypeError, () => date.with({}, { get overflow() { throw new EvalError('x'); } }));
+}
+
+// A consistent month/monthCode pair still resolves, and overflow is read exactly once.
+{
+    let calls = 0;
+    shouldBe(date.with({ month: 4, monthCode: 'M04' }, { get overflow() { calls++; return 'constrain'; } }).toString(), '2025-04-30');
+    shouldBe(calls, 1);
+
+    shouldBe(date.with({ monthCode: 'M04' }).toString(), '2025-04-30');
+    shouldBe(date.with({ month: 4 }).toString(), '2025-04-30');
+    shouldThrow(RangeError, () => date.with({ month: 4 }, { overflow: 'reject' }));
+    shouldBe(date.with({ day: 15 }).toString(), '2025-07-15');
+}
+
+// The non-ISO branch already read options first and must stay that way.
+{
+    const gregory = Temporal.PlainDate.from('2025-07-31[u-ca=gregory]');
+    const log = [];
+    shouldThrow(RangeError, () => gregory.with({ month: 3, monthCode: 'M04' }, { get overflow() { log.push('overflow'); return 'constrain'; } }));
+    shouldBe(log.join(','), 'overflow');
+    shouldThrow(TypeError, () => gregory.with({}));
+}

--- a/JSTests/stress/temporal-relativeto-field-order.js
+++ b/JSTests/stress/temporal-relativeto-field-order.js
@@ -1,0 +1,69 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${String(expected)} but got ${String(actual)}`);
+}
+function shouldThrow(ctor, fn) {
+    try { fn(); } catch (e) {
+        if (!(e instanceof ctor))
+            throw new Error(`expected ${ctor.name}, got ${e}`);
+        return e;
+    }
+    throw new Error(`expected ${ctor.name} but no exception thrown`);
+}
+
+// A bad timeZone must be reported from timeZone's own slot, before year is even read.
+{
+    const log = [];
+    shouldThrow(TypeError, () => Temporal.Duration.from({ days: 1 }).total({ unit: 'days', relativeTo: {
+        get day() { log.push('day'); return 1; },
+        get timeZone() { log.push('timeZone'); return 5; },
+        get month() { log.push('month'); return 1; },
+        get year() { log.push('year'); throw new EvalError('year must not be reached'); },
+    } }));
+    shouldBe(log.join(','), 'day,month,timeZone');
+}
+
+// The same holds when a later field would raise a missing-field TypeError: the timeZone conversion
+// runs first because timeZone is read before year.
+{
+    shouldThrow(TypeError, () => Temporal.Duration.from({ days: 1 })
+        .total({ unit: 'days', relativeTo: { timeZone: 123, month: 1, monthCode: 'M01' } }));
+    shouldThrow(TypeError, () => Temporal.Duration.from({ days: 1 })
+        .round({ largestUnit: 'year', relativeTo: { timeZone: {}, month: 1, day: 1 } }));
+}
+
+// Every field is read, in alphabetical order, before the missing-field TypeError.
+{
+    const log = [];
+    const names = ['calendar', 'day', 'hour', 'microsecond', 'millisecond', 'minute', 'month', 'monthCode', 'nanosecond', 'offset', 'second', 'timeZone', 'year'];
+    const bag = {};
+    for (const name of names)
+        Object.defineProperty(bag, name, { get() { log.push(name); return undefined; }, enumerable: true });
+    shouldThrow(TypeError, () => Temporal.Duration.from({ days: 1 }).total({ unit: 'days', relativeTo: bag }));
+    shouldBe(log.join(','), names.join(','));
+}
+
+// A well-formed zoned relativeTo still resolves, and the timeZone getter runs exactly once.
+{
+    let calls = 0;
+    const bag = { year: 2024, month: 1, day: 1, get timeZone() { calls++; return 'UTC'; } };
+    shouldBe(Temporal.Duration.from({ hours: 48 }).round({ largestUnit: 'day', relativeTo: bag }).toString(), 'P2D');
+    shouldBe(calls, 1);
+
+    shouldBe(Temporal.Duration.from({ hours: 24 }).total({ unit: 'day', relativeTo: { year: 2024, month: 1, day: 1, timeZone: 'UTC' } }), 1);
+    shouldBe(Temporal.Duration.from({ hours: 24 }).total({ unit: 'day', relativeTo: { year: 2024, month: 1, day: 1 } }), 1);
+}
+
+// An invalid time zone string is a RangeError from the same slot, not a TypeError.
+{
+    const log = [];
+    shouldThrow(RangeError, () => Temporal.Duration.from({ days: 1 }).total({ unit: 'days', relativeTo: {
+        get day() { log.push('day'); return 1; },
+        get month() { log.push('month'); return 1; },
+        get timeZone() { log.push('timeZone'); return 'Not/AZone'; },
+        get year() { log.push('year'); return 2024; },
+    } }));
+    shouldBe(log.join(','), 'day,month,timeZone');
+}

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -178,38 +178,6 @@ static auto withCalendar(CalendarID calendarId, F&& fn) -> decltype(fn(static_ca
     return fn(entry->cal.get());
 }
 
-// lunarCalendarExtendedYearFor1972 — probes UCAL_EXTENDED_YEAR for the given lunisolar calendar
-// at ISO 1972-02-15. Returns 1972 on ISO-proleptic ICU; epoch-based year on older Apple ICU.
-// Chinese uses epoch 2637 BCE -> returns 4609 on ICU ≥76; Dangi uses epoch 2333 BCE -> returns 4305.
-// Result is cached per calendar: ICU version is fixed for the process lifetime.
-int32_t lunarCalendarExtendedYearFor1972(CalendarID calendarId)
-{
-    static std::atomic<int32_t> chineseCached { INT32_MIN };
-    static std::atomic<int32_t> dangiCached { INT32_MIN };
-    auto& cached = (calendarId == dangiCalendarID()) ? dangiCached : chineseCached;
-    int32_t value = cached.load(std::memory_order_relaxed);
-    if (value != INT32_MIN)
-        return value;
-    // Use ucal_setMillis with a precomputed ISO epoch time — NOT ucal_setDateTime which
-    // sets calendar-native fields (not ISO fields) on a non-Gregorian calendar.
-    // ISO 1972-02-15 00:00:00 UTC = 66,960,000,000 ms from Unix epoch (1970-01-01).
-    static constexpr double iso1972Feb15EpochMs = 66960000000.0;
-    value = withCalendar(calendarId, [&](UCalendar* cal) -> int32_t {
-        if (!cal) [[unlikely]]
-            return 1972; // fallback: assume ISO-proleptic
-        UErrorCode status = U_ZERO_ERROR;
-        ucal_setMillis(cal, iso1972Feb15EpochMs, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return 1972; // fallback: assume ISO-proleptic
-        int32_t extYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return 1972; // fallback: assume ISO-proleptic
-        return extYear;
-    });
-    cached.store(value, std::memory_order_relaxed);
-    return value;
-}
-
 // isoDateToEpochMs — internal: converts ISO PlainDate to epoch ms at noon UTC
 // (avoids DST boundary issues).
 static double isoDateToEpochMs(const ISO8601::PlainDate& date)

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
@@ -134,8 +134,6 @@ enum class EcmaReferenceYearError : uint8_t {
 
 Expected<int32_t, EcmaReferenceYearError> ecmaReferenceYear(CalendarID, uint8_t monthNumber, bool isLeapMonth, uint8_t day);
 
-JS_EXPORT_PRIVATE int32_t lunarCalendarExtendedYearFor1972(CalendarID);
-
 JS_EXPORT_PRIVATE std::optional<ASCIILiteral> canonicalizeEraInCalendar(CalendarID, StringView era);
 
 JS_EXPORT_PRIVATE std::optional<std::pair<ASCIILiteral, int32_t>> remapNonPositiveEraYear(CalendarID, StringView era, int32_t eraYear);


### PR DESCRIPTION
#### f6c491404f2de22f0215652f915ff852bef51043
<pre>
[JSC][Temporal] Adopt three audit tests and remove a dead ICU epoch probe
<a href="https://bugs.webkit.org/show_bug.cgi?id=321521">https://bugs.webkit.org/show_bug.cgi?id=321521</a>
<a href="https://rdar.apple.com/184631238">rdar://184631238</a>

Reviewed by Yusuke Suzuki.

lunarCalendarExtendedYearFor1972 has no callers. constrainMonthCodeInternal now reads the year
field positionCalendarToYearStart writes back. Adds coverage for monthCode coercion, relativeTo
field order and PlainDate.prototype.with option order.

Tests: JSTests/stress/temporal-monthcode-wrong-type.js
       JSTests/stress/temporal-plaindate-with-option-order.js
       JSTests/stress/temporal-relativeto-field-order.js

Canonical link: <a href="https://commits.webkit.org/318991@main">https://commits.webkit.org/318991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d56716be885acedeb0615994ebb7ba4f83c2249

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144378 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140422 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120873 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42747 "Build is in progress. Recent messages:") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41065 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2841 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9689 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40731 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1428 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41333 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192203 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53671 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149764 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54358 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149495 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27346 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44134 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126621 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121730 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52875 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15719 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52258 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52495 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->