### PR TITLE
[Cocoa] Hold a strong reference to QueuedVideoOutput in its main run loop callbacks

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
@@ -84,8 +84,8 @@ SPECIALIZE_TYPE_TRAITS_END()
         return;
 
     callOnMainRunLoop([videoFrameEntries = WTF::move(videoFrameEntries), parent = _parent] () mutable {
-        if (parent)
-            parent->addVideoFrameEntries(WTF::move(videoFrameEntries));
+        if (RefPtr protectedParent = parent.get())
+            protectedParent->addVideoFrameEntries(WTF::move(videoFrameEntries));
     });
 }
 
@@ -95,8 +95,8 @@ SPECIALIZE_TYPE_TRAITS_END()
     [videoOutput requestNotificationOfMediaDataChangeAsSoonAsPossible];
 
     callOnMainRunLoop([parent = _parent] {
-        if (parent)
-            parent->purgeVideoFrameEntries();
+        if (RefPtr protectedParent = parent.get())
+            protectedParent->purgeVideoFrameEntries();
     });
 }
 
@@ -109,8 +109,8 @@ SPECIALIZE_TYPE_TRAITS_END()
     auto rate = rateValue.get().floatValue;
 
     ensureOnMainRunLoop([parent = _parent, rate] {
-        if (parent)
-            parent->rateChanged(rate);
+        if (RefPtr protectedParent = parent.get())
+            protectedParent->rateChanged(rate);
     });
 }
 @end
@@ -161,8 +161,8 @@ QueuedVideoOutput::QueuedVideoOutput(AVPlayerItem* item, AVPlayer* player)
 
         // And purge the back buffer of past frames.
         callOnMainRunLoop([weakThis = weakThis, time = PAL::toMediaTime(currentTime)] {
-            if (weakThis)
-                weakThis->purgeImagesBeforeTime(time);
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->purgeImagesBeforeTime(time);
         });
     }];
 }
@@ -261,8 +261,8 @@ void QueuedVideoOutput::configureNextImageTimeObserver()
 
     m_nextImageTimebaseObserver = [m_player addBoundaryTimeObserverForTimes:@[[NSValue valueWithCMTime:PAL::toCMTime(nextImageTime)]] queue:globalOutputDelegateQueue() usingBlock:[weakThis = WeakPtr { *this }, protectedDelegate = m_delegate, protectedOutput = m_videoOutput] () mutable {
         callOnMainRunLoop([weakThis = WTF::move(weakThis)] {
-            if (weakThis)
-                weakThis->nextImageTimeReached();
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->nextImageTimeReached();
         });
     }];
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
@@ -83,8 +83,8 @@ SPECIALIZE_TYPE_TRAITS_END()
         return;
 
     callOnMainRunLoop([videoFrameEntries = WTF::move(videoFrameEntries), parent = _parent] () mutable {
-        if (parent)
-            parent->addVideoFrameEntries(WTF::move(videoFrameEntries));
+        if (RefPtr protectedParent = parent.get())
+            protectedParent->addVideoFrameEntries(WTF::move(videoFrameEntries));
     });
 }
 
@@ -94,8 +94,8 @@ SPECIALIZE_TYPE_TRAITS_END()
     [videoOutput requestNotificationOfMediaDataChangeAsSoonAsPossible];
 
     callOnMainRunLoop([parent = _parent] {
-        if (parent)
-            parent->purgeVideoFrameEntries();
+        if (RefPtr protectedParent = parent.get())
+            protectedParent->purgeVideoFrameEntries();
     });
 }
 
@@ -108,8 +108,8 @@ SPECIALIZE_TYPE_TRAITS_END()
     auto rate = rateValue.get().floatValue;
 
     ensureOnMainRunLoop([parent = _parent, rate] {
-        if (parent)
-            parent->rateChanged(rate);
+        if (RefPtr protectedParent = parent.get())
+            protectedParent->rateChanged(rate);
     });
 }
 @end
@@ -160,8 +160,8 @@ QueuedVideoOutput::QueuedVideoOutput(AVPlayerItem* item, AVPlayer* player)
 
         // And purge the back buffer of past frames.
         callOnMainRunLoop([weakThis = weakThis, time = PAL::toMediaTime(currentTime)] {
-            if (weakThis)
-                weakThis->purgeImagesBeforeTime(time);
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->purgeImagesBeforeTime(time);
         });
     }];
 }
@@ -260,8 +260,8 @@ void QueuedVideoOutput::configureNextImageTimeObserver()
 
     m_nextImageTimebaseObserver = [m_player addBoundaryTimeObserverForTimes:@[[NSValue valueWithCMTime:PAL::toCMTime(nextImageTime)]] queue:globalOutputDelegateQueue() usingBlock:[weakThis = WeakPtr { *this }, protectedDelegate = m_delegate, protectedOutput = m_videoOutput] () mutable {
         callOnMainRunLoop([weakThis = WTF::move(weakThis)] {
-            if (weakThis)
-                weakThis->nextImageTimeReached();
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->nextImageTimeReached();
         });
     }];
 }


### PR DESCRIPTION
#### f90b4eaa220663e3507f7811d041c812ea016dc5
<pre>
[Cocoa] Hold a strong reference to QueuedVideoOutput in its main run loop callbacks
&lt;<a href="https://rdar.apple.com/181438985">rdar://181438985</a>&gt;

Reviewed by Jonathan Bedard.

The WebQueuedVideoOutputDelegate callbacks and the AVFoundation time
observer blocks hop their work to the main run loop capturing only a
WeakPtr to the QueuedVideoOutput, then dereference it as a raw pointer
after a plain null check.  The null check does not keep the object
alive: addVideoFrameEntries() fires the current-image-changed
observers, which can synchronously tear down the media player and
release the last strong reference to the QueuedVideoOutput while the
callback is still on the stack, so the trailing member access reads
freed memory.

Promote the captured WeakPtr to a RefPtr inside each block before use
so the object is kept alive for the duration of the call.  The sole
strong owner only ever runs on the main thread, so the non-atomic
RefPtr is sufficient and no ThreadSafeRefCounted change is needed.

No new tests since this change is not directly testable.

* Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm:
(-[WebQueuedVideoOutputDelegate outputMediaDataWillChange:]):
(-[WebQueuedVideoOutputDelegate outputSequenceWasFlushed:]):
(-[WebQueuedVideoOutputDelegate observeValueForKeyPath:ofObject:change:context:]):
(WebCore::QueuedVideoOutput::QueuedVideoOutput):
(WebCore::QueuedVideoOutput::configureNextImageTimeObserver):

Originally-landed-as: 305413.1094@safari-7624.5-branch (f53714d59190). <a href="https://rdar.apple.com/184745139">rdar://184745139</a>
Canonical link: <a href="https://commits.webkit.org/320818@main">https://commits.webkit.org/320818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85b87e83f674b0f1382c121c3afd7dd574a03cc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150589 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187816 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145310 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100736 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125623 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47721 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45726 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158077 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45447 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7323 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198226 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59512 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154867 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60221 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154513 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28243 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48961 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129567 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58672 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58116 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->