### PR TITLE
Refactor iframe-loading-lazy-cross-site to check subframe's loaded URL

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-cross-site.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-cross-site.sub.html
@@ -14,6 +14,8 @@
   const t_below_viewport =
     async_test('Below-viewport iframes load lazily');
 
+  const expected_url = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport";
+
   let has_window_loaded = false;
 
   const in_viewport_iframe_onload = t_in_viewport.step_func_done(() => {
@@ -26,25 +28,26 @@
     document.getElementById("below_viewport").scrollIntoView();
   });
 
-  const below_viewport_iframe_onload = t_below_viewport.step_func_done(() => {
+  window.addEventListener("message", t_below_viewport.step_func_done(event => {
+    assert_equals(event.data, expected_url,
+                  "The below-viewport iframe should have loaded its cross-site document");
     assert_true(has_window_loaded,
-                "The window load event should have fired before " +
-                "the below-viewport iframe loads");
-  });
+                "The window load event should have fired before the below-viewport iframe loads");
+  }));
 
 </script>
 
 <body>
-  <iframe id="in_viewport" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/
-  the-iframe-element/resources/subframe.html?in-viewport"
+  <iframe id="in_viewport"
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?in-viewport"
           loading="lazy" width="200px" height="100px"
           onload="in_viewport_iframe_onload();"></iframe>
 
 
  <div style="height:2000vh;"></div>
-  <iframe id="below_viewport" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/resources/subframe.html?below-viewport"
-          loading="lazy" width="200px" height="100px"
-          onload="below_viewport_iframe_onload();"></iframe>
+  <iframe id="below_viewport"
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross-site/resources/subframe-post-msg.html?below-viewport"
+          loading="lazy" width="200px" height="100px"></iframe>
 
 
   <!-- This async script loads very slowly in order to ensure that, if the


### PR DESCRIPTION
#### fe8673c31cf645e645a9ed37189c3d26414b895c
<pre>
Refactor iframe-loading-lazy-cross-site to check subframe&apos;s loaded URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=321621">https://bugs.webkit.org/show_bug.cgi?id=321621</a>
<a href="https://rdar.apple.com/184750792">rdar://184750792</a>

Reviewed by Sihui Liu.

Checking the deferred iframe&apos;s url will more robustly test that it correctly loads.

See <a href="https://github.com/WebKit/WebKit/pull/71207#discussion_r3754327384">https://github.com/WebKit/WebKit/pull/71207#discussion_r3754327384</a> for more detail.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross-site/iframe-loading-lazy-cross-site.sub.html:

Canonical link: <a href="https://commits.webkit.org/319091@main">https://commits.webkit.org/319091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d44edc44769b6f115bb8b80bea4a5eac2815af73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190554 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144664 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6a49899-9890-47a1-97ce-dc51821060c7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54004 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140666 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/233d9aed-37e3-46eb-9c65-1894d22b206e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121118 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/81e9e4e6-9947-4b85-ac9f-16942ef1e5e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42991 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41293 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40974 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1713 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192489 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150018 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54642 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149740 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27384 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44375 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122067 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53159 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15963 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52541 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52778 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52606 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->