### PR TITLE
[JSC][Temporal] Give CalendarDateUntil and NonISODateUntil one home each

### DIFF
--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -444,19 +444,19 @@ static void testCalendarDateUntil()
 {
     // ISO8601 path only — mirrors temporal_rs: Calendar::date_until + date_until_largest_year
     // 1969-07-24 until 1996-03-03 in days = 9719
-    auto r1 = calendarDateUntil({ 1969, 7, 24 }, { 1996, 3, 3 }, TemporalUnit::Day);
+    auto r1 = diffISODate({ 1969, 7, 24 }, { 1996, 3, 3 }, TemporalUnit::Day);
     TCHECK_EQ(static_cast<int64_t>(r1.days()), 9719LL, "calendarDateUntil: 9719 days");
 
     // Same date -> zero
-    auto r2 = calendarDateUntil({ 2020, 6, 15 }, { 2020, 6, 15 }, TemporalUnit::Day);
+    auto r2 = diffISODate({ 2020, 6, 15 }, { 2020, 6, 15 }, TemporalUnit::Day);
     TCHECK_EQ(static_cast<int64_t>(r2.days()), 0LL, "calendarDateUntil: same date");
 
     // 1969-07-24 until 1969-10-05 in months = 2m11d
-    auto r3 = calendarDateUntil({ 1969, 7, 24 }, { 1969, 10, 5 }, TemporalUnit::Month);
+    auto r3 = diffISODate({ 1969, 7, 24 }, { 1969, 10, 5 }, TemporalUnit::Month);
     TCHECK_EQ(static_cast<int64_t>(r3.months()), 2LL, "calendarDateUntil: 2 months");
 
     // Negative: later until earlier
-    auto r4 = calendarDateUntil({ 1996, 3, 3 }, { 1969, 7, 24 }, TemporalUnit::Day);
+    auto r4 = diffISODate({ 1996, 3, 3 }, { 1969, 7, 24 }, TemporalUnit::Day);
     TCHECK_EQ(static_cast<int64_t>(r4.days()), -9719LL, "calendarDateUntil: -9719 days");
 
     // temporal_rs: date_until_largest_year — full ISO8601 table
@@ -507,7 +507,7 @@ static void testCalendarDateUntil()
         { { 2021, 8, 17 }, { 2021, 7, 16 }, 0, -1, -1 },
     };
     for (auto& c : cases) {
-        auto r = calendarDateUntil(c.one, c.two, TemporalUnit::Year);
+        auto r = diffISODate(c.one, c.two, TemporalUnit::Year);
         TCHECK_EQ(static_cast<int64_t>(r.years()),  c.years,  "dateUntilLargestYear: years");
         TCHECK_EQ(static_cast<int64_t>(r.months()), c.months, "dateUntilLargestYear: months");
         TCHECK_EQ(static_cast<int64_t>(r.days()),   c.days,   "dateUntilLargestYear: days");

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -509,12 +509,9 @@ ISO8601::PlainDate calendarDateAdd(JSGlobalObject* globalObject, CalendarID cale
     return *result;
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil
 ISO8601::Duration calendarDateUntil(JSGlobalObject* globalObject, CalendarID calendarId, const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    if (calendarId == iso8601CalendarID())
-        return TemporalCore::calendarDateUntil(one, two, largestUnit);
     auto result = TemporalCore::calendarDateUntil(calendarId, one, two, largestUnit);
     if (!result) [[unlikely]] {
         throwTemporalError(globalObject, scope, result.error());

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -428,12 +428,8 @@ ISO8601::Duration TemporalPlainDate::differenceTemporalPlainDate(JSGlobalObject*
         return ISO8601::Duration();
 
     // Step 6: dateDifference = CalendarDateUntil(calendar, this, other, largestUnit).
-    ISO8601::Duration dateDiff;
-    if (!TemporalCore::calendarIsISO(m_calendarID)) {
-        dateDiff = calendarDateUntil(globalObject, m_calendarID, plainDate(), other->plainDate(), largestUnit);
-        RETURN_IF_EXCEPTION(scope, { });
-    } else
-        dateDiff = TemporalCore::calendarDateUntil(plainDate(), other->plainDate(), largestUnit);
+    ISO8601::Duration dateDiff = calendarDateUntil(globalObject, m_calendarID, plainDate(), other->plainDate(), largestUnit);
+    RETURN_IF_EXCEPTION(scope, { });
 
     // Step 7: duration = CombineDateAndTimeDuration(dateDifference, 0).
     ISO8601::InternalDuration duration = ISO8601::InternalDuration::combineDateAndTimeDuration(dateDiff, 0);

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarArithmetic.cpp
@@ -29,16 +29,6 @@
 namespace JSC {
 namespace TemporalCore {
 
-// CalendarDateUntil (ISO8601 path) — temporal_rs: Calendar::date_until
-// https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil (ISO8601 path)
-ISO8601::Duration calendarDateUntil(const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
-{
-    // 3. If calendar is "iso8601", then
-    //    3.k. Return ! CreateDateDurationRecord(years, months, weeks, days).
-    // (full ISO8601 path implemented in diffISODate)
-    return diffISODate(one, two, largestUnit);
-}
-
 // CalendarDateAdd (ISO8601 path) — temporal_rs: Calendar::date_add
 // https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd (ISO8601 path)
 TemporalResult<ISO8601::PlainDate> calendarDateAdd(const ISO8601::PlainDate& date, const ISO8601::Duration& duration, TemporalOverflow overflow)

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarArithmetic.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarArithmetic.h
@@ -38,8 +38,6 @@
 namespace JSC {
 namespace TemporalCore {
 
-JS_EXPORT_PRIVATE ISO8601::Duration calendarDateUntil(const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit);
-
 JS_EXPORT_PRIVATE TemporalResult<ISO8601::PlainDate> calendarDateAdd(const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
 
 } // namespace TemporalCore

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
@@ -660,7 +660,7 @@ TemporalResult<ISO8601::Duration> differenceYearMonth(CalendarID calendarId, con
             || std::abs(dateToDaysFrom1970(otherDate.year(), static_cast<int>(otherDate.month()) - 1, 1)) > 1e8)
             return makeUnexpected(rangeError("date is outside the representable range for Temporal"_s));
         // Steps 10-14: CalendarDateUntil(thisDate, otherDate, largestUnit).
-        return calendarDateUntil(thisDate, otherDate, largestUnit);
+        return calendarDateUntil(calendarId, thisDate, otherDate, largestUnit);
     }
 
     // Non-ISO: resolve both to day=1 via dateFromFields (matching temporal_rs).

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -2042,26 +2042,12 @@ static std::optional<bool> setMonths(UCalendar* cal, int32_t sourceDay)
     return true;
 }
 
-// calendarDateUntil — temporal_rs: Calendar::date_until (src/builtins/core/calendar.rs)
+// NonISODateUntil — temporal_rs: Calendar::date_until (src/builtins/core/calendar.rs)
 //   temporal_rs delegates to icu4x: AnyCalendar::until -> ArithmeticDate::until + SurpassesChecker (components/calendar/src/calendar_arithmetic.rs)
 //   ICU4C has no equivalent: fixed-solar calendars balance native fields directly; lunisolar calendars walk months with ucal_add.
-// https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil
-TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
+// https://tc39.es/proposal-intl-era-monthcode/#sup-temporal-nonisodateuntil
+static TemporalResult<ISO8601::Duration> nonISODateUntil(CalendarID calendarId, const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
 {
-    ASSERT(largestUnit == TemporalUnit::Year || largestUnit == TemporalUnit::Month || largestUnit == TemporalUnit::Week || largestUnit == TemporalUnit::Day);
-
-    // Step 3 (iso8601 inline algorithm): ISODateSurpasses-based diff.
-    if (calendarUsesISODateArithmetic(calendarId))
-        return diffISODate(one, two, largestUnit);
-    // Fast path: day/week diff is calendar-independent regardless of largestUnit.
-    if (largestUnit == TemporalUnit::Day || largestUnit == TemporalUnit::Week)
-        return diffISODate(one, two, largestUnit);
-    if (calendarUsesISOFallbackForExtremeYear(calendarId, one.year()) || calendarUsesISOFallbackForExtremeYear(calendarId, two.year()))
-        return diffISODate(one, two, largestUnit);
-
-    // Step 4 (non-ISO tail return): `Return NonISODateUntil(calendar, one, two, largestUnit)`.
-    // https://tc39.es/proposal-intl-era-monthcode/#sup-temporal-nonisodateuntil
-
     // Snapshot source (one) and target (two) fields — separate withCalendar calls for minimal lock scope.
     struct DateSnapshot {
         double epochMs { 0 };
@@ -2135,15 +2121,9 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         return makeUnexpected(sourceOrError.error());
     auto& source = *sourceOrError;
 
-    // CalendarDateUntil Steps 1-2 (deferred from the top): sign compute + zero-return.
-    // +1 (one < two), -1 (one > two), 0 (equal → zero duration).
-    int32_t sign;
-    if (source.epochMs < target.epochMs)
-        sign = 1;
-    else if (source.epochMs > target.epochMs)
-        sign = -1;
-    else
-        return ISO8601::Duration { };
+    // +1 (one < two), -1 (one > two). CalendarDateUntil's steps 1-2 already returned for equal dates.
+    ASSERT(source.epochMs != target.epochMs);
+    int32_t sign = source.epochMs < target.epochMs ? 1 : -1;
 
     // Fixed-solar calendars have a constant month count, so jump directly to the native
     // total-month difference. At most one candidate can surpass because it is already in
@@ -2283,6 +2263,27 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
     });
 }
 
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil
+TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
+{
+    ASSERT(largestUnit == TemporalUnit::Year || largestUnit == TemporalUnit::Month || largestUnit == TemporalUnit::Week || largestUnit == TemporalUnit::Day);
+
+    // Steps 1-2: sign = -CompareISODate(one, two); if sign = 0, return the zero duration.
+    if (!isoDateCompare(one, two))
+        return ISO8601::Duration { };
+
+    // Step 3 (iso8601 inline algorithm): ISODateSurpasses-based diff.
+    if (calendarUsesISODateArithmetic(calendarId))
+        return diffISODate(one, two, largestUnit);
+    // Fast path: day/week diff is calendar-independent regardless of largestUnit.
+    if (largestUnit == TemporalUnit::Day || largestUnit == TemporalUnit::Week)
+        return diffISODate(one, two, largestUnit);
+    if (calendarUsesISOFallbackForExtremeYear(calendarId, one.year()) || calendarUsesISOFallbackForExtremeYear(calendarId, two.year()))
+        return diffISODate(one, two, largestUnit);
+
+    // Step 4: Return NonISODateUntil(calendar, one, two, largestUnit).
+    return nonISODateUntil(calendarId, one, two, largestUnit);
+}
 
 // ecmaReferenceYear — no spec AO, no ICU4C equivalent.
 // Ported line-for-line from icu4x: ecma_reference_year (components/calendar/src/cal/{east_asian_traditional,hijri,hebrew,coptic,persian,indian}.rs).

--- a/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
@@ -197,7 +197,7 @@ static bool isoDateSurpasses(int32_t sign, int32_t y1, int32_t m1, int32_t d1, c
 }
 
 // DiffISODate — temporal_rs: IsoDate::diff_iso_date
-// https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil (ISO8601 path)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil step 3, the iso8601 branch.
 ISO8601::Duration diffISODate(const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
 {
     // 1. Let sign be CompareISODate(one, two).


### PR DESCRIPTION
#### ee16ce938a8f8535cce4d77bfc0a7150d864dc5b
<pre>
[JSC][Temporal] Give CalendarDateUntil and NonISODateUntil one home each
<a href="https://bugs.webkit.org/show_bug.cgi?id=321538">https://bugs.webkit.org/show_bug.cgi?id=321538</a>
<a href="https://rdar.apple.com/184650946">rdar://184650946</a>

Reviewed by Yusuke Suzuki.

Four functions claimed #sec-temporal-calendardateuntil and only one held an algorithm. The
CalendarArithmetic.cpp pass-through and the JS wrapper&apos;s iso8601 dispatch are gone; step 4&apos;s body is
now nonISODateUntil, so calendarDateUntil is 15 lines of dispatch. Steps 1-2 are hoisted above it as
the spec writes them, which also stops d.until(d) on a non-ISO calendar taking two field snapshots
before noticing the dates are equal.

No behaviour change: stress suite and testapi unchanged.

Canonical link: <a href="https://commits.webkit.org/319002@main">https://commits.webkit.org/319002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e40d02733493559f6040e7227dd41d2b0012c38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190316 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144423 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f695f3c7-15ba-4ba3-9f9a-4bde38a81a3a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140461 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c508f73c-614d-4885-94a3-d4bd420e766e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120913 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41100 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2880 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9725 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40768 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1475 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41378 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192249 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53716 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149807 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54404 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149532 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27354 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44170 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126667 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121781 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52920 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15755 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52303 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52540 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52368 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->