### PR TITLE
fetch() ignores targetAddressSpace when constructed from a URL string

### DIFF
--- a/LayoutTests/fetch/request-target-address-space-from-init-expected.txt
+++ b/LayoutTests/fetch/request-target-address-space-from-init-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Request constructed from a URL string reads targetAddressSpace from init
+PASS Request constructed from another Request reads targetAddressSpace from init
+PASS Request defaults targetAddressSpace to public when init omits it
+

--- a/LayoutTests/fetch/request-target-address-space-from-init.html
+++ b/LayoutTests/fetch/request-target-address-space-from-init.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LocalNetworkAccessEnabled=true ] -->
+<html>
+<head>
+<title>Request must read targetAddressSpace from init when constructed from a URL string</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+test(() => {
+    assert_equals(new Request("http://example.com/", { targetAddressSpace: "local" }).targetAddressSpace, "local");
+    assert_equals(new Request("http://example.com/", { targetAddressSpace: "loopback" }).targetAddressSpace, "loopback");
+    assert_equals(new Request("http://example.com/", { targetAddressSpace: "public" }).targetAddressSpace, "public");
+}, "Request constructed from a URL string reads targetAddressSpace from init");
+
+test(() => {
+    const original = new Request("http://example.com/");
+    assert_equals(new Request(original, { targetAddressSpace: "local" }).targetAddressSpace, "local");
+}, "Request constructed from another Request reads targetAddressSpace from init");
+
+test(() => {
+    assert_equals(new Request("http://example.com/").targetAddressSpace, "public");
+}, "Request defaults targetAddressSpace to public when init omits it");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -211,7 +211,7 @@ ExceptionOr<void> FetchRequest::initializeWith(const String& url, Init&& init)
     m_request.setInitiatorIdentifier(context->resourceRequestIdentifier());
 
     if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext()); document && document->settings().localNetworkAccessEnabled())
-        m_targetAddressSpace = updateTargetAddressSpaceIfNeeded(m_targetAddressSpace, m_request.url());
+        m_targetAddressSpace = updateTargetAddressSpaceIfNeeded(init.targetAddressSpace.value_or(m_targetAddressSpace), m_request.url());
 
     auto optionsResult = initializeOptions(init);
     if (optionsResult.hasException())


### PR DESCRIPTION
#### e5961e3ed7e9a15be44a0a2c21c06b2a25d51859
<pre>
fetch() ignores targetAddressSpace when constructed from a URL string
<a href="https://bugs.webkit.org/show_bug.cgi?id=321626">https://bugs.webkit.org/show_bug.cgi?id=321626</a>
<a href="https://rdar.apple.com/184756177">rdar://184756177</a>

Reviewed by Zak Ridouh.

Only the FetchRequest-copying overload read init.targetAddressSpace, so
fetch(url, { targetAddressSpace }) and new Request(url, { targetAddressSpace })
left the default of Public. The value gates the mixed-content exemption and the
address-space mismatch check for Local Network Access,
<a href="https://wicg.github.io/local-network-access/">https://wicg.github.io/local-network-access/</a>

* LayoutTests/fetch/request-target-address-space-from-init-expected.txt: Added.
* LayoutTests/fetch/request-target-address-space-from-init.html: Added.
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::initializeWith):

Canonical link: <a href="https://commits.webkit.org/319835@main">https://commits.webkit.org/319835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d87b6a76951a2991a791956b9273f314a2170635

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190824 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144935 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140874 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97600 "3 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121326 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43219 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41502 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41179 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1984 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192760 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161168 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150250 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40782 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54912 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149968 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44588 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127177 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122392 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53429 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16172 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52811 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53048 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->