### PR TITLE
[Memory64] Hoist memory64 offset sum overflow checks into a helper

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -1243,9 +1243,8 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint64_t uoffset)
 
 [[nodiscard]] PartialResult BBQJIT::atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex)
 {
-    const bool overflow = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(uoffset, sizeOfAtomicOpMemoryAccess(loadOp))
-        : sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(loadOp));
+    const bool overflow = m_info.memory(memoryIndex).doesAccessOverflow(uoffset, sizeOfAtomicOpMemoryAccess(loadOp));
+
     if (overflow) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
@@ -1261,9 +1260,8 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint64_t uoffset)
 
 [[nodiscard]] PartialResult BBQJIT::atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint64_t uoffset, uint8_t memoryIndex)
 {
-    const bool overflow = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(uoffset, sizeOfAtomicOpMemoryAccess(storeOp))
-        : sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(storeOp));
+    const bool overflow = m_info.memory(memoryIndex).doesAccessOverflow(uoffset, sizeOfAtomicOpMemoryAccess(storeOp));
+
     Location valueLocation = locationOf(value);
     if (overflow) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
@@ -1280,9 +1278,8 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint64_t uoffset)
 
 [[nodiscard]] PartialResult BBQJIT::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex)
 {
-    const bool overflow = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))
-        : sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op));
+    const bool overflow = m_info.memory(memoryIndex).doesAccessOverflow(uoffset, sizeOfAtomicOpMemoryAccess(op));
+
     Location valueLocation = locationOf(value);
     if (overflow) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
@@ -1301,9 +1298,8 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint64_t uoffset)
 
 [[nodiscard]] PartialResult BBQJIT::atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex)
 {
-    const bool overflow = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))
-        : sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op));
+    const bool overflow = m_info.memory(memoryIndex).doesAccessOverflow(uoffset, sizeOfAtomicOpMemoryAccess(op));
+
     Location valueLocation = locationOf(value);
     if (overflow) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1114,7 +1114,7 @@ public:
 
     inline Location emitCheckAndPreparePointer(Value pointer, uint64_t uoffset, uint32_t sizeOfOperation, uint8_t memoryIndex)
     {
-        if (WTF::sumOverflows<uint64_t>(static_cast<uint64_t>(sizeOfOperation), uoffset)) {
+        if (m_info.memory(memoryIndex).doesAccessOverflow(uoffset, sizeOfOperation)) {
             recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.jump());
             consume(pointer);
             return Location::fromGPR(wasmScratchGPR);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -342,9 +342,7 @@ Value BBQJIT::instanceValue()
 
 [[nodiscard]] PartialResult BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint64_t uoffset, uint8_t memoryIndex)
 {
-    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(uoffset, sizeOfLoadOp(loadOp))
-        : sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp));
+    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).doesAccessOverflow(uoffset, sizeOfLoadOp(loadOp));
 
     if (offsetAndSizeOverflows) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
@@ -439,9 +437,7 @@ Value BBQJIT::instanceValue()
 [[nodiscard]] PartialResult BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint64_t uoffset, uint8_t memoryIndex)
 {
     Location valueLocation = locationOf(value);
-    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(uoffset, sizeOfStoreOp(storeOp))
-        : sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp));
+    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).doesAccessOverflow(uoffset, sizeOfStoreOp(storeOp));
 
     if (offsetAndSizeOverflows) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -42,7 +42,7 @@ namespace JSC { namespace Wasm { namespace BBQJITImpl {
 template<typename Functor>
 auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64_t uoffset, uint32_t sizeOfOperation, uint8_t memoryIndex, Functor&& functor) -> decltype(auto)
 {
-    if (WTF::sumOverflows<uint64_t>(static_cast<uint64_t>(sizeOfOperation), uoffset)) {
+    if (m_info.memory(memoryIndex).doesAccessOverflow(uoffset, sizeOfOperation)) {
         recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.jump());
         return functor(CCallHelpers::Address(wasmBaseMemoryPointer, 0));
     }

--- a/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
@@ -25,10 +25,12 @@
 
 #include "config.h"
 #include "WasmMemoryInformation.h"
+#include <limits>
 
 #if ENABLE(WEBASSEMBLY)
 
 #include "WasmContext.h"
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace JSC { namespace Wasm {
@@ -43,6 +45,14 @@ MemoryInformation::MemoryInformation(PageCount initial, PageCount maximum, bool 
     RELEASE_ASSERT(!!m_initial);
     RELEASE_ASSERT(!m_maximum || m_maximum >= m_initial);
     ASSERT(!!*this);
+}
+
+
+bool MemoryInformation::doesAccessOverflow(uint64_t first, uint64_t second) const
+{
+    if (isMemory64())
+        return WTF::sumOverflows<uint64_t>(first, second);
+    return WTF::sumOverflows<uint32_t>(first, second);
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmMemoryInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmMemoryInformation.h
@@ -62,6 +62,7 @@ public:
     bool isImport() const { return m_isImport; }
     AddressType addressType() const { return m_addressType; }
     bool isMemory64() const { return m_addressType.is64Bit(); }
+    bool doesAccessOverflow(uint64_t offset, uint64_t size) const;
 
     explicit operator bool() const { return !!m_initial; }
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2501,7 +2501,7 @@ inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint64_
             // We're not using signal handling only when the memory is not shared.
             // Regardless of signaling, we must check that no memory access exceeds the current memory size.
             static_assert(GPRInfo::wasmBoundsCheckingSizeRegister != InvalidGPRReg);
-            if (WTF::sumOverflows<uint64_t>(offset, sizeOfOperation)) {
+            if (m_info.memory(memoryIndex).doesAccessOverflow(offset, sizeOfOperation)) {
                 B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
                 throwException->setGenerator([this, origin = this->origin()](CCallHelpers& jit, const B3::StackmapGenerationParams&) {
                     this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
@@ -2543,9 +2543,7 @@ inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint64_
 
     // if memoryIndex != 0, force bounds checking
 
-    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(offset, sizeOfOperation)
-        : sumOverflows<uint32_t>(offset, sizeOfOperation);
+    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).doesAccessOverflow(offset, sizeOfOperation);
 
     if (offsetAndSizeOverflows) [[unlikely]] {
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -2718,9 +2716,7 @@ auto OMGIRGenerator::load(LoadOpType op, ExpressionType pointerVar, ExpressionTy
 {
     Value* pointer = get(pointerVar);
 
-    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(offset, sizeOfLoadOp(op))
-        : sumOverflows<uint32_t>(offset, sizeOfLoadOp(op));
+    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).doesAccessOverflow(offset, sizeOfLoadOp(op));
 
     if (offsetAndSizeOverflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
@@ -2828,9 +2824,8 @@ auto OMGIRGenerator::store(StoreOpType op, ExpressionType pointerVar, Expression
     Value* pointer = get(pointerVar);
     Value* value = get(valueVar);
     ASSERT(pointer->type() == m_info.memory(memoryIndex).addressType());
-    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(offset, sizeOfStoreOp(op))
-        : sumOverflows<uint32_t>(offset, sizeOfStoreOp(op));
+
+    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).doesAccessOverflow(offset, sizeOfStoreOp(op));
 
     if (offsetAndSizeOverflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
@@ -2924,9 +2919,7 @@ auto OMGIRGenerator::atomicLoad(ExtAtomicOpType op, Type valueType, ExpressionTy
 {
     ASSERT(pointer.type().kind() == m_info.memory(memoryIndex).addressType().asB3TypeKind());
 
-    const bool overflows = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(offset, sizeOfAtomicOpMemoryAccess(op))
-        : sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op));
+    const bool overflows = m_info.memory(memoryIndex).doesAccessOverflow(offset, sizeOfAtomicOpMemoryAccess(op));
 
     if (overflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
@@ -2968,9 +2961,7 @@ inline void OMGIRGenerator::emitAtomicStoreOp(ExtAtomicOpType op, Type valueType
 auto OMGIRGenerator::atomicStore(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, uint64_t offset, uint8_t memoryIndex) -> PartialResult
 {
     ASSERT(pointer.type().kind() == m_info.memory(memoryIndex).addressType().asB3TypeKind());
-    const bool overflows = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(offset, sizeOfAtomicOpMemoryAccess(op))
-        : sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op));
+    const bool overflows = m_info.memory(memoryIndex).doesAccessOverflow(offset, sizeOfAtomicOpMemoryAccess(op));
 
     if (overflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
@@ -3064,9 +3055,7 @@ auto OMGIRGenerator::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, Express
 {
     ASSERT(pointer.type().kind() == m_info.memory(memoryIndex).addressType().asB3TypeKind());
 
-    const bool overflows = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(offset, sizeOfAtomicOpMemoryAccess(op))
-        : sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op));
+    const bool overflows = m_info.memory(memoryIndex).doesAccessOverflow(offset, sizeOfAtomicOpMemoryAccess(op));
 
     if (overflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
@@ -3181,9 +3170,7 @@ auto OMGIRGenerator::atomicCompareExchange(ExtAtomicOpType op, Type valueType, E
 {
     ASSERT(pointer.type().kind() == m_info.memory(memoryIndex).addressType().asB3TypeKind());
 
-    const bool overflows = m_info.memory(memoryIndex).isMemory64()
-        ? sumOverflows<uint64_t>(offset, sizeOfAtomicOpMemoryAccess(op))
-        : sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op));
+    const bool overflows = m_info.memory(memoryIndex).doesAccessOverflow(offset, sizeOfAtomicOpMemoryAccess(op));
 
     if (overflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it


### PR DESCRIPTION
#### c7c0c2f7dfaebb618e33e9f8f6ebe5748d246c9e
<pre>
[Memory64] Hoist memory64 offset sum overflow checks into a helper
<a href="https://bugs.webkit.org/show_bug.cgi?id=321546">https://bugs.webkit.org/show_bug.cgi?id=321546</a>
<a href="https://rdar.apple.com/184657114">rdar://184657114</a>

Reviewed by Keith Miller.

There is a lot of duplicate code that checks for overflow after
adding the offset and size of operation. This patch consolidates
these checks into a helper function.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicLoad):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicStore):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicBinaryRMW):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicCompareExchange):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCheckAndPreparePointer):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::load):
(JSC::Wasm::BBQJITImpl::BBQJIT::store):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCheckAndPrepareAndMaterializePointerApply):
* Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp:
(JSC::Wasm::MemoryInformation::doesAccessOverflow const):
* Source/JavaScriptCore/wasm/WasmMemoryInformation.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitCheckAndPreparePointer):
(JSC::Wasm::OMGIRGenerator::load):
(JSC::Wasm::OMGIRGenerator::store):
(JSC::Wasm::OMGIRGenerator::atomicLoad):
(JSC::Wasm::OMGIRGenerator::atomicStore):
(JSC::Wasm::OMGIRGenerator::atomicBinaryRMW):
(JSC::Wasm::OMGIRGenerator::atomicCompareExchange):

Canonical link: <a href="https://commits.webkit.org/319042@main">https://commits.webkit.org/319042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/924974a6b233f269de039507ea302ac3d2d56475

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190345 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144452 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b1c1af3-bb93-44e5-9a79-cdd77ded7d7f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140485 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb2daa80-6c01-4171-927c-ae616afa6840) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120937 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd9b3ae8-589b-4c72-a37d-e7d183bd7ce2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42812 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41125 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2904 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9755 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153216 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40799 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1504 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41407 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46678 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45377 "Found 1 new test failure: imported/w3c/web-platform-tests/payment-request/show-consume-activation.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192279 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53745 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149833 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40155 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54433 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149561 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44202 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126696 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121813 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52950 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15787 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52332 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52569 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52397 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->