### PR TITLE
[WebCore] Use-after-free in `DataListButtonElement::defaultEventHandler`

### DIFF
--- a/LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash-expected.txt
+++ b/LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash-expected.txt
@@ -1,0 +1,5 @@
+PASS if no crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash.html
+++ b/LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    width: 300px;
+    height: 50px;
+}
+</style>
+</head>
+<body>
+<input id="input" type="text" list="list">
+<datalist id="list"><option value="a"><option value="b"></datalist>
+<script>
+
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    input.addEventListener('click', (e) => {
+        input.type = 'button';
+        gc();
+    }, { once: true });
+
+    if (window.internals) {
+        let shadow = internals.shadowRoot(input);
+        let listButton = shadow.querySelector("div[useragentpart='-webkit-list-button']");
+
+        await UIHelper.activateElement(listButton);
+    }
+
+    debug("PASS if no crash.");
+    finishJSTest();
+});
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -428,6 +428,8 @@ void TextFieldInputType::removeShadowSubtree()
     if (RefPtr autoFillButton = m_autoFillButton.get())
         autoFillButton->removeOwner();
     m_autoFillButton = nullptr;
+    if (RefPtr dataListDropdownIndicator = m_dataListDropdownIndicator)
+        dataListDropdownIndicator->removeOwner();
     m_dataListDropdownIndicator = nullptr;
     m_container = nullptr;
 }

--- a/Source/WebCore/html/shadow/DataListButtonElement.cpp
+++ b/Source/WebCore/html/shadow/DataListButtonElement.cpp
@@ -61,7 +61,8 @@ void DataListButtonElement::defaultEventHandler(Event& event)
     }
 
     if (isAnyClick(*mouseEvent)) {
-        m_owner.dataListButtonElementWasClicked();
+        if (RefPtr owner = m_owner)
+            owner->dataListButtonElementWasClicked();
         event.setDefaultHandled();
     }
 

--- a/Source/WebCore/html/shadow/DataListButtonElement.h
+++ b/Source/WebCore/html/shadow/DataListButtonElement.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "HTMLDivElement.h"
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ class DataListButtonElement final : public HTMLDivElement {
     WTF_MAKE_TZONE_ALLOCATED(DataListButtonElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DataListButtonElement);
 public:
-    class DataListButtonOwner {
+    class DataListButtonOwner : public AbstractRefCountedAndCanMakeWeakPtr<DataListButtonOwner> {
     public:
         virtual ~DataListButtonOwner() = default;
         virtual void dataListButtonElementWasClicked() = 0;
@@ -47,6 +48,8 @@ public:
 
     bool canAdjustStyleForAppearance() const { return m_canAdjustStyleForAppearance; }
 
+    void removeOwner() { m_owner = nullptr; }
+
 private:
     explicit DataListButtonElement(Document&, DataListButtonOwner&);
 
@@ -56,7 +59,7 @@ private:
     void defaultEventHandler(Event&) final;
     bool isDisabledFormControl() const final;
 
-    DataListButtonOwner& m_owner;
+    WeakPtr<DataListButtonOwner> m_owner;
     bool m_canAdjustStyleForAppearance { true };
 };
 


### PR DESCRIPTION
#### be08720593705c04826f1e0804581ea8aafb2748
<pre>
[WebCore] Use-after-free in `DataListButtonElement::defaultEventHandler`
<a href="https://bugs.webkit.org/show_bug.cgi?id=313521">https://bugs.webkit.org/show_bug.cgi?id=313521</a>
<a href="https://rdar.apple.com/175672489">rdar://175672489</a>

Reviewed by Ryosuke Niwa.

`DataListButtonElement` stores its owner as a raw `DataListButtonOwner&amp; m_owner`.
The only `DataListButtonOwner` is `TextFieldInputType`. When the type of the
owning input element is changed, `HTMLInputElement::updateType()` calls
`removeShadowSubtree()`. This will null out `m_dataListDropdownIndicator` but
does not clear the owner member in `DataListButtonElement`. Changing the type
inside a `click` listener results in the `TextFieldInputType` being freed while
event dispatch is in progress. Eventually, `DataListButtonElement::defaultEventHandler()`
is called, calling `m_owner.dataListButtonElementWasClicked()` after `m_owner`
was already freed.

Fix storing the owner as a `WeakPtr` and by clearing it out in
`removeShadowSubtree()`. This matches the implementation of `SpinButtonElement`.

* LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash-expected.txt: Added.
* LayoutTests/fast/forms/datalist/datalist-button-change-input-type-on-click-crash.html: Added.
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::removeShadowSubtree):
* Source/WebCore/html/shadow/DataListButtonElement.cpp:
(WebCore::DataListButtonElement::defaultEventHandler):
* Source/WebCore/html/shadow/DataListButtonElement.h:

Originally-landed-as: 305413.1011@safari-7624.5-branch (1207b71f0518). <a href="https://rdar.apple.com/184744860">rdar://184744860</a>
Canonical link: <a href="https://commits.webkit.org/319066@main">https://commits.webkit.org/319066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d29867079e736ffd5d8371d12d05a3d317fb447

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190578 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140684 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183322 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44338 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121136 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41309 "Build is in progress. Recent messages:") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153415 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40989 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1737 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/46911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192513 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/53978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160978 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40167 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54666 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149760 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44392 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/126929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122091 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53183 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15978 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52565 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->