### PR TITLE
check-webkit-style applies C++ rules to the contents of raw string literals

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -883,13 +883,69 @@ def cleanse_comments(line):
     return _RE_PATTERN_CLEANSE_LINE_C_COMMENTS.sub('', line)
 
 
+def cleanse_raw_strings(raw_lines):
+    """Removes the contents of C++ raw string literals.
+
+    A raw string literal, R"delim( ... )delim", holds its contents verbatim, so what
+    is between the delimiters is data and not C++. Checking it against C++ rules
+    produces false positives, and the text often cannot be changed at all without
+    changing the value of the string.
+
+    Each literal is replaced by an empty string. One line of output is produced per
+    line of input, so line numbers still line up with the file.
+
+    Args:
+      raw_lines: A list of all the lines in the file.
+
+    Returns:
+      The lines with the contents of raw string literals removed.
+    """
+    delimiter = None
+    lines_without_raw_strings = []
+    for line in raw_lines:
+        if delimiter:
+            # Inside a literal, look for the end of it.
+            end = line.find(delimiter)
+            if end >= 0:
+                # Found it. Keep this line's indentation so indentation checks still
+                # see something sensible, and keep whatever follows the delimiter.
+                leading_space = match(r'^(\s*)\S', line)
+                line = (leading_space.group(1) if leading_space else '') + '""' + line[end + len(delimiter):]
+                delimiter = None
+            else:
+                line = '""'
+
+        # Look for the start of a literal. This is a loop so that several literals on
+        # one line are all handled.
+        while delimiter is None:
+            matched = match(r'^(.*?)\b(?:R|u8R|uR|UR|LR)"([^\s\\()]*)\((.*)$', line)
+            # Ignore an opener that sits after a // comment. The quoted alternatives in
+            # the pattern keep a // inside a string from counting as a comment.
+            if not matched or match(r'^([^\'"]|\'(\\.|[^\'])*\'|"(\\.|[^"])*")*//', matched.group(1)):
+                break
+            delimiter = ')' + matched.group(2) + '"'
+            end = matched.group(3).find(delimiter)
+            if end >= 0:
+                # Opened and closed on the same line.
+                line = matched.group(1) + '""' + matched.group(3)[end + len(delimiter):]
+                delimiter = None
+            else:
+                line = matched.group(1) + '""'
+
+        lines_without_raw_strings.append(line)
+
+    return lines_without_raw_strings
+
+
 class CleansedLines(object):
-    """Holds 3 copies of all lines with different preprocessing applied to them.
+    """Holds 4 copies of all lines with different preprocessing applied to them.
 
     1) elided member contains lines without strings and comments,
     2) lines member contains lines without comments, and
     3) raw member contains all the lines without processing.
-    All these three members are of <type 'list'>, and of the same length.
+    4) lines_without_raw_strings member contains lines with the contents of raw
+       string literals removed, but comments and ordinary strings left alone.
+    All these four members are of <type 'list'>, and of the same length.
     """
 
     def __init__(self, lines):
@@ -897,9 +953,10 @@ class CleansedLines(object):
         self.lines = []
         self.raw_lines = lines
         self._num_lines = len(lines)
-        for line_number in range(len(lines)):
-            self.lines.append(cleanse_comments(lines[line_number]))
-            elided = self.collapse_strings(lines[line_number])
+        self.lines_without_raw_strings = cleanse_raw_strings(lines)
+        for line_number in range(len(self.lines_without_raw_strings)):
+            self.lines.append(cleanse_comments(self.lines_without_raw_strings[line_number]))
+            elided = self.collapse_strings(self.lines_without_raw_strings[line_number])
             self.elided.append(cleanse_comments(elided))
 
     def num_lines(self):
@@ -2215,7 +2272,10 @@ def check_spacing(file_extension, clean_lines, line_number, file_state, error):
       error: The function to call with any errors found.
     """
 
-    raw = clean_lines.raw_lines
+    # Don't use "elided" lines here, otherwise we can't check commented lines.
+    # Don't use "raw_lines" either, because the contents of a raw string literal
+    # are not C++ and must not be checked as if they were.
+    raw = clean_lines.lines_without_raw_strings
     line = raw[line_number]
 
     # Before nixing comments, check if the line is blank for no good
@@ -3653,7 +3713,9 @@ def check_for_null(clean_lines, line_number, file_state, error):
         error(line_number, 'readability/null', 5, 'Use nullptr instead of NULL.')
         return
 
-    line = clean_lines.raw_lines[line_number]
+    # Comments are still present here, which is the point of this second check, but the
+    # contents of raw string literals are not.
+    line = clean_lines.lines_without_raw_strings[line_number]
     # See if NULL occurs in any comments in the line. If the search for NULL using the raw line
     # matches, then do the check with strings collapsed to avoid giving errors for
     # NULLs occurring in strings.
@@ -3966,7 +4028,10 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
       error: The function to call with any errors found.
     """
 
-    raw_lines = clean_lines.raw_lines
+    # Don't use "elided" lines here, otherwise we can't check commented lines.
+    # Don't use "raw_lines" either, because the contents of a raw string literal
+    # are not C++ and must not be checked as if they were.
+    raw_lines = clean_lines.lines_without_raw_strings
     line = raw_lines[line_number]
 
     check_namespace_indentation(clean_lines, line_number, file_extension, file_state, error)

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -2310,6 +2310,36 @@ class CppStyleTest(CppStyleTestBase):
         self.assert_lint('while (  foo) {', 'Extra space after ( in while'
                          '  [whitespace/parens] [5]')
 
+    def test_raw_string_contents_are_not_checked(self):
+        # The text inside a raw string literal is data, not C++, so C++ rules must not
+        # be applied to it. https://bugs.webkit.org/show_bug.cgi?id=321583
+        self.assert_multi_line_lint(
+            'static const char* script = R"js(function f() {\n'
+            '    if(!window.x) { return; }\n'
+            '    window.y = 1;  // two spaces before this comment\n'
+            '    window.z = (window.a==window.b);\n'
+            '    var p = NULL;\n'
+            '})js";\n',
+            '',
+            'foo.cpp')
+
+        # A literal opening and closing on one line, contents likewise ignored.
+        self.assert_multi_line_lint(
+            'static const char* script = R"js(if(x) { })js";\n',
+            '',
+            'foo.cpp')
+
+        # The same code outside a literal is still reported, so the rules are not
+        # simply switched off.
+        self.assert_multi_line_lint(
+            'void f(bool b)\n'
+            '{\n'
+            '    if (!b) { return; }\n'
+            '}\n',
+            'More than one command on the same line in if'
+            '  [whitespace/parens] [4]',
+            'foo.cpp')
+
     def test_spacing_for_fncall(self):
         self.assert_lint('if (foo) {', '')
         self.assert_lint('for (foo;bar;baz) {', '')
@@ -3443,6 +3473,45 @@ class CleansedLinesTest(unittest.TestCase):
                           collapse('StringReplace(body, "\\\\", "\\\\\\\\");'))
         self.assertEqual('\'\' ""',
                           collapse('\'"\' "foo"'))
+
+    def test_cleanse_raw_strings(self):
+        cleanse = cpp_style.cleanse_raw_strings
+
+        # A literal opening and closing on one line, with and without a delimiter.
+        self.assertEqual(['const char* a = "";'], cleanse(['const char* a = R"(xyz)";']))
+        self.assertEqual(['const char* a = "";'], cleanse(['const char* a = R"js(xyz)js";']))
+
+        # Encoding prefixes.
+        self.assertEqual(['auto a = "";'], cleanse(['auto a = LR"(xyz)";']))
+        self.assertEqual(['auto a = "";'], cleanse(['auto a = u8R"js(xyz)js";']))
+
+        # Two literals on one line.
+        self.assertEqual(['f("", "");'], cleanse(['f(R"({)", R"js(})js");']))
+
+        # A literal spanning lines. One line of output per line of input, so line
+        # numbers still match, the contents are gone, and the indentation of the
+        # closing line is kept.
+        self.assertEqual(['    static const char* a = ""',
+                          '""',
+                          '    "";'],
+                         cleanse(['    static const char* a = R"js(function f() {',
+                                  '        if (x) { return "}"; }',
+                                  '    })js";']))
+
+        # Contents that look like C++ are not treated as C++.
+        self.assertEqual(['auto a = ""', '""', '"";'],
+                         cleanse(['auto a = R"(NULL',
+                                  '\tif(x) { }  // comment',
+                                  ')";']))
+
+        # An opener inside a // comment is not an opener.
+        self.assertEqual(['// see R"js( for details'], cleanse(['// see R"js( for details']))
+
+        # Ordinary strings are left alone. Collapsing those is collapse_strings' job.
+        self.assertEqual(['const char* a = "xyz";'], cleanse(['const char* a = "xyz";']))
+
+        # Text before and after the literal is kept.
+        self.assertEqual(['f("", 1);'], cleanse(['f(R"js(a)js", 1);']))
 
 
 class OrderOfIncludesTest(CppStyleTestBase):


### PR DESCRIPTION
#### 066ce9b56345506df9fbab492d869434dffbdeb3
<pre>
check-webkit-style applies C++ rules to the contents of raw string literals
<a href="https://bugs.webkit.org/show_bug.cgi?id=321583">https://bugs.webkit.org/show_bug.cgi?id=321583</a>
<a href="https://rdar.apple.com/184699987">rdar://184699987</a>

Reviewed by NOBODY (OOPS!).

The text between the delimiters of a raw string literal, R&quot;delim( ... )delim&quot;,
is data rather than C++, but the style checker read it as code and applied
C++ rules to it. Embedding a script in a .cpp file, as Quirks.cpp does
twice, therefore produced errors on JavaScript: a JavaScript if block was
reported as a C++ one line control clause, a tab in the script text as one
that should be a space, and a NULL in the script as one that should be
nullptr. None of them can be acted on without changing the value of the
string.

CleansedLines collapses strings a line at a time, so it could never see a
literal that opens on one line and closes on another. Fix by adding a pass
that removes the contents of raw string literals before that collapsing
runs, keeping one line of output per line of input so line numbers still
match, and taking the results from it in the two checks that deliberately
work on unprocessed lines, check_spacing and check_style. This mirrors
cpplint, which grew the same pass and pointed the same two checks at it.
The second NULL check also moves over: it reads unprocessed lines so it can
look inside comments, and it already meant to ignore NULLs in strings.

Checks that read the elided or cleansed lines, check_braces and the first
NULL check among them, are fixed by the new pass without further change.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(cleanse_raw_strings):
(CleansedLines.__init__):
(check_spacing):
(check_for_null):
(check_style):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CleansedLinesTest.test_cleanse_raw_strings):
(CppStyleTest.test_raw_string_contents_are_not_checked):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/066ce9b56345506df9fbab492d869434dffbdeb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144533 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1772218a-93ef-417e-841d-6e69059ad50e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140553 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97351 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a27f0a7-a8d9-42cd-9dfe-8bf7fa1ade52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121005 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/090cf3f6-3eb1-447d-84a0-e2b56d3b4148) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/179538 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42887 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41192 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40864 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1584 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192360 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53825 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149901 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54513 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149630 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44270 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121921 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53030 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15853 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52412 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52649 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52477 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->