### PR TITLE
[JSC] Improve FastStringifier's short string copy tiers

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -707,6 +707,8 @@ public:
     static constexpr unsigned staticBufferSize = bufferMode == BufferMode::StaticBuffer ? 8192 : 8;
     static constexpr unsigned dynamicBufferInlineCapacity = bufferMode == BufferMode::StaticBuffer ? 0 : 1024;
 
+    static constexpr bool useShortCopyTier = bufferMode == BufferMode::DynamicBuffer;
+
 private:
     explicit FastStringifier(JSGlobalObject&);
     template<HasGap hasGap> void append(JSValue);
@@ -1167,6 +1169,13 @@ static ALWAYS_INLINE uint64_t copyEightBytesAndLoad(const CharType* source, Char
     return word;
 }
 
+static ALWAYS_INLINE uint32_t copyFourBytesAndLoad(const Latin1Character* source, Latin1Character* destination)
+{
+    uint32_t word = WTF::unalignedLoad<uint32_t>(source);
+    WTF::unalignedStore<uint32_t>(destination, word);
+    return word;
+}
+
 static ALWAYS_INLINE uint64_t upconvertEightBytesAndLoad(const Latin1Character* source, char16_t* destination)
 {
     uint64_t word = WTF::unalignedLoad<uint64_t>(source);
@@ -1177,10 +1186,18 @@ static ALWAYS_INLINE uint64_t upconvertEightBytesAndLoad(const Latin1Character* 
     return word;
 }
 
-template<typename CharType>
+#if (CPU(ARM64) || CPU(X86_64)) && COMPILER(CLANG)
+#define JSON_STRING_COPY_HAS_SIMD 1
+#else
+#define JSON_STRING_COPY_HAS_SIMD 0
+#endif
+
+static constexpr size_t narrowStride = sizeof(uint64_t);
+
+template<typename CharType, bool useShortCopyTier = false>
 static ALWAYS_INLINE bool stringCopySameType(std::span<const CharType> span, CharType* cursor)
 {
-#if (CPU(ARM64) || CPU(X86_64)) && COMPILER(CLANG)
+#if JSON_STRING_COPY_HAS_SIMD
     constexpr size_t stride = SIMD::stride<CharType>;
     if (span.size() >= stride) {
         using UnsignedType = SameSizeUnsignedInteger<CharType>;
@@ -1222,17 +1239,33 @@ static ALWAYS_INLINE bool stringCopySameType(std::span<const CharType> span, Cha
     }
 #endif
     if constexpr (sizeof(CharType) == 1) {
-        constexpr size_t narrowStride = 8;
         if (span.size() >= narrowStride) {
             const auto* ptr = span.data();
             const auto* end = ptr + span.size();
             auto* cursorEnd = cursor + span.size();
             uint64_t accumulated = 0;
+#if JSON_STRING_COPY_HAS_SIMD
+            static_assert(stride <= 2 * narrowStride);
+            ASSERT(span.size() < 2 * narrowStride);
+            accumulated = eightByteRangeNeedsJSONEscape(copyEightBytesAndLoad(ptr, cursor));
+            accumulated |= eightByteRangeNeedsJSONEscape(copyEightBytesAndLoad(end - narrowStride, cursorEnd - narrowStride));
+#else
             for (; ptr + narrowStride <= end; ptr += narrowStride, cursor += narrowStride)
                 accumulated |= eightByteRangeNeedsJSONEscape(copyEightBytesAndLoad(ptr, cursor));
             if (ptr < end)
                 accumulated |= eightByteRangeNeedsJSONEscape(copyEightBytesAndLoad(end - narrowStride, cursorEnd - narrowStride));
+#endif
             return accumulated;
+        }
+        if constexpr (useShortCopyTier) {
+            if (span.size() >= 4) {
+                const auto* ptr = span.data();
+                const auto* end = ptr + span.size();
+                auto* cursorEnd = cursor + span.size();
+                uint64_t low = copyFourBytesAndLoad(ptr, cursor);
+                uint64_t high = copyFourBytesAndLoad(end - 4, cursorEnd - 4);
+                return eightByteRangeNeedsJSONEscape(low | (high << 32));
+            }
         }
     }
     for (auto character : span) {
@@ -1249,7 +1282,7 @@ static ALWAYS_INLINE bool stringCopySameType(std::span<const CharType> span, Cha
 
 static ALWAYS_INLINE bool stringCopyUpconvert(std::span<const Latin1Character> span, char16_t* cursor)
 {
-#if (CPU(ARM64) || CPU(X86_64)) && COMPILER(CLANG)
+#if JSON_STRING_COPY_HAS_SIMD
     constexpr size_t stride = SIMD::stride<Latin1Character>;
     if (span.size() >= stride) {
         using UnsignedType = uint8_t;
@@ -1281,15 +1314,22 @@ static ALWAYS_INLINE bool stringCopyUpconvert(std::span<const Latin1Character> s
         return SIMD::isNonZero(accumulated);
     }
 #endif
-    if (span.size() >= 8) {
+    if (span.size() >= narrowStride) {
         const auto* ptr = span.data();
         const auto* end = ptr + span.size();
         auto* cursorEnd = cursor + span.size();
         uint64_t accumulated = 0;
-        for (; ptr + 8 <= end; ptr += 8, cursor += 8)
+#if JSON_STRING_COPY_HAS_SIMD
+        static_assert(stride <= 2 * narrowStride);
+        ASSERT(span.size() < 2 * narrowStride);
+        accumulated = eightByteRangeNeedsJSONEscape(upconvertEightBytesAndLoad(ptr, cursor));
+        accumulated |= eightByteRangeNeedsJSONEscape(upconvertEightBytesAndLoad(end - narrowStride, cursorEnd - narrowStride));
+#else
+        for (; ptr + narrowStride <= end; ptr += narrowStride, cursor += narrowStride)
             accumulated |= eightByteRangeNeedsJSONEscape(upconvertEightBytesAndLoad(ptr, cursor));
         if (ptr < end)
-            accumulated |= eightByteRangeNeedsJSONEscape(upconvertEightBytesAndLoad(end - 8, cursorEnd - 8));
+            accumulated |= eightByteRangeNeedsJSONEscape(upconvertEightBytesAndLoad(end - narrowStride, cursorEnd - narrowStride));
+#endif
         return accumulated;
     }
     for (auto character : span) {
@@ -1299,6 +1339,8 @@ static ALWAYS_INLINE bool stringCopyUpconvert(std::span<const Latin1Character> s
     }
     return false;
 }
+
+#undef JSON_STRING_COPY_HAS_SIMD
 
 template<typename CharType, BufferMode bufferMode>
 template<HasGap hasGap>
@@ -1380,7 +1422,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
 
         if constexpr (std::same_as<CharType, Latin1Character>) {
             if (string.data.is8Bit()) [[likely]] {
-                if (!stringCopySameType(string.data.span8(), buffer() + m_length + 1)) [[likely]] {
+                if (!stringCopySameType<CharType, useShortCopyTier>(string.data.span8(), buffer() + m_length + 1)) [[likely]] {
                     buffer()[m_length + 1 + stringLength] = '"';
                     m_length += 1 + stringLength + 1;
                     return;
@@ -1559,7 +1601,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                         return false;
                     }
                 } else {
-                    if (stringCopySameType(span, out + length + 1)) [[unlikely]] {
+                    if (stringCopySameType<CharType, useShortCopyTier>(span, out + length + 1)) [[unlikely]] {
                         m_length = length;
                         recordFailure("property name character needs escaping"_s);
                         return false;
@@ -1588,7 +1630,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                             return false;
                         }
                         buffer()[m_length] = '"';
-                        if (!stringCopySameType(valueString.data.span8(), buffer() + m_length + 1)) [[likely]] {
+                        if (!stringCopySameType<CharType, useShortCopyTier>(valueString.data.span8(), buffer() + m_length + 1)) [[likely]] {
                             buffer()[m_length + 1 + valueLength] = '"';
                             m_length += 1 + valueLength + 1;
                             return true;


### PR DESCRIPTION
#### da12fb32aeb97f8774681deafc767602667934e2
<pre>
[JSC] Improve FastStringifier&apos;s short string copy tiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321622">https://bugs.webkit.org/show_bug.cgi?id=321622</a>
<a href="https://rdar.apple.com/184750925">rdar://184750925</a>

Reviewed by Yusuke Suzuki.

stringCopySameType tiers by length: SIMD at the vector stride, an 8-byte SWAR
loop below that, then a per-character loop. Short JSON property names fall into
the lower tiers.

Add a 4-7 byte tier: copy the first and last four bytes, packed into one 64-bit
word and validated by the existing eightByteRangeNeedsJSONEscape. The two
four-byte windows overlap below 8 bytes, but they rewrite the repeated bytes
with the same values, and duplicates cannot change the escape verdict. Only
BufferMode::DynamicBuffer enables the tier, leaving StaticBuffer&apos;s inlined code
unchanged; the 16-bit site is left out since the tier is Latin1-only.

Where SIMD is compiled in, the 8-byte tier only ever sees 8-15 bytes, so its
loop always runs exactly once. Replace it with the same two-window form in both
stringCopySameType and stringCopyUpconvert, dropping a backedge and a tail
branch from each. A static_assert ties this to the SIMD threshold: two narrow
strides must cover whatever the SIMD tier leaves behind. narrowStride counts
elements, so in stringCopyUpconvert one window advances the source by eight
bytes and the destination by sixteen.

Also name that threshold condition JSON_STRING_COPY_HAS_SIMD instead of
repeating it three times, and hoist narrowStride to file scope as
sizeof(uint64_t), which is what the eight-byte helpers actually operate on.
stringCopyUpconvert now uses it in place of a bare 8.

Canonical link: <a href="https://commits.webkit.org/319109@main">https://commits.webkit.org/319109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/240876ae8424421fadda2d444682bc1a75ea4355

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144726 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bde8e158-ee9c-4c38-9744-a5a97b8d76ad) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140709 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a4f8fc3-f2c1-4f76-8f0d-ce5701f23d81) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121161 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aab9a433-d640-4159-954a-5f47fbf66a7a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43034 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41331 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3128 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9979 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41023 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1775 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41679 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46949 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192551 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54016 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150062 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54704 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37637 "Too many flaky failures: http/tests/media/media-play-stream-chunked-icy.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/downgraded-referrer-for-navigation-with-link-query-from-prevalent-resource.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/image-blocked-alt-text.html, http/tests/security/mixedContent/redirect-https-to-http-image-secure-cookies-UpgradeMixedContent.html, http/tests/site-isolation/exit-fullscreen-from-ui-process.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html, http/tests/webgpu/webgpu/api/operation/sampling/sampler_texture.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149785 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27392 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44422 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126967 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122129 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53221 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16012 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52603 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->