### PR TITLE
[Text Extraction] zoom.us: text extraction is unnecessarily verbose on account profile/settings pages

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-bare-images-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-bare-images-expected.txt
@@ -1,0 +1,27 @@
+root
+    label='Inside a control'
+        button uid=… label='Show password'
+        link uid=… url=example.com/settings
+        uid=… role=button
+        button uid=… 'Save'
+    label='No preceding text'
+    label='Mixed case and fallback roles'
+        uid=… role=BUTTON
+            'Edit'
+        role=menuitem
+            'Open'
+            image uid=…
+        role=tab
+            'Details'
+            image uid=…
+    label='False valued aria'
+    label='Following plain text'
+        'Sign-In Password'
+        image uid=…
+    label='Self describing'
+        image uid=… label='Edit password' alt='Edit password'
+        image uid=… alt='Delete account'
+        image uid=… role=img
+        image uid=… clickable
+        image uid=… src=green-256x256.jpg alt='Green square'
+        image uid=… src=green-256x256.jpg

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-bare-images.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-bare-images.html
@@ -1,0 +1,48 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+body {
+    white-space: pre-wrap;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<div aria-label="Inside a control"><button aria-label="Show password"><svg width="16" height="16"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg></button><a href="https://example.com/settings"><svg width="16" height="16"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg></a><div role="button" tabindex="0"><svg width="16" height="16"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg></div><button>Save<svg width="16" height="16"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg></button></div>
+
+<div aria-label="No preceding text"><svg width="16" height="16"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg><svg width="16" height="16"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg></div>
+
+<div aria-label="Mixed case and fallback roles"><div role="BUTTON" tabindex="0">Edit<svg width="16" height="16"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg></div><div role="menuitem">Open<svg width="16" height="16"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg></div><div role="tab">Details<svg width="16" height="16"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg></div></div>
+
+<div aria-label="False valued aria"><svg width="16" height="16" aria-disabled="false"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg></div>
+
+<div aria-label="Following plain text">Sign-In Password<svg width="16" height="16"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg></div>
+
+<div aria-label="Self describing"><svg width="16" height="16" aria-label="Edit password"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg><svg width="16" height="16"><title>Delete account</title><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg><svg width="16" height="16" role="img"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg><svg width="16" height="16" style="cursor: pointer;" onclick="console.log('clicked')"><path d="M3 13 L11 5 L13 7 L5 15 Z"></path></svg><img src="../images/resources/green-256x256.jpg" alt="Green square"><img src="../images/resources/green-256x256.jpg"></div>
+
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    document.body.textContent = await UIHelper.requestDebugText({
+        normalize: true,
+        includeURLs: true,
+        shortenURLs: true,
+        nodeIdentifierInclusion: "interactive",
+        includeAccessibilityAttributes: true,
+    });
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -2,9 +2,8 @@ root
     role=banner
         label='Main Page Title' 'Welcome to Test Page' […]
     navigation label='Main navigation'
-        list
-            link uid=… url=mailto:wenson_hsieh@apple.com 'Section 1' […]
-            link uid=… url=https://example.com/ 'Section 2' […]
+        link uid=… url=mailto:wenson_hsieh@apple.com 'Section 1' […]
+        link uid=… url=https://example.com/ 'Section 2' […]
     role=main
         section label='Interactive Elements'
             button uid=… describedby='This button does nothing' label='Test button' 'Click Me' […]
@@ -30,10 +29,9 @@ root
                 'This is some article content with highlighted text.' […]
             label='Related information'
                 'Related Links' […]
-                list
-                    link uid=… url=https://webkit.org/ 'Example Link' […]
-                        canvas uid=… […]
-                    link uid=… url=https://apple.com/ 'Test Link' […]
+                link uid=… url=https://webkit.org/ 'Example Link' […]
+                    canvas uid=… […]
+                link uid=… url=https://apple.com/ 'Test Link' […]
             role=region
                 role=status 'Ready' […]
                 button uid=… 'Update Status' […]
@@ -58,7 +56,6 @@ root
             button uid=… 'Sign In' […]
             button uid=… label=Profile 'YZ' […]
             uid=… role=button class=account-btn
-                image uid=… […]
             input uid=… […] placeholder=Username
     'Footer content with' […]
     role=img label='copyright symbol' '©' […]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -4,9 +4,8 @@ root
     role=banner
         label='Main Page Title' 'Welcome to Test Page'
     navigation label='Main navigation'
-        list
-            link 'Section 1'
-            link 'Section 2'
+        link 'Section 1'
+        link 'Section 2'
     role=main
         section label='Interactive Elements'
             button describedby='This button does nothing' label='Test button' 'Click Me'
@@ -20,9 +19,8 @@ root
                 'This is some article content with highlighted text.'
             label='Related information'
                 'Related Links'
-                list
-                    link 'Example Link'
-                    link 'Test Link'
+                link 'Example Link'
+                link 'Test Link'
             role=region
                 role=status 'Ready'
                 button 'Update Status'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt
@@ -1,9 +1,8 @@
 root
     'Welcome to Test Page'
     navigation
-        list
-            link 'Section 1'
-            link 'Section 2'
+        link 'Section 1'
+        link 'Section 2'
     'Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.'
     section
         button 'Click Me'
@@ -16,9 +15,8 @@ root
             'January 1, 2024'
             'This is some article content with highlighted text.'
         'Related Links'
-        list
-            link 'Example Link'
-            link 'Test Link'
+        link 'Example Link'
+        link 'Test Link'
         'Ready'
         button 'Update Status'
     'The quick brown fox jumped over the lazy dog.'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
@@ -1,9 +1,8 @@
 root
     'Welcome to Test Page'
     navigation
-        list
-            link 'Section 1'
-            link 'Section 2'
+        link 'Section 1'
+        link 'Section 2'
     'Here’s to the crazy ones…'
     section
         button 'Click Me'
@@ -16,9 +15,8 @@ root
             'January 1, 2024'
             'This is some article content…'
         'Related Links'
-        list
-            link 'Example Link'
-            link 'Test Link'
+        link 'Example Link'
+        link 'Test Link'
         'Ready'
         button 'Update Status'
     'The quick brown fox jumped…'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields-expected.txt
@@ -2,10 +2,9 @@
 
 root
     scrollable scrollPosition=(0,0) contentSize=[…]
-        section
-            article
-                'Article Title'
-                'This is some visible content.'
+        article
+            'Article Title'
+            'This is some visible content.'
         form autocomplete=on name=login
             'Log in to your account'
             input placeholder=Username name=username required

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-role-suppression-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-role-suppression-expected.txt
@@ -18,6 +18,8 @@ root
     'Footer content'
     contentEditable uid=… role=textbox 'Editable content'
     role=dialog label='Test dialog' 'Dialog content'
-    list role=tree
-        'Tree item 1'
-        'Tree item 2'
+    'Tree item 1'
+    'Tree item 2'
+    label='Side menu'
+        link uid=… 'Meetings'
+        'Custom tree item'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-role-suppression.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-role-suppression.html
@@ -41,6 +41,10 @@ body {
     <li role="treeitem">Tree item 1</li>
     <li role="treeitem">Tree item 2</li>
 </ul>
+<div role="tree" aria-label="Side menu">
+    <a role="treeitem" href="https://example.com/meetings">Meetings</a>
+    <div role="treeitem" tabindex="0">Custom tree item</div>
+</div>
 
 <script>
 addEventListener("load", async () => {

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1133,7 +1133,19 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
 
         if (!role.isEmpty()) {
             auto shouldSuppressRole = [&] {
-                static constexpr auto ignoredRoles = WTF::toArray({ "presentation"_s, "none"_s, "generic"_s, "group"_s, "rowgroup"_s, "directory"_s, "complementary"_s, "contentinfo"_s });
+                static constexpr auto ignoredRoles = WTF::toArray({
+                    "presentation"_s,
+                    "none"_s,
+                    "generic"_s,
+                    "group"_s,
+                    "rowgroup"_s,
+                    "directory"_s,
+                    "complementary"_s,
+                    "contentinfo"_s,
+                    "tree"_s,
+                    "treeitem"_s
+                });
+
                 for (auto ignoredRole : ignoredRoles) {
                     if (equalLettersIgnoringASCIICase(role, ignoredRole))
                         return true;

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -2095,6 +2095,98 @@ static bool childTextNodeIsRedundant(const TextExtractionAggregator& aggregator,
     return false;
 }
 
+static bool isUninformativeImage(const TextExtraction::Item& item, const TextExtraction::Item& parent, const TextExtraction::Item* previousSibling, const TextExtractionAggregator& aggregator)
+{
+    if (!aggregator.useTextTreeOutput())
+        return false;
+
+    auto* imageData = std::get_if<TextExtraction::ImageItemData>(&item.data);
+    if (!imageData)
+        return false;
+
+    if (!imageData->altText.isEmpty())
+        return false;
+
+    if (!imageData->completedSource.isEmpty() && aggregator.includeURLs())
+        return false;
+
+    if (!item.children.isEmpty() || !item.accessibilityRole.isEmpty() || !item.title.isEmpty())
+        return false;
+
+    bool hasEmittedAriaAttribute = std::ranges::any_of(item.ariaAttributes, [](auto& entry) {
+        return entry.value != "false"_s;
+    });
+    if (hasEmittedAriaAttribute || !item.clientAttributes.isEmpty())
+        return false;
+
+    if (!item.classNames.isEmpty() || !item.idAttribute.isEmpty())
+        return false;
+
+    if (shouldEmitClickableToken(item))
+        return false;
+
+    static constexpr auto actionableRoles = WTF::toArray({
+        "button"_s,
+        "link"_s,
+        "checkbox"_s,
+        "radio"_s,
+        "switch"_s,
+        "menuitemcheckbox"_s,
+        "menuitemradio"_s,
+        "option"_s,
+    });
+
+    bool parentHasActionableRole = std::ranges::any_of(actionableRoles, [&](const auto& role) {
+        return equalLettersIgnoringASCIICase(parent.accessibilityRole, role);
+    });
+
+    bool parentIsActionable = parent.hasData<TextExtraction::LinkItemData>()
+        || parent.dataAs<TextExtraction::ContainerType>() == TextExtraction::ContainerType::Button
+        || parent.isVisuallyClickable
+        || parent.eventListeners.contains(TextExtraction::EventListenerCategory::Click)
+        || parentHasActionableRole;
+
+    return parentIsActionable || !previousSibling || !previousSibling->hasData<TextExtraction::TextItemData>();
+}
+
+static bool isIdentityFreeContainer(const TextExtraction::Item& item, const std::optional<TextExtraction::ContainerType>& containerType, const TextExtractionAggregator& aggregator)
+{
+    if (!aggregator.useTextTreeOutput() || !containerType || aggregator.includeTagName())
+        return false;
+
+    switch (*containerType) {
+    case TextExtraction::ContainerType::List:
+    case TextExtraction::ContainerType::ListItem:
+    case TextExtraction::ContainerType::Section:
+    case TextExtraction::ContainerType::Generic:
+        break;
+    case TextExtraction::ContainerType::ViewportConstrained:
+    case TextExtraction::ContainerType::BlockQuote:
+    case TextExtraction::ContainerType::Article:
+    case TextExtraction::ContainerType::Nav:
+    case TextExtraction::ContainerType::Button:
+    case TextExtraction::ContainerType::Canvas:
+    case TextExtraction::ContainerType::Subscript:
+    case TextExtraction::ContainerType::Superscript:
+    case TextExtraction::ContainerType::Strikethrough:
+        return false;
+    }
+
+    if (item.nodeIdentifier || !item.accessibilityRole.isEmpty() || !item.title.isEmpty())
+        return false;
+
+    bool hasEmittedAriaAttribute = std::ranges::any_of(item.ariaAttributes, [](auto& entry) {
+        return entry.value != "false"_s;
+    });
+    if (hasEmittedAriaAttribute || !item.clientAttributes.isEmpty())
+        return false;
+
+    if (!item.classNames.isEmpty() || !item.idAttribute.isEmpty())
+        return false;
+
+    return !shouldEmitClickableToken(item);
+}
+
 static void addTextRepresentationRecursive(const TextExtraction::Item& item, std::optional<NodeIdentifier>&& enclosingNode, unsigned depth, TextExtractionAggregator& aggregator, HasAdjacentLinkAfter hasAdjacentLinkAfter = HasAdjacentLinkAfter::No)
 {
     auto identifier = item.nodeIdentifier;
@@ -2148,6 +2240,21 @@ static void addTextRepresentationRecursive(const TextExtraction::Item& item, std
 
     if (aggregator.useTextTreeOutput() && containerType == TextExtraction::ContainerType::ListItem && item.children.size() == 1 && !item.nodeIdentifier) {
         addTextRepresentationRecursive(item.children[0], std::optional { identifier }, depth, aggregator, hasAdjacentLinkAfter);
+        return;
+    }
+
+    if (isIdentityFreeContainer(item, containerType, aggregator)) {
+        for (size_t i = 0; i < item.children.size(); ++i) {
+            auto& child = item.children[i];
+            if (isUninformativeImage(child, item, i ? &item.children[i - 1] : nullptr, aggregator))
+                continue;
+
+            auto childHasLinkAfter = i + 1 < item.children.size()
+                ? (item.children[i + 1].hasData<TextExtraction::LinkItemData>() ? HasAdjacentLinkAfter::Yes : HasAdjacentLinkAfter::No)
+                : hasAdjacentLinkAfter;
+
+            addTextRepresentationRecursive(child, std::optional { identifier }, depth, aggregator, childHasLinkAfter);
+        }
         return;
     }
 
@@ -2244,6 +2351,9 @@ static void addTextRepresentationRecursive(const TextExtraction::Item& item, std
             continue;
 
         auto& child = item.children[i];
+        if (isUninformativeImage(child, item, i ? &item.children[i - 1] : nullptr, aggregator))
+            continue;
+
         bool childHasLinkAfter = i + 1 < item.children.size() && item.children[i + 1].hasData<TextExtraction::LinkItemData>();
         addTextRepresentationRecursive(child, std::optional { identifier }, depth + 1, aggregator, childHasLinkAfter ? HasAdjacentLinkAfter::Yes : HasAdjacentLinkAfter::No);
     }


### PR DESCRIPTION
#### 3e0eda365bed271d84448984bb5f392bed1e2258
<pre>
[Text Extraction] zoom.us: text extraction is unnecessarily verbose on account profile/settings pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=321566">https://bugs.webkit.org/show_bug.cgi?id=321566</a>
<a href="https://rdar.apple.com/184671350">rdar://184671350</a>

Reviewed by Abrar Rahman Protyasha.

Make several adjustments to further streamline resulting text extractions on zoom.us; see below for
more details.

Test: fast/text-extraction/debug-text-extraction-bare-images.html

* LayoutTests/fast/text-extraction/debug-text-extraction-bare-images-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-bare-images.html: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-role-suppression-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-role-suppression.html:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):

Avoid surfacing `tree` and `treeitem` as relevant accessibility roles.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::isUninformativeImage):

Exclude redundant image items with no semantically meaningful roles or attributes. For instance,

```
button uid=5234 label=&apos;Learn more&apos;
  image uid=5235
```

...can simply become:

```
button uid=5234 label=&apos;Learn more&apos;
```

(WebKit::isIdentityFreeContainer):

Eliminate interstitial container elements with no semantically meaningful roles or attributes.

(WebKit::addTextRepresentationRecursive):

Canonical link: <a href="https://commits.webkit.org/319037@main">https://commits.webkit.org/319037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7667c6319695da5e95aef38e202b4f7958846de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144495 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140524 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6b8bb3c-0456-4baf-9a9d-fffeae0c3648) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120976 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42851 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41159 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9788 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40832 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1547 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192322 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149871 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40149 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54476 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149598 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44237 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126739 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121874 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52993 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15821 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52375 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52612 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52440 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->