### PR TITLE
[Memory64] rename m_cachedIsMemory64

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -911,7 +911,7 @@ reservedOpcode(0x27)
 # Pops the address operand of a memory access, whose width follows memory 0's address type.
 macro popMemoryAddress(reg)
     popInt64(reg) # Note that popInt32 and popInt64 are same implementation.
-    btbnz JSWebAssemblyInstance::m_cachedIsMemory64[wasmInstance], .done
+    btbnz JSWebAssemblyInstance::m_cachedMemory0IsMemory64[wasmInstance], .done
     zxi2q reg, reg
 .done:
 end
@@ -10109,7 +10109,7 @@ ipintAtomicOp(_memory_atomic_wait32, macro()
     loadb IPInt::AtomicMemoryAccessMetadata::memoryIndex[MC], t0
     pushInt32(t0)
     loadq (StackValueSize * 3)[sp], t0
-    btbnz JSWebAssemblyInstance::m_cachedIsMemory64[wasmInstance], .pointerIsMemory64
+    btbnz JSWebAssemblyInstance::m_cachedMemory0IsMemory64[wasmInstance], .pointerIsMemory64
     zxi2q t0, t0
 .pointerIsMemory64:
     loadq IPInt::AtomicMemoryAccessMetadata::offset[MC], t1
@@ -10142,7 +10142,7 @@ ipintAtomicOp(_memory_atomic_wait64, macro()
     loadb IPInt::AtomicMemoryAccessMetadata::memoryIndex[MC], t0
     pushInt32(t0)
     loadq (StackValueSize * 3)[sp], t0
-    btbnz JSWebAssemblyInstance::m_cachedIsMemory64[wasmInstance], .pointerIsMemory64
+    btbnz JSWebAssemblyInstance::m_cachedMemory0IsMemory64[wasmInstance], .pointerIsMemory64
     zxi2q t0, t0
 .pointerIsMemory64:
     loadq IPInt::AtomicMemoryAccessMetadata::offset[MC], t1

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -412,7 +412,7 @@ auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
         const uint64_t maxDeclarablePageCount = maxDeclarablePages(AddressType { isMemory64 });
         WASM_PARSER_FAIL_IF(initial > maxDeclarablePageCount, "Memory's initial page count of "_s, initial, " is invalid"_s);
 
-        // FIXME(wasm-memory64): for now IPInt checks m_cachedIsMemory64 (flag if memory 0 is 64-bit)
+        // FIXME(wasm-memory64): for now IPInt checks m_cachedMemory0IsMemory64 (flag if memory 0 is 64-bit)
         // no matter which memory is being accessed
         if (m_info->memoryCount())
             WASM_PARSER_FAIL_IF(isMemory64 || m_info->memory(0).isMemory64(), "if using memory64 then multiple memories are illegal for now"_s);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -124,7 +124,7 @@ public:
             m_cachedMemory0Size = m_memories[i]->memory().size();
             m_wasmMemory = value->memory();
         }
-        m_cachedIsMemory64 = moduleInformation().memory(0).isMemory64();
+        m_cachedMemory0IsMemory64 = moduleInformation().memory(0).isMemory64();
         m_memories[i]->memory().registerInstance(*this);
     }
 
@@ -229,7 +229,7 @@ public:
     uint32_t cachedTable0Length() const { return m_cachedTable0Length; }
     Wasm::FuncRefTable::Function* cachedTable0Buffer() const { return m_cachedTable0Buffer; }
 
-    bool cachedIsMemory64() const { return m_cachedIsMemory64; }
+    bool cachedMemory0IsMemory64() const { return m_cachedMemory0IsMemory64; }
 
     void updateCachedTable0();
 
@@ -306,7 +306,7 @@ public:
     static constexpr ptrdiff_t offsetOfCachedTable0Buffer() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedTable0Buffer); }
     static constexpr ptrdiff_t offsetOfCachedTable0Length() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedTable0Length); }
     static constexpr ptrdiff_t offsetOfBuiltinCalleeBits() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_builtinCalleeBits); }
-    static constexpr ptrdiff_t offsetOfCachedIsMemory64() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedIsMemory64); }
+    static constexpr ptrdiff_t offsetOfCachedMemory0IsMemory64() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedMemory0IsMemory64); }
     static constexpr ptrdiff_t offsetOfCachedMemory0Size() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedMemory0Size); }
 
     // Tail accessors.
@@ -456,7 +456,7 @@ private:
     const Ref<const Wasm::ModuleInformation> m_moduleInformation;
     RefPtr<Wasm::InstanceAnchor> m_anchor;
     RefPtr<SourceProvider> m_sourceProvider;
-    bool m_cachedIsMemory64 { false }; // FIXME(wasm-memory64): rename this to cachedMemory0IsMemory64 or something similar
+    bool m_cachedMemory0IsMemory64 { false };
     uint64_t m_cachedMemory0Size { 0 }; // memory.size for memory 0, handled specially to avoid performance regressions
 
     RefPtr<Wasm::Memory> m_wasmMemory;


### PR DESCRIPTION
#### 92bcef1cb48493eb468de6af4163c783b6594fb6
<pre>
[Memory64] rename m_cachedIsMemory64
<a href="https://bugs.webkit.org/show_bug.cgi?id=321542">https://bugs.webkit.org/show_bug.cgi?id=321542</a>
<a href="https://rdar.apple.com/184653931">rdar://184653931</a>

Reviewed by Yusuke Suzuki.

m_cachedIsMemory64 should be named m_cachedMemory0IsMemory64 to reflect that
IPInt only checks the cached value for memory 0.

* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseMemoryHelper):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Canonical link: <a href="https://commits.webkit.org/319044@main">https://commits.webkit.org/319044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e25cf0cf54877d1b69d19222998ab47ffa2b9ca2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144449 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31319744-c6fd-4351-9175-b27a552cbb05) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140489 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c284f14b-b5ff-4334-b85a-775c07130889) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120941 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d42da22-a8f2-4d21-a4c8-09de721edbac) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42810 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41120 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2908 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9750 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40794 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1501 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41404 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192276 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53742 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149834 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40154 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54430 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149562 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44198 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126693 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121810 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52947 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15782 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52329 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52566 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52394 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->