### PR TITLE
Log git-fetch failure output as warnings during setup

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -36,7 +36,19 @@ HTTPBasicAuth = CallByNeed(lambda: __import__('requests.auth', fromlist=['HTTPBa
 
 def _fetch(path, remote):
     log.info('    Fetching {}...'.format(remote))
-    return run([local.Git.executable(), 'fetch', '--prune', remote], cwd=path, capture_output=True).returncode
+    result = run(
+        [local.Git.executable(), 'fetch', '--prune', '--quiet', remote],
+        cwd=path, capture_output=True, encoding='utf-8', errors='replace',
+    )
+    if result.returncode:
+        if result.stderr:
+            log.warning("    Failed to fetch '{}':\n        {}".format(
+                remote,
+                '\n        '.join(result.stderr.rstrip().splitlines()),
+            ))
+        else:
+            log.warning("    Failed to fetch '{}'".format(remote))
+    return result.returncode
 
 
 class Setup(Command):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
@@ -242,6 +242,37 @@ Fetched 2 remotes!
 '''.format(repository=self.path),
         )
 
+    def test_fetch_failure(self):
+        self.maxDiff = None
+        stderr = (
+            "remote: The 'apple' organization has enabled or enforced SAML SSO.\n"
+            "remote: To access this repository, visit https://github.com/orgs/apple/sso?authorization_request=REDACTED and try your request again.\n"
+            "fatal: unable to access 'https://github.com/apple/WebKit.git/': The requested URL returned error: 403\n"
+            "error: could not fetch apple\n"
+        )
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn():
+            repo.add_remote('apple')
+            with wkmocks.Subprocess(wkmocks.Subprocess.Route(
+                repo.executable, 'fetch', '--prune', '--quiet', 'apple',
+                completion=wkmocks.ProcessCompletion(returncode=1, stderr=stderr),
+            )):
+                self.assertEqual(1, program.main(
+                    args=('setup', '--defaults'),
+                    path=self.path,
+                ))
+
+        self.assertEqual(
+            captured.root.log.getvalue(),
+            '''Fetching 2 remotes...
+    Failed to fetch 'apple':
+        remote: The 'apple' organization has enabled or enforced SAML SSO.
+        remote: To access this repository, visit https://github.com/orgs/apple/sso?authorization_request=REDACTED and try your request again.
+        fatal: unable to access 'https://github.com/apple/WebKit.git/': The requested URL returned error: 403
+        error: could not fetch apple
+Fetched 1 remote!
+''',
+        )
+
     def test_commit_message(self):
         with OutputCapture(level=logging.INFO), MockTerminal.input('n'), mocks.local.Git(self.path) as git, mocks.local.Svn():
             self.assertEqual(0, program.main(


### PR DESCRIPTION
#### a09cb8ae6f37d37bd0b132de20f7e60d4e8a2dd2
<pre>
Log git-fetch failure output as warnings during setup
<a href="https://bugs.webkit.org/show_bug.cgi?id=321617">https://bugs.webkit.org/show_bug.cgi?id=321617</a>
<a href="https://rdar.apple.com/184742480">rdar://184742480</a>

Reviewed by Ryan Haddad.

This exposes `git fetch`&apos;s output when a remote fetch fails (e.g., due
to SAML SSO enforcement, invalid credentials, or inaccessible repos),
because otherwise it&apos;s hard for users to know what is wrong.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(_fetch): Capture stderr and log as warning on fetch failure.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:
(TestSetup.test_fetch_failure): Added test verifying failure message
surfaces at default verbosity. This uses its own mock because we don&apos;t
want to make the `git fetch` fail in general.

Canonical link: <a href="https://commits.webkit.org/319113@main">https://commits.webkit.org/319113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d791086c236d3a15c01e868b630424989ef7988

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144630 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5f3a62d-46e0-4d11-ae73-02528341922a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182171 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140633 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a74810c-5ab2-4ca9-a6a7-323a4c3abf49) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121085 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a60c0f6-bc5d-42fc-ac79-050142ed5f5a) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/179633 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42964 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41267 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40941 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1679 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192455 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/179710 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53920 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149985 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54608 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149708 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27394 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44344 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122032 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53125 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15930 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52507 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52744 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52572 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->