### PR TITLE
REGRESSION (259876@main): Check for end iterator in WebStorageNamespaceProvider::decrementUseCount()

### DIFF
--- a/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp
@@ -64,7 +64,8 @@ void WebStorageNamespaceProvider::decrementUseCount(const StorageNamespaceImpl::
 {
     if (auto& provider = existingStorageNameSpaceProvider()) {
         auto iterator = provider->m_sessionStorageNamespaces.find(identifier);
-        ASSERT(iterator != provider->m_sessionStorageNamespaces.end());
+        if (iterator == provider->m_sessionStorageNamespaces.end())
+            return;
         auto& sessionStorageNamespaces = iterator->value;
         ASSERT(sessionStorageNamespaces.useCount);
         if (!--sessionStorageNamespaces.useCount)


### PR DESCRIPTION
#### 313a4e84e9cc3044d9d5587e807074d0d6240dc1
<pre>
REGRESSION (259876@main): Check for end iterator in WebStorageNamespaceProvider::decrementUseCount()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=317082">https://bugs.webkit.org/show_bug.cgi?id=317082</a>&gt;
&lt;<a href="https://rdar.apple.com/179209792">rdar://179209792</a>&gt;

Reviewed by Zak Ridouh.

Guard against a missing entry before dereferencing the result of
`HashMap::find()` in `decrementUseCount()`.  The function relies on
`ASSERT(iterator != ...end())`, which compiles to nothing in release
builds, then reads `iterator-&gt;value` unconditionally.  When the
identifier is absent, `find()` returns `end()`, and reading
`end()-&gt;value` accesses memory one entry past the table&apos;s backing
buffer.

The absent-entry case became reachable in 259876@main, which replaced
the page-group-keyed owning map of providers with a single weakly-held
provider (`existingStorageNameSpaceProvider()`).  The provider is now
destroyed when the last page in a Web Content process goes away and
recreated empty for the next page, so a `WebPage` torn down after that
point decrements against a provider that never held its identifier.

Return early when the iterator is `end()`, matching the existing guard
in the sibling accessor `sessionStorageNamespace()`.  The
`ASSERT(sessionStorageNamespaces.useCount)` is retained so debug builds
still flag a use-count imbalance.

No new tests since this path is reached only during web page teardown
when the session storage namespace entry has already been removed, and
is not directly testable through public API.

* Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp:
(WebKit::WebStorageNamespaceProvider::decrementUseCount):

Originally-landed-as: 305413.965@safari-7624.4-branch (6254fe9499a7). <a href="https://rdar.apple.com/184744974">rdar://184744974</a>
Canonical link: <a href="https://commits.webkit.org/319447@main">https://commits.webkit.org/319447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a933a84665905424e47fc1b18329429b0c4d74bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190574 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144684 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140682 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97441 "3 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44337 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43010 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41310 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153413 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40984 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1733 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53974 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150035 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54662 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37597 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149757 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44394 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126925 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122087 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53179 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15973 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52798 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->