### PR TITLE
[css-values-5] Include the custom property name in the random() caching key

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt
@@ -129,7 +129,7 @@ PASS Maximum random - shorthand: random(a, b)
 PASS Shared by property name and value index: random(property-index-scoped, a, b)
 PASS Shared by property and index in list value: random(a, b)
 FAIL Nested in fixed value random() function used for custom property: 'random(a, b)' assert_false: Different custom properties on the same element should not have equal values expected false got true
-FAIL random() in different custom properties on the same element should not be shared assert_false: Different custom properties on the same element should not have equal values expected false got true
+PASS random() in different custom properties on the same element should not be shared
 PASS Shared by name within an element: 'random(--identifier element-scoped, a, b)'
 PASS Shared by name within an element - shorthand: random(--identifier element-scoped, a, b))
 PASS Shared between elements within a property: random(property-index-scoped, a, b)
@@ -146,7 +146,7 @@ FAIL random() with percentages inside multiple nested functions should have 'fix
 PASS random(--identifier element-scoped, ...) should be different between elements
 PASS random() values should not be allowed as initial values in @property
 PASS random() shared by property in var()
-FAIL random() shared by custom property in var() assert_false: Random values should not be equal expected false got true
+PASS random() shared by custom property in var()
 PASS random() shared by shorthand property in var(), test random() value index
 PASS random() shared by property in attr()
 PASS random() shared by property in typed attr()

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-if.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-if.tentative-expected.txt
@@ -1,6 +1,6 @@
 
 PASS random() should not be allowed in if() style() condition
 PASS random() in var() should not be allowed in if() style() condition
-FAIL random() with different property names should not be shared in if() declaration value assert_false: Random values should be equal expected false got true
+PASS random() with different property names should not be shared in if() declaration value
 PASS random() with same property name on different elements in if() declaration value should be equal
 

--- a/Source/WebCore/css/CSSRandomKeyParser.h
+++ b/Source/WebCore/css/CSSRandomKeyParser.h
@@ -47,14 +47,14 @@ namespace CSSPropertyParserHelpers {
 //
 // <random-ua-ident> is intentionally not yet supported by this consumer (follow-up).
 //
-// The implementation-derived parts of a <random-key> come from the caller: `property` is the property the
-// value is being parsed for, `autoElementScoped` is the scoping `auto` resolves to, and `consumeIndex`
-// yields the value index under the caller's own scheme (parse-time for random(), substitution-time for
-// random-item()). `property` is a plain value, and `consumeIndex` is only called for the productions that
-// actually carry an index (`auto` and property-index-scoped), so property-scoped cannot disturb a caller's
-// index counter.
+// The implementation-derived parts of a <random-key> come from the caller: `property` identifies the
+// property the value is being parsed for, `autoElementScoped` is the scoping `auto` resolves to, and
+// `consumeIndex` yields the value index under the caller's own scheme (parse-time for random(),
+// substitution-time for random-item()). `consumeIndex` is only called for the productions that actually
+// carry an index (`auto` and property-index-scoped), so property-scoped cannot disturb a caller's index
+// counter.
 struct RandomKeySource {
-    CSSPropertyID property { CSSPropertyInvalid };
+    CSSCalc::RandomScopedProperty property;
     std::optional<CSS::Keyword::ElementScoped> autoElementScoped;
 };
 

--- a/Source/WebCore/css/calc/CSSCalcRandomSharing.h
+++ b/Source/WebCore/css/calc/CSSCalcRandomSharing.h
@@ -28,7 +28,9 @@
 #include <WebCore/CSSCustomIdent.h>
 #include <WebCore/CSSValueKeywords.h>
 #include <optional>
+#include <wtf/Hasher.h>
 #include <wtf/Variant.h>
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
@@ -36,13 +38,28 @@ enum CSSPropertyID : uint16_t;
 
 namespace CSSCalc {
 
+// The property a random key is scoped to. Every custom property shares CSSPropertyCustom, so the name
+// is what tells them apart and is empty for everything else.
+// FIXME: Same concept as AssociatedProperty and AnimatableCSSProperty.
+struct RandomScopedProperty {
+    CSSPropertyID property { CSSPropertyInvalid };
+    AtomString customPropertyName { };
+
+    bool operator==(const RandomScopedProperty&) const = default;
+};
+
+inline void add(Hasher& hasher, const RandomScopedProperty& scopedProperty)
+{
+    add(hasher, scopedProperty.property, scopedProperty.customPropertyName);
+}
+
 // `auto` is a top-level <random-key> alternative; its scoping is chosen per-usage by the caller.
 // The (property, index) pair is the implementation-derived caching identity.
 //
 // `index` is 0-based. § 9.4.1 spells the simplified form ua-PROPERTY-INDEX with a 1-indexed INDEX, so
 // the <random-ua-ident> serialization follow-up has to add one when serializing.
 struct RandomSharingAuto {
-    CSSPropertyID property;
+    RandomScopedProperty property;
     unsigned index;
     std::optional<CSS::Keyword::ElementScoped> elementScoped;
 
@@ -53,13 +70,13 @@ struct RandomSharingAuto {
 // NOTE: <random-ua-ident> is intentionally not yet supported (follow-up).
 struct RandomSharingKey {
     struct PropertyScoped {
-        CSSPropertyID property;
+        RandomScopedProperty property;
 
         bool operator==(const PropertyScoped&) const = default;
     };
     // `index` is 0-based; see the note on RandomSharingAuto.
     struct PropertyIndexScoped {
-        CSSPropertyID property;
+        RandomScopedProperty property;
         unsigned index;
 
         bool operator==(const PropertyIndexScoped&) const = default;

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -673,11 +673,8 @@ static std::optional<TypedChild> consumeRandom(CSSParserTokenRange& tokens, int 
 
     using Op = Random;
 
-    // FIXME: currentProperty is CSSPropertyCustom for every custom property, so an `auto` or
-    // property-scoped key in one collapses all custom properties onto a single base value. The name
-    // needs to be part of the key.
     auto keySource = CSSPropertyParserHelpers::RandomKeySource {
-        .property = state.propertyParserState.currentProperty,
+        .property = { state.propertyParserState.currentProperty, state.propertyParserState.currentCustomPropertyName },
         .autoElementScoped = CSS::Keyword::ElementScoped { }
     };
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -359,6 +359,7 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> CSSProp
         .context = context,
         .currentRule = StyleRuleType::Style,
         .currentProperty = CSSPropertyCustom,
+        .currentCustomPropertyName = name,
         .important = IsImportant::No,
         .randomFunctionsDisallowed = builderState.isResolvingContainerQueries(),
     };

--- a/Source/WebCore/css/parser/CSSPropertyParserState.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserState.h
@@ -28,6 +28,7 @@
 #include "CSSPropertyNames.h"
 #include "CSSValuePool.h"
 #include "StyleRuleType.h"
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
@@ -41,6 +42,8 @@ struct PropertyParserState {
 
     StyleRuleType currentRule { StyleRuleType::Style };
     CSSPropertyID currentProperty { CSSPropertyInvalid };
+    // Set when currentProperty is CSSPropertyCustom, which every custom property shares.
+    AtomString currentCustomPropertyName { };
     IsImportant important { IsImportant::No };
 
     // Count of CSS random() functions seen so far for the current property.

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -305,6 +305,16 @@ CSSPropertyID BuilderState::cssPropertyID() const
     return m_currentProperty ? m_currentProperty->id : CSSPropertyInvalid;
 }
 
+// Every custom property shares CSSPropertyCustom, so anything keying on cssPropertyID() needs this to
+// tell them apart. Null unless a custom property is being applied.
+AtomString BuilderState::customPropertyName() const
+{
+    if (cssPropertyID() != CSSPropertyCustom)
+        return nullAtom();
+    RefPtr customPropertyValue = dynamicDowncast<CSSCustomPropertyValue>(m_currentProperty->cssValue[SelectorChecker::MatchDefault]);
+    return customPropertyValue ? customPropertyValue->name() : nullAtom();
+}
+
 bool BuilderState::isCurrentPropertyInvalidAtComputedValueTime() const
 {
     return m_invalidAtComputedValueTimeProperties.get(cssPropertyID());

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -191,6 +191,7 @@ public:
     }
 
     CSSPropertyID NODELETE cssPropertyID() const;
+    AtomString NODELETE customPropertyName() const;
 
     bool NODELETE isCurrentPropertyInvalidAtComputedValueTime() const;
     void NODELETE setCurrentPropertyInvalidAtComputedValueTime();

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -1062,14 +1062,6 @@ bool SubstitutionResolver::substituteRandomItemFunction(CSSParserTokenRange rang
     return true;
 }
 
-// Whether the key explicitly asked for a property scope, i.e. property-scoped or property-index-scoped.
-// `auto` also keys on the property, but rejecting it would break the omitted-key form, so it is excluded.
-static bool randomKeyHasExplicitPropertyScope(const CSSCalc::Random::Sharing& sharing)
-{
-    auto* key = std::get_if<CSSCalc::Random::Key>(&sharing);
-    return key && key->propertyScoped;
-}
-
 std::optional<double> SubstitutionResolver::randomItemBaseValue(Vector<CSSParserToken> randomKey)
 {
     // <random-key> = auto | <random-cache-key> | fixed <number [0,1]>
@@ -1080,8 +1072,6 @@ std::optional<double> SubstitutionResolver::randomItemBaseValue(Vector<CSSParser
     randomKeyRange.consumeWhitespace();
 
     auto parserState = CSS::PropertyParserState { .context = m_substitutionValue->context() };
-
-    auto propertyID = m_styleBuilder.state().cssPropertyID();
 
     // FIXME: § 9.4.1 turns `auto` into element-scoped property-index-scoped unconditionally, for both
     // random() and random-item(), but this keys random-item()'s `auto` on the current property
@@ -1094,18 +1084,14 @@ std::optional<double> SubstitutionResolver::randomItemBaseValue(Vector<CSSParser
     // property value can therefore land on the same RandomCachingKey and share a base value, and the
     // index follows the selected branch rather than parse position. Unifying this with random()'s
     // counter is a follow-up.
-    auto keySource = CSSPropertyParserHelpers::RandomKeySource { .property = propertyID, .autoElementScoped = std::nullopt };
+    auto keySource = CSSPropertyParserHelpers::RandomKeySource {
+        .property = { m_styleBuilder.state().cssPropertyID(), m_styleBuilder.state().customPropertyName() },
+        .autoElementScoped = std::nullopt
+    };
     auto sharing = CSSPropertyParserHelpers::consumeUnresolvedRandomKey(randomKeyRange, parserState, keySource, [&] {
         return m_randomItemAutoIndex++;
     });
     if (!sharing || !randomKeyRange.atEnd())
-        return { };
-
-    // cssPropertyID() is CSSPropertyCustom for every custom property, since the name is not threaded into
-    // the caching key, so honoring a property scope here would collapse all custom properties onto one
-    // shared base value. Reject instead of sharing incorrectly; random() likewise refuses to parse inside
-    // a custom property. Threading the name through is a follow-up.
-    if (propertyID == CSSPropertyCustom && randomKeyHasExplicitPropertyScope(*sharing))
         return { };
 
     return CSSCalc::resolveRandomBaseValue(*sharing, m_styleBuilder.state());


### PR DESCRIPTION
#### fb50bab0720850e2f8e9370afe9966af050f743f
<pre>
[css-values-5] Include the custom property name in the random() caching key
<a href="https://bugs.webkit.org/show_bug.cgi?id=321598">https://bugs.webkit.org/show_bug.cgi?id=321598</a>
<a href="https://rdar.apple.com/184722866">rdar://184722866</a>

Reviewed by Sam Weinig.

Currently all custom properties on the same element share the same random() value.

A property-scoped random key carried only a CSSPropertyID, which is CSSPropertyCustom for all of
them. Pair the name with the id, taking it from the declaration being parsed for random() and from
BuilderState for random-item(), which until now refused a property scope inside a custom property
rather than share incorrectly.

A key naming a function&apos;s result or local still cannot tell two functions apart.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-in-if.tentative-expected.txt:
* Source/WebCore/css/CSSRandomKeyParser.h:
* Source/WebCore/css/calc/CSSCalcRandomSharing.h:
(WebCore::CSSCalc::add):
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::consumeRandom):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
* Source/WebCore/css/parser/CSSPropertyParserState.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::customPropertyName const):
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::randomItemBaseValue):
(WebCore::Style::randomKeyHasExplicitPropertyScope): Deleted.

Canonical link: <a href="https://commits.webkit.org/319096@main">https://commits.webkit.org/319096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eccc93e095360b15e5df2369e0dfb96007a474ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190711 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f684edf-3265-44cc-a640-afc51c911cc3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54161 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27bcdb8f-47ab-49ed-9632-20e7bf6cd356) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44449 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121233 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05f1e9d9-e11d-4790-97f6-0969b4c4fb8b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41079 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1870 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/47044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192646 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54111 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150147 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40186 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54799 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149869 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44490 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122234 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53316 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16068 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52698 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52935 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52763 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->