### PR TITLE
[GLIB] fast/canvas/canvas-composite-text-alpha.html is failing since r277024

### DIFF
--- a/LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.gradient.html
+++ b/LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.gradient.html
@@ -25,7 +25,7 @@ function drawCanvas(ctx) {
   ctx.fillText("X", 0, 80, -10);
 }
 
-function doDeferredTest() {
+function doDeferredTest(ctx) {
   drawCanvas(ctx);
 
   // Check that the letter rendered appropriately
@@ -52,17 +52,19 @@ if (window.testRunner) {
   testRunner.waitUntilDone();
 }
 
-var canvas = document.getElementById('c');
-var ctx = canvas.getContext("2d");
-ctx.font = "100px Ahem";
+addEventListener("load", async () => {
+  const font = "100px Ahem"
+  await document.fonts.load(font);
 
-// Kick off loading of the font
-ctx.fillText(" ", 0, 0);
+  var canvas = document.getElementById('c');
+  var ctx = canvas.getContext("2d");
+  ctx.font = font;
 
-// Wait for the font to load, then run
-setTimeout(function() {
-  doDeferredTest();
-}, 50);
+  doDeferredTest(ctx);
+}, () => {
+  if (window.testRunner)
+    testRunner.notifyDone();
+});
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.negative.html
+++ b/LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.negative.html
@@ -20,7 +20,7 @@ function drawCanvas(ctx) {
   ctx.fillText("X", 0, 100, -5);
 }
 
-function doDeferredTest() {
+function doDeferredTest(ctx) {
   drawCanvas(ctx);
 
   // Check that the letter rendered appropriately
@@ -47,17 +47,19 @@ if (window.testRunner) {
   testRunner.waitUntilDone();
 }
 
-var canvas = document.getElementById('c');
-var ctx = canvas.getContext("2d");
-ctx.font = "200px Ahem";
+addEventListener("load", async () => {
+  const font = "200px Ahem"
+  await document.fonts.load(font);
 
-// Kick off loading of the font
-ctx.fillText(" ", 0, 0);
+  var canvas = document.getElementById('c');
+  var ctx = canvas.getContext("2d");
+  ctx.font = font;
 
-// Wait for the font to load, then run
-setTimeout(function() {
-  doDeferredTest();
-}, 50);
+  doDeferredTest(ctx);
+}, () => {
+  if (window.testRunner)
+    testRunner.notifyDone();
+});
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html
+++ b/LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html
@@ -20,7 +20,7 @@ function drawCanvas(ctx) {
   ctx.fillText("X", -100, 100, 200);
 }
 
-function doDeferredTest() {
+function doDeferredTest(ctx) {
   drawCanvas(ctx);
 
   // Check that the letter rendered appropriately
@@ -47,17 +47,19 @@ if (window.testRunner) {
   testRunner.waitUntilDone();
 }
 
-var canvas = document.getElementById('c');
-var ctx = canvas.getContext("2d");
-ctx.font = "100px Ahem";
+addEventListener("load", async () => {
+  const font = "100px Ahem";
+  await document.fonts.load(font);
 
-// Kick off loading of the font
-ctx.fillText(" ", 0, 0);
+  var canvas = document.getElementById('c');
+  var ctx = canvas.getContext("2d");
+  ctx.font = font;
 
-// Wait for the font to load, then run
-setTimeout(function() {
-  doDeferredTest();
-}, 50);
+  doDeferredTest(ctx);
+}, () => {
+  if (window.testRunner)
+    testRunner.notifyDone();
+});
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html
+++ b/LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html
@@ -20,7 +20,7 @@ function drawCanvas(ctx) {
   ctx.fillText("XX", -10, 100, 10);
 }
 
-function doDeferredTest() {
+function doDeferredTest(ctx) {
   drawCanvas(ctx);
 
   // Check that the letter rendered appropriately
@@ -47,17 +47,19 @@ if (window.testRunner) {
   testRunner.waitUntilDone();
 }
 
-var canvas = document.getElementById('c');
-var ctx = canvas.getContext("2d");
-ctx.font = "100px Ahem";
+addEventListener('load', async () => {
+  const font = "100px Ahem";
+  await document.fonts.load(font);
 
-// Kick off loading of the font
-ctx.fillText(" ", 0, 0);
+  var canvas = document.getElementById('c');
+  var ctx = canvas.getContext("2d");
+  ctx.font = font;
 
-// Wait for the font to load, then run
-setTimeout(function() {
-  doDeferredTest();
-}, 50);
+  doDeferredTest(ctx);
+}, () => {
+  if (window.testRunner)
+    testRunner.notifyDone();
+});
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/canvas/canvas-composite-text-alpha.html
+++ b/LayoutTests/fast/canvas/canvas-composite-text-alpha.html
@@ -430,16 +430,19 @@
           name: "stroke text"
       };
 
-      function draw()
-      {
+      addEventListener("load", async () => {
+          await document.fonts.load("20px Ahem");
           drawTable(useFillText);
           drawTable(useStrokeText);
           if (window.testRunner)
               testRunner.notifyDone();
-      }
+      }, () => {
+          if (window.testRunner)
+              testRunner.notifyDone();
+      });
     </script>
   </head>
-  <body onload="draw();">
+  <body>
     <p>This test exercises a bunch of alpha composition operations on text. The top-left rectangles are the source images and bottom-right rectangles are the destination images.</p>
     <div id="results">
     </div>

--- a/LayoutTests/fast/canvas/font-update.html
+++ b/LayoutTests/fast/canvas/font-update.html
@@ -15,11 +15,15 @@
     canvas.parentNode.removeChild(canvas);
     if (window.testRunner)
         testRunner.waitUntilDone();
-    setTimeout(function()
-    {
+
+    addEventListener("load", async () => {
+        try {
+            await document.fonts.load(ctx.font);
+        } catch (e) {}
+
         ctx.fillText("A", 0, 100);
         document.body.appendChild(canvas);
         if (window.testRunner)
             testRunner.notifyDone();
-    }, 50);
+    });
 </script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4174,8 +4174,6 @@ webkit.org/b/194044 imported/w3c/web-platform-tests/media-source/mediasource-add
 # Added in r276357. Also marked as ImageOnlyFailure in iOS TestExpectations.
 fast/text/line-break-with-locale.html [ ImageOnlyFailure ]
 
-webkit.org/b/225423 fast/canvas/canvas-composite-text-alpha.html [ Failure ]
-
 # Decoded images/video frames are always tagged as sRGB regardless of their embedded ICC
 # profile: PNGImageDecoder/JPEGImageDecoder convert via LCMS straight to sRGB during decode,
 # and ImageBackingStoreSkia.cpp hardcodes SkColorSpace::MakeSRGB() on the result. Wide-gamut


### PR DESCRIPTION
#### 629cd7f94cc300a02b64912b3750515b87b01710
<pre>
[GLIB] fast/canvas/canvas-composite-text-alpha.html is failing since r277024
<a href="https://bugs.webkit.org/show_bug.cgi?id=225423">https://bugs.webkit.org/show_bug.cgi?id=225423</a>

Reviewed by Nikolas Zimmermann.

This test was failing in GLIB ports because at the time of running the
test the required &quot;Ahem&quot; font was not loaded.

Similarly to other canvas tests such as &apos;fill-gradient-text-with-web-font.html&apos;,
now this test forces the load of the &quot;Ahem&quot; font before running the proper test.
In case the Ahem font could not be loaded, the test will fall quickly
instead of timing out.

Also, refactor other canvas tests that need to load a font and were using
&apos;setTimeout&apos; to wait for the font loading. Now theses test follow the
same approach, async call plus await for the font loading.

* LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.gradient.html:
* LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.negative.html:
* LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html:
* LayoutTests/fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html:
* LayoutTests/fast/canvas/canvas-composite-text-alpha.html:
* LayoutTests/fast/canvas/font-update.html:
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/319273@main">https://commits.webkit.org/319273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b293b9fe56543693eab278272355382291780f3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54968 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48766 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54684 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/191237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183978 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/44907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/41520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2397 "Failed to checkout and rebase branch from PR 71424") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/193172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54634 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/161509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/193172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55322 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/193172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27471 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/44938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123105 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53839 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/16516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53458 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->