### PR TITLE
[git-webkit] Uploading a pull request repeatedly duplicates the branch's bug and title in .git/config

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -50,7 +50,7 @@ except ImportError:
         "See https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy"
     )
 
-version = Version(7, 0, 4)
+version = Version(7, 0, 5)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('markupsafe', Version(3, 0, 3), pypi_name='MarkupSafe', wheel=True))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -39,6 +39,10 @@ from webkitscmpy.program.canonicalize.committer import main as committer_main
 from webkitscmpy.program.canonicalize.message import main as message_main
 
 
+# 'git config' spells listing two ways, and both appear in the wild
+LIST_OPTION = re.compile(r'^(-l|--list)$')
+
+
 class Git(mocks.Subprocess):
     # Parse a .git/config that looks like this
     # [core]
@@ -48,7 +52,7 @@ class Git(mocks.Subprocess):
     #     merge = refs/heads/main
     RE_SINGLE_TOP = re.compile(r'^\[\s*(?P<key>\S+)\s*\]')
     RE_MULTI_TOP = re.compile(r'^\[\s*(?P<keya>\S+) "(?P<keyb>\S+)"\s*\]')
-    RE_ELEMENT = re.compile(r'^\s+(?P<key>\S+)\s*=\s*(?P<value>.*\S+)')
+    RE_ELEMENT = re.compile(r'^\s+(?P<key>[^\s=]+)\s*=\s*(?P<value>.*\S+)')
 
     def __init__(
         self, path='/.invalid-git', datafile=None,
@@ -522,12 +526,12 @@ nothing to commit, working tree clean
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.pull(autostash=True),
             ), mocks.Subprocess.Route(
-                self.executable, 'config', '-l',
+                self.executable, 'config', LIST_OPTION,
                 cwd=self.path,
                 generator=lambda *args, **kwargs:
                     mocks.ProcessCompletion(
                         returncode=0,
-                        stdout='\n'.join(['{}={}'.format(key, value) for key, value in self.config().items()])
+                        stdout='\n'.join([f'{key}={value}' for key, value in self.config_entries()])
                     ),
             ), mocks.Subprocess.Route(
                 self.executable, 'config', '--get-regexp', re.compile(r'.+'),
@@ -538,17 +542,17 @@ nothing to commit, working tree clean
                         stdout='\n'.join(['{} {}'.format(key, value) for key, value in self.config().items() if key.startswith(args[3])])
                     ),
             ), mocks.Subprocess.Route(
-                self.executable, 'config', '-l', '--file', re.compile(r'.+'),
+                self.executable, 'config', LIST_OPTION, '--file', re.compile(r'.+'),
                 cwd=self.path,
                 generator=lambda *args, **kwargs:
                     mocks.ProcessCompletion(
                         returncode=0,
                         stdout='\n'.join([
-                            '{}={}'.format(key, value) for key, value in self.config(path=os.path.join(self.path, args[4])).items()
+                            f'{key}={value}' for key, value in self.config_entries(path=os.path.join(self.path, args[4]))
                         ])
                     ),
             ), mocks.Subprocess.Route(
-                self.executable, 'config', '-l', '--global',
+                self.executable, 'config', LIST_OPTION, '--global',
                 generator=lambda *args, **kwargs:
                     mocks.ProcessCompletion(
                         returncode=0,
@@ -556,6 +560,11 @@ nothing to commit, working tree clean
                     ),
             ), mocks.Subprocess.Route(
                 self.executable, 'config', '--add', re.compile(r'.+'), re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs:
+                    self.edit_config(args[3], args[4], add=True),
+            ), mocks.Subprocess.Route(
+                self.executable, 'config', '--replace-all', re.compile(r'.+'), re.compile(r'.+'),
                 cwd=self.path,
                 generator=lambda *args, **kwargs:
                     self.edit_config(args[3], args[4]),
@@ -1125,28 +1134,33 @@ nothing to commit, working tree clean
                 'sendemail.transferencoding': 'base64',
             })
 
-        top = None
-        result = Git.config()
-        path = path or os.path.join(context.path, '.git', 'config')
+        return OrderedDict(context.config_entries(path=path))
+
+    def config_entries(self, path=None):
+        """Every configured value in order, keeping the repeated keys git allows a single option."""
+        result = list(Git.config().items())
+        path = path or os.path.join(self.path, '.git', 'config')
         if not os.path.isfile(path):
             return result
+
+        top = None
         with open(path, 'r') as configfile:
             for line in configfile.readlines():
-                match = context.RE_MULTI_TOP.match(line)
+                match = self.RE_MULTI_TOP.match(line)
                 if match:
-                    top = '{}.{}'.format(match.group('keya'), match.group('keyb'))
+                    top = f"{match.group('keya')}.{match.group('keyb')}"
                     continue
-                match = context.RE_SINGLE_TOP.match(line)
+                match = self.RE_SINGLE_TOP.match(line)
                 if match:
                     top = match.group('key')
                     continue
 
-                match = context.RE_ELEMENT.match(line)
+                match = self.RE_ELEMENT.match(line)
                 if top and match:
-                    result['{}.{}'.format(top, match.group('key'))] = match.group('value')
+                    result.append((f"{top}.{match.group('key')}", match.group('value')))
         return result
 
-    def edit_config(self, key, value):
+    def edit_config(self, key, value, add=False):
         with open(os.path.join(self.path, '.git', 'config'), 'r') as configfile:
             lines = [line for line in configfile.readlines()]
 
@@ -1157,7 +1171,7 @@ nothing to commit, working tree clean
         with open(os.path.join(self.path, '.git', 'config'), 'w') as configfile:
             for line in lines:
                 match = self.RE_ELEMENT.match(line)
-                if not match or match.group('key') != key_b:
+                if add or not match or match.group('key') != key_b:
                     configfile.write(line)
                 match = self.RE_MULTI_TOP.match(line)
                 if not match or '{}.{}'.format(match.group('keya'), match.group('keyb')) != key_a:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -220,14 +220,10 @@ class Branch(Command):
             sys.stderr.write("'{}' is an invalid branch name, cannot create it\n".format(args.issue))
             return 1
 
-        bug_urls = getattr(args, '_bug_urls', None) or ''
-        if isinstance(bug_urls, (list, tuple)):
-            bug_urls = '\n'.join(bug_urls)
-        title = getattr(args, '_title', None) or ''
         cls.write_branch_variables(
             repository, args.issue,
-            title=title,
-            bug=bug_urls,
+            title=getattr(args, '_title', None) or '',
+            bug=getattr(args, '_bug_urls', None) or [],
         )
 
         if args.issue in repository.branches_for(remote=target_remote):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
@@ -45,9 +45,12 @@ class Command(object):
         for key, value in variables.items():
             if not value:
                 continue
-            for v in value if isinstance(value, (list, tuple)) else [value]:
+            values = value if isinstance(value, (list, tuple)) else [value]
+            for position, entry in enumerate(values):
+                # The first write clears whatever a previous run left behind, the rest accumulate
+                option = '--replace-all' if position == 0 else '--add'
                 result &= run(
-                    [repository.executable(), 'config', '--add', 'branch.{}.{}'.format(branch, key), str(v)],
+                    [repository.executable(), 'config', option, f'branch.{branch}.{key}', str(entry)],
                     cwd=repository.root_path, capture_output=True,
                 ).returncode == 0
         return result

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -328,14 +328,10 @@ class PullRequest(Command):
                 if result:
                     return None
 
-                bug_urls = getattr(args, '_bug_urls', None) or ''
-                if isinstance(bug_urls, (list, tuple)):
-                    bug_urls = '\n'.join(bug_urls)
-                title = getattr(args, '_title', None) or ''
                 cls.write_branch_variables(
                     repository, repository.branch,
-                    title=title,
-                    bug=bug_urls,
+                    title=getattr(args, '_title', None) or '',
+                    bug=getattr(args, '_bug_urls', None) or [],
                 )
 
         if not repository.config().get('remote.{}.url'.format(source_remote)):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -27,7 +27,7 @@ from unittest.mock import patch
 
 from webkitbugspy import Tracker, bugzilla, radar
 from webkitbugspy import mocks as bmocks
-from webkitcorepy import OutputCapture, testing
+from webkitcorepy import OutputCapture, run, testing
 from webkitcorepy import mocks as wkmocks
 from webkitcorepy.mocks import Environment
 from webkitcorepy.mocks import Terminal as MockTerminal
@@ -567,3 +567,42 @@ Created the local development branch 'eng/4'
         self.assertEqual(captured.root.log.getvalue(), '')
         self.assertEqual(captured.stdout.getvalue(), '')
         self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_bug_urls_stored_separately(self):
+        with OutputCapture(), mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            issues=bmocks.ISSUES,
+            projects=bmocks.PROJECTS,
+            users=bmocks.USERS,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), bmocks.Radar(issues=bmocks.ISSUES), patch('webkitbugspy.Tracker._trackers', [
+            bugzilla.Tracker(self.BUGZILLA, radar_importer=bmocks.USERS['Radar WebKit Bug Importer']),
+            radar.Tracker(),
+        ]), mocks.local.Svn(), MockTime, MockTerminal.input(
+            f'{self.BUGZILLA}/show_bug.cgi?id=2', '',
+        ):
+            self.assertEqual(0, program.main(args=('branch',), path=self.path))
+
+            entries = run(
+                [local.Git.executable(), 'config', '--list'],
+                cwd=self.path, capture_output=True, encoding='utf-8',
+            ).stdout.splitlines()
+
+            # Each URL is a value of its own, rather than one truncated value and one bogus key
+            self.assertEqual(
+                [line for line in entries if line.startswith('branch.eng/Example-feature-1.bug=')],
+                [
+                    f'branch.eng/Example-feature-1.bug={self.BUGZILLA}/show_bug.cgi?id=2',
+                    'branch.eng/Example-feature-1.bug=rdar://4',
+                ],
+            )
+            self.assertEqual(
+                sorted({
+                    line.split('=')[0] for line in entries
+                    if line.startswith('branch.eng/Example-feature-1.')
+                }),
+                ['branch.eng/Example-feature-1.bug', 'branch.eng/Example-feature-1.title'],
+            )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/command_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/command_unittest.py
@@ -28,7 +28,7 @@ from unittest.mock import patch
 
 from webkitcorepy import OutputCapture, Terminal, testing
 from webkitcorepy.mocks import Time as MockTime
-from webkitscmpy import program, mocks
+from webkitscmpy import local, program, mocks
 
 
 class TestFilteredCommandBase(testing.PathTestCase, abc.ABC):
@@ -324,3 +324,55 @@ class TestFilteredCommandRevision(TestFilteredCommandBase):
             '    git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n',
             self._run_log(git, ref=root.hash),
         )
+
+
+class TestWriteBranchVariables(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self):
+        super().setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+
+    def values_for(self, key):
+        with open(os.path.join(self.path, '.git', 'config')) as configfile:
+            return [
+                line.split('=', 1)[-1].strip() for line in configfile.readlines()
+                if line.strip().startswith(f'{key}=')
+            ]
+
+    def test_single_value_is_not_duplicated(self):
+        with OutputCapture(), mocks.local.Git(self.path):
+            repository = local.Git(self.path)
+            for _ in range(3):
+                self.assertTrue(program.Command.write_branch_variables(
+                    repository, 'eng/example',
+                    bug='https://bugs.example.com/show_bug.cgi?id=1',
+                ))
+
+            self.assertEqual(
+                self.values_for('eng/example.bug'),
+                ['https://bugs.example.com/show_bug.cgi?id=1'],
+            )
+
+    def test_value_is_replaced(self):
+        with OutputCapture(), mocks.local.Git(self.path):
+            repository = local.Git(self.path)
+            program.Command.write_branch_variables(repository, 'eng/example', title='Old title')
+            program.Command.write_branch_variables(repository, 'eng/example', title='New title')
+
+            self.assertEqual(self.values_for('eng/example.title'), ['New title'])
+            self.assertEqual(repository.config(cached=False).get('branch.eng/example.title'), 'New title')
+
+    def test_multiple_values_are_kept(self):
+        with OutputCapture(), mocks.local.Git(self.path):
+            repository = local.Git(self.path)
+            for _ in range(2):
+                program.Command.write_branch_variables(
+                    repository, 'eng/example',
+                    bug=['https://bugs.example.com/show_bug.cgi?id=1', 'rdar://2'],
+                )
+
+            self.assertEqual(
+                self.values_for('eng/example.bug'),
+                ['https://bugs.example.com/show_bug.cgi?id=1', 'rdar://2'],
+            )


### PR DESCRIPTION
#### f824f17ebf1dd60a79614693ec98f1ee7ca2c55c
<pre>
[git-webkit] Uploading a pull request repeatedly duplicates the branch&apos;s bug and title in .git/config
<a href="https://bugs.webkit.org/show_bug.cgi?id=321562">https://bugs.webkit.org/show_bug.cgi?id=321562</a>
<a href="https://rdar.apple.com/184673539">rdar://184673539</a>

Reviewed by Sam Sneddon.

`write_branch_variables` wrote every value with `git config --add`, which
appends rather than replaces, so each run left another copy of
`branch.&lt;name&gt;.bug` and `branch.&lt;name&gt;.title` behind.

- Write a key&apos;s first value with `--replace-all` and the rest with `--add`,
  making the write idempotent and collapsing duplicates that earlier
  runs left behind
- Pass bug URLs as a list rather than joining them with a newline:
  `git config -l` would unescape the newline but the value was truncated
  at the first URL and the remainder became a bogus key in `Git.config()`
- Modeled `--add` as appending in `mocks.local.Git`, taught it the `--list`
  spelling of `-l`, and made both report every value of a repeated key
  rather than flattening them through a dict, without which no test can
  observe the duplication
- `RE_ELEMENT` was mis-parsing config values that contain &apos;=&apos;

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py:
(Command.write_branch_variables):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.pull_request_branch_point):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/command_unittest.py:
(TestFilteredCommandRevision.test_revision_in_body_not_transformed):
(TestWriteBranchVariables):
(TestWriteBranchVariables.setUp):
(TestWriteBranchVariables.values_for):
(TestWriteBranchVariables.test_single_value_is_not_duplicated):
(TestWriteBranchVariables.test_value_is_replaced):
(TestWriteBranchVariables.test_multiple_values_are_kept):

Canonical link: <a href="https://commits.webkit.org/319768@main">https://commits.webkit.org/319768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1200176b2d58172aaad3910b44509eb7e84640ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142574 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123009 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182021 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44981 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42864 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4079 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194852 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182096 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56286 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152024 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40736 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56990 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151725 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46300 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125279 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55498 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17865 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54870 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55108 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->