### PR TITLE
[Navigation API] navigateerror is not fired for a navigation started from a navigateerror handler

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7127,8 +7127,6 @@ imported/w3c/web-platform-tests/navigation-api/navigate-event/dangling-navigate-
 
 # Out of target of Interop 2025.
 imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-infinite.optional.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-history-pushState.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-location.html [ Skip ]
 
 # Require enabling CSS Scroll Anchoring
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-history-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-history-pushState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL history.pushState() called multiple times gives correct event order assert_array_equals: lengths differ, expected array ["navigate #1", "navigateerror #1", "navigate #3", "navigateerror #3", "navigate #2", "navigatesuccess #2"] length 6, got ["navigate #1", "navigateerror #1", "navigate #3", "navigate #2", "navigatesuccess #2"] length 5
+PASS history.pushState() called multiple times gives correct event order
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-location-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-location-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL location.href set multiple times gives correct event order assert_array_equals: lengths differ, expected array ["navigate #1", "navigateerror #1", "navigate #3", "navigateerror #3", "navigate #2", "navigatesuccess #2"] length 6, got ["navigate #1", "navigateerror #1", "navigate #3", "navigate #2", "navigatesuccess #2"] length 5
+PASS location.href set multiple times gives correct event order
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-navigation-navigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-navigation-navigate-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigation.navigate() multiple times gives correct event order assert_array_equals: lengths differ, expected array ["navigate #1", "navigateerror #1", "navigate #3", "navigateerror #3", "navigate #2", "navigatesuccess #2"] length 6, got ["navigate #1", "navigateerror #1", "navigate #3", "navigate #2", "navigatesuccess #2"] length 5
+PASS navigation.navigate() multiple times gives correct event order
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-nested-navigateerror-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-nested-navigateerror-expected.txt
@@ -1,0 +1,3 @@
+
+PASS aborting a navigation repeatedly aborts navigations started from navigateerror handlers
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-nested-navigateerror.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-nested-navigateerror.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(t => {
+  const expected = [
+    "navigate #1",
+    "navigateerror #1",
+    "navigate #3",
+    "navigateerror #3",
+    "navigate #4",
+    "navigateerror #4",
+    "navigate #5",
+    "navigateerror #5",
+    "navigate #2",
+    "navigatesuccess #2"
+  ];
+
+  // Each navigateerror handler starts a navigation of its own, so aborting the ongoing navigate
+  // event leaves behind a new one that must be aborted in turn.
+  const nextHash = { "#1": "#3", "#3": "#4", "#4": "#5" };
+
+  const result = [];
+  navigation.onnavigate = t.step_func(e => {
+    result.push(`${e.type} ${new URL(e.destination.url).hash}`);
+  });
+
+  navigation.onnavigateerror = t.step_func(e => {
+    const hash = new URL(navigation.currentEntry.url).hash;
+    result.push(`${e.type} ${hash}`);
+
+    if (nextHash[hash])
+      navigation.navigate(nextHash[hash]);
+  });
+
+  navigation.onnavigatesuccess = t.step_func_done(e => {
+    result.push(`${e.type} ${new URL(navigation.currentEntry.url).hash}`);
+    assert_array_equals(result, expected);
+  });
+
+  navigation.navigate("#1");
+  navigation.navigate("#2");
+
+}, "aborting a navigation repeatedly aborts navigations started from navigateerror handlers");
+</script>

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1616,8 +1616,12 @@ bool Navigation::dispatchDownloadNavigateEvent(const URL& url, const String& dow
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inform-the-navigation-api-about-aborting-navigation
 void Navigation::abortOngoingNavigationIfNeeded()
 {
-    if (RefPtr ongoingNavigateEvent = m_ongoingNavigateEvent)
+    while (RefPtr ongoingNavigateEvent = m_ongoingNavigateEvent) {
         abortOngoingNavigation(*ongoingNavigateEvent);
+        // abortOngoingNavigation() bails without clearing the event when there is no global object.
+        if (m_ongoingNavigateEvent == ongoingNavigateEvent)
+            break;
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inform-the-navigation-api-about-child-navigable-destruction


### PR DESCRIPTION
#### d51804111884ac3c7870c8fc24b1e5b36056aa3f
<pre>
[Navigation API] navigateerror is not fired for a navigation started from a navigateerror handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=321526">https://bugs.webkit.org/show_bug.cgi?id=321526</a>
<a href="https://rdar.apple.com/184633618">rdar://184633618</a>

Reviewed by Rupin Mittal.

The inner navigate event firing algorithm aborts the ongoing navigate event
before it starts, which fires navigateerror synchronously. A navigateerror
handler is free to start a navigation of its own, and that nested navigation runs
the whole algorithm to completion, leaving its own event as navigation&apos;s ongoing
navigate event.

The outer navigation then overwrote that with its own event without aborting it
first, so the nested navigation was silently dropped and never fired
navigateerror. Since the nested navigateerror handler can start yet another
navigation, aborting a second time is not enough either. Follow the spec and keep
aborting in a loop until there is no ongoing navigate event left, bailing out if
abortOngoingNavigation() left the event in place because there was no global
object.

* LayoutTests/TestExpectations: Unskip now passing tests
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-history-pushState-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-location-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-navigation-navigate-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-nested-navigateerror-expected.txt: Added
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-nested-navigateerror.html: Added
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::abortOngoingNavigationIfNeeded):

Canonical link: <a href="https://commits.webkit.org/319222@main">https://commits.webkit.org/319222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/654d8a2eb7a8f244b19fa92333de1c92d42de4af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145147 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3137772-bf26-44d2-bdee-748485a6a972) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141055 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/377ccbcc-d16b-459a-be3c-0053cf0dadf0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121507 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65a4381f-3857-406e-ab15-8e439a3be4f2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41338 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2198 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192973 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150441 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40266 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55123 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150159 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44750 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127389 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122689 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53640 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16331 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53022 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53259 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->