### PR TITLE
[ANGLE] Fix MSL symbol table key comparison logic

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -1748,6 +1748,7 @@
 		7BFAF8F92DE6EE7A00327F7F /* AstcDecompressor_unittest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF8F62DE6EE7A00327F7F /* AstcDecompressor_unittest.cpp */; };
 		7BFAF8FA2DE6EE7A00327F7F /* LoadToNative_unittest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF8F82DE6EE7A00327F7F /* LoadToNative_unittest.cpp */; };
 		7BFAF8FF2DE6F67600327F7F /* libutils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BFAF8232DE6EADC00327F7F /* libutils.a */; };
+		7BFAF9022DE6ECA700327F7F /* MSLSymbolEnv_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF9012DE6ECA700327F7F /* MSLSymbolEnv_test.cpp */; };
 		7BFAF9122DE6F85B00327F7F /* TranslatorESSL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B359DC42A7CEE9C0016DC59 /* TranslatorESSL.cpp */; };
 		7BFAF9132DE6F85B00327F7F /* BuiltInFunctionEmulatorGLSL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B359DC22A7CEE9C0016DC59 /* BuiltInFunctionEmulatorGLSL.cpp */; };
 		7BFAF9142DE6F85B00327F7F /* TranslatorGLSL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B359DCC2A7CEE9D0016DC59 /* TranslatorGLSL.cpp */; };
@@ -4158,6 +4159,7 @@
 		7BFAF8F72DE6EE7A00327F7F /* AstcDecompressorTestUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AstcDecompressorTestUtils.h; sourceTree = "<group>"; };
 		7BFAF8F82DE6EE7A00327F7F /* LoadToNative_unittest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LoadToNative_unittest.cpp; sourceTree = "<group>"; };
 		7BFAF8FB2DE6F43700327F7F /* utils.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = utils.xcconfig; sourceTree = "<group>"; };
+		7BFAF9012DE6ECA700327F7F /* MSLSymbolEnv_test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MSLSymbolEnv_test.cpp; sourceTree = "<group>"; };
 		7BFAF91A2DE6F8B500327F7F /* compiler_test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = compiler_test.h; sourceTree = "<group>"; };
 		7BFAF91B2DE6F8B500327F7F /* compiler_test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = compiler_test.cpp; sourceTree = "<group>"; };
 		7BFAF91E2DE6F8B500327F7F /* ShaderCompileTreeTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShaderCompileTreeTest.h; sourceTree = "<group>"; };
@@ -6736,6 +6738,7 @@
 				7BFAF8532DE6ECA700327F7F /* ImmutableString_test_autogen.cpp */,
 				7BFAF8562DE6ECA700327F7F /* IntermNode_test.cpp */,
 				7BFAF8582DE6ECA700327F7F /* MSLOutput_test.cpp */,
+				7BFAF9012DE6ECA700327F7F /* MSLSymbolEnv_test.cpp */,
 				7BFAF8762DE6ECA700327F7F /* Type_test.cpp */,
 				7BFAF87A2DE6ECA700327F7F /* VariablePacker_test.cpp */,
 			);
@@ -10879,6 +10882,7 @@
 				7BFAF8E72DE6EDE400327F7F /* matrix_utils_unittest.cpp in Sources */,
 				7BFAF8EC2DE6EDE400327F7F /* MemoryBuffer_unittest.cpp in Sources */,
 				7BFAF8A72DE6ECA700327F7F /* MSLOutput_test.cpp in Sources */,
+				7BFAF9022DE6ECA700327F7F /* MSLSymbolEnv_test.cpp in Sources */,
 				7BFAF8E62DE6EDE400327F7F /* Optional_unittest.cpp in Sources */,
 				7BFAF8F02DE6EDE400327F7F /* PoolAlloc_unittest.cpp in Sources */,
 				7BFAF8F12DE6EDE400327F7F /* SimpleMutex_unittest.cpp in Sources */,

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/SymbolEnv.h
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/SymbolEnv.h
@@ -39,7 +39,7 @@ class VarField
     ANGLE_INLINE bool operator==(const VarField &other) const
     {
         const int thisVarId  = mVariable ? mVariable->uniqueId().get() : -1;
-        const int otherVarId = other.mVariable ? mVariable->uniqueId().get() : -1;
+        const int otherVarId = other.mVariable ? other.mVariable->uniqueId().get() : -1;
         return thisVarId == otherVarId && mField == other.mField;
     }
 

--- a/Source/ThirdParty/ANGLE/src/tests/angle_unittests.gni
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_unittests.gni
@@ -140,6 +140,7 @@ angle_unittests_msl_sources = [
   "../common/apple/ObjCPtr_test.mm",
   "../libANGLE/renderer/metal/VertexArrayMtl_unittest.mm",
   "../tests/compiler_tests/MSLOutput_test.cpp",
+  "../tests/compiler_tests/MSLSymbolEnv_test.cpp",
 ]
 
 angle_unittests_wgsl_sources = [ "../tests/compiler_tests/WGSLOutput_test.cpp" ]

--- a/Source/ThirdParty/ANGLE/src/tests/compiler_tests/MSLSymbolEnv_test.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/compiler_tests/MSLSymbolEnv_test.cpp
@@ -1,0 +1,45 @@
+//
+// Copyright 2026 The ANGLE Project Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// MSLSymbolEnv_test.cpp:
+//   Tests for the MSL translator's SymbolEnv.
+//
+
+#include "compiler/translator/Common.h"
+#include "compiler/translator/PoolAlloc.h"
+#include "compiler/translator/SymbolTable.h"
+#include "compiler/translator/msl/SymbolEnv.h"
+#include "gtest/gtest.h"
+
+namespace sh
+{
+
+// SymbolEnv's address space maps are keyed by VarField, which holds either a TVariable or a
+// TField. Verify that a key compares equal only to a key wrapping the same symbol.
+TEST(MSLSymbolEnv, VarFieldEquality)
+{
+    TScopedPoolAllocator scopedAllocator;
+    TSymbolTable symbolTable;
+
+    auto makeVariable = [&symbolTable]() -> const TVariable & {
+        return *new TVariable(&symbolTable, ImmutableString("v"), new TType(EbtFloat, EbpHigh),
+                              SymbolType::AngleInternal);
+    };
+
+    const TVariable &firstVariable  = makeVariable();
+    const TVariable &secondVariable = makeVariable();
+    ASSERT_NE(firstVariable.uniqueId().get(), secondVariable.uniqueId().get());
+
+    const TField &field = *new TField(new TType(EbtFloat, EbpHigh), ImmutableString("f"),
+                                      kNoSourceLoc, SymbolType::AngleInternal);
+
+    EXPECT_TRUE(VarField(firstVariable) == VarField(firstVariable));
+    EXPECT_TRUE(VarField(field) == VarField(field));
+    EXPECT_FALSE(VarField(firstVariable) == VarField(secondVariable));
+    EXPECT_FALSE(VarField(field) == VarField(firstVariable));
+    EXPECT_FALSE(VarField(firstVariable) == VarField(field));
+}
+
+}  // namespace sh


### PR DESCRIPTION
#### 3f38d00a27f16fbabbc82dfe589651351e3fd599
<pre>
[ANGLE] Fix MSL symbol table key comparison logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=321580">https://bugs.webkit.org/show_bug.cgi?id=321580</a>
<a href="https://rdar.apple.com/180734422">rdar://180734422</a>

Reviewed by Kimmo Kinnunen.

Fix a correctness issue in MSL symbol table key comparison. Previously, we
mistakenly compared the variable&apos;s unique ID with itself, leading to incorrect
translator state that crashes later in the pipeline, or emits invalid MSL.

This change corrects the comparison logic, but does not update the hash template
specialisation for VarField, which continues to use object addresses rather than
unique IDs to avoid behavioural changes and to stay consistent with the more common
pattern in this part of the codebase.

* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
* Source/ThirdParty/ANGLE/src/compiler/translator/msl/SymbolEnv.h:
(sh::VarField::operator== const):
* Source/ThirdParty/ANGLE/src/tests/angle_unittests.gni:
* Source/ThirdParty/ANGLE/src/tests/compiler_tests/MSLSymbolEnv_test.cpp: Added.
(sh::TEST(MSLSymbolEnv, VarFieldEquality)):

Canonical link: <a href="https://commits.webkit.org/319786@main">https://commits.webkit.org/319786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06cb929c52693f13cbb0b239166def22c6cb4327

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144515 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140541 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97339 "3 flakes 4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120993 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ac1b128-47d7-4608-815e-cfc012f3f1fa) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/179521 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42869 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41176 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153273 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40855 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1567 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192342 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53808 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149888 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40748 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54496 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149617 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44256 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121900 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53013 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15844 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52395 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52632 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52460 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->