### PR TITLE
Remove Quirk needsGeforcenowWarningDisplayNoneQuirk for play.geforcenow.com

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -923,15 +923,6 @@ bool Quirks::needsNetflixVolumeSliderQuirk() const
 #endif
 }
 
-// play.geforcenow.com https://webkit.org/b/303622
-// FIXME: Remove as soon as nvidia adjusts the site for Safari. https://webkit.org/b/303718
-bool Quirks::needsGeforcenowWarningDisplayNoneQuirk() const
-{
-    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
-
-    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsGeforcenowWarningDisplayNoneQuirk);
-}
-
 // yahoo.com rdar://170502516
 bool Quirks::needsYahooVolumeSliderQuirk() const
 {
@@ -3475,13 +3466,6 @@ static void handleEAQuirks(QuirksData& quirksData, const URL& /* quirksURL */, c
     quirksData.isEA = true;
 }
 
-static void handleGeforcenowQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
-{
-    QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("play.geforcenow.com"_s);
-
-    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsGeforcenowWarningDisplayNoneQuirk);
-}
-
 static void handleGoogleQuirks(QuirksData& quirksData, const URL& quirksURL, const String& /* quirksDomainString */, const URL& /* documentURL */)
 {
     quirksData.isGoogleProperty = true;
@@ -4203,7 +4187,6 @@ void Quirks::determineRelevantQuirks()
 #if PLATFORM(IOS_FAMILY)
         { "gizmodo"_s, &handleGizmodoQuirks },
 #endif
-        { "geforcenow"_s, &handleGeforcenowQuirks },
         { "google"_s, &handleGoogleQuirks },
         { "hbomax"_s, &handleHBOMaxQuirks },
         // Expedia Group rdar://126631968

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -151,7 +151,6 @@ public:
     bool NODELETE needsGoogleMapsScrollingQuirk() const;
     bool NODELETE needsGoogleTranslateScrollingQuirk() const;
     bool NODELETE needsNetflixVolumeSliderQuirk() const;
-    bool needsGeforcenowWarningDisplayNoneQuirk() const;
 
     bool needsYahooVolumeSliderQuirk() const;
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -113,7 +113,6 @@ struct QuirksData {
 #if PLATFORM(IOS) || PLATFORM(VISION)
         NeedsNetflixVolumeSliderQuirk,
 #endif
-        NeedsGeforcenowWarningDisplayNoneQuirk,
         NeedsExpediaGroupAnimationQuirk,
         NeedsMediaRewriteRangeRequestQuirk,
         NeedsMozillaFileTypeForDataTransferQuirk,

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1045,13 +1045,6 @@ void Adjuster::adjustForSiteSpecificQuirks(Style::ComputedStyle& style) const
             style.setOverflowY(Overflow::Auto);
     }
 
-    if (documentQuirks.needsGeforcenowWarningDisplayNoneQuirk()) {
-        static MainThreadNeverDestroyed<const AtomString> overlayClassName("cdk-overlay-container"_s);
-        static MainThreadNeverDestroyed<const AtomString> unsupportedClassName("unsupported-scenario-container"_s);
-        if (is<HTMLDivElement>(*m_element) && (m_element->hasClassName(overlayClassName) || m_element->hasClassName(unsupportedClassName)))
-            style.setDisplayMaintainingOriginalDisplay(DisplayType::None);
-    }
-
     // yahoo.com rdar://170502516
     if (documentQuirks.needsYahooVolumeSliderQuirk()) {
         static MainThreadNeverDestroyed<const AtomString> className("vjs-volume-control"_s);


### PR DESCRIPTION
#### 87bb218835853e851f12848056c965b441d5efe0
<pre>
Remove Quirk needsGeforcenowWarningDisplayNoneQuirk for play.geforcenow.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=303718">https://bugs.webkit.org/show_bug.cgi?id=303718</a>
<a href="https://rdar.apple.com/166497647">rdar://166497647</a>

Reviewed by NOBODY (OOPS!).

nvidia was warning users on play.geforcenow.com that Safari was missing
features. The features had landed in WebKit (see the dependencies of
<a href="https://webkit.org/b/303622">https://webkit.org/b/303622</a> ), so <a href="https://commits.webkit.org/304080@main">304080@main</a> added a quirk to hide the
warning, setting display: none on the divs carrying the
unsupported-scenario-container and cdk-overlay-container classes. It was
temporary from the start, there so internal automated testing could run
without the warning in the way until nvidia validated a developer beta
and adjusted the site to feature detect instead.

nvidia has adjusted the site, so the quirk has nothing left to hide.
Also worth removing on its own merit: cdk-overlay-container is Angular&apos;s
generic overlay container, so the quirk was hiding every dialog, menu
and tooltip on the site, not only the warning.

Remove the quirk and handleGeforcenowQuirks, which served nothing else.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsGeforcenowWarningDisplayNoneQuirk const): Deleted.
(WebCore::handleGeforcenowQuirks): Deleted.
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87bb218835853e851f12848056c965b441d5efe0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145157 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d831ce7-7bc6-4946-9b80-ec18126a27e3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141068 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97766 "2 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6df3706-ccd7-4b2d-a7cf-222cd9c1c88d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44729 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161815 "Found 1 new API test failure: TestWebKitAPI.IsolatedSiteStore.PersistsAcrossSessions (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121520 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a740920-e41f-4309-8363-6d07787b6ff4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43402 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41682 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153806 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41343 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2208 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192983 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54445 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150451 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55133 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150169 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44756 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127399 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122699 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53650 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16336 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53032 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53269 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53097 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->