### PR TITLE
Complete HDR CanvasRenderingContext2DBase::drawImage from 2d canvas

### DIFF
--- a/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-display-p3-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-display-p3-expected.txt
@@ -1,0 +1,83 @@
+Tests that drawImage() from a 2D canvas preserves HDR (extended-range float16) values, and clamps them when the destination is SDR.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+canvas.dataset.colorSpace: display-p3
+canvas.dataset.renderingMode: Accelerated
+
+Simple drawImage (globalCompositeOperation = "source-over")
+PASS float16 -> float16 (simple): red is 3.5
+PASS float16 -> float16 (simple): green is 0.6
+PASS float16 -> float16 (simple): blue is 0
+PASS float16 -> float16 (simple): alpha is 1
+PASS float16 -> unorm8 (simple): red is 1
+PASS float16 -> unorm8 (simple): green is 0.6
+PASS float16 -> unorm8 (simple): blue is 0
+PASS float16 -> unorm8 (simple): alpha is 1
+PASS unorm8 -> float16 (simple): red is 0.6
+PASS unorm8 -> float16 (simple): green is 0.6
+PASS unorm8 -> float16 (simple): blue is 0
+PASS unorm8 -> float16 (simple): alpha is 1
+PASS unorm8 -> unorm8 (simple): red is 0.6
+PASS unorm8 -> unorm8 (simple): green is 0.6
+PASS unorm8 -> unorm8 (simple): blue is 0
+PASS unorm8 -> unorm8 (simple): alpha is 1
+
+Self-copy (globalCompositeOperation = "copy")
+PASS float16 self-draw (copy-self): red is 3.5
+PASS float16 self-draw (copy-self): green is 0.6
+PASS float16 self-draw (copy-self): blue is 0
+PASS float16 self-draw (copy-self): alpha is 1
+PASS unorm8 self-draw (copy-self): red is 0.6
+PASS unorm8 self-draw (copy-self): green is 0.6
+PASS unorm8 self-draw (copy-self): blue is 0
+PASS unorm8 self-draw (copy-self): alpha is 1
+
+Full-canvas composite (globalCompositeOperation = "source-in")
+PASS float16 -> float16 (source-in): red is 3.5
+PASS float16 -> float16 (source-in): green is 0.6
+PASS float16 -> float16 (source-in): blue is 0
+PASS float16 -> float16 (source-in): alpha is 1
+PASS float16 -> unorm8 (source-in): red is 1
+PASS float16 -> unorm8 (source-in): green is 0.6
+PASS float16 -> unorm8 (source-in): blue is 0
+PASS float16 -> unorm8 (source-in): alpha is 1
+PASS unorm8 -> float16 (source-in): red is 0.6
+PASS unorm8 -> float16 (source-in): green is 0.6
+PASS unorm8 -> float16 (source-in): blue is 0
+PASS unorm8 -> float16 (source-in): alpha is 1
+PASS unorm8 -> unorm8 (source-in): red is 0.6
+PASS unorm8 -> unorm8 (source-in): green is 0.6
+PASS unorm8 -> unorm8 (source-in): blue is 0
+PASS unorm8 -> unorm8 (source-in): alpha is 1
+PASS float16 self-draw (source-in): red is 3.5
+PASS float16 self-draw (source-in): green is 0.6
+PASS float16 self-draw (source-in): blue is 0
+PASS float16 self-draw (source-in): alpha is 1
+PASS unorm8 self-draw (source-in): red is 0.6
+PASS unorm8 self-draw (source-in): green is 0.6
+PASS unorm8 self-draw (source-in): blue is 0
+PASS unorm8 self-draw (source-in): alpha is 1
+
+Cross-canvas copy (globalCompositeOperation = "copy")
+PASS float16 -> float16 (copy-cross): red is 3.5
+PASS float16 -> float16 (copy-cross): green is 0.6
+PASS float16 -> float16 (copy-cross): blue is 0
+PASS float16 -> float16 (copy-cross): alpha is 1
+PASS float16 -> unorm8 (copy-cross): red is 1
+PASS float16 -> unorm8 (copy-cross): green is 0.6
+PASS float16 -> unorm8 (copy-cross): blue is 0
+PASS float16 -> unorm8 (copy-cross): alpha is 1
+PASS unorm8 -> float16 (copy-cross): red is 0.6
+PASS unorm8 -> float16 (copy-cross): green is 0.6
+PASS unorm8 -> float16 (copy-cross): blue is 0
+PASS unorm8 -> float16 (copy-cross): alpha is 1
+PASS unorm8 -> unorm8 (copy-cross): red is 0.6
+PASS unorm8 -> unorm8 (copy-cross): green is 0.6
+PASS unorm8 -> unorm8 (copy-cross): blue is 0
+PASS unorm8 -> unorm8 (copy-cross): alpha is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-display-p3.html
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-display-p3.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+    <canvas id="canvas" data-color-space="display-p3" data-rendering-mode="Accelerated"></canvas>
+<script src="float16-canvas-drawimage-canvas.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-expected.txt
@@ -1,0 +1,83 @@
+Tests that drawImage() from a 2D canvas preserves HDR (extended-range float16) values, and clamps them when the destination is SDR.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+canvas.dataset.colorSpace: srgb
+canvas.dataset.renderingMode: Accelerated
+
+Simple drawImage (globalCompositeOperation = "source-over")
+PASS float16 -> float16 (simple): red is 3.5
+PASS float16 -> float16 (simple): green is 0.6
+PASS float16 -> float16 (simple): blue is 0
+PASS float16 -> float16 (simple): alpha is 1
+PASS float16 -> unorm8 (simple): red is 1
+PASS float16 -> unorm8 (simple): green is 0.6
+PASS float16 -> unorm8 (simple): blue is 0
+PASS float16 -> unorm8 (simple): alpha is 1
+PASS unorm8 -> float16 (simple): red is 0.6
+PASS unorm8 -> float16 (simple): green is 0.6
+PASS unorm8 -> float16 (simple): blue is 0
+PASS unorm8 -> float16 (simple): alpha is 1
+PASS unorm8 -> unorm8 (simple): red is 0.6
+PASS unorm8 -> unorm8 (simple): green is 0.6
+PASS unorm8 -> unorm8 (simple): blue is 0
+PASS unorm8 -> unorm8 (simple): alpha is 1
+
+Self-copy (globalCompositeOperation = "copy")
+PASS float16 self-draw (copy-self): red is 3.5
+PASS float16 self-draw (copy-self): green is 0.6
+PASS float16 self-draw (copy-self): blue is 0
+PASS float16 self-draw (copy-self): alpha is 1
+PASS unorm8 self-draw (copy-self): red is 0.6
+PASS unorm8 self-draw (copy-self): green is 0.6
+PASS unorm8 self-draw (copy-self): blue is 0
+PASS unorm8 self-draw (copy-self): alpha is 1
+
+Full-canvas composite (globalCompositeOperation = "source-in")
+PASS float16 -> float16 (source-in): red is 3.5
+PASS float16 -> float16 (source-in): green is 0.6
+PASS float16 -> float16 (source-in): blue is 0
+PASS float16 -> float16 (source-in): alpha is 1
+PASS float16 -> unorm8 (source-in): red is 1
+PASS float16 -> unorm8 (source-in): green is 0.6
+PASS float16 -> unorm8 (source-in): blue is 0
+PASS float16 -> unorm8 (source-in): alpha is 1
+PASS unorm8 -> float16 (source-in): red is 0.6
+PASS unorm8 -> float16 (source-in): green is 0.6
+PASS unorm8 -> float16 (source-in): blue is 0
+PASS unorm8 -> float16 (source-in): alpha is 1
+PASS unorm8 -> unorm8 (source-in): red is 0.6
+PASS unorm8 -> unorm8 (source-in): green is 0.6
+PASS unorm8 -> unorm8 (source-in): blue is 0
+PASS unorm8 -> unorm8 (source-in): alpha is 1
+PASS float16 self-draw (source-in): red is 3.5
+PASS float16 self-draw (source-in): green is 0.6
+PASS float16 self-draw (source-in): blue is 0
+PASS float16 self-draw (source-in): alpha is 1
+PASS unorm8 self-draw (source-in): red is 0.6
+PASS unorm8 self-draw (source-in): green is 0.6
+PASS unorm8 self-draw (source-in): blue is 0
+PASS unorm8 self-draw (source-in): alpha is 1
+
+Cross-canvas copy (globalCompositeOperation = "copy")
+PASS float16 -> float16 (copy-cross): red is 3.5
+PASS float16 -> float16 (copy-cross): green is 0.6
+PASS float16 -> float16 (copy-cross): blue is 0
+PASS float16 -> float16 (copy-cross): alpha is 1
+PASS float16 -> unorm8 (copy-cross): red is 1
+PASS float16 -> unorm8 (copy-cross): green is 0.6
+PASS float16 -> unorm8 (copy-cross): blue is 0
+PASS float16 -> unorm8 (copy-cross): alpha is 1
+PASS unorm8 -> float16 (copy-cross): red is 0.6
+PASS unorm8 -> float16 (copy-cross): green is 0.6
+PASS unorm8 -> float16 (copy-cross): blue is 0
+PASS unorm8 -> float16 (copy-cross): alpha is 1
+PASS unorm8 -> unorm8 (copy-cross): red is 0.6
+PASS unorm8 -> unorm8 (copy-cross): green is 0.6
+PASS unorm8 -> unorm8 (copy-cross): blue is 0
+PASS unorm8 -> unorm8 (copy-cross): alpha is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-no-gpu-process-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-no-gpu-process-expected.txt
@@ -1,0 +1,83 @@
+Tests that drawImage() from a 2D canvas preserves HDR (extended-range float16) values, and clamps them when the destination is SDR.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+canvas.dataset.colorSpace: srgb
+canvas.dataset.renderingMode: Accelerated
+
+Simple drawImage (globalCompositeOperation = "source-over")
+PASS float16 -> float16 (simple): red is 3.5
+PASS float16 -> float16 (simple): green is 0.6
+PASS float16 -> float16 (simple): blue is 0
+PASS float16 -> float16 (simple): alpha is 1
+PASS float16 -> unorm8 (simple): red is 1
+PASS float16 -> unorm8 (simple): green is 0.6
+PASS float16 -> unorm8 (simple): blue is 0
+PASS float16 -> unorm8 (simple): alpha is 1
+PASS unorm8 -> float16 (simple): red is 0.6
+PASS unorm8 -> float16 (simple): green is 0.6
+PASS unorm8 -> float16 (simple): blue is 0
+PASS unorm8 -> float16 (simple): alpha is 1
+PASS unorm8 -> unorm8 (simple): red is 0.6
+PASS unorm8 -> unorm8 (simple): green is 0.6
+PASS unorm8 -> unorm8 (simple): blue is 0
+PASS unorm8 -> unorm8 (simple): alpha is 1
+
+Self-copy (globalCompositeOperation = "copy")
+PASS float16 self-draw (copy-self): red is 3.5
+PASS float16 self-draw (copy-self): green is 0.6
+PASS float16 self-draw (copy-self): blue is 0
+PASS float16 self-draw (copy-self): alpha is 1
+PASS unorm8 self-draw (copy-self): red is 0.6
+PASS unorm8 self-draw (copy-self): green is 0.6
+PASS unorm8 self-draw (copy-self): blue is 0
+PASS unorm8 self-draw (copy-self): alpha is 1
+
+Full-canvas composite (globalCompositeOperation = "source-in")
+PASS float16 -> float16 (source-in): red is 3.5
+PASS float16 -> float16 (source-in): green is 0.6
+PASS float16 -> float16 (source-in): blue is 0
+PASS float16 -> float16 (source-in): alpha is 1
+PASS float16 -> unorm8 (source-in): red is 1
+PASS float16 -> unorm8 (source-in): green is 0.6
+PASS float16 -> unorm8 (source-in): blue is 0
+PASS float16 -> unorm8 (source-in): alpha is 1
+PASS unorm8 -> float16 (source-in): red is 0.6
+PASS unorm8 -> float16 (source-in): green is 0.6
+PASS unorm8 -> float16 (source-in): blue is 0
+PASS unorm8 -> float16 (source-in): alpha is 1
+PASS unorm8 -> unorm8 (source-in): red is 0.6
+PASS unorm8 -> unorm8 (source-in): green is 0.6
+PASS unorm8 -> unorm8 (source-in): blue is 0
+PASS unorm8 -> unorm8 (source-in): alpha is 1
+PASS float16 self-draw (source-in): red is 3.5
+PASS float16 self-draw (source-in): green is 0.6
+PASS float16 self-draw (source-in): blue is 0
+PASS float16 self-draw (source-in): alpha is 1
+PASS unorm8 self-draw (source-in): red is 0.6
+PASS unorm8 self-draw (source-in): green is 0.6
+PASS unorm8 self-draw (source-in): blue is 0
+PASS unorm8 self-draw (source-in): alpha is 1
+
+Cross-canvas copy (globalCompositeOperation = "copy")
+PASS float16 -> float16 (copy-cross): red is 3.5
+PASS float16 -> float16 (copy-cross): green is 0.6
+PASS float16 -> float16 (copy-cross): blue is 0
+PASS float16 -> float16 (copy-cross): alpha is 1
+PASS float16 -> unorm8 (copy-cross): red is 1
+PASS float16 -> unorm8 (copy-cross): green is 0.6
+PASS float16 -> unorm8 (copy-cross): blue is 0
+PASS float16 -> unorm8 (copy-cross): alpha is 1
+PASS unorm8 -> float16 (copy-cross): red is 0.6
+PASS unorm8 -> float16 (copy-cross): green is 0.6
+PASS unorm8 -> float16 (copy-cross): blue is 0
+PASS unorm8 -> float16 (copy-cross): alpha is 1
+PASS unorm8 -> unorm8 (copy-cross): red is 0.6
+PASS unorm8 -> unorm8 (copy-cross): green is 0.6
+PASS unorm8 -> unorm8 (copy-cross): blue is 0
+PASS unorm8 -> unorm8 (copy-cross): alpha is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-no-gpu-process.html
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-no-gpu-process.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true UseGPUProcessForCanvasRenderingEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+    <canvas id="canvas" data-color-space="srgb" data-rendering-mode="Accelerated"></canvas>
+<script src="float16-canvas-drawimage-canvas.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated.html
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+    <canvas id="canvas" data-color-space="srgb" data-rendering-mode="Accelerated"></canvas>
+<script src="float16-canvas-drawimage-canvas.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated-expected.txt
@@ -1,0 +1,83 @@
+Tests that drawImage() from a 2D canvas preserves HDR (extended-range float16) values, and clamps them when the destination is SDR.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+canvas.dataset.colorSpace: srgb
+canvas.dataset.renderingMode: Unaccelerated
+
+Simple drawImage (globalCompositeOperation = "source-over")
+PASS float16 -> float16 (simple): red is 3.5
+PASS float16 -> float16 (simple): green is 0.6
+PASS float16 -> float16 (simple): blue is 0
+PASS float16 -> float16 (simple): alpha is 1
+PASS float16 -> unorm8 (simple): red is 1
+PASS float16 -> unorm8 (simple): green is 0.6
+PASS float16 -> unorm8 (simple): blue is 0
+PASS float16 -> unorm8 (simple): alpha is 1
+PASS unorm8 -> float16 (simple): red is 0.6
+PASS unorm8 -> float16 (simple): green is 0.6
+PASS unorm8 -> float16 (simple): blue is 0
+PASS unorm8 -> float16 (simple): alpha is 1
+PASS unorm8 -> unorm8 (simple): red is 0.6
+PASS unorm8 -> unorm8 (simple): green is 0.6
+PASS unorm8 -> unorm8 (simple): blue is 0
+PASS unorm8 -> unorm8 (simple): alpha is 1
+
+Self-copy (globalCompositeOperation = "copy")
+PASS float16 self-draw (copy-self): red is 3.5
+PASS float16 self-draw (copy-self): green is 0.6
+PASS float16 self-draw (copy-self): blue is 0
+PASS float16 self-draw (copy-self): alpha is 1
+PASS unorm8 self-draw (copy-self): red is 0.6
+PASS unorm8 self-draw (copy-self): green is 0.6
+PASS unorm8 self-draw (copy-self): blue is 0
+PASS unorm8 self-draw (copy-self): alpha is 1
+
+Full-canvas composite (globalCompositeOperation = "source-in")
+PASS float16 -> float16 (source-in): red is 3.5
+PASS float16 -> float16 (source-in): green is 0.6
+PASS float16 -> float16 (source-in): blue is 0
+PASS float16 -> float16 (source-in): alpha is 1
+PASS float16 -> unorm8 (source-in): red is 1
+PASS float16 -> unorm8 (source-in): green is 0.6
+PASS float16 -> unorm8 (source-in): blue is 0
+PASS float16 -> unorm8 (source-in): alpha is 1
+PASS unorm8 -> float16 (source-in): red is 0.6
+PASS unorm8 -> float16 (source-in): green is 0.6
+PASS unorm8 -> float16 (source-in): blue is 0
+PASS unorm8 -> float16 (source-in): alpha is 1
+PASS unorm8 -> unorm8 (source-in): red is 0.6
+PASS unorm8 -> unorm8 (source-in): green is 0.6
+PASS unorm8 -> unorm8 (source-in): blue is 0
+PASS unorm8 -> unorm8 (source-in): alpha is 1
+PASS float16 self-draw (source-in): red is 3.5
+PASS float16 self-draw (source-in): green is 0.6
+PASS float16 self-draw (source-in): blue is 0
+PASS float16 self-draw (source-in): alpha is 1
+PASS unorm8 self-draw (source-in): red is 0.6
+PASS unorm8 self-draw (source-in): green is 0.6
+PASS unorm8 self-draw (source-in): blue is 0
+PASS unorm8 self-draw (source-in): alpha is 1
+
+Cross-canvas copy (globalCompositeOperation = "copy")
+PASS float16 -> float16 (copy-cross): red is 3.5
+PASS float16 -> float16 (copy-cross): green is 0.6
+PASS float16 -> float16 (copy-cross): blue is 0
+PASS float16 -> float16 (copy-cross): alpha is 1
+PASS float16 -> unorm8 (copy-cross): red is 1
+PASS float16 -> unorm8 (copy-cross): green is 0.6
+PASS float16 -> unorm8 (copy-cross): blue is 0
+PASS float16 -> unorm8 (copy-cross): alpha is 1
+PASS unorm8 -> float16 (copy-cross): red is 0.6
+PASS unorm8 -> float16 (copy-cross): green is 0.6
+PASS unorm8 -> float16 (copy-cross): blue is 0
+PASS unorm8 -> float16 (copy-cross): alpha is 1
+PASS unorm8 -> unorm8 (copy-cross): red is 0.6
+PASS unorm8 -> unorm8 (copy-cross): green is 0.6
+PASS unorm8 -> unorm8 (copy-cross): blue is 0
+PASS unorm8 -> unorm8 (copy-cross): alpha is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated-no-gpu-process-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated-no-gpu-process-expected.txt
@@ -1,0 +1,83 @@
+Tests that drawImage() from a 2D canvas preserves HDR (extended-range float16) values, and clamps them when the destination is SDR.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+canvas.dataset.colorSpace: srgb
+canvas.dataset.renderingMode: Unaccelerated
+
+Simple drawImage (globalCompositeOperation = "source-over")
+PASS float16 -> float16 (simple): red is 3.5
+PASS float16 -> float16 (simple): green is 0.6
+PASS float16 -> float16 (simple): blue is 0
+PASS float16 -> float16 (simple): alpha is 1
+PASS float16 -> unorm8 (simple): red is 1
+PASS float16 -> unorm8 (simple): green is 0.6
+PASS float16 -> unorm8 (simple): blue is 0
+PASS float16 -> unorm8 (simple): alpha is 1
+PASS unorm8 -> float16 (simple): red is 0.6
+PASS unorm8 -> float16 (simple): green is 0.6
+PASS unorm8 -> float16 (simple): blue is 0
+PASS unorm8 -> float16 (simple): alpha is 1
+PASS unorm8 -> unorm8 (simple): red is 0.6
+PASS unorm8 -> unorm8 (simple): green is 0.6
+PASS unorm8 -> unorm8 (simple): blue is 0
+PASS unorm8 -> unorm8 (simple): alpha is 1
+
+Self-copy (globalCompositeOperation = "copy")
+PASS float16 self-draw (copy-self): red is 3.5
+PASS float16 self-draw (copy-self): green is 0.6
+PASS float16 self-draw (copy-self): blue is 0
+PASS float16 self-draw (copy-self): alpha is 1
+PASS unorm8 self-draw (copy-self): red is 0.6
+PASS unorm8 self-draw (copy-self): green is 0.6
+PASS unorm8 self-draw (copy-self): blue is 0
+PASS unorm8 self-draw (copy-self): alpha is 1
+
+Full-canvas composite (globalCompositeOperation = "source-in")
+PASS float16 -> float16 (source-in): red is 3.5
+PASS float16 -> float16 (source-in): green is 0.6
+PASS float16 -> float16 (source-in): blue is 0
+PASS float16 -> float16 (source-in): alpha is 1
+PASS float16 -> unorm8 (source-in): red is 1
+PASS float16 -> unorm8 (source-in): green is 0.6
+PASS float16 -> unorm8 (source-in): blue is 0
+PASS float16 -> unorm8 (source-in): alpha is 1
+PASS unorm8 -> float16 (source-in): red is 0.6
+PASS unorm8 -> float16 (source-in): green is 0.6
+PASS unorm8 -> float16 (source-in): blue is 0
+PASS unorm8 -> float16 (source-in): alpha is 1
+PASS unorm8 -> unorm8 (source-in): red is 0.6
+PASS unorm8 -> unorm8 (source-in): green is 0.6
+PASS unorm8 -> unorm8 (source-in): blue is 0
+PASS unorm8 -> unorm8 (source-in): alpha is 1
+PASS float16 self-draw (source-in): red is 3.5
+PASS float16 self-draw (source-in): green is 0.6
+PASS float16 self-draw (source-in): blue is 0
+PASS float16 self-draw (source-in): alpha is 1
+PASS unorm8 self-draw (source-in): red is 0.6
+PASS unorm8 self-draw (source-in): green is 0.6
+PASS unorm8 self-draw (source-in): blue is 0
+PASS unorm8 self-draw (source-in): alpha is 1
+
+Cross-canvas copy (globalCompositeOperation = "copy")
+PASS float16 -> float16 (copy-cross): red is 3.5
+PASS float16 -> float16 (copy-cross): green is 0.6
+PASS float16 -> float16 (copy-cross): blue is 0
+PASS float16 -> float16 (copy-cross): alpha is 1
+PASS float16 -> unorm8 (copy-cross): red is 1
+PASS float16 -> unorm8 (copy-cross): green is 0.6
+PASS float16 -> unorm8 (copy-cross): blue is 0
+PASS float16 -> unorm8 (copy-cross): alpha is 1
+PASS unorm8 -> float16 (copy-cross): red is 0.6
+PASS unorm8 -> float16 (copy-cross): green is 0.6
+PASS unorm8 -> float16 (copy-cross): blue is 0
+PASS unorm8 -> float16 (copy-cross): alpha is 1
+PASS unorm8 -> unorm8 (copy-cross): red is 0.6
+PASS unorm8 -> unorm8 (copy-cross): green is 0.6
+PASS unorm8 -> unorm8 (copy-cross): blue is 0
+PASS unorm8 -> unorm8 (copy-cross): alpha is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated-no-gpu-process.html
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated-no-gpu-process.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true UseGPUProcessForCanvasRenderingEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+    <canvas id="canvas" data-color-space="srgb" data-rendering-mode="Unaccelerated"></canvas>
+<script src="float16-canvas-drawimage-canvas.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated.html
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+    <canvas id="canvas" data-color-space="srgb" data-rendering-mode="Unaccelerated"></canvas>
+<script src="float16-canvas-drawimage-canvas.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas.js
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas.js
@@ -1,0 +1,151 @@
+description("Tests that drawImage() from a 2D canvas preserves HDR (extended-range float16) values, and clamps them when the destination is SDR.");
+
+// Exercises CanvasRenderingContext2DBase::drawImage(CanvasBase&, ...) for every
+// combination of float16 (HDR) and unorm8 (SDR) source/destination, across the three
+// distinct code paths in that function:
+//   1. "simple"     - a plain drawImageBuffer(), no intermediate buffer.
+//   2. "copy-self"  - globalCompositeOperation="copy" drawing a canvas onto itself,
+//                     which copies through an intermediate buffer.
+//   3. "source-in"  - a full-canvas composite mode, which composites through an
+//                     intermediate buffer in fullCanvasCompositedDrawImage().
+
+const colorSpace = canvas.dataset.colorSpace;
+const renderingMode = canvas.dataset.renderingMode;
+debug(`canvas.dataset.colorSpace: ${colorSpace}`);
+debug(`canvas.dataset.renderingMode: ${renderingMode}`);
+
+const componentsPerPixel = 4;
+// A float16 destination stores the drawn values essentially exactly, so half of a unorm8
+// color component unit is plenty.
+const float16_tolerance = 0.5 / 255;
+// A unorm8 destination quantizes to 1/255 steps (up to half a unit of representation
+// error), and drawing an extended-range source into it additionally requires CG to convert
+// out-of-range values into the destination's non-extended color space. That conversion has
+// been observed to shift a component by up to one unorm8 unit, so allow both.
+const unorm8_tolerance = 1.5 / 255;
+
+function toleranceFor(destinationColorType)
+{
+    return destinationColorType == "float16" ? float16_tolerance : unorm8_tolerance;
+}
+
+const canvasSize = 4;
+// Draw into a sub-rect, so that drawImage() does not take the rectContainsCanvas() path.
+const drawSize = canvasSize / 2;
+
+// An HDR red component, well outside [0,1], plus in-range green/blue.
+const hdrRed = 3.5;
+const green = 0.6;
+const blue = 0;
+const alpha = 1;
+
+function createContext(colorType)
+{
+    const element = document.createElement("canvas");
+    element.width = canvasSize;
+    element.height = canvasSize;
+    const settings = { colorSpace, colorType };
+    if (renderingMode)
+        settings.renderingModeForTesting = renderingMode;
+    const context = element.getContext("2d", settings);
+    if (!context) {
+        testFailed(`Could not create a "${colorType}" 2D context`);
+        return null;
+    }
+    if (context.getContextAttributes().colorType != colorType)
+        testFailed(`Expected colorType "${colorType}", got "${context.getContextAttributes().colorType}"`);
+    return context;
+}
+
+function fill(context, red)
+{
+    const imageData = context.createImageData(canvasSize, canvasSize, { pixelFormat: "rgba-float16" });
+    for (let pixel = 0; pixel < canvasSize * canvasSize; ++pixel) {
+        imageData.data[pixel * componentsPerPixel + 0] = red;
+        imageData.data[pixel * componentsPerPixel + 1] = green;
+        imageData.data[pixel * componentsPerPixel + 2] = blue;
+        imageData.data[pixel * componentsPerPixel + 3] = alpha;
+    }
+    context.putImageData(imageData, 0, 0);
+    return context;
+}
+
+function verifyPixel(label, context, expectedRed, tolerance)
+{
+    const data = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-float16" }).data;
+    const expected = [expectedRed, green, blue, alpha];
+    const names = ["red", "green", "blue", "alpha"];
+    for (let component = 0; component < componentsPerPixel; ++component) {
+        const actual = data[component];
+        if (Math.abs(actual - expected[component]) <= tolerance)
+            testPassed(`${label}: ${names[component]} is ${expected[component]}`);
+        else
+            testFailed(`${label}: ${names[component]} should be ${expected[component]}. Was ${actual}.`);
+    }
+}
+
+function sourceRed(sourceColorType)
+{
+    return sourceColorType == "float16" ? hdrRed : green;
+}
+
+function expectedRed(sourceColorType, destinationColorType)
+{
+    if (sourceColorType != "float16")
+        return green;
+    return destinationColorType == "float16" ? hdrRed : 1;
+}
+
+function testCrossCanvas(path, composite, sourceColorType, destinationColorType)
+{
+    const source = createContext(sourceColorType);
+    const destination = createContext(destinationColorType);
+    if (!source || !destination)
+        return;
+
+    fill(source, sourceRed(sourceColorType));
+    fill(destination, green);
+
+    destination.globalCompositeOperation = composite;
+    destination.drawImage(source.canvas, 0, 0, drawSize, drawSize);
+    verifyPixel(`${sourceColorType} -> ${destinationColorType} (${path})`, destination, expectedRed(sourceColorType, destinationColorType), toleranceFor(destinationColorType));
+}
+
+function testSelfDraw(path, composite, colorType)
+{
+    const context = createContext(colorType);
+    if (!context)
+        return;
+
+    fill(context, sourceRed(colorType));
+
+    context.globalCompositeOperation = composite;
+    context.drawImage(context.canvas, 0, 0, drawSize, drawSize);
+    verifyPixel(`${colorType} self-draw (${path})`, context, expectedRed(colorType, colorType), toleranceFor(colorType));
+}
+
+const colorTypes = ["float16", "unorm8"];
+
+debug('\nSimple drawImage (globalCompositeOperation = "source-over")');
+for (const sourceColorType of colorTypes) {
+    for (const destinationColorType of colorTypes)
+        testCrossCanvas("simple", "source-over", sourceColorType, destinationColorType);
+}
+
+debug('\nSelf-copy (globalCompositeOperation = "copy")');
+for (const colorType of colorTypes)
+    testSelfDraw("copy-self", "copy", colorType);
+
+debug('\nFull-canvas composite (globalCompositeOperation = "source-in")');
+for (const sourceColorType of colorTypes) {
+    for (const destinationColorType of colorTypes)
+        testCrossCanvas("source-in", "source-in", sourceColorType, destinationColorType);
+}
+for (const colorType of colorTypes)
+    testSelfDraw("source-in", "source-in", colorType);
+
+debug('\nCross-canvas copy (globalCompositeOperation = "copy")');
+for (const sourceColorType of colorTypes) {
+    for (const destinationColorType of colorTypes)
+        testCrossCanvas("copy-cross", "copy", sourceColorType, destinationColorType);
+}

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1862,7 +1862,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
         repaintEntireCanvas = true;
     } else if (state().globalComposite == CompositeOperator::Copy) {
         if (&sourceCanvas == &canvasBase()) {
-            if (auto copy = c->createImageBuffer(normalizedSrcRect.size(), 1, colorSpace())) {
+            if (auto copy = createCompatibleImageBuffer(*c, normalizedSrcRect.size())) {
                 copy->context().drawImageBuffer(*buffer, -normalizedSrcRect.location());
                 clearCanvas();
                 c->drawImageBuffer(*copy, normalizedDstRect, { { }, normalizedSrcRect.size() }, { state().globalComposite, state().globalBlend });
@@ -2097,7 +2097,7 @@ template<class T> void CanvasRenderingContext2DBase::fullCanvasCompositedDrawIma
     if (!c)
         return;
 
-    auto buffer = c->createImageBuffer(bufferRect.size());
+    auto buffer = createCompatibleImageBuffer(*c, bufferRect.size());
     if (!buffer)
         return;
 
@@ -3396,6 +3396,11 @@ RefPtr<ImageBuffer> CanvasRenderingContext2DBase::allocateImageBuffer() const
     if (auto renderingModeForTesting = this->renderingModeForTesting())
         renderingMode = *renderingModeForTesting;
     return ImageBuffer::create(canvasBase().size(), renderingMode, RenderingPurpose::Canvas, 1, colorSpace(), pixelFormat(), scriptExecutionContext->graphicsClient());
+}
+
+RefPtr<ImageBuffer> CanvasRenderingContext2DBase::createCompatibleImageBuffer(GraphicsContext& context, const FloatSize& size) const
+{
+    return context.createImageBuffer(size, colorSpace(), pixelFormat());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -412,6 +412,7 @@ protected:
     void NODELETE updateStateTransform(const AffineTransform&);
 
     RefPtr<ImageBuffer> allocateImageBuffer() const;
+    RefPtr<ImageBuffer> createCompatibleImageBuffer(GraphicsContext&, const FloatSize&) const;
     bool hasCreatedImageBuffer() const { return m_hasCreatedImageBuffer; }
     ImageBuffer* buffer() const;
     RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -265,6 +265,11 @@ RefPtr<ImageBuffer> GraphicsContext::createImageBuffer(const FloatSize& size, fl
     return ImageBuffer::create(size, renderingMode.value_or(this->renderingModeForCompatibleBuffer()), RenderingPurpose::Unspecified, resolutionScale, colorSpace, pixelFormat);
 }
 
+RefPtr<ImageBuffer> GraphicsContext::createImageBuffer(const FloatSize& size, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat) const
+{
+    return createImageBuffer(size, 1, colorSpace, std::nullopt, std::nullopt, { pixelFormat });
+}
+
 RefPtr<ImageBuffer> GraphicsContext::createScaledImageBuffer(const FloatSize& size, const FloatSize& scale, const DestinationColorSpace& colorSpace, std::optional<RenderingMode> renderingMode, std::optional<RenderingMethod> renderingMethod) const
 {
     auto expandedScaledSize = scaledImageBufferSize(size, scale);

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -247,6 +247,7 @@ public:
     IntSize compatibleImageBufferSize(const FloatSize&) const;
 
     WEBCORE_EXPORT virtual RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, float resolutionScale = 1, const DestinationColorSpace& = DestinationColorSpace::SRGB(), std::optional<RenderingMode> = std::nullopt, std::optional<RenderingMethod> = std::nullopt, ImageBufferFormat = { PixelFormat::BGRA8 }) const;
+    RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, const DestinationColorSpace&, PixelFormat) const;
 
     WEBCORE_EXPORT RefPtr<ImageBuffer> createScaledImageBuffer(const FloatSize&, const FloatSize& scale = { 1, 1 }, const DestinationColorSpace& = DestinationColorSpace::SRGB(), std::optional<RenderingMode> = std::nullopt, std::optional<RenderingMethod> = std::nullopt) const;
     WEBCORE_EXPORT RefPtr<ImageBuffer> createScaledImageBuffer(const FloatRect&, const FloatSize& scale = { 1, 1 }, const DestinationColorSpace& = DestinationColorSpace::SRGB(), std::optional<RenderingMode> = std::nullopt, std::optional<RenderingMethod> = std::nullopt) const;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -42,6 +42,17 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBufferCGBitmapBackend);
 
+static CGBitmapInfo bitmapInfoForPixelFormat(PixelFormat pixelFormat)
+{
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (pixelFormat == PixelFormat::RGBA16F)
+        return static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedLast) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder16Host) | static_cast<CGBitmapInfo>(kCGBitmapFloatComponents);
+#else
+    UNUSED_PARAM(pixelFormat);
+#endif
+    return static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedFirst) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
+}
+
 size_t ImageBufferCGBitmapBackend::calculateMemoryCost(const Parameters& parameters)
 {
     return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize, parameters.bufferFormat.pixelFormat));
@@ -49,16 +60,18 @@ size_t ImageBufferCGBitmapBackend::calculateMemoryCost(const Parameters& paramet
 
 std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
 {
-    ASSERT(parameters.bufferFormat.pixelFormat == PixelFormat::BGRA8);
+    auto pixelFormat = parameters.bufferFormat.pixelFormat;
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    RELEASE_ASSERT(parameters.bufferFormat.pixelFormat != PixelFormat::RGBA16F);
+    ASSERT(pixelFormat == PixelFormat::BGRA8 || pixelFormat == PixelFormat::RGBA16F);
+#else
+    ASSERT(pixelFormat == PixelFormat::BGRA8);
 #endif
 
     IntSize backendSize = calculateSafeBackendSize(parameters);
     if (backendSize.isEmpty())
         return nullptr;
 
-    CheckedSize bytesPerRow = checkedProduct<size_t>(4, backendSize.width());
+    CheckedSize bytesPerRow = checkedProduct<size_t>(PixelBuffer::bytesPerPixel(pixelFormat), backendSize.width());
     if (bytesPerRow.hasOverflowed())
         return nullptr;
 
@@ -74,7 +87,7 @@ std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(c
 
     verifyImageBufferIsBigEnough(data.span());
 
-    RetainPtr cgContext = adoptCF(CGBitmapContextCreate(data.mutableSpan().data(), backendSize.width(), backendSize.height(), 8, bytesPerRow, parameters.colorSpace.platformColorSpace(), static_cast<uint32_t>(kCGImageAlphaPremultipliedFirst) | static_cast<uint32_t>(kCGBitmapByteOrder32Host)));
+    RetainPtr cgContext = adoptCF(CGBitmapContextCreate(data.mutableSpan().data(), backendSize.width(), backendSize.height(), PixelBuffer::bytesPerPixelComponent(pixelFormat) * 8, bytesPerRow, parameters.colorSpace.platformColorSpace(), bitmapInfoForPixelFormat(pixelFormat)));
     if (!cgContext)
         return nullptr;
 
@@ -123,9 +136,10 @@ RefPtr<NativeImage> ImageBufferCGBitmapBackend::copyNativeImage()
 RefPtr<NativeImage> ImageBufferCGBitmapBackend::createNativeImageReference()
 {
     auto backendSize = size();
+    auto pixelFormat = m_parameters.bufferFormat.pixelFormat;
     return NativeImage::create(adoptCF(CGImageCreate(
-        backendSize.width(), backendSize.height(), 8, 32, bytesPerRow(),
-        colorSpace().platformColorSpace(), static_cast<uint32_t>(kCGImageAlphaPremultipliedFirst) | static_cast<uint32_t>(kCGBitmapByteOrder32Host), m_dataProvider.get(),
+        backendSize.width(), backendSize.height(), PixelBuffer::bytesPerPixelComponent(pixelFormat) * 8, PixelBuffer::bytesPerPixel(pixelFormat) * 8, bytesPerRow(),
+        colorSpace().platformColorSpace(), bitmapInfoForPixelFormat(pixelFormat), m_dataProvider.get(),
         0, true, kCGRenderingIntentDefault)));
 }
 


### PR DESCRIPTION
#### 4067adafd0c995efd469d79f7ad8fc4fc2160ced
<pre>
Complete HDR CanvasRenderingContext2DBase::drawImage from 2d canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=321625">https://bugs.webkit.org/show_bug.cgi?id=321625</a>
<a href="https://rdar.apple.com/184755917">rdar://184755917</a>

Reviewed by Mike Wyrzykowski.

The only missing parts were to ensure that we create an ImageBuffer with
the same pixel format as the current context, so that HDR data is not
clamped.
And ImageBuffer now supports the RGBA16F pixel format.

Add tests for all combinations of SDR/HDR canvas to SDR/HDR canvas,
different composition operations, with/without GPU process, and with
accelerated or unaccelerated rendering.

* LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-display-p3-expected.txt: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-display-p3.html: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-expected.txt: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-no-gpu-process-expected.txt: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated-no-gpu-process.html: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-accelerated.html: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated-expected.txt: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated-no-gpu-process-expected.txt: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated-no-gpu-process.html: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas-unaccelerated.html: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-drawimage-canvas.js: Added.
(toleranceFor):
(createContext):
(fill):
(verifyPixel):
(expectedRed):
(testCrossCanvas):
(testSelfDraw):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::fullCanvasCompositedDrawImage):
(WebCore::CanvasRenderingContext2DBase::createCompatibleImageBuffer const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::createImageBuffer const):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::bitmapInfoForPixelFormat):
(WebCore::ImageBufferCGBitmapBackend::create):
(WebCore::ImageBufferCGBitmapBackend::createNativeImageReference):

Canonical link: <a href="https://commits.webkit.org/319201@main">https://commits.webkit.org/319201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b017b409e9c64b84e8b003a04ae0e8d27a4cfe7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190906 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145017 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140945 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121397 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41570 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41242 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2067 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192843 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150323 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40251 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54994 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150040 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44654 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127259 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122495 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53511 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16235 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52893 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53130 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52958 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->