### PR TITLE
[GFC] Update affectedTracksMatchingMinSizeFunction to handle all phases

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -60,14 +60,17 @@ enum class ExtraSpaceDistributionTarget : bool { BaseSizes, GrowthLimits };
 // Content and flexible tracks are resolved in separate phases.
 enum class ResolveIntrinsicTrackSizesPhase : bool { ContentSizedTracks, FlexibleTracks };
 
-// The min track sizing functions a base-size pass of https://drafts.csswg.org/css-grid-1/#algo-spanning-items
-// distributes space to. Legacy names these passes ResolveIntrinsicMinimums, ResolveContentBasedMinimums
-// and ResolveMaxContentMinimums in TrackSizeComputationPhase, the last covering both halves of item 3.
-enum class MinTrackSizingFunctionType : uint8_t {
-    Intrinsic, // Item 1: "tracks with an intrinsic min track sizing function".
-    MinContentOrMaxContent, // Item 2: "a min track sizing function of min-content or max-content".
-    AutoOrMaxContent, // Item 3, under a max-content constraint: "a min track sizing function of auto or max-content".
-    MaxContent // Item 3, in all cases: "a min track sizing function of max-content".
+// The passes of https://drafts.csswg.org/css-grid-1/#algo-spanning-items, one per item, each named
+// after the track sizing function it distributes space to. Legacy's TrackSizeComputationPhase
+// enumerates the same items, except that a single ResolveMaxContentMinimums covers both halves of
+// item 3.
+enum class GridItemSizeContributionType : uint8_t {
+    ForIntrinsicMinimums, // Item 1: "tracks with an intrinsic min track sizing function".
+    ForContentBasedMinimums, // Item 2: "a min track sizing function of min-content or max-content".
+    ForAutoOrMaxContentMinimums, // Item 3, under a max-content constraint: "a min track sizing function of auto or max-content".
+    ForMaxContentMinimums, // Item 3, in all cases: "a min track sizing function of max-content".
+    ForIntrinsicMaximums, // Item 5: "tracks with intrinsic max track sizing function".
+    ForMaxContentMaximums // Item 6: "tracks with a max track sizing function of max-content".
 };
 
 struct UnsizedTrack {
@@ -467,6 +470,8 @@ static Vector<size_t> indexesForUnfrozenAffectedTracks(const Vector<size_t>& spa
 
 // Distributes space equally among trackIndexes in successive rounds, freezing tracks (per
 // spaceDistributedToTrack, below) as needed, until space is exhausted or no tracks remain unfrozen.
+// FIXME: https://drafts.csswg.org/css-grid-1/#algo-spanning-flex-items update to handle flex tracks
+// which do not distribute space equally, but according to their flex factor.
 static void distributeSpaceEquallyAmongTracks(LayoutUnit& space, const Vector<size_t>& trackIndexes,
     const UnsizedTracks& unsizedTracks, Vector<LayoutUnit>& itemIncurredIncreases, ExtraSpaceDistributionTarget target, SpaceDistributionLimit limit)
 {
@@ -505,6 +510,50 @@ static void distributeSpaceEquallyAmongTracks(LayoutUnit& space, const Vector<si
         }
         unfrozenTrackIndexes = indexesForUnfrozenAffectedTracks(trackIndexes, unsizedTracks, itemIncurredIncreases, target, limit);
     }
+}
+
+// https://drafts.csswg.org/css-grid-1/#algo-spanning-items
+static bool shouldTrackAccommodateContributionType(const UnsizedTrack& track, GridItemSizeContributionType sizeContributionType)
+{
+    auto& minTrackSizingFunction = track.trackSizingFunction.min;
+    auto& maxTrackSizingFunction = track.trackSizingFunction.max;
+    switch (sizeContributionType) {
+    case GridItemSizeContributionType::ForIntrinsicMinimums:
+        return minTrackSizingFunction.isContentSized();
+    case GridItemSizeContributionType::ForContentBasedMinimums:
+        return minTrackSizingFunction.isLength() && (minTrackSizingFunction.length().isMinContent() || minTrackSizingFunction.length().isMaxContent());
+    case GridItemSizeContributionType::ForAutoOrMaxContentMinimums:
+        return minTrackSizingFunction.isAuto() || (minTrackSizingFunction.isLength() && minTrackSizingFunction.length().isMaxContent());
+    case GridItemSizeContributionType::ForMaxContentMinimums:
+        return minTrackSizingFunction.isLength() && minTrackSizingFunction.length().isMaxContent();
+    case GridItemSizeContributionType::ForIntrinsicMaximums:
+        return maxTrackSizingFunction.isContentSized();
+    case GridItemSizeContributionType::ForMaxContentMaximums:
+        // https://drafts.csswg.org/css-grid-1/#track-sizing
+        // As a maximum, auto "represents the largest max-content contribution of the grid items
+        // occupying the grid track", so it is accommodated together with max-content here.
+        return maxTrackSizingFunction.isAuto()
+            || (maxTrackSizingFunction.isLength() && maxTrackSizingFunction.length().isMaxContent());
+    }
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
+// Whether a track participates in the given phase: the content sized phase distributes space to
+// tracks which are not flexible, the flexible phase only to flexible tracks.
+// https://drafts.csswg.org/css-grid-1/#algo-spanning-flex-items
+// "...distributing space only to flexible tracks (i.e. treating all other tracks as having a fixed
+// sizing function)."
+static bool isTrackAffectedForSpaceDistributionInPhase(const UnsizedTrack& track, ResolveIntrinsicTrackSizesPhase phase)
+{
+    switch (phase) {
+    case ResolveIntrinsicTrackSizesPhase::ContentSizedTracks:
+        return !track.trackSizingFunction.max.isFlex();
+    case ResolveIntrinsicTrackSizesPhase::FlexibleTracks:
+        return track.trackSizingFunction.max.isFlex();
+    }
+    ASSERT_NOT_REACHED();
+    return false;
 }
 
 // https://drafts.csswg.org/css-grid-1/#extra-space
@@ -599,38 +648,12 @@ static void distributeExtraSpace(ExtraSpaceDistributionTarget spaceDistributionT
     }
 }
 
-// Collects the tracks whose min track sizing function the given base-size pass distributes space to.
-static TrackIndexes affectedTracksMatchingMinSizeFunction(const UnsizedTracks& unsizedTracks, MinTrackSizingFunctionType minTrackSizingFunctionType, ResolveIntrinsicTrackSizesPhase phase)
+// Collects the tracks the given pass distributes space to.
+static TrackIndexes affectedTracks(const UnsizedTracks& unsizedTracks, GridItemSizeContributionType sizeContributionType, ResolveIntrinsicTrackSizesPhase phase)
 {
-    auto isMinTrackSizingFunctionValidForType = [&](const auto& minTrackSizingFunction) {
-        switch (minTrackSizingFunctionType) {
-        case MinTrackSizingFunctionType::Intrinsic:
-            return minTrackSizingFunction.isContentSized();
-        case MinTrackSizingFunctionType::MinContentOrMaxContent:
-            return minTrackSizingFunction.isLength() && (minTrackSizingFunction.length().isMinContent() || minTrackSizingFunction.length().isMaxContent());
-        case MinTrackSizingFunctionType::AutoOrMaxContent:
-            return minTrackSizingFunction.isAuto() || (minTrackSizingFunction.isLength() && minTrackSizingFunction.length().isMaxContent());
-        case MinTrackSizingFunctionType::MaxContent:
-            return minTrackSizingFunction.isLength() && minTrackSizingFunction.length().isMaxContent();
-        }
-        ASSERT_NOT_REACHED();
-        return false;
-    };
-
-    auto isMaxTrackSizingFunctionValidForPhase = [&](const auto& maxTrackSizingFunction) {
-        switch (phase) {
-        case ResolveIntrinsicTrackSizesPhase::ContentSizedTracks:
-            return !maxTrackSizingFunction.isFlex();
-        case ResolveIntrinsicTrackSizesPhase::FlexibleTracks:
-            return maxTrackSizingFunction.isFlex();
-        }
-        ASSERT_NOT_REACHED();
-        return false;
-    };
-
     TrackIndexes trackIndexes;
     for (auto [trackIndex, track] : WTF::indexedRange(unsizedTracks)) {
-        if (isMinTrackSizingFunctionValidForType(track.trackSizingFunction.min) && isMaxTrackSizingFunctionValidForPhase(track.trackSizingFunction.max))
+        if (shouldTrackAccommodateContributionType(track, sizeContributionType) && isTrackAffectedForSpaceDistributionInPhase(track, phase))
             trackIndexes.append(trackIndex);
     }
     return trackIndexes;
@@ -668,7 +691,7 @@ static void resolveIntrinsicTrackSizesWithSpanningItems(const ResolveIntrinsicTr
     // min track sizing function, to accommodate these items' minimum contributions. If the grid
     // container is being sized under a min-/max-content constraint, use the items' limited min-content
     // contributions instead.
-    auto tracksWithIntrinsicMinimums = affectedTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::Intrinsic, phase);
+    auto tracksWithIntrinsicMinimums = affectedTracks(unsizedTracks, GridItemSizeContributionType::ForIntrinsicMinimums, phase);
     auto minimumSizeContributions = isSizedUnderMinOrMaxContentConstraint(resolveIntrinsicTrackSizesContext.axisConstraint)
         ? limitedContentContributions(minContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions), fixedMaxTrackSizingFunctionSums, minimumContributionsList)
         : minimumContributionsList;
@@ -678,20 +701,20 @@ static void resolveIntrinsicTrackSizesWithSpanningItems(const ResolveIntrinsicTr
     // a min track sizing function of min-content or max-content, to accommodate the items' min-content
     // contributions.
     auto minContentSizeContributions = minContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions);
-    auto tracksWithContentBasedMinimums = affectedTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::MinContentOrMaxContent, phase);
+    auto tracksWithContentBasedMinimums = affectedTracks(unsizedTracks, GridItemSizeContributionType::ForContentBasedMinimums, phase);
     distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, tracksWithContentBasedMinimums, minContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
 
     // 3. For max-content minimums: if the grid container is being sized under a max-content constraint
     if (scenario == AxisConstraint::FreeSpaceScenario::MaxContent) {
         // continue to distribute extra space to the base sizes of tracks with a min track sizing function
         // of auto or max-content, to accommodate the items' limited max-content contributions...
-        auto tracksWithAutoOrMaxContentMinimums = affectedTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::AutoOrMaxContent, phase);
+        auto tracksWithAutoOrMaxContentMinimums = affectedTracks(unsizedTracks, GridItemSizeContributionType::ForAutoOrMaxContentMinimums, phase);
         auto limitedMaxContentSizeContributions = limitedContentContributions(maxContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions), fixedMaxTrackSizingFunctionSums, minimumContributionsList);
         distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, tracksWithAutoOrMaxContentMinimums, limitedMaxContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
     }
     // ...In all cases, distribute to tracks with a max-content min track sizing function
     // to accommodate the items' max-content contributions.
-    auto tracksWithMaxContentMinimums = affectedTracksMatchingMinSizeFunction(unsizedTracks, MinTrackSizingFunctionType::MaxContent, phase);
+    auto tracksWithMaxContentMinimums = affectedTracks(unsizedTracks, GridItemSizeContributionType::ForMaxContentMinimums, phase);
     auto maxContentSizeContributions = maxContentContributions(trackSizingItems, spanningItems, gridItemSizingFunctions);
     distributeExtraSpace(ExtraSpaceDistributionTarget::BaseSizes, tracksWithMaxContentMinimums, maxContentSizeContributions, spanningItems, gridItemSpanList, unsizedTracks, gapSize);
 
@@ -708,11 +731,15 @@ static void resolveIntrinsicTrackSizesWithSpanningItems(const ResolveIntrinsicTr
     //    intrinsic max track sizing function, to accommodate these items' min-content contributions.
     //    Not applicable: a flexible track's max track sizing function is <flex>, which is not an
     //    intrinsic max track sizing function, so no flexible track is affected.
+    auto tracksWithIntrinsicMaximums = affectedTracks(unsizedTracks, GridItemSizeContributionType::ForIntrinsicMaximums, phase);
+    UNUSED_VARIABLE(tracksWithIntrinsicMaximums);
 
     // 6. For max-content maximums: distribute extra space to the growth limits of tracks with a
     //    max-content max track sizing function, to accommodate these items' max-content contributions.
     //    Not applicable: a flexible track's max track sizing function is <flex>, not max-content, so no
     //    flexible track is affected.
+    auto tracksWithMaxContentMaximums = affectedTracks(unsizedTracks, GridItemSizeContributionType::ForMaxContentMaximums, phase);
+    UNUSED_VARIABLE(tracksWithMaxContentMaximums);
 }
 
 // https://drafts.csswg.org/css-grid-1/#algo-content


### PR DESCRIPTION
#### a393d6c9433905905c7ccec8b904376283d4c5fd
<pre>
[GFC] Update affectedTracksMatchingMinSizeFunction to handle all phases
<a href="https://bugs.webkit.org/show_bug.cgi?id=321574">https://bugs.webkit.org/show_bug.cgi?id=321574</a>
&lt;<a href="https://rdar.apple.com/184683817">rdar://184683817</a>&gt;

Reviewed by Sammy Gill.

affectedTracksMatchingMinSizeFunction has been renamed to affectedTracks
and updated to support space distributions across tracks&apos; intrinsic
maximums and max-content maximums, steps 5 and 6 of:

<a href="https://www.w3.org/TR/css-grid-1/#track-size-max-content-min">https://www.w3.org/TR/css-grid-1/#track-size-max-content-min</a>

This refactor also updates:

MinTrackSizingFunctionType -&gt; GridItemSizeContributionType

and adds ForIntrinsicMaximums and ForMaxContentMaximums
to the renamed enum class.

We have also renamed

isMinTrackSizingFunctionValidForType -&gt; shouldTrackAccommodateContributionType
isMaxTrackSizingFunctionValidForPhase -&gt; isTrackAffectedForSpaceDistributionInPhase

To better reflect the new track sizing steps we are supporting.

The affected track lists in steps 5 and 6 of:

<a href="https://www.w3.org/TR/css-grid-1/#track-size-max-content-min">https://www.w3.org/TR/css-grid-1/#track-size-max-content-min</a>

Are created and temporarily marked as UNUSED_VARIABLE

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::isContributionAppliedToTrack):
(WebCore::Layout::isTrackAffectedInPhase):
(WebCore::Layout::affectedTracks):
(WebCore::Layout::resolveIntrinsicTrackSizesWithSpanningItems):
(WebCore::Layout::affectedTracksMatchingMinSizeFunction): Deleted.
(WebCore::Layout::isTrackAffectedForSpaceDistributionInPhase):
(WebCore::Layout::shouldTrackAccommodateContributionType):

Canonical link: <a href="https://commits.webkit.org/319056@main">https://commits.webkit.org/319056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecc172a1f7e27123cd6f1d7f705dc9971ab1b0d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190552 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10e5c1c7-08a7-4dc0-9c93-0f6ad374a6e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54002 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c33efa9-1238-4057-a9d3-77ab217b42f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183296 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/44319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121116 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/78f6e238-90be-4249-8a0d-5481b47f7c09) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40969 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1711 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192487 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53952 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54640 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149741 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27368 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44374 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122065 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53157 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15958 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52539 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52604 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->