### PR TITLE
prepare-ChangeLog emits no function names for files containing C++ raw string literals

### DIFF
--- a/Tools/Scripts/prepare-ChangeLog
+++ b/Tools/Scripts/prepare-ChangeLog
@@ -793,6 +793,7 @@ sub get_function_line_ranges_for_cpp($$)
     my $in_parentheses = 0;
     my $in_test_declaration = 0;
     my $quotation_mark;
+    my $raw_string_terminator;
     my $in_braces = 0;
     my $in_toplevel_array_brace = 0;
     my $brace_start = 0;
@@ -819,6 +820,12 @@ sub get_function_line_ranges_for_cpp($$)
     my @all_namespaces;
 
     while (<$file_handle>) {
+        # Handle continued raw string literal.
+        if (defined $raw_string_terminator) {
+            next unless s-.*?\Q$raw_string_terminator\E--;
+            undef $raw_string_terminator;
+        }
+
         # Handle continued quoted string.
         if ($quotation_mark) {
             if (!s-([^\\]|\\.)*$quotation_mark--) {
@@ -847,6 +854,19 @@ sub get_function_line_ranges_for_cpp($$)
         if (/^\s*\#/) {
             $in_macro = 1 if /^([^\\]|\\.)*\\$/;
             next;
+        }
+
+        # Handle raw string literals, e.g. R"js( ... )js". The text between the delimiters
+        # is literal, so it can hold quotes, comment markers and unbalanced braces. Strip
+        # them before the comment and quote handling below, which would otherwise take a
+        # // inside the literal for a comment and its braces for code.
+        while (m-R"([^("\s\\]{0,16})\(-) {
+            my $delimiter = $1;
+            my $terminator = ")$delimiter\"";
+            next if s-R"\Q$delimiter\E\(.*?\Q$terminator\E--;
+            s-R"\Q$delimiter\E\(.*--;
+            $raw_string_terminator = $terminator;
+            last;
         }
 
         # Handle comments and quoted text.

--- a/Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/resources/cpp_unittests-expected.txt
+++ b/Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/resources/cpp_unittests-expected.txt
@@ -246,6 +246,26 @@
       '424',
       '427',
       'Foo::Arrow::otherArrow const volatile'
+    ],
+    [
+      '440',
+      '443',
+      'RawString::afterMultiLineRawString'
+    ],
+    [
+      '448',
+      '451',
+      'RawString::afterEmptyDelimiterRawString'
+    ],
+    [
+      '456',
+      '459',
+      'RawString::afterSingleLineRawString'
+    ],
+    [
+      '464',
+      '467',
+      'RawString::afterTwoRawStringsOnOneLine'
     ]
   ]
 }

--- a/Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/resources/cpp_unittests.cpp
+++ b/Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/resources/cpp_unittests.cpp
@@ -426,3 +426,43 @@ namespace Foo {
         return 0xc0defefe;
     }
 }
+
+namespace RawString {
+
+    // A raw string spanning several lines, holding text with unbalanced braces,
+    // parentheses, quotes and comment markers. https://webkit.org/b/321581
+    static const char* multiLineScript = R"js(function unbalanced() {
+        window.x = "}";
+        window.y = '('; // a comment inside the literal
+        return window.x + window.y;
+    })js";
+
+    void afterMultiLineRawString()
+    {
+        return;
+    }
+
+    // Same, with an empty delimiter.
+    static const char* emptyDelimiter = R"(} ) " /* not a comment */)";
+
+    void afterEmptyDelimiterRawString()
+    {
+        return;
+    }
+
+    // A single-line raw string holding a URL, so the // must not start a comment.
+    static const char* url = R"js(https://webkit.org/b/321581)js";
+
+    void afterSingleLineRawString()
+    {
+        return;
+    }
+
+    // Two raw strings on one line.
+    static const char* pair[] = { R"({)", R"js(})js" };
+
+    void afterTwoRawStringsOnOneLine()
+    {
+        return;
+    }
+}


### PR DESCRIPTION
#### 7fca7cefac47e6019e0c5e30ef4520d2dbe039a4
<pre>
prepare-ChangeLog emits no function names for files containing C++ raw string literals
<a href="https://bugs.webkit.org/show_bug.cgi?id=321581">https://bugs.webkit.org/show_bug.cgi?id=321581</a>
<a href="https://rdar.apple.com/184695084">rdar://184695084</a>

Reviewed by NOBODY (OOPS!).

get_function_line_ranges_for_cpp expects a string to close on the line it
opened on, and the only multi-line case it knows is a trailing backslash
continuation. A raw string, R&quot;js( ... )js&quot;, is neither, so the parser
deleted the rest of the opening line, losing that line&apos;s braces, then
counted the literal&apos;s JavaScript braces as C++. That left more closing
braces than opening ones, and since the brace depth is what maps a
changed line to its enclosing function, the file came out with no
function names at all. Source/WebCore/page/Quirks.cpp holds two such
literals, so every patch touching it needed its ChangeLog written by
hand.

Fix by recognizing R&quot;delim( and skipping to the matching )delim&quot;, reusing
the state the backslash continuation already uses to carry a string
across lines. This runs before the comment and quote handling on purpose:
a // or a quote inside the literal, a URL for instance, would otherwise
be taken for C++.

Covered by the existing parser unit tests. The four cases added to the
cpp fixture are a literal spanning lines with unbalanced braces, an empty
delimiter, a URL on one line, and two literals on one line.

* Tools/Scripts/prepare-ChangeLog:
(get_function_line_ranges_for_cpp):
* Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/resources/cpp_unittests-expected.txt:
* Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/resources/cpp_unittests.cpp:
(RawString::afterMultiLineRawString):
(RawString::afterEmptyDelimiterRawString):
(RawString::afterSingleLineRawString):
(RawString::afterTwoRawStringsOnOneLine):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fca7cefac47e6019e0c5e30ef4520d2dbe039a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144519 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80143598-3cd3-47bf-b5f9-cc0b316c8efd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140545 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97341 "1 flakes 4 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17bd31cd-7a37-4b58-be54-1b06e2f6eff9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120997 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4c54207-fab1-4540-a736-283e4d68a228) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42872 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41179 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 11 api tests failed or timed out") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153276 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40857 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1571 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192346 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53812 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149892 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54500 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149621 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44262 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121903 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53017 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15846 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52399 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52636 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52464 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->