### PR TITLE
[Navigation API] navigation-back-cross-document-preventDefault.html is failing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7120,8 +7120,6 @@ imported/w3c/web-platform-tests/navigation-api/navigate-event/defer/tentative/de
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/opaque-origin.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-forward-opaque-origin.html [ Skip ]
 
-webkit.org/b/300006 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault.html [ Skip ]
-
 # Crashing. rdar://179168475
 imported/w3c/web-platform-tests/navigation-api/navigate-event/dangling-navigate-event-after-bfcache-restore.html [ Skip ]
 

--- a/LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache-expected.txt
+++ b/LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache-expected.txt
@@ -5,6 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 Visting Page 1 for the first time, navigating to page-that-goes-back
 Visiting Page 1 for the second time
+PASS navigateFired is false
 PASS window.navigation.entries().length is 1
 PASS successfullyParsed is true
 

--- a/LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache.html
+++ b/LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache.html
@@ -15,12 +15,16 @@ window.addEventListener('pageshow', function() {
         }, 0);
     } else {
         sessionStorage.removeItem('hasVisited');
+        debug('Visiting Page 1 for the second time');
 
-        window.navigation.addEventListener('navigate', function() {
-            debug('Visiting Page 1 for the second time');
+        window.navigateFired = false;
+        window.navigation.addEventListener('navigate', () => { window.navigateFired = true; });
+
+        setTimeout(() => {
+            shouldBeFalse("navigateFired");
             shouldBeEqualToNumber("window.navigation.entries().length", 1);
             finishJSTest();
-        });
+        }, 0);
     }
 });
 </script>

--- a/LayoutTests/http/tests/navigation-api/in-flight-navigation-aborted-when-entering-bfcache-expected.txt
+++ b/LayoutTests/http/tests/navigation-api/in-flight-navigation-aborted-when-entering-bfcache-expected.txt
@@ -1,0 +1,14 @@
+An intercepted navigation still in flight when its document is navigated away must be aborted rather than carried live into the back/forward cache. The navigation here is started by a cross-origin opener, so no navigate event is fired on the popup and nothing else aborts it.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS transitionBeforeLeaving is true
+Navigating the popup from its cross-origin opener
+PASS restoredFromBackForwardCache is true
+PASS transitionAfterRestore is false
+PASS finishedState is "rejected: AbortError"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/navigation-api/in-flight-navigation-aborted-when-entering-bfcache.html
+++ b/LayoutTests/http/tests/navigation-api/in-flight-navigation-aborted-when-entering-bfcache.html
@@ -1,0 +1,56 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+
+<script>
+description("An intercepted navigation still in flight when its document is navigated away must be aborted rather than carried live into the back/forward cache. The navigation here is started by a cross-origin opener, so no navigate event is fired on the popup and nothing else aborts it.");
+jsTestIsAsync = true;
+
+const POPUP_URL = 'http://localhost:8000/navigation-api/resources/in-flight-navigation-popup.html';
+const GO_BACK_URL = 'http://localhost:8000/navigation-api/resources/page-that-goes-back.html';
+
+if (window.testRunner && testRunner.setCanOpenWindows)
+    testRunner.setCanOpenWindows();
+
+let popup = null;
+let readyCount = 0;
+
+// Globals so that the shouldBe* helpers, which evaluate their argument as a string, can see them.
+window.transitionBeforeLeaving = false;
+window.restoredFromBackForwardCache = false;
+window.transitionAfterRestore = true;
+window.finishedState = '';
+
+window.addEventListener('message', function(event) {
+    const data = event.data;
+
+    if (data.stage === 'ready') {
+        if (++readyCount > 1) {
+            testFailed('The popup was reloaded instead of being restored from the back/forward cache.');
+            finishJSTest();
+            return;
+        }
+
+        window.transitionBeforeLeaving = data.transitionBeforeLeaving;
+        shouldBeTrue("transitionBeforeLeaving");
+
+        debug('Navigating the popup from its cross-origin opener');
+        popup.location = GO_BACK_URL;
+        return;
+    }
+
+    if (data.stage === 'restored') {
+        window.restoredFromBackForwardCache = data.persisted;
+        window.transitionAfterRestore = data.transitionAfterRestore;
+        window.finishedState = data.finished;
+
+        shouldBeTrue("restoredFromBackForwardCache");
+        shouldBeFalse("transitionAfterRestore");
+        shouldBeEqualToString("finishedState", "rejected: AbortError");
+
+        popup.close();
+        finishJSTest();
+    }
+});
+
+popup = window.open(POPUP_URL);
+</script>

--- a/LayoutTests/http/tests/navigation-api/resources/in-flight-navigation-popup.html
+++ b/LayoutTests/http/tests/navigation-api/resources/in-flight-navigation-popup.html
@@ -1,0 +1,44 @@
+<script>
+// Establishes an intercepted same-document navigation that never completes, so this document has a
+// live navigation.transition and an in-flight navigation API method tracker. The opener (which is
+// cross-origin) then navigates this window away, and this page reports its state if it is later
+// restored from the back/forward cache.
+window.inFlightFinishedState = 'pending';
+
+window.addEventListener('pageshow', function(event) {
+    if (!event.persisted) {
+        // Only intercept the fragment navigation below, so the navigation the opener triggers later
+        // is not turned into a same-document one.
+        navigation.addEventListener('navigate', function(navigateEvent) {
+            if (navigateEvent.destination.url.indexOf('#intercepted') === -1)
+                return;
+            navigateEvent.intercept({ handler: () => new Promise(() => { }) });
+        });
+
+        const result = navigation.navigate('#intercepted');
+        result.finished.then(
+            () => window.inFlightFinishedState = 'fulfilled',
+            e => window.inFlightFinishedState = 'rejected: ' + ((e && e.name) || e));
+
+        result.committed.then(() => {
+            opener.postMessage({
+                stage: 'ready',
+                transitionBeforeLeaving: !!navigation.transition
+            }, '*');
+        });
+        return;
+    }
+
+    // The finished promise's rejection reaction is queued while this document is being deactivated,
+    // and cannot run until the document is reactivated and its microtask queue drains, which is after
+    // pageshow. So report on the next task rather than synchronously here.
+    setTimeout(() => {
+        opener.postMessage({
+            stage: 'restored',
+            persisted: event.persisted,
+            transitionAfterRestore: !!navigation.transition,
+            finished: window.inFlightFinishedState
+        }, '*');
+    }, 0);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/defer/tentative/defer-back-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/defer/tentative/defer-back-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL
+PASS
   navigateEvent.deferPageSwap: deferring is not allowed for cross-document traverse
   navigations
- assert_array_equals: lengths differ, expected array ["navigate", "pagehide"] length 2, got ["pagehide"] length 1
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigation.back() cross-document cannot be cancelled with the navigate event assert_true: expected true got false
+PASS navigation.back() cross-document cannot be cancelled with the navigate event
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -628,8 +628,11 @@ void FrameLoader::stopLoading(UnloadEventPolicy unloadEventPolicy)
         DatabaseManager::singleton().stopDatabases(*document, nullptr);
 
         if (document->settings().navigationAPIEnabled() && !m_doNotAbortNavigationAPI && unloadEventPolicy != UnloadEventPolicy::UnloadAndPageHide) {
-            RefPtr window = frame->document()->window();
-            protect(window->navigation())->abortOngoingNavigationIfNeeded();
+            if (RefPtr window = document->window()) {
+                Ref navigation = window->navigation();
+                if (document->backForwardCacheState() == Document::NotInBackForwardCache || navigation->hasInterceptedOngoingNavigateEvent())
+                    navigation->abortOngoingNavigationIfNeeded();
+            }
         }
     }
 
@@ -2569,16 +2572,6 @@ void FrameLoader::commitProvisionalLoad()
         RefPtr page = frame->page();
         cachedPage->restore(*page);
 
-        // Dispatch any pending navigate event after BFCache restoration is complete.
-        if (RefPtr item = std::exchange(m_pendingNavigationAPIItem, nullptr)) {
-            // Ensure we use the restored document context, not the previous one
-            if (m_frame->document() && m_frame->document()->window()) {
-                RefPtr navigation = protect(m_frame->document()->window())->navigation();
-                if (navigation && navigation->frame())
-                    navigation->dispatchTraversalNavigateEvent(*item);
-            }
-        }
-
 #if PLATFORM(IOS_FAMILY)
         page->chrome().setDispatchViewportDataDidChangeSuppressed(false);
 #endif
@@ -4220,25 +4213,18 @@ void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& reque
     bool navigateEventAborted = false;
     bool shouldCloseResult = true;
 
-    if (m_pendingNavigationAPIItem) {
-        // Check if this will be a BFCache load - if so, defer navigate event until after restoration
-        bool willLoadFromBFCache = false;
-        if (RefPtr provisionalItem = history().provisionalItem(); provisionalItem && provisionalItem->isInBackForwardCache())
-            willLoadFromBFCache = true;
-
+    if (RefPtr pendingItem = std::exchange(m_pendingNavigationAPIItem, nullptr)) {
         // Only call shouldClose() early for Navigation API traversals
         shouldCloseResult = shouldClose();
 
-        if (shouldCloseResult && !willLoadFromBFCache) {
-            // For non-BFCache traversals, dispatch navigate event now
-            if (RefPtr window = frame->document()->window()) {
-                if (RefPtr navigation = window->navigation(); navigation->frame()) {
-                    if (navigation->dispatchTraversalNavigateEvent(Ref { *m_pendingNavigationAPIItem }) == Navigation::DispatchResult::Aborted)
+        if (shouldCloseResult) {
+            RefPtr document = frame->document();
+            if (RefPtr window = document ? document->window() : nullptr) {
+                if (Ref navigation = window->navigation(); navigation->frame()) {
+                    if (navigation->dispatchTraversalNavigateEvent(*pendingItem) == Navigation::DispatchResult::Aborted)
                         navigateEventAborted = true;
                 }
             }
-
-            m_pendingNavigationAPIItem = nullptr;
         }
     } else {
         // For non-Navigation API traversals, use original behavior with short-circuit evaluation

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -643,6 +643,9 @@ void LocalDOMWindow::suspendForBackForwardCache()
     SetForScope isSuspendingObservers(m_isSuspendingObservers, true);
     RELEASE_ASSERT(frame());
 
+    if (RefPtr navigation = m_navigation)
+        navigation->discardOngoingNavigationForBackForwardCache();
+
     m_observers.forEach([](auto& observer) {
         Ref { observer }->suspendForBackForwardCache();
     });

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1637,6 +1637,19 @@ void Navigation::informAboutChildNavigableDestruction()
         rejectFinishedPromise(tracker.ptr());
 }
 
+void Navigation::discardOngoingNavigationForBackForwardCache()
+{
+    if (hasInterceptedOngoingNavigateEvent())
+        return;
+
+    m_ongoingNavigateEvent = nullptr;
+    m_focusChangedDuringOngoingNavigation = FocusDidChange::No;
+    m_suppressNormalScrollRestorationDuringOngoingNavigation = false;
+
+    if (RefPtr ongoingAPIMethodTracker = m_methodTrackers.ongoing())
+        m_methodTrackers.unregister(*ongoingAPIMethodTracker);
+}
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-session-history-entries-for-the-navigation-api
 Vector<Ref<HistoryItem>> Navigation::filterHistoryItemsForNavigationAPI(Vector<Ref<HistoryItem>>&& allItems, HistoryItem& currentItem)
 {

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -169,6 +169,7 @@ public:
     void informAboutChildNavigableDestruction();
 
     void abortOngoingNavigationIfNeeded();
+    void discardOngoingNavigationForBackForwardCache();
 
     NavigationHistoryEntry* findEntryByKey(const String&) const;
     bool suppressNormalScrollRestoration() const { return m_suppressNormalScrollRestorationDuringOngoingNavigation; }


### PR DESCRIPTION
#### c2efc73ec496407f393d9b8edb6f8e7fca48241c
<pre>
[Navigation API] navigation-back-cross-document-preventDefault.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=300006">https://bugs.webkit.org/show_bug.cgi?id=300006</a>
<a href="https://rdar.apple.com/161203519">rdar://161203519</a>

Reviewed by Basuke Suzuki.

The very last assert in this test is failing: assert_true(navigate_called);

For a cross-document traversal of the top-level frame, the navigate event must be
fired on the document being navigated away from, right after beforeunload. Currently,
if the document being navigated to is being restored from the BFCache, dispatch is
deferred until after CachedPage::restore(). By then m_frame-&gt;document() is the restored
document, so the event landed on that document&apos;s Navigation object. This means that the
navigate event is (wrongly) never fired on the document that we navigated away from.

We fix this by not deferring the firing of the navigate event:
(1) FrameLoader::continueLoadAfterNavigationPolicy() no longer leaves
    m_pendingNavigationAPIItem set if the item we&apos;re navigating to comes from the BFCache.
    It fires the navigate event.
(2) FrameLoader::commitProvisionalLoad() no longer has to check if a pending item is set
    and fire the navigate event.

After we make this change, the navigate event is correctly fired on the document that
we&apos;re navigating away from. Our test passes and another test defer-back.html is also fixed.

But running the test shows that there is a unhandled AbortError. This is preexisting but
needs to be fixed as well.

According to the spec &quot;For cross-document navigations ... both promises will never settle.&quot;
But FrameLoader::closeURL() (which is called when we navigate away from a document) calls
FrameLoader::stopLoading() with UnloadEventPolicy::UnloadOnly and then stopLoading() calls
abortOngoingNavigationIfNeeded() which rejects the promises (and leads to the AbortError).

To fix this we:
(1) Amend the condition in FrameLoader::stopLoading() not abort the ongoing navigation if
    the document is going into the BFCache.
(2) This leaves a live ongoing navigation on the cached document, and when the document is
    reactivated, the next time a navigate event is fired on it, that stale ongoing navigation
    will be aborted (Navigation::innerDispatchNavigateEvent() calls
    abortOngoingNavigationIfNeeded()). So the AbortError is simply deferred. To fix this,
    we discard this ongoing navigation and related state when caching the document.
(3) A document can be navigated away from and put into the back/forward cache while a
    different, earlier navigation of its own is still in flight — one that called intercept(),
    and is therefore same-document (The new in-flight layout test covers this). Those promises
    should reject rather than hang: that navigation was genuinely pending and can
    never complete now the document is being deactivated. So for this case we abort rather than
    discard, which rejects the tracker&apos;s promises and also rejects and clears
    navigation.transition.

    The abort cannot happen in discardOngoingNavigationForBackForwardCache() because this
    runs from CachedFrame&apos;s constructor inside a ScriptDisallowedScope, and sborting
    dispatches events, which is not allowed. So the abort happens in a later function,
    FrameLoader::stopLoading().

These changes break different-origin-entries-removed-after-bfcache.html because
it was wrongly depending on the navigate event to be fired on the navigated-to
document. So we amend it to not depend on that wrong behavior and also to test
that the navigate event is not fired on the document being navigated to.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache.html:
* LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache-expected.txt:
* LayoutTests/http/tests/navigation-api/in-flight-navigation-aborted-when-entering-bfcache-expected.txt: Added.
* LayoutTests/http/tests/navigation-api/in-flight-navigation-aborted-when-entering-bfcache.html: Added.
* LayoutTests/http/tests/navigation-api/resources/in-flight-navigation-popup.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/defer/tentative/defer-back-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::stopLoading):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy): Deleted.
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::suspendForBackForwardCache):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::discardOngoingNavigationForBackForwardCache):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/319242@main">https://commits.webkit.org/319242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e87c7d8a509b4d20dfede9e7a7346ea56b78d08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145150 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a661de4d-9f67-4fe5-9e6b-3b714c0c7ab3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141066 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64ca3163-c92e-464d-869c-30e152c6c757) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121518 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4fbd8ab0-5a7b-43c8-b44e-a0ffd8ff939b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43403 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41680 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41342 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2201 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192976 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150442 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55126 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150160 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27461 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44755 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127392 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122692 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53643 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16335 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53025 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53262 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53090 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->