### PR TITLE
UAF in ManualSlotAssignment via WeakHashMap rehash during reentrant composed-tree teardown

### DIFF
--- a/LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash-expected.txt
+++ b/LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash.html
+++ b/LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<body>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function setup(ghosts, pumps) {
+    const host = document.body.appendChild(document.createElement('div'));
+    const shadowRoot = host.attachShadow({ mode: 'open', slotAssignment: 'manual' });
+
+    const targetSlot = shadowRoot.appendChild(document.createElement('slot'));
+    const otherSlot = shadowRoot.appendChild(document.createElement('slot'));
+    const childA = host.appendChild(document.createElement('span'));
+    const childB = host.appendChild(document.createElement('span'));
+    targetSlot.assign(childA);
+    otherSlot.assign(childB);
+
+    // Insert and remove ghost slots so m_slots accumulates entries whose WeakPtr keys go null after GC.
+    for (let i = 0; i < ghosts; ++i)
+        shadowRoot.appendChild(document.createElement('slot')).remove();
+
+    return { host, targetSlot, pumps };
+}
+
+function trigger({ host, targetSlot, pumps }) {
+    // Advance the WeakHashMap operation counter toward its amortized-cleanup threshold.
+    for (let i = 0; i < pumps; ++i)
+        targetSlot.assignedNodes();
+
+    // Reassigning targetSlot tears down renderers; the composed-tree iterator visits otherSlot,
+    // re-enters assignedNodesForSlot, and may trigger a rehash that frees the bucket array.
+    targetSlot.assign(host.appendChild(document.createElement('span')));
+    host.remove();
+}
+
+// Each case uses its own shadow root (its own m_slots), and GC only nulls the ghost WeakPtr keys
+// without touching the operation counter, so building every case before a single GCController.collect()
+// is equivalent to collecting per case but avoids ~1000 separate full GCs.
+//
+// The reentrant rehash fires when the WeakHashMap operation counter crosses its amortized-cleanup
+// threshold, which is reset to 2 * table size after each cleanup. With ~ghosts entries in the table
+// that threshold sits near 2 * ghosts, so sweep a band of pump counts bracketing it.
+const cases = [];
+for (let ghosts = 20; ghosts <= 100; ghosts += 10)
+    for (let pumps = ghosts; pumps <= ghosts * 3; ++pumps)
+        cases.push(setup(ghosts, pumps));
+
+if (window.GCController)
+    GCController.collect();
+
+// One layout pass gives every host a renderer so tearDownRenderersAfterSlotChange traverses the
+// composed tree. Doing it once up front (rather than per case) avoids O(n^2) relayout, since each
+// host.remove() below would otherwise re-dirty the document for the next case's forced layout.
+document.body.offsetHeight;
+
+for (const testCase of cases)
+    trigger(testCase);
+
+document.body.textContent = 'This test passes if it does not crash.';
+</script>
+</body>

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -549,15 +549,19 @@ void ManualSlotAssignment::slotManualAssignmentDidChange(HTMLSlotElement& slot, 
     }
 
     ++m_slottableVersion;
-    auto effectiveCurrent = assignedNodesForSlot(slot, shadowRoot);
+    // Compute effectiveCurrent as a local copy rather than via assignedNodesForSlot, which would
+    // return a raw pointer into m_slots. tearDownRenderersAfterSlotChange below can re-enter
+    // assignedNodesForSlot via ComposedTreeIterator and trigger a WeakHashMap rehash, freeing the
+    // bucket array such a pointer would address.
+    auto effectiveCurrent = effectiveAssignedNodes(shadowRoot, current);
 
     auto scheduleSlotChangeEventIfNeeded = [&]() {
-        if (effectivePrevious.size() != (effectiveCurrent ? effectiveCurrent->size() : 0)) {
+        if (effectivePrevious.size() != effectiveCurrent.size()) {
             slot.enqueueSlotChangeEvent();
             return;
         }
-        for (unsigned i = 0; i < effectivePrevious.size();++i) {
-            if (effectivePrevious[i] != effectiveCurrent->at(i)) {
+        for (unsigned i = 0; i < effectivePrevious.size(); ++i) {
+            if (effectivePrevious[i] != effectiveCurrent[i]) {
                 slot.enqueueSlotChangeEvent();
                 return;
             }


### PR DESCRIPTION
#### 0bab5af95da144b45e240675e21391b3f5518a30
<pre>
UAF in ManualSlotAssignment via WeakHashMap rehash during reentrant composed-tree teardown
<a href="https://bugs.webkit.org/show_bug.cgi?id=REDACTED">https://bugs.webkit.org/show_bug.cgi?id=REDACTED</a>
<a href="https://rdar.apple.com/179729192">rdar://179729192</a>

Reviewed by Anne van Kesteren.

ManualSlotAssignment::slotManualAssignmentDidChange computed effectiveCurrent
by calling assignedNodesForSlot, which returns a raw pointer to the
cachedAssignment Vector inside a Slot value stored directly in the m_slots
WeakHashMap bucket array. It then called
RenderTreeUpdater::tearDownRenderersAfterSlotChange, whose composed-tree
traversal can call HTMLSlotElement::assignedNodes on a sibling slot and
re-enter ManualSlotAssignment::assignedNodesForSlot. The reentrant
m_slots.ensure call may invoke the WeakHashMap amortized cleanup, sweep
null-keyed entries left by previously inserted, removed and GC-collected slot
elements, and rehash the table, freeing the bucket array effectiveCurrent
points into. The stale pointer was then dereferenced in
scheduleSlotChangeEventIfNeeded.

Compute effectiveCurrent as a local Vector via effectiveAssignedNodes,
mirroring effectivePrevious, so no pointer into m_slots is held across the
render-tree teardown.

* LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash-expected.txt: Added.
* LayoutTests/fast/shadow-dom/manual-slot-assign-renderer-teardown-crash.html: Added.
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::ManualSlotAssignment::slotManualAssignmentDidChange):

Originally-landed-as: 305413.1004@safari-7624.5-branch (ddc8b3fae09f). <a href="https://rdar.apple.com/184744200">rdar://184744200</a>
Canonical link: <a href="https://commits.webkit.org/319089@main">https://commits.webkit.org/319089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6515dd79dd5d99a719d67200b54159a28f32d1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140676 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121128 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43008 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41305 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40978 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1726 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192502 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150030 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40185 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54655 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149752 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44389 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126918 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122080 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53172 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15967 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52554 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52791 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52619 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->