### PR TITLE
[CSS] Implement user-select (-webkit-user-select as legacy override)

### DIFF
--- a/LayoutTests/editing/selection/user-select-all-prefixed-vs-unprefixed-in-editable-expected.txt
+++ b/LayoutTests/editing/selection/user-select-all-prefixed-vs-unprefixed-in-editable-expected.txt
@@ -1,0 +1,24 @@
+before ATOMIC after
+before ATOxMIC after
+'-webkit-user-select: all' overrides contenteditable, while 'user-select: all' is overridden by it'
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Prefixed: '-webkit-user-select: all' overrides editable behavior - the span is atomic.
+PASS extendIntoSpan("prefixedHost") is "ATOMIC"
+
+Unprefixed: 'user-select: all' is overridden on editable content, so the span is not atomic.
+PASS extendIntoSpan("unprefixedHost") is "A"
+
+Both report isContentEditable.
+PASS document.getElementById("prefixedSpan").isContentEditable is true
+PASS document.getElementById("unprefixedSpan").isContentEditable is true
+
+Inserting text at the caret: only the overridden span accepts the character.
+PASS prefixedAcceptedTyping is false
+PASS unprefixedAcceptedTyping is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/user-select-all-prefixed-vs-unprefixed-in-editable.html
+++ b/LayoutTests/editing/selection/user-select-all-prefixed-vs-unprefixed-in-editable.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="prefixedHost" contenteditable>before <span id="prefixedSpan" style="-webkit-user-select: all; font-weight: bold;">ATOMIC</span> after</div>
+<div id="unprefixedHost" contenteditable>before <span id="unprefixedSpan" style="user-select: all; font-weight: bold;">ATOMIC</span> after</div>
+
+<div id="description"></div>
+<div id="console"></div>
+<script>
+description("'-webkit-user-select: all' overrides contenteditable, while 'user-select: all' is overridden by it'");
+
+var prefixedAcceptedTyping;
+var unprefixedAcceptedTyping;
+
+// Places the caret immediately before the span, then extends forward by one character:
+function extendIntoSpan(hostId)
+{
+    const leadingText = document.getElementById(hostId).firstChild;
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.setPosition(leadingText, leadingText.length);
+    selection.modify("extend", "forward", "character");
+    const result = selection.toString();
+    selection.removeAllRanges();
+    return result;
+}
+
+// Places the caret inside the span, then types a character there:
+function typedTextLandsInSpan(hostId, spanId)
+{
+    document.getElementById(hostId).focus();
+
+    const span = document.getElementById(spanId);
+    getSelection().setPosition(span.firstChild, 3);
+    document.execCommand("insertText", false, "x");
+    return span.textContent === 'ATOxMIC';
+}
+
+debug("");
+debug("Prefixed: '-webkit-user-select: all' overrides editable behavior - the span is atomic.");
+shouldBeEqualToString('extendIntoSpan("prefixedHost")', "ATOMIC");
+
+debug("");
+debug("Unprefixed: 'user-select: all' is overridden on editable content, so the span is not atomic.");
+shouldBeEqualToString('extendIntoSpan("unprefixedHost")', "A");
+
+debug("");
+debug("Both report isContentEditable.");
+shouldBeTrue('document.getElementById("prefixedSpan").isContentEditable');
+shouldBeTrue('document.getElementById("unprefixedSpan").isContentEditable');
+
+debug("");
+debug("Inserting text at the caret: only the overridden span accepts the character.");
+prefixedAcceptedTyping = typedTextLandsInSpan("prefixedHost", "prefixedSpan");
+unprefixedAcceptedTyping = typedTextLandsInSpan("unprefixedHost", "unprefixedSpan");
+shouldBeFalse('prefixedAcceptedTyping');
+shouldBeTrue('unprefixedAcceptedTyping');
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/user-select-auto-in-modal-dialog-inside-inert-expected.txt
+++ b/LayoutTests/editing/selection/user-select-auto-in-modal-dialog-inside-inert-expected.txt
@@ -1,0 +1,7 @@
+
+PASS 'user-select: auto' inside a modal dialog is selectable
+PASS A modal dialog marks outside nodes as inert, making them unselectable
+PASS 'user-select: auto' inside a modal dialog stays selectable when an ancestor of the dialog is inert
+PASS 'user-select: text' in an inert subtree is not selectable
+PASS 'user-select: auto' inside an inert modal dialog is not selectable
+wrapper explicitText

--- a/LayoutTests/editing/selection/user-select-auto-in-modal-dialog-inside-inert.html
+++ b/LayoutTests/editing/selection/user-select-auto-in-modal-dialog-inside-inert.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>user-select: auto resolves against the ancestor's used value without considering inertness</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#content-selection">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#inert">
+<meta name="assert" content="User-select: auto should not inherit None from an inert ancestor.">
+<div id="log"></div>
+<div id="wrapper">
+  wrapper
+  <span id="explicitText" style="user-select: text">explicitText</span>
+  <dialog id="dialog">
+    dialog
+    <span id="autoChild" style="user-select: auto">autoChild</span>
+  </dialog>
+</div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+setup(() => {
+  dialog.showModal();
+  add_completion_callback(() => {
+    dialog.close();
+    getSelection().removeAllRanges();
+  });
+});
+
+function selectedText() {
+  const selection = getSelection();
+  selection.selectAllChildren(document.documentElement);
+  return selection.toString();
+}
+
+test(function() {
+  assert_true(selectedText().includes("autoChild"));
+}, "'user-select: auto' inside a modal dialog is selectable");
+
+test(function() {
+  assert_false(selectedText().includes("wrapper"));
+}, "A modal dialog marks outside nodes as inert, making them unselectable");
+
+test(function() {
+  wrapper.inert = true;
+  this.add_cleanup(() => { wrapper.inert = false; });
+  assert_true(selectedText().includes("autoChild"));
+}, "'user-select: auto' inside a modal dialog stays selectable when an ancestor of the dialog is inert");
+
+test(function() {
+  wrapper.inert = true;
+  this.add_cleanup(() => { wrapper.inert = false; });
+  assert_false(selectedText().includes("explicitText"));
+}, "'user-select: text' in an inert subtree is not selectable");
+
+test(function() {
+  dialog.inert = true;
+  this.add_cleanup(() => { dialog.inert = false; });
+  assert_false(selectedText().includes("autoChild"));
+}, "'user-select: auto' inside an inert modal dialog is not selectable");
+</script>

--- a/LayoutTests/editing/selection/user-select-in-text-control-expected.txt
+++ b/LayoutTests/editing/selection/user-select-in-text-control-expected.txt
@@ -1,0 +1,47 @@
+
+Verifies the used user-select value for the inner text element of a text control.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The inner text element is editable in a mutable control and read-only in a read-only one.
+PASS innerTextElementContentEditableValue("mutable") is "plaintext-only"
+PASS innerTextElementContentEditableValue("textarea") is "plaintext-only"
+PASS innerTextElementContentEditableValue("readOnly") is "false"
+PASS innerTextElementContentEditableValue("textareaReadOnly") is "false"
+
+By default, a control's value is selectable.
+PASS selectTextIn("mutable") is "mutable"
+PASS selectTextIn("readOnly") is "readOnly"
+PASS selectTextIn("textarea") is "textarea"
+PASS selectTextIn("textareaReadOnly") is "textareaReadOnly"
+
+'none' makes it unselectable, but it is overridden if text is editable
+PASS selectTextIn("prefixedNone") is "prefixedNone"
+PASS selectTextIn("unprefixedNone") is "unprefixedNone"
+PASS selectTextIn("textareaPrefixedNone") is "textareaPrefixedNone"
+PASS selectTextIn("textareaUnprefixedNone") is "textareaUnprefixedNone"
+PASS selectTextIn("readOnlyPrefixedNone") is ""
+PASS selectTextIn("readOnlyUnprefixedNone") is ""
+PASS selectTextIn("textareaReadOnlyPrefixedNone") is ""
+PASS selectTextIn("textareaReadOnlyUnprefixedNone") is ""
+
+By default, a control's value is not atomically selectable (all).
+PASS extendOneCharacterIn("mutable") is "m"
+PASS extendOneCharacterIn("readOnly") is "r"
+PASS extendOneCharacterIn("textarea") is "t"
+PASS extendOneCharacterIn("textareaReadOnly") is "t"
+
+'all' is overridden if editable and unprefixed
+PASS extendOneCharacterIn("prefixedAll") is "prefixedAll"
+PASS extendOneCharacterIn("unprefixedAll") is "u"
+PASS extendOneCharacterIn("textareaPrefixedAll") is "textareaPrefixedAll"
+PASS extendOneCharacterIn("textareaUnprefixedAll") is "t"
+PASS extendOneCharacterIn("readOnlyPrefixedAll") is "readOnlyPrefixedAll"
+PASS extendOneCharacterIn("readOnlyUnprefixedAll") is "readOnlyUnprefixedAll"
+PASS extendOneCharacterIn("textareaReadOnlyPrefixedAll") is "textareaReadOnlyPrefixedAll"
+PASS extendOneCharacterIn("textareaReadOnlyUnprefixedAll") is "textareaReadOnlyUnprefixedAll"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/user-select-in-text-control.html
+++ b/LayoutTests/editing/selection/user-select-in-text-control.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- A text control's value is rendered by shadow dom elements that do not go through regular
+     style cascade/adjusting. This can cause problems for used user-select, so its behavior
+     is tested independently here. -->
+
+<input id="mutable" value="mutable">
+<input id="readOnly" readonly value="readOnly">
+<textarea id="textarea">textarea</textarea>
+<textarea id="textareaReadOnly" readonly>textareaReadOnly</textarea>
+
+<input id="prefixedNone" value="prefixedNone" style="-webkit-user-select: none">
+<input id="unprefixedNone" value="unprefixedNone" style="user-select: none">
+<textarea id="textareaPrefixedNone" style="-webkit-user-select: none">textareaPrefixedNone</textarea>
+<textarea id="textareaUnprefixedNone" style="user-select: none">textareaUnprefixedNone</textarea>
+
+<input id="readOnlyPrefixedNone" readonly value="readOnlyPrefixedNone" style="-webkit-user-select: none">
+<input id="readOnlyUnprefixedNone" readonly value="readOnlyUnprefixedNone" style="user-select: none">
+<textarea id="textareaReadOnlyPrefixedNone" readonly style="-webkit-user-select: none">textareaReadOnlyPrefixedNone</textarea>
+<textarea id="textareaReadOnlyUnprefixedNone" readonly style="user-select: none">textareaReadOnlyUnprefixedNone</textarea>
+
+<input id="prefixedAll" value="prefixedAll" style="-webkit-user-select: all">
+<input id="unprefixedAll" value="unprefixedAll" style="user-select: all">
+<textarea id="textareaPrefixedAll" style="-webkit-user-select: all">textareaPrefixedAll</textarea>
+<textarea id="textareaUnprefixedAll" style="user-select: all">textareaUnprefixedAll</textarea>
+
+<input id="readOnlyPrefixedAll" readonly value="readOnlyPrefixedAll" style="-webkit-user-select: all">
+<input id="readOnlyUnprefixedAll" readonly value="readOnlyUnprefixedAll" style="user-select: all">
+<textarea id="textareaReadOnlyPrefixedAll" readonly style="-webkit-user-select: all">textareaReadOnlyPrefixedAll</textarea>
+<textarea id="textareaReadOnlyUnprefixedAll" readonly style="user-select: all">textareaReadOnlyUnprefixedAll</textarea>
+
+<div id="description"></div>
+<div id="console"></div>
+<script>
+description("Verifies the used user-select value for the inner text element of a text control.");
+
+function innerTextElementContentEditableValue(id)
+{
+    return internals.shadowRoot(document.getElementById(id))
+      .querySelector("div[contenteditable]")
+      .getAttribute("contenteditable");
+}
+
+function selectTextIn(id)
+{
+    const innerText = internals.shadowRoot(document.getElementById(id)).querySelector("div[contenteditable]").firstChild;
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.setBaseAndExtent(innerText, 0, innerText, innerText.length);
+    return selection.toString();
+}
+
+function extendOneCharacterIn(id)
+{
+    const innerText = internals.shadowRoot(document.getElementById(id)).querySelector("div[contenteditable]").firstChild;
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.setPosition(innerText, 0);
+    selection.modify("extend", "forward", "character");
+    return selection.toString();
+}
+
+debug("");
+debug("The inner text element is editable in a mutable control and read-only in a read-only one.");
+shouldBeEqualToString('innerTextElementContentEditableValue("mutable")', "plaintext-only");
+shouldBeEqualToString('innerTextElementContentEditableValue("textarea")', "plaintext-only");
+shouldBeEqualToString('innerTextElementContentEditableValue("readOnly")', "false");
+shouldBeEqualToString('innerTextElementContentEditableValue("textareaReadOnly")', "false");
+
+debug("");
+debug("By default, a control's value is selectable.");
+shouldBeEqualToString('selectTextIn("mutable")', "mutable");
+shouldBeEqualToString('selectTextIn("readOnly")', "readOnly");
+shouldBeEqualToString('selectTextIn("textarea")', "textarea");
+shouldBeEqualToString('selectTextIn("textareaReadOnly")', "textareaReadOnly");
+
+debug("");
+debug("'none' makes it unselectable, but it is overridden if text is editable");
+shouldBeEqualToString('selectTextIn("prefixedNone")', "prefixedNone");
+shouldBeEqualToString('selectTextIn("unprefixedNone")', "unprefixedNone");
+shouldBeEqualToString('selectTextIn("textareaPrefixedNone")', "textareaPrefixedNone");
+shouldBeEqualToString('selectTextIn("textareaUnprefixedNone")', "textareaUnprefixedNone");
+shouldBeEqualToString('selectTextIn("readOnlyPrefixedNone")', "");
+shouldBeEqualToString('selectTextIn("readOnlyUnprefixedNone")', "");
+shouldBeEqualToString('selectTextIn("textareaReadOnlyPrefixedNone")', "");
+shouldBeEqualToString('selectTextIn("textareaReadOnlyUnprefixedNone")', "");
+
+debug("");
+debug("By default, a control's value is not atomically selectable (all).");
+shouldBeEqualToString('extendOneCharacterIn("mutable")', 'm');
+shouldBeEqualToString('extendOneCharacterIn("readOnly")', 'r');
+shouldBeEqualToString('extendOneCharacterIn("textarea")', 't');
+shouldBeEqualToString('extendOneCharacterIn("textareaReadOnly")', 't');
+
+debug("");
+debug("'all' is overridden if editable and unprefixed");
+shouldBeEqualToString('extendOneCharacterIn("prefixedAll")', "prefixedAll");
+shouldBeEqualToString('extendOneCharacterIn("unprefixedAll")', "u");
+shouldBeEqualToString('extendOneCharacterIn("textareaPrefixedAll")', "textareaPrefixedAll");
+shouldBeEqualToString('extendOneCharacterIn("textareaUnprefixedAll")', "t");
+shouldBeEqualToString('extendOneCharacterIn("readOnlyPrefixedAll")', "readOnlyPrefixedAll");
+shouldBeEqualToString('extendOneCharacterIn("readOnlyUnprefixedAll")', "readOnlyUnprefixedAll");
+shouldBeEqualToString('extendOneCharacterIn("textareaReadOnlyPrefixedAll")', "textareaReadOnlyPrefixedAll");
+shouldBeEqualToString('extendOneCharacterIn("textareaReadOnlyUnprefixedAll")', "textareaReadOnlyUnprefixedAll");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/user-select-in-ua-stylesheet-expected.txt
+++ b/LayoutTests/editing/selection/user-select-in-ua-stylesheet-expected.txt
@@ -1,0 +1,18 @@
+
+An author's user-select: none should override -webkit-user-select set on the UA's stylesheet.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+A read-only control is selectable by default.
+PASS selectValueOfControl("selectable") is "selectable value"
+
+Setting either spelling of 'user-select: none' on the control makes its value unselectable.
+PASS selectValueOfControl("unprefixedNone") is ""
+PASS selectValueOfControl("prefixedNone") is ""
+PASS selectValueOfControl("textareaUnprefixedNone") is ""
+PASS selectValueOfControl("textareaPrefixedNone") is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/user-select-in-ua-stylesheet.html
+++ b/LayoutTests/editing/selection/user-select-in-ua-stylesheet.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="selectable" readonly value="selectable value">
+<input id="unprefixedNone" readonly value="unprefixed value" style="user-select: none">
+<input id="prefixedNone" readonly value="prefixed value" style="-webkit-user-select: none">
+<textarea id="textareaUnprefixedNone" readonly style="user-select: none">unprefixed textarea</textarea>
+<textarea id="textareaPrefixedNone" readonly style="-webkit-user-select: none">prefixed textarea</textarea>
+
+<div id="description"></div>
+<div id="console"></div>
+<script>
+description("An author's user-select: none should override -webkit-user-select set on the UA's stylesheet.");
+
+// Selects a control's whole value through the document selection and returns the text that ended up
+// selected. The value lives in a text node inside the control's user agent shadow tree, so internals
+// is needed to reach it. Unselectable endpoints do not survive canonicalization, and unselectable
+// content is skipped when the selection is stringified, so 'none' yields the empty string. Each
+// control has a distinct value so that a canonicalized endpoint landing outside cannot pass.
+function selectValueOfControl(id)
+{
+    const innerText = internals.shadowRoot(document.getElementById(id)).querySelector("div[contenteditable]").firstChild;
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.setBaseAndExtent(innerText, 0, innerText, innerText.length);
+    const result = selection.toString();
+    selection.removeAllRanges();
+    return result;
+}
+
+debug("");
+debug("A read-only control is selectable by default.");
+shouldBeEqualToString('selectValueOfControl("selectable")', "selectable value");
+
+debug("");
+debug("Setting either spelling of 'user-select: none' on the control makes its value unselectable.");
+shouldBeEqualToString('selectValueOfControl("unprefixedNone")', "");
+shouldBeEqualToString('selectValueOfControl("prefixedNone")', "");
+shouldBeEqualToString('selectValueOfControl("textareaUnprefixedNone")', "");
+shouldBeEqualToString('selectValueOfControl("textareaPrefixedNone")', "");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section-expected.txt
+++ b/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section-expected.txt
@@ -4,9 +4,14 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS !!document.querySelector('.placard') became true
-PASS window.getComputedStyle(document.querySelector('.title')).webkitUserSelect is "none"
+PASS selectedText.includes("text selection is turned off") is true
+PASS document.querySelector('.title').textContent is "AirPlay"
+PASS document.querySelector('.title').getClientRects().length > 0 is true
+PASS selectedText.includes("AirPlay") is false
 PASS window.getComputedStyle(document.querySelector('.title')).cursor is "default"
-PASS window.getComputedStyle(document.querySelector('.description')).webkitUserSelect is "none"
+PASS document.querySelector('.description').textContent is "This video is playing on the TV."
+PASS document.querySelector('.description').getClientRects().length > 0 is true
+PASS selectedText.includes("This video is playing on the TV.") is false
 PASS window.getComputedStyle(document.querySelector('.description')).cursor is "default"
 
 PASS successfullyParsed is true

--- a/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section.html
+++ b/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section.html
@@ -13,9 +13,18 @@ mediaControls.placard = mediaControls.airplayPlacard;
 document.body.appendChild(mediaControls.element);
 
 shouldBecomeEqual("!!document.querySelector('.placard')", "true", () => {
-    shouldBeEqualToString("window.getComputedStyle(document.querySelector('.title')).webkitUserSelect", "none");
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.selectAllChildren(document.body);
+    window.selectedText = selection.toString();
+    shouldBeTrue('selectedText.includes("text selection is turned off")');
+    shouldBeEqualToString("document.querySelector('.title').textContent", "AirPlay");
+    shouldBeTrue("document.querySelector('.title').getClientRects().length > 0");
+    shouldBeFalse('selectedText.includes("AirPlay")');
     shouldBeEqualToString("window.getComputedStyle(document.querySelector('.title')).cursor", "default");
-    shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).webkitUserSelect", "none");
+    shouldBeEqualToString("document.querySelector('.description').textContent", "This video is playing on the TV.");
+    shouldBeTrue("document.querySelector('.description').getClientRects().length > 0");
+    shouldBeFalse('selectedText.includes("This video is playing on the TV.")');
     shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).cursor", "default");
 
     mediaControls.element.remove();

--- a/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section-expected.txt
+++ b/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section-expected.txt
@@ -3,7 +3,10 @@ Testing that text selection is turned off for PiPPlacard.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS window.getComputedStyle(document.querySelector('.description')).webkitUserSelect is "none"
+PASS selectedText.includes("text selection is turned off") is true
+PASS document.querySelector('.description').textContent is "This video is playing in picture in picture."
+PASS document.querySelector('.description').getClientRects().length > 0 is true
+PASS selectedText.includes("This video is playing in picture in picture.") is false
 PASS window.getComputedStyle(document.querySelector('.description')).cursor is "default"
 
 PASS successfullyParsed is true

--- a/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section.html
+++ b/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section.html
@@ -14,7 +14,14 @@ document.body.appendChild(mediaControls.element);
 
 scheduler.frameDidFire = function()
 {
-    shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).webkitUserSelect", "none");
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.selectAllChildren(document.body);
+    window.selectedText = selection.toString();
+    shouldBeTrue('selectedText.includes("text selection is turned off")');
+    shouldBeEqualToString("document.querySelector('.description').textContent", "This video is playing in picture in picture.");
+    shouldBeTrue("document.querySelector('.description').getClientRects().length > 0");
+    shouldBeFalse('selectedText.includes("This video is playing in picture in picture.")');
     shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).cursor", "default");
 
     mediaControls.element.remove();

--- a/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection-expected.txt
+++ b/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection-expected.txt
@@ -3,7 +3,10 @@ Testing that text selection is turned off for StatusLabel.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS window.getComputedStyle(mediaControls.statusLabel.element).webkitUserSelect is "none"
+PASS selectedText.includes("text selection is turned off") is true
+PASS mediaControls.statusLabel.element.textContent is "Hello"
+PASS mediaControls.statusLabel.element.getClientRects().length > 0 is true
+PASS selectedText.includes("Hello") is false
 PASS window.getComputedStyle(mediaControls.statusLabel.element).cursor is "default"
 
 PASS successfullyParsed is true

--- a/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection.html
+++ b/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection.html
@@ -16,7 +16,14 @@ document.body.appendChild(mediaControls.element);
 
 scheduler.frameDidFire = function()
 {
-    shouldBeEqualToString("window.getComputedStyle(mediaControls.statusLabel.element).webkitUserSelect", "none");
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.selectAllChildren(document.body);
+    window.selectedText = selection.toString();
+    shouldBeTrue('selectedText.includes("text selection is turned off")');
+    shouldBeEqualToString("mediaControls.statusLabel.element.textContent", "Hello");
+    shouldBeTrue("mediaControls.statusLabel.element.getClientRects().length > 0");
+    shouldBeFalse('selectedText.includes("Hello")');
     shouldBeEqualToString("window.getComputedStyle(mediaControls.statusLabel.element).cursor", "default");
     mediaControls.element.remove();
     debug("");

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12541,14 +12541,14 @@
                 "all"
             ],
             "codegen-properties": {
-                "computed-style-has-explicitly-set-policy": "value-only",
+                "computed-style-has-explicitly-set-policy": "all-author-origin",
                 "computed-style-has-explicitly-set-storage-path": ["m_inheritedRareData"],
                 "computed-style-name-for-methods": "WebkitUserSelect",
                 "computed-style-storage-path": ["m_inheritedRareData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "UserSelect",
                 "parser-grammar": "<<values>>",
-                "comment": "Not an alias of 'user-select': this property is inherited, it overrides 'user-select' whenever it has been specified (hence the has-explicitly-set flag)."
+                "comment": "Not an alias of 'user-select': this property is inherited and, when present, overrides 'user-select' for the entire subtree (see the has-explicitly-set flag)."
             },
             "status": "non-standard"
         },

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -423,6 +423,7 @@ input {
 #endif
     -webkit-rtl-ordering: logical;
     -webkit-user-select: text;
+    user-select: text;
     cursor: auto;
 }
 
@@ -592,6 +593,7 @@ input::-webkit-inner-spin-button {
     height: 1.5em;
     flex: none;
     -webkit-user-select: none;
+    user-select: none;
 }
 
 input::-webkit-strong-password-auto-fill-button {
@@ -599,6 +601,7 @@ input::-webkit-strong-password-auto-fill-button {
     font-family: -apple-system !important;
     -webkit-text-security: none !important;
     -webkit-user-select: none !important;
+    user-select: none !important;
     pointer-events: none !important;
     text-align: right !important;
     color: rgba(0, 0, 0, 0.8) !important;
@@ -623,6 +626,7 @@ input::-webkit-credentials-auto-fill-button {
 #endif
     flex: none;
     -webkit-user-select: none;
+    user-select: none;
 }
 
 input::-webkit-credentials-auto-fill-button:hover {
@@ -650,6 +654,7 @@ input::-webkit-contacts-auto-fill-button {
     background-color: black;
     flex: none;
     -webkit-user-select: none;
+    user-select: none;
 }
 
 input::-webkit-contacts-auto-fill-button:hover {
@@ -669,6 +674,7 @@ input::-webkit-credit-card-auto-fill-button {
     background-color: black;
     flex: none;
     -webkit-user-select: none;
+    user-select: none;
 }
 
 input::-webkit-credit-card-auto-fill-button:hover {
@@ -686,6 +692,7 @@ input::-internal-loading-auto-fill-button {
     margin-inline: 3px 2px;
     flex: none;
     -webkit-user-select: none;
+    user-select: none;
 }
 
 input::-webkit-caps-lock-indicator {
@@ -694,6 +701,7 @@ input::-webkit-caps-lock-indicator {
     align-self: stretch;
     flex: none;
     -webkit-user-select: none;
+    user-select: none;
 }
 
 input::-webkit-list-button {
@@ -704,6 +712,7 @@ input::-webkit-list-button {
     align-self: stretch;
     flex: none;
     -webkit-user-select: none;
+    user-select: none;
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     /* Make it easier to hit the button on iOS */
     padding: 7px;
@@ -721,6 +730,7 @@ textarea {
     border: 1px solid;
     -webkit-rtl-ordering: logical;
     -webkit-user-select: text;
+    user-select: text;
     padding: 2px;
 #else
     -webkit-nbsp-mode: space;
@@ -777,6 +787,7 @@ input:-webkit-autofill-and-obscured {
 
 input:-webkit-autofill-strong-password {
     -webkit-user-select: none !important;
+    user-select: none !important;
 }
 
 input:-webkit-autofill-strong-password, input:-webkit-autofill-strong-password-viewable {

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -53,6 +53,7 @@ static void NODELETE applyUASheetBehaviorsToContext(CSSParserContext& context)
     context.cssTextTransformMathAutoEnabled = true;
     context.popoverAttributeEnabled = true;
     context.propertySettings.cssInputSecurityEnabled = true;
+    context.propertySettings.cssUserSelectEnabled = true;
     context.propertySettings.supportHDRDisplayEnabled = true;
     context.propertySettings.cssFieldSizingEnabled = true;
     context.cssMathDepthEnabled = true;

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -858,9 +858,9 @@ static Node::Editability NODELETE computeEditabilityFromComputedStyle(const Styl
     // ContainerNode::setFocus() calls invalidateStyleForSubtree(), so the assertion
     // would fire in the middle of Document::setFocusedElement().
 
-    // Elements with user-select: all style are considered atomic
+    // Elements with -webkit-user-select: all are considered atomic
     // therefore non editable.
-    if (treatment == Node::UserSelectAllTreatment::NotEditable && style.usedUserSelect() == UserSelect::All)
+    if (treatment == Node::UserSelectAllTreatment::NotEditable && style.usedUserSelect() == UserSelect::All && style.hasExplicitlySetWebkitUserSelect())
         return Node::Editability::ReadOnly;
 
     if (pageIsEditable == PageIsEditable::Yes)

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -59,6 +59,7 @@
 #include "RenderTheme.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
+#include "StyleAdjuster.h"
 #include "StyleComputedStyle+SettersInlines.h"
 #include "StyleKeyword+Mappings.h"
 #include "Text.h"
@@ -959,6 +960,10 @@ void HTMLTextFormControlElement::adjustInnerTextStyle(const Style::ComputedStyle
                 textBlockStyle.setUserModify(fromCSSValueID<UserModify>(*value));
         }
     }
+
+    // usedUserSelect needs ajusting and the adjuster won't run later because this style was not produced by the cascade:
+    Style::Adjuster adjuster(document(), parentStyle, nullptr, nullptr);
+    adjuster.adjustUsedUserSelect(textBlockStyle);
 
     if (parentStyle.fieldSizing() == FieldSizing::Content)
         textBlockStyle.setLogicalMinWidth(Style::MinimumSize::Fixed { static_cast<float>(caretWidth()) });

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -49,6 +49,7 @@
 #include "ScriptController.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
+#include "StyleAdjuster.h"
 #include "StyleComputedStyle+SettersInlines.h"
 #include "StyleLengthResolution.h"
 #include "StyleResolver.h"
@@ -132,6 +133,10 @@ std::optional<Style::UnadjustedStyle> TextControlInnerElement::resolveCustomStyl
     newStyle->setDirection(TextDirection::LTR);
     // We don't want the shadow DOM to be editable, so we set this block to read-only in case the input itself is editable.
     newStyle->setUserModify(UserModify::ReadOnly);
+
+    // usedUserSelect needs ajusting and the adjuster won't run later because this style was not produced by the cascade:
+    Style::Adjuster adjuster(document(), *shadowHostStyle, nullptr, nullptr);
+    adjuster.adjustUsedUserSelect(*newStyle);
 
     if (isStrongPasswordTextField(shadowHost())) {
         newStyle->setFlexShrink(0);

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -638,15 +638,8 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
 #if ENABLE(IMAGE_ANALYSIS)
         // Don't allow selecting individual glyphs on text recognized inside an image:
         if (m_element->isInUserAgentShadowTree() && m_element->userAgentPart() == UserAgentParts::internalImageOverlayText()) {
-            switch (style.webkitUserSelect()) {
-            case UserSelect::All:
-            case UserSelect::None:
-                break;
-            case UserSelect::Auto:
-            case UserSelect::Text:
-                style.setWebkitUserSelect(UserSelect::All);
-                break;
-            }
+            style.setWebkitUserSelect(style.webkitUserSelect() == UserSelect::None ? UserSelect::None : UserSelect::All);
+            style.setUserSelect(style.userSelect() == UserSelect::None ? UserSelect::None : UserSelect::All);
         }
 #endif
 
@@ -826,6 +819,38 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
 #endif
 
     adjustForSiteSpecificQuirks(style);
+
+    adjustUsedUserSelect(style);
+}
+
+void Adjuster::adjustUsedUserSelect(Style::ComputedStyle& style) const
+{
+    // The hasExplicitlySetWebkitUserSelect flag is inherited along with -webkit-user-select, so legacy behavior propagates to children:
+    if (!m_document->settings().cssUserSelectEnabled() || style.hasExplicitlySetWebkitUserSelect()) {
+        auto value = style.webkitUserSelect();
+
+        // Legacy behavior: on editable, non-draggable content, we override None to Text
+        if (style.userModify() != UserModify::ReadOnly && style.userDrag() != UserDrag::Element && value == UserSelect::None)
+            value = UserSelect::Text;
+
+        // Legacy behavior: Auto implies we have not inherited from a parent with
+        // All / None, so it is handled as Text.
+        if (value == UserSelect::Auto)
+            value = UserSelect::Text;
+
+        style.setUsedUserSelect(value);
+        return;
+    }
+
+    auto value = style.userSelect();
+    if (value == UserSelect::Auto)
+        value = m_parentStyle.usedUserSelectIgnoringEffectivelyInert();
+
+    // FIXME: should be overridden to UserSelect::Contain (already behaves as such)
+    if (style.userModify() != UserModify::ReadOnly)
+        value = UserSelect::Text;
+
+    style.setUsedUserSelect(value);
 }
 
 static bool NODELETE hasEffectiveDisplayNoneForDisplayContents(const Element& element)
@@ -1089,8 +1114,10 @@ void Adjuster::adjustForSiteSpecificQuirks(Style::ComputedStyle& style) const
 
     if (documentQuirks.needsPrimeVideoUserSelectNoneQuirk()) {
         static MainThreadNeverDestroyed<const AtomString> className("webPlayerSDKUiContainer"_s);
-        if (m_element->hasClassName(className))
+        if (m_element->hasClassName(className)) {
+            style.setUserSelect(UserSelect::None);
             style.setWebkitUserSelect(UserSelect::None);
+        }
     }
 
     if (auto tikTokOverflowingContentQuery = documentQuirks.needsTikTokOverflowingContentQuirk(protect(*m_element), m_parentStyle)) {

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -53,6 +53,7 @@ public:
     static void adjustFromBuilder(Style::ComputedStyle&);
     void adjust(Style::ComputedStyle&) const;
     void adjustAnimatedStyle(Style::ComputedStyle&, OptionSet<AnimationImpact>) const;
+    void adjustUsedUserSelect(Style::ComputedStyle&) const;
 
     static void adjustVisibilityForPseudoElement(Style::ComputedStyle&, const Element& host);
     static void NODELETE adjustFirstLetterStyle(Style::ComputedStyle&);

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -801,6 +801,7 @@ public:
         return a.effectiveInert != b.effectiveInert
             || a.userModify != b.userModify
             || a.webkitUserSelect != b.webkitUserSelect
+            || a.usedUserSelect != b.usedUserSelect
             || a.appleColorFilter != b.appleColorFilter
             || a.imageRendering != b.imageRendering
             || a.accentColor != b.accentColor

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -528,11 +528,7 @@ UserSelect ComputedStyle::usedUserSelect() const
     if (effectiveInert())
         return UserSelect::None;
 
-    auto value = webkitUserSelect();
-    if (userModify() != UserModify::ReadOnly && userDrag() != UserDrag::Element)
-        return value == UserSelect::None ? UserSelect::Text : value;
-
-    return value;
+    return static_cast<UserSelect>(m_inheritedRareData->usedUserSelect);
 }
 
 WebCore::Color ComputedStyle::usedScrollbarThumbColor() const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -249,6 +249,11 @@ inline ContentVisibility ComputedStyleBase::usedContentVisibility() const
     return static_cast<ContentVisibility>(m_inheritedRareData->usedContentVisibility);
 }
 
+inline UserSelect ComputedStyleBase::usedUserSelectIgnoringEffectivelyInert() const
+{
+    return static_cast<UserSelect>(m_inheritedRareData->usedUserSelect);
+}
+
 inline TouchAction ComputedStyleBase::usedTouchAction() const
 {
     return m_inheritedRareData->usedTouchAction;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -199,6 +199,11 @@ inline void ComputedStyleBase::setUsedAppearance(StyleAppearance a)
     SET_NESTED(m_nonInheritedData, miscData, usedAppearance, static_cast<unsigned>(a));
 }
 
+inline void ComputedStyleBase::setUsedUserSelect(UserSelect userSelect)
+{
+    SET(m_inheritedRareData, usedUserSelect, static_cast<unsigned>(userSelect));
+}
+
 inline void ComputedStyleBase::setUsedContentVisibility(ContentVisibility usedContentVisibility)
 {
     SET(m_inheritedRareData, usedContentVisibility, static_cast<unsigned>(usedContentVisibility));

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -558,6 +558,9 @@ public:
     inline StyleAppearance usedAppearance() const;
     inline void setUsedAppearance(StyleAppearance);
 
+    inline UserSelect usedUserSelectIgnoringEffectivelyInert() const;
+    inline void setUsedUserSelect(UserSelect);
+
     // usedContentVisibility will return ContentVisibility::Hidden in a content-visibility: hidden subtree (overriding
     // content-visibility: auto at all times), ContentVisibility::Auto in a content-visibility: auto subtree (when the
     // content is not user relevant and thus skipped), and ContentVisibility::Visible otherwise.

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
@@ -92,6 +92,7 @@ InheritedRareData::InheritedRareData()
     , nbspMode(static_cast<unsigned>(NBSPMode::Normal))
     , lineBreak(static_cast<unsigned>(LineBreak::Auto))
     , webkitUserSelect(static_cast<unsigned>(ComputedStyle::initialWebkitUserSelect()))
+    , usedUserSelect(static_cast<unsigned>(UserSelect::Text))
     , speakAs(ComputedStyle::initialSpeakAs().toRaw())
     , hyphens(static_cast<unsigned>(Hyphens::Manual))
     , textCombine(static_cast<unsigned>(ComputedStyle::initialTextCombine()))
@@ -199,6 +200,7 @@ inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     , nbspMode(o.nbspMode)
     , lineBreak(o.lineBreak)
     , webkitUserSelect(o.webkitUserSelect)
+    , usedUserSelect(o.usedUserSelect)
     , speakAs(o.speakAs)
     , hyphens(o.hyphens)
     , textCombine(o.textCombine)
@@ -296,6 +298,7 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
         && textSizeAdjust == o.textSizeAdjust
 #endif
         && webkitUserSelect == o.webkitUserSelect
+        && usedUserSelect == o.usedUserSelect
         && speakAs == o.speakAs
         && hyphens == o.hyphens
         && hyphenateLimitBefore == o.hyphenateLimitBefore
@@ -413,6 +416,7 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
     LOG_IF_DIFFERENT_WITH_CAST(NBSPMode, nbspMode);
     LOG_IF_DIFFERENT_WITH_CAST(LineBreak, lineBreak);
     LOG_IF_DIFFERENT_WITH_CAST(UserSelect, webkitUserSelect);
+    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, usedUserSelect);
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(SpeakAs, speakAs);
 

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -184,6 +184,7 @@ public:
     PREFERRED_TYPE(NBSPMode) unsigned nbspMode : 1;
     PREFERRED_TYPE(LineBreak) unsigned lineBreak : 3;
     PREFERRED_TYPE(UserSelect) unsigned webkitUserSelect : 2;
+    PREFERRED_TYPE(UserSelect) unsigned usedUserSelect : 2;
     PREFERRED_TYPE(SpeakAs) unsigned speakAs : 4;
     PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
     PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm
@@ -35,6 +35,7 @@
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKPreferencesRefPrivate.h>
+#import <WebKit/WKString.h>
 #import <wtf/RetainPtr.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -67,6 +68,7 @@ static RetainPtr<NSAttributedString> copyAttributedStringFromHTML(NSString *html
 
     auto preferences = (__bridge WKPreferencesRef)[[webView configuration] preferences];
     WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging(preferences, true);
+    WKPreferencesSetBoolValueForKeyForTesting(preferences, true, WKStringCreateWithUTF8CString("CSSUserSelectEnabled"));
 
     if (forceDarkMode)
         [webView forceDarkMode];
@@ -175,6 +177,36 @@ TEST(CopyRTF, StripsUserSelectNone)
         "<div style='-webkit-user-select: none; user-select: none;'>some<br>user-select-none<br>content</div><span inert>foo </span>bar", false);
 
     EXPECT_WK_STREQ([attributedString string].UTF8String, "hello WebKit bar");
+}
+
+TEST(CopyRTF, StripUnprefixedUserSelectInsideNone)
+{
+    auto attributedString = copyAttributedStringFromHTML(@"hello <span style='user-select: none;'>world "
+        "<span style='user-select: auto;'>WebKit </span>really "
+        "<span style='user-select: initial;'>rocks </span></span>bar", false);
+
+    EXPECT_WK_STREQ([attributedString string].UTF8String, "hello bar");
+}
+
+TEST(CopyRTF, DoNotStripExplicitlySetWebkitUserSelectInsideNone)
+{
+    // Unlike the unprefixed version, -webkit-user-select set to auto/initial will not
+    // pick up the surrounding 'none' since inheritance does not occur
+    auto attributedString = copyAttributedStringFromHTML(@"hello <span style='-webkit-user-select: none;'>world "
+        "<span style='-webkit-user-select: auto;'>WebKit </span>really "
+        "<span style='-webkit-user-select: initial;'>rocks </span></span>bar", false);
+
+    EXPECT_WK_STREQ([attributedString string].UTF8String, "hello WebKit rocks bar");
+}
+
+TEST(CopyRTF, StripAccordingToPrefixedWebkitUserSelect)
+{
+    // When both are present, prefixed (-webkit-user-select) behavior wins:
+    auto attributedString = copyAttributedStringFromHTML(@"hello <span style='-webkit-user-select: none; user-select: none;'>world "
+        "<span style='-webkit-user-select: auto; user-select: auto;'>WebKit </span>really "
+        "<span style='-webkit-user-select: initial; user-select: initial;'>rocks </span></span>bar", false);
+
+    EXPECT_WK_STREQ([attributedString string].UTF8String, "hello WebKit rocks bar");
 }
 
 TEST(CopyRTF, StripsUserSelectNoneQuirks)


### PR DESCRIPTION
#### 01cfc5ed7d9ad64ac3e0c2319977578820389c0b
<pre>
[CSS] Implement user-select (-webkit-user-select as legacy override)
<a href="https://bugs.webkit.org/show_bug.cgi?id=321616">https://bugs.webkit.org/show_bug.cgi?id=321616</a>
<a href="https://rdar.apple.com/184741549">rdar://184741549</a>

Reviewed by NOBODY (OOPS!).

Implements the (already stubbed) user-select CSS property, while keeping
-webkit-user-select as an independent property that acts as a legacy
override (not an alias) with slightly different behavior. Unprefixed
user-select remains behind a feature flag (cssUserSelectEnabled), which
is currently testable.

The stored value that determines selection behavior is now
Style::InheritedRareData::usedUserSelect, and it participates in style
invalidation for descendants. It is updated on
Adjuster::adjustUsedUserSelect(), which usually runs on
Adjuster::adjust(), but it also is called manually for shadow-dom text
control elements that skip adjust().

Here&apos;s a breakdown of differences in behavior between prefixed and
unprefixed user-select:
 * `-webkit-user-select: all` makes content uneditable (see
   computeEditabilityFromComputedStyle()). `user-select: all`
   will instead be ignored on editable content
 * `user-select: none` is ignored on editable content, so the content
   can be selected and carets can be placed. The same will happen to
   `-webkit-user-select: none`, but only if the element is not
   draggable (style.userDrag() != UserDrag::Element)
 * Parent-derived values are obtained through different mechanisms:
   `-webkit-user-select` propagates by inheritance, while `user-select`
   instead mentions the parent&apos;s used value in the behavior of `auto`
 * getComputedStyle() doesn&apos;t reflect the value obtained from the
   parent with `user-select` since inheritance isn&apos;t used
 * `-webkit-user-select: initial` is not &apos;auto&apos; and causes the value to
   not be derived from the parent in any way

Whenever -webkit-user-select is set explicitly for an element, that
element and descendants that inherit that value will ignore user-select.
This is controlled by a flag (hasExplicitlySetWebkitUserSelect) inherited
by descendants. This is to ensure no change in behavior for nodes that
currently inherit -webkit-user-select.

The html.css stylesheet was updated to contain both user-select and
-webkit-user-select. This is needed because when the -webkit-user-select
cascade is won by an UA stylesheet, the `hasExplicitlySetWebkitUserSelect`
flag is reset (due &quot;computed-style-has-explicitly-set-policy&quot;: &quot;all-author-origin&quot;).

Having two separate properties is not in strict accordance with the
spec, which suggests -webkit-user-select as an alias (see
<a href="https://www.w3.org/TR/css-ui-4/#content-selection).">https://www.w3.org/TR/css-ui-4/#content-selection).</a> However, the
prefixed version wouldn&apos;t always win if it were an alias, and we&apos;d be
forced to abandon legacy behavior.

Tests added:
 * LayoutTests/editing/selection/user-select-all-prefixed-vs-unprefixed-in-editable.html
 * LayoutTests/editing/selection/user-select-auto-in-modal-dialog-inside-inert.html
 * LayoutTests/editing/selection/user-select-in-text-control.html
 * LayoutTests/editing/selection/user-select-in-ua-stylesheet.html
 * Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm:
   (TEST(CopyRTF, StripUnprefixedUserSelectInsideNone))
   (TEST(CopyRTF, DoNotStripExplicitlySetWebkitUserSelectInsideNone))
   (TEST(CopyRTF, StripAccordingToPrefixedWebkitUserSelect))

Tests updated to check behavior instead of using
getComputedStyle (which is now less reliable):
 * LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section.html
 * LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section.html
 * LayoutTests/media/modern-media-controls/status-label/status-label-text-selection.html
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01cfc5ed7d9ad64ac3e0c2319977578820389c0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144841 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c59af9f0-1709-4731-b826-a1ac79ddc4a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140799 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121251 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56547254-5b9a-4034-92da-fa29bef6d264) 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43140 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed layout tests; 1 new passes 2 flakes; Uploaded test results; Ignored 1 pre-existing failure based on results-db") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41426 "Passed tests") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10057 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153544 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41101 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1890 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192666 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150167 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54819 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37716 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149888 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44511 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127082 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122268 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53336 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16090 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52718 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52955 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52783 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->