### PR TITLE
Unreviewed, reverting 318045@main (04e3d47960f3)

### DIFF
--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -51,10 +51,6 @@ protected:
     virtual ~URLTextEncoding() = default;
 };
 
-// Maximum length (in code units) of a URL that may be passed across an IPC boundary.
-// Matches Chromium's url::kMaxURLChars; URLs longer than this are rejected when decoded.
-constexpr unsigned maxURLLength = 2 * 1024 * 1024;
-
 class URL {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(URL);
 public:

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -23,12 +23,7 @@
 webkit_platform_headers: "StreamConnectionEncoder.h"
 
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::URL {
-#if PLATFORM(COCOA)
-    [Validator='(*string).length() <= WTF::maxURLLength'] String string()
-#endif
-#if !PLATFORM(COCOA)
     String string()
-#endif
 }
 
 header: <wtf/text/CString.h>

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -36,8 +36,6 @@
 #include <WebCore/ShareableResource.h>
 #include <limits>
 #include <wtf/StdLibExtras.h>
-#include <wtf/URL.h>
-#include <wtf/text/StringBuilder.h>
 
 namespace TestWebKitAPI {
 
@@ -778,62 +776,5 @@ TEST(ArgumentCoderShareableResourceHandle, OverflowingOffsetAndSizeIsRejectedNot
     EXPECT_FALSE(result.has_value());
 }
 #endif // ENABLE(SHAREABLE_RESOURCE)
-
-// Builds a valid "https://webkit.org/aaa...a" URL string of exactly the requested length.
-static String makeURLStringOfLength(size_t length)
-{
-    ASSERT(length >= 19);
-    StringBuilder builder;
-    builder.append("https://webkit.org/"_s);
-    while (builder.length() < length)
-        builder.append('a');
-    return builder.toString();
-}
-
-// Round-trips a URL wire payload (a String) through an Encoder/Decoder and decodes it as a URL,
-// exercising the decode-side length validator.
-static std::optional<URL> decodeURLFromWireString(const String& wireString)
-{
-    IPC::Encoder encoder(IPC::MessageName::IPCTester_EmptyMessage, 0);
-    encoder << wireString;
-    auto decoder = IPC::Decoder::create(encoder.span(), encoder.releaseAttachments());
-    if (!decoder)
-        return std::nullopt;
-    return decoder->decode<URL>();
-}
-
-TEST(ArgumentCoderURL, RoundTripsNormalURL)
-{
-    auto url = decodeURLFromWireString("https://webkit.org/path?q=1"_str);
-    ASSERT_TRUE(url.has_value());
-    EXPECT_TRUE(url->isValid());
-    EXPECT_EQ(url->string(), "https://webkit.org/path?q=1"_str);
-}
-
-TEST(ArgumentCoderURL, URLAtLengthLimitIsPreserved)
-{
-    auto urlString = makeURLStringOfLength(WTF::maxURLLength);
-    ASSERT_EQ(urlString.length(), WTF::maxURLLength);
-
-    auto url = decodeURLFromWireString(urlString);
-    ASSERT_TRUE(url.has_value());
-    EXPECT_TRUE(url->isValid());
-    EXPECT_EQ(url->string().length(), WTF::maxURLLength);
-}
-
-// The over-limit rejection is enforced by the WTF::URL IPC validator, which is
-// currently Cocoa-only (see WTFArgumentCoders.serialization.in).
-#if PLATFORM(COCOA)
-TEST(ArgumentCoderURL, OversizedURLIsRejectedOnDecode)
-{
-    auto urlString = makeURLStringOfLength(WTF::maxURLLength + 1);
-    ASSERT_EQ(urlString.length(), WTF::maxURLLength + 1);
-
-    // An over-limit URL on the wire fails to decode (the message is rejected) and is
-    // never parsed, matching Chromium's GURL/KURL mojo traits.
-    auto url = decodeURLFromWireString(urlString);
-    EXPECT_FALSE(url.has_value());
-}
-#endif // PLATFORM(COCOA)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 5720766c80568bbb1e4b70e958636ea36eb8b8e1
<pre>
Unreviewed, reverting 318045@main (04e3d47960f3)
<a href="https://bugs.webkit.org/show_bug.cgi?id=321571">https://bugs.webkit.org/show_bug.cgi?id=321571</a>
<a href="https://rdar.apple.com/184652023">rdar://184652023</a>

causes webcontent being killed when using data URL greater than 2MB

Reverted change:

    Limit URL size at the IPC boundary to match Chrome/Blink
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320340">https://bugs.webkit.org/show_bug.cgi?id=320340</a>
    <a href="https://rdar.apple.com/183139377">rdar://183139377</a>
    318045@main (04e3d47960f3)

Canonical link: <a href="https://commits.webkit.org/319018@main">https://commits.webkit.org/319018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e4e2bfe81b3f3d893bc0d3a6ca9d103e28dfdd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144494 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/63197e4a-37f4-4aa8-a61f-0469e9d56d8a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53837 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3b2610b-5607-433c-9050-b576b2d6bed7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161304 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/120985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33521944-0e87-42b3-bbed-b47b6c717ca5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/2952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9789 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40833 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1546 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41450 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46720 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192321 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53787 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149872 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40135 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54475 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149599 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44238 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126738 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121872 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52992 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15822 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52374 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52611 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52439 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->