### PR TITLE
[LBSE] Apply filters specified on the outermost <svg>

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -49,12 +49,10 @@ svg/filters/feImage-filterUnits-userSpaceOnUse-primitiveUnits-objectBoundingBox.
 svg/filters/feImage-filterUnits-userSpaceOnUse-primitiveUnits-userSpaceOnUse.svg       [ ImageOnlyFailure ]
 svg/filters/feImage-late-indirect-update.svg                                           [ ImageOnlyFailure ]
 svg/filters/feImage-reference-svg-primitive.svg                                        [ ImageOnlyFailure ]
-svg/filters/filter-image-ref-root.html                                                 [ ImageOnlyFailure ]
 svg/filters/filter-on-root-tile-boundary.html                                          [ ImageOnlyFailure ]
 svg/filters/filter-on-tspan.svg                                                        [ ImageOnlyFailure ]
 svg/filters/filter-placement-issue.svg                                                 [ ImageOnlyFailure ]
 svg/filters/filter-source-position.svg                                                 [ ImageOnlyFailure ]
-svg/filters/filter-specified-on-svg-root.html                                          [ ImageOnlyFailure ]
 
 # Regressed by conditional layer creation (bugs.webkit.org/b/308565). Filter and resource-buffer
 # painting for non-layered SVG renderers is corrected by a follow-up PR, which restores these.

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1055,7 +1055,7 @@ bool RenderLayer::shouldPaintWithFilters(OptionSet<PaintBehavior> paintBehavior)
     if (filter.isNone())
         return false;
 
-    if (renderer().isRenderOrLegacyRenderSVGRoot() && filter.isReferenceFilter())
+    if (renderer().isLegacyRenderSVGRoot() && filter.isReferenceFilter())
         return false;
 
     if (RenderLayerFilters::isIdentity(renderer()))
@@ -3771,6 +3771,11 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
 
         LayerPaintingInfo localPaintingInfo(paintingInfo);
 
+        // The outermost <svg> is a replaced element in the CSS box tree, so its filter is set up in
+        // CSS box coordinates (see RenderLayerFilters::beginFilterEffect) and none of the SVG user
+        // space corrections in this scope apply to it.
+        bool filtersInSVGUserSpace = renderer().isSVGLayerAwareRenderer() && !renderer().isRenderSVGRoot();
+
         // Position the filter buffer and composite its result at the element's
         // nominalSVGLayoutLocation, independent of intermediate force-layers that perturb offsetFromRoot.
         auto svgFilterOffset = columnAwareOffsetFromRoot;
@@ -3783,29 +3788,16 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
 
         auto* filterContext = setupFilters(context, localPaintingInfo, localPaintFlags, svgFilterOffset, backgroundRect);
 
-        // Non-layer content drawn into the buffer uses a distinct offset. The buffer coordinate
-        // system is the filter region (transform-aware objectBoundingBox), whereas svgFilterOffset is
-        // based on objectBoundingBoxWithoutTransformations. The two differ by the child-transform delta
-        // only when the filtered element has a transformed child (e.g. a layered <use> with x/y), and
-        // are equal otherwise. This positions non-layer fragment collection only. A layer child already
-        // carries its transform in its CTM, so it uses svgFilterOffset (the buffer origin). Adding the
-        // delta there would double-count the transform (svg/filters/filter-refresh.svg).
         auto svgFilterContentOffset = svgFilterOffset;
-        if (filterContext && renderer().isSVGLayerAwareRenderer())
+        if (filterContext && filtersInSVGUserSpace)
             svgFilterContentOffset += renderer().objectBoundingBoxLocation() - renderer().nominalSVGLayoutLocation();
 
-        // Layer children reset their CTM via offsetFromAncestor(rootLayer) and miss the buffer origin
-        // that non-layer children pick up through containerBaseOffset, so translate them by
-        // svgFilterOffset to match. Needed when rootLayer == this, and when this filter is nested
-        // inside another filter whose buffer was coordinate-origin shifted (our buffer inherits the
-        // shift but the layer child does not, svg/filters/filter-refresh.svg). The nested case is read
-        // from rootLayer directly: a descendant painting inside a shifted buffer always has that
-        // shifting ancestor (transformed, hence rootLayer-establishing, and filtered) as its rootLayer.
         // A failed filter does not paint its descendants, so a rootLayer with hasFilter() set up a buffer.
         CheckedPtr currentRootLayer = localPaintingInfo.rootLayer;
         bool rootLayerShiftedFilterBuffer = currentRootLayer && currentRootLayer != this
-            && currentRootLayer->hasFilter() && currentRootLayer->renderer().isSVGLayerAwareRenderer();
-        bool appliesFilterChildCorrection = filterContext && renderer().isSVGLayerAwareRenderer()
+            && currentRootLayer->hasFilter() && currentRootLayer->renderer().isSVGLayerAwareRenderer()
+            && !currentRootLayer->renderer().isRenderSVGRoot();
+        bool appliesFilterChildCorrection = filterContext && filtersInSVGUserSpace
             && (currentRootLayer == this || rootLayerShiftedFilterBuffer);
 
         // This applies to this layer's immediate child layers only, and a nested filter re-derives its own.
@@ -3933,7 +3925,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
             // element is its own rootLayer, or a force-created ancestor layer baked it in). In the plain
             // non-layer case offsetFromRoot equals the nominal position and isZero() skips.
             GraphicsContextStateSaver filterCompensationSaver(context, false);
-            if (renderer().isSVGLayerAwareRenderer()) {
+            if (filtersInSVGUserSpace) {
                 auto svgFilterCompensation = columnAwareOffsetFromRoot - svgFilterOffset;
                 if (!svgFilterCompensation.isZero()) {
                     filterCompensationSaver.save();

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -169,7 +169,8 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
     // LBSE seeds the filter region with objectBoundingBox, expandFilterRegionForSVGReferences()
     // grows it to cover <filter> reference regions. The caller passes the nominal SVG position
     // as the offset, so the buffer shares the SVG coordinate space and needs no shift compensation.
-    if (renderer.isSVGLayerAwareRenderer()) {
+    bool usesSVGUserSpace = renderer.isSVGLayerAwareRenderer() && !renderer.isRenderSVGRoot();
+    if (usesSVGUserSpace) {
         auto boundingBox = renderer.objectBoundingBox();
         filterRegion = dirtyFilterRegion = enclosingLayoutRect(boundingBox);
     } else {
@@ -189,7 +190,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
             filterRegion.expand(toLayoutBoxExtent(outsets));
     }
 
-    if (filterRegion.isEmpty() && !renderer.isSVGLayerAwareRenderer())
+    if (filterRegion.isEmpty() && !usesSVGUserSpace)
         return nullptr;
 
     auto geometryReferenceGeometryChanged = [](auto& existingGeometry, auto& newGeometry) {
@@ -199,11 +200,11 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
     // The reference box must stay in the original SVG coordinate system (objectBoundingBox,
     // as legacy does) with no shift, otherwise filter region resolution is wrong.
     auto referenceBox = filterBoxRect;
-    if (renderer.isSVGLayerAwareRenderer())
+    if (usesSVGUserSpace)
         referenceBox = enclosingLayoutRect(renderer.objectBoundingBox());
 
     auto filterScale = m_filterScale;
-    if (renderer.isSVGLayerAwareRenderer())
+    if (usesSVGUserSpace)
         filterScale = m_filterScale * SVGTransformComputation(downcast<RenderLayerModelObject>(renderer)).calculateAccumulatedSVGAncestorTransformScale();
 
     auto geometry = FilterGeometry {
@@ -221,19 +222,19 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
             renderingOptions.add(FilterRenderingOption::ShowDebugOverlay);
         if (paintBehavior.contains(PaintBehavior::FastAndLowQualityFilters))
             renderingOptions.add(FilterRenderingOption::FastAndLowQuality);
-        if (renderer.isSVGLayerAwareRenderer())
+        if (usesSVGUserSpace)
             renderingOptions.add(FilterRenderingOption::ApplyToSVGRenderer);
         m_filter = CSSFilterRenderer::create(renderer, renderer.style().filter(), geometry, preferredFilterRenderingModes, renderingOptions, context);
         m_lastUnclampedFilterScale = filterScale;
         hasUpdatedBackingStore = true;
-    } else if (!renderer.isSVGLayerAwareRenderer() && filterRegion != m_filter->filterRegion()) {
+    } else if (!usesSVGUserSpace && filterRegion != m_filter->filterRegion()) {
         m_filter->setFilterRegion(filterRegion);
         hasUpdatedBackingStore = true;
     }
 
     // Read back the region expandFilterRegionForSVGReferences() produced - it may have
     // grown to cover SVG reference regions and clamped the scale.
-    if (renderer.isSVGLayerAwareRenderer() && m_filter) {
+    if (usesSVGUserSpace && m_filter) {
         filterRegion = enclosingLayoutRect(m_filter->filterRegion());
         dirtyFilterRegion = filterRegion;
     }
@@ -258,7 +259,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
 
     if (!m_targetSwitcher || hasUpdatedBackingStore) {
         FloatRect sourceImageRect;
-        if (renderer.isSVGLayerAwareRenderer()) {
+        if (usesSVGUserSpace) {
             // If the region was clamped to MaxClampedArea, source from the bounding box to
             // avoid a huge mostly-transparent buffer. Otherwise source the full region.
             bool filterRegionOversized = !referenceBox.isEmpty() && m_filter->filterScale() != m_lastUnclampedFilterScale;
@@ -270,7 +271,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
         // operations should happen in linear color space. Match legacy SVG filter behavior.
         auto colorSpace = DestinationColorSpace::SRGB();
 #if !USE(CAIRO)
-        if (renderer.isSVGLayerAwareRenderer())
+        if (usesSVGUserSpace)
             colorSpace = DestinationColorSpace::LinearSRGB();
 #endif
 
@@ -294,7 +295,7 @@ void RenderLayerFilters::applyFilterEffect(GraphicsContext& destinationContext)
     auto colorSpace = DestinationColorSpace::SRGB();
 #if !USE(CAIRO)
     if (CheckedPtr layer = m_layer.get()) {
-        if (layer->renderer().isSVGLayerAwareRenderer())
+        if (layer->renderer().isSVGLayerAwareRenderer() && !layer->renderer().isRenderSVGRoot())
             colorSpace = DestinationColorSpace::LinearSRGB();
     }
 #endif


### PR DESCRIPTION
#### cb885befbe2f2f4515f045781a1ddb0f47346d29
<pre>
[LBSE] Apply filters specified on the outermost &lt;svg&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=321427">https://bugs.webkit.org/show_bug.cgi?id=321427</a>

Reviewed by Alejandro G. Castro.

A filter on an outermost &lt;svg&gt; was either dropped entirely or set up with the wrong
geometry under the layer-based SVG engine.

RenderLayer::shouldPaintWithFilters() bailed out for any SVG root referencing a
&lt;filter&gt;. That is correct for the legacy engine, where LegacyRenderSVGRoot applies
the referenced filter itself through SVGRenderingContext::prepareToRenderSVGContent()
and the layer must not apply it a second time. The layer-based engine has no such path,
RenderSVGRoot relies on its layer, exactly like an HTML box with &apos;filter: url(...)&apos; -
so the filter was silently never applied. Fix that behavior for LBSE.

RenderLayerFilters::beginFilterEffect() then treated RenderSVGRoot as a renderer
whose filter lives in SVG user space, seeding the filter region and the reference
box from objectBoundingBox() and scaling by the accumulated SVG ancestor transform.
The outermost &lt;svg&gt; is a replaced element in the CSS box tree: its filter resolves
against its border box, in its container&apos;s coordinate system, not against the SVG
user space its children live in - fix that too.

Fixes svg/filters/filter-specified-on-svg-root.html and svg/filters/filter-image-ref-root.html.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::shouldPaintWithFilters const):
(WebCore::RenderLayer::paintLayerContents):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
(WebCore::RenderLayerFilters::applyFilterEffect):

Canonical link: <a href="https://commits.webkit.org/319121@main">https://commits.webkit.org/319121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ce3f21da39f66b6d7157f031b6917329d1f6b1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144553 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140569 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97362 "3 flakes 4 failures") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183187 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121021 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42905 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41209 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153308 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40890 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1602 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192378 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53843 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149919 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40204 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54531 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37502 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149647 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44285 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126794 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121942 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53048 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15879 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52430 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52667 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->