### PR TITLE
Only give the offscreen web view access to the browser.runtime API

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm
@@ -35,6 +35,7 @@
 #import "WKNavigationDelegate.h"
 #import "WKUIDelegate.h"
 #import "WKWebViewInternal.h"
+#import "WebExtensionContextProxyMessages.h"
 #import "WebExtensionOffscreenDocumentParameters.h"
 
 namespace WebKit {
@@ -76,6 +77,8 @@ void WebExtensionContext::offscreenCreateDocument(const WebExtensionOffscreenDoc
 
     Ref offscreenPage = *m_offscreenWebView.get()._page;
     Ref offscreenProcess = offscreenPage->siteIsolatedProcess();
+
+    offscreenProcess->send(Messages::WebExtensionContextProxy::SetOffscreenPageIdentifier(offscreenPage->webPageIDInMainFrameProcess()), identifier());
 
     constexpr ASCIILiteral activityName = "Web Extension offscreen document"_s;
     if (protect(offscreenPage->preferences())->siteIsolationEnabled())

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.cpp
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.cpp
@@ -61,6 +61,15 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
     if (extensionContext->isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
+    if (name == "test"_s)
+        return extensionContext->inTestingMode();
+
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    // The offscreen document is not a full extension environment; only runtime and test are reachable from it.
+    if (page && extensionContext->isOffscreenPage(*page))
+        return name == "runtime"_s;
+#endif
+
     if (name == "action"_s)
         return extensionContext->supportsManifestVersion(3) && doesDictionaryExist(extensionContext->manifest(), "action"_s);
 
@@ -110,8 +119,8 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
     if (name == "storage"_s)
         return extensionContext->hasPermission(name) || extensionContext->hasPermission("unlimitedStorage"_s);
 
-    if (name == "test"_s)
-        return extensionContext->inTestingMode();
+    if (name == "dom"_s || name == "extension"_s || name == "i18n"_s || name == "permissions"_s || name == "runtime"_s || name == "tabs"_s || name == "windows"_s)
+        return true;
 
 finish:
     // The rest of the property names marked dynamic in WebExtensionAPINamespace.idl match permission names.

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
@@ -28,6 +28,10 @@
     ReturnsPromiseWhenCallbackIsOmitted,
     UseCPPAPI,
 ] interface WebExtensionAPINamespace {
+    /*
+    * When adding a new always-present API to the top level namespace, make sure that it is dynamic (so it will be omitted
+    * in the offscreen web view context) - and automatically grant it in WebExtensionAPINamespace::isPropertyAllowed.
+    */
 
     [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIAction action;
 
@@ -47,13 +51,13 @@
 
     [Dynamic, Platform=COCOA, Conditional=INSPECTOR_EXTENSIONS] readonly attribute WebExtensionAPIDevTools devtools;
 
-    [Platform=COCOA] readonly attribute WebExtensionAPIDOM dom;
+    [Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIDOM dom;
 
-    [Platform=COCOA] readonly attribute WebExtensionAPIExtension extension;
+    [Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIExtension extension;
 
-    [Platform=COCOA] readonly attribute WebExtensionAPILocalization i18n;
+    [Dynamic, Platform=COCOA] readonly attribute WebExtensionAPILocalization i18n;
 
-    [Platform=COCOA] readonly attribute WebExtensionAPIRuntime runtime;
+    [Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIRuntime runtime;
 
     [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIMenus menus;
 
@@ -63,7 +67,7 @@
 
     [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIAction pageAction;
 
-    [MainWorldOnly, Platform=COCOA] readonly attribute WebExtensionAPIPermissions permissions;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIPermissions permissions;
 
     [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIScripting scripting;
 
@@ -73,9 +77,9 @@
 
     [Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIStorage storage;
 
-    [MainWorldOnly, Platform=COCOA] readonly attribute WebExtensionAPITabs tabs;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPITabs tabs;
 
-    [MainWorldOnly, Platform=COCOA] readonly attribute WebExtensionAPIWindows windows;
+    [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIWindows windows;
 
     [MainWorldOnly, Dynamic, Platform=COCOA] readonly attribute WebExtensionAPIWebNavigation webNavigation;
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -95,6 +95,18 @@ void WebExtensionContextProxy::setBackgroundPage(WebPage& page)
     m_backgroundPage = page;
 }
 
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+void WebExtensionContextProxy::setOffscreenPage(WebPage& page)
+{
+    m_offscreenPage = page;
+}
+
+bool WebExtensionContextProxy::isOffscreenPage(WebPage& page) const
+{
+    return m_offscreenPage.get() == &page;
+}
+#endif
+
 #if ENABLE(INSPECTOR_EXTENSIONS)
 void WebExtensionContextProxy::addInspectorPage(WebPage& page, std::optional<WebExtensionTabIdentifier> tabIdentifier, std::optional<WebExtensionWindowIdentifier> windowIdentifier)
 {
@@ -173,6 +185,14 @@ void WebExtensionContextProxy::setBackgroundPageIdentifier(WebCore::PageIdentifi
     if (RefPtr page = WebProcess::singleton().webPage(pageIdentifier))
         setBackgroundPage(*page);
 }
+
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+void WebExtensionContextProxy::setOffscreenPageIdentifier(WebCore::PageIdentifier pageIdentifier)
+{
+    if (RefPtr page = WebProcess::singleton().webPage(pageIdentifier))
+        setOffscreenPage(*page);
+}
+#endif
 
 void WebExtensionContextProxy::addPopupPageIdentifier(WebCore::PageIdentifier pageIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, std::optional<WebExtensionWindowIdentifier> windowIdentifier)
 {

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -136,6 +136,11 @@ public:
     Vector<Ref<WebPage>> tabPages(std::optional<WebExtensionTabIdentifier> = std::nullopt, std::optional<WebExtensionWindowIdentifier> = std::nullopt) const;
     void addTabPage(WebPage&, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
 
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    void NODELETE setOffscreenPage(WebPage&);
+    bool NODELETE isOffscreenPage(WebPage&) const;
+#endif
+
     void enumerateFramesAndNamespaceObjects(NOESCAPE const Function<void(WebFrame&, WebExtensionAPINamespace&)>&, Ref<WebCore::DOMWrapperWorld>&& = mainWorldSingleton());
     void enumerateFramesAndWebPageNamespaceObjects(NOESCAPE const Function<void(WebFrame&, WebExtensionAPIWebPageNamespace&)>&);
 
@@ -183,6 +188,11 @@ private:
     void setBackgroundPageIdentifier(WebCore::PageIdentifier);
     void addPopupPageIdentifier(WebCore::PageIdentifier, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
     void addTabPageIdentifier(WebCore::PageIdentifier, WebExtensionTabIdentifier, std::optional<WebExtensionWindowIdentifier>);
+
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    // Offscreen
+    void setOffscreenPageIdentifier(WebCore::PageIdentifier);
+#endif
 
     // Menus
     void dispatchMenusClickedEvent(const WebExtensionMenuItemParameters&, bool wasChecked, const WebExtensionMenuItemContextParameters&, const std::optional<WebExtensionTabParameters>&);
@@ -255,6 +265,9 @@ private:
     RefPtr<WebCore::DOMWrapperWorld> m_contentScriptWorld;
     WeakFrameSet m_extensionContentFrames;
     WeakPtr<WebPage> m_backgroundPage;
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    WeakPtr<WebPage> m_offscreenPage;
+#endif
 #if ENABLE(INSPECTOR_EXTENSIONS)
     WeakPageTabWindowMap m_inspectorPageMap;
     WeakPageTabWindowMap m_inspectorBackgroundPageMap;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -63,6 +63,11 @@ messages -> WebExtensionContextProxy {
     AddPopupPageIdentifier(WebCore::PageIdentifier pageID, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier)
     AddTabPageIdentifier(WebCore::PageIdentifier pageID, WebKit::WebExtensionTabIdentifier tabIdentifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier)
 
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    // Offscreen
+    SetOffscreenPageIdentifier(WebCore::PageIdentifier pageID)
+#endif
+
     // Menus
     DispatchMenusClickedEvent(struct WebKit::WebExtensionMenuItemParameters menuItemParameters, bool wasChecked, struct WebKit::WebExtensionMenuItemContextParameters contextParameters, std::optional<WebKit::WebExtensionTabParameters> tabParameters)
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm
@@ -272,6 +272,38 @@ TEST_F(WKWebExtensionAPIOffscreen, SendMessageToDocument)
     }, offscreenConfig);
 }
 
+TEST_F(WKWebExtensionAPIOffscreen, OffscreenDocumentAPIAvailability)
+{
+    auto *script = @[
+        @"browser.test.assertFalse(browser.dom === undefined)",
+        @"browser.test.assertFalse(browser.extension === undefined)",
+        @"browser.test.assertFalse(browser.i18n === undefined)",
+        @"browser.test.assertFalse(browser.runtime === undefined)",
+        @"browser.test.assertFalse(browser.permissions === undefined)",
+        @"browser.test.assertFalse(browser.tabs === undefined)",
+        @"browser.test.assertFalse(browser.windows === undefined)",
+        @"browser.offscreen.createDocument({ url: 'offscreen.html', reasons: ['TESTING'], justification: 'test' })",
+    ];
+
+    auto *offscreenScript = @[
+        @"browser.test.assertFalse(browser.runtime === undefined)",
+
+        @"browser.test.assertTrue(browser.dom === undefined)",
+        @"browser.test.assertTrue(browser.extension === undefined)",
+        @"browser.test.assertTrue(browser.i18n === undefined)",
+        @"browser.test.assertTrue(browser.permissions === undefined)",
+        @"browser.test.assertTrue(browser.tabs === undefined)",
+        @"browser.test.assertTrue(browser.windows === undefined)",
+        @"browser.test.notifyPass()"
+    ];
+
+    Util::loadAndRunExtension(offscreenManifest, @{
+        @"background.js": Util::constructScript(script),
+        @"offscreen.html": @"<script type='module' src='offscreen.js'></script>",
+        @"offscreen.js": Util::constructScript(offscreenScript),
+    }, offscreenConfig);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)


### PR DESCRIPTION
#### 8a263e30ddaddc768bbe708ffe6f4ed7363518c7
<pre>
Only give the offscreen web view access to the browser.runtime API
<a href="https://bugs.webkit.org/show_bug.cgi?id=321615">https://bugs.webkit.org/show_bug.cgi?id=321615</a>
<a href="https://rdar.apple.com/184269255">rdar://184269255</a>

Reviewed by Kiara Rose.

To do this, we needed to make the existing non-dynamic APIs in the top level web extension namespace
dynamic, and always mark them as allowed in the non-offscreen page case.

This PR also tells the Web Process which page is the offscreen page, which we will need to implement
runtime.getContexts (<a href="https://bugs.webkit.org/show_bug.cgi?id=294456).">https://bugs.webkit.org/show_bug.cgi?id=294456).</a>

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm:
(WebKit::WebExtensionContext::offscreenCreateDocument): Tell the web process about the offscreen page identifier.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.cpp:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed): Move up the logic to grant the test API if we are in testing mode,
only grant runtime for offscreen pages, and make sure everything else is always granted.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::setOffscreenPage):
(WebKit::WebExtensionContextProxy::isOffscreenPage const):
(WebKit::WebExtensionContextProxy::setOffscreenPageIdentifier):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIOffscreen.mm:
(TestWebKitAPI::TEST_F(WKWebExtensionAPIOffscreen, OffscreenDocumentAPIAvailability)): Check the availability for all APIs
in the background page, and just runtime in the offscreen page.

Canonical link: <a href="https://commits.webkit.org/319135@main">https://commits.webkit.org/319135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2986daca69bdc838a31428653d5499cebb061675

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144866 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ea0a850-966f-49c6-9a8a-5c3c7da8eda0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140821 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/715e00d3-e146-4993-9e04-3195b383c455) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121273 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/63bdd1ef-9897-413a-81df-46263a03b33d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41120 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1914 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47088 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45700 "Found 1 new test failure: media/video-multiple-concurrent-playback.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192691 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54155 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150189 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40214 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54843 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149909 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44530 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127107 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122313 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53360 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16109 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52742 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->