### PR TITLE
[Custom Highlight] ::highlight() pseudo-element is not repainted after a CSS rule change.

### DIFF
--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -844,8 +844,43 @@ public:
         return false;
     }
 
+    // Highlight pseudo-elements have no renderer of their own; the originating element paints them, so a change confined to one must still repaint that element.
+    static bool highlightPseudoStyleRequiresRepaint(const Style::ComputedStyle& a, const Style::ComputedStyle& b)
+    {
+        if (!a.hasPseudoElementStyles() && !b.hasPseudoElementStyles())
+            return false;
+
+        auto highlightPseudoCount = [](const Style::ComputedStyle& style) {
+            unsigned count = 0;
+            for (const auto& identifier : style.pseudoElementStyles().keys()) {
+                if (isHighlightPseudoElement(identifier.type))
+                    ++count;
+            }
+            return count;
+        };
+
+        if (highlightPseudoCount(a) != highlightPseudoCount(b))
+            return true;
+
+        for (const auto& identifier : a.pseudoElementStyles().keys()) {
+            if (!isHighlightPseudoElement(identifier.type))
+                continue;
+            CheckedPtr aStyle = a.pseudoElementStyle(identifier);
+            CheckedPtr bStyle = b.pseudoElementStyle(identifier);
+            if (!aStyle || !bStyle)
+                return true;
+            auto pseudoChangedProperties = OptionSet<DifferenceContextSensitiveProperty>();
+            if (changeRequiresRepaint(*aStyle, *bStyle, pseudoChangedProperties))
+                return true;
+        }
+        return false;
+    }
+
     static bool changeRequiresRepaint(const Style::ComputedStyle& a, const Style::ComputedStyle& b, OptionSet<DifferenceContextSensitiveProperty>& changedContextSensitiveProperties)
     {
+        if (highlightPseudoStyleRequiresRepaint(a, b))
+            return true;
+
         bool currentColorDiffers = a.inheritedData().color != b.inheritedData().color;
 
         if (currentColorDiffers || &a.svgData() != &b.svgData()) {

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -27,6 +27,7 @@
 #include "StyleTreeResolver.h"
 
 #include "AXObjectCache.h"
+#include "AbstractRange.h"
 #include "AnchorPositionEvaluator.h"
 #include "CSSFontSelector.h"
 #include "CSSPositionTryRule.h"
@@ -46,6 +47,8 @@
 #include "HTMLProgressElement.h"
 #include "HTMLSelectElement.h"
 #include "HTMLSlotElement.h"
+#include "Highlight.h"
+#include "HighlightRegistry.h"
 #include "KeyframeEffectStack.h"
 #include "LoaderStrategy.h"
 #include "LocalFrame.h"
@@ -63,6 +66,7 @@
 #include "SelectPopoverElement.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
+#include "SimpleRange.h"
 #include "StyleAdjuster.h"
 #include "StyleBuilder.h"
 #include "StyleComputedStyle+SettersInlines.h"
@@ -79,6 +83,7 @@
 #include "WebAnimationTypes.h"
 #include "WebAnimationUtilities.h"
 #include <ranges>
+#include <wtf/HashSet.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
@@ -432,12 +437,30 @@ auto TreeResolver::resolveElement(Element& element, const Style::ComputedStyle* 
         }
     }
 
-    // Highlight pseudo-elements are resolved lazily and have no other resolution trigger.
-    // Re-resolve any that were previously cached.
-    if (existingStyle) {
-        for (auto& [identifier, _] : existingStyle->pseudoElementStyles()) {
-            if (isHighlightPseudoElement(identifier.type))
+    // Highlight pseudo-elements have no selector-based invalidation; cache those covering this element so a change is caught by Style::difference.
+    {
+        HashSet<PseudoElementIdentifier> resolvedHighlightPseudos;
+        auto resolveHighlightPseudoStyle = [&](const PseudoElementIdentifier& identifier) {
+            if (resolvedHighlightPseudos.add(identifier).isNewEntry)
                 resolveAndAddPseudoElementStyle(identifier);
+        };
+
+        if (existingStyle) {
+            for (const auto& identifier : existingStyle->pseudoElementStyles().keys()) {
+                if (isHighlightPseudoElement(identifier.type))
+                    resolveHighlightPseudoStyle(identifier);
+            }
+        }
+
+        if (RefPtr highlightRegistry = m_document->highlightRegistryIfExists()) {
+            Ref protectedElement = element;
+            for (auto& [highlightName, highlight] : highlightRegistry->map()) {
+                bool coversElement = std::ranges::any_of(highlight->highlightRanges(), [&](auto& highlightRange) {
+                    return intersects(makeSimpleRange(highlightRange->range()), protectedElement.get());
+                });
+                if (coversElement)
+                    resolveHighlightPseudoStyle({ PseudoElementType::Highlight, highlightName });
+            }
         }
     }
 


### PR DESCRIPTION
#### 792fd9b773a0f35d47e889c95012468bc56d53e1
<pre>
[Custom Highlight] ::highlight() pseudo-element is not repainted after a CSS rule change.
<a href="https://bugs.webkit.org/show_bug.cgi?id=321530">https://bugs.webkit.org/show_bug.cgi?id=321530</a>
<a href="https://rdar.apple.com/184643272">rdar://184643272</a>

Reviewed by NOBODY (OOPS!).

Highlight pseudo-elements (::highlight(), ::selection, etc.) have no renderer of their own;
the originating element paints them, and their styles are resolved lazily at paint time and
never cached on the element&apos;s style during normal painting. As a result, a change confined
to a highlight pseudo-element -- e.g. a class change that starts matching .foo::highlight(name),
or a CSSOM edit to a ::highlight() rule -- left the originating element&apos;s own style unchanged,
so Style::difference reported no change and no repaint was scheduled. The overlay only updated
on the next unrelated full repaint.

Fix this in two coordinated steps:

1. During style resolution, seed and re-resolve the highlight pseudo
   styles for every registered highlight whose range covers the element,
   so that both the previous and the newly resolved style carry the
   pseudos were re-resolved, which never happened for elements that were
   only ever painted (not queried via getComputedStyle).

2. Teach changeRequiresRepaint() to compare highlight pseudo styles.
   With the styles now cached on both the old and new style, a change to
   a highlight pseudo is detected and repaints the originating element at
   the usual point in RenderElement::setStyle(). The comparison early-outs
   when neither style has any cached pseudo styles, so unaffected elements
   are not penalized.

imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-invalidation-007.html
imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-decoration-dynamic-001.html

* Source/WebCore/style/StyleDifference.cpp:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/792fd9b773a0f35d47e889c95012468bc56d53e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144661 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/991e880e-6431-45ae-9e4b-2afe64a6b25a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140663 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97433 "3 flakes 5 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ead1159-d14d-4657-863f-3d4613144ff4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121115 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab22b964-57b3-4ab5-bd43-c10cbf848ed2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42990 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41292 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40965 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1710 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192486 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53951 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150017 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54639 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149739 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44373 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126902 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122064 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53156 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15954 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52538 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52775 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->