### PR TITLE
Remove unused AtomStrings from the AtomString table.

### DIFF
--- a/Source/WebCore/platform/CommonAtomStrings.h
+++ b/Source/WebCore/platform/CommonAtomStrings.h
@@ -32,7 +32,6 @@ namespace WebCore {
 
 #define WEBCORE_COMMON_ATOM_STRINGS_FOR_EACH_KEYWORD(macro) \
     macro(all, "all") \
-    macro(alternative, "alternative") \
     macro(any, "any") \
     macro(applicationXHTMLContentType, "application/xhtml+xml") \
     macro(applicationXMLContentType, "application/xml") \
@@ -42,13 +41,10 @@ namespace WebCore {
     macro(closerequest, "closerequest") \
     macro(commentary, "commentary") \
     macro(cssContentType, "text/css") \
-    macro(eager, "eager") \
     macro(email, "email") \
     macro(false, "false") \
     macro(hint, "hint") \
     macro(imageSVGContentType, "image/svg+xml") \
-    macro(lazy, "lazy") \
-    macro(main, "main") \
     macro(manual, "manual") \
     macro(none, "none") \
     macro(off, "off") \


### PR DESCRIPTION
#### aab1af852467d68bcc3197e6a5b1b28706a27bd9
<pre>
Remove unused AtomStrings from the AtomString table.
<a href="https://bugs.webkit.org/show_bug.cgi?id=321532">https://bugs.webkit.org/show_bug.cgi?id=321532</a>
<a href="https://rdar.apple.com/183145568">rdar://183145568</a>

Reviewed by Mike Wyrzykowski and Vitor Roriz.

There were a few strings in the AtomString table which were no longer used anywhere. In some cases
strings were only being used for case-insensitive comparisons which are more efficiently done with
ASCII literals. And in other cases the strings were only meant to be used off the main thread, which
AtomStrings don&apos;t support.

These are being removed to free up a small amount of space in the table and to prevent false-positive leak
repots from some memory analysis tools.

No new tests.

* Source/WebCore/platform/CommonAtomStrings.h:

Canonical link: <a href="https://commits.webkit.org/319016@main">https://commits.webkit.org/319016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80ccedb79f8df3e4bbe384f8b084d91d44edc1fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144407 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47e10080-d3f2-414d-a273-4d1c324f3242) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140457 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2dda969-5a36-4fc7-aa06-98f77a78a7ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120908 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c25e619-8b94-4626-8f70-78cd2221dc37) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42776 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41088 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40760 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1459 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192232 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53700 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149792 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40136 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54388 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149522 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44161 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126650 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121760 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52904 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15747 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52287 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52524 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52351 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->