### PR TITLE
[css-values-5] Allow random() in custom properties

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4611,6 +4611,9 @@ webkit.org/b/203356 imported/w3c/web-platform-tests/css/css-transitions/properti
 imported/w3c/web-platform-tests/css/css-transitions/transitioncancel-003.html [ Failure Pass ]
 
 # wpt css-values failures
+# The "Shared between elements within a property - shorthand" subtest compares two random() draws in
+# a margin shorthand for inequality and does not always get distinct ones.
+imported/w3c/web-platform-tests/css/css-values/random-computed.tentative.html [ Failure Pass ]
 webkit.org/b/203320 imported/w3c/web-platform-tests/css/css-values/percentage-rem-low.html [ ImageOnlyFailure ]
 webkit.org/b/259025 imported/w3c/web-platform-tests/css/css-values/ic-unit-015.html [ ImageOnlyFailure ]
 webkit.org/b/277995 imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-aspect-ratio-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt
@@ -90,7 +90,7 @@ FAIL Property border-image-slice value 'random(10%, 30%)' assert_true: Computed 
 PASS Property background-color value 'rgb(225, 215, 0, random(30%, 10%))'
 PASS Property font-size value 'random(30%, 10%)'
 FAIL Property font-size value 'random(10px * 10% / 1%, 0%)' assert_true: Random values should be equal expected true got false
-FAIL Property --percent value 'random(10%, 30%)' assert_greater_than_equal: random(10%, 30%) expected a number greater than or equal to 10 but got 3
+PASS Property --percent value 'random(10%, 30%)'
 FAIL Property width value 'random(fixed random(1, 2), 10px, 100px)' assert_true: 'random(fixed random(1, 2), 10px, 100px)' is a supported value for width. expected true got false
 FAIL Property translate value 'random(fixed random(-2, -1), 10%, 100%)' assert_true: 'random(fixed random(-2, -1), 10%, 100%)' is a supported value for translate. expected true got false
 PASS Property color value 'rgb(random(30, 10) random(60, 10) random(90, 10))'

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-animations.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-animations.tentative-expected.txt
@@ -1,19 +1,19 @@
 
-FAIL CSS Transitions: property <--number> from [100] to [random(300, 100)] at (-0.5) should be [0] assert_equals: expected "0 " but got "150 "
+PASS CSS Transitions: property <--number> from [100] to [random(300, 100)] at (-0.5) should be [0]
 PASS CSS Transitions: property <--number> from [100] to [random(300, 100)] at (0) should be [100]
-FAIL CSS Transitions: property <--number> from [100] to [random(300, 100)] at (0.5) should be [200] assert_equals: expected "200 " but got "50 "
-FAIL CSS Transitions: property <--number> from [100] to [random(300, 100)] at (1) should be [300] assert_equals: expected "300 " but got "0 "
-FAIL CSS Transitions: property <--number> from [100] to [random(300, 100)] at (1.5) should be [400] assert_equals: expected "400 " but got "- 50 "
-FAIL CSS Animations: property <--number> from [100] to [random(300, 100)] at (-0.5) should be [0] assert_equals: expected "0 " but got "150 "
+PASS CSS Transitions: property <--number> from [100] to [random(300, 100)] at (0.5) should be [200]
+PASS CSS Transitions: property <--number> from [100] to [random(300, 100)] at (1) should be [300]
+PASS CSS Transitions: property <--number> from [100] to [random(300, 100)] at (1.5) should be [400]
+PASS CSS Animations: property <--number> from [100] to [random(300, 100)] at (-0.5) should be [0]
 PASS CSS Animations: property <--number> from [100] to [random(300, 100)] at (0) should be [100]
-FAIL CSS Animations: property <--number> from [100] to [random(300, 100)] at (0.5) should be [200] assert_equals: expected "200 " but got "50 "
-FAIL CSS Animations: property <--number> from [100] to [random(300, 100)] at (1) should be [300] assert_equals: expected "300 " but got "0 "
-FAIL CSS Animations: property <--number> from [100] to [random(300, 100)] at (1.5) should be [400] assert_equals: expected "400 " but got "- 50 "
-FAIL Web Animations: property <--number> from [100] to [random(300, 100)] at (-0.5) should be [0] assert_equals: expected "0 " but got "150 "
+PASS CSS Animations: property <--number> from [100] to [random(300, 100)] at (0.5) should be [200]
+PASS CSS Animations: property <--number> from [100] to [random(300, 100)] at (1) should be [300]
+PASS CSS Animations: property <--number> from [100] to [random(300, 100)] at (1.5) should be [400]
+PASS Web Animations: property <--number> from [100] to [random(300, 100)] at (-0.5) should be [0]
 PASS Web Animations: property <--number> from [100] to [random(300, 100)] at (0) should be [100]
-FAIL Web Animations: property <--number> from [100] to [random(300, 100)] at (0.5) should be [200] assert_equals: expected "200 " but got "50 "
-FAIL Web Animations: property <--number> from [100] to [random(300, 100)] at (1) should be [300] assert_equals: expected "300 " but got "0 "
-FAIL Web Animations: property <--number> from [100] to [random(300, 100)] at (1.5) should be [400] assert_equals: expected "400 " but got "- 50 "
+PASS Web Animations: property <--number> from [100] to [random(300, 100)] at (0.5) should be [200]
+PASS Web Animations: property <--number> from [100] to [random(300, 100)] at (1) should be [300]
+PASS Web Animations: property <--number> from [100] to [random(300, 100)] at (1.5) should be [400]
 PASS CSS Transitions: property <font-weight> from [100] to [random(300, 100)] at (-0.5) should be [1]
 PASS CSS Transitions: property <font-weight> from [100] to [random(300, 100)] at (0) should be [100]
 PASS CSS Transitions: property <font-weight> from [100] to [random(300, 100)] at (0.5) should be [200]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL random() in function result assert_true: expected true got false
-FAIL random() in function typed result assert_true: expected true got false
-FAIL random() in different function same local name assert_true: expected true got false
-FAIL random() in same function different locals assert_true: expected true got false
-FAIL random() in same registered function same locals different positions assert_true: expected true got false
+PASS random() in function result
+FAIL random() in function typed result assert_false: Random values should not be equal expected false got true
+PASS random() in different function same local name
+PASS random() in same function different locals
+PASS random() in same registered function same locals different positions
 FAIL random() in different function same default locals assert_true: expected true got false
-FAIL random() in function in local overrides argument assert_true: expected true got false
-FAIL random() in function argument assert_true: expected true got false
+FAIL random() in function in local overrides argument assert_false: Random values should not be equal expected false got true
+PASS random() in function argument
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-if.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-if.tentative-expected.txt
@@ -1,6 +1,6 @@
 
 PASS random() should not be allowed in if() style() condition
 PASS random() in var() should not be allowed in if() style() condition
-FAIL random() with different property names should not be shared in if() declaration value assert_false: expected false got true
-FAIL random() with same property name on different elements in if() declaration value should be equal assert_false: expected false got true
+FAIL random() with different property names should not be shared in if() declaration value assert_false: Random values should be equal expected false got true
+PASS random() with same property name on different elements in if() declaration value should be equal
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -668,12 +668,14 @@ static std::optional<TypedChild> consumeRandom(CSSParserTokenRange& tokens, int 
     if (state.propertyParserState.currentProperty == CSSPropertyInvalid)
         return { };
 
-    // FIXME: Add support for custom properties by including the custom property name in CSS::PropertyParserState for registered properties.
-    if (state.propertyParserState.currentProperty == CSSPropertyCustom)
+    if (state.propertyParserState.randomFunctionsDisallowed)
         return { };
 
     using Op = Random;
 
+    // FIXME: currentProperty is CSSPropertyCustom for every custom property, so an `auto` or
+    // property-scoped key in one collapses all custom properties onto a single base value. The name
+    // needs to be part of the key.
     auto keySource = CSSPropertyParserHelpers::RandomKeySource {
         .property = state.propertyParserState.currentProperty,
         .autoElementScoped = CSS::Keyword::ElementScoped { }

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -360,6 +360,7 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> CSSProp
         .currentRule = StyleRuleType::Style,
         .currentProperty = CSSPropertyCustom,
         .important = IsImportant::No,
+        .randomFunctionsDisallowed = builderState.isResolvingContainerQueries(),
     };
 
     auto value = consumeTypedCustomPropertyValue(range, state, name, syntax, builderState, isAttrTainted);
@@ -378,6 +379,7 @@ RefPtr<const Style::CustomProperty> CSSPropertyParser::parseTypedCustomPropertyI
         .currentRule = StyleRuleType::Style,
         .currentProperty = CSSPropertyCustom,
         .important = IsImportant::No,
+        .randomFunctionsDisallowed = true,
     };
 
     auto value = consumeTypedCustomPropertyValue(range, state, name, syntax, builderState);

--- a/Source/WebCore/css/parser/CSSPropertyParserState.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserState.h
@@ -46,6 +46,10 @@ struct PropertyParserState {
     // Count of CSS random() functions seen so far for the current property.
     unsigned cssRandomFunctionCount { 0 };
 
+    // Set where there is no element to key a random draw to: a @container style() query value or an @property initial value.
+    // FIXME: Should cover every function needing an element context, like the tree counting ones, not just random(). https://github.com/w3c/csswg-drafts/issues/10982
+    bool randomFunctionsDisallowed { false };
+
     // Used by non-CSS users of the CSS parsers like `DOMMatrix` to limit <length> and <length-percentage> parsing to only absolute units.
     bool absoluteLengthUnitsOnly { false };
 };


### PR DESCRIPTION
#### a57d3936e9a5d33ed231a75a40adbcb41c51e852
<pre>
[css-values-5] Allow random() in custom properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=321595">https://bugs.webkit.org/show_bug.cgi?id=321595</a>
<a href="https://rdar.apple.com/184715508">rdar://184715508</a>

Reviewed by Tim Nguyen.

But also disallow it when element context is not present.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-animations.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-custom-function.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-if.tentative-expected.txt:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::consumeRandom):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
(WebCore::CSSPropertyParser::parseTypedCustomPropertyInitialValue):
* Source/WebCore/css/parser/CSSPropertyParserState.h:

Canonical link: <a href="https://commits.webkit.org/319039@main">https://commits.webkit.org/319039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30bb578a89f27a85b7356f6d682c4a5e977f1cd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190455 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144565 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31860fcc-8cb2-422a-a16e-82bcb7d84a73) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140583 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121035 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8d79611b-75b5-4621-98d1-c62138198de0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/42915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41219 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9850 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40894 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1614 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192390 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160883 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/149935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40151 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54543 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149657 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44299 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126806 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121963 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53060 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15883 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52679 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52507 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->