### PR TITLE
Cherry-pick 7509f55d43eb. https://bugs.webkit.org/show_bug.cgi?id=311800

### DIFF
--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -77,8 +77,16 @@ function mac_process_webcontent_captiveportal_entitlements()
 
 function mac_process_webcontent_enhancedsecurity_entitlements()
 {
-    plistbuddy Add :com.apple.security.fatal-exceptions array
-    plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
+    if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
+    then
+        plistbuddy Add :com.apple.security.fatal-exceptions array
+        plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
+    fi
+
+    if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
+    then
+        plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
+    fi
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
@@ -155,6 +163,12 @@ function mac_process_gpu_entitlements()
         plistbuddy Add :com.apple.QuartzCore.webkit-end-points bool YES
         plistbuddy Add :com.apple.private.coremedia.allow-fps-attachment bool YES
         plistbuddy Add :com.apple.developer.hardened-process bool YES
+
+        if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
+        then
+            plistbuddy Add :com.apple.private.pac.exception bool YES
+        fi
+        plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
     fi
 }
 
@@ -207,6 +221,7 @@ function mac_process_network_entitlements()
         plistbuddy Add :com.apple.private.webkit.adattributiond bool YES
         plistbuddy Add :com.apple.private.webkit.webpush bool YES
         plistbuddy Add :com.apple.developer.hardened-process bool YES
+        plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
         # FIXME: This should be removed after crash investigation as part of <rdar://problem/160965793>
         plistbuddy Add :com.apple.private.get-system-corpse bool YES
     fi
@@ -312,6 +327,7 @@ function mac_process_webcontent_shared_entitlements()
         fi
 
         plistbuddy Add :com.apple.developer.hardened-process bool YES
+        plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
     fi
 
     if [[ "${WK_XPC_SERVICE_VARIANT}" == Development ]]
@@ -352,6 +368,7 @@ function maccatalyst_process_webcontent_entitlements()
     plistbuddy Add :com.apple.security.fatal-exceptions array
     plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
     plistbuddy Add :com.apple.developer.hardened-process bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 
     if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
     then
@@ -389,6 +406,7 @@ function maccatalyst_process_webcontent_captiveportal_entitlements()
     plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
     plistbuddy Add :com.apple.QuartzCore.webkit-end-points bool YES
     plistbuddy Add :com.apple.developer.hardened-process bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 
     plistbuddy Add :com.apple.imageio.allowabletypes array
     plistbuddy Add :com.apple.imageio.allowabletypes:0 string org.webmproject.webp
@@ -461,6 +479,7 @@ function maccatalyst_process_gpu_entitlements()
     plistbuddy Add :com.apple.QuartzCore.webkit-limited-types bool YES
     plistbuddy Add :com.apple.private.coremedia.allow-fps-attachment bool YES
     plistbuddy Add :com.apple.developer.hardened-process bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
@@ -481,6 +500,7 @@ function maccatalyst_process_network_entitlements()
     plistbuddy Add :com.apple.private.pac.exception bool YES
     plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
     plistbuddy Add :com.apple.developer.hardened-process bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 
     plistbuddy Add :com.apple.private.tcc.manager.check-by-audit-token array
     plistbuddy Add :com.apple.private.tcc.manager.check-by-audit-token:0 string kTCCServiceWebKitIntelligentTrackingPrevention
@@ -529,6 +549,7 @@ fi
     plistbuddy add :com.apple.coreaudio.LoadDecodersInProcess bool YES
     plistbuddy add :com.apple.coreaudio.allow-vorbis-decode bool YES
     plistbuddy Add :com.apple.developer.hardened-process bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 
     notify_entitlements
     webcontent_sandbox_entitlements
@@ -572,6 +593,7 @@ function ios_family_process_webcontent_enhancedsecurity_entitlements()
 {
     plistbuddy Add :com.apple.private.webkit.enhanced-security bool YES
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
 
     ios_family_process_webcontent_shared_entitlements
 }
@@ -633,6 +655,7 @@ if [[ "${WK_PLATFORM_NAME}" == xros ]]; then
 fi
 
     plistbuddy Add :com.apple.developer.hardened-process bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
 }
@@ -649,6 +672,12 @@ function ios_family_process_model_entitlements()
     plistbuddy Add :com.apple.pac.shared_region_id string WebKitModel
     plistbuddy Add :com.apple.developer.hardened-process bool YES
     plistbuddy Add :com.apple.private.usd.enableusdgltf bool YES
+
+    if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
+    then
+        plistbuddy Add :com.apple.private.pac.exception bool YES
+    fi
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 }
 
 function ios_family_process_adattributiond_entitlements()
@@ -709,6 +738,7 @@ fi
     plistbuddy Add :com.apple.private.assets.accessible-asset-types array
     plistbuddy Add :com.apple.private.assets.accessible-asset-types:0 string com.apple.MobileAsset.WebContentRestrictions
     plistbuddy Add :com.apple.developer.hardened-process bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
 
     plistbuddy Add :com.apple.private.security.mutable-state-flags array
     plistbuddy Add :com.apple.private.security.mutable-state-flags:0 string BlockNetworkAccess

--- a/Source/bmalloc/bmalloc/TZoneHeap.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeap.cpp
@@ -55,7 +55,8 @@ void* tzoneAllocateNonCompactSlow(size_t requestedSize, const TZoneSpecification
             return tzoneAllocateNonCompactSlow(requestedSize, spec);
         }
 
-        RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc);
+        RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc
+            || tzoneMallocFallback == TZoneMallocFallback::ForceFastMalloc);
         return api::malloc(requestedSize, CompactAllocationMode::NonCompact);
     }
 
@@ -79,7 +80,8 @@ void* tzoneAllocateCompactSlow(size_t requestedSize, const TZoneSpecification& s
             return tzoneAllocateCompactSlow(requestedSize, spec);
         }
 
-        RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc);
+        RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc
+            || tzoneMallocFallback == TZoneMallocFallback::ForceFastMalloc);
         return api::malloc(requestedSize, CompactAllocationMode::Compact);
     }
 

--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -123,7 +123,12 @@ namespace api {
 
 enum class TZoneMallocFallback : uint8_t {
     Undecided,
+    // Currently, ForceFastMalloc and ForceDebugMalloc
+    // route to the same place (call into FastMalloc);
+    // however, they are semantically different, and
+    // set for different reasons.
     ForceDebugMalloc,
+    ForceFastMalloc = ForceDebugMalloc,
     DoNotFallBack
 };
 
@@ -214,7 +219,7 @@ public: \
     { \
         if (!s_heapRef || size != sizeof(_type)) [[unlikely]] \
             BMUST_TAIL_CALL return operatorNewSlow(size); \
-        BASSERT(::bmalloc::api::tzoneMallocFallback > TZoneMallocFallback::ForceDebugMalloc); \
+        BASSERT(::bmalloc::api::tzoneMallocFallback == TZoneMallocFallback::DoNotFallBack); \
         if constexpr (::bmalloc::api::compactAllocationMode<_type>() == CompactAllocationMode::Compact) \
             return ::bmalloc::api::tzoneAllocateCompact(s_heapRef); \
         return ::bmalloc::api::tzoneAllocate ## _compactMode(s_heapRef); \

--- a/Source/bmalloc/bmalloc/TZoneHeapInlines.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapInlines.h
@@ -70,7 +70,7 @@ public: \
                 return ::bmalloc::api::tzoneAllocateCompactSlow(size, s_heapSpec); \
             return ::bmalloc::api::tzoneAllocate ## _compactMode ## Slow(size, s_heapSpec); \
         } \
-        BASSERT(::bmalloc::api::tzoneMallocFallback > TZoneMallocFallback::ForceDebugMalloc); \
+        BASSERT(::bmalloc::api::tzoneMallocFallback == TZoneMallocFallback::DoNotFallBack); \
         if constexpr (::bmalloc::api::compactAllocationMode<_type>() == CompactAllocationMode::Compact) \
             return ::bmalloc::api::tzoneAllocateCompact(s_heapRef); \
         return ::bmalloc::api::tzoneAllocate ## _compactMode(s_heapRef); \

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -167,6 +167,17 @@ bool isEnabled(HeapKind)
     return !Environment::get()->shouldBmallocAllocateThroughSystemHeap();
 }
 
+bool isMTEEnabled(HeapKind kind)
+{
+#if PAS_BMALLOC && defined(PAS_ENABLE_MTE) && PAS_ENABLE_MTE
+    // MTE is not currently enabled for the Gigacage
+    return isEnabled(kind) && kind == HeapKind::Primary && pas_mte_is_mte_enabled();
+#else
+    BUNUSED_PARAM(kind);
+    return false;
+#endif
+}
+
 #if BOS(DARWIN)
 void setScavengerThreadQOSClass(qos_class_t overrideClass)
 {
@@ -220,27 +231,7 @@ void enableMiniMode(bool forceMiniMode)
     pas_physical_page_sharing_pool_balancing_enabled = true;
     pas_physical_page_sharing_pool_balancing_enabled_for_utility = true;
 
-    // Switch to bitfit allocation for anything that isn't isoheaped.
-    bmalloc_intrinsic_runtime_config.base.max_segregated_object_size = 0;
-    bmalloc_primitive_runtime_config.base.max_segregated_object_size = 0;
-    bmalloc_intrinsic_runtime_config.base.max_bitfit_object_size = UINT_MAX;
-    bmalloc_primitive_runtime_config.base.max_bitfit_object_size = UINT_MAX;
-
-    // If large-object delegation is enabled, we don't want to override that
-    // just because we've entered mini-mode.
-    // One way we could get around that would be to leave the bitfit object
-    // size limits the way they are. However, in cases where the bitfit
-    // size-limit had previously been constrained for performance, e.g. by
-    // setting them to 0, we do want enableMiniMode to be able to re-expand
-    // them.
-    // So we take the object-delegation path to be a special case and make
-    // sure to re-apply after performing the above expansion.
-    PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
-#if defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
-    if (PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
-        pas_mte_force_nontaggable_user_allocations_into_large_heap();
-#endif // defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
-    PAS_IGNORE_WARNINGS_END;
+    pas_bmalloc_force_allocations_into_bitfit_heaps_where_available();
 #endif // BENABLE(LIBPAS)
 
 #if !BUSE(LIBPAS)

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -234,6 +234,7 @@ BEXPORT void scavengeThisThread();
 BEXPORT void scavenge();
 
 BEXPORT bool isEnabled(HeapKind kind = HeapKind::Primary);
+BEXPORT bool isMTEEnabled(HeapKind kind = HeapKind::Primary);
 
 // ptr must be aligned to vmPageSizePhysical and size must be divisible 
 // by vmPageSizePhysical.

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
@@ -897,17 +897,17 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
 
         pas_bitfit_page_testing_verify(page);
 
-        pas_lock_unlock(&owner->ownership_lock);
-        break;
-    } }
+        switch (mode) {
+        case pas_bitfit_page_deallocate_with_page_impl_deallocate_mode: {
+            PAS_PROFILE(BITFIT_PAGE_DEALLOCATION, page_config, begin, (num_bits << page_config.base.min_align_shift));
+            PAS_MTE_HANDLE(BITFIT_PAGE_DEALLOCATION, page_config, begin, (num_bits << page_config.base.min_align_shift));
+            break;
+        case pas_bitfit_page_deallocate_with_page_impl_get_allocation_size_mode:
+        case pas_bitfit_page_deallocate_with_page_impl_shrink_mode:
+            break;
+        } }
 
-    switch (mode) {
-    case pas_bitfit_page_deallocate_with_page_impl_deallocate_mode: {
-        PAS_PROFILE(BITFIT_PAGE_DEALLOCATION, page_config, begin, (num_bits << page_config.base.min_align_shift));
-        PAS_MTE_HANDLE(BITFIT_PAGE_DEALLOCATION, page_config, begin, (num_bits << page_config.base.min_align_shift));
-        break;
-    case pas_bitfit_page_deallocate_with_page_impl_get_allocation_size_mode:
-    case pas_bitfit_page_deallocate_with_page_impl_shrink_mode:
+        pas_lock_unlock(&owner->ownership_lock);
         break;
     } }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_mte.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte.h
@@ -66,9 +66,11 @@ PAS_IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage")
 #endif
 
 #define PAS_MTE_SMALL_PAGE_NO_MASK (0x0000ffffffffffffull & ~((1ull << PAS_SMALL_PAGE_DEFAULT_SHIFT) - 1ull))
-#define PAS_MTE_MEDIUM_PAGE_NO_MASK (0x0000ffffffffffffull & ~((1ull << PAS_MEDIUM_PAGE_DEFAULT_SHIFT) - 1ull))
+#define PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO_MASK (0x0000ffffffffffffull & ~((1ull << PAS_MEDIUM_PAGE_DEFAULT_SHIFT) - 1ull))
+#define PAS_MTE_MEDIUM_BITFIT_PAGE_NO_MASK (0x0000ffffffffffffull & ~((1ull << PAS_MEDIUM_BITFIT_PAGE_DEFAULT_SHIFT) - 1ull))
 #define PAS_MTE_SMALL_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_SMALL_PAGE_NO_MASK)
-#define PAS_MTE_MEDIUM_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_MEDIUM_PAGE_NO_MASK)
+#define PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO_MASK)
+#define PAS_MTE_MEDIUM_BITFIT_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_MEDIUM_BITFIT_PAGE_NO_MASK)
 
 #define PAS_MTE_GET_MTAG(ptr) do { \
         __asm__ volatile( \
@@ -133,19 +135,6 @@ PAS_IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage")
             : \
         ); \
     } while (0)
-#define PAS_MTE_CREATE_RANDOM_TAG(ptr, mask) do { \
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ZERO_TAG_ALL)) { \
-            ptr &= (uintptr_t)~PAS_MTE_TAG_MASK; \
-            break; \
-        } \
-        __asm__ volatile( \
-            ".arch_extension memtag\n\t" \
-            "irg %0, %0, %1" \
-            : "+r"(ptr) \
-            : "r"((uintptr_t)(mask)) \
-            : \
-        ); \
-    } while (0)
 
 /*
  * DC GVA writes tags for a contiguous range of addresses in bulk. The size of this
@@ -202,7 +191,7 @@ typedef enum pas_mte_tag_constraint pas_mte_tag_constraint;
 
 PAS_ALWAYS_INLINE pas_mte_tag_constraint pas_mte_exclude_tag(pas_mte_tag_constraint base, uint8_t tag_value_to_exclude)
 {
-    return (pas_mte_tag_constraint)((unsigned)base & ~(1u << tag_value_to_exclude));
+    return (pas_mte_tag_constraint)((unsigned)base | (1u << tag_value_to_exclude));
 }
 
 PAS_ALWAYS_INLINE pas_mte_tag_constraint
@@ -239,9 +228,17 @@ pas_mte_compute_valid_tags_under_adjacent_tag_exclusion(
             succeeding_pageno = PAS_MTE_SMALL_PAGE_NO(succeeding_granule);
             current_pageno = PAS_MTE_SMALL_PAGE_NO(ptr);
         } else {
-            prior_pageno = PAS_MTE_MEDIUM_PAGE_NO(prior_granule);
-            succeeding_pageno = PAS_MTE_MEDIUM_PAGE_NO(succeeding_granule);
-            current_pageno = PAS_MTE_MEDIUM_PAGE_NO(ptr);
+            if (homogeneity == pas_mte_homogeneous_allocator) {
+                prior_pageno = PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO(prior_granule);
+                succeeding_pageno = PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO(succeeding_granule);
+                current_pageno = PAS_MTE_MEDIUM_SEGREGATED_PAGE_NO(ptr);
+            } else if (homogeneity == pas_mte_nonhomogeneous_allocator) {
+                prior_pageno = PAS_MTE_MEDIUM_BITFIT_PAGE_NO(prior_granule);
+                succeeding_pageno = PAS_MTE_MEDIUM_BITFIT_PAGE_NO(succeeding_granule);
+                current_pageno = PAS_MTE_MEDIUM_BITFIT_PAGE_NO(ptr);
+            } else {
+                PAS_ASSERT_NOT_REACHED();
+            }
         }
         // Since we cannot ldg addresses which lie on another page
         // from our own, we need some way to ensure that if the
@@ -483,19 +480,21 @@ inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_switching(uint8_t*
 
 PAS_IGNORE_WARNINGS_END
 
-#define ASSERT_PRIOR_TAG_IS_DISJOINT(ptr) do { \
-        uint8_t* prev_ptr = (uint8_t*)((uintptr_t)ptr - 16); \
-        uint8_t* curr_ptr = (uint8_t*)ptr; \
-        if (PAS_MTE_SMALL_PAGE_NO(prev_ptr) == PAS_MTE_SMALL_PAGE_NO(curr_ptr)) { \
-            PAS_MTE_GET_MTAG(prev_ptr); \
-            PAS_MTE_GET_MTAG(curr_ptr); \
-            uintptr_t prev_tag = (uintptr_t)prev_ptr & PAS_MTE_TAG_MASK; \
-            uintptr_t curr_tag = (uintptr_t)curr_ptr & PAS_MTE_TAG_MASK; \
-            if (prev_tag == curr_tag && !curr_tag) \
-                printf("[MTE]\tAdjacent tag collision between %p and %p: crashing\n", prev_ptr, curr_ptr); \
-            PAS_ASSERT(prev_tag != curr_tag || !curr_tag); \
-        } \
-    } while (0)
+PAS_ALWAYS_INLINE void
+pas_mte_assert_prior_tag_is_disjoint(uintptr_t begin)
+{
+    uint8_t* prev_ptr = (uint8_t*)((uintptr_t)begin - 16);
+    uint8_t* curr_ptr = (uint8_t*)begin;
+    if (PAS_MTE_SMALL_PAGE_NO(prev_ptr) == PAS_MTE_SMALL_PAGE_NO(curr_ptr)) {
+        PAS_MTE_GET_MTAG(prev_ptr);
+        PAS_MTE_GET_MTAG(curr_ptr);
+        uintptr_t prev_tag = (uintptr_t)prev_ptr & PAS_MTE_TAG_MASK;
+        uintptr_t curr_tag = (uintptr_t)curr_ptr & PAS_MTE_TAG_MASK;
+        if (prev_tag == curr_tag && curr_tag)
+            printf("[MTE]\tAdjacent tag collision between %p and %p: crashing\n", prev_ptr, curr_ptr);
+        PAS_ASSERT(prev_tag != curr_tag || !curr_tag, (uintptr_t)prev_ptr, (uintptr_t)curr_ptr);
+    }
+}
 
 PAS_ALWAYS_INLINE void
 pas_mte_tag_region_from_pointer(
@@ -580,43 +579,52 @@ pas_mte_tag_region_from_pointer(
 #define PAS_MTE_IS_KNOWN_MEDIUM_PAGE(page_config) 0
 #endif
 
-/*
- * Tagging is what actually applies an PAS_MTE tag to an allocation. If the
- * pas_allocation_mode passed to this macro is compact, we zero the upper
- * bits of the pointer and tag the object with a zero tag. Otherwise, we
- * randomly choose a nonzero tag. It's assumed that this macro will be
- * invoked with a size that's a multiple of 16, and it's really important
- * that the size passed be the allocation size of the object, not the
- * actual size.
- */
 PAS_ALWAYS_INLINE uintptr_t
-pas_mte_generate_tag_and_tag_region(
+pas_mte_generate_random_tag(
     uintptr_t begin,
-    size_t size,
-    pas_allocation_mode mode,
-    pas_allocator_homogeneity homogeneity,
-    bool is_known_medium)
+    pas_mte_tag_constraint constraint)
 {
-    if (mode != pas_non_compact_allocation_mode)
-        begin &= ~PAS_MTE_TAG_MASK;
-    else {
-        pas_mte_tag_constraint valid_tags;
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION))
-            valid_tags = pas_mte_compute_valid_tags_under_adjacent_tag_exclusion(begin, size, homogeneity, is_known_medium);
-        else
-            valid_tags = pas_mte_any_nonzero_tag;
-        PAS_MTE_CREATE_RANDOM_TAG(begin, valid_tags);
-    }
-    if (mode != pas_always_compact_allocation_mode) {
-        pas_mte_tag_region_from_pointer(begin, size, is_known_medium);
-        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION)
-            && PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT)) {
-            ASSERT_PRIOR_TAG_IS_DISJOINT(begin);
-            ASSERT_PRIOR_TAG_IS_DISJOINT(begin + size);
-        }
-    }
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ZERO_TAG_ALL))
+        return begin & ~PAS_MTE_TAG_MASK;
+    __asm__ volatile( \
+        ".arch_extension memtag\n\t"
+        "irg %0, %0, %1"
+        : "+r"(begin)
+        : "r"((uintptr_t)(constraint))
+        :
+    );
     return begin;
 }
+
+// Tagging is what actually applies an PAS_MTE tag to an allocation. If the
+// pas_allocation_mode passed to this macro is compact, we zero the upper
+// bits of the pointer and tag the object with a zero tag. Otherwise, we
+// randomly choose a nonzero tag. It's assumed that this macro will be
+// invoked with a size that's a multiple of 16, and it's really important
+// that the size passed be the allocation size of the object, not the
+// actual size.
+#define PAS_MTE_TAG_REGION(ptr, size, mode, is_allocator_homogeneous, is_known_medium) do { \
+        if (PAS_MTE_SHOULD_STORE_TAG) { \
+            if (mode != pas_non_compact_allocation_mode) \
+                ptr &= ~PAS_MTE_TAG_MASK; \
+            else { \
+                pas_mte_tag_constraint valid_tags; \
+                if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION)) \
+                    valid_tags = pas_mte_compute_valid_tags_under_adjacent_tag_exclusion(ptr, size, homogeneity, is_known_medium); \
+                else \
+                    valid_tags = pas_mte_any_nonzero_tag; \
+                ptr = pas_mte_generate_random_tag(begin, valid_tags); \
+            } \
+            if (mode != pas_always_compact_allocation_mode) { \
+                TAG_REGION_FROM_POINTER(ptr, size, is_known_medium); \
+                if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION) \
+                    && PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT)) { \
+                    pas_mte_assert_prior_tag_is_disjoint(ptr); \
+                    pas_mte_assert_prior_tag_is_disjoint(ptr + size); \
+                } \
+            } \
+        } \
+    } while (0)
 
 #ifdef __cplusplus
 extern "C" {
@@ -689,6 +697,9 @@ pas_mte_retag_freed_region_if_tagged(
  *                         [-----]    [--------------]            [-----]
  *      Segregated heaps:  ^     ^                   ^                  ^
  *      Bitfit heaps:      ^     ^    ^              ^            ^     ^
+ * Except that PAS_WORKAROUND_RDAR_171662605_UNCONDITIONAL_TAG_ON_ALLOC,
+ * when set, will force tag-on-alloc, as in the 'Tag-on-Alloc/Free' policy
+ * described above.
  *
  * N.b.: the current implementation (as the name RETAG_ON_SCAVENGE
  * implies) does not retag-on-free, but on scavenge. This somewhat weakens
@@ -708,6 +719,7 @@ pas_mte_maybe_tag_allocated_region(
     bool is_known_medium)
 {
     if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_RETAG_ON_SCAVENGE)
+        && !PAS_WORKAROUND_RDAR_171662605_UNCONDITIONAL_TAG_ON_ALLOC
         && initiality == pas_non_initial_allocation
         && mode == pas_non_compact_allocation_mode) {
         /* can assume: size >= 16 && begin % 16 == 0 */

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
@@ -205,6 +205,26 @@ static void pas_mte_do_initialization(void)
         *medium_byte = 1; // Tag libpas medium objects in privileged processes
         *hardened_byte = 1;
     }
+
+    PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
+    // Retag-on-scavenge functionally supports both segregated and bitfit heaps.
+    // However, true to the name, for segregated heaps the retag operation only
+    // takes place on the scavenging path.
+    // For bitfit heaps, there is no such path: as such, freed bitfit objects are
+    // immediately retagged. This closes the window where attackers could in
+    // theory exploit a UAF.
+    // As such, when retag-on-scavenge is enabled, we prefer to allocate from
+    // bitfit heaps to exploit this property -- the exception of course being
+    // isoheaps, due to the intrinsic type-unsafety of bitfit heaps.
+    // In practice, for privileged processes this already takes place when WebCore
+    // enables fastMiniMode(), but that enablement takes place later on and as such
+    // can allow for some local-allocators to sneak by. This is not a problem for
+    // mini-mode because a few stray allocations there won't hurt, but for a
+    // security boundary those stray allocations are more of a problem. So we force
+    // this here, prior to the creation of such segregated directories.
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_RETAG_ON_SCAVENGE))
+        pas_bmalloc_force_allocations_into_bitfit_heaps_where_available();
+    PAS_IGNORE_WARNINGS_END;
 }
 
 static bool pas_mte_is_enabled(void)
@@ -360,6 +380,43 @@ void pas_mte_ensure_initialized(void)
 #endif
 void pas_mte_ensure_initialized(void) { }
 #endif // PAS_OS(DARWIN)
+
+void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void)
+{
+#if PAS_ENABLE_BMALLOC
+    // Switch to bitfit allocation for anything that isn't isoheaped.
+    bmalloc_intrinsic_runtime_config.base.max_segregated_object_size = 0;
+    bmalloc_primitive_runtime_config.base.max_segregated_object_size = 0;
+    bmalloc_intrinsic_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+    bmalloc_primitive_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+#endif
+
+    // If large-object delegation is enabled, we don't want to override that
+    // just because we've entered mini-mode.
+    // One way we could get around that would be to leave the bitfit object
+    // size limits the way they are. However, in cases where the bitfit
+    // size-limit had previously been constrained for performance, e.g. by
+    // setting them to 0, we do want enableMiniMode to be able to re-expand
+    // them.
+    // So we take the object-delegation path to be a special case and make
+    // sure to re-apply after performing the above expansion.
+    PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
+#if defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
+    if (PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
+        pas_mte_force_nontaggable_user_allocations_into_large_heap();
+#endif // defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
+    PAS_IGNORE_WARNINGS_END;
+}
+
+bool pas_mte_is_mte_enabled(void)
+{
+    pas_mte_ensure_initialized();
+#if PAS_ENABLE_MTE
+    return PAS_MTE_CONFIG_BYTE(PAS_MTE_ENABLE_FLAG);
+#else
+    return false;
+#endif
+}
 
 void pas_mte_force_nontaggable_user_allocations_into_large_heap(void)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
@@ -126,8 +126,15 @@ extern Slot g_config[];
 #define PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION 5
 #define PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT 6
 
+// FIXME: rdar://171662605
+#define PAS_WORKAROUND_RDAR_171662605_UNCONDITIONAL_TAG_ON_ALLOC (1)
+
 #define PAS_MTE_FEATURE_FORCED(feature) (0)
+#if !PAS_PLATFORM(VISION)
+#define PAS_MTE_FEATURE_HARDENED_FORCED(feature) (feature == PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION || feature == PAS_MTE_FEATURE_RETAG_ON_SCAVENGE)
+#else // PAS_PLATFORM(VISION)
 #define PAS_MTE_FEATURE_HARDENED_FORCED(feature) (feature == PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION)
+#endif // !PAS_PLATFORM(VISION)
 #define PAS_MTE_FEATURE_DEBUG_FORCED(feature) (feature == PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT)
 
 #define PAS_MTE_FEATURE_FORCED_IN_RELEASE_BUILD(feature) \
@@ -194,8 +201,10 @@ extern Slot g_config[];
 #ifdef __cplusplus
 extern "C" {
 #endif
+bool pas_mte_is_mte_enabled(void);
 void pas_mte_ensure_initialized(void);
 void pas_mte_force_nontaggable_user_allocations_into_large_heap(void);
+void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
#### 5e28547d6393e1912651f056287336dd9734d38f
<pre>
Cherry-pick 7509f55d43eb. <a href="https://bugs.webkit.org/show_bug.cgi?id=311800">https://bugs.webkit.org/show_bug.cgi?id=311800</a>

Unreviewed backport.

    [libpas] Enable retag-on-free and soft-mode as combined patch sans xrOS
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313680">https://bugs.webkit.org/show_bug.cgi?id=313680</a>
    <a href="https://rdar.apple.com/175767115">rdar://175767115</a>

    Reviewed by Keith Miller.

    This is morally a combination of changes from six radars that
    originally landed on main, whose combined effect is to implement
    a fixed version of retag-on-scavenge, enable it, change various
    allocator configurations to strengthen that to retag-on-free,
    and take WebKit processes to soft-mode. It should not be merged
    back to main, as the changes herewithin are already implemented
    there.

    Importantly, this does NOT enable retag-on-free for visionOS.
    This is because soft-mode enablement did not work correctly on that
    platform when we enabled this the first time around.

    The soft mode enablement is done to help insulate us from any potential
    security fallout: since this patch adds a new security hardening
    measure, we run the risk of turning currently-silent UaFs into actual
    crashes. Enabling soft-mode obviates that risk, as those crashes would
    only happen once per process, after which MTE would be disabled.

    As a result, however, this patch CANNOT be taken for any actual customer
    release, other than seeds and internal builds, unless paired with a
    subsequent patch which disables soft-mode.

    The patches included are as follows:

    [libpas] Unconditionally tag-on-alloc
    <a href="https://bugs.webkit.org/show_bug.cgi?id=308483">https://bugs.webkit.org/show_bug.cgi?id=308483</a>
    <a href="https://rdar.apple.com/171007509">rdar://171007509</a>
    Canonical link: <a href="https://commits.webkit.org/308769@main">https://commits.webkit.org/308769@main</a>

    [libpas] Fix adjacent-tag-exclusion for bitfit objects
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310736">https://bugs.webkit.org/show_bug.cgi?id=310736</a>
    <a href="https://rdar.apple.com/171744344">rdar://171744344</a>
    Canonical link: <a href="https://commits.webkit.org/310329@main">https://commits.webkit.org/310329@main</a>

    [libpas] Enable soft-mode and retag-on-scavenge
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309358">https://bugs.webkit.org/show_bug.cgi?id=309358</a>
    <a href="https://rdar.apple.com/171908706">rdar://171908706</a>
    Canonical link: <a href="https://commits.webkit.org/309353@main">https://commits.webkit.org/309353@main</a>

    [libpas] Quickly use bitfit heaps (as possible) when retag-on-scavenge is enabled
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309598">https://bugs.webkit.org/show_bug.cgi?id=309598</a>
    <a href="https://rdar.apple.com/172220367">rdar://172220367</a>
    Canonical link: <a href="https://commits.webkit.org/309573@main">https://commits.webkit.org/309573@main</a>

    [bmalloc] Disable TZone allocations when MTE is enabled
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309913">https://bugs.webkit.org/show_bug.cgi?id=309913</a>
    <a href="https://rdar.apple.com/172500381">rdar://172500381</a>
    Canonical link: <a href="https://commits.webkit.org/309849@main">https://commits.webkit.org/309849@main</a>

    [libpas] Fix and re-enable retag-on-scavenge
    <a href="https://bugs.webkit.org/show_bug.cgi?id=305435">https://bugs.webkit.org/show_bug.cgi?id=305435</a>
    <a href="https://rdar.apple.com/165772439">rdar://165772439</a>
    Canonical link: <a href="https://commits.webkit.org/306782@main">https://commits.webkit.org/306782@main</a>

    N.b.: the effect of this patch is NOT the same as that of cherry-picking
    the above six patches would be, as some changes were necessary for them
    to go in without other intervening patches that were landed on main but
    which will not be included here.

    Identifier: 305413.910@safari-7624-branch

    Identifier: 305413.969@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.1093@webkitglib/2.52">https://commits.webkit.org/305877.1093@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef266ffd05b743e30f7704260985de07e659f0a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180829 "2 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/54774 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48572 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191043 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145152 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/56072 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54490 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141063 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145152 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183784 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/56072 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/48572 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121515 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180153 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/56072 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54490 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3481 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/48572 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/56072 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48572 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2203 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/42103 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/47386 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/54490 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192978 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/54440 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/48572 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150448 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/55128 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48572 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150166 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27453 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/55128 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127394 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122694 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/53645 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/48572 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/53027 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53264 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53092 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->