### PR TITLE
PathCG should use thread-safe scratchContext

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-isPointInStroke-svg-stroke-bounds-race-crash-expected.txt
+++ b/LayoutTests/fast/canvas/offscreen-isPointInStroke-svg-stroke-bounds-race-crash-expected.txt
@@ -1,0 +1,5 @@
+Ensure Path uses thread-safe context to check strokeContains() and to calculate strokeBoundingBox().
+
+PASS if this test does not crash.
+
+

--- a/LayoutTests/fast/canvas/offscreen-isPointInStroke-svg-stroke-bounds-race-crash.html
+++ b/LayoutTests/fast/canvas/offscreen-isPointInStroke-svg-stroke-bounds-race-crash.html
@@ -1,0 +1,119 @@
+<body>
+<p>Ensure Path uses thread-safe context to check strokeContains() and to calculate strokeBoundingBox().</p>
+<p>PASS if this test does not crash.</p>
+<div id="container"></div>
+<script>
+    window.testRunner?.waitUntilDone();
+    window.testRunner?.dumpAsText();
+
+    function createOffscreenCanvasWorkers() {
+        const workerCode = `
+            self.onmessage = function(e) {
+                const ctx = e.data.getContext("2d");
+                let iter = 0;
+                while (true) {
+                    const dashLen = 2 + (iter % 6);
+                    const dashes = [];
+                    for (let d = 0; d < dashLen; d++)
+                        dashes.push(3 + ((iter * 7 + d * 13) % 30));
+
+                    ctx.setLineDash(dashes);
+                    ctx.lineDashOffset = iter % 50;
+                    ctx.lineWidth = 2 + (iter % 15);
+                    ctx.beginPath();
+
+                    for (let j = 0; j < 15; j++) {
+                        const a = j / 15 * Math.PI * 2 + iter * 0.1;
+                        const r = 30 + 20 * Math.sin(j * 0.7 + iter * 0.3);
+                        const x = 64 + r * Math.cos(a);
+                        const y = 64 + r * Math.sin(a);
+                        if (j === 0)
+                            ctx.moveTo(x, y);
+                        else 
+                            ctx.bezierCurveTo(x + 10 * Math.sin(iter + j), y + 10 * Math.cos(iter + j), x - 6 * Math.cos(iter * j), y - 6 * Math.sin(iter * j), x, y);
+                    }
+                    ctx.closePath();
+                    ctx.isPointInStroke(64, 64);
+                    iter++;
+                }
+            };
+        `;
+
+        // Launch 8 workers to hammer strokeContains
+        for (let i = 0; i < 8; i++) {
+            const canvas = document.createElement("canvas");
+            canvas.width = canvas.height = 128;
+            const offscreen = canvas.transferControlToOffscreen();
+            const worker = new Worker(URL.createObjectURL(new Blob([workerCode])));
+            worker.postMessage(offscreen, [offscreen]);
+        }
+    }
+
+    const svgPaths = [];
+
+    function createSVGPaths() {
+        const svgNS = "http://www.w3.org/2000/svg";
+        const container = document.getElementById('container');
+
+        // Create SVG paths with clip-path: circle(100%) stroke-box
+        // This forces strokeBoundingBox() computation during every paint
+        for (let i = 0; i < 20; i++) {
+            const svg = document.createElementNS(svgNS, "svg");
+            svg.setAttribute("width", "80");
+            svg.setAttribute("height", "80");
+            svg.style.display = "inline-block";
+
+            const path = document.createElementNS(svgNS, "path");
+            path.setAttribute("d", "M10,10 C50,0 50,80 70,70 L60,20 Q30,60 70,40 Z");
+            path.setAttribute("stroke", "red");
+            path.setAttribute("stroke-width", "4");
+            path.setAttribute("stroke-dasharray", "10,5,3,7");
+            path.setAttribute("fill", "blue");
+            // clip-path with stroke-box reference box forces strokeBoundingBox() on every paint
+            path.style.clipPath = "inset(0) stroke-box";
+
+            svg.appendChild(path);
+            container.appendChild(svg);
+            svgPaths.push(path);
+        }
+    }
+
+    let frameCount = 0;
+
+    function animationLoop() {
+        let generatePath = function (seed) {
+            let d = 'M' + (5 + seed % 40) + ',' + (5 + seed % 30);
+            for (let i = 0; i < 5; i++) {
+                const x1 = 5 + ((seed * 7 + i * 13) % 70);
+                const y1 = 5 + ((seed * 11 + i * 17) % 70);
+                const x2 = 5 + ((seed * 3 + i * 23) % 70);
+                const y2 = 5 + ((seed * 5 + i * 29) % 70);
+                const x = 5 + ((seed * 13 + i * 31) % 70);
+                const y = 5 + ((seed * 17 + i * 37) % 70);
+                d += ' C' + x1 + ',' + y1 + ' ' + x2 + ',' + y2 + ' ' + x + ',' + y;
+            }
+            d += ' Z';
+            return d;
+        };
+
+        // Modify all SVG paths to invalidate their stroke bounding box cache
+        for (let i = 0; i < svgPaths.length; i++) {
+            const seed = frameCount * 20 + i;
+            svgPaths[i].setAttribute('d', generatePath(seed));
+            // Vary dash pattern to ensure CGContextSetLineDash allocates different arrays
+            const d1 = 3 + ((seed * 7) % 20);
+            const d2 = 2 + ((seed * 11) % 12);
+            const d3 = 4 + ((seed * 3) % 15);
+            svgPaths[i].setAttribute('stroke-dasharray', d1 + ',' + d2 + ',' + d3);
+        }
+
+        if (++frameCount <= 10)
+            requestAnimationFrame(animationLoop);
+        else
+             window.testRunner?.notifyDone();
+    }
+
+    createOffscreenCanvasWorkers();
+    createSVGPaths();
+    requestAnimationFrame(animationLoop);
+</script>

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -598,16 +598,18 @@ static RetainPtr<CGContextRef> createScratchContext()
 
 static inline CGContextRef scratchContext()
 {
-    static NeverDestroyed<RetainPtr<CGContextRef>> context = createScratchContext();
-    return context.get().get();
+    static NeverDestroyed<ThreadSpecific<RetainPtr<CGContextRef>>> context;
+
+    auto& result = *context.get();
+    if (!result)
+        result = createScratchContext();
+
+    return result.get();
 }
 
 bool PathCG::strokeContains(const FloatPoint& point, NOESCAPE const Function<void(GraphicsContext&)>& strokeStyleApplier) const
 {
     ASSERT(strokeStyleApplier);
-
-    static Lock scratchContextLock;
-    Locker locker { scratchContextLock };
 
     CGContextRef context = scratchContext();
 
@@ -644,9 +646,6 @@ FloatRect PathCG::boundingRect() const
 
 FloatRect PathCG::strokeBoundingRect(NOESCAPE const Function<void(GraphicsContext&)>& strokeStyleApplier) const
 {
-    static Lock scratchContextLock;
-    Locker locker { scratchContextLock };
-
     CGContextRef context = scratchContext();
 
     CGContextSaveGState(context);


### PR DESCRIPTION
#### 2917a663b046e5d58a97db8eb33a938a27a49161
<pre>
PathCG should use thread-safe scratchContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=316567">https://bugs.webkit.org/show_bug.cgi?id=316567</a>
<a href="https://rdar.apple.com/178176596">rdar://178176596</a>

Reviewed by Darin Adler.

The fix of bug 313935 was incomplete. The fix was done by adding two static Locks
to PathCG::strokeContains() and PathCG::strokeBoundingRect(). This fix makes these
two functions be thread-safe independently. But this is not enough. It is possible
to call PathCG::strokeContains() and PathCG::strokeBoundingRect() from two
different threads at the same time.

The fix is to make scratchContext() return a thread-specific graphics context.
So two threads can&apos;t access the same context at the same time.

Test: fast/canvas/offscreen-isPointInStroke-svg-stroke-bounds-race-crash.html

* LayoutTests/fast/canvas/offscreen-isPointInStroke-svg-stroke-bounds-race-crash-expected.txt: Added.
* LayoutTests/fast/canvas/offscreen-isPointInStroke-svg-stroke-bounds-race-crash.html: Added.
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::scratchContext):
(WebCore::PathCG::strokeContains const):
(WebCore::PathCG::strokeBoundingRect const):

Originally-landed-as: 305413.920@safari-7624.4-branch (6ab6f0e16b4d). <a href="https://rdar.apple.com/184744291">rdar://184744291</a>
Canonical link: <a href="https://commits.webkit.org/319095@main">https://commits.webkit.org/319095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f2604c7657dfbd9f3888daeb1394a913ff3ebe5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140681 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43007 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41308 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40983 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1732 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192508 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150034 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40189 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54661 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149756 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44391 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126924 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122086 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53178 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15972 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52625 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->