### PR TITLE
[site-isolation] media/

### DIFF
--- a/LayoutTests/media/ios/short-audio-now-playing-expected.txt
+++ b/LayoutTests/media/ios/short-audio-now-playing-expected.txt
@@ -3,14 +3,12 @@ RUN(audio.src = "../content/short.mp3")
 RUN(audio.load())
 EVENT(canplay)
 RUN(audio.play())
-EVENT(playing)
 EXPECTED (internals.nowPlayingState.registeredAsNowPlayingApplication == 'false') OK
 Test playing long audio; should become now playing
 RUN(audio.src = "../content/silence.mp3")
 RUN(audio.load())
 EVENT(canplay)
 RUN(audio.play())
-EVENT(playing)
 EXPECTED (internals.nowPlayingState.registeredAsNowPlayingApplication == 'true') OK
 END OF TEST
 

--- a/LayoutTests/media/ios/short-audio-now-playing.html
+++ b/LayoutTests/media/ios/short-audio-now-playing.html
@@ -13,16 +13,14 @@
         run('audio.src = "../content/short.mp3"');
         run('audio.load()');
         await waitFor(audio, 'canplay');
-        run('audio.play()');
-        await waitFor(audio, 'playing');
+        await run('audio.play()');
         testExpected('internals.nowPlayingState.registeredAsNowPlayingApplication', false);
 
         consoleWrite('Test playing long audio; should become now playing');
         run('audio.src = "../content/silence.mp3"');
         run('audio.load()');
         await waitFor(audio, 'canplay');
-        run('audio.play()');
-        await waitFor(audio, 'playing');
+        await run('audio.play()');
         testExpected('internals.nowPlayingState.registeredAsNowPlayingApplication', true);
     }
     window.addEventListener('load', event => {

--- a/LayoutTests/media/track/track-in-band-cues-added-once.html
+++ b/LayoutTests/media/track/track-in-band-cues-added-once.html
@@ -51,26 +51,42 @@
                 case 3:
                     if (inbandTrack1.cues.length < cuesStarts.length)
                         break;
-    
+
+                    // Keep polling until the replay has delivered the last cue collected before it.
+                    // Cues arrive ahead of the playback position, so this does not require playing as
+                    // far as that cue's start time.
+                    var newStarts = [];
+                    for (var i = 0; i < inbandTrack1.cues.length; ++i)
+                        newStarts.push(inbandTrack1.cues[i].startTime);
+
+                    if (!newStarts.includes(cuesStarts[cuesStarts.length - 1]))
+                        break;
+
                     run("video.pause()");
+
+                    // Each collected cue must be there exactly once. Cues are not compared by index:
+                    // the replay can deliver a cue from earlier in the file that playback had not
+                    // reached when the start times were collected.
                     var failure = false;
                     for (var i = 0; i < cuesStarts.length; ++i) {
-                        if (cuesStarts[i] != inbandTrack1.cues[i].startTime) {
+                        var occurrences = 0;
+                        for (var j = 0; j < newStarts.length; ++j) {
+                            if (newStarts[j] == cuesStarts[i])
+                                ++occurrences;
+                        }
+                        if (occurrences != 1) {
                             failure = true;
                             break;
                         }
                     }
-    
+
                     if (failure) {
                         consoleWrite("<br><i>** FAIL<" + "/i>");
-                        for (var i = 0; i < cuesStarts.length; ++i) {
-                            var oldStart = cuesStarts[i];
-                            var newStart = inbandTrack1.cues[i].startTime;
-                            consoleWrite("Cue " + i + " start time was: " + oldStart + ", is now: " + newStart);
-                        }
+                        consoleWrite("Cue start times were: " + cuesStarts.join(", "));
+                        consoleWrite("Cue start times are now: " + newStarts.join(", "));
                         consoleWrite("");
                     }
-    
+
                     endTest();
                     break;
                 }

--- a/LayoutTests/media/video-is-playing-audio-after-load-expected.txt
+++ b/LayoutTests/media/video-is-playing-audio-after-load-expected.txt
@@ -2,7 +2,7 @@
 RUN(video.src = findMediaFile("video", "content/audio-tracks"))
 EVENT(canplay)
 EXPECTED (video.audioTracks.length > '1') OK
-RUN(video.play())
+RUN(video.play().catch(() => { }))
 EVENT(playing)
 EXPECTED (internals.pageMediaState().includes("IsPlayingAudio") == 'true') OK
 RUN(video.src = "")

--- a/LayoutTests/media/video-is-playing-audio-after-load.html
+++ b/LayoutTests/media/video-is-playing-audio-after-load.html
@@ -11,7 +11,9 @@
             await waitFor(video, 'canplay');
 
             testExpected('video.audioTracks.length', '1', '>');
-            runWithKeyDown('video.play()');
+            // load() below rejects the play promise, which may still be pending until the media session
+            // admits playback.
+            runWithKeyDown('video.play().catch(() => { })');
             await waitFor(video, 'playing');
 
             testExpected('internals.pageMediaState().includes("IsPlayingAudio")', true);

--- a/LayoutTests/media/video-main-content-allow-then-deny.html
+++ b/LayoutTests/media/video-main-content-allow-then-deny.html
@@ -15,7 +15,9 @@
     }
 
     function canPlayThrough() {
-        video.play();
+        // Hiding the video below denies playback, rejecting the play promise if the media session has
+        // not admitted playback by then.
+        video.play().catch(() => { });
         waitForEvent('playing', playing);
     }
 

--- a/LayoutTests/media/video-multiple-concurrent-playback-expected.txt
+++ b/LayoutTests/media/video-multiple-concurrent-playback-expected.txt
@@ -32,6 +32,7 @@ EVENT(playing)
 
 *** Play the fourth video, the third should pause ***
 RUN(videos[3].play())
+EVENT(playing)
 EVENT(pause)
 
 EXPECTED (videos[0].paused == 'false') OK

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -613,7 +613,7 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
     , m_seekToPlaybackPositionEndedTimer(*this, &HTMLMediaElement::seekToPlaybackPositionEndedTimerFired)
     , m_checkPlaybackTargetCompatibilityTimer(*this, &HTMLMediaElement::checkPlaybackTargetCompatibility)
     , m_seekRequest(NativePromiseRequest::create())
-    , m_playRequest(NativePromiseRequest::create())
+    , m_beginPlaybackRequest(NativePromiseRequest::create())
     , m_currentIdentifier(MediaUniqueIdentifier::generate())
     , m_lastTimeUpdateEventMovieTime(MediaTime::positiveInfiniteTime())
     , m_firstTimePlaying(true)
@@ -785,8 +785,8 @@ HTMLMediaElement::~HTMLMediaElement()
     if (m_seekRequest->hasCallback())
         m_seekRequest->disconnect();
 
-    if (m_playRequest->hasCallback())
-        m_playRequest->disconnect();
+    if (m_beginPlaybackRequest->hasCallback())
+        m_beginPlaybackRequest->disconnect();
 
     invalidateWatchtimeTimer();
     invalidateBufferingStopwatch();
@@ -1416,7 +1416,7 @@ void HTMLMediaElement::resolvePendingPlayPromises(PlayPromiseVector&& pendingPla
         promise.resolve();
 }
 
-void HTMLMediaElement::scheduleNotifyAboutPlaying(bool deferWhileSeeking)
+void HTMLMediaElement::scheduleNotifyAboutPlaying(bool deferWhileSeeking, ShouldResolvePlayPromises shouldResolvePlayPromises)
 {
     // A readyState-driven 'playing' that coincides with seek completion must be queued after the
     // seek's 'seeked' event; defer it until finishSeek() flushes it via maybeFirePendingPlaying().
@@ -1426,7 +1426,13 @@ void HTMLMediaElement::scheduleNotifyAboutPlaying(bool deferWhileSeeking)
         return;
     }
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [pendingPlayPromises = WTF::move(m_pendingPlayPromises)](auto& element) mutable {
+    // play() leaves the promises pending and settles them once the media session admits playback, so
+    // that they report that playback started rather than that enough data arrived.
+    PlayPromiseVector pendingPlayPromises;
+    if (shouldResolvePlayPromises == ShouldResolvePlayPromises::Yes)
+        pendingPlayPromises = WTF::move(m_pendingPlayPromises);
+
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [pendingPlayPromises = WTF::move(pendingPlayPromises)](auto& element) mutable {
         if (!element.isContextStopped())
             element.notifyAboutPlaying(WTF::move(pendingPlayPromises));
     });
@@ -1445,6 +1451,9 @@ void HTMLMediaElement::notifyAboutPlaying(PlayPromiseVector&& pendingPlayPromise
     Ref protectedThis { *this }; // The 'playing' event can make arbitrary DOM mutations.
     m_playbackStartedTime = currentMediaTime().toDouble();
     m_hasEverNotifiedAboutPlaying = true;
+    // updatePlayState() runs from the admission reply, so report the element as playing here or a
+    // 'playing' handler would observe it as not playing.
+    setPlaying(true);
     dispatchEvent(Event::create(eventNames().playingEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
     resolvePendingPlayPromises(WTF::move(pendingPlayPromises));
 
@@ -4593,45 +4602,11 @@ void HTMLMediaElement::play()
     playInternal();
 }
 
-void HTMLMediaElement::completePlayInternal(bool shouldSeekToStart)
+void HTMLMediaElement::completePlayInternal()
 {
-    // 4.8.10.9. Playing the media resource
-    // The NETWORK_EMPTY + no-src case is handled synchronously in playInternal().
-    // Call selectMediaResource() here when:
-    //   - !m_player && src: player not created yet (first play with a src)
-    //   - m_player && NETWORK_EMPTY && HAVE_NOTHING && src: player was created but
-    //     loading was suppressed (e.g., iOS autoplay policy); readyState == HAVE_NOTHING
-    //     confirms nothing has loaded. Exclude the case where readyState > HAVE_NOTHING
-    //     because the resource selection is already underway; restarting it would cause
-    //     spurious state resets (MediaBufferingPolicy regression on Release builds).
-    auto needsResourceSelection = [&] {
-        if (!m_player)
-            return hasAttributeWithoutSynchronization(srcAttr) || m_mediaProvider;
-        return m_networkState == NETWORK_EMPTY && m_readyState == HAVE_NOTHING
-            && (hasAttributeWithoutSynchronization(srcAttr) || m_mediaProvider);
-    }();
-    if (needsResourceSelection)
-        selectMediaResource();
-
-    if (shouldSeekToStart)
-        seekInternal(MediaTime::zeroTime());
-
     if (RefPtr mediaController = m_mediaController)
         mediaController->bringElementUpToSpeed(*this);
 
-    // The readyState-dependent task (waitingEvent / scheduleNotifyAboutPlaying /
-    // scheduleResolvePendingPlayPromises) is queued from playInternal() and
-    // canBeginPlaybackCompletion based on readyState captured at play() call
-    // time, NOT recomputed here. Recomputing post-async-admission would miss
-    // transitions during the admission window (e.g. media-source unbalanced
-    // buffers can briefly drop readyState to HAVE_CURRENT_DATA).
-
-    // m_autoplayEventPlaybackState is set synchronously in playInternal() —
-    // see comment there. Calling processingUserGestureForMedia() here would
-    // see false because the user gesture has expired across the async
-    // session-admission IPC.
-
-    m_autoplaying = false;
     updatePlayState();
 
     ImageOverlay::removeOverlaySoonIfNeeded(*this);
@@ -4655,14 +4630,22 @@ void HTMLMediaElement::playInternal()
     Ref mediaSession = this->mediaSession();
     mediaSession->setActive(true);
 
-    // Spec step: if networkState is NETWORK_EMPTY, invoke resource selection synchronously.
-    // Restrict to the no-source case (no src attribute and no srcObject): when a src is
-    // already assigned, the attribute-triggered load has either started or will start on
-    // its own. Calling selectMediaResource() only for the truly-empty case ensures the
-    // no-src reset task is enqueued before any networking-source tasks that could trigger
-    // prepareForLoad() and call setPaused(true) unexpectedly.
-    if (m_networkState == NETWORK_EMPTY && !hasAttributeWithoutSynchronization(srcAttr) && !m_mediaProvider)
+    // Internal play steps, step 1: invoke the resource selection algorithm when networkState is
+    // NETWORK_EMPTY. With a src assigned, only do so when no load is underway yet — either no player
+    // exists, or one exists but loading was suppressed (e.g. iOS autoplay policy) and readyState is
+    // still HAVE_NOTHING. Restarting a selection that is already underway resets state
+    // (MediaBufferingPolicy regression on Release builds).
+    bool hasSource = hasAttributeWithoutSynchronization(srcAttr) || m_mediaProvider;
+    bool needsResourceSelection = hasSource
+        ? !m_player || (m_networkState == NETWORK_EMPTY && m_readyState == HAVE_NOTHING)
+        : m_networkState == NETWORK_EMPTY;
+    if (needsResourceSelection)
         selectMediaResource();
+
+    // Step 2: if playback has ended and the direction of playback is forwards, seek to the earliest
+    // possible position.
+    if (endedPlayback())
+        seekInternal(MediaTime::zeroTime());
 
     // Per HTML spec: when play() is called and paused is true, set paused = false
     // and queue the play event synchronously, BEFORE any user-agent-specific
@@ -4697,69 +4680,51 @@ void HTMLMediaElement::playInternal()
     } else
         setAutoplayEventPlaybackState(AutoplayEventPlaybackState::StartedWithoutUserGesture);
 
-    // Capture the readyState-dependent decision at sync play() call time.
-    // The waitingEvent must be queued synchronously per spec; the
-    // notifyAboutPlaying / resolvePendingPlayPromises tasks are deferred to
-    // the admission completion handler so they interleave correctly with
-    // other tasks queued during the async session-admission window.
+    // Internal play steps 3.4 and 4 decide which event is queued here, synchronously. The pending play
+    // promises are settled from the session admission below instead, so they report that playback
+    // started.
     bool shouldNotifyAboutPlaying = didTransitionFromPaused && m_readyState > HAVE_CURRENT_DATA;
     bool shouldResolvePromises = !didTransitionFromPaused && m_readyState >= HAVE_FUTURE_DATA;
     // True if the admission completion handler below is guaranteed to settle
     // m_pendingPlayPromises itself, even if pause() races the in-flight admission.
     m_playPromiseSettlementGuaranteed = shouldNotifyAboutPlaying || shouldResolvePromises;
-    // Whether the spec's seek-to-start step applies is decided at play() time: playback can reach the
-    // end of the media during the admission round trip.
-    bool shouldSeekToStart = endedPlayback();
+
     if (didTransitionFromPaused && m_readyState <= HAVE_CURRENT_DATA)
         scheduleEvent(eventNames().waitingEvent);
+    else if (shouldNotifyAboutPlaying) {
+        // Not gated on m_pendingPlayPromises: resuming after an interruption has no promise but still
+        // needs the event. setReadyState() cannot queue a second 'playing' here, since readyState is
+        // already past HAVE_CURRENT_DATA.
+        scheduleNotifyAboutPlaying(false, ShouldResolvePlayPromises::No);
+        // Entering fullscreen when playback requires it must also precede the event: a 'playing'
+        // handler reads webkitDisplayingFullscreen.
+        if (mediaSession->requiresFullscreenForVideoPlayback() && !m_waitingToEnterFullscreen && !isFullscreen())
+            enterFullscreen();
+    }
 
-    if (m_playRequest->hasCallback())
-        m_playRequest->disconnect();
+    if (m_beginPlaybackRequest->hasCallback())
+        m_beginPlaybackRequest->disconnect();
 
-    auto onAdmissionSettled = [weakThis = WeakPtr { *this }, didTransitionFromPaused, shouldNotifyAboutPlaying, shouldResolvePromises, shouldSeekToStart, logSiteIdentifier](bool canBegin) {
+    auto onAdmissionSettled = [weakThis = WeakPtr { *this }, didTransitionFromPaused, shouldNotifyAboutPlaying, shouldResolvePromises, logSiteIdentifier](bool canBegin) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
         if (!canBegin) {
             ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "returning because of interruption");
-            if (didTransitionFromPaused) {
-                // Revert the synchronous transition since playback was not permitted.
-                // pauseInternal() fires the pause event (balancing the play event we
-                // already scheduled) and rejects the pending play promises.
+            // pauseInternal() reverts the synchronous transition: it fires the pause event balancing
+            // the play event already scheduled, and rejects any promise the internal play steps left
+            // pending. An element that was already playing needs that rejection on its own.
+            if (didTransitionFromPaused)
                 protectedThis->pauseInternal();
-            }
-            // pauseInternal() above only runs (and rejects) when didTransitionFromPaused
-            // is true. When play() is called on an already-playing element and this
-            // admission is later denied (e.g. an interruption or audio session
-            // activation failure), didTransitionFromPaused is false, pauseInternal()
-            // is skipped, and this promise from that play() call would otherwise
-            // never settle. Safe to call unconditionally: already-drained promises
-            // make this a no-op (see scheduleRejectPendingPlayPromises).
-            protectedThis->scheduleRejectPendingPlayPromises(DOMException::create(ExceptionCode::AbortError));
+            else
+                protectedThis->scheduleRejectPendingPlayPromises(DOMException::create(ExceptionCode::AbortError));
             return;
         }
 
-        // Schedule the readyState-dependent task based on the booleans
-        // captured at playInternal() sync time. We deliberately do NOT gate
-        // on `m_pendingPlayPromises` being non-empty:
-        //   - For interruption resumption (no JS play() promise), pending
-        //     promises is empty but we still need the playing event.
-        //   - The double-fire concern (setReadyState's natural transition
-        //     already moved promises into a T_notify task) does not apply
-        //     here: shouldNotifyAboutPlaying captured=true means readyState
-        //     was already > HAVE_CURRENT_DATA at sync time, so
-        //     setReadyState's upward-transition scheduleNotifyAboutPlaying
-        //     (HTMLMediaElement.cpp:3373) cannot fire. When
-        //     shouldNotifyAboutPlaying captured=false (readyState was low
-        //     at sync), this branch doesn't schedule and setReadyState's
-        //     natural transition handles the late notify when readyState
-        //     eventually transitions up.
-        if (shouldNotifyAboutPlaying)
-            protectedThis->scheduleNotifyAboutPlaying(false);
-        else if (shouldResolvePromises)
+        if (shouldNotifyAboutPlaying || shouldResolvePromises)
             protectedThis->scheduleResolvePendingPlayPromises();
-        protectedThis->completePlayInternal(shouldSeekToStart);
+        protectedThis->completePlayInternal();
     };
 
     // Already admitted (e.g. resuming after endInterruption() restores state() to Playing): run inline instead of deferring through whenSettled().
@@ -4781,9 +4746,9 @@ void HTMLMediaElement::playInternal()
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        protectedThis->m_playRequest->complete();
+        protectedThis->m_beginPlaybackRequest->complete();
         onAdmissionSettled(!!result);
-    })->track(m_playRequest);
+    })->track(m_beginPlaybackRequest);
 }
 
 void HTMLMediaElement::pause()
@@ -4846,9 +4811,9 @@ void HTMLMediaElement::pauseInternal()
 
     // A pause() racing an in-flight play() admission must not preempt a settlement
     // that the admission's own callback is already guaranteed to deliver (see m_playPromiseSettlementGuaranteed).
-    bool hadInFlightPlayRequest = m_playRequest->hasCallback();
+    bool hadInFlightPlayRequest = m_beginPlaybackRequest->hasCallback();
     if (hadInFlightPlayRequest && !m_playPromiseSettlementGuaranteed)
-        m_playRequest->disconnect();
+        m_beginPlaybackRequest->disconnect();
 
     if (!m_paused && !m_pausedInternal) {
         setPaused(true);

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -243,7 +243,8 @@ public:
     using PlayPromiseVector = Vector<DOMPromiseDeferred<void>>;
     void rejectPendingPlayPromises(PlayPromiseVector&&, Ref<DOMException>&&);
     void resolvePendingPlayPromises(PlayPromiseVector&&);
-    void scheduleNotifyAboutPlaying(bool deferWhileSeeking = true);
+    enum class ShouldResolvePlayPromises : bool { No, Yes };
+    void scheduleNotifyAboutPlaying(bool deferWhileSeeking = true, ShouldResolvePlayPromises = ShouldResolvePlayPromises::Yes);
     void maybeFirePendingPlaying();
     void handlePlaybackPositionChanged();
     void notifyAboutPlaying(PlayPromiseVector&&);
@@ -1023,7 +1024,7 @@ private:
     // These "internal" functions do not check user gesture restrictions.
     void playInternal();
     void pauseInternal();
-    void completePlayInternal(bool shouldSeekToStart);
+    void completePlayInternal();
 
     enum class IsExplicitLoad : bool { No, Yes };
     void prepareForLoad(IsExplicitLoad = IsExplicitLoad::No);
@@ -1245,7 +1246,7 @@ private:
     TaskCancellationGroup m_periodicTimeupdateCancellationGroup;
     TaskCancellationGroup m_volumeRevertTaskCancellationGroup;
 
-    const Ref<NativePromiseRequest> m_playRequest;
+    const Ref<NativePromiseRequest> m_beginPlaybackRequest;
     PlayPromiseVector m_pendingPlayPromises;
     bool m_playPromiseSettlementGuaranteed { false };
 

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1631,7 +1631,7 @@ void MediaElementSession::updateMediaUsageIfChanged()
     MediaUsageInfo usage = {
         element->currentSrc(),
         element->hasSource(),
-        state() == PlatformMediaSession::State::Playing,
+        isPlaying,
         canShowControlsManager(PlaybackControlsPurpose::ControlsManager),
         !page->isVisibleAndActive(),
         element->isSuspended(),

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -543,7 +543,9 @@ void MediaSessionManagerInterface::sessionWillBeginPlayback(PlatformMediaSession
         if (m_currentInterruption && sessionWasAlreadyInterrupted)
             endInterruption(PlatformMediaSession::EndInterruptionFlags::NoFlags);
 
-        if (RefPtr session = weakSession.get())
+        // Only the session that is still current enforces the restriction: another session admitted
+        // while this one was activating has enforced it for itself already, and would be paused here.
+        if (RefPtr session = weakSession.get(); session && currentSession() == session)
             enforceConcurrentPlaybackRestriction(*session);
         ALWAYS_LOG(logSiteIdentifier, sessionLogId, " returning true");
         completionHandler(true);
@@ -602,7 +604,9 @@ void MediaSessionManagerInterface::enforceConcurrentPlaybackRestriction(Platform
 
     forEachMatchingSession([&newSession](auto& otherSession) {
         bool isOther = &otherSession == &newSession;
-        bool isPlaying = otherSession.state() == PlatformMediaSession::State::Playing;
+        // preparingToPlay() covers a session whose own admission has not completed yet: it intends to
+        // play, so it must not survive this restriction just because its state is not Playing.
+        bool isPlaying = otherSession.state() == PlatformMediaSession::State::Playing || otherSession.preparingToPlay();
         bool canConcurrent = otherSession.canPlayConcurrently(newSession);
         if (isOther)
             return false;

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -347,11 +347,7 @@ void RemoteMediaSessionManagerProxy::setCurrentSession(WebCore::PlatformMediaSes
         }
     }
 
-    // Make this the current session (moves it to the front) so currentSession() returns it, rather
-    // than addSession() which moves it to the back and leaves a stale session current -- which would
-    // make tryToSetActiveInternal activate the wrong web process. PlatformMediaSessionManager's
-    // implementation only reorders the list; NowPlaying routing is a separate follow-up.
-    WebCore::PlatformMediaSessionManager::setCurrentSession(session);
+    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::setCurrentSession(session);
 }
 
 void RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback(IPC::Connection& connection, RemoteMediaSessionState&& state, CompletionHandler<void(bool, WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&& completionHandler)


### PR DESCRIPTION
#### 9c134d2178715ec191c2f43a114a89113f3045d2
<pre>
[site-isolation] media/track/track-in-band-cues-added-once.html is a permanent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=321558">https://bugs.webkit.org/show_bug.cgi?id=321558</a>
<a href="https://rdar.apple.com/184667127">rdar://184667127</a>

Reviewed by NOBODY (OOPS!).

The test plays a segment, collects the start times of the in-band cues delivered
so far, seeks back to the beginning, plays the same segment again and compares
the two lists by index. It reported cue N&apos;s start time as cue N-1&apos;s, for every
cue.

Which six cues the first pass collected depended on how far playback had got when
its 100ms poll saw more than five of them. When the cue at 0.2002 had not been
delivered yet, the first pass collected 1.001 through 4.471133 instead, and the
replay delivered 0.2002 as the first cue, shifting every index by one. The cues
themselves were added once: the log shows the replay&apos;s cues being rejected by
addGenericCue()&apos;s duplicate check, which is what the test is named for.

The test now checks that each cue collected before the replay is present exactly
once afterwards, rather than at the same index, and waits for the replay to
deliver the last cue it collected before comparing, since that cue may not have
been re-delivered when the list first reaches the collected length.

* LayoutTests/media/track/track-in-band-cues-added-once.html:
</pre>
----------------------------------------------------------------------
#### 96e6652d01c8c68bc0ae602a204c1a6a03bd1d4b
<pre>
[site-isolation] media/video-seek-after-end-play.html is a permanent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=321429">https://bugs.webkit.org/show_bug.cgi?id=321429</a>
<a href="https://rdar.apple.com/184503400">rdar://184503400</a>

Reviewed by NOBODY (OOPS!).

REGRESSION(<a href="https://commits.webkit.org/317782@main">317782@main</a>): HTMLMediaElement&apos;s internal play steps must run synchronously

The test seeks an ended element back to the start and calls play() while that seek is still in flight.
It expected play, playing, seeking, seeked, ended; with site isolation enabled it got play, seeking,
seeked, playing, ended.

<a href="https://commits.webkit.org/317782@main">317782@main</a> moved the internal play steps&apos; notify about playing and resolve pending play promises out
of playInternal() and into the completion handler of clientWillBeginPlayback(). Per spec those steps
are synchronous: HTML 4.8.11.8 &quot;Playing the media resource&quot; has the internal play steps queue the play
event (step 3.3) and then, depending on readyState, either queue waiting or notify about playing
(step 3.4), all before play() returns. Once the session admission had to cross to the UI process, the
seek the element had already enqueued completed first and fired seeking and seeked ahead of playing.

The same split, which <a href="https://commits.webkit.org/304036@main">304036@main</a> introduced by replacing a synchronous clientWillBeginPlayback() check
that already sat ahead of them, also left step 1 (invoke the resource selection algorithm), step 2 (seek
to the earliest possible position when playback has ended) and step 5 (clear the can autoplay flag)
running from the reply. None of the three depend on whether the session admits playback, so they run
synchronously again, in spec order. Only updatePlayState(), which starts the player, still waits for the
reply.

To resolve the event order, we are taking a hybrid approach:
the play, playing and waiting events are queued synchronously, as the spec states.
A page that needs to know playback has actually started can do what it did before play()
returned a promise and wait for playing followed by timeupdate. The play promises, on the other hand,
are resolved from the admission reply. That deviates from the spec, which resolves them in the same
task that fires playing, but it is hard to observe: promise reactions never run synchronously, they run
in a microtask after the promise is resolved, so a playing handler runs before the play() promise&apos;s
reaction either way. What changes is that the promise settles a task later, and therefore its ordering
against unrelated tasks.

scheduleNotifyAboutPlaying() takes a ShouldResolvePlayPromises argument so the queued task can fire
playing while leaving the promises pending; the readyState transitions that also notify about playing
keep settling them. m_playRequest is renamed m_beginPlaybackRequest, since it tracks the
clientWillBeginPlayback() reply rather than play().

We can revert <a href="https://commits.webkit.org/318932@main">318932@main</a>, whose shouldSeekToStart parameter carried step 2&apos;s decision across the reply:
with the step itself back in playInternal() there is nothing to carry, so the parameter and its plumbing are removed
as endedPlayback() is false while currentTime is still short of the duration, so no seek is
issued at all.

Queueing the events synchronously left three kinds of work on the reply side that JS can now observe at
those events, which sixteen media tests caught without site isolation.

1) Eleven of them reported an unhandled AbortError, or NotAllowedError for
    media/video-main-content-allow-then-deny.html: the play promises settle from the reply, so
    pauseInternal() rejected a promise the reply was about to resolve.

2) media/video-concurrent-playback.html and media/video-multiple-concurrent-playback.html paused the
    wrong element. A page that calls play() from a &apos;playing&apos; handler leaves two admissions in flight, and
    enforceConcurrentPlaybackRestriction() ran from each completion, so the earlier admission&apos;s
    enforcement paused the element the later one had just started.

3) Four tests read state that updatePlayState() sets from the reply: usage.isPlaying and
    userHasPlayedAudioBefore in media/media-usage-state.html, pageMediaState() in
    media/video-is-playing-audio-after-load.html, and webkitDisplayingFullscreen in
    media/video-playsinline.html and media/video-fullscreen-only-playback.html.

For 1), <a href="https://commits.webkit.org/317907@main">317907@main</a>&apos;s m_playPromiseSettlementGuaranteed stays: pauseInternal() must not reject a promise
the reply will settle. For 2), a session enforces the restriction on completion only while it is still
the current session, and a session whose own admission is in flight counts as playing so the current one
can pause it. For 3), notifyAboutPlaying() reports the element as playing, playInternal() enters
fullscreen when playback requires it, and the media usage snapshot reads the element&apos;s playing state
rather than the session&apos;s, as the two neighbouring fields in that snapshot already do.

This fixes media/video-seek-after-end-play.html and
platform/mac/media/audio-session-category-video-track-change.html under site isolation; the latter&apos;s
assert runs on the playing event, which no longer waits for the category the admission reply applies.

media/video-multiple-concurrent-playback.html&apos;s baseline dates from webkit.org/b/162366 and omitted the
fourth video&apos;s playing event, which recorded the behaviour of the time: another element&apos;s concurrency
pause was queued ahead of the element&apos;s own playing event. The baseline gains that event.

media/video-is-playing-audio-after-load.html and media/video-main-content-allow-then-deny.html now catch
their play promise. A load() that tears the element down and a policy denial both reject a promise that
stays pending until the media session admits playback.

media/ios/short-audio-now-playing.html reported an unhandled AbortError on iOS. It
called play() without awaiting the promise and read the now-playing registration
at the &apos;playing&apos; event, which is now queued during the internal play steps. The
promise was therefore still pending when the test assigned the second source, and
load() rejected it through prepareForLoad()&apos;s cancelPendingEventsAndCallbacks().
The test now awaits play(), which settles where the &apos;playing&apos; event used to and
after MediaSessionManagerCocoa::sessionWillBeginPlayback() has scheduled the
session status update that registers the application.

media/video-concurrent-playback.html still fails with site isolation enabled and is left for a follow-up:
its assertion runs in the second element&apos;s &apos;playing&apos; handler, one round trip before the UI process can
pause the first.

Fly-by fix: RemoteMediaSessionManagerProxy::setCurrentSession() called
PlatformMediaSessionManager::setCurrentSession() directly, which only reorders the
session list. It now calls the base class, so the supported remote-control commands
are refreshed for the session that has become current, as they are for an
in-process manager.

* LayoutTests/media/ios/short-audio-now-playing-expected.txt:
* LayoutTests/media/ios/short-audio-now-playing.html:
* LayoutTests/media/video-is-playing-audio-after-load-expected.txt:
* LayoutTests/media/video-is-playing-audio-after-load.html:
* LayoutTests/media/video-main-content-allow-then-deny.html:
* LayoutTests/media/video-multiple-concurrent-playback-expected.txt:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::~HTMLMediaElement):
(WebCore::HTMLMediaElement::scheduleNotifyAboutPlaying): Optionally leave the pending play promises for
the caller to settle.
(WebCore::HTMLMediaElement::notifyAboutPlaying): Report the element as playing.
(WebCore::HTMLMediaElement::completePlayInternal): Keep only what needs the admission reply.
(WebCore::HTMLMediaElement::playInternal): Run the resource selection, the seek to the earliest possible
position, the readyState-dependent event and the can autoplay flag synchronously; enter fullscreen when
playback requires it; settle the play promises from the admission reply.
(WebCore::HTMLMediaElement::pauseInternal): Don&apos;t reject a promise the reply will settle.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::updateMediaUsageIfChanged): Report the element&apos;s playing state.
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::sessionWillBeginPlayback): Enforce the concurrent playback
restriction only while this session is the current one.
(WebCore::MediaSessionManagerInterface::enforceConcurrentPlaybackRestriction): Treat a session whose
admission is in flight as playing.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxy::setCurrentSession): Call the base cocoa class.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c134d2178715ec191c2f43a114a89113f3045d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190442 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/858391b2-81fc-459e-a3b2-30d746f0440e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53892 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/966b4125-261c-4965-8827-1bcbe6770d0b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183186 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/44230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/121023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca395105-16b7-48e5-ab35-01b1c2a55d91) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/40883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1601 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46775 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192377 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53842 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/160872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54530 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/149646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44289 "Build is in progress. Recent messages:") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126793 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121941 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53047 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/15872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52429 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52494 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->