### PR TITLE
[Xcode] Fix orphaned source file in TestWebKitAPI

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1764,6 +1764,7 @@
 				07C93B2D2F821630003A09D8 /* Resources */,
 				07C907C22F820940003A09D8 /* Runner */,
 				07C913E62F820CF1003A09D8 /* Scripts */,
+				DD7024AE302CE42A009B6CC0 /* Shared */,
 				07C913EF2F820D85003A09D8 /* TestBundle */,
 				07C907D82F820949003A09D8 /* TestWebKitAPILibrary */,
 				07C910F42F820CC7003A09D8 /* Tests */,
@@ -1772,7 +1773,6 @@
 				5C9D921D22D7DBF7008E9266 /* Sources.txt */,
 				5C9D921E22D7DBF8008E9266 /* SourcesCocoa.txt */,
 				07597D7E2F81DD59000C96D0 /* config.h */,
-				0D54DDFD301FFF4C00DEB1E8 /* Recovered References */,
 			);
 			name = TestWebKitAPI;
 			sourceTree = "<group>";
@@ -1787,14 +1787,6 @@
 				C081224813FC1B0300DC39AE /* WebKit.framework */,
 			);
 			name = "External Frameworks and Libraries";
-			sourceTree = "<group>";
-		};
-		0D54DDFD301FFF4C00DEB1E8 /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				CC1FEED000000000000FF001 /* WebFoundTextRange.cpp */,
-			);
-			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		1AB674ADFE9D54B511CA2CBB /* Products */ = {
@@ -1955,6 +1947,14 @@
 			);
 			path = InjectedBundle;
 			sourceTree = "<group>";
+		};
+		DD7024AE302CE42A009B6CC0 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				CC1FEED000000000000FF001 /* WebFoundTextRange.cpp */,
+			);
+			name = Shared;
+			sourceTree = SOURCE_ROOT;
 		};
 		DDF3A82A28930475005920CF /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
#### 950adada99dbf197440527ad28f41d1021b4feab
<pre>
[Xcode] Fix orphaned source file in TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=321605">https://bugs.webkit.org/show_bug.cgi?id=321605</a>
<a href="https://rdar.apple.com/184732893">rdar://184732893</a>

Reviewed by Mike Wyrzykowski.

Having an orphaned source file not in a group makes the project&apos;s PIF
non-deterministic and results in unnecessary work during incremental
builds (cf. <a href="https://rdar.apple.com/184259116">rdar://184259116</a>).

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/319050@main">https://commits.webkit.org/319050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/401ef6a79e95c6ba05ded18d3d35dca15ffc90e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144589 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ce3eff1-57e7-4a06-b1e6-d7b8b1cc9640) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140603 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e886db57-b650-41f6-a13b-57e66daf7647) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44260 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121055 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/97a519a5-a400-4fa4-8fe1-729a4bbd9362) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42933 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41242 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40913 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1638 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192414 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53879 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149950 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40160 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54567 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37525 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149675 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44319 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121991 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53084 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15902 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52466 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52703 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->