### PR TITLE
[Interop] Re-sync WPT for  html/semantics/interactive-elements/the-dialog-element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/WEB_FEATURES.yml
@@ -1,16 +1,17 @@
-features:
-- name: dialog
-  files: "**"
-- name: closewatcher
-  files:
-  - "dialog-cancel-events.html"
-  - "dialog-canceling.html"
-- name: dialog-closedby
-  files:
-  - dialog-closedby.html
-  - dialog-closedby-*
-  - dialog-popover-closedby-*
-- name: requestclose
-  files:
-  - dialog-requestclose.html
-  - dialog-requestclose-*
+rules:
+- dialog-cancel-events.html: [closewatcher]
+- dialog-canceling.html: [closewatcher]
+- dialog-closedby.html: [dialog-closedby]
+- dialog-closedby-*: [dialog-closedby]
+- dialog-popover-closedby-*: [dialog-closedby]
+- dialog-requestclose.html: [requestclose]
+- dialog-requestclose-*: [requestclose]
+- backdrop-*: [backdrop]
+- dialogs-with-no-backdrop.html: [backdrop]
+- modal-dialog-backdrop.html: [backdrop]
+- modal-dialog-backdrop-opacity.html: [backdrop]
+- modal-dialog-display-contents.html: [backdrop]
+- modal-dialog-generated-content.html: [backdrop]
+- dialog-open-pseudo-invalidation.html: [open-pseudo]
+- dialog-toggle-source.html: [toggleevent-source]
+- "*": [dialog]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-in-flow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-in-flow.html
@@ -31,7 +31,6 @@ Test that position 'static' or 'relative' for ::backdrop computes to 'absolute'.
 The test passes if there is a single green box.
 <dialog id="left"></dialog>
 <dialog id="right"></dialog>
-</div>
 <script>
 document.querySelector('#left').showModal();
 document.querySelector('#right').showModal();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus-multiple-times.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus-multiple-times.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./resources/common.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./resources/common.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases-expected.txt
@@ -5,7 +5,7 @@ PASS Clicking outside, when focusin removes and reinserts, modeless
 PASS Pressing escape, when focusin closes dialog, modeless
 PASS Clicking outside, when focusin closes dialog, modeless
 FAIL Pressing escape, when focusin calls showModal, modeless assert_equals: Dialog should respond to ESC expected true but got false
-FAIL Clicking outside, when focusin calls showModal, modeless assert_true: true expected true got false
+FAIL Clicking outside, when focusin calls showModal, modeless assert_equals: Dialog respond to light dismiss expected true but got false
 PASS Pressing escape, when beforetoggle closes dialog, modeless
 PASS Clicking outside, when beforetoggle closes dialog, modeless
 PASS Pressing escape, when beforetoggle calls showModal, modeless
@@ -15,7 +15,7 @@ PASS Clicking outside, when focusin removes and reinserts, modal
 PASS Pressing escape, when focusin closes dialog, modal
 PASS Clicking outside, when focusin closes dialog, modal
 PASS Pressing escape, when focusin calls showModal, modal
-FAIL Clicking outside, when focusin calls showModal, modal assert_true: expected true got false
+PASS Clicking outside, when focusin calls showModal, modal
 PASS Pressing escape, when beforetoggle closes dialog, modal
 PASS Clicking outside, when beforetoggle closes dialog, modal
 PASS Pressing escape, when beforetoggle calls showModal, modal

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases.html
@@ -175,7 +175,7 @@
 
       const shouldRespond = changeMethod.respondsTo?.(openMethod) ?? true;
 
-      assert_true(respondsToLightDismiss, shouldRespond, 'Dialog respond to light dismiss');
+      assert_equals(respondsToLightDismiss, shouldRespond, 'Dialog respond to light dismiss');
     }, `Clicking outside, when ${changeMethod.description}, ${openMethod}`);
   }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-start-open.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-start-open.html
@@ -31,16 +31,14 @@ promise_test(async (t) => {
 
 <dl>
   <dt contenteditable></dt>
-  <dialog id=test2 open></dialog>
+  <dialog id=test2></dialog>
 </dl>
 
 <script>
 promise_test(async (t) => {
   // This test case is pulled from `dialog-closewatcher-crash.html`. It is
   // constructed such that this happens:
-  //  1. The dialog `open` attribute is removed, which (depending on whether
-  //     https://github.com/whatwg/html/pull/10124 behavior is happening) calls
-  //     the close() steps.
+  //  1. close() is called.
   //  2. the last step of close() is to restore focus to the previously-focused
   //     element.
   //  3. Changing focus triggers the `focusin` event, which calls `showModal()`.
@@ -51,15 +49,16 @@ promise_test(async (t) => {
   // the dialog to be closed.
   const dialog = document.querySelector('dialog#test2');
   const controller = new AbortController();
+  document.querySelector('dt').focus();
   document.querySelector('dl').addEventListener("focusin", () => {
     dialog.showModal();
   },{signal:controller.signal});
+  dialog.showModal();
   // This will trigger the focus-the-previous-element behavior, which will fire
   // the `focusin` event.
-  dialog.open = false;
+  dialog.close();
   await new Promise(resolve => {
-    document.defaultView.requestIdleCallback(() => {
-      window.getSelection().addRange(document.createRange());
+    requestAnimationFrame(() => {
       dialog.close();
       resolve();
     });

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt
@@ -1,4 +1,5 @@
 button 1 button 2
+hello world
 
 FAIL Focus should not be restored if the currently focused element is not inside the dialog. assert_equals: expected Element node <button id="b2">button 2</button> but got Element node <button id="b1">button 1</button>
 FAIL Focus restore should not occur when the focused element is in a shadowroot outside of the dialog. assert_equals: document.activeElement should point at the shadow host. expected Element node <div id="host">
@@ -7,4 +8,5 @@ FAIL Focus restore should not occur when the focused element is in a shadowroot 
 PASS Focus restore should occur when the focused element is in a shadowroot inside the dialog.
 PASS Focus restore should occur when the focused element is slotted into a dialog.
 PASS Focus restore should always occur for modal dialogs.
+FAIL Focus restore should work when the dialog itself is focused. assert_equals: The dialog should be focused after show() because it has no interactive descendants. expected Element node <dialog id="mydialog2" open="">hello world</dialog> but got Element node <button id="b1">button 1</button>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside.html
@@ -79,4 +79,22 @@ test(() => {
   assert_equals(document.activeElement, b1,
     'Focus should be restored to the previously focused element.');
 }, 'Focus restore should always occur for modal dialogs.');
+
+test(() => {
+  b1.focus();
+  const dialog = document.getElementById('mydialog2');
+  dialog.showModal();
+  assert_equals(document.activeElement, dialog,
+    'The dialog should be focused after showModal() because it has no interactive descendants.');
+  dialog.close();
+  assert_equals(document.activeElement, b1,
+    'Focus should be restored, showModal().');
+
+  dialog.show();
+  assert_equals(document.activeElement, dialog,
+    'The dialog should be focused after show() because it has no interactive descendants.');
+  dialog.close();
+  assert_equals(document.activeElement, b1,
+    'Focus should be restored, show().');
+}, 'Focus restore should work when the dialog itself is focused.');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focusing-steps-disconnected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focusing-steps-disconnected.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Test focusing steps when dialog is disconnected</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focusing-steps-inert.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focusing-steps-inert.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Test focusing steps when dialog is inert</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-drag-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-drag-expected.txt
@@ -1,0 +1,4 @@
+outside dialog dialog
+
+PASS Dialog should not light dismiss when clicking inside the dialog and dragging outside of it.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-drag.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-drag.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://issues.chromium.org/issues/425579196">
+<link rel=help href="https://github.com/w3c/pointerevents/issues/542">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<button id=outside>outside dialog</button>
+<dialog closedby=any>dialog</dialog>
+
+<script>
+const dialog = document.querySelector('dialog');
+const outside = document.getElementById('outside');
+
+promise_test(async () => {
+  dialog.showModal();
+  assert_true(dialog.open, 'dialog should be open after showModal().');
+  await (new test_driver.Actions()
+    .pointerMove(0, 0, {origin: dialog})
+    .pointerDown()
+    .pointerMove(0, 0, {origin: outside})
+    .pointerUp())
+    .send();
+  assert_true(dialog.open, 'dialog should still be open after clicking and dragging.');
+}, 'Dialog should not light dismiss when clicking inside the dialog and dragging outside of it.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-pointer-capture-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-pointer-capture-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Light dismiss on dialog with touch input with pointer capture. assert_false: dialog should light dismiss when pointer capture is not being used. expected false got true
+PASS Light dismiss on dialog with mouse input with pointer capture.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-pointer-capture.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-pointer-capture.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/w3c/pointerevents/issues/542">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+
+<dialog id=dialog closedby=any>
+  dialog
+  <button>pointer capturing button</button>
+</dialog>
+
+<script>
+const dialog = document.getElementById('dialog');
+
+function click() {
+  return (new test_driver.Actions()
+    .pointerMove(1, 1)
+    .pointerDown()
+    .pointerUp())
+    .send();
+}
+
+function touch() {
+  return (new test_driver.Actions()
+    .addPointer('finger', 'touch')
+    .pointerMove(1, 1)
+    .pointerDown()
+    .pointerUp())
+    .send();
+}
+
+[true, false].forEach(useTouch => {
+  promise_test(async t => {
+    let usePointerCapture = true;
+    t.add_cleanup(() => {
+      usePointerCapture = false;
+      dialog.close();
+    });
+
+    const button = dialog.querySelector('button');
+    document.body.addEventListener('pointerdown', event => {
+      if (usePointerCapture) {
+        button.setPointerCapture(event.pointerId);
+      }
+    });
+
+    dialog.showModal();
+    assert_true(dialog.open, 'dialog should be open at the start of the test.');
+
+    if (useTouch) {
+      await touch();
+    } else {
+      await click();
+    }
+    assert_true(dialog.open, 'dialog should not light dismiss when pointer capture is being used.');
+
+    usePointerCapture = false;
+    if (useTouch) {
+      await touch();
+    } else {
+      await click();
+    }
+    assert_false(dialog.open, 'dialog should light dismiss when pointer capture is not being used.');
+  }, `Light dismiss on dialog with ${useTouch ? 'touch' : 'mouse'} input with pointer capture.`);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-touch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-touch-expected.txt
@@ -1,0 +1,4 @@
+dialog
+
+FAIL Dialog light dismiss should work with touch and not trigger a click event. assert_false: Dialog should be closed by light dismiss. expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-touch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-touch.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://issues.chromium.org/issues/425579196">
+<link rel=help href="https://github.com/w3c/pointerevents/issues/542">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<div id=fullscreen></div>
+<dialog closedby=any>
+  dialog
+</dialog>
+
+<style>
+#fullscreen {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+</style>
+
+<script>
+promise_test(async () => {
+  const fullscreen = document.getElementById('fullscreen');
+  const dialog = document.querySelector('dialog');
+
+  let fullscreenClicked = false;
+  fullscreen.addEventListener('click', () => {
+    fullscreenClicked = true;
+  });
+  dialog.showModal();
+
+  await (new test_driver.Actions()
+    .addPointer('finger', 'touch')
+    .pointerMove(1, 1)
+    .pointerDown()
+    .pointerUp())
+    .send();
+
+  assert_false(dialog.open, 'Dialog should be closed by light dismiss.');
+  assert_false(fullscreenClicked, 'Elements outside of the dialog should not receive a click.');
+}, 'Dialog light dismiss should work with touch and not trigger a click event.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-5-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-5-crash.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<link rel="help" href="https://html.spec.whatwg.org/#dom-dialog-requestclose" />
+
+<!-- This test passes if it does not crash. -->
+
+<dialog id=d></dialog>
+
+<script>
+let fired = false;
+d.addEventListener('beforetoggle', e => {
+  if (e.newState === 'closed' && !fired) {
+    fired = true;
+    d.close();
+    d.setAttribute('open', '');
+  }
+});
+d.showModal();
+d.requestClose('close');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-6-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-6-crash.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<link rel="help" href="https://html.spec.whatwg.org/#dom-dialog-requestclose" />
+
+<!-- This test passes if it does not crash. -->
+
+<dialog id=d></dialog>
+
+<script>
+d.showModal();
+d.oncancel = e => e.preventDefault();
+d.requestClose('first');
+d.requestClose('second');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-closedby.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-closedby.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS requestClose() should close the dialog even when computed closedby becomes none
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-closedby.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-closedby.tentative.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel=help href="https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-request-close">
+<link rel=help href="https://github.com/whatwg/html/issues/12482">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" href="mailto:lwarlow@igalia.com" />
+
+<dialog id="dialog" closedby="any"></dialog>
+<script>
+  test(() => {
+      dialog.show();
+      dialog.oncancel = () => {
+          dialog.removeAttribute('closedby');
+      }
+      dialog.requestClose();
+      assert_false(dialog.open);
+  }, "requestClose() should close the dialog even when computed closedby becomes none");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-setup-cleanup-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-setup-cleanup-crash.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="help" href="https://html.spec.whatwg.org/#the-dialog-element" />
+
+<!-- This test passes if it does not crash. -->
+
+<iframe src="./resources/showmodal-frame.html"></iframe>
+
+<script>
+  new Promise((resolve) => (window.loaded = resolve)).then(() => {
+    const iframe = document.body.querySelector("iframe");
+    const iframeDoc = iframe.contentDocument;
+    iframe.remove();
+    iframeDoc.querySelector("dialog").close();
+    iframeDoc.querySelector("dialog").setAttribute("open", "");
+    document.body.append(iframe);
+    iframeDoc.querySelector("dialog").show();
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/fixed-position-child-with-fo-ancestor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/fixed-position-child-with-fo-ancestor.html
@@ -20,7 +20,7 @@
         Dialog should be centered.
         <div style="position: fixed; top: 0px; left: 0px">This fixed positioned element is aligned to viewport top-left.</div>
     </dialog>
-  </foreignobject>
+  </foreignObject>
 </svg>
 <script>
 dialog.showModal();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-focus-in-frames.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-focus-in-frames.html
@@ -3,6 +3,8 @@
 <link rel=author href="mailto:falken@chromium.org">
 <link rel=help href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element">
 <link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=242848">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
@@ -32,6 +34,9 @@ window.onload = frameLoaded;
 
 promise_test(async () => {
   await framesLoadedPromise;
+  // Chrome and edge auto-focus the URL bar when the browser is launched.
+  // This is needed to ensure the 'focus' events fire below.
+  await test_driver.click(document.documentElement);
 
   function testFocus(element, expectFocus) {
     let focusedElement = null;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-expected.html
@@ -4,7 +4,7 @@
 <style>
 body p, span {
     -webkit-user-select: none;
-    user-select: none;
+    -webkit-user-select: none;
 }
 
 ::backdrop {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-unfocusable.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-unfocusable.html
@@ -3,6 +3,8 @@
 <head>
 <link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#blocked-by-a-modal-dialog">
 <meta name="assert" content="Checks that, when opening modal dialogs, inert nodes are not focusable.">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
@@ -33,7 +35,7 @@ dialog {
 // The test passses if only the topmost dialog and its button are focusable.
 
 function testFocus(element, expectFocus) {
-    test(function() {
+    promise_test(async function() {
         var focusedElement = null;
         element.addEventListener('focus', function() { focusedElement = element; }, false);
         element.focus();
@@ -56,7 +58,8 @@ function testTree(element, expectFocus) {
 
 var bottomDialog = document.getElementById('bottom-dialog');
 var topDialog = document.getElementById('top-dialog');
-setup(function() {
+promise_setup(async function() {
+    await test_driver.click(document.documentElement);
     bottomDialog.showModal();
     topDialog.showModal();
     add_completion_callback(function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
@@ -19,7 +21,11 @@ function testFocus(element, expectFocus) {
     assert_equals(focusedElement === theElement, expectFocus, element.id);
 }
 
-test(function() {
+promise_setup(async function() {
+    await test_driver.click(document.documentElement);
+})
+
+promise_test(async function() {
     var dialog = document.querySelector('dialog');
     dialog.showModal();
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/common.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/common.js
@@ -14,5 +14,6 @@ function waitUntilLoadedAndAutofocused() {
           if (loaded)
               resolve();
       }, false);
+      test_driver.click(document.documentElement);
     });
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/showmodal-frame.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/showmodal-frame.html
@@ -1,0 +1,8 @@
+<!doctype html>
+
+<dialog id="dialog"></dialog>
+
+<script>
+dialog.showModal();
+window.onload = parent.parent.loaded();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/w3c-import.log
@@ -10,12 +10,11 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/common.js
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/dialog.css
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/inert-focus-in-frames-frame1.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/inert-focus-in-frames-frame2.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/showmodal-frame.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/submit.jpg

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/show-modal-focusing-steps.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/show-modal-focusing-steps.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./resources/common.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 user-select
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/WEB_FEATURES.yml
@@ -74,6 +72,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-inert.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-insert-disconnected-node-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-keydown-preventDefault.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-drag.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-pointer-capture.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-touch.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-no-throw-requested-state.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-not-in-tree-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-open-2.html
@@ -93,14 +94,22 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-overlay.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-remove-open-attr-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-2-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-2.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-3-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-3.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-4-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-5-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-6-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-closedby.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-recurse.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-return-value.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-setup-cleanup-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-showModal-inert-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-showModal-remove.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-showModal.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-synthetic-keydown.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-toggle-source.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialogs-with-no-backdrop-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialogs-with-no-backdrop-ref.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases-expected.txt
@@ -15,7 +15,7 @@ PASS Clicking outside, when focusin removes and reinserts, modal
 PASS Pressing escape, when focusin closes dialog, modal
 PASS Clicking outside, when focusin closes dialog, modal
 PASS Pressing escape, when focusin calls showModal, modal
-FAIL Clicking outside, when focusin calls showModal, modal assert_true: expected true got false
+PASS Clicking outside, when focusin calls showModal, modal
 PASS Pressing escape, when beforetoggle closes dialog, modal
 PASS Clicking outside, when beforetoggle closes dialog, modal
 PASS Pressing escape, when beforetoggle calls showModal, modal

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-pointer-capture-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-pointer-capture-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Light dismiss on dialog with touch input with pointer capture. assert_false: dialog should light dismiss when pointer capture is not being used. expected false got true
+FAIL Light dismiss on dialog with mouse input with pointer capture. assert_false: dialog should light dismiss when pointer capture is not being used. expected false got true
+


### PR DESCRIPTION
#### bd11dfe61f6e52206cef9b21dd234188645fd988
<pre>
[Interop] Re-sync WPT for  html/semantics/interactive-elements/the-dialog-element
<a href="https://bugs.webkit.org/show_bug.cgi?id=321554">https://bugs.webkit.org/show_bug.cgi?id=321554</a>
<a href="https://rdar.apple.com/184663087">rdar://184663087</a>

Unreviewed re-sync with upstream WPT.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/0e64d6885439d5a2eff75351133a46c88c572e5c1">https://github.com/web-platform-tests/wpt/commit/0e64d6885439d5a2eff75351133a46c88c572e5c1</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-in-flow.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus-multiple-times.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-start-open.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focusing-steps-disconnected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focusing-steps-inert.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-drag-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-drag.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-pointer-capture-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-pointer-capture.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-touch-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-touch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-5-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-6-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-closedby.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-closedby.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-setup-cleanup-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/fixed-position-child-with-fo-ancestor.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-focus-in-frames.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-unfocusable.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/common.js:
(waitUntilLoadedAndAutofocused):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/showmodal-frame.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/show-modal-focusing-steps.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-light-dismiss-pointer-capture-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/319051@main">https://commits.webkit.org/319051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f88e7cc6c1033649dd8d8e8b4be85661cf24367c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144590 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa962d7e-458a-419f-a454-5b1fb97d0528) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140602 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f525e3ca-1ae6-4e1f-9d1f-53c72fe592da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121054 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7cb2219e-a488-4bf0-bc92-564a2f2df7c4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41241 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40914 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1639 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41543 "Build is in progress. Recent messages:") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192415 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160903 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54568 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37526 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149677 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27366 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44324 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121992 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53085 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15903 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52467 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52704 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52532 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->