### PR TITLE
[AppKit Gestures] Momentum scrolling starts with a zero-delta event

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -194,7 +194,6 @@ private:
 
     std::atomic<bool> m_fingerDownIntervalIsActive = false;
     std::atomic<bool> m_momentumIntervalIsActive = false;
-    std::atomic<bool> m_momentumIntervalHasSeenNonZeroDeltaEvent = false;
 
     enum class SynchronizationState : uint8_t {
         Idle,

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -815,7 +815,6 @@ void RemoteLayerTreeEventDispatcher::startMomentumSignpostInterval()
     if (!m_momentumIntervalIsActive) {
         WTFBeginSignpostAlways(nullptr, ScrollingPerformanceTestMomentumInterval, "isAnimation=YES;");
         m_momentumIntervalIsActive = true;
-        m_momentumIntervalHasSeenNonZeroDeltaEvent = false;
     }
 }
 
@@ -837,12 +836,7 @@ void RemoteLayerTreeEventDispatcher::handleSyntheticWheelEvent(PageIdentifier pa
         if (event.momentumPhase() == WebWheelEvent::Phase::Began)
             startMomentumSignpostInterval();
 
-        bool eventHasNonZeroDelta = std::abs(event.delta().height()) > 0;
-        if (eventHasNonZeroDelta)
-            m_momentumIntervalHasSeenNonZeroDeltaEvent = true;
-
-        // FIXME: <rdar://184036413> Momentum intervals should only start with non-zero deltas.
-        if (m_momentumIntervalIsActive && ((!eventHasNonZeroDelta && m_momentumIntervalHasSeenNonZeroDeltaEvent) || event.momentumPhase() == WebWheelEvent::Phase::Ended))
+        if (m_momentumIntervalIsActive && (!std::abs(event.delta().height()) || event.momentumPhase() == WebWheelEvent::Phase::Ended))
             endMomentumSignpostInterval();
     }
 

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -211,8 +211,10 @@ void MomentumEventDispatcher::didStartMomentumPhase(WebCore::PageIdentifier page
 
     tracePoint(SyntheticMomentumStart);
 
+    auto inputSourceIsAutomation = event.inputSource() == WebEventInputSource::Automation;
+
     m_currentGesture.active = true;
-    m_currentGesture.momentumCurve = event.inputSource() == WebEventInputSource::Automation ? MomentumCurve::Simple : MomentumCurve::Default;
+    m_currentGesture.momentumCurve = inputSourceIsAutomation ? MomentumCurve::Simple : MomentumCurve::Default;
     m_currentGesture.pageIdentifier = pageIdentifier;
     m_currentGesture.initiatingEvent = event;
     m_currentGesture.currentOffset = { };
@@ -228,12 +230,23 @@ void MomentumEventDispatcher::didStartMomentumPhase(WebCore::PageIdentifier page
     float idealCurveMultiplier = m_currentGesture.accelerationCurve->frameRate() / idealCurveFrameRate;
     buildOffsetTableWithInitialDelta(*event.rawPlatformDelta() * idealCurveMultiplier * event.momentumFastScrollMultiplier());
 
-    WebCore::FloatSize consumedDelta = event.delta();
-    if (m_currentGesture.initiatingEvent->directionInvertedFromDevice())
-        consumedDelta.scale(-1);
-    m_currentGesture.currentOffset += consumedDelta;
-    
-    dispatchSyntheticMomentumEvent(WebWheelEvent::Phase::Began, event.delta());
+    WebCore::FloatSize beganDelta;
+
+    // When there is no backing platform momentum event to carry over
+    // the first frame from, we take it from the scrolling curve.
+    auto eventDelta = event.delta();
+    ASSERT_IMPLIES(inputSourceIsAutomation, eventDelta.isZero());
+    if (eventDelta.isZero())
+        beganDelta = consumeDeltaForCurrentTime().value_or(WebCore::FloatSize { });
+    else {
+        auto consumedDelta = eventDelta;
+        if (m_currentGesture.initiatingEvent->directionInvertedFromDevice())
+            consumedDelta.scale(-1);
+        m_currentGesture.currentOffset += consumedDelta;
+        beganDelta = eventDelta;
+    }
+
+    dispatchSyntheticMomentumEvent(WebWheelEvent::Phase::Began, beganDelta);
 }
 
 void MomentumEventDispatcher::didEndMomentumPhase()


### PR DESCRIPTION
#### 0a6dc7ee13339f81bc9af9c5e7f9a7393d3da1ca
<pre>
[AppKit Gestures] Momentum scrolling starts with a zero-delta event
<a href="https://bugs.webkit.org/show_bug.cgi?id=321589">https://bugs.webkit.org/show_bug.cgi?id=321589</a>
<a href="https://rdar.apple.com/184036413">rdar://184036413</a>

Reviewed by NOBODY (OOPS!).

MomentumEventDispatcher uses the &quot;began&quot; event for a momentum phase as
the first frame of the offset table, following which the rest of the
frames of the table are computed by MED. This uses the currentOffset
field on m_currentGesture to do so, which is derived from the momentum
event&apos;s delta.

For paths where there is no backing platform momentum event, we end up
producing a first frame with zero delta. Every later frame is computed
as a difference against currentOffset, though, so the total distance
scrolled is unaffected. However, we still want to fix this to address
the distribution of the first frame.

To fix, we teach didStartMomentumPhase() that it should not respect the
case that event.delta == 0, and should instead just directly call into
consumeDeltaForCurrentTime().

Note that we also undo the workaround we added to our momentum signpost
interval recording in RemoteLayerTreeEventDispatcher (<a href="https://commits.webkit.org/318752@main">318752@main</a>) since
&quot;first delta is zero&quot; can principally not happen again.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::startMomentumSignpostInterval):
(WebKit::RemoteLayerTreeEventDispatcher::handleSyntheticWheelEvent):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::didStartMomentumPhase):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a6dc7ee13339f81bc9af9c5e7f9a7393d3da1ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144579 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140597 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97383 "1 flakes 7 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121049 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42932 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41234 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40908 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1628 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192404 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53869 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149945 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54557 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149670 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44310 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126820 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121981 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53074 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15897 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52456 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52693 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52521 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->