### PR TITLE
[JSC] Tighten WasmGC allocation

### DIFF
--- a/JSTests/wasm/gc/array-new-constant-size.js
+++ b/JSTests/wasm/gc/array-new-constant-size.js
@@ -1,0 +1,34 @@
+import { instantiate } from "./wast-wrapper.js";
+// array.new_default with a constant length picks its size class at compile time. Cover a small
+// array (inline fast path), one straddling the largeCutoff, and one that must be a precise
+// allocation (no fast path at all).
+function make(elementType, len, init, get) {
+  return instantiate(`
+(module
+  (type $a (array (mut ${elementType})))
+  (func (export "t") (param i32) (result ${elementType})
+    (local $arr (ref null $a))
+    (loop $l
+      (local.set $arr (array.new_default $a (i32.const ${len})))
+      (array.set $a (ref.as_non_null (local.get $arr)) (i32.const ${len - 1}) (${init}))
+      (local.set 0 (i32.sub (local.get 0) (i32.const 1)))
+      (br_if $l (local.get 0)))
+    (${get} $a (ref.as_non_null (local.get $arr)) (i32.const ${len - 1}))))
+`);
+}
+
+for (const [elementType, init, get, want] of [
+  ["i32", "i32.const 7", "array.get", 7],
+  ["i64", "i64.const 7", "array.get", 7n],
+  ["f64", "f64.const 7", "array.get", 7],
+]) {
+  // 1 and 8 stay well inside the size classes; 4096/8192 cross largeCutoff into precise allocation.
+  for (const len of [1, 8, 100, 4096, 8192, 65536]) {
+    const i = make(elementType, len, init, get);
+    for (const n of [1, 5, 2000]) {
+      const got = i.exports.t(n);
+      if (got !== want)
+        throw new Error(`${elementType} len=${len} n=${n}: got ${got} want ${want}`);
+    }
+  }
+}

--- a/JSTests/wasm/gc/struct-new-does-not-clobber-loads.js
+++ b/JSTests/wasm/gc/struct-new-does-not-clobber-loads.js
@@ -1,0 +1,27 @@
+import { instantiate } from "./wast-wrapper.js";
+// A load of $a.f cached across an allocation must still see a store made through
+// an aliasing reference AFTER the allocation.
+const i = instantiate(`
+(module
+  (type $s (struct (field $f (mut i32))))
+  (type $t (struct (field $g (mut i32))))
+  (func (export "t") (param i32) (result i32)
+    (local $a (ref null $s))
+    (local $sum i32)
+    (local.set $a (struct.new $s (i32.const 1)))
+    (loop $l
+      ;; read, allocate (must not clobber the read), store, read again
+      (local.set $sum (i32.add (local.get $sum) (struct.get $s $f (ref.as_non_null (local.get $a)))))
+      (drop (struct.new $t (i32.const 9)))
+      (struct.set $s $f (ref.as_non_null (local.get $a)) (i32.const 2))
+      (local.set $sum (i32.add (local.get $sum) (struct.get $s $f (ref.as_non_null (local.get $a)))))
+      (struct.set $s $f (ref.as_non_null (local.get $a)) (i32.const 1))
+      (local.set 0 (i32.sub (local.get 0) (i32.const 1)))
+      (br_if $l (local.get 0)))
+    (local.get $sum)))
+`);
+// each iteration contributes 1 + 2 = 3
+for (const n of [1, 10, 1000, 200000]) {
+  const got = i.exports.t(n), want = 3 * n;
+  if (got !== want) throw new Error(`n=${n}: got ${got} want ${want}`);
+}

--- a/JSTests/wasm/gc/struct-new-nested-alloc-gc.js
+++ b/JSTests/wasm/gc/struct-new-nested-alloc-gc.js
@@ -1,0 +1,29 @@
+import { instantiate } from "./wast-wrapper.js";
+// Keep freshly allocated objects reachable through a global while allocating heavily,
+// so a GC that lands between the allocation and its field stores would be observable.
+const i = instantiate(`
+(module
+  (type $inner (struct (field $v (mut i32))))
+  (type $s (struct (field $a (mut (ref null $inner))) (field $b (mut (ref null $inner)))))
+  (global $keep (mut (ref null $s)) (ref.null $s))
+  (func (export "run") (param i32) (result i32)
+    (local $sum i32)
+    (loop $l
+      (global.set $keep
+        (struct.new $s
+          (struct.new $inner (local.get 0))
+          (struct.new $inner (i32.add (local.get 0) (i32.const 7)))))
+      (local.set $sum (i32.add (local.get $sum)
+        (i32.add
+          (struct.get $inner $v (ref.as_non_null (struct.get $s $a (ref.as_non_null (global.get $keep)))))
+          (struct.get $inner $v (ref.as_non_null (struct.get $s $b (ref.as_non_null (global.get $keep))))))))
+      (local.set 0 (i32.sub (local.get 0) (i32.const 1)))
+      (br_if $l (local.get 0)))
+    (local.get $sum)))
+`);
+// sum over k=n..1 of (k + k+7)
+function want(n){ let s=0; for(let k=n;k>=1;--k) s += k + (k+7); return s|0; }
+for (const n of [1, 100, 5000]) {
+  const got = i.exports.run(n);
+  if (got !== want(n)) throw new Error(`n=${n}: got ${got} want ${want(n)}`);
+}

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp
@@ -35,7 +35,9 @@
 #include "B3ValueInlines.h"
 #include "B3WasmArrayGetValue.h"
 #include "B3WasmArrayLengthValue.h"
+#include "B3WasmArrayNewValue.h"
 #include "B3WasmArraySetValue.h"
+#include "B3WasmStructNewValue.h"
 #include "ClonedArguments.h"
 #include "ConcatKeyAtomStringCache.h"
 #include "DateInstance.h"
@@ -120,6 +122,9 @@ AbstractHeapRepository::AbstractHeapRepository()
     JSRopeString_flags.changeParent(&JSRopeString_fiber0);
     JSRopeString_length.changeParent(&JSRopeString_fiber1);
 
+    VM_heap_barrierThreshold.changeParent(&VM_heapState);
+    VM_heap_mutatorShouldBeFenced.changeParent(&VM_heapState);
+
     RELEASE_ASSERT(!JSCell_freeListNext.offset());
 }
 
@@ -175,6 +180,11 @@ void AbstractHeapRepository::decorateWasmStructSet(const AbstractHeap* heap, Val
     m_heapForWasmStructSet.append(HeapForValue(heap, value));
 }
 
+void AbstractHeapRepository::decorateWasmStructNew(const AbstractHeap* heap, Value* value)
+{
+    m_heapForWasmStructNew.append(HeapForValue(heap, value));
+}
+
 void AbstractHeapRepository::decorateWasmArrayGet(const AbstractHeap* heap, Value* value)
 {
     m_heapForWasmArrayGet.append(HeapForValue(heap, value));
@@ -183,6 +193,11 @@ void AbstractHeapRepository::decorateWasmArrayGet(const AbstractHeap* heap, Valu
 void AbstractHeapRepository::decorateWasmArraySet(const AbstractHeap* heap, Value* value)
 {
     m_heapForWasmArraySet.append(HeapForValue(heap, value));
+}
+
+void AbstractHeapRepository::decorateWasmArrayNew(const AbstractHeap* heap, Value* value)
+{
+    m_heapForWasmArrayNew.append(HeapForValue(heap, value));
 }
 
 void AbstractHeapRepository::decorateWasmArrayLength(const AbstractHeap* heap, Value* value)
@@ -235,6 +250,10 @@ void AbstractHeapRepository::computeRangesAndDecorateInstructions()
         auto* wasmStructSet = entry.value->as<WasmStructSetValue>();
         wasmStructSet->setRange(rangeFor(entry.heap));
     }
+    for (HeapForValue entry : m_heapForWasmStructNew) {
+        auto* wasmStructNew = entry.value->as<WasmStructNewValue>();
+        wasmStructNew->setRange(rangeFor(entry.heap));
+    }
     for (HeapForValue entry : m_heapForWasmArrayGet) {
         auto* wasmArrayGet = entry.value->as<WasmArrayGetValue>();
         wasmArrayGet->setRange(rangeFor(entry.heap));
@@ -242,6 +261,10 @@ void AbstractHeapRepository::computeRangesAndDecorateInstructions()
     for (HeapForValue entry : m_heapForWasmArraySet) {
         auto* wasmArraySet = entry.value->as<WasmArraySetValue>();
         wasmArraySet->setRange(rangeFor(entry.heap));
+    }
+    for (HeapForValue entry : m_heapForWasmArrayNew) {
+        auto* wasmArrayNew = entry.value->as<WasmArrayNewValue>();
+        wasmArrayNew->setRange(rangeFor(entry.heap));
     }
     for (HeapForValue entry : m_heapForWasmArrayLength) {
         auto* wasmArrayLength = entry.value->as<WasmArrayLengthValue>();

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -38,6 +38,7 @@ namespace JSC::B3 {
     macro(TypedArrayProperties) \
     macro(JSCellHeaderAndNamedProperties) \
     macro(OrderedHashTableData) \
+    macro(VM_heapState) \
 
 // macro(name, offset, mutability)
 #define FOR_EACH_ABSTRACT_FIELD(macro) \
@@ -359,8 +360,10 @@ public:
     void decorateFencedAccess(const AbstractHeap*, Value*);
     void decorateWasmStructGet(const AbstractHeap*, Value*);
     void decorateWasmStructSet(const AbstractHeap*, Value*);
+    void decorateWasmStructNew(const AbstractHeap*, Value*);
     void decorateWasmArrayGet(const AbstractHeap*, Value*);
     void decorateWasmArraySet(const AbstractHeap*, Value*);
+    void decorateWasmArrayNew(const AbstractHeap*, Value*);
     void decorateWasmArrayLength(const AbstractHeap*, Value*);
 
     void computeRangesAndDecorateInstructions();
@@ -392,8 +395,10 @@ private:
     Vector<HeapForValue> m_heapForFencedAccess;
     Vector<HeapForValue> m_heapForWasmStructGet;
     Vector<HeapForValue> m_heapForWasmStructSet;
+    Vector<HeapForValue> m_heapForWasmStructNew;
     Vector<HeapForValue> m_heapForWasmArrayGet;
     Vector<HeapForValue> m_heapForWasmArraySet;
+    Vector<HeapForValue> m_heapForWasmArrayNew;
     Vector<HeapForValue> m_heapForWasmArrayLength;
 };
 

--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -721,28 +721,26 @@ private:
                 uint32_t typeIndex = structNew->typeIndex();
                 int32_t allocatorsBaseOffset = structNew->allocatorsBaseOffset();
 
-                size_t allocationSize = JSWebAssemblyStruct::allocationSize(rtt->instancePayloadSize());
+                size_t sizeInBytes = JSWebAssemblyStruct::allocationSize(rtt->instancePayloadSize());
 
                 static_assert(!(MarkedSpace::sizeStep & (MarkedSpace::sizeStep - 1)), "MarkedSpace::sizeStep must be a power of two.");
-                unsigned stepShift = getLSBSet(MarkedSpace::sizeStep);
-                size_t sizeClass = (allocationSize + MarkedSpace::sizeStep - 1) >> stepShift;
-                bool useFastPath = (sizeClass <= (MarkedSpace::largeCutoff >> stepShift));
+                size_t sizeClassIndex = MarkedSpace::sizeClassToIndex(sizeInBytes);
 
                 BasicBlock* before = m_blockInsertionSet.splitForward(m_block, m_index, &m_insertionSet);
                 BasicBlock* slowPath = m_blockInsertionSet.insertBefore(m_block);
 
                 UpsilonValue* fastUpsilon = nullptr;
-                if (useFastPath) {
+                if (sizeInBytes <= MarkedSpace::largeCutoff) {
                     BasicBlock* fastPathContinuation = m_blockInsertionSet.insertBefore(m_block);
 
                     // Replace the Jump added by splitForward with Nop so we can add our own control flow
                     before->replaceLastWithNew<Value>(m_proc, Nop, m_origin);
 
                     // The Instance constructor initializes all the allocators on creation, thus it is never nullptr.
-                    int32_t allocatorOffset = allocatorsBaseOffset + static_cast<int32_t>(sizeClass * sizeof(Allocator));
+                    int32_t allocatorOffset = allocatorsBaseOffset + static_cast<int32_t>(sizeClassIndex * sizeof(Allocator));
                     Value* allocator = before->appendNew<MemoryValue>(m_proc, Load, pointerType(), m_origin, instance, allocatorOffset);
 
-                    Value* cell = emitWasmGCAllocationPatchpoint(before, allocator, fastPathContinuation, slowPath);
+                    Value* cell = emitWasmGCAllocationPatchpoint(before, allocator, fastPathContinuation, slowPath, MarkedSpace::s_sizeClassForSizeStep[sizeClassIndex]);
                     emitWasmGCCellInit(fastPathContinuation, cell, structureID, JSWebAssemblyStruct::typeInfoBlob().blob());
 
                     fastUpsilon = fastPathContinuation->appendNew<UpsilonValue>(m_proc, m_origin, cell);
@@ -884,44 +882,66 @@ private:
                 unsigned stepShift = getLSBSet(MarkedSpace::sizeStep);
                 size_t largeCutoffClass = MarkedSpace::largeCutoff >> stepShift;
 
+                // When the element count is known, so is the size class, so we can skip computing it
+                // at runtime and hand the allocator a constant cell size. A constant size needing a
+                // precise allocation has no fast path at all and always goes to the slow path.
+                bool isConstantSize = size->hasInt32();
+                std::optional<unsigned> constantSizeInBytes;
+                if (isConstantSize)
+                    constantSizeInBytes = JSWebAssemblyArray::allocationSizeInBytes(rtt->elementType(), static_cast<unsigned>(size->asInt32()));
+                bool hasFastPath = !isConstantSize || (constantSizeInBytes && constantSizeInBytes.value() <= MarkedSpace::largeCutoff);
+
                 BasicBlock* before = m_blockInsertionSet.splitForward(m_block, m_index, &m_insertionSet);
                 BasicBlock* slowPath = m_blockInsertionSet.insertBefore(m_block);
-                BasicBlock* fastAlloc = m_blockInsertionSet.insertBefore(m_block);
-                BasicBlock* fastInit = m_blockInsertionSet.insertBefore(m_block);
+                BasicBlock* fastAlloc = hasFastPath ? m_blockInsertionSet.insertBefore(m_block) : nullptr;
+                BasicBlock* fastInit = hasFastPath ? m_blockInsertionSet.insertBefore(m_block) : nullptr;
                 BasicBlock* mergeBlock = m_blockInsertionSet.insertBefore(m_block);
 
                 before->replaceLastWithNew<Value>(m_proc, Nop, m_origin);
 
-                auto* extSize = before->appendNew<Value>(m_proc, ZExt32, Int64, m_origin, size);
-                auto* shifted = before->appendNew<Value>(m_proc, Shl, pointerType(), m_origin, extSize, before->appendNew<Const32Value>(m_proc, m_origin, getLSBSet(elementSize)));
-                auto* sizeInBytes = before->appendNew<Value>(m_proc, Add, pointerType(), m_origin, shifted, before->appendNew<ConstPtrValue>(m_proc, m_origin, JSWebAssemblyArray::allocationMetadataSize(elementSize)));
+                Value* sizeClassIndex = nullptr;
+                if (isConstantSize) {
+                    if (hasFastPath)
+                        sizeClassIndex = before->appendNew<ConstPtrValue>(m_proc, m_origin, MarkedSpace::sizeClassToIndex(constantSizeInBytes.value()));
+                    before->appendNewControlValue(m_proc, Jump, m_origin, hasFastPath ? fastAlloc : slowPath);
+                } else {
+                    auto* extSize = before->appendNew<Value>(m_proc, ZExt32, Int64, m_origin, size);
+                    auto* shifted = before->appendNew<Value>(m_proc, Shl, pointerType(), m_origin, extSize, before->appendNew<Const32Value>(m_proc, m_origin, getLSBSet(elementSize)));
+                    auto* sizeInBytes = before->appendNew<Value>(m_proc, Add, pointerType(), m_origin, shifted, before->appendNew<ConstPtrValue>(m_proc, m_origin, JSWebAssemblyArray::allocationMetadataSize(elementSize)));
 
-                auto* rounded = before->appendNew<Value>(m_proc, Add, pointerType(), m_origin, sizeInBytes, before->appendNew<ConstPtrValue>(m_proc, m_origin, MarkedSpace::sizeStep - 1));
-                auto* sizeClassIndex = before->appendNew<Value>(m_proc, ZShr, pointerType(), m_origin, rounded, before->appendNew<Const32Value>(m_proc, m_origin, stepShift));
+                    auto* rounded = before->appendNew<Value>(m_proc, Add, pointerType(), m_origin, sizeInBytes, before->appendNew<ConstPtrValue>(m_proc, m_origin, MarkedSpace::sizeStep - 1));
+                    sizeClassIndex = before->appendNew<Value>(m_proc, ZShr, pointerType(), m_origin, rounded, before->appendNew<Const32Value>(m_proc, m_origin, stepShift));
 
-                auto* isLarge = before->appendNew<Value>(m_proc, Above, m_origin, sizeClassIndex, before->appendNew<ConstPtrValue>(m_proc, m_origin, largeCutoffClass));
-                before->appendNewControlValue(m_proc, B3::Branch, m_origin, isLarge,
-                    { slowPath, FrequencyClass::Rare }, { fastAlloc, FrequencyClass::Normal });
+                    auto* isLarge = before->appendNew<Value>(m_proc, Above, m_origin, sizeClassIndex, before->appendNew<ConstPtrValue>(m_proc, m_origin, largeCutoffClass));
+                    before->appendNewControlValue(m_proc, B3::Branch, m_origin, isLarge,
+                        { slowPath, FrequencyClass::Rare }, { fastAlloc, FrequencyClass::Normal });
+                }
 
-                auto* sizeClassOffset = fastAlloc->appendNew<Value>(m_proc, Mul, pointerType(), m_origin, sizeClassIndex, fastAlloc->appendNew<ConstPtrValue>(m_proc, m_origin, sizeof(Allocator)));
-                auto* allocatorBaseAddr = fastAlloc->appendNew<Value>(m_proc, Add, pointerType(), m_origin, instance, fastAlloc->appendNew<ConstPtrValue>(m_proc, m_origin, allocatorsBaseOffset));
-                auto* allocatorAddr = fastAlloc->appendNew<Value>(m_proc, Add, pointerType(), m_origin, allocatorBaseAddr, sizeClassOffset);
-                auto* allocator = fastAlloc->appendNew<MemoryValue>(m_proc, Load, pointerType(), m_origin, allocatorAddr, 0);
-                allocator->setControlDependent(false);
+                UpsilonValue* fastUpsilon = nullptr;
+                if (hasFastPath) {
+                    auto* sizeClassOffset = fastAlloc->appendNew<Value>(m_proc, Mul, pointerType(), m_origin, sizeClassIndex, fastAlloc->appendNew<ConstPtrValue>(m_proc, m_origin, sizeof(Allocator)));
+                    auto* allocatorBaseAddr = fastAlloc->appendNew<Value>(m_proc, Add, pointerType(), m_origin, instance, fastAlloc->appendNew<ConstPtrValue>(m_proc, m_origin, allocatorsBaseOffset));
+                    auto* allocatorAddr = fastAlloc->appendNew<Value>(m_proc, Add, pointerType(), m_origin, allocatorBaseAddr, sizeClassOffset);
+                    auto* allocator = fastAlloc->appendNew<MemoryValue>(m_proc, Load, pointerType(), m_origin, allocatorAddr, 0);
+                    allocator->setControlDependent(false);
 
-                PatchpointValue* patchpoint = emitWasmGCAllocationPatchpoint(fastAlloc, allocator, fastInit, slowPath);
+                    std::optional<unsigned> constantCellSize;
+                    if (isConstantSize)
+                        constantCellSize = MarkedSpace::s_sizeClassForSizeStep[MarkedSpace::sizeClassToIndex(constantSizeInBytes.value())];
+                    auto* cell = emitWasmGCAllocationPatchpoint(fastAlloc, allocator, fastInit, slowPath, constantCellSize);
 
-                auto* cell = patchpoint;
-                emitWasmGCCellInit(fastInit, cell, structureID, JSWebAssemblyArray::typeInfoBlob().blob());
+                    emitWasmGCCellInit(fastInit, cell, structureID, JSWebAssemblyArray::typeInfoBlob().blob());
 
-                auto* fastUpsilon = fastInit->appendNew<UpsilonValue>(m_proc, m_origin, cell);
-                fastInit->appendNewControlValue(m_proc, Jump, m_origin, mergeBlock);
+                    fastUpsilon = fastInit->appendNew<UpsilonValue>(m_proc, m_origin, cell);
+                    fastInit->appendNewControlValue(m_proc, Jump, m_origin, mergeBlock);
+                }
 
                 auto* slowUpsilon = emitWasmGCSlowPath(slowPath, mergeBlock, instance, typeIndex,
                     tagCFunction<OperationPtrTag>(Wasm::operationWasmArrayNewEmpty), Wasm::ExceptionType::BadArrayNew, size);
 
                 auto* phi = mergeBlock->appendNew<Value>(m_proc, Phi, pointerType(), m_origin);
-                fastUpsilon->setPhi(phi);
+                if (fastUpsilon)
+                    fastUpsilon->setPhi(phi);
                 slowUpsilon->setPhi(phi);
                 mergeBlock->appendNew<MemoryValue>(m_proc, Store, m_origin, size, phi, static_cast<int32_t>(JSWebAssemblyArray::offsetOfSize()));
 
@@ -1587,7 +1607,7 @@ private:
         return result;
     }
 
-    PatchpointValue* emitWasmGCAllocationPatchpoint(BasicBlock* allocBlock, Value* allocator, BasicBlock* fastInit, BasicBlock* slowPath)
+    PatchpointValue* emitWasmGCAllocationPatchpoint(BasicBlock* allocBlock, Value* allocator, BasicBlock* fastInit, BasicBlock* slowPath, std::optional<unsigned> constantCellSize = std::nullopt)
     {
         PatchpointValue* patchpoint = allocBlock->appendNew<PatchpointValue>(m_proc, pointerType(), m_origin);
         if (isARM64()) {
@@ -1612,7 +1632,8 @@ private:
             // AssemblyHelpers::emitAllocate(). That way, the same optimized path is shared by
             // all of the compiler tiers.
             jit.emitAllocateWithNonNullAllocator(
-                params[0].gpr(), JITAllocator::variableNonNull(), allocatorGPR, params.gpScratch(0),
+                params[0].gpr(), constantCellSize ? JITAllocator::variableNonNullWithConstantCellSize(*constantCellSize) : JITAllocator::variableNonNull(),
+                allocatorGPR, params.gpScratch(0),
                 jumpToSlowPath, CCallHelpers::SlowAllocationResult::UndefinedBehavior);
 
             CCallHelpers::Jump jumpToSuccess;

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -691,8 +691,10 @@ constexpr Effects constantEffectsForOpcode(Opcode opcode)
     case WasmBoundsCheck:
     case WasmStructGet:
     case WasmStructSet:
+    case WasmStructNew:
     case WasmArrayGet:
     case WasmArraySet:
+    case WasmArrayNew:
     case WasmArrayLength:
         return Effects::invalid();
     case Div:
@@ -709,16 +711,6 @@ constexpr Effects constantEffectsForOpcode(Opcode opcode)
     case CheckMul:
     case Check:
         result = Effects::forCheck();
-        break;
-    case WasmStructNew:
-        result.reads = HeapRange::top();
-        result.writes = HeapRange::top();
-        result.exitsSideways = true;
-        break;
-    case WasmArrayNew:
-        result.reads = HeapRange::top();
-        result.writes = HeapRange::top();
-        result.exitsSideways = true;
         break;
     case WasmRefCast:
         result.reads = HeapRange::top();
@@ -890,6 +882,19 @@ Effects Value::effectsSlow() const
         result.reads = as<WasmArrayLengthValue>()->range();
         result.controlDependent = true;
         result.readsMutability = Mutability::Immutable;
+        break;
+    case WasmStructNew:
+    case WasmArrayNew:
+        // Allocation can trap and can trigger GC, so it reads everything and exits sideways. It
+        // only stores into the object it just produced, which nothing loaded earlier can alias, so
+        // it need not clobber cached field loads. What it must clobber is the collector state a
+        // triggered GC updates: the barrier threshold and the mutator-fence flag. Every allocation
+        // site is followed by a mutator fence that branches on that flag and full-clobbers when
+        // set, so keeping the flag's load from being hoisted above the allocation is what makes
+        // the narrow write range sound for everything else, including cached cell states.
+        result.reads = HeapRange::top();
+        result.writes = opcode() == WasmStructNew ? as<WasmStructNewValue>()->range() : as<WasmArrayNewValue>()->range();
+        result.exitsSideways = true;
         break;
     default:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/b3/B3WasmArrayNewValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmArrayNewValue.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(B3_JIT)
 
+#include "B3Effects.h"
+#include "B3HeapRange.h"
 #include "B3Value.h"
 #include "WasmTypeDefinition.h"
 #include <wtf/StdLibExtras.h>
@@ -57,6 +59,10 @@ public:
 
     // Offset from instance for allocator lookup (pre-computed from ModuleInformation)
     int32_t allocatorsBaseOffset() const { return m_allocatorsBaseOffset; }
+
+    // The GC state that a collection triggered by this allocation may mutate.
+    const HeapRange& range() const { return m_range; }
+    void setRange(HeapRange range) { m_range = range; }
 
     B3_SPECIALIZE_VALUE_FOR_NON_VARARGS_CHILDREN
     B3_SPECIALIZE_VALUE_FOR_FINAL_SIZE_FIXED_CHILDREN
@@ -93,6 +99,7 @@ private:
     const Ref<const Wasm::RTT> m_rtt;
     uint32_t m_typeIndex;
     int32_t m_allocatorsBaseOffset;
+    HeapRange m_range { HeapRange::top() };
     bool m_hasInitValue;
 };
 

--- a/Source/JavaScriptCore/b3/B3WasmStructNewValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmStructNewValue.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(B3_JIT)
 
+#include "B3Effects.h"
+#include "B3HeapRange.h"
 #include "B3Value.h"
 #include "WasmTypeDefinition.h"
 #include <wtf/StdLibExtras.h>
@@ -52,6 +54,10 @@ public:
     // Offset from instance for allocator lookup (pre-computed from ModuleInformation)
     int32_t allocatorsBaseOffset() const { return m_allocatorsBaseOffset; }
 
+    // The GC state that a collection triggered by this allocation may mutate.
+    const HeapRange& range() const { return m_range; }
+    void setRange(HeapRange range) { m_range = range; }
+
     B3_SPECIALIZE_VALUE_FOR_FIXED_CHILDREN(2)
     B3_SPECIALIZE_VALUE_FOR_FINAL_SIZE_FIXED_CHILDREN
 
@@ -75,6 +81,7 @@ private:
     const Ref<const Wasm::RTT> m_rtt;
     uint32_t m_typeIndex;
     int32_t m_allocatorsBaseOffset;
+    HeapRange m_range { HeapRange::top() };
 };
 
 } // namespace JSC::B3

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -203,7 +203,7 @@ void* CompleteSubspace::reallocatePreciseAllocationNonVirtual(VM& vm, HeapCell* 
 
 void CompleteSubspace::prepareAllAllocators()
 {
-    for (unsigned i = MarkedSpace::numSizeClasses - 1; i--;) {
+    for (unsigned i = MarkedSpace::numSizeClasses; i--;) {
         if (!m_allocatorForSizeStep[i])
             allocatorForSlow(MarkedSpace::s_sizeClassForSizeStep[i]);
         ASSERT(m_allocatorForSizeStep[i]);

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -944,8 +944,8 @@ void AssemblyHelpers::emitAllocateWithNonNullAllocator(GPRReg resultGPR, const J
     loadPairPtr(allocatorGPR, TrustedImm32(LocalAllocator::offsetOfFreeList() + FreeList::offsetOfIntervalStart()), resultGPR, scratchGPR);
     popPath = branchPtr(RelationalCondition::AboveOrEqual, resultGPR, scratchGPR);
     auto bumpLabel = label();
-    if (allocator.isConstant())
-        addPtr(TrustedImm32(allocator.allocator().cellSize()), resultGPR, scratchGPR);
+    if (allocator.hasConstantCellSize())
+        addPtr(TrustedImm32(allocator.constantCellSize()), resultGPR, scratchGPR);
     else {
         load32(Address(allocatorGPR, LocalAllocator::offsetOfCellSize()), scratchGPR);
         addPtr(resultGPR, scratchGPR);
@@ -970,8 +970,8 @@ void AssemblyHelpers::emitAllocateWithNonNullAllocator(GPRReg resultGPR, const J
     loadPtr(Address(allocatorGPR, LocalAllocator::offsetOfFreeList() + FreeList::offsetOfIntervalStart()), resultGPR);
     popPath = branchPtr(RelationalCondition::AboveOrEqual, resultGPR, Address(allocatorGPR, LocalAllocator::offsetOfFreeList() + FreeList::offsetOfIntervalEnd()));
     auto bumpLabel = label();
-    if (allocator.isConstant())
-        add64(TrustedImm32(allocator.allocator().cellSize()), Address(allocatorGPR, LocalAllocator::offsetOfFreeList() + FreeList::offsetOfIntervalStart()));
+    if (allocator.hasConstantCellSize())
+        add64(TrustedImm32(allocator.constantCellSize()), Address(allocatorGPR, LocalAllocator::offsetOfFreeList() + FreeList::offsetOfIntervalStart()));
     else {
         load32(Address(allocatorGPR, LocalAllocator::offsetOfCellSize()), scratchGPR);
         add64(scratchGPR, Address(allocatorGPR, LocalAllocator::offsetOfFreeList() + FreeList::offsetOfIntervalStart()));
@@ -999,9 +999,9 @@ void AssemblyHelpers::emitAllocateWithNonNullAllocator(GPRReg resultGPR, const J
     loadPtr(Address(allocatorGPR, LocalAllocator::offsetOfFreeList() + FreeList::offsetOfIntervalEnd()), scratchGPR);
     popPath = branchPtr(RelationalCondition::AboveOrEqual, resultGPR, scratchGPR);
     auto bumpLabel = label();
-    if (allocator.isConstant()) {
+    if (allocator.hasConstantCellSize()) {
         move(resultGPR, scratchGPR);
-        addPtr(TrustedImm32(allocator.allocator().cellSize()), scratchGPR);
+        addPtr(TrustedImm32(allocator.constantCellSize()), scratchGPR);
     } else {
         load32(Address(allocatorGPR, LocalAllocator::offsetOfCellSize()), scratchGPR);
         addPtr(resultGPR, scratchGPR);
@@ -1048,6 +1048,7 @@ void AssemblyHelpers::emitAllocate(GPRReg resultGPR, const JITAllocator& allocat
         slowPath.append(branchTestPtr(Zero, allocatorGPR));
         break;
     case JITAllocator::VariableNonNull:
+    case JITAllocator::VariableNonNullWithConstantCellSize:
         break;
     }
 

--- a/Source/JavaScriptCore/jit/JITAllocator.h
+++ b/Source/JavaScriptCore/jit/JITAllocator.h
@@ -36,38 +36,56 @@ public:
         Constant,
         Variable,
         VariableNonNull,
+        VariableNonNullWithConstantCellSize,
     };
     using enum Kind;
-    
+
     JITAllocator() = default;
-    
+
     static JITAllocator constant(Allocator allocator)
     {
         JITAllocator result(Constant);
         result.m_allocator = allocator;
         return result;
     }
-    
+
     static JITAllocator variable() { return JITAllocator(Variable); }
     static JITAllocator variableNonNull() { return JITAllocator(VariableNonNull); }
-    
+
+    static JITAllocator variableNonNullWithConstantCellSize(unsigned cellSize)
+    {
+        JITAllocator result(VariableNonNullWithConstantCellSize);
+        result.m_cellSize = cellSize;
+        return result;
+    }
+
     friend bool operator==(const JITAllocator&, const JITAllocator&) = default;
-    
+
     explicit operator bool() const
     {
         return *this != JITAllocator();
     }
-    
+
     Kind kind() const { return m_kind; }
     bool isConstant() const { return m_kind == Constant; }
     bool isVariable() const { return m_kind != Constant; }
-    
+
+    bool hasConstantCellSize() const { return m_kind == Constant || m_kind == VariableNonNullWithConstantCellSize; }
+
+    unsigned constantCellSize() const
+    {
+        RELEASE_ASSERT(hasConstantCellSize());
+        if (m_kind == Constant)
+            return m_allocator.cellSize();
+        return m_cellSize;
+    }
+
     Allocator allocator() const
     {
         RELEASE_ASSERT(isConstant());
         return m_allocator;
     }
-    
+
 private:
     JITAllocator(Kind kind)
         : m_kind(kind)
@@ -75,6 +93,7 @@ private:
 
     Kind m_kind { Constant };
     Allocator m_allocator;
+    unsigned m_cellSize { 0 };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -1463,7 +1463,7 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, TypeSignatureInd
             size_t sizeClassIndex = MarkedSpace::sizeClassToIndex(sizeInBytes.value());
             m_jit.loadPtr(allocatorBufferBase.withOffset(sizeClassIndex * sizeof(Allocator)), scratchGPR2);
             JIT_COMMENT(m_jit, "Do array allocation constant sized");
-            m_jit.emitAllocateWithNonNullAllocator(resultGPR, JITAllocator::variableNonNull(), scratchGPR2, scratchGPR, slowPath, AssemblyHelpers::SlowAllocationResult::UndefinedBehavior);
+            m_jit.emitAllocateWithNonNullAllocator(resultGPR, JITAllocator::variableNonNullWithConstantCellSize(MarkedSpace::s_sizeClassForSizeStep[sizeClassIndex]), scratchGPR2, scratchGPR, slowPath, AssemblyHelpers::SlowAllocationResult::UndefinedBehavior);
             m_jit.load32(structureIDAddress, scratchGPR);
             m_jit.move(TrustedImm32(JSWebAssemblyArray::typeInfoBlob().blob()), scratchGPR2);
             static_assert(JSCell::structureIDOffset() + sizeof(int32_t) == JSCell::indexingTypeAndMiscOffset());
@@ -2001,7 +2001,7 @@ void BBQJIT::emitAllocateGCStructUninitialized(GPRReg resultGPR, TypeSignatureIn
         size_t sizeClassIndex = MarkedSpace::sizeClassToIndex(sizeInBytes);
         m_jit.loadPtr(allocatorBufferBase.withOffset(sizeClassIndex * sizeof(Allocator)), scratchGPR2);
         JIT_COMMENT(m_jit, "Do struct allocation");
-        m_jit.emitAllocateWithNonNullAllocator(resultGPR, JITAllocator::variableNonNull(), scratchGPR2, scratchGPR, slowPath, AssemblyHelpers::SlowAllocationResult::UndefinedBehavior);
+        m_jit.emitAllocateWithNonNullAllocator(resultGPR, JITAllocator::variableNonNullWithConstantCellSize(MarkedSpace::s_sizeClassForSizeStep[sizeClassIndex]), scratchGPR2, scratchGPR, slowPath, AssemblyHelpers::SlowAllocationResult::UndefinedBehavior);
         m_jit.load32(structureIDAddress, scratchGPR);
         m_jit.move(TrustedImm32(JSWebAssemblyStruct::typeInfoBlob().blob()), scratchGPR2);
         static_assert(JSCell::structureIDOffset() + sizeof(int32_t) == JSCell::indexingTypeAndMiscOffset());

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -3674,6 +3674,7 @@ auto OMGIRGenerator::addArrayNew(TypeSignatureIndex typeIndex, ExpressionType si
     m_proc.setUsesWasmGCArrayAllocations();
 
     auto* array = m_currentBlock->appendNew<WasmArrayNewValue>(m_proc, origin(), wasmRefType(), Ref { rtt }, typeIndex.rawIndex(), allocatorsBaseOffset, instanceValue(), structureID, sizeValue, initValue);
+    m_heaps.decorateWasmArrayNew(&m_heaps.VM_heapState, array);
 
     mutatorFence();
     result = push(array);
@@ -3715,6 +3716,7 @@ auto OMGIRGenerator::addArrayNewDefault(TypeSignatureIndex typeIndex, Expression
     m_proc.setUsesWasmGCArrayAllocations();
 
     auto* array = m_currentBlock->appendNew<WasmArrayNewValue>(m_proc, origin(), wasmRefType(), Ref { rtt }, typeIndex.rawIndex(), allocatorsBaseOffset, instanceValue(), structureID, sizeValue, initValue);
+    m_heaps.decorateWasmArrayNew(&m_heaps.VM_heapState, array);
 
     mutatorFence();
     result = push(array);
@@ -3748,6 +3750,7 @@ auto OMGIRGenerator::addArrayNewFixed(TypeSignatureIndex typeIndex, ArgumentList
     m_proc.setUsesWasmGCArrayAllocations();
 
     auto* object = m_currentBlock->appendNew<WasmArrayNewValue>(m_proc, origin(), wasmRefType(), Ref { rtt }, typeIndex.rawIndex(), allocatorsBaseOffset, instanceValue(), structureID, size);
+    m_heaps.decorateWasmArrayNew(&m_heaps.VM_heapState, object);
 
     for (uint32_t i = 0; i < args.size(); ++i) {
         // Emit the array set code -- note that this omits the bounds check, since
@@ -4038,6 +4041,7 @@ auto OMGIRGenerator::addStructNew(TypeSignatureIndex typeIndex, ArgumentList& ar
     m_proc.setUsesWasmGCStructAllocations();
 
     auto* structNew = m_currentBlock->appendNew<WasmStructNewValue>(m_proc, origin(), wasmRefType(), Ref { rtt }, typeIndex.rawIndex(), allocatorsBaseOffset, instanceValue(), structureID);
+    m_heaps.decorateWasmStructNew(&m_heaps.VM_heapState, structNew);
 
     for (uint32_t i = 0; i < args.size(); ++i) {
         bool needsWriteBarrier = emitStructSet(/* canTrap */ false, structNew, i, rtt, get(args[i]));
@@ -4058,6 +4062,7 @@ auto OMGIRGenerator::addStructNewDefault(TypeSignatureIndex typeIndex, Expressio
     m_proc.setUsesWasmGCStructAllocations();
 
     auto* structNew = m_currentBlock->appendNew<WasmStructNewValue>(m_proc, origin(), wasmRefType(), Ref { rtt }, typeIndex.rawIndex(), allocatorsBaseOffset, instanceValue(), structureID);
+    m_heaps.decorateWasmStructNew(&m_heaps.VM_heapState, structNew);
 
     for (StructFieldCount i = 0; i < rtt.fieldCount(); ++i) {
         Value* initValue;


### PR DESCRIPTION
#### 6589b2e5c18c0a0d4180c0e77ad2fb46f4be0d46
<pre>
[JSC] Tighten WasmGC allocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=321522">https://bugs.webkit.org/show_bug.cgi?id=321522</a>
<a href="https://rdar.apple.com/184632964">rdar://184632964</a>

Reviewed by Yijia Huang.

This patch tightens WasmGC allocations.

1. While allocator is not a constant in WasmGC struct allocations (it is
   coming from JSWebAssemblyInstance field), size is constant when
   compiling. We add VariableNonNullWithConstantCellSize mode, which
   means that &quot;allocator is in GPR as a variable, but cell size is constant&quot;
   to tighten the code generation.
2. We revisit effect model of WasmGC allocations, now it is more aligned
   to DFG&apos;s allocations (not saying write-top).
3. We also fold WasmGC array allocations with constant size too.

Tests: JSTests/wasm/gc/struct-new-does-not-clobber-loads.js
       JSTests/wasm/gc/struct-new-nested-alloc-gc.js

* JSTests/wasm/gc/array-new-constant-size.js: Added.
(get return):
(make):
(get for):
* JSTests/wasm/gc/struct-new-does-not-clobber-loads.js: Added.
* JSTests/wasm/gc/struct-new-nested-alloc-gc.js: Added.
(want):
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp:
(JSC::B3::AbstractHeapRepository::AbstractHeapRepository):
(JSC::B3::AbstractHeapRepository::decorateWasmStructNew):
(JSC::B3::AbstractHeapRepository::decorateWasmArrayNew):
(JSC::B3::AbstractHeapRepository::computeRangesAndDecorateInstructions):
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effectsSlow const):
* Source/JavaScriptCore/b3/B3WasmArrayNewValue.h:
* Source/JavaScriptCore/b3/B3WasmStructNewValue.h:
* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::prepareAllAllocators):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::emitAllocateWithNonNullAllocator):
(JSC::AssemblyHelpers::emitAllocate):
* Source/JavaScriptCore/jit/JITAllocator.h:
(JSC::JITAllocator::variableNonNullWithConstantCellSize):
(JSC::JITAllocator::hasConstantCellSize const):
(JSC::JITAllocator::constantCellSize const):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCArrayUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCStructUninitialized):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addArrayNew):
(JSC::Wasm::OMGIRGenerator::addArrayNewDefault):
(JSC::Wasm::OMGIRGenerator::addArrayNewFixed):
(JSC::Wasm::OMGIRGenerator::addStructNew):
(JSC::Wasm::OMGIRGenerator::addStructNewDefault):

Canonical link: <a href="https://commits.webkit.org/319020@main">https://commits.webkit.org/319020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6053356f10aab9df7aa803f03942bc4daa99171c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190392 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144499 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12b757a1-79da-4c36-a41b-10d3ca53df0e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140525 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14c107bd-c976-451c-a13d-629005e8d554) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120977 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a9ed537-b44a-4cf4-b3e6-732e5b269cf4) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/179505 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2944 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9794 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40838 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1551 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41455 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192326 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53792 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149878 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54480 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37450 "Too many flaky failures: http/tests/media/now-playing-info-private-browsing.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/privateClickMeasurement/store-private-click-measurement-nested.html, http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/report-status-code-zero-when-using-https.html, http/tests/security/mixedContent/redirect-https-to-http-script-in-iframe-UpgradeMixedContent.html, http/tests/site-isolation/frame-index.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149605 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27362 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44242 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126743 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121878 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52997 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15827 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52379 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52616 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52444 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->