### PR TITLE
[CMake] Prewarmed modules not cached when compiling WebKit

### DIFF
--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -2155,14 +2155,7 @@ target_compile_options(WebKitSwift PRIVATE
     "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-DBUILDING_WITH_CMAKE=1>"
 )
 
-# Explicit-module-build for WebKitSwift Swift compile. Mirrors the macro
-# WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER's enablement of the
-# same flags for WebKit / WebGPU / PAL. https://bugs.webkit.org/show_bug.cgi?id=312083
 target_compile_options(WebKitSwift PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-late-parse-attributes>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-bounds-safety-attributes>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-module-cache-path ${CMAKE_BINARY_DIR}/SwiftModuleCache>"
     # Swift macro expansion runs swift-plugin-server under sandbox-exec;
     # -disable-sandbox avoids a nested sandbox_apply failure in a sandboxed build.
     "$<$<COMPILE_LANGUAGE:Swift>:-disable-sandbox>"
@@ -2268,15 +2261,7 @@ if (USE_LIBWEBRTC)
     endforeach ()
 endif ()
 
-# Explicit-module-build for _WebKit_SwiftUI Swift compile. The dep graph
-# includes WebKit (the cross-import-overlay does `@_exported public import WebKit`)
-# so libSwiftScan must be able to find WebKit.swiftmodule built by our cmake
-# WebKit target. https://bugs.webkit.org/show_bug.cgi?id=312083
 target_compile_options(_WebKit_SwiftUI PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-late-parse-attributes>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-bounds-safety-attributes>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-module-cache-path ${CMAKE_BINARY_DIR}/SwiftModuleCache>"
     # @Entry and other SwiftUI macros run swift-plugin-server under sandbox-exec;
     # -disable-sandbox avoids a nested sandbox_apply failure in a sandboxed build.
     "$<$<COMPILE_LANGUAGE:Swift>:-disable-sandbox>"

--- a/Source/WebKit/SwiftPrewarmMac.swift
+++ b/Source/WebKit/SwiftPrewarmMac.swift
@@ -20,3 +20,10 @@ import PDFKit
 import Quartz
 import QuickLook
 import QuickLookUI
+
+// Modules from the WebKit stack, used by WebKit
+import JavaScriptCore
+import JavaScriptCore_Private
+import WebCore_Private
+import bmalloc
+import wtf

--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -163,6 +163,18 @@ WEBKIT_OPTION_END()
 # ---------------------------------------------------------------------------
 set(SWIFT_REQUIRED ON)
 
+# Configure module building
+add_compile_options(
+    "$<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>"
+    # Needed for compatibility with modules in the (internal) SDK:
+    # https://bugs.webkit.org/show_bug.cgi?id=312083
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-bounds-safety-attributes>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-late-parse-attributes>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-module-cache-path ${CMAKE_BINARY_DIR}/SwiftModuleCache>"
+)
+set_property(DIRECTORY "${CMAKE_BINARY_DIR}" APPEND PROPERTY
+    ADDITIONAL_CLEAN_FILES "${CMAKE_BINARY_DIR}/SwiftModuleCache")
+
 if (WEBKIT_SDK_IS_MACOS AND USE_APPLE_INTERNAL_SDK)
     set(WEBKIT_CODE_SIGN_IDENTITY "Safari Engineering")
     WEBKITADDITIONS_FIND_KEYCHAIN()

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -1366,34 +1366,6 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         # found". -disable-sandbox skips the inner sandbox; the macros are
         # WebKit's own, so the isolation it provides isn't load-bearing here.
         list(APPEND _swift_options "-disable-sandbox")
-        # Explicit module builds (EMB) pre-build all Clang PCMs once via
-        # libSwiftScan, so each swift-frontend process reuses them rather than
-        # rebuilding from scratch. This is faster when many Swift source files
-        # import the same C++ interop modules. Targets opt in by setting
-        # ${_target}_SWIFT_EXPLICIT_MODULE_BUILD before the macro call.
-        # All Apple targets (PAL/WebGPU/WebKit on iOS and Mac) use EMB;
-        # non-Apple builds rely on -module-cache-path for implicit sharing.
-        if (${_target}_SWIFT_EXPLICIT_MODULE_BUILD)
-            list(APPEND _swift_options "-explicit-module-build")
-            # Force experimental clang attributes ON to match cached SwiftShims
-            # PCM content. SDK swiftinterfaces carry -strict-memory-safety in
-            # their swift-module-flags-ignorable, which on older swift-driver
-            # paths implicitly enables late-parse-attributes and
-            # bounds-safety-attributes when building SwiftShims PCM. Without
-            # the explicit flags here, our consumer's clang has them OFF and
-            # rejects the cached PCM with
-            #   "experimental late parsing of attributes was enabled in
-            #    precompiled file but is currently disabled" (or the
-            #    equivalent for bounds-safety).
-            # https://bugs.webkit.org/show_bug.cgi?id=312083
-            list(APPEND _swift_options
-                "-Xcc" "-fexperimental-bounds-safety-attributes"
-                "-Xcc" "-fexperimental-late-parse-attributes"
-            )
-        endif ()
-        list(APPEND _swift_options "-module-cache-path" "${CMAKE_BINARY_DIR}/SwiftModuleCache")
-        set_property(DIRECTORY "${CMAKE_BINARY_DIR}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${CMAKE_BINARY_DIR}/SwiftModuleCache")
-        list(APPEND _swift_options "-track-system-dependencies")
         # We'll use these options both for mainstream cmake invocations of swiftc (here)
         # and for our own invocation to output an interoperability .h file (later).
         # target_compile_options deduplicates repeated tokens, so collapse each

--- a/Source/cmake/WebKitSwiftPrewarm.cmake
+++ b/Source/cmake/WebKitSwiftPrewarm.cmake
@@ -13,6 +13,36 @@ function(WEBKIT_ADD_SWIFT_PREWARM _consumer _swift_source)
     list(FILTER _opts EXCLUDE REGEX "(-emit-clang-header-path|-import-underlying-module)")
     target_compile_options(${_prewarm} PRIVATE ${_opts})
 
+    get_target_property(_opts ${_consumer} COMPILE_DEFINITIONS)
+    target_compile_definitions(${_prewarm} PRIVATE ${_opts})
+
+    get_target_property(_opts ${_consumer} INCLUDE_DIRECTORIES)
+    target_include_directories(${_prewarm} PRIVATE ${_opts})
+    target_include_directories(${_prewarm} PRIVATE ${${_consumer}_SYSTEM_INCLUDE_DIRECTORIES})
+
+    get_target_property(_linked_libraries ${_consumer} LINK_LIBRARIES)
+    foreach (_target ${_linked_libraries})
+        if (NOT TARGET ${_target})
+            continue()
+        endif ()
+
+        get_target_property(_opts ${_target} INTERFACE_COMPILE_OPTIONS)
+        if (_opts)
+            list(FILTER _opts EXCLUDE REGEX "(-emit-clang-header-path|-import-underlying-module)")
+            target_compile_options(${_prewarm} PRIVATE ${_opts})
+        endif ()
+
+        get_target_property(_opts ${_target} INTERFACE_COMPILE_DEFINITIONS)
+        if (_opts)
+            target_compile_definitions(${_prewarm} PRIVATE ${_opts})
+        endif ()
+
+        get_target_property(_opts ${_target} INTERFACE_INCLUDE_DIRECTORIES)
+        if (_opts)
+            target_include_directories(${_prewarm} PRIVATE ${_opts})
+        endif ()
+    endforeach ()
+
     get_target_property(_consumer_bindir ${_consumer} BINARY_DIR)
     set_property(SOURCE "${_swift_source}" APPEND PROPERTY OBJECT_DEPENDS
         "${_consumer_bindir}/${_consumer}.platform-swift-args.resp")

--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -54,15 +54,6 @@ set(TESTWEBKITAPI_SWIFT_FLAGS
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${CMAKE_BINARY_DIR}>"
 )
 
-# Mirrors the EMB block in _WEBKIT_TARGET_SETUP, which these hand-rolled flags
-# bypass. The -Xcc flags are required: clang rejects the cached SwiftShims PCM
-# without them.
-list(APPEND TESTWEBKITAPI_SWIFT_FLAGS
-    "$<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-bounds-safety-attributes>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fexperimental-late-parse-attributes>"
-)
-
 foreach (_f IN LISTS _test_swift_cc_flags)
     list(APPEND TESTWEBKITAPI_SWIFT_FLAGS "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc ${_f}>")
 endforeach ()


### PR DESCRIPTION
#### 092eccdd01d2d8ef6a437024d3a9ba099b00c18f
<pre>
[CMake] Prewarmed modules not cached when compiling WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=321533">https://bugs.webkit.org/show_bug.cgi?id=321533</a>
<a href="https://rdar.apple.com/183370889">rdar://183370889</a>

Reviewed by Geoffrey Garen.

The prewarm target was missing some necessary definition and search path
flags needed to produce the same module cache key. This meant that it
wasn&apos;t prewarming at all, and WebKit&apos;s swift task was rebuilding all
modules downstream of wtf. The performance impact worsened when
317797@main added modulemaps for JavaScriptCore_Private and WebCore.

Fix by doing more work in WEBKIT_ADD_SWIFT_PREWARM to discover compiler
flags. Also add the new modules we produce to our prewarm target. On an
M5 Max, this is about a 1% (5 sec) progression.

Verified that the modules are no longer being built twice by capturing
the swift driver invocation and re-running with `-v` to show -emit-pcm
commands. Confirmed that the command for WebKit does not build any
modules upstream of WebKit itself:

    set swiftc_webkit (ninja -t commands Source/WebKit/WebKit.swiftmodule | tail -1)
    set swiftc_prewarm (ninja -t commands Source/WebKit/SwiftPrewarmMac.swiftmodule | tail -1)
    eval $swiftc_prewarm -v | grep -o &apos;\-emit-pcm.*-module-name [A-Za-z_]*&apos;
    eval $swiftc_webkit -v | grep -o &apos;\-emit-pcm.*-module-name [A-Za-z_]*&apos;

As a drive-by, refactor how `-explicit-module-builds` is passed to
remove duplication and apply it more consistently across the codebase.

* Source/WebKit/PlatformCocoa.cmake:
* Source/WebKit/SwiftPrewarmMac.swift:
* Source/cmake/OptionsCocoa.cmake:
* Source/cmake/WebKitMacros.cmake:
* Source/cmake/WebKitSwiftPrewarm.cmake:
* Tools/TestWebKitAPI/PlatformCocoa.cmake:

Canonical link: <a href="https://commits.webkit.org/319083@main">https://commits.webkit.org/319083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39e0c3997c244c5e188abdfdf8314dc59f753825

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180482 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54427 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190693 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54143 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183437 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/44433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/121221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/3188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/10024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/41068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/1852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41756 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/47026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/192628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54093 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/161057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/192628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54781 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/192628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27379 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/44478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122216 "Failed to checkout and rebase branch from PR 71443") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53298 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/16057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52680 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52917 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52745 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->