### PR TITLE
[Web Automation] Element Click targets the wrong position inside a cross-origin iframe under Site Isolation

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1608,6 +1608,44 @@ static std::optional<CoordinateSystem> NODELETE protocolStringToCoordinateSystem
     return std::nullopt;
 }
 
+// WebAutomationSessionProxy::computeElementLayout() can't produce main-frame-relative
+// LayoutViewport coordinates for an out-of-process frame, because that frame's web process cannot
+// see where the frame sits within the page. It stops at the frame's local root and leaves the rest
+// to the UI process, since only it can traverse the whole frame tree.
+static std::optional<WebCore::FrameIdentifier> localRootFrameNeedingMainFrameConversion(std::optional<WebCore::FrameIdentifier> frameID, CoordinateSystem coordinateSystem)
+{
+    if (coordinateSystem != CoordinateSystem::LayoutViewport)
+        return std::nullopt;
+
+    RefPtr frame = WebFrameProxy::webFrame(frameID);
+    if (!frame)
+        return std::nullopt;
+
+    Ref localRootFrame = frame->rootFrame();
+    if (localRootFrame->isMainFrame())
+        return std::nullopt;
+
+    return localRootFrame->frameID();
+}
+
+// convertRectToMainFrameCoordinates() and convertPointToMainFrameCoordinates() produce main frame
+// *root view* coordinates, which include the obscured content inset area. The LayoutViewport space
+// the Automation protocol reports excludes it. The web process arrives at it via
+// LocalFrameView::rootViewToContents(), which subtracts the insets, and consumers add them back
+// (see viewportLocationToWindowLocation() when synthesizing events). Drop the insets here so both
+// the site-isolated and non-isolated paths report the same space.
+//
+// FIXME: https://bugs.webkit.org/show_bug.cgi?id=322023 - Element coordinates in cross-origin iframes under Site Isolation omit the page scale and layout viewport offset
+// The non-Site Isolation path also divides by Frame::frameScaleFactor()
+// and subtracts FrameView::layoutViewportRect().location(), ScrollView::headerHeight() and insetForLeftScrollbarSpace().
+// Those cancel out at frame scale 1 with no header banner or left-hand scrollbar.
+// But under pinch zoom the reported coordinates are off by roughly the page scale factor and Element Click misses the element.
+static WebCore::FloatSize obscuredContentInsetOffset(WebPageProxy& page)
+{
+    auto insets = page.obscuredContentInsets();
+    return { -insets.left(), -insets.top() };
+}
+
 void WebAutomationSession::computeElementLayout(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, std::optional<bool>&& optionalScrollIntoViewIfNeeded, Inspector::Protocol::Automation::CoordinateSystem coordinateSystemValue, CommandCallbackOf<Ref<Inspector::Protocol::Automation::Rect>, RefPtr<Inspector::Protocol::Automation::Point>, bool>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
@@ -1620,35 +1658,64 @@ void WebAutomationSession::computeElementLayout(const Inspector::Protocol::Autom
     std::optional<CoordinateSystem> coordinateSystem = protocolStringToCoordinateSystem(coordinateSystemValue);
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!coordinateSystem, InvalidParameter, "The parameter 'coordinateSystem' is invalid."_s);
 
-    WTF::CompletionHandler<void(std::optional<String>&&, WebCore::FloatRect&&, std::optional<WebCore::IntPoint>&&, bool)> completionHandler = [callback = WTF::move(callback)](std::optional<String> optionalError, WebCore::FloatRect rect, std::optional<WebCore::IntPoint> inViewCenterPoint, bool isObscured) mutable {
+    WTF::CompletionHandler<void(std::optional<String>&&, WebCore::FloatRect&&, std::optional<WebCore::IntPoint>&&, bool)> completionHandler = [callback = WTF::move(callback), page = protect(*page), frameID, coordinateSystem = *coordinateSystem](std::optional<String> optionalError, WebCore::FloatRect rect, std::optional<WebCore::IntPoint> inViewCenterPoint, bool isObscured) mutable {
         ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF_SET(optionalError);
 
-        auto originObject = Inspector::Protocol::Automation::Point::create()
-            .setX(rect.x())
-            .setY(rect.y())
-            .release();
+        auto buildAndRespond = [callback = WTF::move(callback)](std::optional<WebCore::FloatRect> optionalRect, std::optional<WebCore::IntPoint> inViewCenterPoint, bool isObscured) mutable {
+            ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!optionalRect, InternalError, "Failed to convert the element's layout into main frame coordinates."_s);
+            auto rect = *optionalRect;
 
-        auto sizeObject = Inspector::Protocol::Automation::Size::create()
-            .setWidth(rect.width())
-            .setHeight(rect.height())
-            .release();
+            auto originObject = Inspector::Protocol::Automation::Point::create()
+                .setX(rect.x())
+                .setY(rect.y())
+                .release();
 
-        auto rectObject = Inspector::Protocol::Automation::Rect::create()
-            .setOrigin(WTF::move(originObject))
-            .setSize(WTF::move(sizeObject))
-            .release();
+            auto sizeObject = Inspector::Protocol::Automation::Size::create()
+                .setWidth(rect.width())
+                .setHeight(rect.height())
+                .release();
 
-        if (!inViewCenterPoint) {
-            callback({ { WTF::move(rectObject), nullptr, isObscured } });
-            return;
-        }
+            auto rectObject = Inspector::Protocol::Automation::Rect::create()
+                .setOrigin(WTF::move(originObject))
+                .setSize(WTF::move(sizeObject))
+                .release();
 
-        auto inViewCenterPointObject = Inspector::Protocol::Automation::Point::create()
-            .setX(inViewCenterPoint.value().x())
-            .setY(inViewCenterPoint.value().y())
-            .release();
+            if (!inViewCenterPoint) {
+                callback({ { WTF::move(rectObject), nullptr, isObscured } });
+                return;
+            }
 
-        callback({ { WTF::move(rectObject), WTF::move(inViewCenterPointObject), isObscured } });
+            auto inViewCenterPointObject = Inspector::Protocol::Automation::Point::create()
+                .setX(inViewCenterPoint.value().x())
+                .setY(inViewCenterPoint.value().y())
+                .release();
+
+            callback({ { WTF::move(rectObject), WTF::move(inViewCenterPointObject), isObscured } });
+        };
+
+        // Under site isolation the frame's web process reports LayoutViewport coordinates relative
+        // to the frame's local root; finish walking them up to the main frame here.
+        auto localRootFrameID = localRootFrameNeedingMainFrameConversion(frameID, coordinateSystem);
+        if (!localRootFrameID)
+            return buildAndRespond(rect, inViewCenterPoint, isObscured);
+
+        page->convertRectToMainFrameCoordinates(rect, *localRootFrameID, [page, localRootFrameID = *localRootFrameID, inViewCenterPoint, isObscured, buildAndRespond = WTF::move(buildAndRespond)](std::optional<WebCore::FloatRect> convertedRect) mutable {
+            if (convertedRect)
+                convertedRect->move(obscuredContentInsetOffset(page.get()));
+
+            if (!convertedRect || !inViewCenterPoint)
+                return buildAndRespond(convertedRect, std::nullopt, isObscured);
+
+            page->convertPointToMainFrameCoordinates(WebCore::FloatPoint { *inViewCenterPoint }, localRootFrameID, [page, convertedRect, isObscured, buildAndRespond = WTF::move(buildAndRespond)](std::optional<WebCore::FloatPoint> convertedPoint) mutable {
+                // A converted rect with an unconvertible center point still describes the element,
+                // so report the rect and let the client treat the element as having no in-view
+                // center point, matching the web process's own behavior for that case.
+                if (convertedPoint)
+                    convertedPoint->move(obscuredContentInsetOffset(page.get()));
+
+                buildAndRespond(convertedRect, convertedPoint ? std::optional { WebCore::flooredIntPoint(*convertedPoint) } : std::nullopt, isObscured);
+            });
+        });
     };
 
     bool scrollIntoViewIfNeeded = optionalScrollIntoViewIfNeeded && *optionalScrollIntoViewIfNeeded;
@@ -2345,7 +2412,7 @@ SimulatedInputDispatcher& WebAutomationSession::inputDispatcherForPage(WebPagePr
 // MARK: SimulatedInputDispatcher::Client API
 void WebAutomationSession::viewportInViewCenterPointOfElement(WebPageProxy& page, std::optional<FrameIdentifier> frameID, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Function<void(std::optional<WebCore::IntPoint>, std::optional<AutomationCommandError>)>&& completionHandler)
 {
-    WTF::CompletionHandler<void(std::optional<String>&&, WebCore::FloatRect&&, std::optional<WebCore::IntPoint>&&, bool)> didComputeElementLayoutHandler = [completionHandler = WTF::move(completionHandler)](std::optional<String>&& optionalError, WebCore::FloatRect&&, std::optional<WebCore::IntPoint>&& inViewCenterPoint, bool) mutable {
+    WTF::CompletionHandler<void(std::optional<String>&&, WebCore::FloatRect&&, std::optional<WebCore::IntPoint>&&, bool)> didComputeElementLayoutHandler = [completionHandler = WTF::move(completionHandler), page = protect(page), frameID](std::optional<String>&& optionalError, WebCore::FloatRect&&, std::optional<WebCore::IntPoint>&& inViewCenterPoint, bool) mutable {
         if (optionalError) {
             completionHandler(std::nullopt, AUTOMATION_COMMAND_ERROR_WITH_MESSAGE(*optionalError));
             return;
@@ -2356,7 +2423,24 @@ void WebAutomationSession::viewportInViewCenterPointOfElement(WebPageProxy& page
             return;
         }
 
-        completionHandler(inViewCenterPoint, std::nullopt);
+        // This is the point synthesized pointer events are dispatched at, so it must be in main
+        // frame viewport coordinates. Under site isolation the web process could only report it
+        // relative to the frame's local root, so finish the conversion here.
+        auto localRootFrameID = localRootFrameNeedingMainFrameConversion(frameID, CoordinateSystem::LayoutViewport);
+        if (!localRootFrameID) {
+            completionHandler(inViewCenterPoint, std::nullopt);
+            return;
+        }
+
+        page->convertPointToMainFrameCoordinates(WebCore::FloatPoint { *inViewCenterPoint }, *localRootFrameID, [page, completionHandler = WTF::move(completionHandler)](std::optional<WebCore::FloatPoint> convertedPoint) mutable {
+            if (!convertedPoint) {
+                completionHandler(std::nullopt, AUTOMATION_COMMAND_ERROR_WITH_NAME(TargetOutOfBounds));
+                return;
+            }
+
+            convertedPoint->move(obscuredContentInsetOffset(page.get()));
+            completionHandler(WebCore::flooredIntPoint(*convertedPoint), std::nullopt);
+        });
     };
 
     page.sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::ComputeElementLayout(page.webPageIDInProcessForFrame(frameID), frameID, nodeHandle, false, CoordinateSystem::LayoutViewport), WTF::move(didComputeElementLayoutHandler));

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -830,6 +830,12 @@ void WebAutomationSessionProxy::computeElementLayout(WebCore::PageIdentifier pag
         return;
     }
 
+    // When the local root is not the page's main frame, this process doesn't know where the frame
+    // sits within the page, so it cannot produce main-frame-relative coordinates. Stop at local
+    // root contents coordinates and let WebAutomationSession::computeElementLayout() finish the
+    // conversion in the UI process, which can walk the frame tree across processes.
+    bool localRootIsMainFrame = localRootFrame->isMainFrame();
+
     WebCore::FloatRect resultElementBounds;
     std::optional<WebCore::IntPoint> resultInViewCenterPoint;
     bool isObscured = false;
@@ -840,7 +846,8 @@ void WebAutomationSessionProxy::computeElementLayout(WebCore::PageIdentifier pag
         break;
     case CoordinateSystem::LayoutViewport: {
         auto elementBoundsInRootCoordinates = convertRectFromFrameClientToRootView(frameView.get(), coreElement->boundingClientRect());
-        resultElementBounds = rootView->absoluteToLayoutViewportRect(rootView->rootViewToContents(elementBoundsInRootCoordinates));
+        auto elementBoundsInLocalRootContents = rootView->rootViewToContents(elementBoundsInRootCoordinates);
+        resultElementBounds = localRootIsMainFrame ? rootView->absoluteToLayoutViewportRect(elementBoundsInLocalRootContents) : elementBoundsInLocalRootContents;
         break;
     }
     }
@@ -900,7 +907,8 @@ void WebAutomationSessionProxy::computeElementLayout(WebCore::PageIdentifier pag
         break;
     case CoordinateSystem::LayoutViewport: {
         auto inViewCenterPointInRootCoordinates = convertPointFromFrameClientToRootView(frameView.get(), elementInViewCenterPoint);
-        resultInViewCenterPoint = flooredIntPoint(rootView->absoluteToLayoutViewportPoint(rootView->rootViewToContents(inViewCenterPointInRootCoordinates)));
+        auto inViewCenterPointInLocalRootContents = rootView->rootViewToContents(inViewCenterPointInRootCoordinates);
+        resultInViewCenterPoint = flooredIntPoint(localRootIsMainFrame ? rootView->absoluteToLayoutViewportPoint(inViewCenterPointInLocalRootContents) : inViewCenterPointInLocalRootContents);
         break;
     }
     }


### PR DESCRIPTION
#### fe0e6eb35c7b113c44dfe6a3d3be81240f30d19a
<pre>
[Web Automation] Element Click targets the wrong position inside a cross-origin iframe under Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=321593">https://bugs.webkit.org/show_bug.cgi?id=321593</a>
<a href="https://rdar.apple.com/184713255">rdar://184713255</a>

Reviewed by BJ Burg.

The `LayoutViewport` coordinates that `WebAutomationSessionProxy::computeElementLayout()`
reports are relative to the frame&apos;s local root, because a frame&apos;s web process cannot see
where that frame sits within the page. With Site Isolation enabled, a cross-origin iframe&apos;s
local root is the iframe itself, so the reported in-view center point is missing the frame&apos;s
offset within the page. The Automation client feeds that point to the pointer input
dispatcher, which synthesizes events at a page-level position, so Element Click lands
somewhere other than the element.

Finish the conversion in the UI process, which is the only side that knows the whole frame
tree. The web process now stops at local root contents coordinates when its local root is
not the main frame, and `WebAutomationSession` walks them up to the main frame with the
existing `convertRectToMainFrameCoordinates()` and `convertPointToMainFrameCoordinates()`.

Those return main frame root view coordinates, which include the obscured content inset area,
whereas the `LayoutViewport` space excludes it and consumers add it back when synthesizing
events (see `viewportLocationToWindowLocation()`); subtract the insets so both paths report
the same space.

Without Site Isolation a frame&apos;s local root is always the main frame, so the new conversion
does not run and behavior is unchanged.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::localRootFrameNeedingMainFrameConversion):
(WebKit::obscuredContentInsetOffset):
(WebKit::WebAutomationSession::computeElementLayout):
(WebKit::WebAutomationSession::viewportInViewCenterPointOfElement):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::computeElementLayout):

Canonical link: <a href="https://commits.webkit.org/319384@main">https://commits.webkit.org/319384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e884b0ed5b1ca11374a64b2f89f41267cd83d5e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145630 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/83ecc283-aae6-4d19-8a2d-4376ac7bf298) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141497 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121937 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77e9ef3b-2652-4753-9599-59cb0a7deec1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43852 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42127 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41781 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2681 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193455 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54920 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40421 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55607 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150598 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45188 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127888 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123476 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54123 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16779 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53505 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53570 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->