### PR TITLE
[css-mixins-1] Function body should inherit computed custom property values from the calling context

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-types.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-types.tentative-expected.txt
@@ -6,4 +6,5 @@ FAIL A parameter type acts as a local registration (parent stack frame) assert_e
 PASS Universally typed parameter can shadow other parameters
 FAIL Invalid value for typed local becomes IACVT assert_equals: expected "PASS" but got "3"
 PASS if() within @function can query registered custom property
+PASS A local is untyped even where a registration of the same name exists
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-types.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-types.tentative.html
@@ -126,6 +126,29 @@
   </style>
 </template>
 
+<!-- Tentative: "only the custom property registrations in registrations are visible" implies
+     a local is untyped where a registration of the same name exists, but does not say so.
+     https://drafts.csswg.org/css-mixins-1/#resolve-function-styles -->
+
+<template data-name="A local is untyped even where a registration of the same name exists">
+  <style>
+    @property --untyped-local {
+      syntax: "<integer>";
+      inherits: true;
+      initial-value: 0;
+    }
+    @function --f() {
+      --untyped-local: red;
+      result: var(--untyped-local);
+    }
+    #target {
+      --untyped-local: 0;
+      --actual: --f();
+      --expected: red;
+    }
+  </style>
+</template>
+
 <script>
   test_all_templates();
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution-expected.txt
@@ -13,10 +13,14 @@ PASS if() cycle in condition specified value through local
 PASS if() cycle through function
 PASS if() no cycle in overridden local
 PASS if() no cycle in overridden argument
-FAIL CSS-wide keywords are interpreted locally (initial) assert_equals: expected "PASS" but got "FAIL"
+PASS CSS-wide keywords are interpreted locally (initial)
 PASS CSS-wide keywords are interpreted locally (inherit)
 PASS CSS-wide keywords are interpreted locally (guaranteed-invalid, initial)
 PASS CSS-wide keywords are interpreted locally (guaranteed-invalid, unset)
 PASS CSS-wide keywords are interpreted locally (revert)
 PASS CSS-wide keywords are interpreted locally (revert-layer)
+PASS Local shadows a registered custom property in if() condition
+PASS Parameter shadows a registered custom property in if() condition
+PASS Local shadows a registered custom property left at its initial value
+PASS A name the function does not declare keeps the registration
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution.html
@@ -299,6 +299,66 @@
   </style>
 </template>
 
+<!-- A local or parameter shadows a registration of the same name.
+     https://drafts.csswg.org/css-mixins-1/#resolve-function-styles -->
+
+<template data-name="Local shadows a registered custom property in if() condition">
+  <style>
+    @property --reg-local { syntax: "<integer>"; inherits: true; initial-value: 0; }
+    @function --f() {
+      --reg-local: 1;
+      result: if(style(--reg-local: 1): PASS; else: FAIL);
+    }
+    #target {
+      --reg-local: 0;
+      --actual: --f();
+      --expected: PASS;
+    }
+  </style>
+</template>
+
+<template data-name="Parameter shadows a registered custom property in if() condition">
+  <style>
+    @property --reg-param { syntax: "<integer>"; inherits: true; initial-value: 0; }
+    @function --f(--reg-param) {
+      result: if(style(--reg-param: 1): PASS; else: FAIL);
+    }
+    #target {
+      --reg-param: 0;
+      --actual: --f(1);
+      --expected: PASS;
+    }
+  </style>
+</template>
+
+<template data-name="Local shadows a registered custom property left at its initial value">
+  <style>
+    @property --reg-initial { syntax: "<integer>"; inherits: true; initial-value: 0; }
+    @function --f() {
+      --reg-initial: 1;
+      result: if(style(--reg-initial: 1): PASS; else: FAIL);
+    }
+    #target {
+      --actual: --f();
+      --expected: PASS;
+    }
+  </style>
+</template>
+
+<template data-name="A name the function does not declare keeps the registration">
+  <style>
+    @property --reg-unbound { syntax: "<integer>"; inherits: true; initial-value: 0; }
+    @function --f() {
+      result: if(style(--reg-unbound: 7): PASS; else: FAIL);
+    }
+    #target {
+      --reg-unbound: 7;
+      --actual: --f();
+      --expected: PASS;
+    }
+  </style>
+</template>
+
 <script>
   test_all_templates();
 </script>

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -49,6 +49,7 @@
 #include "StyleBuilder.h"
 #include "StyleCustomProperty.h"
 #include "StyleCustomPropertyRegistry.h"
+#include "StyleLocalPropertyRegistry.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleZoomPrimitivesInlines.h"
@@ -270,6 +271,15 @@ struct StyleFeatureSchema : public FeatureSchema {
     {
     }
 
+    // The compared value needs the same registrations as the queried property, or a shadowed
+    // registration compares a token stream against a typed value.
+    // https://drafts.csswg.org/css-mixins/#resolve-function-styles
+    static const Style::LocalPropertyRegistry* localPropertyRegistry(const FeatureEvaluationContext& context)
+    {
+        CheckedPtr builderState = context.conversionData.styleBuilderState();
+        return builderState ? builderState->localPropertyRegistry() : nullptr;
+    }
+
     // FeatureSchema conformance
 
     EvaluationResult evaluate(const MQ::Feature& feature, const FeatureEvaluationContext& context) const override
@@ -294,7 +304,8 @@ struct StyleFeatureSchema : public FeatureSchema {
                 .document = context.document.get(),
                 .parentStyle = context.conversionData.parentStyle(),
                 .rootElementStyle = context.conversionData.rootStyle(),
-                .element = context.conversionData.elementForContainerUnitResolution()
+                .element = context.conversionData.elementForContainerUnitResolution(),
+                .localPropertyRegistry = localPropertyRegistry(context)
             };
 
             auto dummyStyle = Style::ComputedStyle::clone(style);
@@ -329,7 +340,8 @@ struct StyleFeatureSchema : public FeatureSchema {
                     .document = context.document.get(),
                     .parentStyle = context.conversionData.parentStyle(),
                     .rootElementStyle = context.conversionData.rootStyle(),
-                    .element = context.conversionData.elementForContainerUnitResolution()
+                    .element = context.conversionData.elementForContainerUnitResolution(),
+                    .localPropertyRegistry = localPropertyRegistry(context)
                 };
                 dummyStyle = Style::ComputedStyle::clonePtr(style);
                 dummyMatchResult = Style::MatchResult::create();

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -56,6 +56,7 @@
 #include "StyleCustomPropertyData.h"
 #include "StyleCustomPropertyRegistry.h"
 #include "StyleFontSizeFunctions.h"
+#include "StyleLocalPropertyRegistry.h"
 #include "StylePropertyShorthand.h"
 #include "StyleSubstitutionResolver.h"
 #include <wtf/SetForScope.h>
@@ -253,7 +254,8 @@ void Builder::applyCustomPropertyFromCallingContext(const AtomString& name)
     auto* callingContextBuilder = m_state->callingContextBuilder();
     ASSERT(callingContextBuilder);
 
-    if (m_state->registeredProperty(name))
+    auto* localRegistry = m_state->localPropertyRegistry();
+    if (localRegistry && localRegistry->get(name))
         applyCustomProperty(name, CSSWideKeyword::Initial);
     else {
         callingContextBuilder->applyCustomProperty(name);

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -46,6 +46,7 @@
 #include "CSSLightDarkImageValue.h"
 #include "CSSNamedImageValue.h"
 #include "CSSPaintImageValue.h"
+#include "CSSParserIdioms.h"
 #include "DocumentInlines.h"
 #include "DocumentView.h"
 #include "ElementInlines.h"
@@ -92,8 +93,17 @@ BuilderState::BuilderState(ComputedStyle& style, BuilderContext&& context)
 
 const CSSRegisteredCustomProperty* BuilderState::registeredProperty(const AtomString& name) const
 {
-    if (m_context.localPropertyRegistry)
-        return m_context.localPropertyRegistry->get(name);
+    // "Only the custom property registrations in registrations are visible" covers the names a custom
+    // function introduces. A name it does not introduce arrives by inheritance carrying the calling
+    // element's computed value, so it keeps the document registration.
+    // https://drafts.csswg.org/css-mixins/#resolve-function-styles
+    if (m_context.localPropertyRegistry) {
+        if (auto* local = m_context.localPropertyRegistry->get(name))
+            return local;
+        // The result descriptor is never registered document-wide.
+        if (!isCustomPropertyName(name))
+            return nullptr;
+    }
     return document().customPropertyRegistry().get(name);
 }
 

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -142,6 +142,9 @@ public:
 
     const CSSRegisteredCustomProperty* registeredProperty(const AtomString&) const;
 
+    // The registrations of the custom function being evaluated, if any. These shadow the document's.
+    const LocalPropertyRegistry* localPropertyRegistry() const { return m_context.localPropertyRegistry; }
+
     inline void setZoom(Zoom);
     inline void setUsedZoom(float);
     inline void setWritingMode(StyleWritingMode);

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -568,6 +568,21 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
         return mutableProperties;
     }();
 
+    // A local is not the document-registered property of the same name, so registering it as universal
+    // keeps it untyped. A parameter keeps its own registration, whose initial value is the argument.
+    for (auto property : bodyProperties.get()) {
+        if (property.id() != CSSPropertyCustom)
+            continue;
+        auto& name = downcast<CSSCustomPropertyValue>(*property.value()).name();
+        if (registrations.get(name))
+            continue;
+        registrations.add({
+            .name = name,
+            .syntax = CSSCustomPropertySyntax::universal(),
+            .inherits = true,
+        });
+    }
+
     auto bodyMatchResult = MatchResult::create();
     bodyMatchResult->authorDeclarations.append({ *resolvedArgumentProperties });
     bodyMatchResult->authorDeclarations.append({ .properties = bodyProperties, .styleScopeOrdinal = foundScopeOrdinal });


### PR DESCRIPTION
#### 52251cec00d0e89ffaca38d21f7782c0da17b0b5
<pre>
[css-mixins-1] Function body should inherit computed custom property values from the calling context
<a href="https://bugs.webkit.org/show_bug.cgi?id=321585">https://bugs.webkit.org/show_bug.cgi?id=321585</a>
<a href="https://rdar.apple.com/184701762">rdar://184701762</a>

Reviewed by Alan Baradlay.

BuilderState::registeredProperty returned only the function&apos;s own registrations, so a document
@property registration was invisible inside a function body. A name the function does not
introduce arrives there by inheritance, carrying the calling element&apos;s computed value, so the
value was typed while the registration view said unregistered. var() reads the equivalent
token sequence either way and never noticed, but if(style()) compared a typed value against a
token stream and never matched.

Make the function&apos;s registrations shadow the document&apos;s rather than replace them, register the
body&apos;s local variables with the universal syntax so a local stays untyped, and resolve the
style() feature value with the same registrations as the property it is compared against.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-types.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-parameter-types.tentative.html:
Tentative because the spec wording does not address an untyped local directly.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution.html:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
(WebCore::CQ::Features::StyleFeatureSchema::localPropertyRegistry):
(WebCore::CQ::Features::StyleFeatureSchema::evaluateRange const):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomPropertyFromCallingContext):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::registeredProperty const):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::localPropertyRegistry const):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteDashedFunction):

Canonical link: <a href="https://commits.webkit.org/319031@main">https://commits.webkit.org/319031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c955ff2f94e411cd4291e2bf112f518a43eec91d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190440 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144550 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/708e8a70-12a2-4e60-ab27-0202166f1712) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140570 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7fcd05dd-df96-4326-bbe4-370b6aad8ec1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121022 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1195491c-ccca-4650-9d3e-1c83d8424435) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41207 "Passed tests") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153303 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40879 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1599 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192375 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149917 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40147 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54528 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149645 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44284 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126791 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121939 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53045 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15868 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52427 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52492 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->