### PR TITLE
font-* properties should use the metrics of the parent element's font for font-relative unit resolution

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/using-font-relative-units-in-font-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/using-font-relative-units-in-font-properties-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Property font-feature-settings value '"swsh" calc(1em / 1px)'
+PASS Property font-palette value 'ident("--test-" calc(1em / 1px))'
+PASS Property font-size-adjust value 'calc(1em / 1px)'
+PASS Property font-style value 'oblique calc(1em / 1px * 1deg)'
+PASS Property font-variant-alternates value 'stylistic(ident("test-" calc(1em / 1px)))'
+PASS Property font-variation-settings value '"xhgt" calc(1em / 1px)'
+PASS Property font-weight value 'calc(1em / 1px)'
+PASS Property font-width value 'calc(1em / 1px * 1%)'
+PASS Property font-size value 'calc(1em / 1)'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/using-font-relative-units-in-font-properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/using-font-relative-units-in-font-properties.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values 4: using font relative units in font-* properties</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.com">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#font-relative-lengths">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #container {
+    font-size: 10px;
+  }
+  #target {
+    font-size: 100px;
+  }
+</style>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+  test_computed_value('font-feature-settings', '"swsh" calc(1em / 1px)', '"swsh" 10');
+  test_computed_value('font-palette', 'ident("--test-" calc(1em / 1px))', '--test-10');
+  test_computed_value('font-size-adjust', 'calc(1em / 1px)', '10');
+  test_computed_value('font-style', 'oblique calc(1em / 1px * 1deg)', 'oblique 10deg');
+  test_computed_value('font-variant-alternates', 'stylistic(ident("test-" calc(1em / 1px)))', 'stylistic(test-10)');
+  test_computed_value('font-variation-settings', '"xhgt" calc(1em / 1px)', '"xhgt" 10');
+  test_computed_value('font-weight', 'calc(1em / 1px)', '10');
+  test_computed_value('font-width', 'calc(1em / 1px * 1%)', '10%');
+
+  // Test font-size last as the other cases are utilizing the one specified in the style.
+  test_computed_value('font-size', 'calc(1em / 1)', '10px');
+</script>

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -62,21 +62,9 @@ public:
     CSSPropertyID property() const { return m_property; }
     Style::BuilderState* styleBuilderState() const { return m_styleBuilderState.get(); }
 
-    CSSToLengthConversionData copyForFontSize() const
-    {
-        CSSToLengthConversionData copy(*this);
-        copy.m_property = CSSPropertyFontSize;
-        return copy;
-    };
-
-    CSSToLengthConversionData copyForLineHeight() const
-    {
-        CSSToLengthConversionData copy(*this);
-        copy.m_property = CSSPropertyLineHeight;
-        return copy;
-    }
-
 private:
+    friend class Style::BuilderState;
+
     const Style::ComputedStyle& m_style;
     const Style::ComputedStyle* m_rootStyle { nullptr };
     const Style::ComputedStyle* m_parentStyle { nullptr };

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -296,7 +296,7 @@ void Builder::applyCustomPropertyImpl(const AtomString& name, const PropertyCasc
         return CSSWideKeyword::Unset;
     };
 
-    SetForScope levelScope(m_state->m_currentProperty, &property);
+    BuilderStatePropertyScope levelScope(m_state, &property);
     SetForScope scopedLinkMatchMutation(m_state->m_linkMatch, SelectorChecker::MatchDefault);
 
     auto resolvedValue = resolveCustomPropertyValue(customPropertyValue.get());
@@ -312,7 +312,7 @@ void Builder::applyCustomPropertyImpl(const AtomString& name, const PropertyCasc
 
 inline void Builder::applyCascadeProperty(const PropertyCascade::Property& property)
 {
-    SetForScope levelScope(m_state->m_currentProperty, &property);
+    BuilderStatePropertyScope levelScope(m_state, &property);
 
     auto applyWithLinkMatch = [&](SelectorChecker::LinkMatchMask linkMatch) {
         if (property.cssValue[linkMatch]) {
@@ -349,7 +349,7 @@ bool Builder::applyRollbackCascadeProperty(const PropertyCascade& rollbackCascad
         return false;
 
     if (RefPtr value = rollbackProperty->cssValue[linkMatchMask]) {
-        SetForScope levelScope(m_state->m_currentProperty, rollbackProperty);
+        BuilderStatePropertyScope levelScope(m_state, rollbackProperty);
         applyProperty(propertyID, *value, linkMatchMask, rollbackProperty->origin);
     }
     return true;
@@ -365,7 +365,7 @@ bool Builder::applyRollbackCascadeCustomProperty(const PropertyCascade& rollback
     if (RefPtr value = rollbackProperty.cssValue[SelectorChecker::MatchDefault]) {
         Ref customPropertyValue = downcast<CSSCustomPropertyValue>(*value);
 
-        SetForScope levelScope(m_state->m_currentProperty, &rollbackProperty);
+        BuilderStatePropertyScope levelScope(m_state, &rollbackProperty);
         auto resolvedValue = resolveCustomPropertyValue(customPropertyValue);
         if (!resolvedValue)
             resolvedValue = CustomProperty::createForGuaranteedInvalid(name);
@@ -707,7 +707,7 @@ std::optional<Builder::CustomPropertyOrKeyword> Builder::resolveFunctionResult()
     if (!m_cascade.hasNormalProperty(CSSPropertyResult))
         return { };
 
-    SetForScope resultScope(m_state->m_currentProperty, &m_cascade.functionResultProperty());
+    BuilderStatePropertyScope resultScope(m_state, &m_cascade.functionResultProperty());
 
     // Apply all local variables, not just those reached by result. A local can be in a cycle with the
     // function even when result never references it.
@@ -856,7 +856,7 @@ const PropertyCascade* Builder::ensureRollbackCascadeForRevert()
 
 const PropertyCascade* Builder::ensureRollbackCascadeForRevertLayer()
 {
-    auto& property = *m_state->m_currentProperty;
+    const auto& property = *m_state->m_currentProperty;
     auto rollbackLayerPriority = property.cascadeLayerPriority;
     if (!rollbackLayerPriority)
         return ensureRollbackCascadeForRevert();

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -624,8 +624,6 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
         // FIXME: Checking `primitiveValue->isPercentageOrParentFontRelativeLength()` is not sufficient to determine if any parent relative length units have been used, as arbitrary calc() expressions may contain them as well. For example, `font-size: calc(1px + 1em)`.
         builderState.setFontDescriptionIsAbsoluteSize(parentIsAbsoluteSize || !primitiveValue->isPercentageOrParentFontRelativeLength());
 
-        auto conversionData = builderState.cssToLengthConversionData().copyForFontSize();
-
         using StyleType = LengthPercentage<CSS::Nonnegative>;
 
         auto handleLength = [](const auto& length) -> float { return length.resolveZoom(ZoomFactor::none()); };
@@ -636,7 +634,7 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
             [&](const CSSPrimitiveValue::Calc& calc) -> float {
                 using CSSRaw = typename StyleType::CSS::Raw;
 
-                auto resolved = toStyle(CSS::UnevaluatedCalc<CSSRaw> { calc }, conversionData);
+                auto resolved = toStyle(CSS::UnevaluatedCalc<CSSRaw> { calc }, builderState);
                 return WTF::switchOn(resolved,
                     [&](const typename StyleType::Dimension& length) {
                         return handleLength(length);
@@ -654,9 +652,9 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
                 using CSSPercentageRaw = typename StyleType::Percentage::CSS::Raw;
 
                 if (auto unit = CSSDimensionRaw::UnitTraits::validate(raw.unit))
-                    return handleLength(toStyle(CSSDimensionRaw(*unit, raw.value), conversionData));
+                    return handleLength(toStyle(CSSDimensionRaw(*unit, raw.value), builderState));
                 if (auto unit = CSSPercentageRaw::UnitTraits::validate(raw.unit))
-                    return handlePercentage(toStyle(CSSPercentageRaw(*unit, raw.value), conversionData));
+                    return handlePercentage(toStyle(CSSPercentageRaw(*unit, raw.value), builderState));
 
                 builderState.setCurrentPropertyInvalidAtComputedValueTime();
                 return 0;

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -52,6 +52,7 @@ struct RandomCachingKey;
 
 namespace Style {
 
+class BuilderStatePropertyScope;
 class BuilderState;
 class Builder;
 class CustomPropertyRegistry;
@@ -258,6 +259,7 @@ public:
 private:
     // See the comment in maybeUpdateFontForLetterSpacingOrWordSpacing() about why this needs to be a friend.
     friend void maybeUpdateFontForLetterSpacingOrWordSpacing(BuilderState&, CSSValue&);
+    friend class BuilderStatePropertyScope;
     friend class Builder;
     friend class SubstitutionResolver;
 
@@ -274,10 +276,21 @@ private:
     void updateFontForOrientationChange();
     void updateFontForSizeChange();
 
+    void setCurrentProperty(const PropertyCascade::Property* property)
+    {
+        if (property) {
+            m_currentProperty = property;
+            m_cssToLengthConversionData.m_property = m_currentProperty->id;
+        } else {
+            m_currentProperty = nullptr;
+            m_cssToLengthConversionData.m_property = CSSPropertyInvalid;
+        }
+    }
+
     Style::ComputedStyle& m_style;
     BuilderContext m_context;
 
-    const CSSToLengthConversionData m_cssToLengthConversionData;
+    CSSToLengthConversionData m_cssToLengthConversionData;
 
     HashSet<AtomString> m_appliedCustomProperties;
     GuardedSubstitutionContexts m_guardedSubstitutionContexts;
@@ -294,6 +307,25 @@ private:
     bool m_isBuildingKeyframeStyle { false };
     bool m_hasRevertRuleOrLayerInKeyframeStyle { false };
     bool m_isResolvingContainerQueries { false };
+};
+
+class BuilderStatePropertyScope {
+public:
+    BuilderStatePropertyScope(BuilderState& state, const PropertyCascade::Property* newProperty)
+        : m_state { state }
+        , m_propertyToRestore { m_state.m_currentProperty }
+    {
+        m_state.setCurrentProperty(newProperty);
+    }
+
+    ~BuilderStatePropertyScope()
+    {
+        m_state.setCurrentProperty(m_propertyToRestore);
+    }
+
+private:
+    BuilderState& m_state;
+    const PropertyCascade::Property* m_propertyToRestore;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -53,10 +53,6 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
     if (!primitiveValue)
         return CSS::Keyword::Normal { };
 
-    auto conversionData = state
-        .cssToLengthConversionData()
-        .copyForLineHeight();
-
     using StyleLengthPercentage = LengthPercentage<CSS::Nonnegative>;
     using CSSRaw = typename StyleLengthPercentage::CSS::Raw;
     using CSSDimensionRaw = typename CSSRaw::Dimension;
@@ -101,14 +97,14 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
     return WTF::switchOn(*primitiveValue,
         [&](const CSSPrimitiveValue::Calc& calc) -> LineHeight {
             if (calc.runtimeCategory() == CSS::Category::Number || calc.runtimeCategory() == CSS::Category::Integer)
-                return handleNumber(toStyle(CSS::UnevaluatedCalc<CSSNumberRaw> { calc }, conversionData));
+                return handleNumber(toStyle(CSS::UnevaluatedCalc<CSSNumberRaw> { calc }, state));
 
             ASSERT(calc.runtimeCategory() == CSS::Category::Length || calc.runtimeCategory() == CSS::Category::Percentage || calc.runtimeCategory() == CSS::Category::LengthPercentage);
 
             // <length-percentage> calc() can become a raw <length> or <percentage>, or can stay a calc() when converting,
             // so we have to handle all those cases here.
 
-            auto convertedCalc = toStyle(CSS::UnevaluatedCalc<CSSRaw> { calc }, conversionData);
+            auto convertedCalc = toStyle(CSS::UnevaluatedCalc<CSSRaw> { calc }, state);
             return WTF::switchOn(convertedCalc,
                 [&](const StyleLengthPercentage::Dimension& length) {
                     return handleLength(length);
@@ -123,13 +119,13 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSVa
         },
         [&](const CSSPrimitiveValue::Raw& raw) -> LineHeight {
             if (auto unit = CSSNumberRaw::UnitTraits::validate(raw.unit))
-                return handleNumber(toStyle(CSSNumberRaw(*unit, raw.value), conversionData));
+                return handleNumber(toStyle(CSSNumberRaw(*unit, raw.value), state));
 
             if (auto unit = CSSPercentageRaw::UnitTraits::validate(raw.unit))
-                return handlePercentage(toStyle(CSSPercentageRaw(*unit, raw.value), conversionData));
+                return handlePercentage(toStyle(CSSPercentageRaw(*unit, raw.value), state));
 
             if (auto unit = CSSDimensionRaw::UnitTraits::validate(raw.unit))
-                return handleLength(toStyle(CSSDimensionRaw(*unit, raw.value), conversionData));
+                return handleLength(toStyle(CSSDimensionRaw(*unit, raw.value), state));
 
             state.setCurrentPropertyInvalidAtComputedValueTime();
             return CSS::Keyword::Normal { };

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -280,7 +280,8 @@ static std::optional<double> resolveContainerUnit(CQ::Axis physicalAxis, const a
             auto widthOrHeight = physicalAxis == CQ::Axis::Width ? containerRenderer->contentBoxWidth() : containerRenderer->contentBoxHeight();
             auto adjustedWidthOrHeight = widthOrHeight.toDouble();
 
-            if (!adaptor.computingFontSize())
+            // FIXME: Document why `font-size` is excluded or remove this special case.
+            if (adaptor.property() != CSSPropertyFontSize)
                 adjustedWidthOrHeight = adjustedWidthOrHeight / adaptor.renderViewForViewportUnits()->pageZoomFactor();
 
             return adjustedWidthOrHeight / 100;
@@ -313,12 +314,40 @@ struct CSSToLengthConversionDataAdaptor {
         return conversionData.property();
     }
 
-    bool computingFontSize() const
+    bool computingFontProperty() const
     {
-        return conversionData.property() == CSSPropertyFontSize;
+        // FIXME: This should be generated but first we need to determine if using `font-*` so literally is the right choice. It might make more sense to have this be all properties that effect font-relative units, so would need to include things like `math-depth`.
+        // See https://github.com/w3c/csswg-drafts/issues/14306.
+        switch (conversionData.property()) {
+        case CSSPropertyFontFeatureSettings:
+        case CSSPropertyFontKerning:
+        case CSSPropertyFontPalette:
+        case CSSPropertyFontSize:
+        case CSSPropertyFontSizeAdjust:
+        case CSSPropertyFontStyle:
+        case CSSPropertyFontSynthesisSmallCaps:
+        case CSSPropertyFontSynthesisStyle:
+        case CSSPropertyFontSynthesisWeight:
+        case CSSPropertyFontVariantAlternates:
+        case CSSPropertyFontVariantCaps:
+        case CSSPropertyFontVariantEastAsian:
+        case CSSPropertyFontVariantEmoji:
+        case CSSPropertyFontVariantLigatures:
+        case CSSPropertyFontVariantNumeric:
+        case CSSPropertyFontVariantPosition:
+        case CSSPropertyFontWeight:
+        case CSSPropertyFontWidth:
+#if ENABLE(VARIATION_FONTS)
+        case CSSPropertyFontOpticalSizing:
+        case CSSPropertyFontVariationSettings:
+#endif
+            return true;
+        default:
+            return false;
+        }
     }
 
-    bool computingLineHeight() const
+    bool computingLineHeightProperty() const
     {
         return conversionData.property() == CSSPropertyLineHeight;
     }
@@ -332,7 +361,7 @@ struct CSSToLengthConversionDataAdaptor {
 
     const FontCascade& fontCascadeForFontUnits() const
     {
-        if (computingFontSize()) {
+        if (computingFontProperty()) {
             ASSERT(conversionData.parentStyle());
             return conversionData.parentStyle()->fontCascade();
         }
@@ -351,7 +380,7 @@ struct CSSToLengthConversionDataAdaptor {
 
     const ComputedStyle* styleForLineHeightUnits() const
     {
-        if (computingLineHeight() || computingFontSize())
+        if (computingLineHeightProperty() || computingFontProperty())
             return conversionData.parentStyle();
 
         // FIXME: This should fallback to the initial style, not the element style. To fix this, we will need to make the initial style (Document::initialStyle()) available to CSSToLengthConversionData.
@@ -406,17 +435,6 @@ struct DirectDataAdaptor {
     {
         return propertyToCompute;
     }
-
-    bool computingFontSize() const
-    {
-        return propertyToCompute == CSSPropertyFontSize;
-    }
-
-    bool computingLineHeight() const
-    {
-        return propertyToCompute == CSSPropertyLineHeight;
-    }
-
 
     double applyTextZoom(double value) const
     {
@@ -474,25 +492,25 @@ static double resolveLengthImpl(double value, CSS::LengthUnit lengthUnit, const 
 {
     using enum CSS::LengthUnit;
 
-    auto applyTextZoomIf = [&](bool condition, double value) {
-        return condition ? adaptor.applyTextZoom(value) : value;
+    auto applyTextZoomIfComputingLineHeight = [&](double value) {
+        return adaptor.property() == CSSPropertyLineHeight ? adaptor.applyTextZoom(value) : value;
     };
 
     switch (lengthUnit) {
     case Px:
-        return value * applyTextZoomIf(adaptor.computingLineHeight(), 1.0);
+        return value * applyTextZoomIfComputingLineHeight(1.0);
     case Cm:
-        return value * applyTextZoomIf(adaptor.computingLineHeight(), CSS::pixelsPerCm);
+        return value * applyTextZoomIfComputingLineHeight(CSS::pixelsPerCm);
     case Mm:
-        return value * applyTextZoomIf(adaptor.computingLineHeight(), CSS::pixelsPerMm);
+        return value * applyTextZoomIfComputingLineHeight(CSS::pixelsPerMm);
     case Q:
-        return value * applyTextZoomIf(adaptor.computingLineHeight(), CSS::pixelsPerQ);
+        return value * applyTextZoomIfComputingLineHeight(CSS::pixelsPerQ);
     case In:
-        return value * applyTextZoomIf(adaptor.computingLineHeight(), CSS::pixelsPerInch);
+        return value * applyTextZoomIfComputingLineHeight(CSS::pixelsPerInch);
     case Pt:
-        return value * applyTextZoomIf(adaptor.computingLineHeight(), CSS::pixelsPerPt);
+        return value * applyTextZoomIfComputingLineHeight(CSS::pixelsPerPt);
     case Pc:
-        return value * applyTextZoomIf(adaptor.computingLineHeight(), CSS::pixelsPerPc);
+        return value * applyTextZoomIfComputingLineHeight(CSS::pixelsPerPc);
 
     // MARK: "font dependent" resolution
 
@@ -510,7 +528,7 @@ static double resolveLengthImpl(double value, CSS::LengthUnit lengthUnit, const 
         return value * adaptor.applyTextZoom(resolveIc(adaptor.property(), adaptor.fontCascadeForFontUnits()));
 
     case Lh:
-        return value * applyTextZoomIf(adaptor.computingLineHeight(), resolveLh(adaptor.styleForLineHeightUnits(), adaptor.fontCascadeForFontUnits()));
+        return value * applyTextZoomIfComputingLineHeight(resolveLh(adaptor.styleForLineHeightUnits(), adaptor.fontCascadeForFontUnits()));
 
     // MARK: "root font dependent" resolution
 
@@ -526,7 +544,7 @@ static double resolveLengthImpl(double value, CSS::LengthUnit lengthUnit, const 
         return value * adaptor.applyTextZoom(resolveIc(adaptor.property(), adaptor.fontCascadeForRootFontUnits()));
 
     case Rlh:
-        return value * applyTextZoomIf(adaptor.computingLineHeight(), resolveLh(adaptor.styleForRootLineHeightUnits(), adaptor.fontCascadeForRootFontUnits()));
+        return value * applyTextZoomIfComputingLineHeight(resolveLh(adaptor.styleForRootLineHeightUnits(), adaptor.fontCascadeForRootFontUnits()));
 
     // MARK: "viewport-percentage" resolution
 


### PR DESCRIPTION
#### c64b47e336944e9e3b62964c2eb0ee90a74c23e4
<pre>
font-* properties should use the metrics of the parent element&apos;s font for font-relative unit resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=320744">https://bugs.webkit.org/show_bug.cgi?id=320744</a>

Reviewed by Antti Koivisto.

Updates length conversion to check for all `font-*` properties, not just `font-size`
when deciding which font metrics to use for font-relative units.

The spec is a bit unclear on which properties this should really cover with discussion
happening in <a href="https://github.com/w3c/csswg-drafts/issues/14306.">https://github.com/w3c/csswg-drafts/issues/14306.</a>

To allow length conversion to check for all the `font-*` properties, we now always
set the CSSPropertyID in CSSToLengthConversionData to the property that is currently
being applied via a new BuilderStatePropertyScope class. Due to always setting the
property, we can remove `copyForFontSize()` and `copyForLineHeight()`.

Test: imported/w3c/web-platform-tests/css/css-values/using-font-relative-units-in-font-properties.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/using-font-relative-units-in-font-properties-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/using-font-relative-units-in-font-properties.html: Added.
* Source/WebCore/css/CSSToLengthConversionData.h:
* Source/WebCore/style/StyleBuilder.cpp:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:

Canonical link: <a href="https://commits.webkit.org/319052@main">https://commits.webkit.org/319052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16110f21ee3955b34fc41727e924e376d7a73ce8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190463 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144573 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140592 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121044 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42922 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41229 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40903 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1622 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192398 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149940 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40161 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54551 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149665 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44311 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126814 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121973 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53068 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15892 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52450 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52687 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->