### PR TITLE
[css-mixins-1] Function arguments invoking the function should not create a cycle

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt
@@ -24,4 +24,9 @@ PASS Function in a cycle with its own default
 PASS Cyclic defaults
 PASS Cyclic outer --b shadows custom property
 PASS Locals are function specific
+PASS Argument calling the same function is not a cycle
+PASS Argument calling the same function does not invalidate the inner call
+PASS Argument calling the same function is not a cycle, dependency declared last
+PASS Argument calling the same function is not a cycle, chained three deep
+PASS Argument reading the property being declared is still a cycle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles.html
@@ -403,6 +403,69 @@
   </style>
 </template>
 
+<!-- Arguments are substituted before the function is evaluated, so an argument calling the
+     same function is not a cycle. https://drafts.csswg.org/css-mixins-1/#replace-a-dashed-function -->
+
+<template data-name="Argument calling the same function is not a cycle">
+  <style>
+    @function --bump(--v) returns <integer> { result: calc(var(--v) + 1); }
+    #target {
+      --early: --bump(1);
+      --late: --bump(var(--early));
+      --actual: var(--late);
+      --expected: 3;
+    }
+  </style>
+</template>
+
+<template data-name="Argument calling the same function does not invalidate the inner call">
+  <style>
+    @function --bump(--v) returns <integer> { result: calc(var(--v) + 1); }
+    #target {
+      --early: --bump(1);
+      --late: --bump(var(--early));
+      --actual: var(--early);
+      --expected: 2;
+    }
+  </style>
+</template>
+
+<template data-name="Argument calling the same function is not a cycle, dependency declared last">
+  <style>
+    @function --bump(--v) returns <integer> { result: calc(var(--v) + 1); }
+    #target {
+      --late: --bump(var(--early));
+      --early: --bump(1);
+      --actual: var(--late);
+      --expected: 3;
+    }
+  </style>
+</template>
+
+<template data-name="Argument calling the same function is not a cycle, chained three deep">
+  <style>
+    @function --bump(--v) returns <integer> { result: calc(var(--v) + 1); }
+    #target {
+      --a: --bump(1);
+      --b: --bump(var(--a));
+      --c: --bump(var(--b));
+      --actual: var(--c);
+      --expected: 4;
+    }
+  </style>
+</template>
+
+<template data-name="Argument reading the property being declared is still a cycle">
+  <style>
+    @function --bump(--v) returns <integer> { result: calc(var(--v) + 1); }
+    #target {
+      --cyclic: --bump(var(--cyclic));
+      --actual: var(--cyclic);
+      /* --expected: <guaranteed-invalid> */
+    }
+  </style>
+</template>
+
 <script>
   test_all_templates();
 </script>

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -488,14 +488,10 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
 
     auto& [customFunction, foundScopeOrdinal] = *resolved;
 
-    auto guard = m_styleBuilder.state().guardSubstitutionContext({ SubstitutionContext::Type::Function, scopedFunctionName.name, foundScopeOrdinal });
-
-    if (guard.isCyclicContext())
-        return false;
-
     auto& parameters = customFunction->parameters;
 
-    // Parse and substitute arguments.
+    // Arguments are substituted before the context is guarded, so an argument that calls the same
+    // function is not a cycle. https://drafts.csswg.org/css-mixins/#replace-a-dashed-function
     auto substitutedArguments = [&] -> std::optional<Vector<Vector<CSSParserToken>>> {
         Vector<Vector<CSSParserToken>> result;
         for (unsigned i = 0; !range.atEnd(); ++i) {
@@ -513,6 +509,13 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     }();
 
     if (!substitutedArguments)
+        return false;
+
+    // Parameter default values and the body are resolved inside the guard, so a function that reaches
+    // itself through either is still cyclic.
+    auto guard = m_styleBuilder.state().guardSubstitutionContext({ SubstitutionContext::Type::Function, scopedFunctionName.name, foundScopeOrdinal });
+
+    if (guard.isCyclicContext())
         return false;
 
     // "Let registrations be an initially empty set of custom property registrations."


### PR DESCRIPTION
#### 750cd66f31bc665a4cc3088d339a85e05bcb787e
<pre>
[css-mixins-1] Function arguments invoking the function should not create a cycle
<a href="https://bugs.webkit.org/show_bug.cgi?id=321592">https://bugs.webkit.org/show_bug.cgi?id=321592</a>
<a href="https://rdar.apple.com/184711017">rdar://184711017</a>

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles.html:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteDashedFunction):

Move cycle detection after argument substitution.

Canonical link: <a href="https://commits.webkit.org/319034@main">https://commits.webkit.org/319034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccff57432b7271ee934776aafe4ad7bba0b00197

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144558 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30c57ce9-d97e-402f-858d-aa03c0bc1a4f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53898 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b35cd82-6ae6-4f57-bf0f-1a57039157b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121029 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc769f71-48b9-403d-bc15-d2a20ca778df) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40887 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1607 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192383 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149923 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40148 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54536 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149651 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44292 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126799 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121948 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53053 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15876 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52435 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52500 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->