### PR TITLE
Cherry-pick 318857@main (9010d6d3bec8). https://bugs.webkit.org/show_bug.cgi?id=321378

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9098,7 +9098,7 @@ UnifyDamagedRegions:
      WebKitLegacy:
        default: false
      WebKit:
-       "PLATFORM(GTK)": true
+       "PLATFORM(GTK) || PLATFORM(WPE)": true
        default: false
      WebCore:
        default: false
@@ -9198,6 +9198,7 @@ UseDamagingInformationForCompositing:
     WebKitLegacy:
       default: false
     WebKit:
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
       default: false

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6241,7 +6241,8 @@ void Document::processCaptureStateDidChange(Function<bool(const Page&)>&& isPage
     if (!hasRealtimeMediaSource(m_captureSources, filterSource))
         return;
 
-    eventLoop().queueTask(TaskSource::MediaElement, [weakDocument = WeakPtr { *this }, weakSession = WeakPtr { *mediaSession }, isPageMuted = isPageMutedCallback(*page), filterSource = WTF::move(filterSource), isPageMutedCallback = WTF::move(isPageMutedCallback), action] {
+    bool isPageMuted = isPageMutedCallback(*page);
+    eventLoop().queueTask(TaskSource::MediaElement, [weakDocument = WeakPtr { *this }, weakSession = WeakPtr { *mediaSession }, isPageMuted, filterSource = WTF::move(filterSource), isPageMutedCallback = WTF::move(isPageMutedCallback), action] {
         RefPtr protecteDocument = weakDocument.get();
         if (!protecteDocument)
             return;

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
@@ -102,13 +102,17 @@ void SkiaCompositingLayerImageSetBatch::addImageSet(SkCanvas& canvas, SkiaBackin
     // Planned once for the whole layer. appendImageSetEntries() then splits each tile by the rects that touch it.
     const auto layerDeviceRect = ctm.mapRect(SkRect(FloatRect { { }, backingStore.size() }));
 
-    if (!planRestrictedDraw(canvas, transform, ctm, layerDeviceRect, *damageRegion, [&](SkCanvas& canvas) {
+    SkMatrix inverse;
+    const auto plan = planRestrictedDraw(canvas, transform, ctm, layerDeviceRect, *damageRegion, inverse, [&](SkCanvas& canvas) {
         backingStore.paintToCanvas(canvas, fallbackPaint, damageRegion);
-    }))
+    });
+    if (plan == RestrictedDraw::Done)
         return;
 
     updateSamplingOptions(canvas, sampling);
-    backingStore.appendImageSetEntries(canvas, ctm, matrixIndexForDraw(ctm), opacity, enableAntialias, m_imageSet, damageRegion);
+    // A covered layer has every tile inside the damage, so there is nothing to split by.
+    backingStore.appendImageSetEntries(canvas, ctm, matrixIndexForDraw(ctm), opacity, enableAntialias, m_imageSet,
+        plan == RestrictedDraw::Whole ? nullptr : damageRegion);
 }
 
 void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<SkImage>& image, const FloatRect& rect, const SkM44& transform, float opacity, bool enableAntialias, const SkiaDamageRegion* damageRegion, const SkPaint& fallbackPaint)
@@ -127,19 +131,28 @@ void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<S
 
     const auto deviceRect = ctm.mapRect(dstRectFull);
 
-    const auto inverse = planRestrictedDraw(canvas, transform, ctm, deviceRect, *damageRegion, [&](SkCanvas& canvas) {
+    SkMatrix inverse;
+    const auto plan = planRestrictedDraw(canvas, transform, ctm, deviceRect, *damageRegion, inverse, [&](SkCanvas& canvas) {
         canvas.drawImageRect(image, srcRectFull, dstRectFull, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &fallbackPaint, SkCanvas::kFast_SrcRectConstraint);
     });
-    if (!inverse)
+    if (plan == RestrictedDraw::Done)
         return;
+
+    updateSamplingOptions(canvas, samplingOptionsForImage(canvas, image, rect, ctm));
+    const auto matrixIndex = matrixIndexForDraw(ctm);
+
+    // Drawn whole, so it has no interior edges and antialiases like a draw with no damage.
+    if (plan == RestrictedDraw::Whole) {
+        const unsigned aaFlags = enableAntialias ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
+        m_imageSet.append(SkCanvas::ImageSetEntry(image, srcRectFull, dstRectFull, matrixIndex, opacity, aaFlags, false));
+        return;
+    }
 
     // Splitting creates edges inside the image, and antialiasing them would blend along those edges. This
     // never happens: a split needs a CTM that keeps rects as rects, which is never antialiased.
     ASSERT(!enableAntialias);
 
-    updateSamplingOptions(canvas, samplingOptionsForImage(canvas, image, rect, ctm));
-    const auto matrixIndex = matrixIndexForDraw(ctm);
-    damageRegion->forEachDamagedSubRect(deviceRect, dstRectFull, srcRectFull, *inverse, [&](const SkRect& srcSubRect, const SkRect& dstSubRect) {
+    damageRegion->forEachDamagedSubRect(deviceRect, dstRectFull, srcRectFull, inverse, [&](const SkRect& srcSubRect, const SkRect& dstSubRect) {
         m_imageSet.append(SkCanvas::ImageSetEntry(image, srcSubRect, dstSubRect, matrixIndex, opacity, SkCanvas::kNone_QuadAAFlags, false));
     });
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
@@ -50,9 +50,9 @@ public:
 
     void updatePaintProperties(SkCanvas&, const sk_sp<SkColorFilter>&, const std::optional<SkBlendMode>&);
 
-    // A null damage region draws everything. Otherwise the draw is split by the rects of the region. A
-    // rotated or skewed transform cannot be split, so it is flushed and drawn under a damage clip with
-    // fallbackPaint, which is used in that case only.
+    // A null damage region draws everything. Otherwise the draw is drawn whole when the damage covers it,
+    // split by the rects of the region when the transform allows, and otherwise flushed and drawn under a
+    // damage clip with fallbackPaint, which is used in that case only.
     void addImageSet(SkCanvas&, SkiaBackingStore&, const SkM44& transform, float opacity, bool enableAntialias, const SkiaDamageRegion*, const SkPaint& fallbackPaint);
     void addImage(SkCanvas&, const sk_sp<SkImage>&, const FloatRect&, const SkM44& transform, float opacity, bool enableAntialias, const SkiaDamageRegion*, const SkPaint& fallbackPaint);
 
@@ -77,30 +77,37 @@ public:
     };
 
 private:
-    // Decides how to limit one draw to the damage. Returns the inverse to split it with, or nothing when
-    // the draw is already handled, either because it misses the damage or because fallbackDraw() has drawn
-    // it under a damage clip, which ends the batch.
+    // What the caller has left to do to limit one draw to the damage.
+    enum class RestrictedDraw : uint8_t {
+        Done,
+        Whole,
+        Split
+    };
+
+    // Entries here carry no clip quad, so a draw needing a damage clip ends the batch.
     template<typename FallbackDrawFunction>
-    std::optional<SkMatrix> planRestrictedDraw(SkCanvas& canvas, const SkM44& transform, const SkMatrix& ctm, const SkRect& deviceRect, const SkiaDamageRegion& damageRegion, NOESCAPE const FallbackDrawFunction& fallbackDraw)
+    RestrictedDraw planRestrictedDraw(SkCanvas& canvas, const SkM44& transform, const SkMatrix& ctm, const SkRect& deviceRect, const SkiaDamageRegion& damageRegion, SkMatrix& inverse, NOESCAPE const FallbackDrawFunction& fallbackDraw)
     {
         ASSERT(!damageRegion.isEmpty());
 
-        SkMatrix inverse;
+        if (damageRegion.covers(deviceRect))
+            return RestrictedDraw::Whole;
+
         switch (damageRegion.planDraw(ctm, deviceRect, inverse)) {
         case SkiaDamageRegion::DrawDamageStrategy::Skip:
-            return std::nullopt;
+            return RestrictedDraw::Done;
         case SkiaDamageRegion::DrawDamageStrategy::ClipToDamage: {
             ScopedFlush autoFlush(canvas, *this, ScopedFlush::Mode::FlushBefore);
             canvas.concat(transform);
             damageRegion.clipCanvasInDeviceSpace(canvas);
             fallbackDraw(canvas);
-            return std::nullopt;
+            return RestrictedDraw::Done;
         }
         case SkiaDamageRegion::DrawDamageStrategy::SplitByRect:
             break;
         }
 
-        return inverse;
+        return RestrictedDraw::Split;
     }
 
     void updateSamplingOptions(SkCanvas&, SkSamplingOptions);

--- a/Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h
@@ -89,6 +89,9 @@ public:
     // region along an edge triggers an intersection - this is conservative, but for sure not wrong.
     bool intersects(const SkRect& deviceRect) const { return m_region.intersects(deviceRect.roundOut()); }
 
+    // roundOut() grows the rect, so coverage is under-reported, never over-reported.
+    bool covers(const SkRect& deviceRect) const { return m_region.contains(deviceRect.roundOut()); }
+
     // How to limit one draw to the damage. A draw is split into as many rects as touch it, with no limit,
     // because the parts share a paint and Skia batches them into one op. Clipping is the slow path instead:
     // a clip of more than one rect cannot be a scissor, so it costs a stencil buffer or a mask texture.
@@ -140,6 +143,11 @@ public:
         const auto ctm = canvas.getLocalToDeviceAs3x3();
         SkRect deviceRect;
         ctm.mapRect(&deviceRect, dstRectFull);
+
+        if (covers(deviceRect)) {
+            draw(srcRectFull, dstRectFull);
+            return;
+        }
 
         SkMatrix inverse;
         switch (planDraw(ctm, deviceRect, inverse)) {


### PR DESCRIPTION
#### 641159c7a8d5899274f2bb9c07cb42db8f901776
<pre>
Cherry-pick 318857@main (9010d6d3bec8). <a href="https://bugs.webkit.org/show_bug.cgi?id=321378">https://bugs.webkit.org/show_bug.cgi?id=321378</a>

Unreviewed backport.

    [Skia] Re-enable damage in composition feature
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321378">https://bugs.webkit.org/show_bug.cgi?id=321378</a>

    Reviewed by Fujii Hironori.

    Re-enable &apos;UseDamagingInformationForCompositing&apos;, since the performance regressions are gone.
    Also enable &apos;UnifyDamagedRegions&apos; since it gives a small performance benefit on rpi4 + MotionMark.

    * Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

    Canonical link: <a href="https://commits.webkit.org/318857@main">https://commits.webkit.org/318857@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.104@webkitglib/2.54">https://commits.webkit.org/317695.104@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 4fe0044afd5cb28a59c815b3a5b5f86ef09e77c6
<pre>
Cherry-pick 318856@main (2f72b3d7740d). <a href="https://bugs.webkit.org/show_bug.cgi?id=321377">https://bugs.webkit.org/show_bug.cgi?id=321377</a>

    [Skia] Skip damage restriction when the damage covers the whole draw
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321377">https://bugs.webkit.org/show_bug.cgi?id=321377</a>

    Reviewed by Alejandro G. Castro.

    Respecting the damage information in compositing regressed the MotionMark
    composition suite by about 20%, and two of its tests by more than 50%.

    A draw is restricted to the damage either by splitting it into multiple
    source-rect-to-destination-rect pieces, which needs a transform that keeps
    rects as rects, or by drawing it under a device-space clip of the damage
    region. Neither restricts a draw that the damage already covers. A composited
    layer in the affected tests is much smaller than a damage grid cell, so most
    layers are covered. Draw those the way they are drawn with damage off.
    The extra clips add nothing and only stop the batching.

    Skia turned a region of more than one rect into a clip path, and the image set
    batch entries carry no clip quad, so a draw needing a clip also flushed the
    batch, leaving it an order of magnitude smaller than it is without damage.
    Solid color layers never reach the batch and paid the clip alone, and filters
    paid it again per layer, compositing their intermediate surface back under
    the clip as well.

    Fix that and recover the performance losses, while keeping damage
    propagation intact for the cases where it pays off.

    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp:
    (WebCore::SkiaCompositingLayerImageSetBatch::addImageSet):
    (WebCore::SkiaCompositingLayerImageSetBatch::addImage):
    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h:
    (WebCore::SkiaCompositingLayerImageSetBatch::planRestrictedDraw):
    * Source/WebCore/platform/graphics/skia/SkiaDamageRegion.h:
    (WebCore::SkiaDamageRegion::covers const):
    (WebCore::SkiaDamageRegion::restrictDraw const):

    Canonical link: <a href="https://commits.webkit.org/318856@main">https://commits.webkit.org/318856@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.103@webkitglib/2.54">https://commits.webkit.org/317695.103@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 6c19621fe6fb19058838803f44c786133ab14189
<pre>
Cherry-pick 318966@main (78dfedf6e4f0). <a href="https://bugs.webkit.org/show_bug.cgi?id=321483">https://bugs.webkit.org/show_bug.cgi?id=321483</a>

    Potential use-after-move in `Document::processCaptureStateDidChange()`
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321483">https://bugs.webkit.org/show_bug.cgi?id=321483</a>
    <a href="https://rdar.apple.com/184571470">rdar://184571470</a>

    Reviewed by Chris Dumez.

    ISO C++23 does not guarantee the initialization order of lambda captures.
    The lambda capture list here both used `isPageMutedCallback` and moved it,
    so the use and the move were unsequenced.

    * Source/WebCore/dom/Document.cpp:
    (WebCore::Document::processCaptureStateDidChange):

    Canonical link: <a href="https://commits.webkit.org/318966@main">https://commits.webkit.org/318966@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.102@webkitglib/2.54">https://commits.webkit.org/317695.102@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9535b1698bea13b47c9aa2a9a6058a29c0c249f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180091 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/54036 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/47832 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190302 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144409 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181953 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/55334 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53752 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140447 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144409 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183046 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/55334 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/47832 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120898 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/55334 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/53752 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2866 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/47832 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/55334 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47832 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1461 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/41364 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46635 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/53752 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192234 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53702 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/47832 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149790 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/54390 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/47832 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149520 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27351 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/54390 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126652 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/121762 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/52906 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/47832 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52289 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52526 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52354 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->