### PR TITLE
Test for 318045@main

### DIFF
--- a/LayoutTests/media/video-large-data-url-expected.txt
+++ b/LayoutTests/media/video-large-data-url-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A video element loads a data: url larger than 2MB without terminating any process
+

--- a/LayoutTests/media/video-large-data-url.html
+++ b/LayoutTests/media/video-large-data-url.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML>
+<title>Test that a video element can load a data: url larger than the 2MB URL size limit</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="media-file.js"></script>
+<script>
+// A data: url longer than WTF::maxURLLength (2MB) used to fail to decode when the
+// MediaPlayer's Load message was received by the GPU process, which then terminated
+// the WebContent process.
+const minimumURLLength = 2 * 1024 * 1024;
+
+function base64Encode(bytes)
+{
+    let string = "";
+    const chunkSize = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunkSize)
+        string += String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize));
+    return btoa(string);
+}
+
+// Returns the media file contained in `url` with a trailing ISO-BMFF 'free' box
+// appended to it, whose content is ignored by demuxers, so that the resulting data:
+// url is longer than `minimumLength` characters.
+function padDataURL(url, minimumLength)
+{
+    const dataStart = url.indexOf(",") + 1;
+    const header = url.substring(0, dataStart).replace(/\s/g, "");
+    const bytes = Uint8Array.from(atob(url.substring(dataStart).replace(/\s/g, "")), character => character.charCodeAt(0));
+
+    // 3 bytes of data produce 4 base64 characters.
+    const paddedSize = Math.max(3 * Math.ceil((minimumLength - header.length) / 4) + 3, bytes.length + 8);
+    const padded = new Uint8Array(paddedSize);
+    padded.set(bytes);
+
+    const box = new DataView(padded.buffer, bytes.length);
+    box.setUint32(0, padded.length - bytes.length);
+    for (const [index, character] of [..."free"].entries())
+        box.setUint8(4 + index, character.charCodeAt(0));
+
+    return header + base64Encode(padded);
+}
+
+promise_test(async (test) => {
+    const video = document.createElement("video");
+
+    const url = findDataURL("video");
+    assert_not_equals(url, "", "a supported video data: url was found");
+
+    const largeURL = padDataURL(url, minimumURLLength);
+    assert_greater_than(largeURL.length, minimumURLLength, "data: url length");
+
+    const loadedmetadata = new Promise((resolve, reject) => {
+        video.onloadedmetadata = resolve;
+        video.onerror = () => reject(new Error(`video failed to load: ${video.error ? video.error.message : "unknown error"}`));
+    });
+
+    video.src = largeURL;
+    await loadedmetadata;
+
+    assert_greater_than(video.videoWidth, 0, "videoWidth");
+    assert_greater_than(video.videoHeight, 0, "videoHeight");
+}, "A video element loads a data: url larger than 2MB without terminating any process");
+</script>


### PR DESCRIPTION
#### f8c837214feb4a806add1b62761e9162dea995a1
<pre>
Test for 318045@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=321576">https://bugs.webkit.org/show_bug.cgi?id=321576</a>
<a href="https://rdar.apple.com/184684164">rdar://184684164</a>

Reviewed by Chris Dumez.

Ensure that data URL greater than 2MB do not cause the web content process to be killed.

* LayoutTests/media/video-large-data-url-expected.txt: Added.
* LayoutTests/media/video-large-data-url.html: Added.

Canonical link: <a href="https://commits.webkit.org/319035@main">https://commits.webkit.org/319035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6726b628bdb891687e2da0a663f28a17e81d59a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190437 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144547 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02c9ab9c-cebd-4a95-81ac-c90c1d7da9ff) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53887 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140566 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc61babe-f597-41b2-90f9-df672df3a678) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121018 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1f95f24-8346-4928-9713-5e51ae9ab3f6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41204 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40881 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1596 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192372 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149912 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40146 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54525 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149641 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44280 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121936 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53042 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15870 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52424 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52661 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52489 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->