### PR TITLE
Fetch dictionaries declared by rel=compression-dictionary and Link headers

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8198,7 +8198,7 @@ imported/w3c/web-platform-tests/css/css-shapes/shape-outside/supported-shapes/sh
 
 webkit.org/b/317017 imported/w3c/web-platform-tests/largest-contentful-paint/multiple-redirects-TAO.html [ Pass Failure ]
 
-# Compression Dictionary Transport is not implemented, so these time out waiting for a dictionary load that never happens.
+# Compression Dictionary Transport is not fully implemented, so these fail waiting for a dictionary that is never registered.
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/compressed-large-resources-001.tentative.https.html [ Skip ]
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/compressed-large-resources-002.tentative.https.html [ Skip ]
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/compressed-large-resources-dictionary-hashes.tentative.https.html [ Skip ]
@@ -8210,23 +8210,12 @@ webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-decompression.tentative.https.h2.html [ Skip ]
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-decompression.tentative.https.html [ Skip ]
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https.html [ Skip ]
-webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-timing-001.tentative.https.html [ Skip ]
-webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-timing-002.tentative.https.html [ Skip ]
-webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-imagesrcset.tentative.https.html [ Skip ]
-webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src-nonce.tentative.https.html [ Skip ]
-webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src.tentative.https.html [ Skip ]
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element-baseURL.tentative.https.html [ Skip ]
-webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element-crossorigin.tentative.https.html [ Skip ]
-webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element-events.tentative.https.html [ Skip ]
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element-in-body.tentative.https.html [ Skip ]
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element.tentative.https.html [ Skip ]
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-header.tentative.https.html [ Skip ]
-webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-integrity.tentative.https.html [ Skip ]
-webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-referrer-and-referrerpolicy.tentative.https.html [ Skip ]
-webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-type-attribute.tentative.https.html [ Skip ]
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-match.tentative.https.html [ Skip ]
 webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-registration.tentative.https.html [ Skip ]
-webkit.org/b/295249 imported/w3c/web-platform-tests/fetch/compression-dictionary/fetch-destination.tentative.https.html [ Skip ]
 
 # Early Hints preload is not implemented, so these time out waiting for a preload that never happens.
 imported/w3c/web-platform-tests/loading/early-hints/preload-finished-before-final-response.h2.window.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-timing-001.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-timing-001.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Timing of compression dictionary fetches for <link> element and Link header.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-timing-002.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-timing-002.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS <link rel=compression-dictionary> are fetched after DOM operations.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-imagesrcset.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-imagesrcset.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS imagesrcset is not supported on <link rel=compression-dictionary>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src-nonce.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src-nonce.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS All <link rel=compression-dictionary> are blocked via CSP rule connect-src 'nonce-abc', even when they have a matching cryptographic nonce.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS link rel=compression-dictionary can be blocked via connect-src.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element-crossorigin.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element-crossorigin.tentative.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Initialize global state
+PASS HTMLLinkElement rel=compression-dictionary
+PASS HTMLLinkElement rel=compression-dictionary crossorigin=anonymous
+PASS HTMLLinkElement rel=compression-dictionary crossorigin=use-credentials
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element-events.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element-events.tentative.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Load event is dispatched on link with rel=compression-dictionary.
+PASS Error event is dispatched on link with rel=compression-dictionary returning a network error.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-integrity.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-integrity.tentative.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Initialize global state
+PASS HTMLLinkElement rel=compression-dictionary, integrity attribute is ignored.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-referrer-and-referrerpolicy.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-referrer-and-referrerpolicy.tentative.https-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Initialize global state
+PASS HTMLLinkElement rel=compression-dictionary (no referrerpolicy attribute)
+PASS HTMLLinkElement rel=compression-dictionary (referrerpolicy='')
+PASS HTMLLinkElement rel=compression-dictionary (referrerpolicy='no-referrer')
+PASS HTMLLinkElement rel=compression-dictionary (referrerpolicy='no-referrer-when-downgrade')
+PASS HTMLLinkElement rel=compression-dictionary (referrerpolicy='same-origin')
+PASS HTMLLinkElement rel=compression-dictionary (referrerpolicy='origin')
+PASS HTMLLinkElement rel=compression-dictionary (referrerpolicy='strict-origin')
+PASS HTMLLinkElement rel=compression-dictionary (referrerpolicy='origin-when-cross-origin')
+PASS HTMLLinkElement rel=compression-dictionary (referrerpolicy='strict-origin-when-cross-origin')
+PASS HTMLLinkElement rel=compression-dictionary (referrerpolicy='unsafe-url')
+PASS HTMLLinkElement rel=compression-dictionary (referrerpolicy='invalid')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-type-attribute.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-type-attribute.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS <link rel=compression-dictionary> are fetched independently of the type.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/fetch-destination.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/fetch-destination.tentative.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Initialize global state
+PASS HTMLLinkElement with rel=compression-dictionary fetches with a "compression-dictionary" string Request.destination
+

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2193,6 +2193,21 @@ CompositingRepaintCountersVisible:
     WebCore:
       default: false
 
+CompressionDictionaryEnabled:
+  type: bool
+  status: testable
+  category: networking
+  humanReadableName: "Compression Dictionary Transport"
+  humanReadableDescription: "Enable compression dictionary transport"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 CompressionStreamEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/Modules/fetch/FetchRequestDestination.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequestDestination.idl
@@ -27,10 +27,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-enum FetchRequestDestination {
+[
+    ExportMacro=WEBCORE_EXPORT
+] enum FetchRequestDestination {
     "",
     "audio",
     "audioworklet",
+    "compression-dictionary",
     "document",
     "embed",
     "environmentmap",

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -185,6 +185,7 @@
 #include "LayoutDisallowedScope.h"
 #include "LazyLoadImageObserver.h"
 #include "LegacySchemeRegistry.h"
+#include "LinkLoader.h"
 #include "LoadableSpeculationRules.h"
 #include "LoaderStrategy.h"
 #include "LocalDOMWindow.h"
@@ -7122,6 +7123,8 @@ void Document::dispatchWindowLoadEvent()
     protect(window())->dispatchLoadEvent();
     m_loadEventFinished = true;
 
+    flushPendingCompressionDictionaryLoads();
+
     // A subframe that finished loading without ever being laid out was hidden (e.g. parent had
     // display:none); note that so the first layout can fire resize for the 0x0 to actual size change.
     if (RefPtr frameView = view()) {
@@ -8244,6 +8247,38 @@ Ref<HTMLCollection> Document::documentNamedItems(const AtomString& name)
 Ref<NodeList> Document::getElementsByName(const AtomString& elementName)
 {
     return ensureRareData().ensureNodeLists().addCacheWithAtomName<NameNodeList>(*this, elementName);
+}
+
+void Document::queueCompressionDictionaryLoad(Function<void()>&& load)
+{
+    if (!m_loadEventFinished) {
+        m_pendingCompressionDictionaryLoads.append(WTF::move(load));
+        return;
+    }
+    eventLoop().queueTask(TaskSource::Networking, WTF::move(load));
+}
+
+// Dictionary fetches must not compete with the page's critical-path loads, so they are held back
+// until the load event has been dispatched: those from <link> elements, and those named by this
+// document's own Link headers, which are only looked at for dictionaries here.
+void Document::flushPendingCompressionDictionaryLoads()
+{
+    ASSERT(m_loadEventFinished);
+
+    if (!settings().compressionDictionaryEnabled())
+        return;
+
+    if (RefPtr documentLoader = loader()) {
+        auto linkHeader = documentLoader->response().httpHeaderField(HTTPHeaderName::Link);
+        if (!linkHeader.isEmpty()) {
+            m_pendingCompressionDictionaryLoads.append([document = Ref { *this }, linkHeader = WTF::move(linkHeader)] {
+                LinkLoader::loadCompressionDictionariesFromHeader(linkHeader, document->url(), document);
+            });
+        }
+    }
+
+    for (auto& load : std::exchange(m_pendingCompressionDictionaryLoads, { }))
+        eventLoop().queueTask(TaskSource::Networking, WTF::move(load));
 }
 
 void Document::finishedParsing()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1361,6 +1361,8 @@ public:
 
     void finishedParsing();
 
+    void queueCompressionDictionaryLoad(Function<void()>&&);
+
     enum BackForwardCacheState : uint8_t { NotInBackForwardCache, AboutToEnterBackForwardCache, InBackForwardCache };
 
     BackForwardCacheState backForwardCacheState() const { return m_backForwardCacheState; }
@@ -2148,6 +2150,8 @@ private:
     friend class ThrowOnDynamicMarkupInsertionCountIncrementer;
     friend class UnloadCountIncrementer;
 
+    void flushPendingCompressionDictionaryLoads();
+
     void updateTitleElement(Element& changingTitleElement);
     void willDetachPage() final;
     void frameDestroyed() final;
@@ -2775,6 +2779,8 @@ private:
     // and should be merged.
     bool m_processingLoadEvent { false };
     bool m_loadEventFinished { false };
+
+    Vector<Function<void()>> m_pendingCompressionDictionaryLoads;
 
     bool m_visuallyOrdered { false };
     bool m_bParsing { false }; // FIXME: rename

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -246,6 +246,13 @@ void HTMLLinkElement::attributeChanged(const QualifiedName& name, const AtomStri
             m_styleScope->didChangeActiveStyleSheetCandidates();
         break;
     }
+    case AttributeNames::crossoriginAttr:
+        HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
+        // Only compression-dictionary lists crossorigin among its appropriate times to fetch:
+        // https://html.spec.whatwg.org/multipage/links.html#link-type-compression-dictionary
+        if (oldValue != newValue && m_relAttribute.isCompressionDictionary)
+            process();
+        break;
     case AttributeNames::disabledAttr:
         setDisabledState(!newValue.isNull());
         break;
@@ -402,6 +409,11 @@ void HTMLLinkElement::process()
         // we no longer contain a stylesheet, e.g. perhaps rel or type was changed
         clearSheet();
         protect(m_styleScope)->didChangeActiveStyleSheetCandidates();
+        return;
+    }
+
+    if (m_relAttribute.isCompressionDictionary) {
+        m_linkLoader->loadCompressionDictionaryLink(params, document);
         return;
     }
 

--- a/Source/WebCore/html/LinkRelAttribute.cpp
+++ b/Source/WebCore/html/LinkRelAttribute.cpp
@@ -53,6 +53,9 @@ static constexpr SortedArrayMap linkTypes { WTF::toArray<std::pair<ComparableLet
     { "alternate"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isAlternate = true; } } },
     { "apple-touch-icon"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.iconType = LinkIconType::TouchIcon; } } },
     { "apple-touch-icon-precomposed"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.iconType = LinkIconType::TouchPrecomposedIcon; } } },
+    { "compression-dictionary"_s, {
+        [](auto document) { return document.settings().compressionDictionaryEnabled(); },
+        [](auto relAttribute) { relAttribute.isCompressionDictionary = true; } } },
     { "dns-prefetch"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isDNSPrefetch = true; } } },
     { "expect"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isInternalResourceLink = true; } } },
     { "icon"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.iconType = LinkIconType::Favicon; } } },

--- a/Source/WebCore/html/LinkRelAttribute.h
+++ b/Source/WebCore/html/LinkRelAttribute.h
@@ -53,6 +53,7 @@ struct LinkRelAttribute {
     bool isApplicationManifest : 1 { false };
 #endif
     bool isInternalResourceLink : 1 { false };
+    bool isCompressionDictionary : 1 { false };
 
     LinkRelAttribute() = default;
     LinkRelAttribute(Document&, StringView);

--- a/Source/WebCore/loader/FetchOptions.h
+++ b/Source/WebCore/loader/FetchOptions.h
@@ -133,6 +133,7 @@ template<> struct EnumTraitsForPersistence<WebCore::FetchOptions::Destination> {
         WebCore::FetchOptions::Destination::EmptyString,
         WebCore::FetchOptions::Destination::Audio,
         WebCore::FetchOptions::Destination::Audioworklet,
+        WebCore::FetchOptions::Destination::CompressionDictionary,
         WebCore::FetchOptions::Destination::Document,
         WebCore::FetchOptions::Destination::Embed,
         WebCore::FetchOptions::Destination::Environmentmap,

--- a/Source/WebCore/loader/FetchOptionsDestination.h
+++ b/Source/WebCore/loader/FetchOptionsDestination.h
@@ -31,6 +31,7 @@ enum class FetchOptionsDestination : uint8_t {
     EmptyString,
     Audio,
     Audioworklet,
+    CompressionDictionary,
     Document,
     Embed,
     Environmentmap,

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -35,6 +35,7 @@
 
 #include "CSSStyleSheet.h"
 #include "CachedCSSStyleSheet.h"
+#include "CachedRawResource.h"
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
 #include "ContainerNode.h"
@@ -86,6 +87,8 @@ LinkLoader::~LinkLoader()
     if (RefPtr cachedLinkResource = m_cachedLinkResource)
         cachedLinkResource->removeClient(*this);
     if (RefPtr client = m_preloadResourceClient)
+        client->clear();
+    if (RefPtr client = m_compressionDictionaryLoadResourceClient)
         client->clear();
 }
 
@@ -146,6 +149,32 @@ void LinkLoader::loadLinksFromHeader(const String& headerValue, const URL& baseU
     }
 }
 
+void LinkLoader::loadCompressionDictionariesFromHeader(const String& headerValue, const URL& baseURL, Document& document)
+{
+    if (headerValue.isEmpty())
+        return;
+    LinkHeaderSet headerSet(headerValue);
+    for (auto& header : headerSet) {
+        if (!header.valid() || header.url().isEmpty() || header.rel().isEmpty())
+            continue;
+
+        LinkRelAttribute relAttribute(document, header.rel());
+        if (!relAttribute.isCompressionDictionary)
+            continue;
+
+        URL url(baseURL, header.url());
+        // Sanity check to avoid re-entrancy here.
+        if (equalIgnoringFragmentIdentifier(url, baseURL))
+            continue;
+
+        auto fetchPriority = parseEnumerationFromString<RequestPriority>(header.fetchPriority()).value_or(RequestPriority::Auto);
+        LinkLoadParameters params { relAttribute, url, header.as(), header.media(), header.mimeType(), header.crossOrigin(), header.imageSrcSet(), header.imageSizes(), header.nonce(),
+            parseReferrerPolicy(header.referrerPolicy(), ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString), fetchPriority };
+
+        loadCompressionDictionaryIfNeeded(params, document, nullptr);
+    }
+}
+
 std::optional<CachedResource::Type> LinkLoader::resourceTypeFromAsAttribute(const String& as, Document& document, ShouldLog shouldLogError, IsModulePreload isModulePreload)
 {
     if (equalLettersIgnoringASCIICase(as, "fetch"_s))
@@ -169,6 +198,8 @@ std::optional<CachedResource::Type> LinkLoader::resourceTypeFromAsAttribute(cons
     case FetchRequestDestination::Audioworklet:
         return CachedResource::Type::Script;
     case FetchRequestDestination::Document:
+        return std::nullopt;
+    case FetchRequestDestination::CompressionDictionary:
         return std::nullopt;
     case FetchRequestDestination::Embed:
         return std::nullopt;
@@ -469,6 +500,8 @@ void LinkLoader::cancelLoad()
 {
     if (RefPtr client = m_preloadResourceClient)
         client->clear();
+    if (RefPtr client = m_compressionDictionaryLoadResourceClient)
+        client->clear();
 }
 
 void LinkLoader::loadLink(const LinkLoadParameters& params, Document& document)
@@ -490,6 +523,61 @@ void LinkLoader::loadLink(const LinkLoadParameters& params, Document& document)
         if (resourceClient)
             m_preloadResourceClient = WTF::move(resourceClient);
     }
+}
+
+// https://whatpr.org/html/11620/links.html#load-a-compression-dictionary
+RefPtr<LinkPreloadResourceClient> LinkLoader::loadCompressionDictionaryIfNeeded(const LinkLoadParameters& params, Document& document, LinkLoader* loader)
+{
+    if (!document.loader())
+        return nullptr;
+
+    URL url = document.encodingParseURL(params.href.string());
+    if (!url.isValid()) {
+        document.addConsoleMessage(MessageSource::Other, MessageLevel::Error, "rel=compression-dictionary has an invalid URL"_s);
+        return nullptr;
+    }
+
+    auto options = CachedResourceLoader::defaultCachedResourceOptions();
+    options.referrerPolicy = params.referrerPolicy;
+    options.fetchPriority = params.fetchPriority;
+    options.nonce = params.nonce;
+    options.destination = FetchOptions::Destination::CompressionDictionary;
+
+    // No CORS is coerced to Anonymous, so this is always a CORS fetch.
+    auto crossOrigin = params.crossOrigin.isNull() ? String { "anonymous"_s } : params.crossOrigin;
+    auto linkRequest = createPotentialAccessControlRequest(ResourceRequest { WTF::move(url) }, WTF::move(options), document, crossOrigin);
+    linkRequest.setPriority(DefaultResourceLoadPriority::forResourceType(CachedResource::Type::RawResource));
+    linkRequest.setInitiatorType("link"_s);
+    linkRequest.setIgnoreForRequestCount(true);
+
+    RefPtr<CachedResource> cachedLinkResource;
+    if (auto result = protect(document.cachedResourceLoader())->requestRawResource(WTF::move(linkRequest)))
+        cachedLinkResource = WTF::move(result.value());
+
+    if (cachedLinkResource && loader)
+        return createLinkPreloadResourceClient(*cachedLinkResource, *loader, document);
+
+    if (loader)
+        loader->triggerError();
+    return nullptr;
+}
+
+void LinkLoader::loadCompressionDictionaryLink(const LinkLoadParameters& params, Document& document)
+{
+    RefPtr client = m_client.get();
+    if (!client || !client->shouldLoadLink())
+        return;
+
+    document.queueCompressionDictionaryLoad([protectedThis = Ref { *this }, params, weakDocument = WeakPtr { document }] {
+        RefPtr document = weakDocument.get();
+        if (!document)
+            return;
+        auto resourceClient = loadCompressionDictionaryIfNeeded(params, *document, protectedThis.ptr());
+        if (RefPtr existingClient = protectedThis->m_compressionDictionaryLoadResourceClient)
+            existingClient->clear();
+        if (resourceClient)
+            protectedThis->m_compressionDictionaryLoadResourceClient = WTF::move(resourceClient);
+    });
 }
 
 }

--- a/Source/WebCore/loader/LinkLoader.h
+++ b/Source/WebCore/loader/LinkLoader.h
@@ -63,12 +63,14 @@ public:
     virtual ~LinkLoader();
 
     void loadLink(const LinkLoadParameters&, Document&);
+    void loadCompressionDictionaryLink(const LinkLoadParameters&, Document&);
     enum class ShouldLog : bool { No, Yes };
     enum class IsModulePreload : bool { No, Yes };
     static std::optional<CachedResource::Type> resourceTypeFromAsAttribute(const String&, Document&, ShouldLog = ShouldLog::No, IsModulePreload = IsModulePreload::No);
 
     enum class MediaAttributeCheck { MediaAttributeEmpty, MediaAttributeNotEmpty, SkipMediaAttributeCheck };
     static void loadLinksFromHeader(const String& headerValue, const URL& baseURL, Document&, MediaAttributeCheck);
+    static void loadCompressionDictionariesFromHeader(const String& headerValue, const URL& baseURL, Document&);
     static bool isSupportedType(CachedResource::Type, const String& mimeType, Document&);
 
     void triggerEvents(const CachedResource&);
@@ -86,10 +88,12 @@ private:
     static void preconnectIfNeeded(const LinkLoadParameters&, Document&);
     static RefPtr<LinkPreloadResourceClient> preloadIfNeeded(const LinkLoadParameters&, Document&, LinkLoader*);
     void prefetchIfNeeded(const LinkLoadParameters&, Document&);
+    static RefPtr<LinkPreloadResourceClient> loadCompressionDictionaryIfNeeded(const LinkLoadParameters&, Document&, LinkLoader*);
 
     WeakPtr<LinkLoaderClient> m_client;
     CachedResourceHandle<CachedResource> m_cachedLinkResource;
     RefPtr<LinkPreloadResourceClient> m_preloadResourceClient;
+    RefPtr<LinkPreloadResourceClient> m_compressionDictionaryLoadResourceClient;
 };
 
 }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -533,6 +533,10 @@ bool CachedResourceLoader::allowedByContentSecurityPolicy(CachedResource::Type t
     if (options.loadedFromPluginElement == LoadedFromPluginElement::Yes)
         return contentSecurityPolicy->allowObjectFromSource(url, document->currentParserSourcePosition(), redirectResponseReceived, preRedirectURL);
 
+    // Compression dictionaries are governed by connect-src.
+    if (options.destination == FetchOptions::Destination::CompressionDictionary)
+        return contentSecurityPolicy->allowConnectToSource(url, document->currentParserSourcePosition(), redirectResponseReceived, preRedirectURL);
+
     switch (type) {
     case CachedResource::Type::JSON:
     case CachedResource::Type::Text:

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -445,6 +445,7 @@ bool NetworkLoadChecker::isAllowedByContentSecurityPolicy(const ResourceRequest&
             return false;
         // FIXME: Check CSP for non-importScripts() initiated loads.
         return true;
+    case FetchOptions::Destination::CompressionDictionary:
     case FetchOptions::Destination::EmptyString:
         return contentSecurityPolicy->allowConnectToSource(request.url(), { }, redirectResponseReceived, preRedirectURL);
     case FetchOptions::Destination::Audio:

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -538,6 +538,7 @@ ResourceLoadInfo NetworkResourceLoader::resourceLoadInfo()
         case WebCore::FetchOptions::Destination::Audio:
             return ResourceLoadInfo::Type::Media;
         case WebCore::FetchOptions::Destination::Audioworklet:
+        case WebCore::FetchOptions::Destination::CompressionDictionary:
             return ResourceLoadInfo::Type::Other;
         case WebCore::FetchOptions::Destination::Document:
         case WebCore::FetchOptions::Destination::Iframe:

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2140,6 +2140,7 @@ enum class WebCore::FetchOptionsDestination : uint8_t {
     EmptyString,
     Audio,
     Audioworklet,
+    CompressionDictionary,
     Document,
     Embed,
     Environmentmap,


### PR DESCRIPTION
#### 6248fa7145849f04f88e49a8a08ee6172b6bb9fe
<pre>
Fetch dictionaries declared by rel=compression-dictionary and Link headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321527">https://bugs.webkit.org/show_bug.cgi?id=321527</a>

Reviewed by Alex Christensen.

Add a runtime flag for Compression Dictionary Transport, handle the
&quot;compression-dictionary&quot; link, and fetch its resource. All described
from whatwg/html#11620

The fetch uses the new &quot;compression-dictionary&quot; destination from
whatwg/fetch#1854, is governed by the connect-src CSP directive,
and is always a CORS fetch. Changing crossorigin on the element re-fetches.

Dictionary fetches should not compete with the page&apos;s critical-path loads, and
the spec allows delaying them. Those declared by a &lt;link&gt; element are held in
Document until the load event has been dispatched; a link added after that
point is queued straight away.

Link headers on subresources do not register dictionaries at all.

Nothing is done with the fetched resource yet; storing dictionaries and
using them to decompress responses comes later.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-timing-001.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-timing-002.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-imagesrcset.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src-nonce.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-connect-src.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element-crossorigin.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element-events.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-integrity.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-referrer-and-referrerpolicy.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-type-attribute.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/fetch-destination.tentative.https-expected.txt: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/fetch/FetchRequestDestination.idl:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::dispatchWindowLoadEvent):
(WebCore::Document::queueCompressionDictionaryLoad):
(WebCore::Document::flushPendingCompressionDictionaryLoads):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::attributeChanged):
(WebCore::HTMLLinkElement::process):
* Source/WebCore/html/LinkRelAttribute.cpp:
* Source/WebCore/html/LinkRelAttribute.h:
* Source/WebCore/loader/FetchOptions.h:
* Source/WebCore/loader/FetchOptionsDestination.h:
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::~LinkLoader):
(WebCore::LinkLoader::loadCompressionDictionariesFromHeader):
(WebCore::LinkLoader::resourceTypeFromAsAttribute):
(WebCore::LinkLoader::cancelLoad):
(WebCore::LinkLoader::loadCompressionDictionaryIfNeeded):
(WebCore::LinkLoader::loadCompressionDictionaryLink):
* Source/WebCore/loader/LinkLoader.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::allowedByContentSecurityPolicy const):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::isAllowedByContentSecurityPolicy):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::resourceLoadInfo):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/319327@main">https://commits.webkit.org/319327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e0bcd5840243f38a765b6acc057bcf841068a5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191339 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145445 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141343 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121794 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43674 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41954 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3759 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10572 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41617 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2502 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42396 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193271 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150723 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55421 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38238 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150439 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45033 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127687 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123236 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53938 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16613 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53320 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53385 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->