### PR TITLE
NativeImage accesses platform image without a lock

### DIFF
--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -30,6 +30,7 @@
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
 #include "RenderingMode.h"
+#include <wtf/Locker.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -72,8 +73,9 @@ NativeImage::~NativeImage()
         observer->willDestroyNativeImage(*this);
 }
 
-const PlatformImagePtr& NativeImage::platformImage() const
+PlatformImagePtr NativeImage::platformImage() const
 {
+    Locker locker { m_lock };
     return m_platformImage;
 }
 
@@ -90,8 +92,9 @@ bool NativeImage::hasHDRContent() const
 void NativeImage::replacePlatformImage(PlatformImagePtr&& platformImage) const
 {
     ASSERT(platformImage);
+    Locker locker { m_lock };
     m_platformImage = WTF::move(platformImage);
-    computeHeadroom();
+    // Intention is that the contents do not change, so properties are not recomputed.
 }
 
 #if !USE(CG)

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -33,6 +33,7 @@
 #include <WebCore/PlatformImage.h>
 #include <WebCore/RenderingResource.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/Lock.h>
 #include <wtf/TZoneMalloc.h>
 
 #if USE(SKIA)
@@ -67,7 +68,7 @@ public:
 
     WEBCORE_EXPORT virtual ~NativeImage();
 
-    WEBCORE_EXPORT virtual const PlatformImagePtr& platformImage() const;
+    WEBCORE_EXPORT virtual PlatformImagePtr platformImage() const;
     WEBCORE_EXPORT const std::optional<GainMap>& gainMap() const;
     WEBCORE_EXPORT virtual IntSize size() const;
     WEBCORE_EXPORT virtual bool hasAlpha() const;
@@ -109,9 +110,10 @@ protected:
     WEBCORE_EXPORT NativeImage(PlatformImagePtr&&, std::optional<GainMap>&&);
 #endif
 
-    void computeHeadroom() const;
+    void computeHeadroom() const WTF_REQUIRES_LOCK(m_lock);
 
-    mutable PlatformImagePtr m_platformImage;
+    mutable Lock m_lock;
+    mutable PlatformImagePtr m_platformImage WTF_GUARDED_BY_LOCK(m_lock);
     mutable std::optional<GainMap> m_gainMap;
     mutable Headroom m_baseImageHeadroom { Headroom::None };
     mutable Headroom m_headroom { Headroom::None };

--- a/Source/WebCore/platform/graphics/cairo/ImageUtilitiesCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageUtilitiesCairo.cpp
@@ -60,11 +60,11 @@ static cairo_status_t writeFunction(void* output, const unsigned char* data, uns
 Vector<uint8_t> platformEncodeData(const NativeImage& nativeImage, const String& mimeType, std::optional<double>)
 {
     ASSERT_UNUSED(mimeType, mimeType == "image/png"_s); // Only PNG output is supported for now.
-    auto* image = nativeImage.platformImage().get();
-    if (!image)
+    auto platformImage = nativeImage.platformImage();
+    if (!platformImage)
         return { };
     Vector<uint8_t> output;
-    if (cairo_surface_write_to_png_stream(image, writeFunction, &output) != CAIRO_STATUS_SUCCESS)
+    if (cairo_surface_write_to_png_stream(platformImage.get(), writeFunction, &output) != CAIRO_STATUS_SUCCESS)
         return { };
     return output;
 }

--- a/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
@@ -37,11 +37,13 @@ namespace WebCore {
 
 IntSize NativeImage::size() const
 {
+    Locker locker { m_lock };
     return cairoSurfaceSize(m_platformImage.get());
 }
 
 bool NativeImage::hasAlpha() const
 {
+    Locker locker { m_lock };
     return cairo_surface_get_content(m_platformImage.get()) != CAIRO_CONTENT_COLOR;
 }
 
@@ -55,12 +57,11 @@ std::optional<Color> NativeImage::singlePixelSolidColor() const
 {
     if (size() != IntSize(1, 1))
         return std::nullopt;
-
-    auto platformImage = this->platformImage().get();
-    if (cairo_surface_get_type(platformImage) != CAIRO_SURFACE_TYPE_IMAGE)
+    Locker locker { m_lock };
+    if (cairo_surface_get_type(m_platformImage.get()) != CAIRO_SURFACE_TYPE_IMAGE)
         return std::nullopt;
 
-    unsigned* pixel = reinterpret_cast_ptr<unsigned*>(cairo_image_surface_get_data(platformImage));
+    unsigned* pixel = reinterpret_cast_ptr<unsigned*>(cairo_image_surface_get_data(m_platformImage.get()));
     return unpremultiplied(asSRGBA(PackedColor::ARGB { *pixel }));
 }
 
@@ -71,7 +72,7 @@ void NativeImage::clearSubimages()
 #if USE(COORDINATED_GRAPHICS)
 uint64_t NativeImage::uniqueID() const
 {
-    if (auto& image = platformImage())
+    if (auto image = platformImage())
         return getSurfaceUniqueID(image.get());
     return 0;
 }

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -70,17 +70,20 @@ RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image)
 
 IntSize NativeImage::size() const
 {
+    Locker locker { m_lock };
     return IntSize(CGImageGetWidth(m_platformImage.get()), CGImageGetHeight(m_platformImage.get()));
 }
 
 bool NativeImage::hasAlpha() const
 {
+    Locker locker { m_lock };
     CGImageAlphaInfo info = CGImageGetAlphaInfo(m_platformImage.get());
     return (info >= kCGImageAlphaPremultipliedLast) && (info <= kCGImageAlphaFirst);
 }
 
 size_t NativeImage::sizeInBytes() const
 {
+    Locker locker { m_lock };
     CheckedSize height = CGImageGetHeight(m_platformImage);
     CheckedSize sizeInBytes = height * CGImageGetBytesPerRow(m_platformImage);
     if (m_gainMap)
@@ -90,6 +93,7 @@ size_t NativeImage::sizeInBytes() const
 
 DestinationColorSpace NativeImage::colorSpace() const
 {
+    Locker locker { m_lock };
     return DestinationColorSpace(CGImageGetColorSpace(m_platformImage.get()));
 }
 

--- a/Source/WebCore/platform/graphics/skia/ImageUtilitiesSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageUtilitiesSkia.cpp
@@ -85,20 +85,20 @@ static sk_sp<SkData> encodeAcceleratedImage(const NativeImage& nativeImage, cons
         return nullptr;
 
     auto* grContext = nativeImage.grContext();
-    auto* image = nativeImage.platformImage().get();
+    auto platformImage = nativeImage.platformImage();
 
     if (MIMETypeRegistry::isJPEGMIMEType(mimeType)) {
         SkJpegEncoder::Options options;
         if (quality && *quality >= 0.0 && *quality <= 1.0)
             options.fQuality = static_cast<int>(*quality * 100.0 + 0.5);
-        return SkJpegEncoder::Encode(grContext, image, options);
+        return SkJpegEncoder::Encode(grContext, platformImage.get(), options);
     }
 
     if (equalLettersIgnoringASCIICase(mimeType, "image/webp"_s))
-        return SkWebpEncoder::Encode(grContext, image, webpEncoderOptions(quality));
+        return SkWebpEncoder::Encode(grContext, platformImage.get(), webpEncoderOptions(quality));
 
     if (equalLettersIgnoringASCIICase(mimeType, "image/png"_s))
-        return SkPngEncoder::Encode(grContext, image, { });
+        return SkPngEncoder::Encode(grContext, platformImage.get(), { });
 
     return nullptr;
 }

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -64,11 +64,13 @@ NativeImage::NativeImage(PlatformImagePtr&& platformImage, std::optional<GainMap
 
 IntSize NativeImage::size() const
 {
-    return m_platformImage ? IntSize(m_platformImage->width(), m_platformImage->height()) : IntSize();
+    Locker locker { m_lock };
+    return IntSize(m_platformImage->width(), m_platformImage->height());
 }
 
 bool NativeImage::hasAlpha() const
 {
+    Locker locker { m_lock };
     switch (m_platformImage->imageInfo().alphaType()) {
     case kUnknown_SkAlphaType:
     case kOpaque_SkAlphaType:
@@ -82,7 +84,8 @@ bool NativeImage::hasAlpha() const
 
 DestinationColorSpace NativeImage::colorSpace() const
 {
-    if (auto colorSpace = platformImage()->refColorSpace())
+    Locker locker { m_lock };
+    if (auto colorSpace = m_platformImage->refColorSpace())
         return DestinationColorSpace(colorSpace);
     // No color space means the default - SRGB.
     return DestinationColorSpace::SRGB();
@@ -121,9 +124,7 @@ void NativeImage::clearSubimages()
 
 uint64_t NativeImage::uniqueID() const
 {
-    if (auto& image = platformImage())
-        return image->uniqueID();
-    return 0;
+    return platformImage()->uniqueID();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -384,14 +384,13 @@ void BitmapTexture::updateContents(NativeImage* frameImage, const IntRect& targe
     if (!frameImage)
         return;
 
+    auto surface = frameImage->platformImage();
 #if USE(CAIRO)
-    cairo_surface_t* surface = frameImage->platformImage().get();
-    const uint8_t* imageData = cairo_image_surface_get_data(surface);
-    int bytesPerLine = cairo_image_surface_get_stride(surface);
+    const uint8_t* imageData = cairo_image_surface_get_data(surface.get());
+    int bytesPerLine = cairo_image_surface_get_stride(surface.get());
 
     updateContents(imageData, targetRect, offset, bytesPerLine, PixelFormat::BGRA8);
 #elif USE(SKIA)
-    sk_sp<SkImage> surface = frameImage->platformImage();
     SkPixmap pixmap;
     if (surface->peekPixels(&pixmap))
         updateContents(pixmap.addr(), targetRect, offset, pixmap.rowBytes(), PixelFormat::BGRA8);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -122,9 +122,9 @@ bool CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer(UseSkiaForCompos
     auto texture = BitmapTexturePool::singleton().acquireTexture(m_size, textureFlags);
 
 #if USE(CAIRO)
-    auto* surface = m_image->platformImage().get();
-    auto* imageData = cairo_image_surface_get_data(surface);
-    texture->updateContents(imageData, IntRect(IntPoint(), m_size), IntPoint(), cairo_image_surface_get_stride(surface), PixelFormat::BGRA8);
+    auto surface = m_image->platformImage();
+    auto* imageData = cairo_image_surface_get_data(surface.get());
+    texture->updateContents(imageData, IntRect(IntPoint(), m_size), IntPoint(), cairo_image_surface_get_stride(surface.get()), PixelFormat::BGRA8);
     UNUSED_PARAM(useSkiaForCompositing);
 #elif USE(SKIA)
     const auto& image = m_image->platformImage();

--- a/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
+++ b/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
@@ -169,7 +169,7 @@ DragImageRef createDragImageFromImage(Image* img, ImageOrientation, GraphicsClie
     cairo_fill_preserve(cr);
 
     if (auto nativeImage = img->currentNativeImage()) {
-        auto& surface = nativeImage->platformImage();
+        auto surface = nativeImage->platformImage();
         // Draw the image.
         cairo_set_source_surface(cr, surface.get(), 0.0, 0.0);
         cairo_paint(cr);

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp
@@ -62,7 +62,7 @@ static GRefPtr<GdkTexture> dragIconTexture(RefPtr<ShareableBitmap>&& iconImage)
     if (!nativeImage)
         return nullptr;
 
-    auto& platformImage = nativeImage->platformImage();
+    auto platformImage = nativeImage->platformImage();
     return skiaImageToGdkTexture(*platformImage.get());
 }
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -3682,7 +3682,7 @@ void webkitWebViewBaseSetCursor(WebKitWebViewBase* webViewBase, const Cursor& cu
         return;
 
     IntPoint effectiveHotSpot = determineHotSpot(cursor.image().get(), cursor.hotSpot());
-    auto& platformImage = nativeImage->platformImage();
+    auto platformImage = nativeImage->platformImage();
 
 #if USE(GTK4)
     auto texture = skiaImageToGdkTexture(*platformImage.get());

--- a/Source/WebKit/UIProcess/gtk/GtkUtilities.cpp
+++ b/Source/WebKit/UIProcess/gtk/GtkUtilities.cpp
@@ -236,7 +236,7 @@ GRefPtr<GdkPixbuf> selectionDataImageAsGdkPixbuf(const SelectionData& selectionD
     if (!nativeImage)
         return nullptr;
 
-    auto& platformImage = nativeImage->platformImage();
+    auto platformImage = nativeImage->platformImage();
     return skiaImageToGdkPixbuf(*platformImage.get());
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp
@@ -32,6 +32,7 @@
 #include <WebCore/Color.h>
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/ImageBuffer.h>
+#include <wtf/Locker.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -73,15 +74,24 @@ RemoteNativeImageProxy::~RemoteNativeImageProxy()
         resourceCache->willDestroyRemoteNativeImageProxy(*this);
 }
 
-const PlatformImagePtr& RemoteNativeImageProxy::platformImage() const
+PlatformImagePtr RemoteNativeImageProxy::platformImage() const
 {
-    if (!m_platformImage) {
-        if (CheckedPtr resourceCache = m_resourceCache.get())
-            m_platformImage = resourceCache->platformImage(*this);
+    {
+        Locker locker { m_lock };
+        if (m_platformImage)
+            return m_platformImage;
     }
+    PlatformImagePtr platformImage;
+    // Currently calls made here are always to a cache that is local to the thread.
+    if (CheckedPtr resourceCache = m_resourceCache.get())
+        platformImage = resourceCache->platformImage(*this);
     // The callers do not expect !platformImage().
-    if (!m_platformImage)
-        m_platformImage = placeholderPlatformImage();
+    if (!platformImage)
+        platformImage = placeholderPlatformImage();
+    Locker locker { m_lock };
+    if (m_platformImage)
+        return m_platformImage;
+    m_platformImage = WTF::move(platformImage);
     return m_platformImage;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.h
@@ -41,7 +41,7 @@ class RemoteNativeImageProxy final : public WebCore::NativeImage {
 public:
     static Ref<RemoteNativeImageProxy> create(const WebCore::IntSize&, WebCore::PlatformColorSpace&&, bool hasAlpha, WeakRef<RemoteResourceCacheProxy>&&);
     ~RemoteNativeImageProxy() override;
-    const WebCore::PlatformImagePtr& platformImage() const override;
+    WebCore::PlatformImagePtr platformImage() const override;
     WebCore::IntSize size() const override;
     bool hasAlpha() const override;
     WebCore::DestinationColorSpace colorSpace() const override;

--- a/Source/WebKitLegacy/mac/Misc/WebCache.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCache.mm
@@ -169,7 +169,7 @@ class DefaultStorageSessionProvider : public WebCore::StorageSessionProvider {
     if (!nativeImage)
         return nullptr;
 
-    return nativeImage->platformImage().get();
+    return nativeImage->platformImage().unsafeGet();
 }
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 93848dd6cac160ace5db5e827e8a30e97bfc88a5
<pre>
NativeImage accesses platform image without a lock
<a href="https://bugs.webkit.org/show_bug.cgi?id=321582">https://bugs.webkit.org/show_bug.cgi?id=321582</a>
<a href="https://rdar.apple.com/problem/184699290">rdar://problem/184699290</a>

Reviewed by Nikolas Zimmermann.

Lock the NativeImage::m_platformImage access, since theoretically
replacePlatformImage could replace the image while other threads
would access it. The uncontended lock is very cheap. Removes false
positives from analysis tools.

The replacement happens as a memory optimization:
 - When sending an image from WCP to GPUP, use the GPUP-shared pixel
   data in WCP source image. Today this is not a multithreaded case,
   but in future will be.
 - When sending the bitmap data of GPUP generated image, use the
   shared pixel data in the GPUP generated image. This is potentially
   multithreaded case.

* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::NativeImage::platformImage const):
(WebCore::NativeImage::replacePlatformImage const):
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::size const):
(WebCore::NativeImage::hasAlpha const):
(WebCore::NativeImage::sizeInBytes const):
(WebCore::NativeImage::colorSpace const):
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::NativeImage::size const):
(WebCore::NativeImage::hasAlpha const):
(WebCore::NativeImage::colorSpace const):
(WebCore::NativeImage::uniqueID const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp:
(WebKit::RemoteNativeImageProxy::platformImage const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.h:

Canonical link: <a href="https://commits.webkit.org/319114@main">https://commits.webkit.org/319114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c39e7131322f0d6a4e0518f67d5da69d8325ce4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180518 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144839 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4fb756fb-1fb0-4a09-a597-2ceb9792104b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140798 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/458affc9-a974-48a9-951b-ad67625e8dc5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121250 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba3c14be-dcc4-4762-890f-2b21eb4f5786) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10056 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41100 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1888 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47062 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192664 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54129 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150164 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54817 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149886 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27395 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44509 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127080 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122266 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53334 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16089 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52716 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52953 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52781 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->