### PR TITLE
Web Inspector: adopted style sheets are still mislabeled

### DIFF
--- a/LayoutTests/inspector/css/getAllStyleSheetsAdoptedStyleSheet-expected.txt
+++ b/LayoutTests/inspector/css/getAllStyleSheetsAdoptedStyleSheet-expected.txt
@@ -1,0 +1,13 @@
+Test that constructed stylesheets applied via document.adoptedStyleSheets are enumerated by CSS.getAllStyleSheets, labeled as constructed rather than attributed to the document, and each given a distinct display name. Bug 320092.
+
+PASS: There should be two constructed stylesheets.
+PASS: Constructed stylesheet should have no URL, since it has no source file.
+PASS: Constructed stylesheet should have Author origin.
+PASS: Constructed stylesheet should be anonymous, so it is grouped with the other style sheets that have no URL.
+PASS: Constructed stylesheet should have no URL, since it has no source file.
+PASS: Constructed stylesheet should have Author origin.
+PASS: Constructed stylesheet should be anonymous, so it is grouped with the other style sheets that have no URL.
+PASS: Each constructed stylesheet should have its own display name.
+DISPLAY NAME: Constructed Style Sheet 1
+DISPLAY NAME: Constructed Style Sheet 2
+

--- a/LayoutTests/inspector/css/getAllStyleSheetsAdoptedStyleSheet.html
+++ b/LayoutTests/inspector/css/getAllStyleSheetsAdoptedStyleSheet.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+const firstSheet = new CSSStyleSheet();
+firstSheet.replaceSync(`div#target { background: steelblue; }`);
+
+const secondSheet = new CSSStyleSheet();
+secondSheet.replaceSync(`div#target { color: white; }`);
+
+document.adoptedStyleSheets = [firstSheet, secondSheet];
+
+function test()
+{
+    InspectorBackend.runAfterPendingDispatches(function() {
+        // Don't count every style sheet the page has. Site isolation gives the inspector one
+        // more than this document declares, and the count is not what this test is about.
+        let constructedStyleSheets = WI.cssManager.styleSheets.filter((styleSheet) => styleSheet.isConstructed());
+        InspectorTest.expectEqual(constructedStyleSheets.length, 2, "There should be two constructed stylesheets.");
+
+        for (let styleSheet of constructedStyleSheets) {
+            InspectorTest.expectNull(styleSheet.url, "Constructed stylesheet should have no URL, since it has no source file.");
+            InspectorTest.expectEqual(styleSheet.origin, WI.CSSStyleSheet.Type.Author, "Constructed stylesheet should have Author origin.");
+
+            // Having no URL and not being an Inspector Style Sheet is what files a style sheet under
+            // "Extra Style Sheets" in the Sources tab, in both grouping modes.
+            InspectorTest.expectTrue(styleSheet.anonymous, "Constructed stylesheet should be anonymous, so it is grouped with the other style sheets that have no URL.");
+        }
+
+        let displayNames = constructedStyleSheets.map((styleSheet) => styleSheet.displayName);
+        InspectorTest.expectEqual(new Set(displayNames).size, displayNames.length, "Each constructed stylesheet should have its own display name.");
+        for (let displayName of displayNames.sort())
+            InspectorTest.log(`DISPLAY NAME: ${displayName}`);
+
+        InspectorTest.completeTest();
+    });
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Test that constructed stylesheets applied via document.adoptedStyleSheets are enumerated by CSS.getAllStyleSheets, labeled as constructed rather than attributed to the document, and each given a distinct display name. <a href="https://bugs.webkit.org/show_bug.cgi?id=320092">Bug 320092</a>.</p>
+<div id="target"></div>
+</body>
+</html>

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet-expected.txt
@@ -1,5 +1,6 @@
-Testing that rules from a constructable CSSStyleSheet attached via document.adoptedStyleSheets are reported with Author origin (not User Agent), so they appear editable in the Web Inspector. Tracking bug.
+Testing that rules from a constructable CSSStyleSheet attached via document.adoptedStyleSheets are reported with Author origin (not User Agent), so they appear editable in the Web Inspector, and are not attributed to the document's URL. Bug 277893 and bug 320092.
 
 PASS: Should have a rule matching "div#target".
 PASS: Adopted stylesheet rule should have "author" origin, not "user-agent".
+PASS: Adopted stylesheet rule should have no sourceURL, since a constructed stylesheet has no source file.
 

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet.html
@@ -47,8 +47,10 @@ async function test()
         }
 
         ProtocolTest.expectThat(!!adoptedRule, "Should have a rule matching \"div#target\".");
-        if (adoptedRule)
+        if (adoptedRule) {
             ProtocolTest.expectEqual(adoptedRule.origin, "author", "Adopted stylesheet rule should have \"author\" origin, not \"user-agent\".");
+            ProtocolTest.expectNull(adoptedRule.sourceURL, "Adopted stylesheet rule should have no sourceURL, since a constructed stylesheet has no source file.");
+        }
     } catch (error) {
         ProtocolTest.log(error);
     } finally {
@@ -58,7 +60,7 @@ async function test()
 </script>
 </head>
 <body onLoad="runTest()">
-<p>Testing that rules from a constructable CSSStyleSheet attached via document.adoptedStyleSheets are reported with Author origin (not User Agent), so they appear editable in the Web Inspector. <a href="https://bugs.webkit.org/show_bug.cgi?id=277893">Tracking bug</a>.</p>
+<p>Testing that rules from a constructable CSSStyleSheet attached via document.adoptedStyleSheets are reported with Author origin (not User Agent), so they appear editable in the Web Inspector, and are not attributed to the document's URL. <a href="https://bugs.webkit.org/show_bug.cgi?id=277893">Bug 277893</a> and <a href="https://bugs.webkit.org/show_bug.cgi?id=320092">bug 320092</a>.</p>
 <div id="target"></div>
 </body>
 </html>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -150,7 +150,8 @@
                 { "name": "disabled", "type": "boolean", "description": "Denotes whether the stylesheet is disabled."},
                 { "name": "isInline", "type": "boolean", "description": "Whether this stylesheet is a <style> tag created by the parser. This is not set for document.written <style> tags." },
                 { "name": "startLine", "type": "number", "description": "Line offset of the stylesheet within the resource (zero based)." },
-                { "name": "startColumn", "type": "number", "description": "Column offset of the stylesheet within the resource (zero based)." }
+                { "name": "startColumn", "type": "number", "description": "Column offset of the stylesheet within the resource (zero based)." },
+                { "name": "isConstructed", "type": "boolean", "optional": true, "description": "<code>true</code> if this stylesheet was created with <code>new CSSStyleSheet()</code> and applied via <code>adoptedStyleSheets</code>, meaning it has no source file of its own." }
             ]
         },
         {

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -613,6 +613,10 @@ static RefPtr<CSSRuleList> asCSSRuleList(CSSRule* rule)
 static String sourceURLForCSSRule(CSSRule& rule)
 {
     if (RefPtr parentStyleSheet = rule.parentStyleSheet()) {
+        // A constructable stylesheet's base URL is its owner document's. See InspectorStyleSheet::finalURL().
+        if (parentStyleSheet->wasConstructedByJS())
+            return nullString();
+
         if (auto sourceURL = parentStyleSheet->contents().baseURL().string(); !sourceURL.isEmpty())
             return sourceURL;
 
@@ -1056,6 +1060,11 @@ InspectorStyleSheet::~InspectorStyleSheet()
 
 String InspectorStyleSheet::finalURL() const
 {
+    // A constructable stylesheet has no source file. Its base URL is the owner document's, which must
+    // not be reported as the stylesheet's own URL, or every rule gets attributed to the document.
+    if (m_pageStyleSheet && m_pageStyleSheet->wasConstructedByJS())
+        return nullString();
+
     String url = styleSheetURL(m_pageStyleSheet.get());
     return url.isEmpty() ? m_documentURL : url;
 }
@@ -1273,7 +1282,7 @@ RefPtr<Inspector::Protocol::CSS::CSSStyleSheetHeader> InspectorStyleSheet::build
 
     RefPtr document = styleSheet->ownerDocument();
     RefPtr frame = document ? document->frame() : nullptr;
-    return Inspector::Protocol::CSS::CSSStyleSheetHeader::create()
+    auto header = Inspector::Protocol::CSS::CSSStyleSheetHeader::create()
         .setStyleSheetId(id())
         .setOrigin(m_origin)
         .setDisabled(styleSheet->disabled())
@@ -1284,6 +1293,11 @@ RefPtr<Inspector::Protocol::CSS::CSSStyleSheetHeader> InspectorStyleSheet::build
         .setStartLine(styleSheet->startPosition().m_line.zeroBasedInt())
         .setStartColumn(styleSheet->startPosition().m_column.zeroBasedInt())
         .release();
+
+    if (styleSheet->wasConstructedByJS())
+        header->setIsConstructed(true);
+
+    return header;
 }
 
 static Ref<Inspector::Protocol::CSS::CSSSelector> buildObjectForSelectorHelper(const String& selectorText, const CSSSelector& selector)
@@ -1426,8 +1440,10 @@ RefPtr<Inspector::Protocol::CSS::CSSRule> InspectorStyleSheet::buildObjectForRul
         .setStyle(buildObjectForStyle(protect(rule->style()).ptr()))
         .release();
 
-    if (m_origin == Inspector::Protocol::CSS::StyleSheetOrigin::Author || m_origin == Inspector::Protocol::CSS::StyleSheetOrigin::User)
-        result->setSourceURL(finalURL());
+    if (m_origin == Inspector::Protocol::CSS::StyleSheetOrigin::Author || m_origin == Inspector::Protocol::CSS::StyleSheetOrigin::User) {
+        if (auto sourceURL = finalURL(); !sourceURL.isEmpty())
+            result->setSourceURL(sourceURL);
+    }
 
     if (canBind()) {
         if (auto ruleId = this->ruleOrStyleId(rule).asProtocolValue<Inspector::Protocol::CSS::CSSRuleId>())

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -664,6 +664,15 @@ const Vector<Ref<CSSStyleSheet>> Scope::activeStyleSheetsForInspector()
         result.append(*sheet);
     }
 
+    // Adopted style sheets are absent from m_styleSheetsForStyleSheetList, since document.styleSheets
+    // must not contain them, but the inspector still needs to see them.
+    for (auto& adoptedStyleSheet : treeScope().adoptedStyleSheets()) {
+        if (adoptedStyleSheet->disabled())
+            continue;
+
+        result.append(adoptedStyleSheet.get());
+    }
+
     return result;
 }
 

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -208,7 +208,6 @@ localizedStrings["Animation Target"] = "Animation Target";
 localizedStrings["Anonymous Script %d"] = "Anonymous Script %d";
 localizedStrings["Anonymous Scripts"] = "Anonymous Scripts";
 localizedStrings["Anonymous Style Sheet %d"] = "Anonymous Style Sheet %d";
-localizedStrings["Anonymous Style Sheets"] = "Anonymous Style Sheets";
 /* Header for section with appearance user preferences. */
 localizedStrings["Appearance @ User Preferences Overrides"] = "Appearance";
 localizedStrings["Appearance:"] = "Appearance:";
@@ -462,6 +461,7 @@ localizedStrings["Console cleared at %s"] = "Console cleared at %s";
 localizedStrings["Console opened at %s"] = "Console opened at %s";
 localizedStrings["Console prompt"] = "Console prompt";
 localizedStrings["Console:"] = "Console:";
+localizedStrings["Constructed Style Sheet %d"] = "Constructed Style Sheet %d";
 localizedStrings["Containing"] = "Containing";
 localizedStrings["Content Security Policy violation of directive: %s"] = "Content Security Policy violation of directive: %s";
 /* Property value for `font-variant-ligatures: contextual`. */

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -584,6 +584,12 @@ WI.CSSManager = class CSSManager extends WI.Object
         if (!styleSheet.noteContentDidChange())
             return;
 
+        // A constructed style sheet has no resource behind it, so there is no resource revision to
+        // write the new text into. noteContentDidChange above has already marked the style sheet's
+        // content stale and told the views, so the UI still refreshes.
+        if (styleSheet.isConstructed())
+            return;
+
         this._updateResourceContent(styleSheet);
     }
 
@@ -596,7 +602,7 @@ WI.CSSManager = class CSSManager extends WI.Object
         let styleSheet = this.styleSheetForIdentifier(styleSheetInfo.styleSheetId, target);
         let parentFrame = WI.networkManager.frameForIdentifier(styleSheetInfo.frameId);
         let origin = WI.CSSManager.protocolStyleSheetOriginToEnum(styleSheetInfo.origin);
-        styleSheet.updateInfo(styleSheetInfo.sourceURL, parentFrame, origin, styleSheetInfo.isInline, styleSheetInfo.startLine, styleSheetInfo.startColumn);
+        styleSheet.updateInfo(styleSheetInfo.sourceURL, parentFrame, origin, styleSheetInfo.isInline, styleSheetInfo.startLine, styleSheetInfo.startColumn, styleSheetInfo.isConstructed);
 
         this.dispatchEventToListeners(WI.CSSManager.Event.StyleSheetAdded, {styleSheet});
     }
@@ -767,7 +773,11 @@ WI.CSSManager = class CSSManager extends WI.Object
                 let origin = WI.CSSManager.protocolStyleSheetOriginToEnum(styleSheetInfo.origin);
 
                 let styleSheet = this.styleSheetForIdentifier(styleSheetInfo.styleSheetId);
-                styleSheet.updateInfo(styleSheetInfo.sourceURL, parentFrame, origin, styleSheetInfo.isInline, styleSheetInfo.startLine, styleSheetInfo.startColumn);
+                styleSheet.updateInfo(styleSheetInfo.sourceURL, parentFrame, origin, styleSheetInfo.isInline, styleSheetInfo.startLine, styleSheetInfo.startColumn, styleSheetInfo.isConstructed);
+
+                // A style sheet without a URL has no resource to be looked up by
+                if (!styleSheetInfo.sourceURL)
+                    continue;
 
                 let key = this._frameURLMapKey(parentFrame, styleSheetInfo.sourceURL);
                 this._styleSheetFrameURLMap.set(key, styleSheet);

--- a/Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js
@@ -40,6 +40,7 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
 
         this._inlineStyleAttribute = false;
         this._inlineStyleTag = false;
+        this._isConstructed = false;
 
         this._hasInfo = false;
     }
@@ -48,7 +49,8 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
 
     static resetUniqueDisplayNameNumbers()
     {
-        WI.CSSStyleSheet._nextUniqueDisplayNameNumber = 1;
+        WI.CSSStyleSheet._nextAnonymousDisplayNameNumber = 1;
+        WI.CSSStyleSheet._nextConstructedDisplayNameNumber = 1;
     }
 
     // Public
@@ -96,10 +98,12 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
         if (this._url)
             return WI.displayNameForURL(this._url, this.urlComponents);
 
-        // Assign a unique number to the StyleSheet object so it will stay the same.
-        if (!this._uniqueDisplayNameNumber)
-            this._uniqueDisplayNameNumber = this.constructor._nextUniqueDisplayNameNumber++;
+        if (this.isConstructed()) {
+            this._uniqueDisplayNameNumber ||= this.constructor._nextConstructedDisplayNameNumber++;
+            return WI.UIString("Constructed Style Sheet %d").format(this._uniqueDisplayNameNumber);
+        }
 
+        this._uniqueDisplayNameNumber ||= this.constructor._nextAnonymousDisplayNameNumber++;
         return WI.UIString("Anonymous Style Sheet %d").format(this._uniqueDisplayNameNumber);
     }
 
@@ -121,6 +125,11 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
     isInspectorStyleSheet()
     {
         return this._origin === WI.CSSStyleSheet.Type.Inspector;
+    }
+
+    isConstructed()
+    {
+        return this._isConstructed;
     }
 
     isInlineStyleTag()
@@ -154,7 +163,7 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
 
     // Protected
 
-    updateInfo(url, parentFrame, origin, inlineStyle, startLineNumber, startColumnNumber)
+    updateInfo(url, parentFrame, origin, inlineStyle, startLineNumber, startColumnNumber, isConstructed)
     {
         this._hasInfo = true;
 
@@ -167,6 +176,8 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
         this._inlineStyleTag = inlineStyle;
         this._startLineNumber = startLineNumber;
         this._startColumnNumber = startColumnNumber;
+
+        this._isConstructed = !!isConstructed;
     }
 
     get revisionForRequestedContent()
@@ -225,7 +236,8 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
     }
 };
 
-WI.CSSStyleSheet._nextUniqueDisplayNameNumber = 1;
+WI.CSSStyleSheet._nextAnonymousDisplayNameNumber = 1;
+WI.CSSStyleSheet._nextConstructedDisplayNameNumber = 1;
 
 WI.CSSStyleSheet.Event = {
     ContentDidChange: "css-style-sheet-content-did-change"

--- a/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
@@ -37,7 +37,6 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         this._extraScriptsFolderTreeElement = null;
         this._extraStyleSheetsFolderTreeElement = null;
         this._anonymousScriptsFolderTreeElement = null;
-        this._anonymousStyleSheetsFolderTreeElement = null;
 
         this._originTreeElementMap = new Map;
 
@@ -692,18 +691,22 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
 
             console.assert(representedObject.anonymous, representedObject);
 
-            if (!this._anonymousStyleSheetsFolderTreeElement)
-                this._anonymousStyleSheetsFolderTreeElement = new WI.FolderTreeElement(WI.UIString("Anonymous Style Sheets"), new WI.CSSStyleSheetCollection);
+            // A style sheet without a URL has no domain or path to file it under, so it goes with the
+            // other style sheets that are not part of the frame tree, in both grouping modes.
 
-            if (!this._anonymousStyleSheetsFolderTreeElement.parent) {
-                let index = insertionIndexForObjectInListSortedByFunction(this._anonymousStyleSheetsFolderTreeElement, this._resourcesTreeOutline.children, this._boundCompareTreeElements);
-                this._resourcesTreeOutline.insertChild(this._anonymousStyleSheetsFolderTreeElement, index);
+            if (!this._extraStyleSheetsFolderTreeElement)
+                this._extraStyleSheetsFolderTreeElement = new WI.FolderTreeElement(WI.UIString("Extra Style Sheets"), new WI.CSSStyleSheetCollection);
+
+            if (!this._extraStyleSheetsFolderTreeElement.parent) {
+                let index = insertionIndexForObjectInListSortedByFunction(this._extraStyleSheetsFolderTreeElement, this._resourcesTreeOutline.children, this._boundCompareTreeElements);
+                this._resourcesTreeOutline.insertChild(this._extraStyleSheetsFolderTreeElement, index);
                 this._resourcesTreeOutline.disclosureButtons = true;
             }
 
-           let cssStyleSheetTreeElement = new WI.CSSStyleSheetTreeElement(representedObject);
-           this._anonymousStyleSheetsFolderTreeElement.appendChild(cssStyleSheetTreeElement);
-           return cssStyleSheetTreeElement;
+            let cssStyleSheetTreeElement = new WI.CSSStyleSheetTreeElement(representedObject);
+            let index = insertionIndexForObjectInListSortedByFunction(cssStyleSheetTreeElement, this._extraStyleSheetsFolderTreeElement.children, this._boundCompareTreeElements);
+            this._extraStyleSheetsFolderTreeElement.insertChild(cssStyleSheetTreeElement, index);
+            return cssStyleSheetTreeElement;
         }
 
         console.assert(false, "Didn't find a TreeElement for representedObject", representedObject);
@@ -1055,15 +1058,13 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
                     && treeElement !== this._extensionStyleSheetsFolderTreeElement
                     && treeElement !== this._extraScriptsFolderTreeElement
                     && treeElement !== this._extraStyleSheetsFolderTreeElement
-                    && treeElement !== this._anonymousScriptsFolderTreeElement
-                    && treeElement !== this._anonymousStyleSheetsFolderTreeElement;
+                    && treeElement !== this._anonymousScriptsFolderTreeElement;
             },
             (treeElement) => treeElement === this._extensionScriptsFolderTreeElement,
             (treeElement) => treeElement === this._extensionStyleSheetsFolderTreeElement,
             (treeElement) => treeElement === this._extraScriptsFolderTreeElement,
             (treeElement) => treeElement === this._extraStyleSheetsFolderTreeElement,
             (treeElement) => treeElement === this._anonymousScriptsFolderTreeElement,
-            (treeElement) => treeElement === this._anonymousStyleSheetsFolderTreeElement,
         ];
 
         let aRank = rankFunctions.findIndex((rankFunction) => rankFunction(a));
@@ -2433,7 +2434,6 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         this._extraScriptsFolderTreeElement = null;
         this._extraStyleSheetsFolderTreeElement = null;
         this._anonymousScriptsFolderTreeElement = null;
-        this._anonymousStyleSheetsFolderTreeElement = null;
 
         this._originTreeElementMap.clear();
 
@@ -2887,10 +2887,6 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
 
         case this._extraStyleSheetsFolderTreeElement:
             this._extraStyleSheetsFolderTreeElement = null;
-            break;
-
-        case this._anonymousStyleSheetsFolderTreeElement:
-            this._anonymousStyleSheetsFolderTreeElement = null;
             break;
         }
     }


### PR DESCRIPTION
#### 39d8b7b7a57f8e3f113cfbe2c5a36e35a6b08167
<pre>
Web Inspector: adopted style sheets are still mislabeled
<a href="https://bugs.webkit.org/show_bug.cgi?id=320092">https://bugs.webkit.org/show_bug.cgi?id=320092</a>
<a href="https://rdar.apple.com/problem/183034825">rdar://problem/183034825</a>

Reviewed by NOBODY (OOPS!).

In the Styles sidebar, a rule from a constructed style sheet (`new
CSSStyleSheet()` applied via `document.adoptedStyleSheets`) is labeled with the
document&apos;s URL at line 1, which is the DOCTYPE line of the HTML.

A constructed style sheet has no source file, but it has a base URL borrowed
from its owner document so that `url()` in its rules resolves.
`InspectorStyleSheet::finalURL` returned that, so every rule was reported as
living in the document.

Nothing marked the sheet as constructed either, and
`Scope::activeStyleSheetsForInspector` reads the StyleSheetList backing store,
which <a href="https://commits.webkit.org/311074@main">311074@main</a> emptied of adopted sheets so that `document.styleSheets`
matches CSSOM.

Fix by reporting no source URL for a constructed style sheet, adding an
`isConstructed` flag to the style sheet header, and listing adopted sheets in
the inspector-only accessor. The label reads &quot;Constructed Style Sheet&quot; and its
line numbers point into the sheet. `document.styleSheets` is unchanged.

Also fixes `sourceURLForCSSRule`, which borrowed the document URL the same way
for a rule&apos;s `@media` groupings. Nothing reads a grouping&apos;s location today, so
this was not visible.

Note that sheets adopted into a shadow root are still not enumerated, since
both CSS agents walk documents only. Bug 272874 tracks that side.

In the Sources tab, a style sheet with no URL was filed under a folder of its
own called &quot;Anonymous Style Sheets&quot;. It now joins the other style sheets that
have no place in the frame tree, under &quot;Extra Style Sheets&quot;, in both grouping
modes.

Tests: inspector/css/getAllStyleSheetsAdoptedStyleSheet.html
       inspector/css/getMatchedStylesForNodeAdoptedStyleSheet.html

* Source/JavaScriptCore/inspector/protocol/CSS.json: Optional `isConstructed`
on CSSStyleSheetHeader.

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::sourceURLForCSSRule): Don&apos;t attribute a constructed sheet&apos;s groupings
to the document. The check goes first, since the base URL is the document&apos;s and
is never empty.
(WebCore::InspectorStyleSheet::finalURL): Empty for a constructed style sheet.
(WebCore::InspectorStyleSheet::buildObjectForStyleSheetInfo):
(WebCore::InspectorStyleSheet::buildObjectForRule): Omit `sourceURL` rather
than sending an empty one, so the frontend builds the location inside the sheet.

* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::activeStyleSheetsForInspector): Append the adopted
style sheets.

* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js:
(WI.CSSManager.prototype.styleSheetChanged): A constructed style sheet has no
resource to write changes back into.
(WI.CSSManager.prototype.styleSheetAdded):
(WI.CSSManager.prototype._fetchInfoForAllStyleSheets): Don&apos;t file a style sheet
without a URL under the frame&apos;s own URL.

* Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js:
(WI.CSSStyleSheet.resetUniqueDisplayNameNumbers): One counter per kind, so a
mix of constructed and anonymous sheets does not skip numbers.
(WI.CSSStyleSheet.prototype.get displayName):
(WI.CSSStyleSheet.prototype.isConstructed): Added.
(WI.CSSStyleSheet.prototype.updateInfo):

* Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js:
(WI.SourcesNavigationSidebarPanel.prototype.treeElementForRepresentedObject):
File a style sheet with no URL under &quot;Extra Style Sheets&quot; instead of a folder of
its own. This is the only path that files such a sheet, and it runs for both
grouping modes, so By Path and By Type read the same. Insert it in sorted order
like the URL-bearing sheets in that folder.
(WI.SourcesNavigationSidebarPanel.prototype._compareTreeElements):
(WI.SourcesNavigationSidebarPanel.prototype._removeStyleSheet): Drop the
now-unused &quot;Anonymous Style Sheets&quot; folder.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

* LayoutTests/inspector/css/getAllStyleSheetsAdoptedStyleSheet.html: Added.
* LayoutTests/inspector/css/getAllStyleSheetsAdoptedStyleSheet-expected.txt: Added.
One constructed style sheet, no URL, Author origin, named &quot;Constructed Style
Sheet 1&quot;. Counts only the constructed sheets rather than every sheet the page
has, since site isolation gives the inspector one more than this document
declares.

* LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet.html:
* LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet-expected.txt:
Also assert the rule carries no sourceURL. Fails without the fix.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39d8b7b7a57f8e3f113cfbe2c5a36e35a6b08167

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145520 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6e029cc-5459-45eb-984a-f98a96867114) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141401 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98085 "3 flakes 11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98cd0ed6-bb44-4bd2-8578-2748587decc8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121852 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b853a8e9-bc97-41ad-95aa-51021ed06235) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43746 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42022 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3817 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10637 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41682 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2573 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42471 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193346 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54808 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161670 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150793 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55496 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150509 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45101 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127764 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123322 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54013 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16678 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53395 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53632 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53460 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->