### PR TITLE
about:blank inherits cross-origin policy container due to empty document URL

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/about-blank-from-javascript-url-inherits-csp-from-initiator.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/about-blank-from-javascript-url-inherits-csp-from-initiator.sub-expected.txt
@@ -1,0 +1,3 @@
+
+PASS about:blank inherits initiator's CSP; cross-origin policy container does not leak.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/about-blank-from-javascript-url-inherits-csp-from-initiator.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/about-blank-from-javascript-url-inherits-csp-from-initiator.sub.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+
+<meta http-equiv="Content-Security-Policy" content="script-src 'unsafe-inline'; img-src 'none'; connect-src 'self'">
+<title>about:blank navigated from javascript: URL popup inherits CSP from initiator</title>
+<body>
+
+<script>
+  // A javascript: URL popup navigates a cross-origin iframe to about:blank.
+  // The about:blank should inherit CSP from the initiator, not the cross-origin page.
+
+  const CROSS_ORIGIN = "http://{{hosts[alt][]}}:{{ports[http][0]}}";
+  const CSP_MARKER = "cross-origin-csp-leak-marker";
+
+  const message_from = (source_token) => {
+    return new Promise(resolve => {
+      window.addEventListener('message', msg => {
+        if (msg.data.token === source_token)
+          resolve(msg.data);
+      });
+    });
+  };
+
+  // Check both correct CSP inheritance and that the cross-origin page's CSP does not leak.
+  promise_test(async t => {
+    const result_token = token();
+    const resource_url = window.origin + "/content-security-policy/support/fail.png";
+    const cross_origin_page = CROSS_ORIGIN +
+      "/content-security-policy/inheritance/support/page-with-csp-marker.html";
+
+    const popupScript = `
+      var i = document.body.appendChild(document.createElement("iframe"));
+      i.addEventListener("load", function() {
+        i.addEventListener("load", function() {
+          var results = {};
+
+          var leakDetected = false;
+          i.contentWindow.addEventListener("securitypolicyviolation", function(e) {
+            if (e.originalPolicy.includes("${CSP_MARKER}")) {
+              leakDetected = true;
+              results.leak = e.originalPolicy;
+            }
+          }, {once: true});
+
+          i.contentWindow.fetch("${resource_url}").finally(function() {
+            var img = i.contentDocument.createElement("img");
+            img.onload = function() {
+              results.imgBlocked = false;
+              opener.postMessage({token: "${result_token}", results: results}, "*");
+            };
+            img.onerror = function() {
+              results.imgBlocked = true;
+              opener.postMessage({token: "${result_token}", results: results}, "*");
+            };
+            img.src = "${resource_url}";
+            i.contentDocument.body.appendChild(img);
+          });
+        }, {once: true});
+        i.contentWindow.location.href = "about:blank";
+      }, {once: true});
+      i.src = "${cross_origin_page}";
+      void 0;
+    `;
+
+    const popup = window.open("javascript:" + popupScript);
+    t.add_cleanup(() => popup.close());
+
+    const { results } = await message_from(result_token);
+    assert_true(results.imgBlocked,
+      "Image should be blocked by initiator's img-src 'none'");
+    assert_equals(results.leak, undefined,
+      "Cross-origin CSP must not leak via SecurityPolicyViolationEvent");
+  }, "about:blank inherits initiator's CSP; cross-origin policy container does not leak.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/support/page-with-csp-marker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/support/page-with-csp-marker.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/support/page-with-csp-marker.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/support/page-with-csp-marker.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: connect-src http://cross-origin-csp-leak-marker

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -4,6 +4,7 @@
 # Tests that crash #
 ####################
 http/tests/security/top-level-unique-origin2.https.html [ Crash ]
+imported/w3c/web-platform-tests/content-security-policy/inheritance/about-blank-from-javascript-url-inherits-csp-from-initiator.sub.html [ Crash ]
 imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html [ Crash ]
 imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html?origin=cross-site-redirect [ Crash ]
 imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https.html [ Crash ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -13,6 +13,7 @@ http/tests/security/referrer-policy-header-same-origin.html [ Crash ]
 http/tests/security/referrer-policy-header-strict-origin-when-cross-origin.html [ Crash ]
 http/tests/security/referrer-policy-header-strict-origin.html [ Crash ]
 http/tests/security/referrer-policy-header-unsafe-url.html [ Crash ]
+imported/w3c/web-platform-tests/content-security-policy/inheritance/about-blank-from-javascript-url-inherits-csp-from-initiator.sub.html [ Crash ]
 
 #######################
 # Tests that time out #

--- a/Source/WebCore/loader/NavigationRequester.cpp
+++ b/Source/WebCore/loader/NavigationRequester.cpp
@@ -56,7 +56,7 @@ NavigationRequester NavigationRequester::from(Document& document)
     RefPtr parentFrame = frame ? frame->tree().parent() : nullptr;
 
     return {
-        document.url(),
+        document.url().isEmpty() ? aboutBlankURL() : document.url(),
         document.securityOrigin(),
         document.topOrigin(),
         document.policyContainer(),


### PR DESCRIPTION
#### 84ea03ded8bb54fd046a1f5c2b2379f308a3f5af
<pre>
about:blank inherits cross-origin policy container due to empty document URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=316512">https://bugs.webkit.org/show_bug.cgi?id=316512</a>
<a href="https://rdar.apple.com/176188073">rdar://176188073</a>

Reviewed by Alex Christensen.

Documents created via javascript: URL have an empty internal URL. Document::setURL() would
normally normalize this to aboutBlankURL(), but the call is conditionally skipped during
document creation.

When one of these documents creates a cross-origin iframe and then navigates it to about:blank,
the empty URL passes through NavigationRequester into NavigationAction::isEmpty(), which
mistakes it for an action that was never set. The fallback in FrameLoader::loadWithDocumentLoader
incorrectly rebuilds the action from the target frame&apos;s cross-origin document rather than the
original initiator (the javascript: URL document). The about:blank then inherits that document&apos;s
policy container instead of the initiator&apos;s, leaking its CSP and referrer via
SecurityPolicyViolationEvent.

Fix by normalizing empty document URLs to aboutBlankURL() in NavigationRequester::from(),
matching what Document::setURL() and Document::urlForBindings() already do.

Tests: imported/w3c/web-platform-tests/content-security-policy/inheritance/about-blank-from-javascript-url-inherits-csp-from-initiator.sub.html
       imported/w3c/web-platform-tests/content-security-policy/inheritance/support/page-with-csp-marker.html

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/about-blank-from-javascript-url-inherits-csp-from-initiator.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/about-blank-from-javascript-url-inherits-csp-from-initiator.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/support/page-with-csp-marker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/support/page-with-csp-marker.html.headers: Added.
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/loader/NavigationRequester.cpp:
(WebCore::NavigationRequester::from):

Originally-landed-as: 305413.1051@safari-7624.5-branch (45512c517789). <a href="https://rdar.apple.com/184744543">rdar://184744543</a>
Canonical link: <a href="https://commits.webkit.org/319079@main">https://commits.webkit.org/319079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c89af95f77ba12309b95e4a852f7faca6668ec8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180456 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190667 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54117 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44405 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121195 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41039 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1826 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/47000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192602 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161028 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40180 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54755 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149828 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44450 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122180 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53272 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16028 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52654 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->