### PR TITLE
[JSC] Fill alignment gap in WasmGC structs

### DIFF
--- a/JSTests/wasm/gc/struct-field-gap-filling.js
+++ b/JSTests/wasm/gc/struct-field-gap-filling.js
@@ -1,0 +1,106 @@
+import { instantiate } from "./wast-wrapper.js"
+import * as assert from "../assert.js"
+
+// Builds a struct whose fields have the given wasm storage types, and returns the
+// payload offset of each field plus the total payload size.
+function layoutOf(...fieldTypes) {
+    const fields = fieldTypes.map(t => `(field (mut ${t}))`).join(" ");
+    const args = fieldTypes.map(t => {
+        switch (t) {
+        case "f32":
+        case "f64":
+            return `(${t}.const 0)`;
+        case "i64":
+            return "(i64.const 0)";
+        case "externref":
+            return "(ref.null extern)";
+        default:
+            return "(i32.const 0)";
+        }
+    }).join(" ");
+    const m = instantiate(`
+      (module
+        (type $s (struct ${fields}))
+        (func (export "make") (result (ref $s))
+          (struct.new $s ${args})))
+    `);
+    const o = m.exports.make();
+    return { offsets: $vm.wasmStructFieldOffsets(o), size: $vm.wasmStructPayloadSize(o) };
+}
+
+function assertLayout(fieldTypes, expectedOffsets, expectedSize) {
+    const { offsets, size } = layoutOf(...fieldTypes);
+    assert.eq(offsets.length, expectedOffsets.length);
+    for (let i = 0; i < expectedOffsets.length; ++i) {
+        if (offsets[i] !== expectedOffsets[i])
+            throw new Error(`(${fieldTypes}) field ${i}: expected offset ${expectedOffsets[i]}, got ${offsets[i]}`);
+    }
+    if (size !== expectedSize)
+        throw new Error(`(${fieldTypes}) expected payload size ${expectedSize}, got ${size}`);
+}
+
+// Payload size is rounded up to a multiple of 8, so it only shrinks once the gap
+// filling saves a whole 8-byte slot.
+
+// No gap to fill.
+assertLayout(["i32", "i32"], [0, 4], 8);
+assertLayout(["i64", "i64"], [0, 8], 16);
+
+// i32 at 0, i64 needs 8-alignment, leaving a 4-byte gap at 4 that the trailing i32 takes.
+assertLayout(["i32", "i64", "i32"], [0, 8, 4], 16);
+
+// The trailing field must be aligned within the gap, not just fit in it: the gap is
+// [1, 4), and the i16 skips a byte to land on offset 2.
+assertLayout(["i8", "i32", "i16"], [0, 4, 2], 8);
+
+// The gap that is tracked is the largest one seen so far. Here i8 at 0 opens [1, 8)
+// before the i64; i32 takes [4, 8) and the remainder [1, 4) stays tracked for the i16.
+assertLayout(["i8", "i64", "i32", "i16"], [0, 8, 4, 2], 16);
+
+// Only one gap is tracked, so the [1, 2) hole between the two i8s is dropped when the
+// larger [2, 8) gap before the i64 replaces it. Both i16s then fit in that larger gap.
+assertLayout(["i8", "i8", "i64", "i16", "i16"], [0, 1, 8, 2, 4], 16);
+
+// Interleaved i8/i32, the motivating case: each i8 packs into the alignment hole left
+// by the preceding i32 instead of opening a new one. Naive placement would need 24
+// payload bytes here.
+assertLayout(["i8", "i32", "i8", "i32", "i8", "i32"], [0, 4, 1, 8, 2, 12], 16);
+
+// A field larger than the gap cannot use it.
+assertLayout(["i8", "i64", "i64"], [0, 8, 16], 24);
+
+// Reference-typed fields participate too. externref is 8 bytes and 8-aligned.
+assertLayout(["i32", "externref", "i32"], [0, 8, 4], 16);
+
+// Gap filling must never reorder fields: a subtype extends its supertype's field list,
+// so the shared prefix has to land at the same offsets in both. Otherwise a
+// supertype-typed read of a subtype instance reads the wrong bytes.
+const sub = instantiate(`
+  (module
+    (rec
+      (type $base (sub (struct (field $a (mut i32)) (field $b (mut i64)))))
+      (type $derived (sub $base (struct (field $a (mut i32)) (field $b (mut i64)) (field $c (mut i32))))))
+    (func (export "viaBase") (result i64)
+      (local $d (ref null $derived))
+      (local.set $d (struct.new $derived (i32.const 7) (i64.const 99) (i32.const 5)))
+      (struct.get $base $b (local.get $d))))
+`);
+assert.eq(sub.exports.viaBase(), 99n);
+
+// Values written through a gap-filled offset must round-trip: the fields must not
+// overlap each other.
+const packed = instantiate(`
+  (module
+    (type $s (struct (field $a (mut i8)) (field $b (mut i64)) (field $c (mut i32)) (field $d (mut i16))))
+    (func (export "sum") (result i64)
+      (local $o (ref null $s))
+      (local.set $o (struct.new $s (i32.const 0xff) (i64.const 0x1122334455667788) (i32.const 0x0a0b0c0d) (i32.const 0xeeee)))
+      (i64.add
+        (i64.add
+          (i64.extend_i32_u (struct.get_u $s $a (local.get $o)))
+          (struct.get $s $b (local.get $o)))
+        (i64.add
+          (i64.extend_i32_u (struct.get $s $c (local.get $o)))
+          (i64.extend_i32_u (struct.get_u $s $d (local.get $o)))))))
+`);
+assert.eq(packed.exports.sum(), 0xffn + 0x1122334455667788n + 0x0a0b0c0dn + 0xeeeen);

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -97,6 +97,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if ENABLE(WEBASSEMBLY)
 #include "JSWebAssemblyHelpers.h"
+#include "JSWebAssemblyStruct.h"
 #include "WasmModuleInformation.h"
 #include "WasmStreamingCompiler.h"
 #include "WasmStreamingParser.h"
@@ -2220,6 +2221,8 @@ static JSC_DECLARE_HOST_FUNCTION(functionTotalGCTime);
 static JSC_DECLARE_HOST_FUNCTION(functionParseCount);
 static JSC_DECLARE_HOST_FUNCTION(functionIsWasmSupported);
 static JSC_DECLARE_HOST_FUNCTION(functionWasmCanonicalTypeCount);
+static JSC_DECLARE_HOST_FUNCTION(functionWasmStructFieldOffsets);
+static JSC_DECLARE_HOST_FUNCTION(functionWasmStructPayloadSize);
 static JSC_DECLARE_HOST_FUNCTION(functionMake16BitStringIfPossible);
 static JSC_DECLARE_HOST_FUNCTION(functionGetStructureTransitionList);;
 static JSC_DECLARE_HOST_FUNCTION(functionGetConcurrently);
@@ -3996,6 +3999,46 @@ JSC_DEFINE_HOST_FUNCTION(functionWasmCanonicalTypeCount, (JSGlobalObject*, CallF
 #endif
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionWasmStructFieldOffsets, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+#if ENABLE(WEBASSEMBLY)
+    auto* structObject = dynamicDowncast<JSWebAssemblyStruct>(callFrame->argument(0));
+    if (!structObject)
+        return throwVMTypeError(globalObject, scope, "argument is not a WebAssembly GC struct"_s);
+
+    SUPPRESS_UNCOUNTED_LOCAL const auto& rtt = structObject->structType();
+    JSArray* result = constructEmptyArray(globalObject, nullptr);
+    RETURN_IF_EXCEPTION(scope, { });
+    for (Wasm::StructFieldCount i = 0; i < rtt.fieldCount(); ++i) {
+        result->push(globalObject, jsNumber(rtt.offsetOfFieldInPayload(i)));
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+    return JSValue::encode(result);
+#else
+    UNUSED_PARAM(callFrame);
+    return throwVMTypeError(globalObject, scope, "WebAssembly is not enabled"_s);
+#endif
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionWasmStructPayloadSize, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+#if ENABLE(WEBASSEMBLY)
+    auto* structObject = dynamicDowncast<JSWebAssemblyStruct>(callFrame->argument(0));
+    if (!structObject)
+        return throwVMTypeError(globalObject, scope, "argument is not a WebAssembly GC struct"_s);
+    return JSValue::encode(jsNumber(structObject->structType().instancePayloadSize()));
+#else
+    UNUSED_PARAM(callFrame);
+    return throwVMTypeError(globalObject, scope, "WebAssembly is not enabled"_s);
+#endif
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionMake16BitStringIfPossible, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
@@ -4663,6 +4706,8 @@ void JSDollarVM::finishCreation(VM& vm)
 
     addFunction(vm, alwaysAllow, "isWasmSupported"_s, functionIsWasmSupported, 0);
     addFunction(vm, alwaysAllow, "wasmCanonicalTypeCount"_s, functionWasmCanonicalTypeCount, 0);
+    addFunction(vm, alwaysAllow, "wasmStructFieldOffsets"_s, functionWasmStructFieldOffsets, 1);
+    addFunction(vm, alwaysAllow, "wasmStructPayloadSize"_s, functionWasmStructPayloadSize, 1);
     addFunction(vm, alwaysAllow, "make16BitStringIfPossible"_s, functionMake16BitStringIfPossible, 1);
 
     addFunction(vm, allowIfNotFuzz, "getStructureTransitionList"_s, functionGetStructureTransitionList, 1);

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 the V8 project authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -304,6 +305,37 @@ inline bool isExnref(Type type)
     return isRefType(type) && type.index() == typeIndexFromTypeKind(TypeKind::Exnref);
 }
 
+// Placing a field in WasmGC Struct, but tracking a gap happening due to alignment requirement.
+// We keep one gap slot so far if exists, and attempt to reuse this gap when it is possible.
+inline unsigned placeStructField(size_t fieldSize, unsigned& currentOffset, unsigned& gapPosition, unsigned& gapSize)
+{
+    if (fieldSize <= gapSize) {
+        unsigned alignedGap = WTF::roundUpToMultipleOf(fieldSize, gapPosition);
+        unsigned gapBefore = alignedGap - gapPosition;
+        unsigned alignedGapSize = gapSize - gapBefore;
+        if (fieldSize <= alignedGapSize) {
+            unsigned gapAfter = alignedGapSize - fieldSize;
+            if (gapBefore > gapAfter)
+                gapSize = gapBefore;
+            else {
+                gapPosition = alignedGap + fieldSize;
+                gapSize = gapAfter;
+            }
+            return alignedGap;
+        }
+    }
+
+    unsigned oldOffset = currentOffset;
+    currentOffset = WTF::roundUpToMultipleOf(fieldSize, currentOffset);
+    unsigned gap = currentOffset - oldOffset;
+    if (gap > gapSize) {
+        gapSize = gap;
+        gapPosition = oldOffset;
+    }
+    unsigned offset = currentOffset;
+    currentOffset += fieldSize;
+    return offset;
+}
 inline JSString* typeToJSAPIString(VM& vm, Type type)
 {
     switch (type.kind()) {

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -582,13 +582,13 @@ Ref<const RTT> TypeInformation::typeDefinitionForStruct(const Vector<FieldType>&
     bool hasRefFieldTypes = false;
     bool hasRecursiveReference = false;
     unsigned currentFieldOffset = 0;
+    unsigned gapPosition = 0;
+    unsigned gapSize = 0;
     auto entries = FixedVector<StructFieldEntry>::createWithSizeFromGenerator(fields.size(), [&](size_t i) -> StructFieldEntry {
         const FieldType& fieldType = fields[i];
         hasRefFieldTypes |= isRefType(fieldType.type);
         hasRecursiveReference |= isRefWithRecursiveReference(fieldType.type);
-        currentFieldOffset = WTF::roundUpToMultipleOf(typeAlignmentInBytes(fieldType.type), currentFieldOffset);
-        unsigned offset = currentFieldOffset;
-        currentFieldOffset += typeSizeInBytes(fieldType.type);
+        unsigned offset = placeStructField(typeSizeInBytes(fieldType.type), currentFieldOffset, gapPosition, gapSize);
         // Anchor external RTT ref inline (null for PackedType or non-ref Type).
         RefPtr<const RTT> anchor;
         if (fieldType.type.is<Type>())

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
@@ -64,14 +64,14 @@ Ref<const RTT> TypeInformation::typeDefinitionForStructFromProvider(StructFieldC
     bool hasRefFieldTypes = false;
     bool hasRecursiveReference = false;
     unsigned currentOffset = 0;
+    unsigned gapPosition = 0;
+    unsigned gapSize = 0;
 
     auto entries = FixedVector<StructFieldEntry>::createWithSizeFromGenerator(fieldCount, [&](size_t i) -> StructFieldEntry {
         FieldType f = provider(i);
         hasRefFieldTypes |= isRefType(f.type);
         hasRecursiveReference |= isRefWithRecursiveReference(f.type);
-        currentOffset = WTF::roundUpToMultipleOf(typeAlignmentInBytes(f.type), currentOffset);
-        unsigned offset = currentOffset;
-        currentOffset += typeSizeInBytes(f.type);
+        unsigned offset = placeStructField(typeSizeInBytes(f.type), currentOffset, gapPosition, gapSize);
         RefPtr<const RTT> anchor;
         if (f.type.is<Type>())
             anchor = extractExternalRTT(f.type.as<Type>());


### PR DESCRIPTION
#### 3eee8becf0b5d458f667d35392b2dc62aeb8b847
<pre>
[JSC] Fill alignment gap in WasmGC structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=321545">https://bugs.webkit.org/show_bug.cgi?id=321545</a>
<a href="https://rdar.apple.com/184655909">rdar://184655909</a>

Reviewed by Vassili Bykov.

WasmGC Struct may have padding like what C++ struct is because of
alignment requirement of fields. But since offset of fields are not
exposed as ABI, we can fill gaps with smaller fields to compact the size
of WasmGC structs. This is effective for example if we are interleaving
i8 and i32.

    struct {
        i8;
        i32;
        i8;
        i32;
    };

This can be like,

    struct {
        i8;
        i8;
        i32;
        i32;
    };

We apply V8&apos;s heuristics[1]. Tracking one gap we found so far, and
reusing this gap when we encounter a field which can fit in this gap.

To make the layout itself testable, $vm gains wasmStructFieldOffsets and
wasmStructPayloadSize, which reflect the placement decisions of a struct
instance back to JS.

[1]: <a href="https://chromium-review.googlesource.com/c/v8/v8/+/4092494">https://chromium-review.googlesource.com/c/v8/v8/+/4092494</a>

Test: JSTests/wasm/gc/struct-field-gap-filling.js

* JSTests/wasm/gc/struct-field-gap-filling.js: Added.
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::functionWasmStructFieldOffsets):
(JSC::functionWasmStructPayloadSize):
(JSC::JSDollarVM::finishCreation):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::placeStructField):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeInformation::typeDefinitionForStruct):
* Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h:
(JSC::Wasm::TypeInformation::typeDefinitionForStructFromProvider):

Canonical link: <a href="https://commits.webkit.org/319015@main">https://commits.webkit.org/319015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/570c0f1959f37cfc61df3acd726b4b44d766de0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190375 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144482 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1cd25bc-5e48-4011-aa1e-f31ec222ac3a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140513 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e2681e0-2583-4f87-971c-adf9dd41b929) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44170 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120965 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d4b56f4-e714-4746-94b5-032abe0eaba8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/2932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9783 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40827 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1534 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41438 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46708 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192309 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53775 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149862 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54463 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149589 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27359 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44225 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126726 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121849 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52980 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15816 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52362 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52599 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52427 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->