### PR TITLE
[JSC] Air DCE worklist should be seeded via backward ordering

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp
@@ -90,18 +90,22 @@ bool eliminateDeadCode(Code& code)
         }
     };
 
-    Vector<Inst*> possiblyDead;
+    Vector<Inst*> deadCandidatesInBackwardOrder;
 
-    for (BasicBlock* block : code) {
-        for (Inst& inst : *block) {
+    for (unsigned blockIndex = code.size(); blockIndex--;) {
+        BasicBlock* block = code[blockIndex];
+        if (!block)
+            continue;
+        for (unsigned instIndex = block->size(); instIndex--;) {
+            Inst& inst = block->at(instIndex);
             if (!isInstLive(inst))
-                possiblyDead.append(&inst);
+                deadCandidatesInBackwardOrder.append(&inst);
             else
                 markArgsLive(inst);
         }
     }
 
-    // Inst in possiblyDead already have hasNonArgEffects() == false, invariant
+    // Inst in deadCandidatesInBackwardOrder already have hasNonArgEffects() == false, invariant
     // under live-set growth, so the fixpoint skips that re-check.
     auto handleInst = [&] (Inst& inst) -> bool {
         if (!isInstLiveByDefs(inst))
@@ -110,9 +114,9 @@ bool eliminateDeadCode(Code& code)
         return true;
     };
 
-    auto runForward = [&] () -> bool {
+    auto runBackward = [&] () -> bool {
         changed = false;
-        possiblyDead.removeAllMatching(
+        deadCandidatesInBackwardOrder.removeAllMatching(
             [&] (Inst* inst) -> bool {
                 bool result = handleInst(*inst);
                 changed |= result;
@@ -121,13 +125,13 @@ bool eliminateDeadCode(Code& code)
         return changed;
     };
 
-    auto runBackward = [&] () -> bool {
+    auto runForward = [&] () -> bool {
         changed = false;
-        for (unsigned i = possiblyDead.size(); i--;) {
-            bool result = handleInst(*possiblyDead[i]);
+        for (unsigned i = deadCandidatesInBackwardOrder.size(); i--;) {
+            bool result = handleInst(*deadCandidatesInBackwardOrder[i]);
             if (result) {
-                possiblyDead[i] = possiblyDead.last();
-                possiblyDead.removeLast();
+                deadCandidatesInBackwardOrder[i] = deadCandidatesInBackwardOrder.last();
+                deadCandidatesInBackwardOrder.removeLast();
                 changed = true;
             }
         }
@@ -146,12 +150,12 @@ bool eliminateDeadCode(Code& code)
             break;
     }
 
-    // After the fixpoint, possiblyDead holds exactly the dead Insts. Null them
+    // After the fixpoint, deadCandidatesInBackwardOrder holds exactly the dead Insts. Null them
     // out and sweep with the cheap !inst predicate.
-    if (possiblyDead.isEmpty())
+    if (deadCandidatesInBackwardOrder.isEmpty())
         return false;
 
-    for (Inst* inst : possiblyDead)
+    for (Inst* inst : deadCandidatesInBackwardOrder)
         *inst = Inst();
 
     for (BasicBlock* block : code) {


### PR DESCRIPTION
#### ee4f0240590dabdfc2fd03598ded4d722c615f13
<pre>
[JSC] Air DCE worklist should be seeded via backward ordering
<a href="https://bugs.webkit.org/show_bug.cgi?id=321624">https://bugs.webkit.org/show_bug.cgi?id=321624</a>
<a href="https://rdar.apple.com/184754923">rdar://184754923</a>

Reviewed by Vassili Bykov.

Currently we are seeding Air DCE worklist in a program ordering and
forward ordering in the basic block, which is really bad for liveness
analysis. Just use the reversed ordering, which removes 20% of time of
this phase.

* Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp:
(JSC::B3::Air::eliminateDeadCode):

Canonical link: <a href="https://commits.webkit.org/319075@main">https://commits.webkit.org/319075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf3439b60db492df32f74e310ac61ad4a3614dbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190560 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140671 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121123 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3090 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9931 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40975 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1719 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41623 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192495 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53960 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150024 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54648 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149746 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44381 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126911 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122073 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53165 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15964 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52547 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52784 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52612 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->