### PR TITLE
[SwiftUI WebKit API] WebPage.backForwardList is extremely unreliable

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -338,6 +338,12 @@ module WebKit_Internal [system] {
         requires objc
     }
 
+    module WKBackForwardListItemInternal {
+        header "../../UIProcess/API/Cocoa/WKBackForwardListItemInternal.h"
+        export *
+        requires objc
+    }
+
     module WKScrollGeometry {
         header "../../UIProcess/API/Cocoa/WKScrollGeometry.h"
         export *

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -103,3 +103,17 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 }
 
 @end
+
+@implementation WKBackForwardListItem (NonCpp)
+
+- (uint64_t)_identifier
+{
+    return _item->identifier().object().toUInt64();
+}
+
+- (uint64_t)_identifierProcess
+{
+    return _item->identifier().processIdentifier().toUInt64();
+}
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemInternal.h
@@ -25,6 +25,8 @@
 
 #import "WKBackForwardListItemPrivate.h"
 
+#ifdef __cplusplus
+
 #import "WKObject.h"
 #import "WebBackForwardListItem.h"
 
@@ -39,5 +41,14 @@ template<> struct WrapperTraits<WebBackForwardListItem> {
 @interface WKBackForwardListItem () <WKObject>
 
 @property (readonly) WebKit::WebBackForwardListItem& _item;
+
+@end
+
+#endif // __cplusplus
+
+@interface WKBackForwardListItem (NonCpp)
+
+@property (nonatomic, readonly) uint64_t _identifier;
+@property (nonatomic, readonly) uint64_t _identifierProcess;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHistoryDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHistoryDelegatePrivate.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class WKWebView;
 @class SSBLookupResult;
 
+NS_SWIFT_UI_ACTOR
 @protocol WKHistoryDelegatePrivate <NSObject>
 
 @optional

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift
@@ -24,6 +24,7 @@
 #if ENABLE_SWIFTUI
 
 public import Foundation
+private import WebKit_Internal.WKBackForwardListItemInternal
 
 @available(anyAppleOSAndDownlevels 26.0, *)
 @_spi_available(watchOSAndOpenSourceTBA, *)
@@ -108,20 +109,33 @@ extension WebPage {
         public struct Item: Equatable, Identifiable, Sendable {
             /// An opaque type representing the identifier for an item.
             public struct ID: Hashable, Sendable {
-                private let value = UUID()
+                @MainActor
+                init(_ wrapped: WKBackForwardListItem) {
+                    self.value = wrapped._identifier
+                    self.processIdentifier = wrapped._identifierProcess
+                }
+
+                private let value: UInt64
+                private let processIdentifier: UInt64
             }
 
             @MainActor
             init(_ wrapped: WKBackForwardListItem) {
                 self.wrapped = wrapped
 
+                self.id = ID(wrapped)
                 self.title = wrapped.title
                 self.url = wrapped.url
                 self.initialURL = wrapped.initialURL
             }
 
+            // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+            public static func == (lhs: Self, rhs: Self) -> Bool {
+                lhs.id == rhs.id && lhs.title == rhs.title && lhs.url == rhs.url && lhs.initialURL == rhs.initialURL
+            }
+
             /// The unique identifier for the item.
-            public let id: ID = ID()
+            public let id: ID
 
             /// The title of the page this item represents.
             ///
@@ -138,32 +152,26 @@ extension WebPage {
             let wrapped: WKBackForwardListItem
         }
 
-        init(_ wrapped: WKBackForwardList? = nil) {
-            self.wrapped = wrapped
+        init(_ wrapped: WKBackForwardList) {
+            self.backList = wrapped.backList.map(Item.init(_:))
+            self.currentItem = wrapped.currentItem.map(Item.init(_:))
+            self.forwardList = wrapped.forwardList.map(Item.init(_:))
         }
 
         /// The array of items that precede the current item.
         ///
         /// The items are in the order in which the page originally visited them.
-        public var backList: [Item] {
-            wrapped?.backList.map(Item.init(_:)) ?? []
-        }
+        public let backList: [Item]
 
         /// The current item.
         ///
         /// When the webpage has not loaded any resources, this value will be `nil`.
-        public var currentItem: Item? {
-            wrapped?.currentItem.map(Item.init(_:))
-        }
+        public let currentItem: Item?
 
         /// The array of items that follow the current item.
         ///
         /// The items are in the order in which they were originally visited.
-        public var forwardList: [Item] {
-            wrapped?.forwardList.map(Item.init(_:)) ?? []
-        }
-
-        private var wrapped: WKBackForwardList? = nil
+        public let forwardList: [Item]
 
         /// Accesses the item at the relative offset from the current item.
         ///
@@ -171,7 +179,13 @@ extension WebPage {
         /// `-1` for the immediately preceding item, `1` for the immediately following item, and so on.
         /// - Returns: The item at the specified offset from the current item, or `nil` if the index exceeds the limits of the list.
         public subscript(_ index: Int) -> Item? {
-            wrapped?.item(at: index).map(Item.init(_:))
+            if index < 0 {
+                backList.count + index >= 0 ? backList[backList.count + index] : nil
+            } else if index > 0 {
+                index - 1 < forwardList.count ? forwardList[index - 1] : nil
+            } else {
+                currentItem
+            }
         }
     }
 }

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -223,7 +223,10 @@ final public class WebPage {
     let configuration: Configuration
 
     /// The webpage's back-forward list.
-    public internal(set) var backForwardList: BackForwardList = BackForwardList()
+    public var backForwardList: BackForwardList {
+        access(keyPath: \.backForwardList)
+        return BackForwardList(backingWebView.backForwardList)
+    }
 
     /// A sequence of all the navigation events that occur throughout the webpage, including both user navigation
     /// and programmatic navigation.
@@ -382,6 +385,7 @@ final public class WebPage {
     public lazy var backingWebView: WebPageWebView = {
         let webView = WebPageWebView(frame: Self.defaultFrame, configuration: WKWebViewConfiguration(configuration))
         webView.navigationDelegate = backingNavigationDelegate
+        webView._historyDelegate = backingNavigationDelegate
         webView.uiDelegate = backingUIDelegate
         #if WTF_PLATFORM_MAC
         webView._usePlatformFindUI = false
@@ -677,6 +681,12 @@ extension WebPage {
                 observation.invalidate()
             }
         }
+    }
+
+    func didChangeBackForwardList() {
+        // `backForwardList` reads through to the backing web view, so there is no stored value to update
+        // here; the mutation exists solely to notify observers that the list has changed.
+        withMutation(keyPath: \.backForwardList) {}
     }
 
     func addEditorStateUpdate(_ newEditorState: [AnyHashable: Any]) {

--- a/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
@@ -30,7 +30,8 @@ private struct DefaultNavigationDecider: WebPage.NavigationDeciding {
 }
 
 @MainActor
-final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate {
+@_expose(!Cxx)
+final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate, WKHistoryDelegatePrivate {
     init(navigationDecider: (any WebPage.NavigationDeciding)?) {
         self.navigationDecider = navigationDecider ?? DefaultNavigationDecider()
     }
@@ -95,7 +96,13 @@ final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate {
         backForwardListItemAdded itemAdded: WKBackForwardListItem!,
         removed itemsRemoved: [WKBackForwardListItem]!
     ) {
-        owner?.backForwardList = .init(webView.backForwardList)
+        owner?.didChangeBackForwardList()
+    }
+
+    // swift-format-ignore: NoLeadingUnderscores
+    @objc(_webView:didUpdateHistoryTitle:forURL:)
+    func _webView(_ webView: WKWebView, didUpdateHistoryTitle title: String, for url: URL) {
+        owner?.didChangeBackForwardList()
     }
 
     // MARK: Navigation decisions

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift
@@ -24,6 +24,7 @@
 #if ENABLE_SWIFTUI
 
 import Testing
+private import Observation
 @_spi(Testing) import WebKit
 private import TestWebKitAPILibrary
 
@@ -171,6 +172,168 @@ struct WebPageNavigationTests {
         try await Task.sleep(for: .seconds(10))
 
         #expect(page.title == "A title")
+    }
+
+    @Test(.bug("https://bugs.webkit.org/show_bug.cgi?id=321578"))
+    func backForwardListNotifiesObserversOfEveryChange() async throws {
+        let page = WebPage()
+
+        let urls = try [1, 2, 3].map { try #require(URL(string: "about:blank?\($0)")) }
+
+        var changes = Observations { page.backForwardList }.makeAsyncIterator()
+        var previousChange = await changes.next()
+
+        for (index, url) in urls.enumerated() {
+            try await page.load(url).wait()
+
+            // A single navigation may produce more than one notification, so this waits for the one that
+            // reflects the navigation.
+            var change = try #require(await changes.next())
+            while change.currentItem?.url != url {
+                change = try #require(await changes.next())
+            }
+
+            // Successive values must not compare equal, otherwise SwiftUI modifiers that diff values,
+            // such as `onChange(of:)`, never observe the navigation.
+            #expect(change != previousChange, "loading \(url) produced a value equal to the previous one")
+            previousChange = change
+
+            #expect(change.backList.map(\.url) == Array(urls.prefix(index)))
+            #expect(change.forwardList.isEmpty)
+        }
+    }
+
+    @Test(.bug("https://bugs.webkit.org/show_bug.cgi?id=321578"))
+    func navigatingToBackForwardListItemNotifiesObservers() async throws {
+        let page = WebPage()
+
+        let firstURL = try #require(URL(string: "about:blank?1"))
+        let secondURL = try #require(URL(string: "about:blank?2"))
+
+        try await page.load(firstURL).wait()
+        try await page.load(secondURL).wait()
+
+        var changes = Observations { page.backForwardList }.makeAsyncIterator()
+        let changeBeforeNavigating = await changes.next()
+
+        let firstItem = try #require(page.backForwardList.backList.last)
+
+        try await page.load(firstItem).wait()
+
+        // A single navigation may produce more than one notification, so this waits for the one that
+        // reflects the navigation.
+        var change = try #require(await changes.next())
+        while change.currentItem?.url != firstURL {
+            change = try #require(await changes.next())
+        }
+
+        #expect(change != changeBeforeNavigating)
+
+        #expect(change.backList.isEmpty)
+        #expect(change.forwardList.map(\.url) == [secondURL])
+    }
+
+    @Test(.bug("https://bugs.webkit.org/show_bug.cgi?id=321578"))
+    func backForwardListItemIdentifiersAreStableAcrossSnapshots() async throws {
+        let page = WebPage()
+
+        let urls = try [1, 2, 3].map { try #require(URL(string: "about:blank?\($0)")) }
+
+        try await page.load(urls[0]).wait()
+        try await page.load(urls[1]).wait()
+
+        let snapshot = page.backForwardList
+        let identifiers = (snapshot.backList + [try #require(snapshot.currentItem)]).map(\.id)
+
+        // Distinct entries must have distinct identifiers.
+        #expect(Set(identifiers).count == identifiers.count)
+
+        try await page.load(urls[2]).wait()
+
+        // The same entries must keep their identifiers in a subsequent snapshot of the list, otherwise
+        // SwiftUI views that identify items by `id`, such as `ForEach`, needlessly recreate them.
+        let subsequentSnapshot = page.backForwardList
+
+        #expect(subsequentSnapshot.backList.map(\.id) == identifiers)
+        #expect(subsequentSnapshot.currentItem?.id != identifiers.last)
+    }
+
+    @Test(.bug("https://bugs.webkit.org/show_bug.cgi?id=321578"))
+    func backForwardListItemsReflectUpdatesToTheirContents() async throws {
+        let page = WebPage()
+
+        let changes = Observations { page.backForwardList }
+
+        // A URL is loaded rather than an HTML string so that the load produces an item in the list; a
+        // string loaded with the default base URL of `about:blank` does not.
+        let url = try #require(URL(string: "data:text/html,%3Ctitle%3EA%20title%3C/title%3E"))
+        try await page.load(url).wait()
+
+        // The item exists as soon as the navigation completes; only its title is not yet known.
+        _ = try #require(page.backForwardList.currentItem)
+
+        // The title of the document is not known when the item is added to the list as the navigation
+        // commits, and is updated afterwards without the list itself changing.
+        let change = try await #require(changes.first { @Sendable in await $0.currentItem?.title != nil })
+
+        #expect(change.currentItem?.title == "A title")
+        #expect(page.backForwardList.currentItem?.title == "A title")
+    }
+
+    @Test(.bug("https://bugs.webkit.org/show_bug.cgi?id=321578"))
+    func backForwardListsWithDifferingHistoriesAreNotEqual() async throws {
+        let page = WebPage()
+
+        let firstURL = try #require(URL(string: "about:blank?1"))
+        let secondURL = try #require(URL(string: "about:blank?2"))
+
+        try await page.load(firstURL).wait()
+        let afterFirstLoad = page.backForwardList
+
+        #expect(afterFirstLoad != WebPage().backForwardList)
+        #expect(afterFirstLoad == page.backForwardList)
+
+        try await page.load(secondURL).wait()
+
+        // Values captured before and after a navigation must not compare equal, otherwise SwiftUI modifiers
+        // that diff values, such as `onChange(of:)`, never observe the navigation.
+        #expect(afterFirstLoad != page.backForwardList)
+    }
+
+    @Test(.bug("https://bugs.webkit.org/show_bug.cgi?id=321578"))
+    func backForwardListSubscriptAccessesItemsRelativeToCurrentItem() async throws {
+        let page = WebPage()
+
+        let urls = try [1, 2, 3].map { try #require(URL(string: "about:blank?\($0)")) }
+        for url in urls {
+            try await page.load(url).wait()
+        }
+
+        // The current item is the last of the three loads, so only the two preceding items are reachable.
+        let listAfterLoading = page.backForwardList
+
+        #expect(listAfterLoading[-1]?.url == urls[1])
+        #expect(listAfterLoading[-2]?.url == urls[0])
+        #expect(listAfterLoading[-3] == nil)
+        #expect(listAfterLoading[0]?.url == urls[2])
+        #expect(listAfterLoading[1] == nil)
+
+        #expect(listAfterLoading[-1] == listAfterLoading.backList.last)
+        #expect(listAfterLoading[0] == listAfterLoading.currentItem)
+
+        // After navigating to the first of the three loads, only the two following items are reachable.
+        try await page.load(try #require(listAfterLoading.backList.first)).wait()
+
+        let listAfterNavigating = page.backForwardList
+
+        #expect(listAfterNavigating[-1] == nil)
+        #expect(listAfterNavigating[0]?.url == urls[0])
+        #expect(listAfterNavigating[1]?.url == urls[1])
+        #expect(listAfterNavigating[2]?.url == urls[2])
+        #expect(listAfterNavigating[3] == nil)
+
+        #expect(listAfterNavigating[0] == listAfterNavigating.currentItem)
+        #expect(listAfterNavigating[1] == listAfterNavigating.forwardList.first)
     }
 }
 


### PR DESCRIPTION
#### 181a547a020ac7a95c32709adfeb519257ce7a8a
<pre>
[SwiftUI WebKit API] WebPage.backForwardList is extremely unreliable
<a href="https://bugs.webkit.org/show_bug.cgi?id=321578">https://bugs.webkit.org/show_bug.cgi?id=321578</a>
<a href="https://rdar.apple.com/184634983">rdar://184634983</a>

Reviewed by Abrar Rahman Protyasha.

The value-type-ness of WebPage.BackForwardList was flawed, since it was essentially just forwarding
everything to a Objective-C class type. Consequently, the `Equatable` conformance was also flawed,
which made observing changes to the list unreliable and incorrect.

Fix this by addressing multiple issues:

1. Change `backForwardList` from a stored property to a computed one that snapshots the live list
on each read, so that the contents are captured eagerly.

2. In addition to listening to `_webView:backForwardListItemAdded:removed:` to update the list, also
listen to `_webView:didUpdateHistoryTitle:forURL:`, since the title gets updated independently of the
rest of the list.

3. Make the id of each item use the actual identifier of the backing engine type, so that identity
is no longer dependent on a pointer address nor needs to retain anything.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift

* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm:
(-[WKBackForwardListItem _identifier]):
(-[WKBackForwardListItem _identifierProcess]):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHistoryDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift:
(backList): Deleted.
(currentItem): Deleted.
(forwardList): Deleted.
(wrapped): Deleted.
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(backForwardList):
(backingWebView):
(didChangeBackForwardList):
* Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift:
(WKNavigationDelegateAdapter._webView(_:didUpdateHistoryTitle:for:)):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift:
(WebPageNavigationTests.backForwardListNotifiesObserversOfEveryChange):
(WebPageNavigationTests.navigatingToBackForwardListItemNotifiesObservers):
(WebPageNavigationTests.backForwardListItemIdentifiersAreStableAcrossSnapshots):
(WebPageNavigationTests.backForwardListItemsReflectUpdatesToTheirContents):
(WebPageNavigationTests.backForwardListsWithDifferingHistoriesAreNotEqual):
(WebPageNavigationTests.backForwardListSubscriptAccessesItemsRelativeToCurrentItem):

Canonical link: <a href="https://commits.webkit.org/319076@main">https://commits.webkit.org/319076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90da82ad51cd34b09baa7cf967330512d3750d72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190531 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144641 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/072e3e61-4a12-4684-bd28-aa1a45f0026e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140646 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af89bd83-2446-4c98-8db6-62d2e49aa3a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121098 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42974 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41276 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40953 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1690 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192466 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53931 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149998 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40178 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54619 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149720 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44354 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126882 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122044 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53136 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15942 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52518 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52755 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52583 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->