### PR TITLE
[Site Isolation] Introduce persistent backend for IsolatedSiteStore

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -124,7 +124,7 @@ constexpr auto updateMostRecentWebPushInteractionTimeQuery = "UPDATE ObservedDom
 // SELECT Queries
 constexpr auto domainIDFromStringQuery = "SELECT domainID FROM ObservedDomains WHERE registrableDomain = ?"_s;
 constexpr auto domainStringFromDomainIDQuery = "SELECT registrableDomain FROM ObservedDomains WHERE domainID = ?"_s;
-constexpr auto domainWithUserInteractionQuery = "SELECT registrableDomain FROM ObservedDomains WHERE hadUserInteraction = 1"_s;
+constexpr auto domainWithUserInteractionQuery = "SELECT registrableDomain, mostRecentUserInteractionTime FROM ObservedDomains WHERE hadUserInteraction = 1"_s;
 constexpr auto isPrevalentResourceQuery = "SELECT isPrevalent FROM ObservedDomains WHERE registrableDomain = ?"_s;
 constexpr auto isVeryPrevalentResourceQuery = "SELECT isVeryPrevalent FROM ObservedDomains WHERE registrableDomain = ?"_s;
 constexpr auto hadUserInteractionQuery = "SELECT hadUserInteraction, mostRecentUserInteractionTime FROM ObservedDomains WHERE registrableDomain = ?"_s;
@@ -464,17 +464,17 @@ void ResourceLoadStatisticsStore::processStatisticsAndDataRecords(CompletionHand
     });
 }
 
-HashSet<RegistrableDomain> ResourceLoadStatisticsStore::loadWebsitesWithUserInteraction()
+std::optional<HashMap<RegistrableDomain, WallTime>> ResourceLoadStatisticsStore::loadWebsitesWithUserInteraction()
 {
     ASSERT(!RunLoop::isMain());
 
-    HashSet<RegistrableDomain> results;
+    HashMap<RegistrableDomain, WallTime> results;
     auto statement = m_database->prepareStatement(domainWithUserInteractionQuery);
     if (!statement)
-        return { };
+        return std::nullopt;
 
     while (statement->step() == SQLITE_ROW)
-        results.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(statement->columnText(0)));
+        results.set(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(statement->columnText(0)), WallTime::fromRawSeconds(statement->columnDouble(1)));
 
     return results;
 }

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -125,7 +125,7 @@ public:
     void requestStorageAccessUnderOpener(DomainInNeedOfStorageAccess&&, WebCore::PageIdentifier openerID, OpenerDomain&&, CanRequestStorageAccessWithoutUserInteraction);
     void removeAllStorageAccess(CompletionHandler<void()>&&);
 
-    HashSet<RegistrableDomain> loadWebsitesWithUserInteraction();
+    std::optional<HashMap<RegistrableDomain, WallTime>> loadWebsitesWithUserInteraction();
 
     void grandfatherExistingWebsiteData(CompletionHandler<void()>&&);
     void setGrandfathered(const RegistrableDomain&, bool value);

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -225,17 +225,27 @@ void WebResourceLoadStatisticsStore::populateMemoryStoreFromDisk(CompletionHandl
     });
 }
 
-void WebResourceLoadStatisticsStore::loadWebsitesWithUserInteraction(CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
+void WebResourceLoadStatisticsStore::loadWebsitesWithUserInteraction(CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>&&)>&& completionHandler)
 {
     if (isEphemeral())
-        return completionHandler({ });
+        return completionHandler(std::nullopt);
 
     ASSERT(RunLoop::isMain());
     postTask([completionHandler = WTF::move(completionHandler)](auto& store) mutable {
-        HashSet<RegistrableDomain> domains;
+        std::optional<HashMap<RegistrableDomain, WallTime>> domains;
         if (RefPtr statisticsStore = store.m_statisticsStore)
             domains = statisticsStore->loadWebsitesWithUserInteraction();
-        store.postTaskReply([domains = crossThreadCopy(WTF::move(domains)), completionHandler = WTF::move(completionHandler)] mutable {
+
+        std::optional<HashMap<RegistrableDomain, WallTime>> isolatedDomains;
+        if (domains) {
+            // crossThreadCopy() has no WallTime specialization, and only the keys need isolating.
+            isolatedDomains = HashMap<RegistrableDomain, WallTime> { };
+            isolatedDomains->reserveInitialCapacity(domains->size());
+            for (auto& [domain, time] : *domains)
+                isolatedDomains->set(crossThreadCopy(domain), time);
+        }
+
+        store.postTaskReply([domains = WTF::move(isolatedDomains), completionHandler = WTF::move(completionHandler)] mutable {
             completionHandler(WTF::move(domains));
         });
     });

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -129,7 +129,7 @@ public:
     SuspendableWorkQueue& statisticsQueue() { return m_statisticsQueue.get(); }
 
     void populateMemoryStoreFromDisk(CompletionHandler<void()>&&);
-    void loadWebsitesWithUserInteraction(CompletionHandler<void(HashSet<RegistrableDomain>&&)>&&);
+    void loadWebsitesWithUserInteraction(CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>&&)>&&);
     void setShouldClassifyResourcesBeforeDataRecordsRemoval(bool, CompletionHandler<void()>&&);
 
     void grantStorageAccess(SubFrameDomain&&, TopFrameDomain&&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebPageProxyIdentifier, StorageAccessPromptWasShown, StorageAccessScope, CompletionHandler<void(RequestStorageAccessResult)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -1771,16 +1771,16 @@ void NetworkProcess::setSessionIsControlledByAutomation(PAL::SessionID sessionID
         m_sessionsControlledByAutomation.remove(sessionID);
 }
 
-void NetworkProcess::fetchWebsitesWithUserInteractions(PAL::SessionID sessionID, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
+void NetworkProcess::fetchWebsitesWithUserInteractions(PAL::SessionID sessionID, CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>&&)>&& completionHandler)
 {
     CheckedPtr session = networkSession(sessionID);
     ASSERT(session);
     if (!session)
-        return completionHandler({ });
+        return completionHandler(std::nullopt);
 
     RefPtr resourceLoadStatistics = session->resourceLoadStatistics();
     if (!resourceLoadStatistics)
-        return completionHandler({ });
+        return completionHandler(std::nullopt);
 
     resourceLoadStatistics->loadWebsitesWithUserInteraction(WTF::move(completionHandler));
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -543,7 +543,7 @@ private:
     void createNetworkConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&,  CompletionHandler<void(std::optional<IPC::Connection::Handle>&&, WebCore::HTTPCookieAcceptPolicy)>&&);
     void sharedPreferencesForWebProcessDidChange(WebCore::ProcessIdentifier, SharedPreferencesForWebProcess&&, CompletionHandler<void()>&&);
 
-    void fetchWebsitesWithUserInteractions(PAL::SessionID, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&&);
+    void fetchWebsitesWithUserInteractions(PAL::SessionID, CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>&&)>&&);
 
     void fetchWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, OptionSet<WebsiteDataFetchOption>, CompletionHandler<void(WebsiteData&&)>&&);
     void deleteWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, WallTime modifiedSince, const HashSet<WebCore::ProcessIdentifier>& activeWebProcesses, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -49,7 +49,7 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     DestroySession(PAL::SessionID sessionID) -> ()
     EnsureSessionWithDataStoreIdentifierRemoved(WTF::UUID identifier) -> ()
 
-    FetchWebsitesWithUserInteractions(PAL::SessionID sessionID) -> (HashSet<WebCore::RegistrableDomain> websites)
+    FetchWebsitesWithUserInteractions(PAL::SessionID sessionID) -> (std::optional<HashMap<WebCore::RegistrableDomain, WallTime>> websites)
 
     FetchWebsiteData(PAL::SessionID sessionID, OptionSet<WebKit::WebsiteDataType> websiteDataTypes, OptionSet<WebKit::WebsiteDataFetchOption> fetchOptions) -> (struct WebKit::WebsiteData websiteData)
     DeleteWebsiteData(PAL::SessionID sessionID, OptionSet<WebKit::WebsiteDataType> websiteDataTypes, WallTime modifiedSince, HashSet<WebCore::ProcessIdentifier> activeWebProcesses) -> ()

--- a/Source/WebKit/Shared/WebsiteData/WebsiteData.cpp
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteData.cpp
@@ -84,6 +84,7 @@ WebsiteDataProcessType WebsiteData::ownerProcess(WebsiteDataType dataType)
         return WebsiteDataProcessType::UI;
 #endif
     case WebsiteDataType::EnhancedSecurityRecord:
+    case WebsiteDataType::IsolatedSiteRecord:
         return WebsiteDataProcessType::UI;
     }
 

--- a/Source/WebKit/Shared/WebsiteData/WebsiteDataType.h
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteDataType.h
@@ -56,6 +56,7 @@ enum class WebsiteDataType : uint32_t {
     ScreenTime = 1 << 21,
 #endif
     EnhancedSecurityRecord = 1 << 22,
+    IsolatedSiteRecord = 1 << 23,
 };
 
 inline ASCIILiteral toString(WebsiteDataType type)
@@ -109,6 +110,8 @@ inline ASCIILiteral toString(WebsiteDataType type)
 #endif
     case WebsiteDataType::EnhancedSecurityRecord:
         return "EnhancedSecurityRecord"_s;
+    case WebsiteDataType::IsolatedSiteRecord:
+        return "IsolatedSiteRecord"_s;
     default:
         break;
     }
@@ -147,7 +150,8 @@ template<> struct EnumTraitsForPersistence<WebKit::WebsiteDataType> {
 #if ENABLE(SCREEN_TIME)
         WebKit::WebsiteDataType::ScreenTime,
 #endif
-        WebKit::WebsiteDataType::EnhancedSecurityRecord
+        WebKit::WebsiteDataType::EnhancedSecurityRecord,
+        WebKit::WebsiteDataType::IsolatedSiteRecord
     >;
 };
 

--- a/Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in
@@ -49,4 +49,5 @@ headers: "WebsiteDataType.h"
     ScreenTime,
 #endif
     EnhancedSecurityRecord,
+    IsolatedSiteRecord,
 };

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -678,6 +678,7 @@ UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp
 
 UIProcess/WebsiteData/EnhancedSecuritySitesHolder.cpp
 UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
+UIProcess/WebsiteData/IsolatedSitePersistence.cpp
 UIProcess/WebsiteData/IsolatedSiteStore.cpp
 UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
 UIProcess/WebsiteData/WebsiteDataRecord.cpp

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -59,6 +59,7 @@ NSString * const _WKWebsiteDataTypePrivateClickMeasurements = @"_WKWebsiteDataTy
 NSString * const _WKWebsiteDataTypeAlternativeServices = @"_WKWebsiteDataTypeAlternativeServices";
 NSString * const _WKWebsiteDataTypeFileSystem = WKWebsiteDataTypeFileSystem;
 NSString* const _WKWebsiteDataTypeEnhancedSecurityRecord = @"_WKWebsiteDataTypeEnhancedSecurityRecord";
+NSString* const _WKWebsiteDataTypeIsolatedSiteRecord = @"_WKWebsiteDataTypeIsolatedSiteRecord";
 
 @implementation WKWebsiteDataRecord
 
@@ -120,6 +121,8 @@ static NSString *dataTypesToString(NSSet *dataTypes)
 #endif
     if ([dataTypes containsObject:_WKWebsiteDataTypeEnhancedSecurityRecord])
         [array addObject:@"Enhanced Security Record"];
+    if ([dataTypes containsObject:_WKWebsiteDataTypeIsolatedSiteRecord])
+        [array addObject:@"Isolated Site Record"];
 
     return [array componentsJoinedByString:@", "];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
@@ -84,6 +84,9 @@ static inline std::optional<WebsiteDataType> toWebsiteDataType(NSString *website
 #endif
     if ([websiteDataType isEqualToString:_WKWebsiteDataTypeEnhancedSecurityRecord])
         return WebsiteDataType::EnhancedSecurityRecord;
+
+    if ([websiteDataType isEqualToString:_WKWebsiteDataTypeIsolatedSiteRecord])
+        return WebsiteDataType::IsolatedSiteRecord;
     return std::nullopt;
 }
 
@@ -147,6 +150,9 @@ static inline RetainPtr<NSSet> toWKWebsiteDataTypes(OptionSet<WebKit::WebsiteDat
 #endif
     if (websiteDataTypes.contains(WebsiteDataType::EnhancedSecurityRecord))
         [wkWebsiteDataTypes addObject:_WKWebsiteDataTypeEnhancedSecurityRecord];
+
+    if (websiteDataTypes.contains(WebsiteDataType::IsolatedSiteRecord))
+        [wkWebsiteDataTypes addObject:_WKWebsiteDataTypeIsolatedSiteRecord];
 
     return wkWebsiteDataTypes;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
@@ -40,6 +40,7 @@ WK_EXTERN NSString * const _WKWebsiteDataTypePrivateClickMeasurements WK_API_AVA
 WK_EXTERN NSString * const _WKWebsiteDataTypeAlternativeServices WK_API_AVAILABLE(macos(11.0), ios(14.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeFileSystem WK_API_DEPRECATED_WITH_REPLACEMENT("WKWebsiteDataTypeFileSystem", macos(13.0, 14.0), ios(16.0, 17.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeEnhancedSecurityRecord WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
+WK_EXTERN NSString * const _WKWebsiteDataTypeIsolatedSiteRecord WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @interface WKWebsiteDataRecord (WKPrivate)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -729,7 +729,8 @@ struct WKWebsiteData {
             _WKWebsiteDataTypeAdClickAttributions,
             _WKWebsiteDataTypePrivateClickMeasurements,
             _WKWebsiteDataTypeAlternativeServices,
-            _WKWebsiteDataTypeEnhancedSecurityRecord
+            _WKWebsiteDataTypeEnhancedSecurityRecord,
+            _WKWebsiteDataTypeIsolatedSiteRecord
         ];
 
         return [retainPtr([self allWebsiteDataTypes]) setByAddingObjectsFromArray:privateTypes];

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -72,40 +72,48 @@ void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataSto
             return completionHandler(nullptr);
         if (websitePolicies && !websitePolicies->allowSharedProcess())
             return completionHandler(nullptr);
-        if (websiteDataStore.isolatedSiteStore().contains(site))
-            return completionHandler(nullptr);
-    }
-    websiteDataStore.fetchDomainsWithUserInteraction([
-        protectedThis = Ref { *this },
-        websiteDataStore = protect(websiteDataStore),
-        preferences = protect(preferences),
-        site = Site { site },
-        mainFrameSite = Site { mainFrameSite },
-        lockdownMode,
-        enhancedSecurity,
-        pageConfiguration = protect(pageConfiguration),
-        completionHandler = WTF::move(completionHandler)
-    ](const HashSet<WebCore::RegistrableDomain>& domainsWithUserInteraction) mutable {
-        if (domainsWithUserInteraction.contains(site.domain()) && !protectedThis->m_sharedProcessSites.contains(site))
-            return completionHandler(nullptr);
 
-        protectedThis->m_sharedProcessSites.add(site);
-        if (RefPtr frameProcess = protectedThis->m_sharedProcess.get()) {
-            ASSERT(frameProcess->isSharedProcess());
-            RELEASE_ASSERT(!frameProcess->process().isInProcessCache());
-            frameProcess->process().addSharedProcessDomain(site.domain());
-            return completionHandler(frameProcess.get());
+        // Placement is not revisited, so deciding early would strand a site promoted in an earlier
+        // session in the shared process for the rest of this one.
+        Ref isolatedSiteStore = websiteDataStore.isolatedSiteStore();
+        if (!isolatedSiteStore->isReady()) {
+            return isolatedSiteStore->whenReady([
+                protectedThis = Ref { *this },
+                websiteDataStore = protect(websiteDataStore),
+                websitePolicies = RefPtr { websitePolicies },
+                preferences = protect(preferences),
+                site = Site { site },
+                mainFrameSite = Site { mainFrameSite },
+                lockdownMode,
+                enhancedSecurity,
+                pageConfiguration = protect(pageConfiguration),
+                isMainFrame,
+                completionHandler = WTF::move(completionHandler)
+            ] mutable {
+                protectedThis->sharedProcessForSite(websiteDataStore, websitePolicies.get(), preferences, site, mainFrameSite, lockdownMode, enhancedSecurity, pageConfiguration, isMainFrame, WTF::move(completionHandler));
+            });
         }
 
-        Ref process = protect(pageConfiguration->processPool())->processForSite(websiteDataStore.get(), WebProcessProxy::IsolatedProcessType::Shared, site, mainFrameSite, domainsWithUserInteraction, lockdownMode, enhancedSecurity, pageConfiguration.get(), ProcessSwapDisposition::Other);
-        ASSERT(!process->isInProcessCache());
-        Ref frameProcess = FrameProcess::create(process, protectedThis, std::nullopt, mainFrameSite, preferences, LoadedWebArchive::No, BrowsingContextGroupUpdate::AddProcessAndInjectBrowsingContext);
+        if (isolatedSiteStore->contains(site))
+            return completionHandler(nullptr);
+    }
+
+    m_sharedProcessSites.add(site);
+    if (RefPtr frameProcess = m_sharedProcess.get()) {
         ASSERT(frameProcess->isSharedProcess());
-        ASSERT(frameProcess->process().isSharedProcess());
+        RELEASE_ASSERT(!frameProcess->process().isInProcessCache());
         frameProcess->process().addSharedProcessDomain(site.domain());
-        protectedThis->m_sharedProcess = frameProcess.ptr();
-        completionHandler(frameProcess.ptr());
-    });
+        return completionHandler(frameProcess.get());
+    }
+
+    Ref process = protect(pageConfiguration.processPool())->processForSite(websiteDataStore, WebProcessProxy::IsolatedProcessType::Shared, site, mainFrameSite, lockdownMode, enhancedSecurity, pageConfiguration, ProcessSwapDisposition::Other);
+    ASSERT(!process->isInProcessCache());
+    Ref frameProcess = FrameProcess::create(process, *this, std::nullopt, mainFrameSite, preferences, LoadedWebArchive::No, BrowsingContextGroupUpdate::AddProcessAndInjectBrowsingContext);
+    ASSERT(frameProcess->isSharedProcess());
+    ASSERT(frameProcess->process().isSharedProcess());
+    frameProcess->process().addSharedProcessDomain(site.domain());
+    m_sharedProcess = frameProcess.ptr();
+    completionHandler(frameProcess.ptr());
 }
 
 Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, const Site& mainFrameSite, WebProcessProxy& process, const WebPreferences& preferences, LoadedWebArchive loadedWebArchive, BrowsingContextGroupUpdate browsingContextGroupUpdate)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1444,7 +1444,7 @@ void WebPageProxy::launchProcess(const Site& site, ProcessLaunchReason reason)
         m_legacyMainFrameProcess = relatedPage->ensureRunningProcess();
         WEBPAGEPROXY_RELEASE_LOG(Loading, "launchProcess: Using process (process=%p, PID=%i) from related page", m_legacyMainFrameProcess.ptr(), m_legacyMainFrameProcess->processID());
     } else
-        m_legacyMainFrameProcess = processPool->processForSite(protect(websiteDataStore()), WebProcessProxy::IsolatedProcessType::MainFrame, site, site, { }, shouldEnableLockdownMode() ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled, currentEnhancedSecurityState(), m_configuration, WebCore::ProcessSwapDisposition::None);
+        m_legacyMainFrameProcess = processPool->processForSite(protect(websiteDataStore()), WebProcessProxy::IsolatedProcessType::MainFrame, site, site, shouldEnableLockdownMode() ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled, currentEnhancedSecurityState(), m_configuration, WebCore::ProcessSwapDisposition::None);
 
     m_shouldReloadDueToCrashWhenVisible = false;
     m_isLockdownModeExplicitlySet = m_configuration->isLockdownModeExplicitlySet();
@@ -4541,7 +4541,7 @@ static std::optional<T> removeOldRedundantEvent(Deque<T>& queue, WebEventType in
 void WebPageProxy::sendMouseEvent(FrameIdentifier frameID, const NativeWebMouseEvent& event, std::optional<Vector<SandboxExtensionHandle>>&& sandboxExtensions)
 {
     if (event.type() == WebEventType::MouseDown || event.type() == WebEventType::MouseUp)
-        processContainingFrame(frameID)->recordUserGestureAuthorizationToken(frameID, webPageIDInMainFrameProcess(), event.authorizationToken());
+        processContainingFrame(frameID)->recordUserGestureAuthorizationToken(webPageIDInMainFrameProcess(), event.authorizationToken());
 
     sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::MouseEvent(frameID, event, WTF::move(sandboxExtensions)), [weakThis = WeakPtr { *this }, eventType = event.type()] (IPC::Connection* connection, bool handled, std::optional<RemoteUserInputEventData> remoteUserInputEventData) mutable {
         RefPtr protectedThis = weakThis.get();
@@ -5098,7 +5098,7 @@ void WebPageProxy::sendKeyEvent(const NativeWebKeyboardEvent& event)
     auto targetFrameID = targetFrame->frameID();
     Ref targetProcess = targetFrame->process();
     targetProcess->startResponsivenessTimer(event.type() == WebEventType::KeyDown ? WebProcessProxy::UseLazyStop::Yes : WebProcessProxy::UseLazyStop::No);
-    targetProcess->recordUserGestureAuthorizationToken(targetFrameID, webPageIDInMainFrameProcess(), event.authorizationToken());
+    targetProcess->recordUserGestureAuthorizationToken(webPageIDInMainFrameProcess(), event.authorizationToken());
     sendWithAsyncReplyToProcessContainingFrame(targetFrameID, Messages::WebPage::KeyEvent(targetFrameID, event), [weakThis = WeakPtr { *this }] (IPC::Connection* connection, bool handled) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !connection)
@@ -5287,7 +5287,7 @@ void WebPageProxy::handleGestureEvent(const NativeWebGestureEvent& event)
 void WebPageProxy::sendPreventableTouchEvent(WebCore::FrameIdentifier frameID, const WebTouchEvent& event)
 {
     if (event.type() == WebEventType::TouchEnd && protect(preferences())->verifyWindowOpenUserGestureFromUIProcess())
-        processContainingFrame(frameID)->recordUserGestureAuthorizationToken(frameID, webPageIDInMainFrameProcess(), event.authorizationToken());
+        processContainingFrame(frameID)->recordUserGestureAuthorizationToken(webPageIDInMainFrameProcess(), event.authorizationToken());
 
     sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::EventDispatcher::TouchEvent(webPageIDInProcess(processContainingFrame(frameID)), frameID, event), [this, weakThis = WeakPtr { *this }, event] (IPC::Connection* connection, bool handled, std::optional<RemoteWebTouchEvent> remoteWebTouchEvent) mutable {
         RefPtr protectedThis = weakThis.get();
@@ -5417,7 +5417,7 @@ void WebPageProxy::didBeginTouchPoint(FloatPoint locationInRootView)
 void WebPageProxy::sendUnpreventableTouchEvent(WebCore::FrameIdentifier frameID, const WebTouchEvent& event)
 {
     if (event.type() == WebEventType::TouchEnd && protect(preferences())->verifyWindowOpenUserGestureFromUIProcess())
-        processContainingFrame(frameID)->recordUserGestureAuthorizationToken(frameID, webPageIDInMainFrameProcess(), event.authorizationToken());
+        processContainingFrame(frameID)->recordUserGestureAuthorizationToken(webPageIDInMainFrameProcess(), event.authorizationToken());
 
     sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::EventDispatcher::TouchEvent(webPageIDInProcess(processContainingFrame(frameID)), frameID, event), [protectedThis = Ref { *this }] (bool, std::optional<RemoteWebTouchEvent> remoteWebTouchEvent) mutable {
         if (!remoteWebTouchEvent)
@@ -8595,7 +8595,8 @@ void WebPageProxy::recordFirstPartyVisit(const URL& url)
     if (site.isEmpty())
         return;
 
-    websiteDataStore().isolatedSiteStore().addSite(site, IsolatedSiteStore::Signal::FirstPartyVisit);
+    Ref dataStore = websiteDataStore();
+    protect(dataStore->isolatedSiteStore())->addSite(site, IsolatedSiteStore::Signal::FirstPartyVisit);
 }
 
 void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, std::optional<WebCore::NavigationIdentifier> navigationID, String&& mimeType, bool frameHasCustomContentProvider, FrameLoadType frameLoadType, bool hasCertificateInfo, bool usedLegacyTLS, bool wasPrivateRelayed, String&& proxyName, const WebCore::ResourceResponseSource source, bool containsPluginDocument, HasInsecureContent hasInsecureContent, MouseEventPolicy mouseEventPolicy, DocumentSecurityPolicy&& documentSecurityPolicy, HashSet<WebCore::SecurityOriginData>&& cspOriginsThatUpgradeInsecureNavigations, const UserData& userData, RestoredFromBackForwardCache restoredFromBackForwardCache, RefPtr<FrameState>&& redirectReplaceFrameState)
@@ -10454,7 +10455,7 @@ void WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation(WebCore::Navig
             auto enableWebAssemblyDebugger = protect(m_configuration->preferences())->webAssemblyDebuggerEnabled() ? WebProcessProxy::EnableWebAssemblyDebugger::Yes : WebProcessProxy::EnableWebAssemblyDebugger::No;
             return protect(m_configuration->processPool())->createNewWebProcess(protect(websiteDataStore()).ptr(), lockdownMode, enhancedSecurity, enableWebAssemblyDebugger, WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Isolated, WebKit::jscOptionsForWebProcess(protect(m_configuration->preferences())->store(), lockdownMode == WebProcessProxy::LockdownMode::Enabled));
         }
-        return protect(m_configuration->processPool())->processForSite(protect(websiteDataStore()), WebProcessProxy::IsolatedProcessType::MainFrame, responseSite, responseSite, { }, lockdownMode, enhancedSecurity, m_configuration, WebCore::ProcessSwapDisposition::COOP);
+        return protect(m_configuration->processPool())->processForSite(protect(websiteDataStore()), WebProcessProxy::IsolatedProcessType::MainFrame, responseSite, responseSite, lockdownMode, enhancedSecurity, m_configuration, WebCore::ProcessSwapDisposition::COOP);
     }();
 
     performProcessSwapForNavigationResponse(*navigation, m_browsingContextGroup.copyRef(), WTF::move(processForNavigation), WebCore::ProcessSwapDisposition::COOP, existingNetworkResourceLoadIdentifierToResume, originalNavigationStartTime, WTF::move(completionHandler));
@@ -10481,7 +10482,7 @@ void WebPageProxy::triggerProcessSwapForEnhancedSecurity(WebCore::NavigationIden
     RefPtr provisionalPage = m_provisionalPage;
     auto lockdownMode = provisionalPage ? provisionalPage->process().lockdownMode() : m_legacyMainFrameProcess->lockdownMode();
 
-    Ref processForNavigation = protect(m_configuration->processPool())->processForSite(protect(websiteDataStore()), WebProcessProxy::IsolatedProcessType::MainFrame, responseSite, responseSite, { }, lockdownMode, EnhancedSecurity::EnabledInsecure, m_configuration, WebCore::ProcessSwapDisposition::None);
+    Ref processForNavigation = protect(m_configuration->processPool())->processForSite(protect(websiteDataStore()), WebProcessProxy::IsolatedProcessType::MainFrame, responseSite, responseSite, lockdownMode, EnhancedSecurity::EnabledInsecure, m_configuration, WebCore::ProcessSwapDisposition::None);
 
     performProcessSwapForNavigationResponse(*navigation, WTF::move(browsingContextGroupForSwap), WTF::move(processForNavigation), WebCore::ProcessSwapDisposition::None, existingNetworkResourceLoadIdentifierToResume, originalNavigationStartTime, WTF::move(completionHandler));
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1265,12 +1265,17 @@ void WebProcessPool::disconnectProcess(WebProcessProxy& process)
 #endif
 }
 
-Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDataStore, WebProcessProxy::IsolatedProcessType isolatedProcessType, const std::optional<Site>& site, const std::optional<Site>& mainFrameSite, const HashSet<RegistrableDomain>& isolatedDomains, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration, ProcessSwapDisposition processSwapDisposition)
+Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDataStore, WebProcessProxy::IsolatedProcessType isolatedProcessType, const std::optional<Site>& site, const std::optional<Site>& mainFrameSite, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration, ProcessSwapDisposition processSwapDisposition)
 {
     if (isolatedProcessType == WebProcessProxy::IsolatedProcessType::Shared) {
         ASSERT(mainFrameSite);
         if (RefPtr process = webProcessCache().takeSharedProcess(*mainFrameSite, websiteDataStore, lockdownMode, enhancedSecurity, pageConfiguration)) {
-            if (process->sharedProcessDomains().intersectionWith(isolatedDomains).isEmpty()) {
+            Ref isolatedSiteStore = websiteDataStore.isolatedSiteStore();
+            ASSERT(isolatedSiteStore->isReady());
+            bool containsIsolatedDomain = std::ranges::any_of(process->sharedProcessDomains(), [&](auto& domain) {
+                return isolatedSiteStore->containsDomain(domain);
+            });
+            if (!containsIsolatedDomain) {
                 ASSERT(m_processes.containsIf([&](auto& item) { return item.ptr() == process; }));
                 WEBPROCESSPOOL_RELEASE_LOG(ProcessSwapping, "processForSite: Using shared WebProcess from WebProcess cache (process=%p, PID=%i)", process.get(), process->processID());
                 ASSERT(!process->isInProcessCache());
@@ -1385,7 +1390,7 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
         }
     } else {
         WEBPROCESSPOOL_RELEASE_LOG(Process, "createWebPage: Not delaying WebProcess launch");
-        process = processForSite(protect(pageConfiguration->websiteDataStore()), WebProcessProxy::IsolatedProcessType::MainFrame, std::nullopt, std::nullopt, { }, lockdownMode, enhancedSecurity, pageConfiguration, WebCore::ProcessSwapDisposition::None);
+        process = processForSite(protect(pageConfiguration->websiteDataStore()), WebProcessProxy::IsolatedProcessType::MainFrame, std::nullopt, std::nullopt, lockdownMode, enhancedSecurity, pageConfiguration, WebCore::ProcessSwapDisposition::None);
     }
 
     Ref userContentController = pageConfiguration->userContentController();
@@ -2265,7 +2270,7 @@ void WebProcessPool::prepareProcessForNavigation(Ref<WebProcessProxy>&& process,
         if (process->state() == AuxiliaryProcessProxy::State::Terminated && previousAttemptsCount < maximumNumberOfAttempts) {
             // The destination process crashed during the IPC to the network process, use a new process.
             ASSERT(isolatedProcessType != WebProcessProxy::IsolatedProcessType::Shared);
-            Ref fallbackProcess = processForSite(dataStore, isolatedProcessType, site, mainFrameSite, { }, lockdownMode, enhancedSecurity, page->configuration(), WebCore::ProcessSwapDisposition::None);
+            Ref fallbackProcess = processForSite(dataStore, isolatedProcessType, site, mainFrameSite, lockdownMode, enhancedSecurity, page->configuration(), WebCore::ProcessSwapDisposition::None);
             prepareProcessForNavigation(WTF::move(fallbackProcess), page, nullptr, reason, isolatedProcessType, site, mainFrameSite, navigation, lockdownMode, enhancedSecurity, loadedWebArchive, WTF::move(dataStore), WTF::move(completionHandler), previousAttemptsCount + 1);
             return;
         }
@@ -2293,7 +2298,7 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
 
     auto createNewProcess = [&] () -> Ref<WebProcessProxy> {
         ASSERT(isolatedProcessType != WebProcessProxy::IsolatedProcessType::Shared);
-        return processForSite(dataStore, isolatedProcessType, targetSite, mainFrameSite, { }, lockdownMode, enhancedSecurity, pageConfiguration, WebCore::ProcessSwapDisposition::None);
+        return processForSite(dataStore, isolatedProcessType, targetSite, mainFrameSite, lockdownMode, enhancedSecurity, pageConfiguration, WebCore::ProcessSwapDisposition::None);
     };
 
     if (usesSingleWebProcess())

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -330,8 +330,7 @@ public:
 
     void reportWebContentCPUTime(Seconds cpuTime, uint64_t activityState);
 
-    Ref<WebProcessProxy> processForSite(WebsiteDataStore&, WebProcessProxy::IsolatedProcessType, const std::optional<WebCore::Site>&, const std::optional<WebCore::Site>& mainFrameSite, const HashSet<WebCore::RegistrableDomain>& isolatedDomains,
-        WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&, WebCore::ProcessSwapDisposition); // Will return an existing one if limit is met or due to caching.
+    Ref<WebProcessProxy> processForSite(WebsiteDataStore&, WebProcessProxy::IsolatedProcessType, const std::optional<WebCore::Site>&, const std::optional<WebCore::Site>& mainFrameSite, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&, WebCore::ProcessSwapDisposition); // Will return an existing one if limit is met or due to caching.
 
     void prewarmProcess();
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1708,13 +1708,8 @@ bool WebProcessProxy::hasGrantedSandboxExtensionForFile(const URL& url) const
         || wasPreviouslyApprovedFileURL(url);
 }
 
-void WebProcessProxy::recordUserGestureAuthorizationToken(FrameIdentifier frameID, PageIdentifier pageID, WTF::UUID authorizationToken)
+void WebProcessProxy::recordUserGestureAuthorizationToken(PageIdentifier pageID, WTF::UUID authorizationToken)
 {
-    if (RefPtr dataStore = websiteDataStore()) {
-        if (RefPtr frame = WebFrameProxy::webFrame(frameID); frame && frame->isMainFrame())
-            dataStore->didHaveUserInteractionForSiteIsolation(frame->url());
-    }
-
     if (!UserInitiatedActionByAuthorizationTokenMap::isValidKey(authorizationToken) || !authorizationToken)
         return;
 
@@ -2450,14 +2445,14 @@ void WebProcessProxy::didCompleteAutofill(const WebCore::Site& site)
 {
     MESSAGE_CHECK(!site.isEmpty());
     if (RefPtr dataStore = websiteDataStore())
-        dataStore->isolatedSiteStore().addSite(site, IsolatedSiteStore::Signal::Autofill);
+        protect(dataStore->isolatedSiteStore())->addSite(site, IsolatedSiteStore::Signal::Autofill);
 }
 
 void WebProcessProxy::didObserveFirstPartyUserGesture(const WebCore::Site& site)
 {
     MESSAGE_CHECK(!site.isEmpty());
     if (RefPtr dataStore = websiteDataStore())
-        dataStore->isolatedSiteStore().addSite(site, IsolatedSiteStore::Signal::FirstPartyUserGesture);
+        protect(dataStore->isolatedSiteStore())->addSite(site, IsolatedSiteStore::Signal::FirstPartyUserGesture);
 }
 
 void WebProcessProxy::activePagesDomainsForTesting(CompletionHandler<void(Vector<String>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -317,7 +317,7 @@ public:
     void addVisitedLinkStoreUser(VisitedLinkStore&, WebPageProxyIdentifier);
     void removeVisitedLinkStoreUser(VisitedLinkStore&, WebPageProxyIdentifier);
 
-    void recordUserGestureAuthorizationToken(WebCore::FrameIdentifier, WebCore::PageIdentifier, WTF::UUID);
+    void recordUserGestureAuthorizationToken(WebCore::PageIdentifier, WTF::UUID);
     RefPtr<API::UserInitiatedAction> userInitiatedActivity(std::optional<WebCore::UserGestureTokenIdentifier>);
     RefPtr<API::UserInitiatedAction> userInitiatedActivity(WebCore::PageIdentifier, std::optional<WTF::UUID>, std::optional<WebCore::UserGestureTokenIdentifier>);
 

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -447,6 +447,14 @@ String WebsiteDataStore::defaultIndexedDBDatabaseDirectory(const String& baseDir
     return websiteDataDirectoryFileSystemRepresentation("IndexedDB"_s);
 }
 
+String WebsiteDataStore::defaultIsolatedSitesDirectory(const String& baseDirectory)
+{
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "IsolatedSites"_s);
+
+    return websiteDataDirectoryFileSystemRepresentation("IsolatedSites"_s, { }, ShouldCreateDirectory::No);
+}
+
 String WebsiteDataStore::defaultServiceWorkerRegistrationDirectory(const String& baseDirectory)
 {
     if (!baseDirectory.isEmpty())

--- a/Source/WebKit/UIProcess/WebsiteData/IsolatedSitePersistence.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/IsolatedSitePersistence.cpp
@@ -1,0 +1,324 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IsolatedSitePersistence.h"
+
+#include "Logging.h"
+#include <WebCore/SQLiteFileSystem.h>
+#include <WebCore/SQLiteStatement.h>
+#include <WebCore/SQLiteTransaction.h>
+#include <iterator>
+#include <wtf/FileSystem.h>
+#include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/WallTime.h>
+#include <wtf/text/MakeString.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IsolatedSitePersistence);
+
+// A migration path, not the current schema: a database opened at version N runs the statements from N
+// onwards, so a schema change appends an array rather than editing an earlier one.
+static constexpr std::array<ASCIILiteral, 2> isolatedSitesSchemaV1Statements {
+    "CREATE TABLE sites (domain TEXT PRIMARY KEY NOT NULL, signals INT NOT NULL, last_updated REAL NOT NULL)"_s,
+    "CREATE TABLE metadata (key TEXT PRIMARY KEY NOT NULL, value INT NOT NULL)"_s,
+};
+
+static constexpr std::array<std::span<const ASCIILiteral>, 1> isolatedSitesSchemaStatements {
+    std::span { isolatedSitesSchemaV1Statements },
+};
+
+static constexpr int currentIsolatedSitesSchemaVersion = std::size(isolatedSitesSchemaStatements);
+static constexpr auto selectAllIsolatedSitesSQL = "SELECT domain, signals, last_updated FROM sites"_s;
+static constexpr auto insertIsolatedSiteSQL = "INSERT OR REPLACE INTO sites (domain, signals, last_updated) VALUES (?, ?, ?)"_s;
+static constexpr auto deleteAllIsolatedSitesSQL = "DELETE FROM sites"_s;
+static constexpr auto deleteSitesUpdatedSinceSQL = "DELETE FROM sites WHERE last_updated >= ?"_s;
+static constexpr auto deleteIsolatedSiteSQL = "DELETE FROM sites WHERE domain = ?"_s;
+static constexpr auto didImportUserInteractionsKey = "didImportUserInteractions"_s;
+static constexpr auto selectMetadataSQL = "SELECT value FROM metadata WHERE key = ?"_s;
+static constexpr auto insertMetadataSQL = "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)"_s;
+
+IsolatedSitePersistence::IsolatedSitePersistence(const String& databaseDirectoryPath)
+{
+    ASSERT(!isMainRunLoop());
+    openDatabase(databaseDirectoryPath);
+}
+
+IsolatedSitePersistence::~IsolatedSitePersistence()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (m_sqliteDB)
+        closeDatabase();
+}
+
+void IsolatedSitePersistence::reportSQLError(ASCIILiteral method, ASCIILiteral action)
+{
+    RELEASE_LOG_ERROR(SiteIsolation, "IsolatedSitePersistence::%" PUBLIC_LOG_STRING ": Failed to %" PUBLIC_LOG_STRING " (%d) - %" PUBLIC_LOG_STRING, method.characters(), action.characters(), protect(m_sqliteDB)->lastError(), protect(m_sqliteDB)->lastErrorMsg());
+}
+
+IsolatedSitePersistence::OpenResult IsolatedSitePersistence::reportSQLErrorAndClassify(ASCIILiteral method, ASCIILiteral action)
+{
+    reportSQLError(method, action);
+
+    // Only a file we cannot interpret is worth starting over for; discarding credential evidence over
+    // a full disk or a locked volume would be far worse than not persisting this run.
+    auto error = protect(m_sqliteDB)->lastError();
+    if (error == SQLITE_CORRUPT || error == SQLITE_NOTADB)
+        return OpenResult::Discard;
+
+    return OpenResult::Retain;
+}
+
+static String isolatedSitesDatabasePath(const String& directoryPath)
+{
+    ASSERT(!directoryPath.isEmpty());
+    return FileSystem::pathByAppendingComponent(directoryPath, "IsolatedSites.db"_s);
+}
+
+IsolatedSitePersistence::OpenResult IsolatedSitePersistence::openDatabase(const String& directoryPath)
+{
+    ASSERT(!isMainRunLoop());
+    ASSERT(!directoryPath.isEmpty());
+
+    FileSystem::makeAllDirectories(directoryPath);
+
+    auto path = isolatedSitesDatabasePath(directoryPath);
+    auto result = openDatabaseAtPath(path);
+    if (result != OpenResult::Discard)
+        return result;
+
+    closeDatabase();
+
+    if (!WebCore::SQLiteFileSystem::deleteDatabaseFile(path)) {
+        RELEASE_LOG_ERROR(SiteIsolation, "IsolatedSitePersistence::%" PUBLIC_LOG_STRING ": Failed to delete unusable database; site isolation signals will not persist.", __FUNCTION__);
+        return OpenResult::Retain;
+    }
+
+    RELEASE_LOG(SiteIsolation, "IsolatedSitePersistence::%" PUBLIC_LOG_STRING ": Deleted unusable database and recreating it from scratch.", __FUNCTION__);
+    return openDatabaseAtPath(path);
+}
+
+IsolatedSitePersistence::OpenResult IsolatedSitePersistence::openDatabaseAtPath(const String& path)
+{
+    ASSERT(!isMainRunLoop());
+
+    m_sqliteDB = makeUnique<WebCore::SQLiteDatabase>();
+
+    CheckedPtr checkedDB = m_sqliteDB.get();
+
+    // This database is only accessed from the serial queue IsolatedSiteStore::sharedWorkQueueSingleton().
+    checkedDB->disableThreadingChecks();
+
+    if (!checkedDB->open(path, WebCore::SQLiteDatabase::OpenMode::ReadWriteCreate, WebCore::SQLiteDatabase::OpenOptions::CanSuspendWhileLocked))
+        return reportSQLErrorAndClassify(__FUNCTION__, "open database"_s);
+
+    int version = 0;
+    {
+        auto versionStatement = checkedDB->prepareStatement("PRAGMA user_version"_s);
+        if (!versionStatement || versionStatement->step() != SQLITE_ROW)
+            return reportSQLErrorAndClassify(__FUNCTION__, "read schema version"_s);
+        version = versionStatement->columnInt(0);
+    }
+
+    if (version < 0 || version > currentIsolatedSitesSchemaVersion) {
+        RELEASE_LOG_ERROR(SiteIsolation, "IsolatedSitePersistence::%" PUBLIC_LOG_STRING ": Found unexpected schema version %d (expected at most %d).", __FUNCTION__, version, currentIsolatedSitesSchemaVersion);
+        return OpenResult::Discard;
+    }
+
+    if (version < currentIsolatedSitesSchemaVersion) {
+        WebCore::SQLiteTransaction transaction(*checkedDB);
+        transaction.begin();
+
+        for (int i = version; i < currentIsolatedSitesSchemaVersion; ++i) {
+            for (auto statement : isolatedSitesSchemaStatements[i]) {
+                if (!checkedDB->executeCommand(statement))
+                    return reportSQLErrorAndClassify(__FUNCTION__, "execute schema statement"_s);
+            }
+        }
+
+        if (!checkedDB->executeCommandSlow(makeString("PRAGMA user_version = "_s, currentIsolatedSitesSchemaVersion)))
+            return reportSQLErrorAndClassify(__FUNCTION__, "set schema version"_s);
+
+        transaction.commit();
+    }
+
+    m_insertSiteSQLStatement = checkedDB->prepareStatement(insertIsolatedSiteSQL);
+    if (!m_insertSiteSQLStatement)
+        return reportSQLErrorAndClassify(__FUNCTION__, "prepare insert statement"_s);
+
+    m_deleteSiteSQLStatement = checkedDB->prepareStatement(deleteIsolatedSiteSQL);
+    if (!m_deleteSiteSQLStatement)
+        return reportSQLErrorAndClassify(__FUNCTION__, "prepare delete statement"_s);
+
+    checkedDB->turnOnIncrementalAutoVacuum();
+
+    return OpenResult::Success;
+}
+
+void IsolatedSitePersistence::closeDatabase()
+{
+    ASSERT(!isMainRunLoop());
+
+    m_insertSiteSQLStatement = nullptr;
+    m_deleteSiteSQLStatement = nullptr;
+
+    if (isDatabaseOpen())
+        protect(m_sqliteDB)->close();
+
+    m_sqliteDB = nullptr;
+}
+
+HashMap<WebCore::RegistrableDomain, IsolatedSitePersistence::SiteRecord> IsolatedSitePersistence::allSites()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(SiteIsolation, "IsolatedSitePersistence::%" PUBLIC_LOG_STRING ": Attempted operation on closed database.", __FUNCTION__);
+        return { };
+    }
+
+    auto selectStatement = protect(m_sqliteDB)->prepareStatement(selectAllIsolatedSitesSQL);
+    if (!selectStatement) {
+        reportSQLError(__FUNCTION__, "prepare select all sites statement"_s);
+        return { };
+    }
+
+    HashMap<WebCore::RegistrableDomain, SiteRecord> sites;
+    while (selectStatement->step() == SQLITE_ROW) {
+        auto domain = WebCore::RegistrableDomain::fromRawString(selectStatement->columnText(0));
+        if (domain.isEmpty())
+            continue;
+        sites.set(WTF::move(domain), SiteRecord {
+            static_cast<uint64_t>(selectStatement->columnInt64(1)),
+            WallTime::fromRawSeconds(selectStatement->columnDouble(2))
+        });
+    }
+
+    return sites;
+}
+
+void IsolatedSitePersistence::setRecordForSite(const WebCore::RegistrableDomain& domain, SiteRecord record)
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(SiteIsolation, "IsolatedSitePersistence::%" PUBLIC_LOG_STRING ": Attempted operation on closed database.", __FUNCTION__);
+        return;
+    }
+
+    auto insertStatement = WebCore::SQLiteStatementAutoResetScope { protect(m_insertSiteSQLStatement).get() };
+    if (!insertStatement
+        || insertStatement->bindText(1, domain.string()) != SQLITE_OK
+        || insertStatement->bindInt64(2, static_cast<int64_t>(record.signals)) != SQLITE_OK
+        || insertStatement->bindDouble(3, record.lastUpdated.secondsSinceEpoch().value()) != SQLITE_OK
+        || !insertStatement->executeCommand())
+        reportSQLError(__FUNCTION__, "insert or replace site"_s);
+}
+
+void IsolatedSitePersistence::deleteAllSites()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(SiteIsolation, "IsolatedSitePersistence::%" PUBLIC_LOG_STRING ": Attempted operation on closed database.", __FUNCTION__);
+        return;
+    }
+
+    auto deleteStatement = protect(m_sqliteDB)->prepareStatement(deleteAllIsolatedSitesSQL);
+    if (!deleteStatement || !deleteStatement->executeCommand())
+        reportSQLError(__FUNCTION__, "delete all sites"_s);
+}
+
+void IsolatedSitePersistence::deleteSitesUpdatedSince(WallTime cutoff)
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(SiteIsolation, "IsolatedSitePersistence::%" PUBLIC_LOG_STRING ": Attempted operation on closed database.", __FUNCTION__);
+        return;
+    }
+
+    auto deleteStatement = protect(m_sqliteDB)->prepareStatement(deleteSitesUpdatedSinceSQL);
+    if (!deleteStatement
+        || deleteStatement->bindDouble(1, cutoff.secondsSinceEpoch().value()) != SQLITE_OK
+        || !deleteStatement->executeCommand())
+        reportSQLError(__FUNCTION__, "delete sites updated since a cutoff"_s);
+}
+
+void IsolatedSitePersistence::deleteSites(const Vector<WebCore::RegistrableDomain>& domains)
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(SiteIsolation, "IsolatedSitePersistence::%" PUBLIC_LOG_STRING ": Attempted operation on closed database.", __FUNCTION__);
+        return;
+    }
+
+    for (auto& domain : domains) {
+        auto deleteStatement = WebCore::SQLiteStatementAutoResetScope { protect(m_deleteSiteSQLStatement).get() };
+        if (!deleteStatement
+            || deleteStatement->bindText(1, domain.string()) != SQLITE_OK
+            || !deleteStatement->executeCommand())
+            reportSQLError(__FUNCTION__, "delete site"_s);
+    }
+}
+
+bool IsolatedSitePersistence::didImportUserInteractions()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen())
+        return false;
+
+    auto selectStatement = protect(m_sqliteDB)->prepareStatement(selectMetadataSQL);
+    if (!selectStatement || selectStatement->bindText(1, didImportUserInteractionsKey) != SQLITE_OK) {
+        reportSQLError(__FUNCTION__, "query metadata"_s);
+        return false;
+    }
+
+    return selectStatement->step() == SQLITE_ROW && selectStatement->columnInt(0);
+}
+
+void IsolatedSitePersistence::setDidImportUserInteractions()
+{
+    ASSERT(!isMainRunLoop());
+
+    if (!isDatabaseOpen()) {
+        RELEASE_LOG_ERROR(SiteIsolation, "IsolatedSitePersistence::%" PUBLIC_LOG_STRING ": Attempted operation on closed database.", __FUNCTION__);
+        return;
+    }
+
+    auto insertStatement = protect(m_sqliteDB)->prepareStatement(insertMetadataSQL);
+    if (!insertStatement
+        || insertStatement->bindText(1, didImportUserInteractionsKey) != SQLITE_OK
+        || insertStatement->bindInt(2, 1) != SQLITE_OK
+        || !insertStatement->executeCommand())
+        reportSQLError(__FUNCTION__, "set metadata"_s);
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/IsolatedSitePersistence.h
+++ b/Source/WebKit/UIProcess/WebsiteData/IsolatedSitePersistence.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/RegistrableDomain.h>
+#include <WebCore/SQLiteDatabase.h>
+#include <WebCore/SQLiteStatementAutoResetScope.h>
+#include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WallTime.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class IsolatedSitePersistence final {
+    WTF_MAKE_TZONE_ALLOCATED(IsolatedSitePersistence);
+public:
+    struct SiteRecord {
+        uint64_t signals { 0 };
+        WallTime lastUpdated;
+    };
+
+    explicit IsolatedSitePersistence(const String& databaseDirectoryPath);
+    ~IsolatedSitePersistence();
+
+    bool isDatabaseOpen() const { return m_sqliteDB && m_sqliteDB->isOpen(); }
+
+    HashMap<WebCore::RegistrableDomain, SiteRecord> allSites();
+    void setRecordForSite(const WebCore::RegistrableDomain&, SiteRecord);
+
+    void deleteAllSites();
+    void deleteSitesUpdatedSince(WallTime);
+    void deleteSites(const Vector<WebCore::RegistrableDomain>&);
+
+    bool didImportUserInteractions();
+    void setDidImportUserInteractions();
+
+private:
+    enum class OpenResult : uint8_t {
+        Success,
+        Discard,
+        Retain
+    };
+    OpenResult openDatabase(const String& directoryPath);
+    OpenResult openDatabaseAtPath(const String& path);
+    void closeDatabase();
+    void reportSQLError(ASCIILiteral method, ASCIILiteral action);
+    OpenResult reportSQLErrorAndClassify(ASCIILiteral method, ASCIILiteral action);
+
+    std::unique_ptr<WebCore::SQLiteDatabase> m_sqliteDB;
+    std::unique_ptr<WebCore::SQLiteStatement> m_insertSiteSQLStatement;
+    std::unique_ptr<WebCore::SQLiteStatement> m_deleteSiteSQLStatement;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp
@@ -26,24 +26,360 @@
 #include "config.h"
 #include "IsolatedSiteStore.h"
 
+#include "IsolatedSitePersistence.h"
+#include <cmath>
+#include <wtf/CrossThreadCopier.h>
+#include <wtf/MainThread.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/Vector.h>
+
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IsolatedSiteStore);
+
+static WallTime roundDownToDay(WallTime time)
+{
+    constexpr double secondsPerDay = 24 * 60 * 60;
+    auto seconds = time.secondsSinceEpoch().value();
+    if (!std::isfinite(seconds) || seconds <= 0)
+        return { };
+
+    return WallTime::fromRawSeconds(std::floor(seconds / secondsPerDay) * secondsPerDay);
+}
+
+static WallTime today()
+{
+    return roundDownToDay(WallTime::now());
+}
+
+WorkQueue& IsolatedSiteStore::sharedWorkQueueSingleton()
+{
+    static NeverDestroyed<Ref<WorkQueue>> workQueue = WorkQueue::create("IsolatedSiteStore Work Queue"_s);
+    return workQueue.get();
+}
+
+Ref<IsolatedSiteStore> IsolatedSiteStore::create(const String& databaseDirectoryPath, UserInteractionDomainFetcher&& userInteractionDomainFetcher, HashSet<WebCore::RegistrableDomain>&& additionalSitesForTesting)
+{
+    return adoptRef(*new IsolatedSiteStore(databaseDirectoryPath, WTF::move(userInteractionDomainFetcher), WTF::move(additionalSitesForTesting)));
+}
+
+IsolatedSiteStore::IsolatedSiteStore(const String& databaseDirectoryPath, UserInteractionDomainFetcher&& userInteractionDomainFetcher, HashSet<WebCore::RegistrableDomain>&& additionalSitesForTesting)
+    : m_userInteractionDomainFetcher(WTF::move(userInteractionDomainFetcher))
+    , m_additionalSitesForTesting(WTF::move(additionalSitesForTesting))
+    , m_isPersistent(!databaseDirectoryPath.isEmpty())
+{
+    ASSERT(isMainRunLoop());
+
+    if (!m_isPersistent) {
+        m_isLoaded = true;
+        becomeReady();
+        return;
+    }
+
+    sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, path = crossThreadCopy(databaseDirectoryPath)] mutable {
+        assertIsCurrent(sharedWorkQueueSingleton());
+
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        protectedThis->m_persistence = makeUnique<IsolatedSitePersistence>(WTF::move(path));
+
+        HashMap<WebCore::RegistrableDomain, Entry> sites;
+        for (auto& [domain, record] : protectedThis->m_persistence->allSites()) {
+            // A bit written by a newer WebKit has no meaning here.
+            auto signals = OptionSet<Signal>::fromRaw(record.signals & allSignals.toRaw());
+            if (signals.isEmpty())
+                continue;
+
+            sites.set(domain, Entry { signals, record.lastUpdated });
+        }
+        bool didImportUserInteractions = protectedThis->m_persistence->didImportUserInteractions();
+
+        callOnMainRunLoop([protectedThis = WTF::move(protectedThis), sites = WTF::move(sites), didImportUserInteractions] mutable {
+            protectedThis->didLoadSites(WTF::move(sites), didImportUserInteractions);
+        });
+    });
+}
+
+IsolatedSiteStore::~IsolatedSiteStore()
+{
+    ASSERT(isMainRunLoop());
+
+    // Every pending handler holds a strong reference to this store or to its owner.
+    ASSERT(m_loadCompletionHandlers.isEmpty());
+    ASSERT(m_readyCompletionHandlers.isEmpty());
+
+    sharedWorkQueueSingleton().dispatch([persistence = WTF::move(m_persistence)] { });
+}
+
+void IsolatedSiteStore::didLoadSites(HashMap<WebCore::RegistrableDomain, Entry>&& sites, bool didImportUserInteractions)
+{
+    ASSERT(isMainRunLoop());
+    ASSERT(!m_isReady);
+
+    for (auto& [domain, loadedEntry] : sites) {
+        auto addResult = m_sites.add(domain, loadedEntry);
+        if (addResult.isNewEntry)
+            continue;
+
+        // A signal recorded while the load was in flight was written after the load read the table, so
+        // the row on disk no longer carries what was just read back.
+        auto& entry = addResult.iterator->value;
+        entry.signals.add(loadedEntry.signals);
+        entry.lastUpdated = std::max(entry.lastUpdated, loadedEntry.lastUpdated);
+        saveSite(domain, entry);
+    }
+
+    m_isLoaded = true;
+    for (auto& completionHandler : std::exchange(m_loadCompletionHandlers, { }))
+        completionHandler();
+
+    if (didImportUserInteractions || !m_userInteractionDomainFetcher)
+        return becomeReady();
+
+    importUserInteractions();
+}
+
+void IsolatedSiteStore::whenLoaded(CompletionHandler<void()>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    if (m_isLoaded)
+        return completionHandler();
+
+    m_loadCompletionHandlers.append(WTF::move(completionHandler));
+}
+
+void IsolatedSiteStore::skipImport()
+{
+    ASSERT(isMainRunLoop());
+
+    if (m_importSuppressed)
+        return;
+
+    m_importSuppressed = true;
+
+    m_userInteractionDomainFetcher = nullptr;
+
+    if (m_isPersistent) {
+        sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }] {
+            assertIsCurrent(sharedWorkQueueSingleton());
+
+            if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_persistence)
+                protectedThis->m_persistence->setDidImportUserInteractions();
+        });
+    }
+
+    if (m_isLoaded && !m_isReady)
+        becomeReady();
+}
+
+void IsolatedSiteStore::importUserInteractions()
+{
+    ASSERT(isMainRunLoop());
+    ASSERT(!m_isReady);
+
+    std::exchange(m_userInteractionDomainFetcher, { })([protectedThis = Ref { *this }](std::optional<HashMap<WebCore::RegistrableDomain, WallTime>>&& domains) mutable {
+        // A removal arrived while this was in flight and has already recorded the import as done.
+        if (protectedThis->m_importSuppressed)
+            return;
+
+        // Leave the import flag in database unset so a later launch can import if tracking prevention is turned on.
+        if (!domains)
+            return protectedThis->becomeReady();
+
+        auto now = today();
+        for (auto& [domain, interactionTime] : *domains) {
+            if (domain.isEmpty())
+                continue;
+            auto lastUpdated = roundDownToDay(interactionTime);
+            if (!lastUpdated || lastUpdated > now)
+                lastUpdated = now;
+            protectedThis->recordSignals(domain, { Signal::FirstPartyVisit, Signal::FirstPartyUserGesture }, lastUpdated);
+        }
+
+        sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { protectedThis.get() }] {
+            assertIsCurrent(sharedWorkQueueSingleton());
+
+            RefPtr protectedThis = weakThis.get();
+            if (protectedThis && protectedThis->m_persistence)
+                protectedThis->m_persistence->setDidImportUserInteractions();
+        });
+
+        protectedThis->becomeReady();
+    });
+}
+
+void IsolatedSiteStore::becomeReady()
+{
+    ASSERT(isMainRunLoop());
+    ASSERT(!m_isReady);
+
+    // Injected after the load and any import so that nothing written here reaches the database. Only
+    // the signal is added: stamping lastUpdated would make a real visit on the same day look already
+    // recorded and so never be written.
+    for (auto& domain : std::exchange(m_additionalSitesForTesting, { }))
+        m_sites.add(domain, Entry { }).iterator->value.signals.add(Signal::FirstPartyVisit);
+
+    m_isReady = true;
+
+    for (auto& completionHandler : std::exchange(m_readyCompletionHandlers, { }))
+        completionHandler();
+}
+
+void IsolatedSiteStore::whenReady(CompletionHandler<void()>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    if (m_isReady)
+        return completionHandler();
+
+    m_readyCompletionHandlers.append(WTF::move(completionHandler));
+}
+
+void IsolatedSiteStore::saveSite(const WebCore::RegistrableDomain& domain, const Entry& entry)
+{
+    ASSERT(isMainRunLoop());
+
+    if (!m_isPersistent)
+        return;
+
+    sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, domain = crossThreadCopy(domain), record = IsolatedSitePersistence::SiteRecord { entry.signals.toRaw(), entry.lastUpdated }] {
+        assertIsCurrent(sharedWorkQueueSingleton());
+
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !protectedThis->m_persistence)
+            return;
+
+        protectedThis->m_persistence->setRecordForSite(domain, record);
+    });
+}
+
+void IsolatedSiteStore::recordSignals(const WebCore::RegistrableDomain& domain, OptionSet<Signal> signals, WallTime lastUpdated)
+{
+    ASSERT(isMainRunLoop());
+
+    auto& entry = m_sites.add(domain, Entry { }).iterator->value;
+    if (entry.signals.containsAll(signals) && entry.lastUpdated >= lastUpdated)
+        return;
+
+    entry.signals.add(signals);
+    entry.lastUpdated = std::max(entry.lastUpdated, lastUpdated);
+    saveSite(domain, entry);
+}
 
 void IsolatedSiteStore::addSite(const WebCore::Site& site, Signal signal)
 {
-    m_sites.add(site.domain(), OptionSet<Signal> { }).iterator->value.add(signal);
+    recordSignals(site.domain(), signal, today());
+}
+
+void IsolatedSiteStore::allDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    whenLoaded([protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] mutable {
+        completionHandler(copyToVector(protectedThis->m_sites.keys()));
+    });
+}
+
+void IsolatedSiteStore::removeAllSites(CompletionHandler<void()>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    skipImport();
+
+    whenLoaded([protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] mutable {
+        protectedThis->m_sites.clear();
+
+        if (!protectedThis->m_isPersistent)
+            return completionHandler();
+
+        sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { protectedThis.get() }, completionHandler = WTF::move(completionHandler)] mutable {
+            assertIsCurrent(sharedWorkQueueSingleton());
+
+            if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_persistence)
+                protectedThis->m_persistence->deleteAllSites();
+
+            callOnMainRunLoop(WTF::move(completionHandler));
+        });
+    });
+}
+
+void IsolatedSiteStore::removeSitesUpdatedSince(WallTime modifiedSince, CompletionHandler<void()>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    // Rounding the cutoff down too makes this over-delete rather than under-delete.
+    auto cutoff = roundDownToDay(modifiedSince);
+
+    whenLoaded([protectedThis = Ref { *this }, cutoff, completionHandler = WTF::move(completionHandler)] mutable {
+        protectedThis->m_sites.removeIf([cutoff](auto& entry) {
+            return entry.value.lastUpdated >= cutoff;
+        });
+
+        if (!protectedThis->m_isPersistent)
+            return completionHandler();
+
+        sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { protectedThis.get() }, cutoff, completionHandler = WTF::move(completionHandler)] mutable {
+            assertIsCurrent(sharedWorkQueueSingleton());
+
+            if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_persistence)
+                protectedThis->m_persistence->deleteSitesUpdatedSince(cutoff);
+
+            callOnMainRunLoop(WTF::move(completionHandler));
+        });
+    });
+}
+
+void IsolatedSiteStore::removeSites(Vector<WebCore::RegistrableDomain>&& domains, CompletionHandler<void()>&& completionHandler)
+{
+    ASSERT(isMainRunLoop());
+
+    if (domains.isEmpty())
+        return completionHandler();
+
+    whenLoaded([protectedThis = Ref { *this }, domains = WTF::move(domains), completionHandler = WTF::move(completionHandler)] mutable {
+        for (auto& domain : domains)
+            protectedThis->m_sites.remove(domain);
+
+        if (!protectedThis->m_isPersistent)
+            return completionHandler();
+
+        sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { protectedThis.get() }, domains = crossThreadCopy(WTF::move(domains)), completionHandler = WTF::move(completionHandler)] mutable {
+            assertIsCurrent(sharedWorkQueueSingleton());
+
+            if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_persistence)
+                protectedThis->m_persistence->deleteSites(domains);
+
+            callOnMainRunLoop(WTF::move(completionHandler));
+        });
+    });
 }
 
 OptionSet<IsolatedSiteStore::Signal> IsolatedSiteStore::reasonsFor(const WebCore::Site& site) const
 {
+    ASSERT(isMainRunLoop());
+
     auto it = m_sites.find(site.domain());
     if (it == m_sites.end())
         return { };
-    return it->value;
+
+    return it->value.signals;
 }
 
 bool IsolatedSiteStore::contains(const WebCore::Site& site) const
 {
-    return m_sites.contains(site.domain());
+    return containsDomain(site.domain());
+}
+
+bool IsolatedSiteStore::containsDomain(const WebCore::RegistrableDomain& domain) const
+{
+    ASSERT(isMainRunLoop());
+
+    return m_sites.contains(domain);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h
@@ -27,25 +27,75 @@
 
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/Site.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/Function.h>
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/WallTime.h>
+#include <wtf/WorkQueue.h>
 
 namespace WebKit {
 
-class IsolatedSiteStore {
+class IsolatedSitePersistence;
+
+class IsolatedSiteStore final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<IsolatedSiteStore, WTF::DestructionThread::MainRunLoop> {
+    WTF_MAKE_TZONE_ALLOCATED(IsolatedSiteStore);
 public:
     enum class Signal : uint8_t {
         Autofill = 1 << 0,
         FirstPartyVisit = 1 << 1,
         FirstPartyUserGesture = 1 << 2,
     };
+    static constexpr OptionSet<Signal> allSignals { Signal::Autofill, Signal::FirstPartyVisit, Signal::FirstPartyUserGesture };
+
+    using UserInteractionDomainFetcher = Function<void(CompletionHandler<void(std::optional<HashMap<WebCore::RegistrableDomain, WallTime>>&&)>&&)>;
+    static Ref<IsolatedSiteStore> create(const String& databaseDirectoryPath, UserInteractionDomainFetcher&&, HashSet<WebCore::RegistrableDomain>&& additionalSitesForTesting);
+    ~IsolatedSiteStore();
 
     void addSite(const WebCore::Site&, Signal);
     OptionSet<Signal> reasonsFor(const WebCore::Site&) const;
     bool contains(const WebCore::Site&) const;
+    bool containsDomain(const WebCore::RegistrableDomain&) const;
+    void allDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&&);
+    void removeAllSites(CompletionHandler<void()>&&);
+    void removeSitesUpdatedSince(WallTime, CompletionHandler<void()>&&);
+    void removeSites(Vector<WebCore::RegistrableDomain>&&, CompletionHandler<void()>&&);
+
+    bool isReady() const { return m_isReady; }
+    void whenReady(CompletionHandler<void()>&&);
 
 private:
-    HashMap<WebCore::RegistrableDomain, OptionSet<Signal>> m_sites;
+    IsolatedSiteStore(const String& databaseDirectoryPath, UserInteractionDomainFetcher&&, HashSet<WebCore::RegistrableDomain>&&);
+
+    static WorkQueue& sharedWorkQueueSingleton();
+
+    struct Entry {
+        OptionSet<Signal> signals;
+        WallTime lastUpdated;
+    };
+
+    void didLoadSites(HashMap<WebCore::RegistrableDomain, Entry>&&, bool didImportUserInteractions);
+    void whenLoaded(CompletionHandler<void()>&&);
+    void importUserInteractions();
+    void becomeReady();
+
+    void skipImport();
+    void recordSignals(const WebCore::RegistrableDomain&, OptionSet<Signal>, WallTime lastUpdated);
+    void saveSite(const WebCore::RegistrableDomain&, const Entry&);
+
+    HashMap<WebCore::RegistrableDomain, Entry> m_sites;
+    Vector<CompletionHandler<void()>> m_loadCompletionHandlers;
+    Vector<CompletionHandler<void()>> m_readyCompletionHandlers;
+    UserInteractionDomainFetcher m_userInteractionDomainFetcher;
+    HashSet<WebCore::RegistrableDomain> m_additionalSitesForTesting;
+    const bool m_isPersistent { false };
+    bool m_isLoaded { false };
+    bool m_isReady { false };
+    bool m_importSuppressed { false };
+    std::unique_ptr<IsolatedSitePersistence> m_persistence WTF_GUARDED_BY_CAPABILITY(sharedWorkQueueSingleton());
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -476,6 +476,9 @@ static void resolveDirectories(WebsiteDataStoreConfiguration::Directories& direc
 
     if (!directories.enhancedSecurityDirectory.isEmpty())
         directories.enhancedSecurityDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.enhancedSecurityDirectory);
+
+    if (!directories.isolatedSitesDirectory.isEmpty())
+        directories.isolatedSitesDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.isolatedSitesDirectory);
 }
 
 const WebsiteDataStoreConfiguration::Directories& WebsiteDataStore::resolvedDirectories() const
@@ -549,27 +552,9 @@ void WebsiteDataStore::handleResolvedDirectoriesAsynchronously(const WebsiteData
     });
 }
 
-void WebsiteDataStore::fetchDomainsWithUserInteraction(CompletionHandler<void(const HashSet<WebCore::RegistrableDomain>&)>&& completionHandler)
+void WebsiteDataStore::fetchDomainsWithUserInteraction(CompletionHandler<void(std::optional<HashMap<WebCore::RegistrableDomain, WallTime>>&&)>&& completionHandler)
 {
-    if (m_domainsWithUserInteractions)
-        return completionHandler(*m_domainsWithUserInteractions);
-
-    bool shouldFetch = m_domainsWithUserInteractionsCompletionHandler.isEmpty();
-    m_domainsWithUserInteractionsCompletionHandler.append(WTF::move(completionHandler));
-
-    if (!shouldFetch)
-        return;
-
-    protect(networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::FetchWebsitesWithUserInteractions(sessionID()), [this, protectedThis = Ref { *this }](HashSet<WebCore::RegistrableDomain>&& domains) {
-        domains.addAll(platformAdditionalDomainsWithUserInteraction());
-        m_domainsWithUserInteractions = WTF::move(domains);
-
-        for (auto& domain : std::exchange(m_pendingDomainsWithUserInteractions, { }))
-            m_domainsWithUserInteractions->add(domain);
-
-        for (auto& completionHandler : std::exchange(m_domainsWithUserInteractionsCompletionHandler, { }))
-            completionHandler(*m_domainsWithUserInteractions);
-    });
+    protect(networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::FetchWebsitesWithUserInteractions(sessionID()), WTF::move(completionHandler));
 }
 
 #if !PLATFORM(COCOA)
@@ -824,6 +809,16 @@ private:
             callbackAggregator->addWebsiteData(WTF::move(websiteData));
         });
     }
+
+    if (dataTypes.contains(WebsiteDataType::IsolatedSiteRecord)) {
+        protect(isolatedSiteStore())->allDomains([callbackAggregator] (Vector<WebCore::RegistrableDomain>&& isolatedSites) {
+            WebsiteData websiteData;
+            websiteData.entries = WTF::map(isolatedSites, [](auto& domain) {
+                return WebsiteData::Entry { WebCore::SecurityOriginData { "https"_s, domain.string(), std::nullopt }, WebsiteDataType::IsolatedSiteRecord, 0 };
+            });
+            callbackAggregator->addWebsiteData(WTF::move(websiteData));
+        });
+    }
 }
 
 void WebsiteDataStore::fetchDataForRegistrableDomains(OptionSet<WebsiteDataType> dataTypes, OptionSet<WebsiteDataFetchOption> fetchOptions, Vector<WebCore::RegistrableDomain>&& domains, CompletionHandler<void(Vector<WebsiteDataRecord>&&, HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
@@ -982,6 +977,14 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, WallTime
 
     if (dataTypes.contains(WebsiteDataType::EnhancedSecurityRecord) && isPersistent())
         removeAllEnhancedSecuritySites([callbackAggregator] { });
+
+    if (dataTypes.contains(WebsiteDataType::IsolatedSiteRecord)) {
+        Ref siteStore = isolatedSiteStore();
+        if (modifiedSince <= WallTime())
+            siteStore->removeAllSites([callbackAggregator] { });
+        else
+            siteStore->removeSitesUpdatedSince(modifiedSince, [callbackAggregator] { });
+    }
 }
 
 void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, const Vector<WebsiteDataRecord>& dataRecords, Function<void()>&& completionHandler)
@@ -1089,6 +1092,17 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, const Ve
 #endif
     if (dataTypes.contains(WebsiteDataType::EnhancedSecurityRecord) && isPersistent())
         removeEnhancedSecuritySites(origins, [callbackAggregator] { });
+
+    if (dataTypes.contains(WebsiteDataType::IsolatedSiteRecord)) {
+        HashSet<WebCore::RegistrableDomain> domainsToRemove;
+        for (auto& origin : origins)
+            domainsToRemove.add(WebCore::RegistrableDomain { origin });
+        for (auto& dataRecord : dataRecords) {
+            for (auto& domain : dataRecord.resourceLoadStatisticsRegistrableDomains)
+                domainsToRemove.add(domain);
+        }
+        protect(isolatedSiteStore())->removeSites(copyToVector(domainsToRemove), [callbackAggregator] { });
+    }
 }
 
 DeviceIdHashSaltStorage& WebsiteDataStore::ensureDeviceIdHashSaltStorage()
@@ -1529,29 +1543,33 @@ void WebsiteDataStore::setTimeToLiveUserInteraction(Seconds seconds, CompletionH
     protect(networkProcess())->setTimeToLiveUserInteraction(m_sessionID, seconds, WTF::move(completionHandler));
 }
 
-void WebsiteDataStore::didHaveUserInteractionForSiteIsolation(const URL& url)
+IsolatedSiteStore& WebsiteDataStore::isolatedSiteStore()
 {
-    if (url.protocolIsAbout() || url.isEmpty())
-        return;
+    ASSERT(RunLoop::isMain());
 
-    WebCore::RegistrableDomain registrableDomain { url };
-    if (m_domainsWithUserInteractions)
-        m_domainsWithUserInteractions->add(registrableDomain);
-    else if (!m_domainsWithUserInteractionsCompletionHandler.isEmpty()) {
-        // Currently waiting for the network process's reply.
-        // Add this domain to the hash set we get from the network process
-        // since the network process may have replied before it had
-        // notififed of user interaction by the web content process.
-        m_pendingDomainsWithUserInteractions.append(registrableDomain);
+    if (!m_isolatedSiteStore) {
+        IsolatedSiteStore::UserInteractionDomainFetcher fetcher = [weakThis = WeakPtr { *this }](CompletionHandler<void(std::optional<HashMap<WebCore::RegistrableDomain, WallTime>>&&)>&& completionHandler) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis || !protectedThis->trackingPreventionEnabled())
+                return completionHandler(std::nullopt);
+
+            protectedThis->fetchDomainsWithUserInteraction(WTF::move(completionHandler));
+        };
+
+        lazyInitialize(m_isolatedSiteStore, IsolatedSiteStore::create(isPersistent() ? resolvedDirectories().isolatedSitesDirectory : String { }, WTF::move(fetcher), platformAdditionalDomainsWithUserInteraction()));
     }
+
+    return *m_isolatedSiteStore;
 }
 
-std::optional<OptionSet<IsolatedSiteStore::Signal>> WebsiteDataStore::isolatedSiteSignalsForTesting(const URL& url) const
+std::optional<OptionSet<IsolatedSiteStore::Signal>> WebsiteDataStore::isolatedSiteSignalsForTesting(const URL& url)
 {
     WebCore::Site site { url };
-    if (!m_isolatedSiteStore.contains(site))
+    Ref siteStore = isolatedSiteStore();
+    if (!siteStore->contains(site))
         return std::nullopt;
-    return m_isolatedSiteStore.reasonsFor(site);
+
+    return siteStore->reasonsFor(site);
 }
 
 void WebsiteDataStore::logUserInteraction(const URL& url, CompletionHandler<void()>&& completionHandler)
@@ -2401,6 +2419,15 @@ String WebsiteDataStore::defaultIndexedDBDatabaseDirectory(const String& baseDat
     return websiteDataDirectoryFileSystemRepresentation(String::fromUTF8("databases" G_DIR_SEPARATOR_S "indexeddb"), baseDataDirectory);
 #else
     return websiteDataDirectoryFileSystemRepresentation("IndexedDB"_s, baseDataDirectory);
+#endif
+}
+
+String WebsiteDataStore::defaultIsolatedSitesDirectory(const String& baseDataDirectory)
+{
+#if PLATFORM(PLAYSTATION) || USE(GLIB)
+    return websiteDataDirectoryFileSystemRepresentation("isolatedsites"_s, baseDataDirectory);
+#else
+    return websiteDataDirectoryFileSystemRepresentation("IsolatedSites"_s, baseDataDirectory);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -213,7 +213,7 @@ public:
     void setUserAgentStringQuirkForTesting(const String& domain, const String& userAgentString, CompletionHandler<void()>&&);
     void setPrivateTokenIPCForTesting(bool enabled);
 
-    void fetchDomainsWithUserInteraction(CompletionHandler<void(const HashSet<WebCore::RegistrableDomain>&)>&&);
+    void fetchDomainsWithUserInteraction(CompletionHandler<void(std::optional<HashMap<WebCore::RegistrableDomain, WallTime>>&&)>&&);
 
     void fetchData(OptionSet<WebsiteDataType>, OptionSet<WebsiteDataFetchOption>, Function<void(Vector<WebsiteDataRecord>)>&& completionHandler);
     void removeData(OptionSet<WebsiteDataType>, WallTime modifiedSince, Function<void()>&& completionHandler);
@@ -231,9 +231,8 @@ public:
     void clearUserInteraction(const URL&, CompletionHandler<void()>&&);
     void dumpResourceLoadStatistics(CompletionHandler<void(const String&)>&&);
     void logTestingEvent(const String&);
-    void didHaveUserInteractionForSiteIsolation(const URL&);
-    IsolatedSiteStore& isolatedSiteStore() { return m_isolatedSiteStore; }
-    std::optional<OptionSet<IsolatedSiteStore::Signal>> isolatedSiteSignalsForTesting(const URL&) const;
+    IsolatedSiteStore& isolatedSiteStore();
+    std::optional<OptionSet<IsolatedSiteStore::Signal>> isolatedSiteSignalsForTesting(const URL&);
     void logUserInteraction(const URL&, CompletionHandler<void()>&&);
     void getAllStorageAccessEntries(WebPageProxyIdentifier, CompletionHandler<void(Vector<String>&& domains)>&&);
     void hasHadUserInteraction(const URL&, CompletionHandler<void(bool)>&&);
@@ -392,6 +391,7 @@ public:
     static String defaultWebSQLDatabaseDirectory(const String& baseDataDirectory = nullString());
     static String defaultHSTSStorageDirectory(const String& baseCacheDirectory = nullString());
     static String defaultIndexedDBDatabaseDirectory(const String& baseDataDirectory = nullString());
+    static String defaultIsolatedSitesDirectory(const String& baseDataDirectory = nullString());
     static String defaultCacheStorageDirectory(const String& baseCacheDirectory = nullString());
     static String defaultGeneralStorageDirectory(const String& baseDataDirectory = nullString());
     static String defaultMediaCacheDirectory(const String& baseCacheDirectory = nullString());
@@ -622,10 +622,7 @@ private:
     String m_resolvedCookieStorageDirectory;
 #endif
 
-    std::optional<HashSet<WebCore::RegistrableDomain>> m_domainsWithUserInteractions;
-    Vector<WebCore::RegistrableDomain> m_pendingDomainsWithUserInteractions;
-    Vector<CompletionHandler<void(const HashSet<WebCore::RegistrableDomain>&)>> m_domainsWithUserInteractionsCompletionHandler;
-    IsolatedSiteStore m_isolatedSiteStore;
+    const RefPtr<IsolatedSiteStore> m_isolatedSiteStore;
 
     bool m_trackingPreventionDebugMode { false };
     enum class TrackingPreventionEnabled : uint8_t { Default, No, Yes };

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -111,6 +111,7 @@ void WebsiteDataStoreConfiguration::initializePaths()
 
     setAlternativeServicesDirectory(WebsiteDataStore::defaultAlternativeServicesDirectory(m_baseDataDirectory));
     setIndexedDBDatabaseDirectory(WebsiteDataStore::defaultIndexedDBDatabaseDirectory(m_baseDataDirectory));
+    setIsolatedSitesDirectory(WebsiteDataStore::defaultIsolatedSitesDirectory(m_baseDataDirectory));
     setServiceWorkerRegistrationDirectory(WebsiteDataStore::defaultServiceWorkerRegistrationDirectory(m_baseDataDirectory));
     setWebSQLDatabaseDirectory(WebsiteDataStore::defaultWebSQLDatabaseDirectory(m_baseDataDirectory));
     setLocalStorageDirectory(WebsiteDataStore::defaultLocalStorageDirectory(m_baseDataDirectory));
@@ -215,6 +216,7 @@ WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Direct
         crossThreadCopy(generalStorageDirectory),
         crossThreadCopy(hstsStorageDirectory),
         crossThreadCopy(indexedDBDatabaseDirectory),
+        crossThreadCopy(isolatedSitesDirectory),
         crossThreadCopy(javaScriptConfigurationDirectory),
         crossThreadCopy(localStorageDirectory),
         crossThreadCopy(mediaCacheDirectory),
@@ -244,6 +246,7 @@ WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Direct
         crossThreadCopy(WTF::move(generalStorageDirectory)),
         crossThreadCopy(WTF::move(hstsStorageDirectory)),
         crossThreadCopy(WTF::move(indexedDBDatabaseDirectory)),
+        crossThreadCopy(WTF::move(isolatedSitesDirectory)),
         crossThreadCopy(WTF::move(javaScriptConfigurationDirectory)),
         crossThreadCopy(WTF::move(localStorageDirectory)),
         crossThreadCopy(WTF::move(mediaCacheDirectory)),

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -274,6 +274,9 @@ public:
     const String& enhancedSecurityDirectory() const LIFETIME_BOUND { return m_directories.enhancedSecurityDirectory; }
     void setEnhancedSecurityDirectory(String&& directory) { m_directories.enhancedSecurityDirectory = WTF::move(directory); }
 
+    const String& isolatedSitesDirectory() const LIFETIME_BOUND { return m_directories.isolatedSitesDirectory; }
+    void setIsolatedSitesDirectory(String&& directory) { m_directories.isolatedSitesDirectory = WTF::move(directory); }
+
     std::optional<unsigned> overridePersistentNotificationMinimumLifetimeForTesting() const { return m_overrideServiceWorkerRegistrationCountTestingValue; }
     void setOverridePersistentNotificationMinimumLifetimeForTesting(unsigned count) { m_overrideServiceWorkerRegistrationCountTestingValue = count; }
 
@@ -288,6 +291,7 @@ public:
         String generalStorageDirectory;
         String hstsStorageDirectory;
         String indexedDBDatabaseDirectory;
+        String isolatedSitesDirectory;
         String javaScriptConfigurationDirectory;
         String localStorageDirectory;
         String mediaCacheDirectory;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1072,6 +1072,7 @@
 		3A05FCD82C890974005EF8CB /* _WKWebPushMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A05FCD02C890946005EF8CB /* _WKWebPushMessage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A05FCDA2C8909A2005EF8CB /* _WKWebPushSubscriptionData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A05FCD32C890946005EF8CB /* _WKWebPushSubscriptionData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A061A313017E09F00F8873B /* IsolatedSiteStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A061A2F3017E09F00F8873B /* IsolatedSiteStore.h */; };
+		3A061A423017E09F00F8873B /* IsolatedSitePersistence.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A061A403017E09F00F8873B /* IsolatedSitePersistence.h */; };
 		3A12CDBB29D4D30200D57EAE /* WebSWRegistrationStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AC4C04529D35D1500402716 /* WebSWRegistrationStore.h */; };
 		3A18A2EF2AFF004C00DB976C /* _WKArchiveConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A18A2EE2AFF004C00DB976C /* _WKArchiveConfiguration.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A18A2F52B02969900DB976C /* _WKArchiveExclusionRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A18A2F32B02969800DB976C /* _WKArchiveExclusionRule.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5556,6 +5557,8 @@
 		3A05FCDC2C8909D3005EF8CB /* APIWebPushDaemonConnection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = APIWebPushDaemonConnection.cpp; sourceTree = "<group>"; };
 		3A05FCDD2C8909D3005EF8CB /* APIWebPushMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIWebPushMessage.h; sourceTree = "<group>"; };
 		3A05FCDE2C8909D3005EF8CB /* APIWebPushSubscriptionData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIWebPushSubscriptionData.h; sourceTree = "<group>"; };
+		3A061A403017E09F00F8873B /* IsolatedSitePersistence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IsolatedSitePersistence.h; sourceTree = "<group>"; };
+		3A061A413017E09F00F8873B /* IsolatedSitePersistence.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IsolatedSitePersistence.cpp; sourceTree = "<group>"; };
 		3A061A2F3017E09F00F8873B /* IsolatedSiteStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IsolatedSiteStore.h; sourceTree = "<group>"; };
 		3A061A303017E09F00F8873B /* IsolatedSiteStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IsolatedSiteStore.cpp; sourceTree = "<group>"; };
 		3A068FF32F98A6AC0038FAC7 /* WKXRControllerManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKXRControllerManager.mm; sourceTree = "<group>"; };
@@ -10256,6 +10259,8 @@
 				5628440E2ED9E5440080DD29 /* EnhancedSecuritySitesHolder.h */,
 				5628440D2ED9E5250080DD29 /* EnhancedSecuritySitesPersistence.cpp */,
 				5628440C2ED9E50D0080DD29 /* EnhancedSecuritySitesPersistence.h */,
+				3A061A413017E09F00F8873B /* IsolatedSitePersistence.cpp */,
+				3A061A403017E09F00F8873B /* IsolatedSitePersistence.h */,
 				3A061A303017E09F00F8873B /* IsolatedSiteStore.cpp */,
 				3A061A2F3017E09F00F8873B /* IsolatedSiteStore.h */,
 				46B0524522668D2400265B97 /* WebDeviceOrientationAndMotionAccessController.cpp */,
@@ -18502,6 +18507,7 @@
 				A73E66BD2AB107C3005FC327 /* IPCEvent.h in Headers */,
 				A31F60A425CC7DB900AF14F4 /* IPCSemaphore.h in Headers */,
 				7BE37F9327C7CA51007A6CD3 /* IPCStreamTesterIdentifier.h in Headers */,
+				3A061A423017E09F00F8873B /* IsolatedSitePersistence.h in Headers */,
 				3A061A313017E09F00F8873B /* IsolatedSiteStore.h in Headers */,
 				46DBC28C2AF96B9F00E6B63A /* ITPThirdPartyData.h in Headers */,
 				46DBC28D2AF96BA400E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8324,6 +8324,8 @@ TEST(SiteIsolation, SharedProcessWithResourceLoadStatistics)
     NSURL *itpRoot = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"SharedProcessWithResourceLoadStatisticsTestITP"] isDirectory:YES];
     auto defaultFileManager = [NSFileManager defaultManager];
     [defaultFileManager removeItemAtPath:itpRoot.path error:nil];
+    // Its recorded import would make a second run of this binary skip the import entirely.
+    [defaultFileManager removeItemAtPath:dataStoreRoot.path error:nil];
 
     [defaultFileManager createDirectoryAtURL:itpRoot withIntermediateDirectories:YES attributes:nil error:nil];
     NSURL *itpDatabaseFile = [itpRoot URLByAppendingPathComponent:@"observations.db"];
@@ -8422,6 +8424,8 @@ TEST(SiteIsolation, SharedProcessAfterClick)
     NSURL *itpRoot = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"SharedProcessAfterClickTestITP"] isDirectory:YES];
     auto defaultFileManager = [NSFileManager defaultManager];
     [defaultFileManager removeItemAtPath:itpRoot.path error:nil];
+    // Its recorded import would make a second run of this binary skip the import entirely.
+    [defaultFileManager removeItemAtPath:dataStoreRoot.path error:nil];
 
     [defaultFileManager createDirectoryAtURL:itpRoot withIntermediateDirectories:YES attributes:nil error:nil];
     NSURL *itpDatabaseFile = [itpRoot URLByAppendingPathComponent:@"observations.db"];
@@ -8482,6 +8486,8 @@ TEST(SiteIsolation, SharedProcessAfterKeyDown)
     NSURL *itpRoot = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"SharedProcessAfterKeyDownTestITP"] isDirectory:YES];
     auto defaultFileManager = [NSFileManager defaultManager];
     [defaultFileManager removeItemAtPath:itpRoot.path error:nil];
+    // Its recorded import would make a second run of this binary skip the import entirely.
+    [defaultFileManager removeItemAtPath:dataStoreRoot.path error:nil];
 
     [defaultFileManager createDirectoryAtURL:itpRoot withIntermediateDirectories:YES attributes:nil error:nil];
     NSURL *itpDatabaseFile = [itpRoot URLByAppendingPathComponent:@"observations.db"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
@@ -31,6 +31,8 @@
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
+#import <WebCore/SQLiteDatabase.h>
+#import <WebCore/SQLiteStatement.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
@@ -2250,6 +2252,13 @@ static NSUInteger isolatedSiteSignals(WKWebsiteDataStore *dataStore, NSString *u
     return [[dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:urlString]] unsignedIntegerValue];
 }
 
+static NSURL *temporaryDirectoryForIsolatedSiteStoreTest(NSString *name)
+{
+    NSURL *directory = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:name] isDirectory:YES];
+    [[NSFileManager defaultManager] removeItemAtPath:directory.path error:nil];
+    return directory;
+}
+
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> webViewForIsolatedSiteStoreTest(const HTTPServer& server)
 {
     RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
@@ -2342,5 +2351,272 @@ TEST(WKWebsiteDataStore, FirstPartyUserGestureInSubframeDoesNotMarkSubframeSite)
 }
 
 #endif // PLATFORM(MAC)
+
+struct IsolatedSiteStoreTestOptions {
+    NSURL *resourceLoadStatisticsDirectory { nil };
+    bool trackingPreventionEnabled { false };
+};
+
+static RetainPtr<WKWebsiteDataStore> persistentDataStore(const HTTPServer& server, NSURL *directory, IsolatedSiteStoreTestOptions options = { })
+{
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithDirectory:directory]);
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    if (options.resourceLoadStatisticsDirectory)
+        storeConfiguration.get()._resourceLoadStatisticsDirectory = options.resourceLoadStatisticsDirectory;
+
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [dataStore _setResourceLoadStatisticsEnabled:options.trackingPreventionEnabled];
+    return dataStore;
+}
+
+static std::pair<RetainPtr<WKWebView>, RetainPtr<TestNavigationDelegate>> webViewForDataStore(WKWebsiteDataStore *dataStore)
+{
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [viewConfiguration setWebsiteDataStore:dataStore];
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:viewConfiguration.get()]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
+}
+
+static NSDate *seededInteractionDate()
+{
+    // Old enough that a cleared range of an hour cannot cover it.
+    return [NSDate dateWithTimeIntervalSinceNow:-30 * 24 * 3600];
+}
+
+static void writeResourceLoadStatisticsDatabase(NSURL *directory)
+{
+    // Seeds a tracking prevention database whose only interacted-with domain is webkit.org.
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    [fileManager createDirectoryAtURL:directory withIntermediateDirectories:YES attributes:nil error:nil];
+
+    NSURL *databaseFile = [directory URLByAppendingPathComponent:@"observations.db"];
+    NSURL *sourceFile = [NSBundle.test_resourcesBundle URLForResource:@"basicITPDatabase" withExtension:@"db"];
+    EXPECT_TRUE([fileManager fileExistsAtPath:sourceFile.path]);
+    [fileManager copyItemAtPath:sourceFile.path toPath:databaseFile.path error:nil];
+
+    auto database = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(database->open(databaseFile.path));
+    auto statement = database->prepareStatement("UPDATE ObservedDomains SET hadUserInteraction = 1, mostRecentUserInteractionTime = ? WHERE registrableDomain = 'webkit.org'"_s);
+    EXPECT_TRUE(!!statement);
+    EXPECT_TRUE(statement->bindDouble(1, seededInteractionDate().timeIntervalSince1970) == SQLITE_OK);
+    EXPECT_TRUE(statement->executeCommand());
+    statement = nullptr;
+    database->close();
+}
+
+TEST(IsolatedSiteStore, PersistsAcrossSessions)
+{
+    HTTPServer server({
+        { "/example"_s, { "example as a top-level page"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    NSURL *directory = temporaryDirectoryForIsolatedSiteStoreTest(@"IsolatedSiteStorePersistsAcrossSessions");
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory);
+        auto [webView, navigationDelegate] = webViewForDataStore(dataStore.get());
+
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+
+        EXPECT_TRUE(isolatedSiteSignals(dataStore.get(), @"https://example.com/") & firstPartyVisitSignal);
+    }
+
+    // No web view this time, so the signal can only have come from the database.
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory);
+        EXPECT_TRUE(Util::waitFor([&] {
+            return !!(isolatedSiteSignals(dataStore.get(), @"https://example.com/") & firstPartyVisitSignal);
+        }));
+        EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://webkit.org/"]]);
+    }
+}
+
+static RetainPtr<WKWebsiteDataRecord> isolatedSiteRecordForDisplayName(WKWebsiteDataStore *dataStore, NSString *displayName)
+{
+    __block RetainPtr<NSArray<WKWebsiteDataRecord *>> records;
+    __block bool done = false;
+    [dataStore fetchDataRecordsOfTypes:[NSSet setWithObject:_WKWebsiteDataTypeIsolatedSiteRecord] completionHandler:^(NSArray<WKWebsiteDataRecord *> *fetchedRecords) {
+        records = fetchedRecords;
+        done = true;
+    }];
+    Util::run(&done);
+
+    for (WKWebsiteDataRecord *record in records.get()) {
+        if ([record.displayName isEqualToString:displayName])
+            return record;
+    }
+    return nil;
+}
+
+static void removeIsolatedSiteData(WKWebsiteDataStore *dataStore, NSArray<WKWebsiteDataRecord *> *records)
+{
+    __block bool done = false;
+    [dataStore removeDataOfTypes:[NSSet setWithObject:_WKWebsiteDataTypeIsolatedSiteRecord] forDataRecords:records completionHandler:^{
+        done = true;
+    }];
+    Util::run(&done);
+}
+
+static void removeIsolatedSiteDataSince(WKWebsiteDataStore *dataStore, NSDate *modifiedSince)
+{
+    __block bool done = false;
+    [dataStore removeDataOfTypes:[NSSet setWithObject:_WKWebsiteDataTypeIsolatedSiteRecord] modifiedSince:modifiedSince completionHandler:^{
+        done = true;
+    }];
+    Util::run(&done);
+}
+
+TEST(IsolatedSiteStore, DataRemoval)
+{
+    HTTPServer server({
+        { "/example"_s, { "example as a top-level page"_s } },
+        { "/webkit"_s, { "webkit as a top-level page"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    NSURL *directory = temporaryDirectoryForIsolatedSiteStoreTest(@"IsolatedSiteStoreDataRemoval");
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory);
+        auto [webView, navigationDelegate] = webViewForDataStore(dataStore.get());
+
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+
+        RetainPtr exampleRecord = isolatedSiteRecordForDisplayName(dataStore.get(), @"example.com");
+        EXPECT_NOT_NULL(exampleRecord.get());
+        removeIsolatedSiteData(dataStore.get(), @[exampleRecord.get()]);
+
+        EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://example.com/"]]);
+        EXPECT_TRUE(isolatedSiteSignals(dataStore.get(), @"https://webkit.org/") & firstPartyVisitSignal);
+    }
+
+    // A store over the same database, so what the per-record removal did on disk is what is read back
+    // here rather than what the previous store had in memory.
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory);
+        EXPECT_TRUE(Util::waitFor([&] {
+            return !!(isolatedSiteSignals(dataStore.get(), @"https://webkit.org/") & firstPartyVisitSignal);
+        }));
+        EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://example.com/"]]);
+
+        removeIsolatedSiteDataSince(dataStore.get(), [NSDate distantPast]);
+        EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://webkit.org/"]]);
+    }
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory);
+        EXPECT_TRUE(Util::waitFor([&] {
+            return ![dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://webkit.org/"]];
+        }));
+    }
+}
+
+TEST(IsolatedSiteStore, PartialDataRemovalAllowsImport)
+{
+    HTTPServer server({
+        { "/example"_s, { "example as a top-level page"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    NSURL *directory = temporaryDirectoryForIsolatedSiteStoreTest(@"IsolatedSiteStorePartialRemoval");
+    NSURL *statisticsDirectory = temporaryDirectoryForIsolatedSiteStoreTest(@"IsolatedSiteStorePartialRemovalITP");
+    writeResourceLoadStatisticsDatabase(statisticsDirectory);
+
+    // Clearing a time range says nothing about history predating this store, so unlike clearing
+    // everything it must leave the import to happen on a later launch.
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory, { .resourceLoadStatisticsDirectory = statisticsDirectory, .trackingPreventionEnabled = false });
+        auto [webView, navigationDelegate] = webViewForDataStore(dataStore.get());
+
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+
+        removeIsolatedSiteDataSince(dataStore.get(), [NSDate dateWithTimeIntervalSinceNow:-3600]);
+    }
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory, { .resourceLoadStatisticsDirectory = statisticsDirectory, .trackingPreventionEnabled = true });
+        EXPECT_TRUE(Util::waitFor([&] {
+            return !!(isolatedSiteSignals(dataStore.get(), @"https://webkit.org/") & firstPartyVisitSignal);
+        }));
+        // Recorded within the cleared range, and not something the import brings back.
+        EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://example.com/"]]);
+    }
+}
+
+TEST(IsolatedSiteStore, DataRemovalDoesNotImport)
+{
+    HTTPServer server({
+        { "/example"_s, { "example as a top-level page"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    NSURL *directory = temporaryDirectoryForIsolatedSiteStoreTest(@"IsolatedSiteStoreRemovalDoesNotImport");
+    NSURL *statisticsDirectory = temporaryDirectoryForIsolatedSiteStoreTest(@"IsolatedSiteStoreRemovalDoesNotImportITP");
+    writeResourceLoadStatisticsDatabase(statisticsDirectory);
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory, { .resourceLoadStatisticsDirectory = statisticsDirectory, .trackingPreventionEnabled = true });
+
+        // The removal must also record the import as done, or the next launch brings the entries back.
+        removeIsolatedSiteDataSince(dataStore.get(), [NSDate distantPast]);
+        EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://webkit.org/"]]);
+    }
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory, { .resourceLoadStatisticsDirectory = statisticsDirectory, .trackingPreventionEnabled = true });
+        auto [webView, navigationDelegate] = webViewForDataStore(dataStore.get());
+
+        // Waited on so that the check below cannot pass merely by being early.
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+        EXPECT_TRUE(Util::waitFor([&] {
+            return !!(isolatedSiteSignals(dataStore.get(), @"https://example.com/") & firstPartyVisitSignal);
+        }));
+
+        EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://webkit.org/"]]);
+    }
+}
+
+TEST(IsolatedSiteStore, ImportsWhenTrackingPreventionIsTurnedOnLater)
+{
+    HTTPServer server({
+        { "/example"_s, { "example as a top-level page"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    NSURL *directory = temporaryDirectoryForIsolatedSiteStoreTest(@"IsolatedSiteStoreImport");
+    NSURL *statisticsDirectory = temporaryDirectoryForIsolatedSiteStoreTest(@"IsolatedSiteStoreImportITP");
+    writeResourceLoadStatisticsDatabase(statisticsDirectory);
+
+    // Tracking prevention is off, so the store must not record that it has imported.
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory, { .resourceLoadStatisticsDirectory = statisticsDirectory, .trackingPreventionEnabled = false });
+        auto [webView, navigationDelegate] = webViewForDataStore(dataStore.get());
+
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+
+        EXPECT_TRUE(isolatedSiteSignals(dataStore.get(), @"https://example.com/") & firstPartyVisitSignal);
+        EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://webkit.org/"]]);
+    }
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory, { .resourceLoadStatisticsDirectory = statisticsDirectory, .trackingPreventionEnabled = true });
+        EXPECT_TRUE(Util::waitFor([&] {
+            return !!(isolatedSiteSignals(dataStore.get(), @"https://webkit.org/") & firstPartyVisitSignal);
+        }));
+        EXPECT_TRUE(isolatedSiteSignals(dataStore.get(), @"https://webkit.org/") & firstPartyUserGestureSignal);
+
+        // Surviving a cleared range that does not reach back to the seeded interaction is what says
+        // the entry carries that time rather than the time it was imported.
+        removeIsolatedSiteDataSince(dataStore.get(), [NSDate dateWithTimeIntervalSinceNow:-3600]);
+        EXPECT_TRUE(isolatedSiteSignals(dataStore.get(), @"https://webkit.org/") & firstPartyVisitSignal);
+    }
+}
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### eab29afc94f6123806de5d36d13f5089b9061767
<pre>
[Site Isolation] Introduce persistent backend for IsolatedSiteStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=321572">https://bugs.webkit.org/show_bug.cgi?id=321572</a>
<a href="https://rdar.apple.com/184681796">rdar://184681796</a>

Reviewed by Ryosuke Niwa.

IsolatedSiteStore was per-session and in-memory, so a site promoted by a first-party visit, a gesture or an autofill was
forgotten at restart. Placement also consulted ITP&apos;s hadUserInteraction set on every shared-process decision, so site
isolation stopped working as soon as tracking prevention was turned off.

To fix these, add a persistent backend for IsolatedSiteStore and remove dependency on ITP.

- Add IsolatedSitePersistence, a SQLite database per WKWebsiteDataStore holding each site&apos;s registrable domain, its
signals, and when a signal for it was last observed, plus whether the one-time import from tracking prevention has
happened. The schema is versioned with PRAGMA user_version so a later column is an added migration step; an
uninterpretable file is recreated, a transient failure such as a full disk is not.

- IsolatedSiteStore owns one for non-ephemeral sessions and remains the only read source: it keeps the full set in
memory, since placement needs a synchronous answer, and writes through. Bring-up is staged — open and read the database,
then, if ITP is enabled, import its user-interaction domains once and record that as done, so it is never asked again.
An ephemeral session has no database and so never imports. Placement waits for the import to resolve, since it wants the
seeded entries. Removal and fetching wait only for the database read, so that asking to inspect or delete this data
cannot cause it to be seeded first. Clearing everything skips a pending import outright and still records it as done,
which avoids importing entries only to delete them and keeps the same browsing from returning out of ITP&apos;s copy of it.
Narrower removals leave the import alone: clearing an hour, or one site, says nothing about history predating this store.

- Placement no longer consults ITP at all, since the store now holds that data itself. sharedProcessForSite drops its
fetchDomainsWithUserInteraction() call, processForSite loses the isolatedDomains parameter that only that caller used,
and  didHaveUserInteractionForSiteIsolation goes away along with the frameID parameter of
recordUserGestureAuthorizationToken that existed only for it.

- Imported domains are tagged FirstPartyVisit and FirstPartyUserGesture, since an interaction implies a visit and also
covers autofill and WebAuthn completion, and they carry ITP&apos;s own mostRecentUserInteractionTime rather than the time of
the import, so eviction can tell recent use from old. FetchWebsitesWithUserInteractions and the store methods behind it
therefore return a timestamp per domain, and return a std::optional so that &quot;nothing recorded&quot; is  distinguishable from
&quot;could not be read&quot;: only the former records the import as done, so a failure retries on a later launch instead of
losing the seeding for good.

- Add WebsiteDataType::IsolatedSiteRecord, scoped to the data store, so this data can be fetched and removed like any
other website data — whole store, by modification time, or per domain. The cutoff is rounded down to a day like the
entries themselves, so it over-deletes rather than under-deletes.

Tests: IsolatedSiteStore.PersistsAcrossSessions
       IsolatedSiteStore.DataRemoval
       IsolatedSiteStore.ImportsWhenTrackingPreventionIsTurnedOnLater
       IsolatedSiteStore.PartialDataRemovalAllowsImport
       IsolatedSiteStore.DataRemovalDoesNotImport

* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::loadWebsitesWithUserInteraction):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::loadWebsitesWithUserInteraction):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::fetchWebsitesWithUserInteractions):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/Shared/WebsiteData/WebsiteData.cpp:
(WebKit::WebsiteData::ownerProcess):
* Source/WebKit/Shared/WebsiteData/WebsiteDataType.h:
(WebKit::toString):
* Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
(dataTypesToString):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h:
(WebKit::toWebsiteDataType):
(WebKit::toWKWebsiteDataTypes):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore _allWebsiteDataTypesIncludingPrivate]):
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::sharedProcessForSite):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::sendMouseEvent):
(WebKit::WebPageProxy::sendKeyEvent):
(WebKit::WebPageProxy::sendPreventableTouchEvent):
(WebKit::WebPageProxy::sendUnpreventableTouchEvent):
(WebKit::WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation):
(WebKit::WebPageProxy::triggerProcessSwapForEnhancedSecurity):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForSite):
(WebKit::WebProcessPool::createWebPage):
(WebKit::WebProcessPool::prepareProcessForNavigation):
(WebKit::WebProcessPool::processForNavigationInternal):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::recordUserGestureAuthorizationToken):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::defaultIsolatedSitesDirectory):
* Source/WebKit/UIProcess/WebsiteData/IsolatedSitePersistence.cpp: Added.
(WebKit::IsolatedSitePersistence::IsolatedSitePersistence):
(WebKit::IsolatedSitePersistence::~IsolatedSitePersistence):
(WebKit::IsolatedSitePersistence::reportSQLError):
(WebKit::IsolatedSitePersistence::reportSQLErrorAndClassify):
(WebKit::databasePath):
(WebKit::IsolatedSitePersistence::openDatabase):
(WebKit::IsolatedSitePersistence::openDatabaseAtPath):
(WebKit::IsolatedSitePersistence::closeDatabase):
(WebKit::IsolatedSitePersistence::allSites):
(WebKit::IsolatedSitePersistence::setRecordForSite):
(WebKit::IsolatedSitePersistence::deleteAllSites):
(WebKit::IsolatedSitePersistence::deleteSitesUpdatedSince):
(WebKit::IsolatedSitePersistence::deleteSites):
(WebKit::IsolatedSitePersistence::didImportUserInteractions):
(WebKit::IsolatedSitePersistence::setDidImportUserInteractions):
* Source/WebKit/UIProcess/WebsiteData/IsolatedSitePersistence.h: Copied from Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h.
* Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp:
(WebKit::roundDownToDay):
(WebKit::today):
(WebKit::IsolatedSiteStore::sharedWorkQueueSingleton):
(WebKit::IsolatedSiteStore::create):
(WebKit::IsolatedSiteStore::IsolatedSiteStore):
(WebKit::IsolatedSiteStore::~IsolatedSiteStore):
(WebKit::IsolatedSiteStore::didLoadSites):
(WebKit::IsolatedSiteStore::whenLoaded):
(WebKit::IsolatedSiteStore::skipImport):
(WebKit::IsolatedSiteStore::importUserInteractions):
(WebKit::IsolatedSiteStore::becomeReady):
(WebKit::IsolatedSiteStore::whenReady):
(WebKit::IsolatedSiteStore::saveSite):
(WebKit::IsolatedSiteStore::recordSignals):
(WebKit::IsolatedSiteStore::addSite):
(WebKit::IsolatedSiteStore::allDomains):
(WebKit::IsolatedSiteStore::removeAllSites):
(WebKit::IsolatedSiteStore::removeSitesUpdatedSince):
(WebKit::IsolatedSiteStore::removeSites):
(WebKit::IsolatedSiteStore::reasonsFor const):
(WebKit::IsolatedSiteStore::contains const):
(WebKit::IsolatedSiteStore::containsDomain const):
* Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::resolveDirectories):
(WebKit::WebsiteDataStore::fetchDomainsWithUserInteraction):
(WebKit::WebsiteDataStore::fetchDataAndApply):
(WebKit::WebsiteDataStore::removeData):
(WebKit::WebsiteDataStore::isolatedSiteStore):
(WebKit::WebsiteDataStore::isolatedSiteSignalsForTesting):
(WebKit::WebsiteDataStore::defaultIsolatedSitesDirectory):
(WebKit::WebsiteDataStore::didHaveUserInteractionForSiteIsolation): Deleted.
(WebKit::WebsiteDataStore::isolatedSiteSignalsForTesting const): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::isolatedSiteStore): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::initializePaths):
(WebKit::WebsiteDataStoreConfiguration::Directories::isolatedCopy const):
(WebKit::WebsiteDataStoreConfiguration::Directories::isolatedCopy):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::setIsolatedSitesDirectory):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, SharedProcessWithResourceLoadStatistics)):
(TestWebKitAPI::(SiteIsolation, SharedProcessAfterClick)):
(TestWebKitAPI::(SiteIsolation, SharedProcessAfterKeyDown)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm:
(TestWebKitAPI::(IsolatedSiteStore, PersistsAcrossSessions)):
(TestWebKitAPI::(IsolatedSiteStore, DataRemoval)):
(TestWebKitAPI::(IsolatedSiteStore, PartialDataRemovalAllowsImport)):
(TestWebKitAPI::(IsolatedSiteStore, DataRemovalDoesNotImport)):
(TestWebKitAPI::(IsolatedSiteStore, ImportsWhenTrackingPreventionIsTurnedOnLater)):

Canonical link: <a href="https://commits.webkit.org/319151@main">https://commits.webkit.org/319151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b59e3261e9a95f1e6e7479b2b13b255816302660

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7d35887-4552-47e3-9eaf-a188f56c40e0) 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36fd9c50-f4e3-4c36-82a3-91bf21023ded) 
| [⏳ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d026fa4-725d-4750-bfb6-5b7173c6fc11) 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40217 "Built successfully and passed tests") | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->