### PR TITLE
[SVG2] Remove use-script, no-change and reset-size from dominant-baseline

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/dominant-baseline.historical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/dominant-baseline.historical-expected.txt
@@ -1,0 +1,6 @@
+text
+
+PASS dominant-baseline does not support the SVG 1.1 values removed in SVG 2
+PASS dominant-baseline removed values are not parsed in a style declaration
+PASS dominant-baseline removed values are not supported SVG presentation attributes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/dominant-baseline.historical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/dominant-baseline.historical.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVG dominant-baseline does not support use-script, no-change or reset-size</title>
+<link rel="help" href="https://www.w3.org/TR/SVG11/text.html#DominantBaselineProperty">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#DominantBaselineProperty">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="svg">
+  <text id="text">text</text>
+</svg>
+<script>
+// use-script, no-change and reset-size were dominant-baseline values in
+// SVG 1.1 but were removed in SVG 2.
+const removedValues = ["use-script", "no-change", "reset-size"];
+
+test(() => {
+  for (const value of removedValues)
+    assert_false(CSS.supports("dominant-baseline", value), value);
+}, "dominant-baseline does not support the SVG 1.1 values removed in SVG 2");
+
+test(() => {
+  const text = document.getElementById("text");
+  for (const value of removedValues) {
+    text.style.setProperty("dominant-baseline", value);
+    assert_equals(text.style.getPropertyValue("dominant-baseline"), "",
+      value + " should not parse in a style declaration");
+    assert_equals(text.style.length, 0, "declaration should remain empty");
+  }
+}, "dominant-baseline removed values are not parsed in a style declaration");
+
+test(() => {
+  const text = document.getElementById("text");
+  // An unsupported presentation attribute value must not contribute a value to
+  // the computed style of the element.
+  for (const value of removedValues) {
+    text.setAttribute("dominant-baseline", value);
+    assert_equals(getComputedStyle(text).getPropertyValue("dominant-baseline"), "auto",
+      value + " should not apply as a presentation attribute");
+  }
+  text.removeAttribute("dominant-baseline");
+}, "dominant-baseline removed values are not supported SVG presentation attributes");
+</script>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4839,9 +4839,6 @@
             "initial": "auto",
             "values": [
                 "auto",
-                "use-script",
-                "no-change",
-                "reset-size",
                 "ideographic",
                 "alphabetic",
                 "hanging",
@@ -4860,7 +4857,7 @@
             },
             "specification": {
                 "category": "svg",
-                "url": "https://www.w3.org/TR/SVG11/text.html#DominantBaselineProperty"
+                "url": "https://w3c.github.io/svgwg/svg2-draft/text.html#DominantBaselineProperty"
             }
         },
         "dynamic-range-limit": {

--- a/Source/WebCore/css/SVGCSSValueKeywords.in
+++ b/Source/WebCore/css/SVGCSSValueKeywords.in
@@ -241,9 +241,6 @@ mathematical
 
 // CSS_PROP_DOMINANT_BASELINE
 //auto
-use-script
-no-change
-reset-size
 
 // CSS_PROP_TEXT_BOX_TRIM
 // none

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1434,9 +1434,6 @@ TextStream& operator<<(TextStream& ts, DominantBaseline value)
 {
     switch (value) {
     case DominantBaseline::Auto: ts << "auto"_s; break;
-    case DominantBaseline::UseScript: ts << "use-script"_s; break;
-    case DominantBaseline::NoChange: ts << "no-change"_s; break;
-    case DominantBaseline::ResetSize: ts << "reset-size"_s; break;
     case DominantBaseline::Ideographic: ts << "ideographic"_s; break;
     case DominantBaseline::Alphabetic: ts << "alphabetic"_s; break;
     case DominantBaseline::Hanging: ts << "hanging"_s; break;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1122,9 +1122,6 @@ enum class AlignmentBaseline : uint8_t {
 
 enum class DominantBaseline : uint8_t {
     Auto,
-    UseScript,
-    NoChange,
-    ResetSize,
     Ideographic,
     Alphabetic,
     Hanging,

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -57,8 +57,6 @@ float SVGTextLayoutEngineBaseline::calculateBaselineShift(const Style::ComputedS
 
 AlignmentBaseline SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseline(bool isVerticalText, const RenderElement& textRenderer) const
 {
-    ASSERT(textRenderer.parent());
-
     DominantBaseline baseline = textRenderer.style().dominantBaseline();
     if (baseline == DominantBaseline::Auto) {
         // Per SVG2 and CSS Inline 3, auto maps to alphabetic in horizontal writing
@@ -75,13 +73,6 @@ AlignmentBaseline SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseli
     }
 
     switch (baseline) {
-    case DominantBaseline::UseScript:
-        // FIXME: The dominant-baseline and the baseline-table components are set by determining the predominant script of the character data content.
-        return AlignmentBaseline::Alphabetic;
-    case DominantBaseline::NoChange:
-        return dominantBaselineToAlignmentBaseline(isVerticalText, *textRenderer.parent());
-    case DominantBaseline::ResetSize:
-        return dominantBaselineToAlignmentBaseline(isVerticalText, *textRenderer.parent());
     case DominantBaseline::Ideographic:
         return AlignmentBaseline::Ideographic;
     case DominantBaseline::Alphabetic:

--- a/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
+++ b/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
@@ -1936,9 +1936,8 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef FOR_EACH
 
 #define TYPE DominantBaseline
-#define FOR_EACH(CASE) CASE(Auto) CASE(UseScript) CASE(NoChange) CASE(ResetSize) CASE(Central) \
-    CASE(Middle) CASE(TextBeforeEdge) CASE(TextAfterEdge) CASE(Ideographic) CASE(Alphabetic) \
-    CASE(Hanging) CASE(Mathematical)
+#define FOR_EACH(CASE) CASE(Auto) CASE(Central) CASE(Middle) CASE(TextBeforeEdge) \
+    CASE(TextAfterEdge) CASE(Ideographic) CASE(Alphabetic) CASE(Hanging) CASE(Mathematical)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH


### PR DESCRIPTION
#### 6744dbe545664327777a5b27b2a160cabaa29238
<pre>
[SVG2] Remove use-script, no-change and reset-size from dominant-baseline
<a href="https://bugs.webkit.org/show_bug.cgi?id=311552">https://bugs.webkit.org/show_bug.cgi?id=311552</a>
<a href="https://rdar.apple.com/174635806">rdar://174635806</a>

Reviewed by Nikolas Zimmermann.

SVG 2 no longer supports the use-script, no-change and reset-size values of
dominant-baseline [1], and they are absent from the css-inline-3 grammar that
now defines the property [2].

All three were already close to no-ops in WebKit: use-script mapped to
alphabetic behind a FIXME, while no-change and reset-size deferred to the
parent element&apos;s dominant baseline, which resolves to alphabetic for
horizontal text. Removing them lets the values fall back to auto, which maps
to alphabetic in horizontal writing modes and central in vertical ones, so
there is no rendering change for the cases these values previously covered.

svg/custom/dominant-baseline-modes.svg and svg/custom/alignment-baseline-modes.svg
continue to specify the three values, which now fall back to auto; their
results are unchanged for the reason above.

Note that WebKit still spells the two edge baselines with their SVG 1.1 names,
text-before-edge and text-after-edge. css-inline-3 renames those to text-top
and text-bottom and keeps the SVG spellings only as legacy aliases [3], and
WebKit does not yet accept the css-inline-3 names. That gap is orthogonal to
this patch, which only removes values; it is tracked separately in
webkit.org/b/321612.

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/text.html#DominantBaselineProperty">https://w3c.github.io/svgwg/svg2-draft/text.html#DominantBaselineProperty</a>
[2] <a href="https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline">https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline</a>
[3] <a href="https://drafts.csswg.org/css-inline/#alignment-baseline-svg-legacy">https://drafts.csswg.org/css-inline/#alignment-baseline-svg-legacy</a>

Test: imported/w3c/web-platform-tests/svg/text/dominant-baseline.historical.html

* LayoutTests/imported/w3c/web-platform-tests/svg/text/dominant-baseline.historical-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/dominant-baseline.historical.html: Added.
* LayoutTests/svg/css/dominant-baseline-legacy-values-expected.txt: Removed.
* LayoutTests/svg/css/dominant-baseline-legacy-values.html: Removed.
* Source/WebCore/css/CSSProperties.json: Also point the specification URL at SVG 2.
* Source/WebCore/css/SVGCSSValueKeywords.in:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
(WebCore::SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseline const):
* Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h:

Canonical link: <a href="https://commits.webkit.org/319256@main">https://commits.webkit.org/319256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd17878f5dff94c654a8369b52fc534abf0a976d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144962 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140907 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97621 "3 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121359 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43246 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41526 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41208 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2011 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192787 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161197 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150277 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40287 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54939 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149994 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44611 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127204 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122419 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53456 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16201 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53075 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->