### PR TITLE
[Custom Highlight] ::highlight() is not repainted when a highlight's range is changed via CSS.highlights.set().

### DIFF
--- a/LayoutTests/fast/css/highlight-text-repaint-expected.txt
+++ b/LayoutTests/fast/css/highlight-text-repaint-expected.txt
@@ -1,8 +1,12 @@
 One two three
 (repaint rects
   (rect 8 8 260 20)
+  (rect 8 8 784 20)
   (rect 8 8 260 20)
+  (rect 8 8 784 20)
   (rect 8 8 260 20)
+  (rect 8 8 784 20)
   (rect 8 8 260 20)
+  (rect 8 8 784 20)
 )
 

--- a/LayoutTests/fast/repaint/highlight-paint-after-range-change-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-paint-after-range-change-expected.txt
@@ -1,5 +1,6 @@
 Highlight this first and then this.
 (repaint rects
   (rect 8 8 415 37)
+  (rect 8 8 784 37)
 )
 When run, the first "this" should be highlighted, followed by the second "this", and the first highlight should be removed.

--- a/LayoutTests/fast/repaint/highlight-removed-when-cleared-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-removed-when-cleared-expected.txt
@@ -1,6 +1,8 @@
 Highlight this first and then clear highlight.
 (repaint rects
   (rect 8 8 554 37)
+  (rect 8 8 784 37)
   (rect 8 8 554 37)
+  (rect 8 8 784 37)
 )
 When run, the first "this" should be highlighted, and then the highlight should be removed.

--- a/LayoutTests/fast/repaint/highlight-removed-when-deleted-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-removed-when-deleted-expected.txt
@@ -1,6 +1,8 @@
 Highlight this first and then delete highlight.
 (repaint rects
   (rect 8 8 568 37)
+  (rect 8 8 784 37)
   (rect 8 8 568 37)
+  (rect 8 8 784 37)
 )
 When run, the first "this" should be highlighted, and then the highlight should be removed.

--- a/LayoutTests/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt
@@ -1,7 +1,10 @@
 Highlight this first and then clear highlight, then add it again.
 (repaint rects
   (rect 8 8 783 37)
+  (rect 8 8 784 37)
   (rect 8 8 783 37)
+  (rect 8 8 784 37)
   (rect 8 8 783 37)
+  (rect 8 8 784 37)
 )
 When run, the first "this" should be highlighted, and then the highlight should be removed. Then then highlight should be added again.

--- a/LayoutTests/platform/glib/fast/repaint/highlight-paint-after-range-change-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/highlight-paint-after-range-change-expected.txt
@@ -1,5 +1,6 @@
 Highlight this first and then this.
 (repaint rects
   (rect 8 8 416 37)
+  (rect 8 8 784 37)
 )
 When run, the first "this" should be highlighted, followed by the second "this", and the first highlight should be removed.

--- a/LayoutTests/platform/glib/fast/repaint/highlight-removed-when-cleared-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/highlight-removed-when-cleared-expected.txt
@@ -1,6 +1,8 @@
 Highlight this first and then clear highlight.
 (repaint rects
   (rect 8 8 556 37)
+  (rect 8 8 784 37)
   (rect 8 8 556 37)
+  (rect 8 8 784 37)
 )
 When run, the first "this" should be highlighted, and then the highlight should be removed.

--- a/LayoutTests/platform/glib/fast/repaint/highlight-removed-when-deleted-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/highlight-removed-when-deleted-expected.txt
@@ -1,6 +1,8 @@
 Highlight this first and then delete highlight.
 (repaint rects
   (rect 8 8 570 37)
+  (rect 8 8 784 37)
   (rect 8 8 570 37)
+  (rect 8 8 784 37)
 )
 When run, the first "this" should be highlighted, and then the highlight should be removed.

--- a/LayoutTests/platform/glib/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt
@@ -3,5 +3,8 @@ Highlight this first and then clear highlight, then add it again.
   (rect 8 8 784 37)
   (rect 8 8 784 37)
   (rect 8 8 784 37)
+  (rect 8 8 784 37)
+  (rect 8 8 784 37)
+  (rect 8 8 784 37)
 )
 When run, the first "this" should be highlighted, and then the highlight should be removed. Then then highlight should be added again.

--- a/Source/WebCore/Modules/highlight/Highlight.cpp
+++ b/Source/WebCore/Modules/highlight/Highlight.cpp
@@ -41,10 +41,17 @@ void Highlight::repaintRange(const AbstractRange& range)
     auto sortedRange = makeSimpleRange(range);
     if (is_gt(treeOrder<ComposedTree>(sortedRange.start, sortedRange.end)))
         std::swap(sortedRange.start, sortedRange.end);
+    // Highlight decorations can paint outside a renderer's ink overflow, so also repaint containing blocks (collected to avoid redundant repaints of shared containers).
+    SingleThreadWeakHashSet<RenderBlock> containingBlocks;
     for (Ref node : intersectingNodes(sortedRange)) {
-        if (CheckedPtr renderer = node->renderer())
+        if (CheckedPtr renderer = node->renderer()) {
             renderer->repaint();
+            if (CheckedPtr containingBlock = renderer->containingBlock())
+                containingBlocks.add(*containingBlock);
+        }
     }
+    for (CheckedRef containingBlock : containingBlocks)
+        containingBlock->repaint();
 }
 
 Ref<Highlight> Highlight::create(FixedVector<std::reference_wrapper<AbstractRange>>&& initialRanges)

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
@@ -119,12 +119,15 @@ Vector<HighlightHitResult> HighlightRegistry::highlightsFromPoint(Document& docu
 
 void HighlightRegistry::setFromMapLike(AtomString&& key, Ref<Highlight>&& value)
 {
+    if (RefPtr previousHighlight = m_map.get(key))
+        previousHighlight->repaint();
+
     auto addResult = m_map.set(key, WTF::move(value));
     if (addResult.isNewEntry) {
         ASSERT(!m_highlightNames.contains(key));
         m_highlightNames.append(WTF::move(key));
-        protect(addResult.iterator->value)->repaint();
     }
+    protect(addResult.iterator->value)->repaint();
 }
 
 void HighlightRegistry::clear()


### PR DESCRIPTION
#### 3de673d8e110e83cf157369d08dbf8d385ff47fb
<pre>
[Custom Highlight] ::highlight() is not repainted when a highlight&apos;s range is changed via CSS.highlights.set().
<a href="https://bugs.webkit.org/show_bug.cgi?id=321567">https://bugs.webkit.org/show_bug.cgi?id=321567</a>
<a href="https://rdar.apple.com/184672580">rdar://184672580</a>

Reviewed by Wenson Hsieh.

Replacing an existing highlight via CSS.highlights.set() with a key that is already registered did not
repaint: HighlightRegistry::setFromMapLike only scheduled a repaint when the key was new, so neither the
ranges of the highlight being replaced nor the ranges of the new highlight were invalidated. Additionally,
Highlight::repaintRange only repainted the renderers of the nodes intersecting the range, whose ink overflow
is computed from the element&apos;s own style and does not include highlight decorations that paint outside it
(e.g. a large text-underline-offset).

imported/w3c/web-platform-tests/css/css-highlight-api/painting/invalidation/css-highlight-invalidation-001.html

* LayoutTests/fast/css/highlight-text-repaint-expected.txt:
* LayoutTests/fast/repaint/highlight-paint-after-range-change-expected.txt:
* LayoutTests/fast/repaint/highlight-removed-when-cleared-expected.txt:
* LayoutTests/fast/repaint/highlight-removed-when-deleted-expected.txt:
* LayoutTests/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt:
* LayoutTests/platform/glib/fast/repaint/highlight-paint-after-range-change-expected.txt:
* LayoutTests/platform/glib/fast/repaint/highlight-removed-when-cleared-expected.txt:
* LayoutTests/platform/glib/fast/repaint/highlight-removed-when-deleted-expected.txt:
* LayoutTests/platform/glib/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt:
* Source/WebCore/Modules/highlight/Highlight.cpp:
(WebCore::Highlight::repaintRange):
* Source/WebCore/Modules/highlight/HighlightRegistry.cpp:
(WebCore::HighlightRegistry::setFromMapLike):

Canonical link: <a href="https://commits.webkit.org/319154@main">https://commits.webkit.org/319154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaab324bc0c7ac1f2d225401657c2c6093e5a455

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190832 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc8555ff-c3bc-4163-89ed-f207471da6d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140878 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3736e91-62a6-46a8-b0eb-a141576750df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121330 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f6dd458-a556-4724-9576-610abfad49a1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41183 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1992 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47175 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192768 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54232 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150256 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40220 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54920 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149974 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44594 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127185 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122400 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53437 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16176 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52819 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53056 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52884 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->