### PR TITLE
[Site Isolation] Some WKWebView-level APIs don't message all processes associated with the page

### DIFF
--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -177,6 +177,7 @@ struct WebPageCreationParameters {
     bool openedByDOM { false };
     bool mayStartMediaWhenInWindow { false };
     bool mediaPlaybackIsSuspended { false };
+    bool areActiveDOMObjectsAndAnimationsSuspended { false };
 
     WebCore::IntSize minimumSizeForAutoLayout { };
     WebCore::IntSize sizeToContentAutoSizeMaximumSize { };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -90,6 +90,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     bool openedByDOM;
     bool mayStartMediaWhenInWindow;
     bool mediaPlaybackIsSuspended;
+    bool areActiveDOMObjectsAndAnimationsSuspended;
 
     WebCore::IntSize minimumSizeForAutoLayout;
     WebCore::IntSize sizeToContentAutoSizeMaximumSize;

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -609,6 +609,12 @@ void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process,
 
     Site site = effectiveOrigin ? Site { *effectiveOrigin } : Site { navigation.currentRequest().url() };
     RefPtr page = m_page.get();
+
+    // Joining a process to a suspended page would leave content running that `_suspendPage:`
+    // promised was frozen. std::nullopt cancels the navigation before the load is sent.
+    if (page->isSuspended())
+        return completionHandler(std::nullopt);
+
     // FIXME: Main resource (of main or subframe) request redirects should go straight from the network to UI process so we don't need to make the processes for each domain in a redirect chain. <rdar://116202119>
     Site mainFrameSite(page->mainFrame()->url());
     auto mainFrameDomain = WebCore::RegistrableDomain { protect(page->mainFrame())->securityOrigin()->data() };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -100,6 +100,7 @@
 #include "LogInitialization.h"
 #include "Logging.h"
 #include "MediaKeySystemPermissionRequestManagerProxy.h"
+#include "MediaPlaybackState.h"
 #include "MessageSenderInlines.h"
 #include "ModelProcessProxy.h"
 #include "NativeWebGestureEvent.h"
@@ -2675,12 +2676,14 @@ void WebPageProxy::stopLoading()
     drainDeferredModalsForNewNavigation();
 #endif
 
-    send(Messages::WebPage::StopLoading());
+    forEachWebContentProcess([&](auto& process, auto pageID) {
+        process.send(Messages::WebPage::StopLoading(), pageID);
+        process.startResponsivenessTimer();
+    });
     if (RefPtr provisionalPage = m_provisionalPage) {
         provisionalPage->cancel();
         m_provisionalPage = nullptr;
     }
-    protect(legacyMainFrameProcess())->startResponsivenessTimer();
 }
 
 RefPtr<API::Navigation> WebPageProxy::reload(OptionSet<WebCore::ReloadOption> options)
@@ -5785,6 +5788,13 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "receivedNavigationActionPolicyDecision: frameID=%" PRIu64 ", isMainFrame=%d, navigationID=%" PRIu64 ", policyAction=%" PUBLIC_LOG_STRING, frame.frameID().toUInt64(), frame.isMainFrame(), navigation.navigationID().toUInt64(), toString(policyAction).characters());
 
+    // suspend() cannot cancel a decision the client is still holding, so refuse it here instead.
+    // Allowing it would choose a process for the new site and join it to a suspended page.
+    if (m_isSuspended && policyAction == PolicyAction::Use) {
+        WEBPAGEPROXY_RELEASE_LOG(Loading, "receivedNavigationActionPolicyDecision: ignoring because the page is suspended");
+        policyAction = PolicyAction::Ignore;
+    }
+
     Ref websiteDataStore = m_websiteDataStore;
     RefPtr policies = navigation.websitePolicies();
     if (policies) {
@@ -6558,7 +6568,9 @@ void WebPageProxy::resumeActiveDOMObjectsAndAnimations()
 
     m_areActiveDOMObjectsAndAnimationsSuspended = false;
 
-    send(Messages::WebPage::ResumeActiveDOMObjectsAndAnimations());
+    forEachWebContentProcess([&](auto& process, auto pageID) {
+        process.send(Messages::WebPage::ResumeActiveDOMObjectsAndAnimations(), pageID);
+    });
 }
 
 void WebPageProxy::suspendActiveDOMObjectsAndAnimations()
@@ -6568,7 +6580,9 @@ void WebPageProxy::suspendActiveDOMObjectsAndAnimations()
 
     m_areActiveDOMObjectsAndAnimationsSuspended = true;
 
-    send(Messages::WebPage::SuspendActiveDOMObjectsAndAnimations());
+    forEachWebContentProcess([&](auto& process, auto pageID) {
+        process.send(Messages::WebPage::SuspendActiveDOMObjectsAndAnimations(), pageID);
+    });
 }
 
 void WebPageProxy::suspend(CompletionHandler<void(bool)>&& completionHandler)
@@ -6578,7 +6592,13 @@ void WebPageProxy::suspend(CompletionHandler<void(bool)>&& completionHandler)
         return completionHandler(false);
 
     m_isSuspended = true;
-    sendWithAsyncReply(Messages::WebPage::Suspend(), WTF::move(completionHandler));
+
+    internals().suspendedProcesses.clear();
+    auto aggregator = MainRunLoopSuccessCallbackAggregator::create(WTF::move(completionHandler));
+    forEachWebContentProcess([&](auto& process, auto pageID) {
+        internals().suspendedProcesses.append(Internals::SuspendedProcess { process, pageID });
+        process.sendWithAsyncReply(Messages::WebPage::Suspend(), aggregator->chain(), pageID);
+    });
 }
 
 void WebPageProxy::resume(CompletionHandler<void(bool)>&& completionHandler)
@@ -6589,7 +6609,12 @@ void WebPageProxy::resume(CompletionHandler<void(bool)>&& completionHandler)
         return completionHandler(false);
 
     m_isSuspended = false;
-    sendWithAsyncReply(Messages::WebPage::Resume(), WTF::move(completionHandler));
+
+    auto aggregator = MainRunLoopSuccessCallbackAggregator::create(WTF::move(completionHandler));
+    for (auto& suspendedProcess : std::exchange(internals().suspendedProcesses, { })) {
+        if (RefPtr process = suspendedProcess.process.get())
+            process->sendWithAsyncReply(Messages::WebPage::Resume(), aggregator->chain(), suspendedProcess.pageID);
+    }
 }
 
 bool WebPageProxy::supportsTextEncoding() const
@@ -11876,7 +11901,55 @@ void WebPageProxy::requestMediaPlaybackState(CompletionHandler<void(MediaPlaybac
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::RequestMediaPlaybackState(), WTF::move(completionHandler));
+    class MediaPlaybackStateCallbackAggregator : public RefCounted<MediaPlaybackStateCallbackAggregator> {
+    public:
+        static Ref<MediaPlaybackStateCallbackAggregator> create(CompletionHandler<void(MediaPlaybackState)>&& completionHandler) { return adoptRef(*new MediaPlaybackStateCallbackAggregator(WTF::move(completionHandler))); }
+
+        void NODELETE addState(MediaPlaybackState state)
+        {
+            if (precedence(state) > precedence(m_state))
+                m_state = state;
+        }
+
+        ~MediaPlaybackStateCallbackAggregator()
+        {
+            m_completionHandler(m_state);
+        }
+
+    private:
+        explicit MediaPlaybackStateCallbackAggregator(CompletionHandler<void(MediaPlaybackState)>&& completionHandler)
+            : m_completionHandler(WTF::move(completionHandler))
+        {
+        }
+
+        // Media playing anywhere in the page outranks media that is merely suspended, which
+        // outranks paused, which outranks a process with no media at all.
+        static unsigned precedence(MediaPlaybackState state)
+        {
+            switch (state) {
+            case MediaPlaybackState::NoMediaPlayback:
+                return 0;
+            case MediaPlaybackState::MediaPlaybackPaused:
+                return 1;
+            case MediaPlaybackState::MediaPlaybackSuspended:
+                return 2;
+            case MediaPlaybackState::MediaPlaybackPlaying:
+                return 3;
+            }
+            ASSERT_NOT_REACHED();
+            return 0;
+        }
+
+        CompletionHandler<void(MediaPlaybackState)> m_completionHandler;
+        MediaPlaybackState m_state { MediaPlaybackState::NoMediaPlayback };
+    };
+
+    Ref aggregator = MediaPlaybackStateCallbackAggregator::create(WTF::move(completionHandler));
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.sendWithAsyncReply(Messages::WebPage::RequestMediaPlaybackState(), [aggregator](MediaPlaybackState state) {
+            aggregator->addState(state);
+        }, pageID);
+    });
 }
 
 void WebPageProxy::pauseAllMediaPlayback(CompletionHandler<void()>&& completionHandler)
@@ -11886,7 +11959,10 @@ void WebPageProxy::pauseAllMediaPlayback(CompletionHandler<void()>&& completionH
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::PauseAllMediaPlayback(), WTF::move(completionHandler));
+    auto aggregator = CallbackAggregator::create(WTF::move(completionHandler));
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.sendWithAsyncReply(Messages::WebPage::PauseAllMediaPlayback(), [aggregator] { }, pageID);
+    });
 }
 
 void WebPageProxy::suspendAllMediaPlayback(CompletionHandler<void()>&& completionHandler)
@@ -11903,7 +11979,10 @@ void WebPageProxy::suspendAllMediaPlayback(CompletionHandler<void()>&& completio
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::SuspendAllMediaPlayback(), WTF::move(completionHandler));
+    auto aggregator = CallbackAggregator::create(WTF::move(completionHandler));
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.sendWithAsyncReply(Messages::WebPage::SuspendAllMediaPlayback(), [aggregator] { }, pageID);
+    });
 }
 
 void WebPageProxy::resumeAllMediaPlayback(CompletionHandler<void()>&& completionHandler)
@@ -11922,7 +12001,10 @@ void WebPageProxy::resumeAllMediaPlayback(CompletionHandler<void()>&& completion
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::ResumeAllMediaPlayback(), WTF::move(completionHandler));
+    auto aggregator = CallbackAggregator::create(WTF::move(completionHandler));
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.sendWithAsyncReply(Messages::WebPage::ResumeAllMediaPlayback(), [aggregator] { }, pageID);
+    });
 }
 
 void WebPageProxy::processWillSuspend()
@@ -14293,6 +14375,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.openedByDOM = m_openedByDOM;
     parameters.mayStartMediaWhenInWindow = m_mayStartMediaWhenInWindow;
     parameters.mediaPlaybackIsSuspended = m_mediaPlaybackIsSuspended;
+    parameters.areActiveDOMObjectsAndAnimationsSuspended = m_areActiveDOMObjectsAndAnimationsSuspended;
     parameters.minimumSizeForAutoLayout = internals().minimumSizeForAutoLayout;
     parameters.sizeToContentAutoSizeMaximumSize = internals().sizeToContentAutoSizeMaximumSize;
     parameters.autoSizingShouldExpandToViewHeight = m_autoSizingShouldExpandToViewHeight;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -424,6 +424,14 @@ public:
 
     EnhancedSecurityTracking enhancedSecurityTracker;
 
+    // Recorded by WebPageProxy::suspend() so resume() reaches exactly the processes that were
+    // suspended. The set of processes backing the page can change while it is suspended.
+    struct SuspendedProcess {
+        WeakPtr<WebProcessProxy> process;
+        WebCore::PageIdentifier pageID;
+    };
+    Vector<SuspendedProcess> suspendedProcesses;
+
 #if PLATFORM(IOS_FAMILY) && ENABLE(UNIFIED_PDF)
     PDFPluginDisplayMode pdfDisplayMode { PDFPluginDisplayMode::SinglePageContinuous };
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1101,6 +1101,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     m_mayStartMediaWhenInWindow = parameters.mayStartMediaWhenInWindow;
     if (parameters.mediaPlaybackIsSuspended)
         page->suspendAllMediaPlayback();
+    if (parameters.areActiveDOMObjectsAndAnimationsSuspended)
+        page->suspendActiveDOMObjectsAndAnimations();
 
     if (parameters.openedByDOM)
         page->setOpenedByDOM();
@@ -2739,14 +2741,16 @@ void WebPage::loadSimulatedRequestAndResponse(LoadParameters&& loadParameters, R
 
 void WebPage::stopLoading()
 {
-    if (!m_page || !m_mainFrame->coreLocalFrame())
+    if (!m_page)
         return;
 
     SendStopResponsivenessTimer stopper;
 
-    Ref coreFrame = *m_mainFrame->coreLocalFrame();
-    coreFrame->loader().stopForUserCancel();
-    coreFrame->loader().completePageTransitionIfNeeded();
+    for (Ref frame : copyToVectorOf<Ref<LocalFrame>>(m_page->rootFrames()))
+        frame->loader().stopForUserCancel();
+
+    if (RefPtr localMainFrame = m_page->localMainFrame())
+        localMainFrame->loader().completePageTransitionIfNeeded();
 }
 
 void WebPage::stopLoadingDueToProcessSwap()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -12959,4 +12959,383 @@ TEST(SiteIsolation, SharedProcessIgnoresHighValueFraudTargetDomainsWhenDisabled)
     });
 }
 
+// Page-wide commands must reach every web content process backing the page, not just the main
+// frame's. Each test below asserts the command took effect *inside* the cross-site iframe; a
+// version that only checks the main frame passes without the fix.
+
+static String notifyScriptForTag(ASCIILiteral tag)
+{
+    return makeString("<script>"
+        "const tag = '"_s, tag, "';"
+        "function notify(suffix) { window.webkit.messageHandlers.testHandler.postMessage(tag + ':' + suffix); }"
+        "</script>"_s);
+}
+
+TEST(SiteIsolation, StopLoadingStopsCrossSiteIframe)
+{
+    // Each frame commits, starts a subresource load that never completes, then blocks its parser
+    // on a script that never arrives. stopLoading must abort the outstanding load in both.
+    auto pendingLoadScript = "<script>"
+        "fetch('/hang').then(() => notify('fetch-completed'), () => notify('fetch-aborted'));"
+        "notify('fetch-started');"
+        "</script>"_s;
+
+    HTTPServer::ResponseMap responses;
+    responses.add("/mainframe"_s, HTTPResponse(makeString(notifyScriptForTag("main"_s), pendingLoadScript,
+        "<iframe src='https://b.com/subframe'></iframe><script src='/hang'></script>"_s)));
+    responses.add("/subframe"_s, HTTPResponse(makeString(notifyScriptForTag("iframe"_s), pendingLoadScript,
+        "<script src='/hang'></script>"_s)));
+    responses.add("/hang"_s, HTTPResponse(HTTPResponse::Behavior::NeverSendResponse));
+    HTTPServer server(WTF::move(responses), HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    RetainPtr<NSMutableSet<NSString *>> received = adoptNS([[NSMutableSet alloc] init]);
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        [received addObject:message];
+    }];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/mainframe"]]];
+
+    EXPECT_TRUE(Util::waitFor([&] {
+        return [received containsObject:@"main:fetch-started"] && [received containsObject:@"iframe:fetch-started"];
+    }));
+    while (![[webView firstChildFrame].securityOrigin.host isEqualToString:@"b.com"])
+        Util::spinRunLoop();
+
+    RetainPtr childFrame = [webView firstChildFrame];
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"document.readyState" inFrame:childFrame.get()], "loading");
+
+    [webView stopLoading];
+
+    EXPECT_TRUE(Util::waitFor([&] {
+        return [received containsObject:@"main:fetch-aborted"];
+    }));
+    EXPECT_TRUE(Util::waitFor([&] {
+        return [received containsObject:@"iframe:fetch-aborted"];
+    }));
+    EXPECT_FALSE([received containsObject:@"iframe:fetch-completed"]);
+}
+
+enum class MainFrameVideo : bool { No, Yes };
+
+static HTTPServer::ResponseMap crossSiteVideoResponses(MainFrameVideo mainFrameVideo)
+{
+    auto playVideoScript = "<script>"
+        "function playVideo() {"
+        "    let video = document.getElementById('video');"
+        "    video.addEventListener('playing', () => notify('playing'));"
+        "    video.addEventListener('pause', () => notify('paused'));"
+        "    video.play().catch(() => notify('play-rejected'));"
+        "}"
+        "</script>"_s;
+    auto videoElement = "<video id='video' webkit-playsinline src='/video-with-audio.mp4'></video>"_s;
+    auto iframeElement = "<iframe src='https://b.com/subframe'></iframe>"_s;
+
+    RetainPtr videoData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"video-with-audio" ofType:@"mp4"] options:0 error:NULL];
+
+    HTTPServer::ResponseMap responses;
+    if (mainFrameVideo == MainFrameVideo::Yes) {
+        responses.add("/mainframe"_s, HTTPResponse(makeString(notifyScriptForTag("main"_s), playVideoScript,
+            "<body onload='playVideo()'>"_s, videoElement, iframeElement, "</body>"_s)));
+    } else {
+        responses.add("/mainframe"_s, HTTPResponse(makeString(notifyScriptForTag("main"_s),
+            "<body>"_s, iframeElement, "</body>"_s)));
+    }
+    responses.add("/subframe"_s, HTTPResponse(makeString(notifyScriptForTag("iframe"_s), playVideoScript,
+        "<body onload='playVideo()'>"_s, videoElement, "</body>"_s)));
+    responses.add("/video-with-audio.mp4"_s, HTTPResponse(videoData.get()));
+    return responses;
+}
+
+static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> autoplayingCrossSiteVideoView(const HTTPServer& server)
+{
+    RetainPtr configuration = server.httpsProxyConfiguration();
+#if PLATFORM(IOS_FAMILY)
+    [configuration setAllowsInlineMediaPlayback:YES];
+    [configuration _setInlineMediaPlaybackRequiresPlaysInlineAttribute:NO];
+#endif
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration, CGRectMake(0, 0, 800, 600));
+    [navigationDelegate setDecidePolicyForNavigationActionWithPreferences:^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        preferences._autoplayPolicy = _WKWebsiteAutoplayPolicyAllow;
+        completionHandler(WKNavigationActionPolicyAllow, preferences);
+    }];
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
+}
+
+static NSString *videoPausedInFrame(TestWKWebView *webView, WKFrameInfo *frame)
+{
+    return [webView stringByEvaluatingJavaScript:@"String(document.getElementById('video').paused)" inFrame:frame];
+}
+
+TEST(SiteIsolation, PauseAllMediaPlaybackPausesCrossSiteIframe)
+{
+    HTTPServer server(crossSiteVideoResponses(MainFrameVideo::Yes), HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = autoplayingCrossSiteVideoView(server);
+
+    RetainPtr<NSMutableSet<NSString *>> received = adoptNS([[NSMutableSet alloc] init]);
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        [received addObject:message];
+    }];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/mainframe"]]];
+    EXPECT_TRUE(Util::waitFor([&] {
+        return [received containsObject:@"main:playing"] && [received containsObject:@"iframe:playing"];
+    }));
+
+    __block bool done = false;
+    [webView pauseAllMediaPlaybackWithCompletionHandler:^{
+        done = true;
+    }];
+    Util::run(&done);
+
+    // The pause reached each process before its reply, so by the time this evaluation is
+    // dispatched to the iframe's process the video there is already paused.
+    EXPECT_WK_STREQ(videoPausedInFrame(webView.get(), nil), "true");
+    EXPECT_WK_STREQ(videoPausedInFrame(webView.get(), [webView firstChildFrame]), "true");
+}
+
+TEST(SiteIsolation, SetAllMediaPlaybackSuspendedSuspendsCrossSiteIframe)
+{
+    HTTPServer server(crossSiteVideoResponses(MainFrameVideo::Yes), HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = autoplayingCrossSiteVideoView(server);
+
+    RetainPtr<NSMutableSet<NSString *>> received = adoptNS([[NSMutableSet alloc] init]);
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        [received addObject:message];
+    }];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/mainframe"]]];
+    EXPECT_TRUE(Util::waitFor([&] {
+        return [received containsObject:@"main:playing"] && [received containsObject:@"iframe:playing"];
+    }));
+
+    __block bool done = false;
+    [webView setAllMediaPlaybackSuspended:YES completionHandler:^{
+        done = true;
+    }];
+    Util::run(&done);
+
+    RetainPtr childFrame = [webView firstChildFrame];
+    EXPECT_WK_STREQ(videoPausedInFrame(webView.get(), nil), "true");
+    EXPECT_WK_STREQ(videoPausedInFrame(webView.get(), childFrame.get()), "true");
+
+    // Suspension must also block the page from resuming itself. play() returns a promise, which
+    // evaluateJavaScript cannot serialize, so discard it.
+    [webView objectByEvaluatingJavaScript:@"document.getElementById('video').play().catch(() => { }); undefined" inFrame:childFrame.get()];
+    Util::runFor(0.1_s);
+    EXPECT_WK_STREQ(videoPausedInFrame(webView.get(), childFrame.get()), "true");
+}
+
+TEST(SiteIsolation, ResumeAllMediaPlaybackResumesCrossSiteIframe)
+{
+    // Playback is suspended before the cross-site iframe exists, so its process is created with
+    // mediaPlaybackIsSuspended already set. Only a resume that reaches that process can let the
+    // video play, which is what makes this a test of the resume path rather than the suspend path.
+    auto videoScript = "<script>"
+        "function playVideo() {"
+        "    let video = document.getElementById('video');"
+        "    video.addEventListener('playing', () => notify('playing'));"
+        "    video.play().catch(() => { });"
+        "}"
+        "</script>"_s;
+
+    RetainPtr videoData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"video-with-audio" ofType:@"mp4"] options:0 error:NULL];
+
+    HTTPServer::ResponseMap responses;
+    responses.add("/mainframe"_s, HTTPResponse(makeString(notifyScriptForTag("main"_s), "<body></body>"_s)));
+    responses.add("/subframe"_s, HTTPResponse(makeString(notifyScriptForTag("iframe"_s), videoScript,
+        "<body onload='notify(\"loaded\"); playVideo()'>"
+        "<video id='video' webkit-playsinline src='/video-with-audio.mp4'></video></body>"_s)));
+    responses.add("/video-with-audio.mp4"_s, HTTPResponse(videoData.get()));
+    HTTPServer server(WTF::move(responses), HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = autoplayingCrossSiteVideoView(server);
+
+    RetainPtr<NSMutableSet<NSString *>> received = adoptNS([[NSMutableSet alloc] init]);
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        [received addObject:message];
+    }];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    __block bool suspended = false;
+    [webView setAllMediaPlaybackSuspended:YES completionHandler:^{
+        suspended = true;
+    }];
+    Util::run(&suspended);
+
+    [webView evaluateJavaScript:@"let iframe = document.createElement('iframe');"
+        "iframe.src = 'https://b.com/subframe';"
+        "document.body.appendChild(iframe);" completionHandler:nil];
+
+    EXPECT_TRUE(Util::waitFor([&] {
+        return [received containsObject:@"iframe:loaded"];
+    }));
+    RetainPtr childFrame = [webView firstChildFrame];
+    EXPECT_WK_STREQ([childFrame securityOrigin].host, "b.com");
+
+    // The iframe's process started suspended, so its autoplay never began.
+    EXPECT_FALSE([received containsObject:@"iframe:playing"]);
+    EXPECT_WK_STREQ(videoPausedInFrame(webView.get(), childFrame.get()), "true");
+
+    __block bool resumed = false;
+    [webView setAllMediaPlaybackSuspended:NO completionHandler:^{
+        resumed = true;
+    }];
+    Util::run(&resumed);
+
+    [webView objectByEvaluatingJavaScript:@"document.getElementById('video').play().catch(() => { }); undefined" inFrame:childFrame.get()];
+
+    EXPECT_TRUE(Util::waitFor([&] {
+        return [videoPausedInFrame(webView.get(), childFrame.get()) isEqualToString:@"false"];
+    }));
+}
+
+TEST(SiteIsolation, RequestMediaPlaybackStateReflectsCrossSiteIframe)
+{
+    // Only the iframe has media, so the main frame's process alone reports no playback at all.
+    HTTPServer server(crossSiteVideoResponses(MainFrameVideo::No), HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = autoplayingCrossSiteVideoView(server);
+
+    RetainPtr<NSMutableSet<NSString *>> received = adoptNS([[NSMutableSet alloc] init]);
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        [received addObject:message];
+    }];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/mainframe"]]];
+    EXPECT_TRUE(Util::waitFor([&] {
+        return [received containsObject:@"iframe:playing"];
+    }));
+
+    __block bool done = false;
+    __block WKMediaPlaybackState state = WKMediaPlaybackStateNone;
+    [webView requestMediaPlaybackStateWithCompletionHandler:^(WKMediaPlaybackState result) {
+        state = result;
+        done = true;
+    }];
+    Util::run(&done);
+
+    EXPECT_EQ(state, WKMediaPlaybackStatePlaying);
+}
+
+TEST(SiteIsolation, SuspendPageSuspendsCrossSiteIframeProcess)
+{
+    auto tickScript = "<script>setInterval(() => notify('tick'), 10);</script>"_s;
+
+    HTTPServer::ResponseMap responses;
+    responses.add("/mainframe"_s, HTTPResponse(makeString(notifyScriptForTag("main"_s), tickScript,
+        "<iframe src='https://b.com/subframe'></iframe>"_s)));
+    responses.add("/subframe"_s, HTTPResponse(makeString(notifyScriptForTag("iframe"_s), tickScript)));
+    HTTPServer server(WTF::move(responses), HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    __block unsigned mainTicks = 0;
+    __block unsigned iframeTicks = 0;
+    __block bool bothFramesTicking = false;
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        if ([message isEqualToString:@"main:tick"])
+            mainTicks++;
+        else if ([message isEqualToString:@"iframe:tick"])
+            iframeTicks++;
+        if (mainTicks > 2 && iframeTicks > 2)
+            bothFramesTicking = true;
+    }];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/mainframe"]]];
+    EXPECT_TRUE(Util::runFor(&bothFramesTicking, 10_s));
+
+    __block bool done = false;
+    [webView _suspendPage:^(BOOL success) {
+        EXPECT_TRUE(success);
+        done = true;
+    }];
+    Util::run(&done);
+
+    // Timers must have stopped in both processes. Evaluating JavaScript throws once the page is
+    // suspended, so the tick counters are the only usable probe here.
+    auto mainTicksWhenSuspended = mainTicks;
+    auto iframeTicksWhenSuspended = iframeTicks;
+    Util::runFor(0.5_s);
+    EXPECT_EQ(mainTicksWhenSuspended, mainTicks);
+    EXPECT_EQ(iframeTicksWhenSuspended, iframeTicks);
+
+    __block bool resumeDone = false;
+    [webView _resumePage:^(BOOL success) {
+        EXPECT_TRUE(success);
+        resumeDone = true;
+    }];
+    Util::run(&resumeDone);
+
+    // Both processes must start ticking again. The counters are __block, so they cannot be read
+    // from a C++ lambda and Util::waitFor is unavailable here.
+    bool bothFramesTickingAgain = false;
+    for (unsigned attempt = 0; attempt < 100 && !bothFramesTickingAgain; ++attempt) {
+        Util::runFor(0.1_s);
+        bothFramesTickingAgain = mainTicks > mainTicksWhenSuspended && iframeTicks > iframeTicksWhenSuspended;
+    }
+    EXPECT_TRUE(bothFramesTickingAgain);
+}
+
+TEST(SiteIsolation, SuspendedPageDoesNotLetANewProcessJoin)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<iframe id='child' src='https://a.com/samesite'></iframe>"_s } },
+        { "/samesite"_s, { "same site subframe"_s } },
+        { "/crosssite"_s, { "cross site subframe"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    // The subframe starts same-site, so one process backs the page.
+    checkFrameTreesInProcesses(webView.get(), { { "https://a.com"_s, { { "https://a.com"_s } } } });
+
+    // Hold the subframe's cross-site navigation. The process for b.com is not chosen until the
+    // decision is allowed, so nothing has joined the page yet.
+    bool didHoldCrossSiteNavigation { false };
+    BlockPtr<void(WKNavigationActionPolicy)> releaseCrossSiteNavigation;
+    navigationDelegate.get().decidePolicyForNavigationAction = makeBlockPtr([&](WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
+        if ([action.request.URL.host isEqualToString:@"b.com"]) {
+            releaseCrossSiteNavigation = makeBlockPtr(completionHandler);
+            didHoldCrossSiteNavigation = true;
+            return;
+        }
+        completionHandler(WKNavigationActionPolicyAllow);
+    }).get();
+
+    [webView evaluateJavaScript:@"document.getElementById('child').src = 'https://b.com/crosssite'" completionHandler:nil];
+    Util::run(&didHoldCrossSiteNavigation);
+
+    __block bool suspended = false;
+    [webView _suspendPage:^(BOOL success) {
+        EXPECT_TRUE(success);
+        suspended = true;
+    }];
+    Util::run(&suspended);
+
+    releaseCrossSiteNavigation(WKNavigationActionPolicyAllow);
+
+    // The decision is refused because the page is suspended, so no process for b.com joins and
+    // there is nothing running that _suspendPage: failed to freeze.
+    Util::runFor(0.5_s);
+    EXPECT_EQ([frameTrees(webView.get()) count], 1u);
+
+    __block bool resumed = false;
+    __block BOOL resumeSucceeded = NO;
+    [webView _resumePage:^(BOOL success) {
+        resumeSucceeded = success;
+        resumed = true;
+    }];
+    Util::run(&resumed);
+    EXPECT_TRUE(resumeSucceeded);
+
+    // The refused navigation left the iframe where it was.
+    checkFrameTreesInProcesses(webView.get(), { { "https://a.com"_s, { { "https://a.com"_s } } } });
+}
+
 }


### PR DESCRIPTION
#### 9c771fce0a906f72dba484655193f91a369f78d3
<pre>
[Site Isolation] Some WKWebView-level APIs don&apos;t message all processes associated with the page
<a href="https://rdar.apple.com/184640337">rdar://184640337</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321529">https://bugs.webkit.org/show_bug.cgi?id=321529</a>

Reviewed by Sihui Liu.

With site isolation a page is usually backed by more than one web content process.
But `stopLoading`, the media playback commands, and the suspend and resume commands
are only sent to the main frame&apos;s process.

Cross-site iframes keep loading, keep playing, and kept running timers after the app
is told the work is done.

Fix this by sending the relevant IPC to every process backing the page, as well as
including relevant state information when creating new pages in new processes.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::stopLoading):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::resumeActiveDOMObjectsAndAnimations):
(WebKit::WebPageProxy::suspendActiveDOMObjectsAndAnimations):
(WebKit::WebPageProxy::suspend):
(WebKit::WebPageProxy::resume):
(WebKit::WebPageProxy::requestMediaPlaybackState):
(WebKit::WebPageProxy::pauseAllMediaPlayback):
(WebKit::WebPageProxy::suspendAllMediaPlayback):
(WebKit::WebPageProxy::resumeAllMediaPlayback):
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_allowsImmersiveEnvironments):
(WebKit::WebPage::stopLoading):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, StopLoadingStopsCrossSiteIframe)):
(TestWebKitAPI::(SiteIsolation, PauseAllMediaPlaybackPausesCrossSiteIframe)):
(TestWebKitAPI::(SiteIsolation, SetAllMediaPlaybackSuspendedSuspendsCrossSiteIframe)):
(TestWebKitAPI::(SiteIsolation, ResumeAllMediaPlaybackResumesCrossSiteIframe)):
(TestWebKitAPI::(SiteIsolation, RequestMediaPlaybackStateReflectsCrossSiteIframe)):
(TestWebKitAPI::(SiteIsolation, SuspendPageSuspendsCrossSiteIframeProcess)):
(TestWebKitAPI::(SiteIsolation, SuspendedPageDoesNotLetANewProcessJoin)):

Canonical link: <a href="https://commits.webkit.org/319380@main">https://commits.webkit.org/319380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/347f61174eb58b69012046495852123ec57822e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145612 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d0f5c7f-4aff-4bb1-8285-90815bbd0645) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141483 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b3517e2-8c78-4f7e-a552-372318b59e23) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121925 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/22e3e0a5-929d-433f-8acd-b79e0ca8bdb1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43841 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42110 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41766 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2663 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193437 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54902 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150878 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40423 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55589 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150586 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45171 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127870 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123449 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54105 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16764 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53487 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53725 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53552 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->