### PR TITLE
Implement CSSOM View GeometryUtils

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-geometryutils-lifecycle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-geometryutils-lifecycle-expected.txt
@@ -4,3 +4,4 @@ PASS getBoxQuads() updates a dirty embedding document
 PASS getBoxQuads() updates a dirty display-locked subtree
 PASS getBoxQuads() applies a pending direct transform update
 PASS getBoxQuads() updates unrelated display-locked endpoints
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-geometryutils-lifecycle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-geometryutils-lifecycle-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS getBoxQuads() updates a dirty embedding document
+PASS getBoxQuads() updates a dirty display-locked subtree
+PASS getBoxQuads() applies a pending direct transform update
+PASS getBoxQuads() updates unrelated display-locked endpoints

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-geometryutils-lifecycle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-geometryutils-lifecycle.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<title>CSSOM View - GeometryUtils lifecycle updates</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#the-geometryutils-interface">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe id="frame" style="border: 0; margin-left: 10px"
+        srcdoc="<div id='target' style='width:20px;height:20px'></div>"></iframe>
+<div id="locked" style="content-visibility:hidden">
+  <div id="locked-target" style="width:20px;height:20px"></div>
+</div>
+<script>
+promise_test(async () => {
+  await new Promise(resolve => frame.addEventListener("load", resolve,
+                                                       {once: true}));
+  const target = frame.contentDocument.getElementById("target");
+  const initial = target.getBoxQuads({relativeTo: document})[0];
+
+  frame.style.marginLeft = "70px";
+  const moved = target.getBoxQuads({relativeTo: document})[0];
+  assert_approx_equals(moved.p1.x - initial.p1.x, 60, 0.01,
+                       "dirty parent document is updated");
+}, "getBoxQuads() updates a dirty embedding document");
+
+test(() => {
+  const target = document.getElementById("locked-target");
+  target.style.width = "50px";
+  const quad = target.getBoxQuads()[0];
+  assert_approx_equals(quad.p2.x - quad.p1.x, 50, 0.01,
+                       "dirty display-locked subtree is updated");
+}, "getBoxQuads() updates a dirty display-locked subtree");
+
+promise_test(async t => {
+  const stage = document.createElement("div");
+  stage.style.cssText = "position:absolute;left:10px;top:10px";
+  const mover = document.createElement("div");
+  mover.style.transform = "translate(0px, 0px)";
+  const target = document.createElement("div");
+  target.style.cssText = "width:20px;height:20px";
+  mover.appendChild(target);
+  stage.appendChild(mover);
+  document.body.appendChild(stage);
+  t.add_cleanup(() => stage.remove());
+
+  await new Promise(resolve => requestAnimationFrame(
+      () => requestAnimationFrame(resolve)));
+  mover.style.transform = "translate(40px, 25px)";
+
+  const bounds = target.getBoxQuads({relativeTo: stage})[0].getBounds();
+  const rect = target.getBoundingClientRect();
+  const stageRect = stage.getBoundingClientRect();
+  assert_approx_equals(bounds.x, rect.x - stageRect.x, 0.01,
+                       "x coordinate");
+  assert_approx_equals(bounds.y, rect.y - stageRect.y, 0.01,
+                       "y coordinate");
+}, "getBoxQuads() applies a pending direct transform update");
+
+test(t => {
+  const sourceLock = document.createElement("div");
+  sourceLock.style.contentVisibility = "hidden";
+  const source = document.createElement("div");
+  source.style.cssText = "width:20px;height:20px";
+  sourceLock.appendChild(source);
+
+  const targetLock = document.createElement("div");
+  targetLock.style.contentVisibility = "hidden";
+  const target = document.createElement("div");
+  target.style.cssText = "width:20px;height:20px";
+  targetLock.appendChild(target);
+
+  document.body.append(sourceLock, targetLock);
+  t.add_cleanup(() => {
+    sourceLock.remove();
+    targetLock.remove();
+  });
+
+  assert_equals(source.getBoxQuads({relativeTo: target}).length, 1);
+}, "getBoxQuads() updates unrelated display-locked endpoints");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-001-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Block layout border box is expected width. bb.getBoxQuads is not a function. (In 'bb.getBoxQuads({box: "border"})', 'bb.getBoxQuads' is undefined)
-FAIL Block layout margin box is expected width. bb.getBoxQuads is not a function. (In 'bb.getBoxQuads({box: "margin"})', 'bb.getBoxQuads' is undefined)
-FAIL Flex layout border box is expected width. fb.getBoxQuads is not a function. (In 'fb.getBoxQuads({box: "border"})', 'fb.getBoxQuads' is undefined)
-FAIL Flex layout margin box is expected width. fb.getBoxQuads is not a function. (In 'fb.getBoxQuads({box: "margin"})', 'fb.getBoxQuads' is undefined)
-FAIL Flex layout border box is expected height. fb.getBoxQuads is not a function. (In 'fb.getBoxQuads({box: "border"})', 'fb.getBoxQuads' is undefined)
-FAIL Flex layout margin box is expected height. fb.getBoxQuads is not a function. (In 'fb.getBoxQuads({box: "margin"})', 'fb.getBoxQuads' is undefined)
+PASS Block layout border box is expected width.
+PASS Block layout margin box is expected width.
+PASS Flex layout border box is expected width.
+PASS Flex layout margin box is expected width.
+PASS Flex layout border box is expected height.
+PASS Flex layout margin box is expected height.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-002-expected.txt
@@ -1,4 +1,4 @@
 hello1 hello2
 
-FAIL CSSOM View - getBoxQuads() returns consistent box for SVG test element.getBoxQuads is not a function. (In 'element.getBoxQuads()', 'element.getBoxQuads' is undefined)
+PASS CSSOM View - getBoxQuads() returns consistent box for SVG test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/idlharness-expected.txt
@@ -206,14 +206,14 @@ PASS Element interface: document.createElement("div") must inherit property "cli
 PASS Element interface: document.createElement("div") must inherit property "clientWidth" with the proper type
 PASS Element interface: document.createElement("div") must inherit property "clientHeight" with the proper type
 PASS Element interface: document.createElement("div") must inherit property "currentCSSZoom" with the proper type
-FAIL Element interface: document.createElement("div") must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type assert_inherits: property "getBoxQuads" not found in prototype chain
-FAIL Element interface: calling getBoxQuads(optional BoxQuadOptions) on document.createElement("div") with too few arguments must throw TypeError assert_inherits: property "getBoxQuads" not found in prototype chain
-FAIL Element interface: document.createElement("div") must inherit property "convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertQuadFromNode" not found in prototype chain
-FAIL Element interface: calling convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("div") with too few arguments must throw TypeError assert_inherits: property "convertQuadFromNode" not found in prototype chain
-FAIL Element interface: document.createElement("div") must inherit property "convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertRectFromNode" not found in prototype chain
-FAIL Element interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("div") with too few arguments must throw TypeError assert_inherits: property "convertRectFromNode" not found in prototype chain
-FAIL Element interface: document.createElement("div") must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertPointFromNode" not found in prototype chain
-FAIL Element interface: calling convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("div") with too few arguments must throw TypeError assert_inherits: property "convertPointFromNode" not found in prototype chain
+PASS Element interface: document.createElement("div") must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type
+PASS Element interface: calling getBoxQuads(optional BoxQuadOptions) on document.createElement("div") with too few arguments must throw TypeError
+PASS Element interface: document.createElement("div") must inherit property "convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Element interface: calling convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("div") with too few arguments must throw TypeError
+PASS Element interface: document.createElement("div") must inherit property "convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Element interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("div") with too few arguments must throw TypeError
+PASS Element interface: document.createElement("div") must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Element interface: calling convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("div") with too few arguments must throw TypeError
 PASS HTMLImageElement interface: attribute x
 PASS HTMLImageElement interface: attribute y
 PASS HTMLImageElement interface: document.createElement("img") must inherit property "x" with the proper type
@@ -251,14 +251,14 @@ PASS Element interface: document.createElement("img") must inherit property "cli
 PASS Element interface: document.createElement("img") must inherit property "clientWidth" with the proper type
 PASS Element interface: document.createElement("img") must inherit property "clientHeight" with the proper type
 PASS Element interface: document.createElement("img") must inherit property "currentCSSZoom" with the proper type
-FAIL Element interface: document.createElement("img") must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type assert_inherits: property "getBoxQuads" not found in prototype chain
-FAIL Element interface: calling getBoxQuads(optional BoxQuadOptions) on document.createElement("img") with too few arguments must throw TypeError assert_inherits: property "getBoxQuads" not found in prototype chain
-FAIL Element interface: document.createElement("img") must inherit property "convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertQuadFromNode" not found in prototype chain
-FAIL Element interface: calling convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("img") with too few arguments must throw TypeError assert_inherits: property "convertQuadFromNode" not found in prototype chain
-FAIL Element interface: document.createElement("img") must inherit property "convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertRectFromNode" not found in prototype chain
-FAIL Element interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("img") with too few arguments must throw TypeError assert_inherits: property "convertRectFromNode" not found in prototype chain
-FAIL Element interface: document.createElement("img") must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertPointFromNode" not found in prototype chain
-FAIL Element interface: calling convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("img") with too few arguments must throw TypeError assert_inherits: property "convertPointFromNode" not found in prototype chain
+PASS Element interface: document.createElement("img") must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type
+PASS Element interface: calling getBoxQuads(optional BoxQuadOptions) on document.createElement("img") with too few arguments must throw TypeError
+PASS Element interface: document.createElement("img") must inherit property "convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Element interface: calling convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("img") with too few arguments must throw TypeError
+PASS Element interface: document.createElement("img") must inherit property "convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Element interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("img") with too few arguments must throw TypeError
+PASS Element interface: document.createElement("img") must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Element interface: calling convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("img") with too few arguments must throw TypeError
 PASS Window interface: operation matchMedia(CSSOMString)
 PASS Window interface: attribute screen
 PASS Window interface: attribute visualViewport
@@ -326,10 +326,10 @@ PASS Document interface: operation elementFromPoint(double, double)
 PASS Document interface: operation elementsFromPoint(double, double)
 PASS Document interface: operation caretPositionFromPoint(double, double, optional CaretPositionFromPointOptions)
 PASS Document interface: attribute scrollingElement
-FAIL Document interface: operation getBoxQuads(optional BoxQuadOptions) assert_own_property: interface prototype object missing non-static operation expected property "getBoxQuads" missing
-FAIL Document interface: operation convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: interface prototype object missing non-static operation expected property "convertQuadFromNode" missing
-FAIL Document interface: operation convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: interface prototype object missing non-static operation expected property "convertRectFromNode" missing
-FAIL Document interface: operation convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: interface prototype object missing non-static operation expected property "convertPointFromNode" missing
+PASS Document interface: operation getBoxQuads(optional BoxQuadOptions)
+PASS Document interface: operation convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)
+PASS Document interface: operation convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)
+PASS Document interface: operation convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)
 PASS Document interface: document must inherit property "elementFromPoint(double, double)" with the proper type
 PASS Document interface: calling elementFromPoint(double, double) on document with too few arguments must throw TypeError
 PASS Document interface: document must inherit property "elementsFromPoint(double, double)" with the proper type
@@ -337,14 +337,14 @@ PASS Document interface: calling elementsFromPoint(double, double) on document w
 PASS Document interface: document must inherit property "caretPositionFromPoint(double, double, optional CaretPositionFromPointOptions)" with the proper type
 PASS Document interface: calling caretPositionFromPoint(double, double, optional CaretPositionFromPointOptions) on document with too few arguments must throw TypeError
 PASS Document interface: document must inherit property "scrollingElement" with the proper type
-FAIL Document interface: document must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type assert_inherits: property "getBoxQuads" not found in prototype chain
-FAIL Document interface: calling getBoxQuads(optional BoxQuadOptions) on document with too few arguments must throw TypeError assert_inherits: property "getBoxQuads" not found in prototype chain
-FAIL Document interface: document must inherit property "convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertQuadFromNode" not found in prototype chain
-FAIL Document interface: calling convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) on document with too few arguments must throw TypeError assert_inherits: property "convertQuadFromNode" not found in prototype chain
-FAIL Document interface: document must inherit property "convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertRectFromNode" not found in prototype chain
-FAIL Document interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) on document with too few arguments must throw TypeError assert_inherits: property "convertRectFromNode" not found in prototype chain
-FAIL Document interface: document must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertPointFromNode" not found in prototype chain
-FAIL Document interface: calling convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) on document with too few arguments must throw TypeError assert_inherits: property "convertPointFromNode" not found in prototype chain
+PASS Document interface: document must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type
+PASS Document interface: calling getBoxQuads(optional BoxQuadOptions) on document with too few arguments must throw TypeError
+PASS Document interface: document must inherit property "convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Document interface: calling convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) on document with too few arguments must throw TypeError
+PASS Document interface: document must inherit property "convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Document interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) on document with too few arguments must throw TypeError
+PASS Document interface: document must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Document interface: calling convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) on document with too few arguments must throw TypeError
 PASS Element interface: operation getClientRects()
 PASS Element interface: operation getBoundingClientRect()
 PASS Element interface: operation checkVisibility(optional CheckVisibilityOptions)
@@ -364,10 +364,10 @@ PASS Element interface: attribute clientLeft
 PASS Element interface: attribute clientWidth
 PASS Element interface: attribute clientHeight
 PASS Element interface: attribute currentCSSZoom
-FAIL Element interface: operation getBoxQuads(optional BoxQuadOptions) assert_own_property: interface prototype object missing non-static operation expected property "getBoxQuads" missing
-FAIL Element interface: operation convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: interface prototype object missing non-static operation expected property "convertQuadFromNode" missing
-FAIL Element interface: operation convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: interface prototype object missing non-static operation expected property "convertRectFromNode" missing
-FAIL Element interface: operation convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: interface prototype object missing non-static operation expected property "convertPointFromNode" missing
+PASS Element interface: operation getBoxQuads(optional BoxQuadOptions)
+PASS Element interface: operation convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)
+PASS Element interface: operation convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)
+PASS Element interface: operation convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)
 PASS Element interface: document.createElementNS("x", "y") must inherit property "getClientRects()" with the proper type
 PASS Element interface: document.createElementNS("x", "y") must inherit property "getBoundingClientRect()" with the proper type
 PASS Element interface: document.createElementNS("x", "y") must inherit property "checkVisibility(optional CheckVisibilityOptions)" with the proper type
@@ -395,26 +395,26 @@ PASS Element interface: document.createElementNS("x", "y") must inherit property
 PASS Element interface: document.createElementNS("x", "y") must inherit property "clientWidth" with the proper type
 PASS Element interface: document.createElementNS("x", "y") must inherit property "clientHeight" with the proper type
 PASS Element interface: document.createElementNS("x", "y") must inherit property "currentCSSZoom" with the proper type
-FAIL Element interface: document.createElementNS("x", "y") must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type assert_inherits: property "getBoxQuads" not found in prototype chain
-FAIL Element interface: calling getBoxQuads(optional BoxQuadOptions) on document.createElementNS("x", "y") with too few arguments must throw TypeError assert_inherits: property "getBoxQuads" not found in prototype chain
-FAIL Element interface: document.createElementNS("x", "y") must inherit property "convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertQuadFromNode" not found in prototype chain
-FAIL Element interface: calling convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElementNS("x", "y") with too few arguments must throw TypeError assert_inherits: property "convertQuadFromNode" not found in prototype chain
-FAIL Element interface: document.createElementNS("x", "y") must inherit property "convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertRectFromNode" not found in prototype chain
-FAIL Element interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) on document.createElementNS("x", "y") with too few arguments must throw TypeError assert_inherits: property "convertRectFromNode" not found in prototype chain
-FAIL Element interface: document.createElementNS("x", "y") must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertPointFromNode" not found in prototype chain
-FAIL Element interface: calling convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElementNS("x", "y") with too few arguments must throw TypeError assert_inherits: property "convertPointFromNode" not found in prototype chain
-FAIL Text interface: operation getBoxQuads(optional BoxQuadOptions) assert_own_property: interface prototype object missing non-static operation expected property "getBoxQuads" missing
-FAIL Text interface: operation convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: interface prototype object missing non-static operation expected property "convertQuadFromNode" missing
-FAIL Text interface: operation convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: interface prototype object missing non-static operation expected property "convertRectFromNode" missing
-FAIL Text interface: operation convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: interface prototype object missing non-static operation expected property "convertPointFromNode" missing
-FAIL Text interface: document.createTextNode("x") must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type assert_inherits: property "getBoxQuads" not found in prototype chain
-FAIL Text interface: calling getBoxQuads(optional BoxQuadOptions) on document.createTextNode("x") with too few arguments must throw TypeError assert_inherits: property "getBoxQuads" not found in prototype chain
-FAIL Text interface: document.createTextNode("x") must inherit property "convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertQuadFromNode" not found in prototype chain
-FAIL Text interface: calling convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) on document.createTextNode("x") with too few arguments must throw TypeError assert_inherits: property "convertQuadFromNode" not found in prototype chain
-FAIL Text interface: document.createTextNode("x") must inherit property "convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertRectFromNode" not found in prototype chain
-FAIL Text interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) on document.createTextNode("x") with too few arguments must throw TypeError assert_inherits: property "convertRectFromNode" not found in prototype chain
-FAIL Text interface: document.createTextNode("x") must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type assert_inherits: property "convertPointFromNode" not found in prototype chain
-FAIL Text interface: calling convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) on document.createTextNode("x") with too few arguments must throw TypeError assert_inherits: property "convertPointFromNode" not found in prototype chain
+PASS Element interface: document.createElementNS("x", "y") must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type
+PASS Element interface: calling getBoxQuads(optional BoxQuadOptions) on document.createElementNS("x", "y") with too few arguments must throw TypeError
+PASS Element interface: document.createElementNS("x", "y") must inherit property "convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Element interface: calling convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElementNS("x", "y") with too few arguments must throw TypeError
+PASS Element interface: document.createElementNS("x", "y") must inherit property "convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Element interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) on document.createElementNS("x", "y") with too few arguments must throw TypeError
+PASS Element interface: document.createElementNS("x", "y") must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Element interface: calling convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElementNS("x", "y") with too few arguments must throw TypeError
+PASS Text interface: operation getBoxQuads(optional BoxQuadOptions)
+PASS Text interface: operation convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)
+PASS Text interface: operation convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)
+PASS Text interface: operation convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)
+PASS Text interface: document.createTextNode("x") must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type
+PASS Text interface: calling getBoxQuads(optional BoxQuadOptions) on document.createTextNode("x") with too few arguments must throw TypeError
+PASS Text interface: document.createTextNode("x") must inherit property "convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Text interface: calling convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) on document.createTextNode("x") with too few arguments must throw TypeError
+PASS Text interface: document.createTextNode("x") must inherit property "convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Text interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) on document.createTextNode("x") with too few arguments must throw TypeError
+PASS Text interface: document.createTextNode("x") must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
+PASS Text interface: calling convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) on document.createTextNode("x") with too few arguments must throw TypeError
 PASS Range interface: operation getClientRects()
 PASS Range interface: operation getBoundingClientRect()
 PASS Range interface: new Range() must inherit property "getClientRects()" with the proper type

--- a/LayoutTests/inspector/model/remote-object/dom-expected.txt
+++ b/LayoutTests/inspector/model/remote-object/dom-expected.txt
@@ -250,14 +250,14 @@ EXPRESSION: text = document.createTextNode("text content"); text
         "_value": ""
       },
       {
-        "_name": "data",
-        "_type": "string",
-        "_value": "text content"
+        "_name": "getBoxQuads",
+        "_type": "function",
+        "_value": ""
       },
       {
-        "_name": "length",
-        "_type": "number",
-        "_value": "12"
+        "_name": "convertQuadFromNode",
+        "_type": "function",
+        "_value": ""
       }
     ],
     "_entries": null

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2032,7 +2032,10 @@ set(WebCore_SUPPLEMENTAL_IDL_FILES
     css/FontFaceSource.idl
     css/LinkStyle.idl
 
+    dom/BoxQuadOptions.idl
+    dom/CSSBoxType.idl
     dom/ChildNode.idl
+    dom/ConvertCoordinateOptions.idl
     dom/Document+CSSOMView.idl
     dom/Document+CaretPositionFromPoint.idl
     dom/Document+Fullscreen.idl
@@ -2058,6 +2061,7 @@ set(WebCore_SUPPLEMENTAL_IDL_FILES
     dom/Element+PointerLock.idl
     dom/Element+Typedom.idl
     dom/ElementContentEditable.idl
+    dom/GeometryUtils.idl
     dom/GlobalEventHandlers+PointerEvents.idl
     dom/GlobalEventHandlers+Selection.idl
     dom/GlobalEventHandlers.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1207,6 +1207,10 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/FocusOptions.idl \
     $(WebCore)/dom/FormDataEvent.idl \
     $(WebCore)/dom/FullscreenOptions.idl \
+    $(WebCore)/dom/BoxQuadOptions.idl \
+    $(WebCore)/dom/ConvertCoordinateOptions.idl \
+    $(WebCore)/dom/CSSBoxType.idl \
+    $(WebCore)/dom/GeometryUtils.idl \
     $(WebCore)/dom/GetHTMLOptions.idl \
     $(WebCore)/dom/GlobalEventHandlers+PointerEvents.idl \
     $(WebCore)/dom/GlobalEventHandlers+Selection.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1294,6 +1294,7 @@ dom/DOMQuad.cpp
 dom/DOMRectList.cpp
 dom/DOMRectReadOnly.cpp
 dom/DOMStringList.cpp
+dom/GeometryUtils.cpp
 dom/DOMTZoneImpls.cpp
 dom/DataTransfer.cpp
 dom/DataTransferItem.cpp
@@ -3935,6 +3936,7 @@ JSCORPViolationReportBody.cpp
 JSCSPViolationReportBody.cpp
 JSCSSAnimation.cpp
 JSCSSAnimationEvent.cpp
+JSCSSBoxType.cpp
 JSCSSConditionRule.cpp
 JSCSSContainerRule.cpp
 JSCSSCounterStyleRule.cpp
@@ -4153,6 +4155,8 @@ JSDOMTokenList.cpp
 JSDOMURL.cpp
 JSDOMWindow.cpp @no-unify-when(bundle<=8) @cost:22
 JSDOMWindowConstructorAttributes.cpp @no-unify-when(bundle<=8) @cost:22
+JSBoxQuadOptions.cpp
+JSConvertCoordinateOptions.cpp
 JSDataCue.cpp
 JSDataTransfer.cpp
 JSDataTransferItem.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -58,6 +58,11 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		A1B2C3013BC0010100000001 /* BoxQuadOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3023BC0010100000001 /* BoxQuadOptions.h */; };
+		A1B2C3033BC0010100000001 /* ConvertCoordinateOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3043BC0010100000001 /* ConvertCoordinateOptions.h */; };
+		A1B2C3053BC0010100000001 /* GeometryBox.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3063BC0010100000001 /* GeometryBox.h */; };
+		A1B2C3073BC0010100000001 /* GeometryNode.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3083BC0010100000001 /* GeometryNode.h */; };
+		A1B2C3093BC0010100000001 /* GeometryUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C30A3BC0010100000001 /* GeometryUtils.h */; };
 		0014628B103CD1DE000B20DB /* OriginAccessEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = 00146289103CD1DE000B20DB /* OriginAccessEntry.h */; };
 		003F1FEA11E6AB43008258D9 /* UserContentTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 003F1FE911E6AB43008258D9 /* UserContentTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		00B9318813BA8DBA0035A948 /* XMLDocumentParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B9318213BA867F0035A948 /* XMLDocumentParser.h */; };
@@ -7747,6 +7752,16 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A1B2C3023BC0010100000001 /* BoxQuadOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BoxQuadOptions.h; sourceTree = "<group>"; };
+		A1B2C3043BC0010100000001 /* ConvertCoordinateOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConvertCoordinateOptions.h; sourceTree = "<group>"; };
+		A1B2C3063BC0010100000001 /* GeometryBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeometryBox.h; sourceTree = "<group>"; };
+		A1B2C3083BC0010100000001 /* GeometryNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeometryNode.h; sourceTree = "<group>"; };
+		A1B2C30A3BC0010100000001 /* GeometryUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeometryUtils.h; sourceTree = "<group>"; };
+		A1B2C30B3BC0010100000001 /* GeometryUtils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GeometryUtils.cpp; sourceTree = "<group>"; };
+		A1B2C30C3BC0010100000001 /* GeometryUtils.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = GeometryUtils.idl; sourceTree = "<group>"; };
+		A1B2C30D3BC0010100000001 /* BoxQuadOptions.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = BoxQuadOptions.idl; sourceTree = "<group>"; };
+		A1B2C30E3BC0010100000001 /* ConvertCoordinateOptions.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = ConvertCoordinateOptions.idl; sourceTree = "<group>"; };
+		A1B2C30F3BC0010100000001 /* CSSBoxType.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = CSSBoxType.idl; sourceTree = "<group>"; };
 		00146288103CD1DE000B20DB /* OriginAccessEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OriginAccessEntry.cpp; sourceTree = "<group>"; };
 		00146289103CD1DE000B20DB /* OriginAccessEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OriginAccessEntry.h; sourceTree = "<group>"; };
 		003F1FE911E6AB43008258D9 /* UserContentTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserContentTypes.h; sourceTree = "<group>"; };
@@ -42813,6 +42828,16 @@
 				9BAAC4562151E39E003D4A98 /* GCReachableRef.h */,
 				054E3A33256C3BD90072C5BF /* GetHTMLOptions.h */,
 				054E3A35256C3BD90072C5BF /* GetHTMLOptions.idl */,
+				A1B2C3023BC0010100000001 /* BoxQuadOptions.h */,
+				A1B2C30D3BC0010100000001 /* BoxQuadOptions.idl */,
+				A1B2C3043BC0010100000001 /* ConvertCoordinateOptions.h */,
+				A1B2C30E3BC0010100000001 /* ConvertCoordinateOptions.idl */,
+				A1B2C30F3BC0010100000001 /* CSSBoxType.idl */,
+				A1B2C3063BC0010100000001 /* GeometryBox.h */,
+				A1B2C3083BC0010100000001 /* GeometryNode.h */,
+				A1B2C30B3BC0010100000001 /* GeometryUtils.cpp */,
+				A1B2C30A3BC0010100000001 /* GeometryUtils.h */,
+				A1B2C30C3BC0010100000001 /* GeometryUtils.idl */,
 				7C2D722E25083A3400539662 /* GlobalEventHandlers+PointerEvents.idl */,
 				44BD2B36252779780055D95A /* GlobalEventHandlers+Selection.idl */,
 				7C4189AB1B07C170000FA757 /* GlobalEventHandlers.idl */,
@@ -45236,6 +45261,11 @@
 				0F49669F1DB408C100A274BB /* DOMPointReadOnly.h in Headers */,
 				7C516AD41F3525200034B6BF /* DOMPromiseProxy.h in Headers */,
 				0FF835C31EE354DA008B4CC7 /* DOMQuad.h in Headers */,
+				A1B2C3013BC0010100000001 /* BoxQuadOptions.h in Headers */,
+				A1B2C3033BC0010100000001 /* ConvertCoordinateOptions.h in Headers */,
+				A1B2C3053BC0010100000001 /* GeometryBox.h in Headers */,
+				A1B2C3073BC0010100000001 /* GeometryNode.h in Headers */,
+				A1B2C3093BC0010100000001 /* GeometryUtils.h in Headers */,
 				0FF835C51EE354DA008B4CC7 /* DOMQuadInit.h in Headers */,
 				0F4710AF1DB56AFC002DCEC3 /* DOMRect.h in Headers */,
 				0F4710B11DB56AFC002DCEC3 /* DOMRectInit.h in Headers */,

--- a/Source/WebCore/dom/BoxQuadOptions.h
+++ b/Source/WebCore/dom/BoxQuadOptions.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include "GeometryBox.h"
+#include "GeometryNode.h"
+#include <optional>
+
+namespace WebCore {
+
+struct BoxQuadOptions {
+    GeometryBox box { GeometryBox::Border };
+    std::optional<GeometryNode> relativeTo;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/BoxQuadOptions.h
+++ b/Source/WebCore/dom/BoxQuadOptions.h
@@ -1,10 +1,26 @@
 /*
  * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once

--- a/Source/WebCore/dom/BoxQuadOptions.idl
+++ b/Source/WebCore/dom/BoxQuadOptions.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary BoxQuadOptions {
+    CSSBoxType box = "border";
+    (Text or Element or Document) relativeTo;
+};

--- a/Source/WebCore/dom/CSSBoxType.idl
+++ b/Source/WebCore/dom/CSSBoxType.idl
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[ImplementedAs=GeometryBox] enum CSSBoxType { "margin", "border", "padding", "content" };

--- a/Source/WebCore/dom/ConvertCoordinateOptions.h
+++ b/Source/WebCore/dom/ConvertCoordinateOptions.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include "GeometryBox.h"
+
+namespace WebCore {
+
+struct ConvertCoordinateOptions {
+    GeometryBox fromBox { GeometryBox::Border };
+    GeometryBox toBox { GeometryBox::Border };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ConvertCoordinateOptions.h
+++ b/Source/WebCore/dom/ConvertCoordinateOptions.h
@@ -1,10 +1,26 @@
 /*
  * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once

--- a/Source/WebCore/dom/ConvertCoordinateOptions.idl
+++ b/Source/WebCore/dom/ConvertCoordinateOptions.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary ConvertCoordinateOptions {
+    CSSBoxType fromBox = "border";
+    CSSBoxType toBox = "border";
+};

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -599,6 +599,11 @@ public:
     std::optional<BoundaryPoint> caretPositionFromPoint(const LayoutPoint& clientPoint, HitTestSource);
     RefPtr<CaretPosition> caretPositionFromPoint(double x, double y, CaretPositionFromPointOptions);
 
+    ExceptionOr<Vector<Ref<DOMQuad>>> getBoxQuads(BoxQuadOptions&&);
+    ExceptionOr<Ref<DOMQuad>> convertQuadFromNode(DOMQuadInit&&, Variant<Ref<Text>, Ref<Element>, Ref<Document>>&&, ConvertCoordinateOptions&&);
+    ExceptionOr<Ref<DOMQuad>> convertRectFromNode(DOMRectReadOnly&, Variant<Ref<Text>, Ref<Element>, Ref<Document>>&&, ConvertCoordinateOptions&&);
+    ExceptionOr<Ref<DOMPoint>> convertPointFromNode(DOMPointInit&&, Variant<Ref<Text>, Ref<Element>, Ref<Document>>&&, ConvertCoordinateOptions&&);
+
     WEBCORE_EXPORT RefPtr<Element> scrollingElementForAPI();
     WEBCORE_EXPORT RefPtr<Element> scrollingElement();
 

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -107,3 +107,4 @@ Document includes GlobalEventHandlers;
 Document includes DocumentAndElementEventHandlers;
 Document includes FontFaceSource;
 Document includes XPathEvaluatorBase;
+Document includes GeometryUtils;

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -55,6 +55,9 @@ class CustomStateSet;
 class DatasetDOMStringMap;
 class DOMRect;
 class DOMRectList;
+class DOMPoint;
+class DOMQuad;
+class DOMRectReadOnly;
 class DOMTokenList;
 class DeferredPromise;
 class Document;
@@ -73,6 +76,11 @@ class KeyboardEvent;
 class LayoutUnit;
 class LocalFrame;
 class Locale;
+class Text;
+struct BoxQuadOptions;
+struct ConvertCoordinateOptions;
+struct DOMPointInit;
+struct DOMQuadInit;
 class PlatformKeyboardEvent;
 class PlatformMouseEvent;
 class PlatformWheelEvent;
@@ -357,6 +365,10 @@ public:
 
     WEBCORE_EXPORT Ref<DOMRectList> getClientRects();
     Ref<DOMRect> getBoundingClientRect();
+    ExceptionOr<Vector<Ref<DOMQuad>>> getBoxQuads(BoxQuadOptions&&);
+    ExceptionOr<Ref<DOMQuad>> convertQuadFromNode(DOMQuadInit&&, Variant<Ref<Text>, Ref<Element>, Ref<Document>>&&, ConvertCoordinateOptions&&);
+    ExceptionOr<Ref<DOMQuad>> convertRectFromNode(DOMRectReadOnly&, Variant<Ref<Text>, Ref<Element>, Ref<Document>>&&, ConvertCoordinateOptions&&);
+    ExceptionOr<Ref<DOMPoint>> convertPointFromNode(DOMPointInit&&, Variant<Ref<Text>, Ref<Element>, Ref<Document>>&&, ConvertCoordinateOptions&&);
 
     // Returns the absolute bounding box translated into screen coordinates.
     WEBCORE_EXPORT IntRect screenRect() const;

--- a/Source/WebCore/dom/Element.idl
+++ b/Source/WebCore/dom/Element.idl
@@ -115,5 +115,6 @@ Element includes NonDocumentTypeChildNode;
 Element includes ParentNode;
 Element includes Slotable;
 Element includes InnerHTML;
+Element includes GeometryUtils;
 
 typedef (TrustedHTML or TrustedScript or TrustedScriptURL) TrustedType;

--- a/Source/WebCore/dom/GeometryBox.h
+++ b/Source/WebCore/dom/GeometryBox.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace WebCore {
+
+enum class GeometryBox : uint8_t {
+    Margin,
+    Border,
+    Padding,
+    Content,
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/GeometryBox.h
+++ b/Source/WebCore/dom/GeometryBox.h
@@ -1,10 +1,26 @@
 /*
  * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once

--- a/Source/WebCore/dom/GeometryNode.h
+++ b/Source/WebCore/dom/GeometryNode.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include <wtf/Ref.h>
+#include <wtf/Variant.h>
+
+namespace WebCore {
+
+class Document;
+class Element;
+class Text;
+
+using GeometryNode = Variant<Ref<Text>, Ref<Element>, Ref<Document>>;
+
+} // namespace WebCore

--- a/Source/WebCore/dom/GeometryNode.h
+++ b/Source/WebCore/dom/GeometryNode.h
@@ -1,10 +1,26 @@
 /*
  * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once

--- a/Source/WebCore/dom/GeometryUtils.cpp
+++ b/Source/WebCore/dom/GeometryUtils.cpp
@@ -1,10 +1,26 @@
 /*
  * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"

--- a/Source/WebCore/dom/GeometryUtils.cpp
+++ b/Source/WebCore/dom/GeometryUtils.cpp
@@ -1,0 +1,398 @@
+/*
+ * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ */
+
+#include "config.h"
+#include "GeometryUtils.h"
+
+#include "ContainerNodeInlines.h"
+#include "DOMPoint.h"
+#include "DOMQuad.h"
+#include "DOMRectReadOnly.h"
+#include "Document.h"
+#include "Element.h"
+#include "FloatQuad.h"
+#include "LocalFrame.h"
+#include "LocalFrameView.h"
+#include "Node.h"
+#include "RenderBox.h"
+#include "RenderBoxInlines.h"
+#include "RenderInline.h"
+#include "RenderObjectInlines.h"
+#include "RenderObjectStyle.h"
+#include "RenderText.h"
+#include "RenderView.h"
+#include "SecurityOrigin.h"
+#include "Text.h"
+#include <wtf/CheckedPtr.h>
+#include <wtf/TypeCasts.h>
+
+namespace WebCore::GeometryUtils {
+
+static Node& nodeForGeometryNode(const GeometryNode& geometryNode)
+{
+    return WTF::switchOn(geometryNode, [](const auto& node) -> Node& {
+        return node.get();
+    });
+}
+
+static RenderObject* rendererForNode(Node& node)
+{
+    if (auto* document = dynamicDowncast<Document>(node))
+        return document->renderView();
+    if (auto* element = dynamicDowncast<Element>(node))
+        return element->renderer();
+    if (auto* text = dynamicDowncast<Text>(node))
+        return text->renderer();
+    return nullptr;
+}
+
+// Text nodes use their parent element's coordinate system for conversion,
+// while their own renderer supplies the fragments returned by getBoxQuads().
+static RenderObject* coordinateRendererForNode(Node& node)
+{
+    if (auto* text = dynamicDowncast<Text>(node)) {
+        if (RefPtr parent = text->parentElement())
+            return parent->renderer();
+    }
+    return rendererForNode(node);
+}
+
+static RefPtr<LocalFrame> sameOriginRoot(Document& document)
+{
+    RefPtr frame = document.frame();
+    if (!frame)
+        return nullptr;
+
+    while (RefPtr parentFrame = frame->tree().parent()) {
+        RefPtr localParent = dynamicDowncast<LocalFrame>(parentFrame.get());
+        if (!localParent)
+            return nullptr;
+        RefPtr childDocument = frame->document();
+        RefPtr parentDocument = localParent->document();
+        if (!childDocument || !parentDocument)
+            return nullptr;
+        if (!childDocument->securityOrigin().isSameOriginDomain(parentDocument->securityOrigin()))
+            return nullptr;
+        frame = WTF::move(localParent);
+    }
+    return frame;
+}
+
+static bool canMapBetween(Document& source, Document& target)
+{
+    if (&source == &target)
+        return true;
+    RefPtr sourceRoot = sameOriginRoot(source);
+    return sourceRoot && sourceRoot == sameOriginRoot(target);
+}
+
+static Element* layoutUpdateContext(Node& node)
+{
+    if (auto* element = dynamicDowncast<Element>(node))
+        return element;
+    if (auto* text = dynamicDowncast<Text>(node))
+        return text->parentElement();
+    if (auto* document = dynamicDowncast<Document>(node))
+        return document->documentElement();
+    return nullptr;
+}
+
+static void updateLayoutForGeometryNode(Node& node)
+{
+    auto options = OptionSet<LayoutOptions> { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::CanDeferUpdateLayerPositions, LayoutOptions::IgnorePendingStylesheets };
+    if (auto* context = layoutUpdateContext(node)) {
+        node.document().updateLayoutIfDimensionsOutOfDate(*context, { DimensionsCheck::Left, DimensionsCheck::Top, DimensionsCheck::Width, DimensionsCheck::Height, DimensionsCheck::IgnoreOverflow }, options);
+        return;
+    }
+    node.document().updateLayoutIgnorePendingStylesheets(options);
+}
+
+static void updateLayoutForGeometryNodes(Node& source, Node* target)
+{
+    updateLayoutForGeometryNode(source);
+    if (target && target != &source && !target->isShadowIncludingInclusiveAncestorOf(source))
+        updateLayoutForGeometryNode(*target);
+}
+
+static LayoutRect boxRect(const RenderObject& renderer, GeometryBox boxType)
+{
+    if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer)) {
+        switch (boxType) {
+        case GeometryBox::Margin: {
+            auto horizontalMargins = box->marginLeft() + box->marginRight();
+            auto verticalMargins = box->marginTop() + box->marginBottom();
+            return { -box->marginLeft(), -box->marginTop(), box->borderBoxWidth() + horizontalMargins, box->borderBoxHeight() + verticalMargins };
+        }
+        case GeometryBox::Border:
+            return box->borderBoxRect();
+        case GeometryBox::Padding:
+            return box->paddingBoxRect();
+        case GeometryBox::Content:
+            return box->contentBoxRect();
+        }
+    }
+
+    if (CheckedPtr inlineRenderer = dynamicDowncast<RenderInline>(renderer)) {
+        Vector<LayoutRect> lineBoxes;
+        inlineRenderer->collectLineBoxRects(lineBoxes, { });
+        if (!lineBoxes.isEmpty())
+            return lineBoxes[0];
+    }
+
+    return { };
+}
+
+static Vector<FloatQuad> absoluteBoxQuads(RenderObject& renderer, GeometryBox boxType)
+{
+    Vector<FloatQuad> quads;
+
+    // RenderObject::absoluteQuads() knows how to enumerate line boxes, text
+    // runs, SVG boxes, and fragmented border boxes.
+    if (boxType == GeometryBox::Border || !is<RenderBox>(renderer)) {
+        renderer.absoluteQuads(quads);
+        return quads;
+    }
+
+    quads.append(renderer.localToAbsoluteQuad(FloatQuad { FloatRect { boxRect(renderer, boxType) } }));
+    return quads;
+}
+
+static FloatQuad mapAbsoluteBetweenDocuments(FloatQuad quad, Document& source, Document& target)
+{
+    if (&source == &target)
+        return quad;
+    RefPtr sourceView = source.view();
+    RefPtr targetView = target.view();
+    ASSERT(sourceView && targetView);
+    return targetView->rootViewToContents(sourceView->contentsToRootView(quad));
+}
+
+static FloatQuad clientToAbsolute(FloatQuad quad, Document& document, const Style::ComputedStyle& style)
+{
+    RefPtr view = document.view();
+    if (!view)
+        return quad;
+    auto offset = view->documentToClientOffset();
+    quad.move(-offset.width(), -offset.height());
+    float scale = view->absoluteToDocumentScaleFactor(document.zoomForClient(style));
+    if (scale && scale != 1)
+        quad.scale(1 / scale);
+    return quad;
+}
+
+static FloatQuad absoluteToClient(FloatQuad quad, Document& document, const Style::ComputedStyle& sourceStyle)
+{
+    Vector<FloatQuad> quads;
+    quads.append(quad);
+    document.convertAbsoluteToClientQuads(quads, sourceStyle);
+    return quads[0];
+}
+
+static FloatQuad mapAbsoluteToTarget(FloatQuad quad, Document& sourceDocument, Node& target, const Style::ComputedStyle& sourceStyle)
+{
+    Document& targetDocument = target.document();
+    quad = mapAbsoluteBetweenDocuments(quad, sourceDocument, targetDocument);
+
+    if (is<Document>(target))
+        return absoluteToClient(quad, targetDocument, sourceStyle);
+
+    auto* targetRenderer = coordinateRendererForNode(target);
+    ASSERT(targetRenderer);
+    quad = targetRenderer->absoluteToLocalQuad(quad);
+    auto origin = boxRect(*targetRenderer, GeometryBox::Border).location();
+    quad.move(-origin.x(), -origin.y());
+    float zoom = targetRenderer->style().usedZoom();
+    if (zoom && zoom != 1)
+        quad.scale(1 / zoom);
+    return quad;
+}
+
+static Ref<DOMQuad> toDOMQuad(const FloatQuad& quad)
+{
+    auto point = [](const FloatPoint& point) {
+        return DOMPointInit { point.x(), point.y(), 0, 1 };
+    };
+    return DOMQuad::create(point(quad.p1()), point(quad.p2()), point(quad.p3()), point(quad.p4()));
+}
+
+static FloatQuad fromDOMQuad(const DOMQuadInit& quad)
+{
+    auto point = [](const DOMPointInit& point) {
+        return FloatPoint { narrowPrecisionToFloat(point.x), narrowPrecisionToFloat(point.y) };
+    };
+    return { point(quad.p1), point(quad.p2), point(quad.p3), point(quad.p4) };
+}
+
+ExceptionOr<Vector<Ref<DOMQuad>>> getBoxQuads(Node& source, BoxQuadOptions&& options)
+{
+    Document& sourceDocument = source.document();
+    Node* target = options.relativeTo ? &nodeForGeometryNode(*options.relativeTo) : &sourceDocument;
+    Document& targetDocument = target->document();
+
+    updateLayoutForGeometryNodes(source, target);
+
+    if (!canMapBetween(sourceDocument, targetDocument))
+        return Exception { ExceptionCode::SecurityError };
+
+    auto* targetRenderer = coordinateRendererForNode(*target);
+    if (!is<Document>(*target) && !targetRenderer)
+        return Exception { ExceptionCode::NotFoundError };
+
+    Vector<FloatQuad> sourceQuads;
+    RenderObject* sourceRenderer = rendererForNode(source);
+    if (is<Document>(source)) {
+        RefPtr view = sourceDocument.view();
+        if (!view || !sourceRenderer)
+            return Vector<Ref<DOMQuad>> { };
+        auto viewportSize = view->layoutViewportRect().size();
+        FloatQuad viewportQuad { FloatRect { { }, FloatSize { viewportSize } } };
+        sourceQuads.append(clientToAbsolute(viewportQuad, sourceDocument, sourceRenderer->style()));
+    } else {
+        if (!sourceRenderer)
+            return Vector<Ref<DOMQuad>> { };
+        sourceQuads = absoluteBoxQuads(*sourceRenderer, options.box);
+    }
+
+    Vector<Ref<DOMQuad>> result;
+    result.reserveInitialCapacity(sourceQuads.size());
+    for (auto& quad : sourceQuads)
+        result.append(toDOMQuad(mapAbsoluteToTarget(quad, sourceDocument, *target, sourceRenderer->style())));
+    return result;
+}
+
+static ExceptionOr<FloatQuad> convertQuad(Node& target, FloatQuad quad, Node& source, const ConvertCoordinateOptions& options)
+{
+    Document& sourceDocument = source.document();
+    Document& targetDocument = target.document();
+    updateLayoutForGeometryNodes(source, &target);
+
+    if (!canMapBetween(sourceDocument, targetDocument))
+        return Exception { ExceptionCode::SecurityError };
+
+    RenderObject* sourceRenderer = coordinateRendererForNode(source);
+    RenderObject* targetRenderer = coordinateRendererForNode(target);
+    if (!sourceRenderer || !targetRenderer)
+        return Exception { ExceptionCode::NotFoundError };
+
+    if (is<Document>(source))
+        quad = clientToAbsolute(quad, sourceDocument, sourceRenderer->style());
+    else {
+        float zoom = sourceRenderer->style().usedZoom();
+        if (zoom && zoom != 1)
+            quad.scale(zoom);
+        auto origin = boxRect(*sourceRenderer, options.fromBox).location();
+        quad.move(origin.x(), origin.y());
+        quad = sourceRenderer->localToAbsoluteQuad(quad);
+    }
+
+    quad = mapAbsoluteBetweenDocuments(quad, sourceDocument, targetDocument);
+    if (is<Document>(target))
+        return absoluteToClient(quad, targetDocument, sourceRenderer->style());
+
+    quad = targetRenderer->absoluteToLocalQuad(quad);
+    auto targetOrigin = boxRect(*targetRenderer, options.toBox).location();
+    quad.move(-targetOrigin.x(), -targetOrigin.y());
+    float targetZoom = targetRenderer->style().usedZoom();
+    if (targetZoom && targetZoom != 1)
+        quad.scale(1 / targetZoom);
+    return quad;
+}
+
+ExceptionOr<Ref<DOMQuad>> convertQuadFromNode(Node& target, DOMQuadInit&& quad, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    auto converted = convertQuad(target, fromDOMQuad(quad), nodeForGeometryNode(from), options);
+    if (converted.hasException())
+        return converted.releaseException();
+    return toDOMQuad(converted.releaseReturnValue());
+}
+
+ExceptionOr<Ref<DOMQuad>> convertRectFromNode(Node& target, DOMRectReadOnly& rect, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    FloatQuad quad { rect.toFloatRect() };
+    auto converted = convertQuad(target, quad, nodeForGeometryNode(from), options);
+    if (converted.hasException())
+        return converted.releaseException();
+    return toDOMQuad(converted.releaseReturnValue());
+}
+
+ExceptionOr<Ref<DOMPoint>> convertPointFromNode(Node& target, DOMPointInit&& point, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    FloatPoint floatPoint { narrowPrecisionToFloat(point.x), narrowPrecisionToFloat(point.y) };
+    auto converted = convertQuad(target, FloatQuad { floatPoint, floatPoint, floatPoint, floatPoint }, nodeForGeometryNode(from), options);
+    if (converted.hasException())
+        return converted.releaseException();
+    auto result = converted.releaseReturnValue().p1();
+    return DOMPoint::create(result.x(), result.y(), 0, 1);
+}
+
+} // namespace WebCore::GeometryUtils
+
+namespace WebCore {
+
+ExceptionOr<Vector<Ref<DOMQuad>>> Element::getBoxQuads(BoxQuadOptions&& options)
+{
+    return GeometryUtils::getBoxQuads(*this, WTF::move(options));
+}
+
+ExceptionOr<Ref<DOMQuad>> Element::convertQuadFromNode(DOMQuadInit&& quad, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    return GeometryUtils::convertQuadFromNode(*this, WTF::move(quad), WTF::move(from), WTF::move(options));
+}
+
+ExceptionOr<Ref<DOMQuad>> Element::convertRectFromNode(DOMRectReadOnly& rect, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    return GeometryUtils::convertRectFromNode(*this, rect, WTF::move(from), WTF::move(options));
+}
+
+ExceptionOr<Ref<DOMPoint>> Element::convertPointFromNode(DOMPointInit&& point, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    return GeometryUtils::convertPointFromNode(*this, WTF::move(point), WTF::move(from), WTF::move(options));
+}
+
+ExceptionOr<Vector<Ref<DOMQuad>>> Text::getBoxQuads(BoxQuadOptions&& options)
+{
+    return GeometryUtils::getBoxQuads(*this, WTF::move(options));
+}
+
+ExceptionOr<Ref<DOMQuad>> Text::convertQuadFromNode(DOMQuadInit&& quad, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    return GeometryUtils::convertQuadFromNode(*this, WTF::move(quad), WTF::move(from), WTF::move(options));
+}
+
+ExceptionOr<Ref<DOMQuad>> Text::convertRectFromNode(DOMRectReadOnly& rect, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    return GeometryUtils::convertRectFromNode(*this, rect, WTF::move(from), WTF::move(options));
+}
+
+ExceptionOr<Ref<DOMPoint>> Text::convertPointFromNode(DOMPointInit&& point, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    return GeometryUtils::convertPointFromNode(*this, WTF::move(point), WTF::move(from), WTF::move(options));
+}
+
+ExceptionOr<Vector<Ref<DOMQuad>>> Document::getBoxQuads(BoxQuadOptions&& options)
+{
+    return GeometryUtils::getBoxQuads(*this, WTF::move(options));
+}
+
+ExceptionOr<Ref<DOMQuad>> Document::convertQuadFromNode(DOMQuadInit&& quad, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    return GeometryUtils::convertQuadFromNode(*this, WTF::move(quad), WTF::move(from), WTF::move(options));
+}
+
+ExceptionOr<Ref<DOMQuad>> Document::convertRectFromNode(DOMRectReadOnly& rect, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    return GeometryUtils::convertRectFromNode(*this, rect, WTF::move(from), WTF::move(options));
+}
+
+ExceptionOr<Ref<DOMPoint>> Document::convertPointFromNode(DOMPointInit&& point, GeometryNode&& from, ConvertCoordinateOptions&& options)
+{
+    return GeometryUtils::convertPointFromNode(*this, WTF::move(point), WTF::move(from), WTF::move(options));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/GeometryUtils.cpp
+++ b/Source/WebCore/dom/GeometryUtils.cpp
@@ -34,14 +34,14 @@
 
 namespace WebCore::GeometryUtils {
 
-static Node& nodeForGeometryNode(const GeometryNode& geometryNode)
+static Ref<Node> nodeForGeometryNode(const GeometryNode& geometryNode)
 {
-    return WTF::switchOn(geometryNode, [](const auto& node) -> Node& {
-        return node.get();
+    return WTF::switchOn(geometryNode, [](const auto& node) -> Ref<Node> {
+        return node;
     });
 }
 
-static RenderObject* rendererForNode(Node& node)
+static CheckedPtr<RenderObject> rendererForNode(Node& node)
 {
     if (auto* document = dynamicDowncast<Document>(node))
         return document->renderView();
@@ -54,9 +54,9 @@ static RenderObject* rendererForNode(Node& node)
 
 // Text nodes use their parent element's coordinate system for conversion,
 // while their own renderer supplies the fragments returned by getBoxQuads().
-static RenderObject* coordinateRendererForNode(Node& node)
+static CheckedPtr<RenderObject> coordinateRendererForNode(Node& node)
 {
-    if (auto* text = dynamicDowncast<Text>(node)) {
+    if (RefPtr text = dynamicDowncast<Text>(node)) {
         if (RefPtr parent = text->parentElement())
             return parent->renderer();
     }
@@ -65,7 +65,8 @@ static RenderObject* coordinateRendererForNode(Node& node)
 
 static RefPtr<LocalFrame> sameOriginRoot(Document& document)
 {
-    RefPtr frame = document.frame();
+    Ref protectedDocument = document;
+    RefPtr frame = protectedDocument->frame();
     if (!frame)
         return nullptr;
 
@@ -77,7 +78,9 @@ static RefPtr<LocalFrame> sameOriginRoot(Document& document)
         RefPtr parentDocument = localParent->document();
         if (!childDocument || !parentDocument)
             return nullptr;
-        if (!childDocument->securityOrigin().isSameOriginDomain(parentDocument->securityOrigin()))
+        Ref childOrigin = childDocument->securityOrigin();
+        Ref parentOrigin = parentDocument->securityOrigin();
+        if (!childOrigin->isSameOriginDomain(parentOrigin))
             return nullptr;
         frame = WTF::move(localParent);
     }
@@ -92,7 +95,7 @@ static bool canMapBetween(Document& source, Document& target)
     return sourceRoot && sourceRoot == sameOriginRoot(target);
 }
 
-static Element* layoutUpdateContext(Node& node)
+static RefPtr<Element> layoutUpdateContext(Node& node)
 {
     if (auto* element = dynamicDowncast<Element>(node))
         return element;
@@ -103,21 +106,22 @@ static Element* layoutUpdateContext(Node& node)
     return nullptr;
 }
 
-static void updateLayoutForGeometryNode(Node& node)
+static void updateLayoutForGeometryNode(Ref<Node> node)
 {
     auto options = OptionSet<LayoutOptions> { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::CanDeferUpdateLayerPositions, LayoutOptions::IgnorePendingStylesheets };
-    if (auto* context = layoutUpdateContext(node)) {
-        node.document().updateLayoutIfDimensionsOutOfDate(*context, { DimensionsCheck::Left, DimensionsCheck::Top, DimensionsCheck::Width, DimensionsCheck::Height, DimensionsCheck::IgnoreOverflow }, options);
+    Ref document = node->document();
+    if (RefPtr context = layoutUpdateContext(node)) {
+        document->updateLayoutIfDimensionsOutOfDate(*context, { DimensionsCheck::Left, DimensionsCheck::Top, DimensionsCheck::Width, DimensionsCheck::Height, DimensionsCheck::IgnoreOverflow }, options);
         return;
     }
-    node.document().updateLayoutIgnorePendingStylesheets(options);
+    document->updateLayoutIgnorePendingStylesheets(options);
 }
 
-static void updateLayoutForGeometryNodes(Node& source, Node* target)
+static void updateLayoutForGeometryNodes(Ref<Node> source, RefPtr<Node> target)
 {
-    updateLayoutForGeometryNode(source);
-    if (target && target != &source && !target->isShadowIncludingInclusiveAncestorOf(source))
-        updateLayoutForGeometryNode(*target);
+    updateLayoutForGeometryNode(source.copyRef());
+    if (target && target != source.ptr() && !target->isShadowIncludingInclusiveAncestorOf(source))
+        updateLayoutForGeometryNode(target.releaseNonNull());
 }
 
 static LayoutRect boxRect(const RenderObject& renderer, GeometryBox boxType)
@@ -196,13 +200,14 @@ static FloatQuad absoluteToClient(FloatQuad quad, Document& document, const Styl
 
 static FloatQuad mapAbsoluteToTarget(FloatQuad quad, Document& sourceDocument, Node& target, const Style::ComputedStyle& sourceStyle)
 {
-    Document& targetDocument = target.document();
+    Ref protectedTarget = target;
+    Ref targetDocument = protectedTarget->document();
     quad = mapAbsoluteBetweenDocuments(quad, sourceDocument, targetDocument);
 
-    if (is<Document>(target))
+    if (is<Document>(protectedTarget.get()))
         return absoluteToClient(quad, targetDocument, sourceStyle);
 
-    auto* targetRenderer = coordinateRendererForNode(target);
+    CheckedPtr targetRenderer = coordinateRendererForNode(protectedTarget);
     ASSERT(targetRenderer);
     quad = targetRenderer->absoluteToLocalQuad(quad);
     auto origin = boxRect(*targetRenderer, GeometryBox::Border).location();
@@ -231,57 +236,59 @@ static FloatQuad fromDOMQuad(const DOMQuadInit& quad)
 
 ExceptionOr<Vector<Ref<DOMQuad>>> getBoxQuads(Node& source, BoxQuadOptions&& options)
 {
-    Document& sourceDocument = source.document();
-    Node* target = options.relativeTo ? &nodeForGeometryNode(*options.relativeTo) : &sourceDocument;
-    Document& targetDocument = target->document();
+    Ref protectedSource = source;
+    Ref sourceDocument = protectedSource->document();
+    Ref<Node> target = options.relativeTo ? nodeForGeometryNode(*options.relativeTo) : Ref<Node> { sourceDocument.get() };
+    Ref targetDocument = target->document();
 
-    updateLayoutForGeometryNodes(source, target);
+    updateLayoutForGeometryNodes(protectedSource.copyRef(), target.copyRef());
 
     if (!canMapBetween(sourceDocument, targetDocument))
         return Exception { ExceptionCode::SecurityError };
 
-    auto* targetRenderer = coordinateRendererForNode(*target);
-    if (!is<Document>(*target) && !targetRenderer)
+    CheckedPtr targetRenderer = coordinateRendererForNode(target);
+    if (!is<Document>(target.get()) && !targetRenderer)
         return Exception { ExceptionCode::NotFoundError };
 
     Vector<FloatQuad> sourceQuads;
-    RenderObject* sourceRenderer = rendererForNode(source);
-    if (is<Document>(source)) {
-        RefPtr view = sourceDocument.view();
-        if (!view || !sourceRenderer)
+    CheckedPtr sourceRenderer = rendererForNode(protectedSource);
+    if (!sourceRenderer)
+        return Vector<Ref<DOMQuad>> { };
+    CheckedRef sourceStyle = sourceRenderer->style();
+    if (is<Document>(protectedSource.get())) {
+        RefPtr view = sourceDocument->view();
+        if (!view)
             return Vector<Ref<DOMQuad>> { };
         auto viewportSize = view->layoutViewportRect().size();
         FloatQuad viewportQuad { FloatRect { { }, FloatSize { viewportSize } } };
-        sourceQuads.append(clientToAbsolute(viewportQuad, sourceDocument, sourceRenderer->style()));
-    } else {
-        if (!sourceRenderer)
-            return Vector<Ref<DOMQuad>> { };
+        sourceQuads.append(clientToAbsolute(viewportQuad, sourceDocument, sourceStyle));
+    } else
         sourceQuads = absoluteBoxQuads(*sourceRenderer, options.box);
-    }
 
     Vector<Ref<DOMQuad>> result;
     result.reserveInitialCapacity(sourceQuads.size());
     for (auto& quad : sourceQuads)
-        result.append(toDOMQuad(mapAbsoluteToTarget(quad, sourceDocument, *target, sourceRenderer->style())));
+        result.append(toDOMQuad(mapAbsoluteToTarget(quad, sourceDocument, target, sourceStyle)));
     return result;
 }
 
-static ExceptionOr<FloatQuad> convertQuad(Node& target, FloatQuad quad, Node& source, const ConvertCoordinateOptions& options)
+static ExceptionOr<FloatQuad> convertQuad(Ref<Node> target, FloatQuad quad, Ref<Node> source, const ConvertCoordinateOptions& options)
 {
-    Document& sourceDocument = source.document();
-    Document& targetDocument = target.document();
-    updateLayoutForGeometryNodes(source, &target);
+    Ref sourceDocument = source->document();
+    Ref targetDocument = target->document();
+    updateLayoutForGeometryNodes(source.copyRef(), target.copyRef());
 
     if (!canMapBetween(sourceDocument, targetDocument))
         return Exception { ExceptionCode::SecurityError };
 
-    RenderObject* sourceRenderer = coordinateRendererForNode(source);
-    RenderObject* targetRenderer = coordinateRendererForNode(target);
+    CheckedPtr sourceRenderer = coordinateRendererForNode(source);
+    CheckedPtr targetRenderer = coordinateRendererForNode(target);
     if (!sourceRenderer || !targetRenderer)
         return Exception { ExceptionCode::NotFoundError };
 
-    if (is<Document>(source))
-        quad = clientToAbsolute(quad, sourceDocument, sourceRenderer->style());
+    CheckedRef sourceStyle = sourceRenderer->style();
+    if (is<Document>(source.get()))
+        quad = clientToAbsolute(quad, sourceDocument, sourceStyle);
     else {
         float zoom = sourceRenderer->style().usedZoom();
         if (zoom && zoom != 1)
@@ -292,8 +299,8 @@ static ExceptionOr<FloatQuad> convertQuad(Node& target, FloatQuad quad, Node& so
     }
 
     quad = mapAbsoluteBetweenDocuments(quad, sourceDocument, targetDocument);
-    if (is<Document>(target))
-        return absoluteToClient(quad, targetDocument, sourceRenderer->style());
+    if (is<Document>(target.get()))
+        return absoluteToClient(quad, targetDocument, sourceStyle);
 
     quad = targetRenderer->absoluteToLocalQuad(quad);
     auto targetOrigin = boxRect(*targetRenderer, options.toBox).location();
@@ -306,7 +313,7 @@ static ExceptionOr<FloatQuad> convertQuad(Node& target, FloatQuad quad, Node& so
 
 ExceptionOr<Ref<DOMQuad>> convertQuadFromNode(Node& target, DOMQuadInit&& quad, GeometryNode&& from, ConvertCoordinateOptions&& options)
 {
-    auto converted = convertQuad(target, fromDOMQuad(quad), nodeForGeometryNode(from), options);
+    auto converted = convertQuad(Ref { target }, fromDOMQuad(quad), nodeForGeometryNode(from), options);
     if (converted.hasException())
         return converted.releaseException();
     return toDOMQuad(converted.releaseReturnValue());
@@ -315,7 +322,7 @@ ExceptionOr<Ref<DOMQuad>> convertQuadFromNode(Node& target, DOMQuadInit&& quad, 
 ExceptionOr<Ref<DOMQuad>> convertRectFromNode(Node& target, DOMRectReadOnly& rect, GeometryNode&& from, ConvertCoordinateOptions&& options)
 {
     FloatQuad quad { rect.toFloatRect() };
-    auto converted = convertQuad(target, quad, nodeForGeometryNode(from), options);
+    auto converted = convertQuad(Ref { target }, quad, nodeForGeometryNode(from), options);
     if (converted.hasException())
         return converted.releaseException();
     return toDOMQuad(converted.releaseReturnValue());
@@ -324,7 +331,7 @@ ExceptionOr<Ref<DOMQuad>> convertRectFromNode(Node& target, DOMRectReadOnly& rec
 ExceptionOr<Ref<DOMPoint>> convertPointFromNode(Node& target, DOMPointInit&& point, GeometryNode&& from, ConvertCoordinateOptions&& options)
 {
     FloatPoint floatPoint { narrowPrecisionToFloat(point.x), narrowPrecisionToFloat(point.y) };
-    auto converted = convertQuad(target, FloatQuad { floatPoint, floatPoint, floatPoint, floatPoint }, nodeForGeometryNode(from), options);
+    auto converted = convertQuad(Ref { target }, FloatQuad { floatPoint, floatPoint, floatPoint, floatPoint }, nodeForGeometryNode(from), options);
     if (converted.hasException())
         return converted.releaseException();
     auto result = converted.releaseReturnValue().p1();

--- a/Source/WebCore/dom/GeometryUtils.h
+++ b/Source/WebCore/dom/GeometryUtils.h
@@ -1,10 +1,26 @@
 /*
  * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once

--- a/Source/WebCore/dom/GeometryUtils.h
+++ b/Source/WebCore/dom/GeometryUtils.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include "BoxQuadOptions.h"
+#include "ConvertCoordinateOptions.h"
+#include "DOMPointInit.h"
+#include "DOMQuadInit.h"
+#include "ExceptionOr.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class DOMPoint;
+class DOMQuad;
+class DOMRectReadOnly;
+class Node;
+
+namespace GeometryUtils {
+
+ExceptionOr<Vector<Ref<DOMQuad>>> getBoxQuads(Node&, BoxQuadOptions&&);
+ExceptionOr<Ref<DOMQuad>> convertQuadFromNode(Node&, DOMQuadInit&&, GeometryNode&&, ConvertCoordinateOptions&&);
+ExceptionOr<Ref<DOMQuad>> convertRectFromNode(Node&, DOMRectReadOnly&, GeometryNode&&, ConvertCoordinateOptions&&);
+ExceptionOr<Ref<DOMPoint>> convertPointFromNode(Node&, DOMPointInit&&, GeometryNode&&, ConvertCoordinateOptions&&);
+
+} // namespace GeometryUtils
+} // namespace WebCore

--- a/Source/WebCore/dom/GeometryUtils.idl
+++ b/Source/WebCore/dom/GeometryUtils.idl
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ */
+
+// https://drafts.csswg.org/cssom-view/#the-geometryutils-interface
+
+interface mixin GeometryUtils {
+    [RaisesException] sequence<DOMQuad> getBoxQuads(optional BoxQuadOptions options = {});
+    [NewObject, RaisesException] DOMQuad convertQuadFromNode(DOMQuadInit quad, (Text or Element or Document) from, optional ConvertCoordinateOptions options = {});
+    [NewObject, RaisesException] DOMQuad convertRectFromNode(DOMRectReadOnly rect, (Text or Element or Document) from, optional ConvertCoordinateOptions options = {});
+    [NewObject, RaisesException] DOMPoint convertPointFromNode(DOMPointInit point, (Text or Element or Document) from, optional ConvertCoordinateOptions options = {});
+};

--- a/Source/WebCore/dom/GeometryUtils.idl
+++ b/Source/WebCore/dom/GeometryUtils.idl
@@ -1,10 +1,26 @@
 /*
  * Copyright (C) 2026 Jochen Kühner (jochen.kuehner@gmx.de)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 // https://drafts.csswg.org/cssom-view/#the-geometryutils-interface

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -27,6 +27,14 @@
 namespace WebCore {
 
 class RenderText;
+class DOMPoint;
+class DOMQuad;
+class DOMRectReadOnly;
+class Element;
+struct BoxQuadOptions;
+struct ConvertCoordinateOptions;
+struct DOMPointInit;
+struct DOMQuadInit;
 
 class Text : public CharacterData {
     WTF_MAKE_TZONE_ALLOCATED(Text);
@@ -54,6 +62,11 @@ public:
     bool canContainRangeEndPoint() const final { return true; }
 
     RenderText* renderer() const;
+
+    ExceptionOr<Vector<Ref<DOMQuad>>> getBoxQuads(BoxQuadOptions&&);
+    ExceptionOr<Ref<DOMQuad>> convertQuadFromNode(DOMQuadInit&&, Variant<Ref<Text>, Ref<Element>, Ref<Document>>&&, ConvertCoordinateOptions&&);
+    ExceptionOr<Ref<DOMQuad>> convertRectFromNode(DOMRectReadOnly&, Variant<Ref<Text>, Ref<Element>, Ref<Document>>&&, ConvertCoordinateOptions&&);
+    ExceptionOr<Ref<DOMPoint>> convertPointFromNode(DOMPointInit&&, Variant<Ref<Text>, Ref<Element>, Ref<Document>>&&, ConvertCoordinateOptions&&);
 
     void updateRendererAfterContentChange(unsigned offsetOfReplacedData, unsigned lengthOfReplacedData);
 

--- a/Source/WebCore/dom/Text.idl
+++ b/Source/WebCore/dom/Text.idl
@@ -29,3 +29,4 @@
 };
 
 Text includes Slotable;
+Text includes GeometryUtils;


### PR DESCRIPTION
## Summary

- Implement the CSSOM View `GeometryUtils` mixin for `Document`, `Element`, and `Text`.
- Add `getBoxQuads()`, `convertQuadFromNode()`, `convertRectFromNode()`, and `convertPointFromNode()` with support for CSS box selection and relative coordinate spaces.
- Synchronize geometry reads with style, layout, transforms, `content-visibility` subtrees, and same-origin frame boundaries.
- Add the required Web IDL dictionaries and enum, and integrate the generated sources with the CMake, Make, and Xcode builds.
- Update the existing CSSOM View WPT expectations and add lifecycle regression coverage.

## Scope note

The current CSSOM View specification also includes `CSSPseudoElement` in `GeometryNode`. WebKit does not yet expose a `CSSPseudoElement` interface, so this change implements the full API for the geometry node types currently available in WebKit: `Document`, `Element`, and `Text`.

Bug: https://bugs.webkit.org/show_bug.cgi?id=321597

Spec: https://drafts.csswg.org/cssom-view/#the-geometryutils-interface

## Testing

- Release WebCore, WebKit, WebKitTestRunner, DumpRenderTree, LayoutTestHelper, and MiniBrowser builds completed successfully.
- `Tools/Scripts/run-webkit-tests --release --no-build imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-001.html imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-002.html imported/w3c/web-platform-tests/css/cssom-view/cssom-geometryutils-lifecycle.html` — all 3 tests ran as expected.
- `Tools/Scripts/check-webkit-style --git-commit=HEAD` — zero errors.
- `git diff --check` — clean.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad41116cc49ee1e028450a7fa80772cf6b66d400

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190605 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140723 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97458 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43035 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41328 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41007 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1764 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192540 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150059 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54693 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37621 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149782 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44412 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126956 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122118 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53210 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15996 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->