### PR TITLE
[css-conditional-5] @supports at-rule should check whether an at-rule is enabled via feature flags

### DIFF
--- a/LayoutTests/css3/supports-at-rule-when-feature-flag-disabled-expected.txt
+++ b/LayoutTests/css3/supports-at-rule-when-feature-flag-disabled-expected.txt
@@ -1,0 +1,3 @@
+
+PASS @supports at-rule(@function) is false when CSSFunctionAtRuleEnabled feature flag is disabled
+

--- a/LayoutTests/css3/supports-at-rule-when-feature-flag-disabled.html
+++ b/LayoutTests/css3/supports-at-rule-when-feature-flag-disabled.html
@@ -1,0 +1,14 @@
+<!-- webkit-test-runner [ CSSFunctionAtRuleEnabled=false ] -->
+
+<!DOCTYPE html>
+
+<title>@supports at-rule() returns Unsupported when an at-rule is disabled by feature flag</title>
+
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<script>
+  test(() => {
+    assert_false(CSS.supports("at-rule(@function)"));
+  }, "@supports at-rule(@function) is false when CSSFunctionAtRuleEnabled feature flag is disabled");
+</script>

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -220,10 +220,47 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsAtRuleFuncti
     if (!function.atEnd())
         return Invalid;
 
-    auto atRuleID = cssAtRuleID(atKeywordToken.value());
+    // List all the at-rules here, so when adding a new at-rule, the compiler
+    // will remind to add them to this list.
+    // FIXME: should look into auto-generating this list using data from CSSProperties.json
+    switch (cssAtRuleID(atKeywordToken.value())) {
+    case CSSAtRuleWebkitKeyframes:
+    case CSSAtRuleAnnotation:
+    case CSSAtRuleCharacterVariant:
+    case CSSAtRuleContainer:
+    case CSSAtRuleCounterStyle:
+    case CSSAtRuleFontFace:
+    case CSSAtRuleFontFeatureValues:
+    case CSSAtRuleFontPaletteValues:
+    case CSSAtRuleImport:
+    case CSSAtRuleKeyframes:
+    case CSSAtRuleLayer:
+    case CSSAtRuleMedia:
+    case CSSAtRuleNamespace:
+    case CSSAtRuleOrnaments:
+    case CSSAtRulePage:
+    case CSSAtRulePositionTry:
+    case CSSAtRuleProperty:
+    case CSSAtRuleScope:
+    case CSSAtRuleStartingStyle:
+    case CSSAtRuleStyleset:
+    case CSSAtRuleStylistic:
+    case CSSAtRuleSupports:
+    case CSSAtRuleSwash:
+    case CSSAtRuleViewTransition:
+        return Supported;
 
+    case CSSAtRuleFunction:
+        return m_parser.context().propertySettings.cssFunctionAtRuleEnabled ? Supported : Unsupported;
+
+    case CSSAtRuleInvalid:
     // Per spec, @charset is not an at-rule.
-    return ((atRuleID != CSSAtRuleInvalid) && (atRuleID != CSSAtRuleCharset)) ? Supported : Unsupported;
+    case CSSAtRuleCharset:
+        return Unsupported;
+    }
+
+    ASSERT_NOT_REACHED();
+    return Invalid;
 }
 
 // <supports-named-feature-fn> = named-feature( <ident> )


### PR DESCRIPTION
#### 0ba64924f939b269a8acda143660ea80eec4161e
<pre>
[css-conditional-5] @supports at-rule should check whether an at-rule is enabled via feature flags
<a href="https://rdar.apple.com/184664687">rdar://184664687</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321556">https://bugs.webkit.org/show_bug.cgi?id=321556</a>

Reviewed by Tim Nguyen and Antti Koivisto.

@supports at-rule() doesn&apos;t take into account when an at-rule is controlled by
a feature flag. For example, @function is controlled by CSSFunctionAtRuleEnabled,
so it&apos;s only supported when CSSFunctionAtRuleEnabled is enabled, but
`@supports at-rule(@function)` returns true at all time.

Fix it so that @supports at-rule() consults the feature flag if an at-rule is
controlled by one.

Test: css3/supports-at-rule-when-feature-flag-disabled.html

* LayoutTests/css3/supports-at-rule-when-feature-flag-disabled-expected.txt: Added.
* LayoutTests/css3/supports-at-rule-when-feature-flag-disabled.html: Added.
* Source/WebCore/css/parser/CSSSupportsParser.cpp:
(WebCore::CSSSupportsParser::consumeSupportsAtRuleFunction):

Canonical link: <a href="https://commits.webkit.org/319936@main">https://commits.webkit.org/319936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33bff895efca8c4443279db2cd681db8e79468db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193411 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147482 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b5514ab-3064-4cc7-9982-5d346735aeca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142982 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1b18c23-0009-4948-8654-0ce58c2b5421) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123409 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5368a37e-00b2-4cdf-966e-ce709b1707f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45412 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43657 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155810 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43279 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4585 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195352 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152472 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40869 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57490 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39899 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/cookies/same-site/popup-cross-site.html, http/tests/media/now-playing-info-private-browsing.html, http/tests/navigation/post-308-response.html, http/tests/privateClickMeasurement/store-private-click-measurement-nested.html, http/tests/resourceLoadStatistics/dont-count-third-party-image-as-third-party-script.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/iframe-srcdoc-external-script.html, http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152168 "Found 1 new API test failure: TestAutocleanups:/webkit/Autocleanups/ui-process-autocleanups (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46723 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129760 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55998 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18290 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55369 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55607 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55436 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->