### PR TITLE
Web Inspector: [SI] frame target IDs use a different format than protocol frame IDs

### DIFF
--- a/Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.cpp
@@ -30,10 +30,10 @@
 #include "WebFrame.h"
 #include "WebPage.h"
 #include <WebCore/FrameInspectorController.h>
+#include <WebCore/InspectorIdentifierRegistry.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/LocalFrameInlines.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/text/MakeString.h>
 
 namespace WebKit {
 
@@ -92,7 +92,11 @@ void FrameInspectorTarget::sendMessageToTargetBackend(const String& message)
 
 String FrameInspectorTarget::toTargetID(WebCore::FrameIdentifier frameID, WebCore::ProcessIdentifier processID)
 {
-    return makeString("frame-"_s, frameID.toUInt64(), '-', processID.toUInt64());
+    // Must match IdentifierRegistry::protocolFrameId(), the source of frame IDs in the Page,
+    // Network, DOM and CSS domains. This used to emit "frame-<frameID>-<processID>" while that
+    // emits "frame-<processID>.<frameID>", so the same frame had two spellings and only the dotted
+    // form round-tripped through parseProtocolFrameId().
+    return Inspector::IdentifierRegistry::protocolFrameId(frameID, processID);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 22e714b84eed9d2772a640c4e42a4cb7fe35bd10
<pre>
Web Inspector: [SI] frame target IDs use a different format than protocol frame IDs
<a href="https://bugs.webkit.org/show_bug.cgi?id=321097">https://bugs.webkit.org/show_bug.cgi?id=321097</a>
<a href="https://rdar.apple.com/184137297">rdar://184137297</a>

Reviewed by NOBODY (OOPS!).

FrameInspectorTarget::toTargetID() emitted &quot;frame-&lt;frameID&gt;-&lt;processID&gt;&quot; while
IdentifierRegistry::protocolFrameId() -- the source of frame IDs in the Page,
Network, DOM and CSS domains -- emits &quot;frame-&lt;processID&gt;.&lt;frameID&gt;&quot;, so the same
frame had two spellings and only the dotted form round-tripped through
parseProtocolFrameId(). Delegate to protocolFrameId(). No behavior change: the
target identifier is used only as a routing key, nothing parses the hyphenated
form, and existing consumers key off colon-delimited
`${target.identifier}:${rawId}` composites.

* Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.cpp:
(WebKit::FrameInspectorTarget::toTargetID):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22e714b84eed9d2772a640c4e42a4cb7fe35bd10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190272 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144379 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140423 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120874 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42750 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41066 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40732 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1429 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46605 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192204 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53672 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149765 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54359 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149496 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44137 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126622 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121731 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52876 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15720 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52259 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52496 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52322 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->