### PR TITLE
Cherry-pick(s) 808715aa71af. rdar://184744718

### DIFF
--- a/LayoutTests/editing/secure-input/bfcache-restore-preserves-secure-input-expected.txt
+++ b/LayoutTests/editing/secure-input/bfcache-restore-preserves-secure-input-expected.txt
@@ -1,0 +1,17 @@
+Verify that restoring a page from the back/forward cache re-enables secure input state when the cached focused element is a password input.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+A password input is focused on the initial page:
+PASS testRunner.secureEventInputIsEnabled is true
+
+Navigating to a helper page that will navigate back:
+
+Page was restored from the back/forward cache:
+PASS document.activeElement is input
+PASS testRunner.secureEventInputIsEnabled is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/secure-input/bfcache-restore-preserves-secure-input.html
+++ b/LayoutTests/editing/secure-input/bfcache-restore-preserves-secure-input.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<input id="input" type=password>
+<script>
+jsTestIsAsync = true;
+
+description("Verify that restoring a page from the back/forward cache re-enables secure input state when the cached focused element is a password input.");
+
+window.addEventListener("pageshow", function(event) {
+    if (!event.persisted)
+        return;
+    debug("\nPage was restored from the back/forward cache:");
+    UIHelper.ensurePresentationUpdate().then(() => {
+        shouldBe("document.activeElement", "input");
+        shouldBe("testRunner.secureEventInputIsEnabled", "true");
+        finishJSTest();
+    });
+});
+
+window.addEventListener("load", function() {
+    debug("A password input is focused on the initial page:");
+    input.focus();
+    UIHelper.ensurePresentationUpdate().then(() => {
+        shouldBe("testRunner.secureEventInputIsEnabled", "true");
+        debug("\nNavigating to a helper page that will navigate back:");
+        window.location.href = "../../fast/history/resources/page-cache-helper.html";
+    });
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/secure-input/mainframe-navigation-with-focused-subframe-password-resets-secure-input-expected.txt
+++ b/LayoutTests/editing/secure-input/mainframe-navigation-with-focused-subframe-password-resets-secure-input-expected.txt
@@ -1,0 +1,10 @@
+Verify that a main-frame navigation away from a page that has a focused password input in a subframe disables secure event input state.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS testRunner.secureEventInputIsEnabled is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/secure-input/mainframe-navigation-with-focused-subframe-password-resets-secure-input.html
+++ b/LayoutTests/editing/secure-input/mainframe-navigation-with-focused-subframe-password-resets-secure-input.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<iframe id="iframe" src="resources/password-frame.html"></iframe>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+window.addEventListener("load", async () => {
+    if (testRunner.secureEventInputIsEnabled) {
+        debug("FAIL: Secure event input was enabled before focusing the subframe password input");
+        testRunner.notifyDone();
+        return;
+    }
+
+    let iframePassword = iframe.contentDocument.getElementById("password");
+    iframePassword.focus();
+    await UIHelper.ensurePresentationUpdate();
+    if (!testRunner.secureEventInputIsEnabled) {
+        debug("FAIL: Secure event input was not enabled after focusing the subframe password input");
+        testRunner.notifyDone();
+        return;
+    }
+
+    location = "resources/mainframe-navigation-with-focused-subframe-password-target.html";
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/secure-input/reload-preserves-secure-input-expected.txt
+++ b/LayoutTests/editing/secure-input/reload-preserves-secure-input-expected.txt
@@ -1,0 +1,12 @@
+Verify that reloading a page with an autofocused password input ends with secure input state enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+After reload:
+PASS document.activeElement is input
+PASS testRunner.secureEventInputIsEnabled is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/secure-input/reload-preserves-secure-input.html
+++ b/LayoutTests/editing/secure-input/reload-preserves-secure-input.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<input id="input" type=password autofocus>
+<script>
+jsTestIsAsync = true;
+
+description("Verify that reloading a page with an autofocused password input ends with secure input state enabled.");
+
+var isReloaded = location.hash === "#reloaded";
+
+window.addEventListener("load", () => {
+    UIHelper.ensurePresentationUpdate().then(() => {
+        if (!isReloaded) {
+            if (document.activeElement !== input || !testRunner.secureEventInputIsEnabled) {
+                testFailed("Initial load: expected password input to be focused with secure input enabled.");
+                finishJSTest();
+                return;
+            }
+            location.hash = "#reloaded";
+            location.reload();
+            return;
+        }
+
+        debug("After reload:");
+        shouldBe("document.activeElement", "input");
+        shouldBe("testRunner.secureEventInputIsEnabled", "true");
+        finishJSTest();
+    });
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/secure-input/reload-without-focus-resets-secure-input-expected.txt
+++ b/LayoutTests/editing/secure-input/reload-without-focus-resets-secure-input-expected.txt
@@ -1,0 +1,12 @@
+Verify that reloading a page disables secure input state when the focused password input is not refocused after the load.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+After reload (no element refocused):
+PASS document.activeElement === input is false
+PASS testRunner.secureEventInputIsEnabled is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/secure-input/reload-without-focus-resets-secure-input.html
+++ b/LayoutTests/editing/secure-input/reload-without-focus-resets-secure-input.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<input id="input" type=password>
+<script>
+jsTestIsAsync = true;
+
+description("Verify that reloading a page disables secure input state when the focused password input is not refocused after the load.");
+
+var isReloaded = location.hash === "#reloaded";
+
+window.addEventListener("load", () => {
+    if (!isReloaded) {
+        input.focus();
+        UIHelper.ensurePresentationUpdate().then(() => {
+            if (document.activeElement !== input || !testRunner.secureEventInputIsEnabled) {
+                testFailed("Initial load: expected password input to be focused with secure input enabled.");
+                finishJSTest();
+                return;
+            }
+            location.hash = "#reloaded";
+            location.reload();
+        });
+        return;
+    }
+
+    UIHelper.ensurePresentationUpdate().then(() => {
+        debug("After reload (no element refocused):");
+        shouldBeFalse("document.activeElement === input");
+        shouldBe("testRunner.secureEventInputIsEnabled", "false");
+        finishJSTest();
+    });
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/secure-input/resources/autofocus-password-frame.html
+++ b/LayoutTests/editing/secure-input/resources/autofocus-password-frame.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<input id="password" type=password autofocus>
+</body>
+</html>

--- a/LayoutTests/editing/secure-input/resources/empty-frame.html
+++ b/LayoutTests/editing/secure-input/resources/empty-frame.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Subframe used by secure-input tests.</p>
+</body>
+</html>

--- a/LayoutTests/editing/secure-input/resources/mainframe-navigation-with-focused-subframe-password-target.html
+++ b/LayoutTests/editing/secure-input/resources/mainframe-navigation-with-focused-subframe-password-target.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+
+description("Verify that a main-frame navigation away from a page that has a focused password input in a subframe disables secure event input state.");
+
+shouldBe("testRunner.secureEventInputIsEnabled", "false");
+
+if (window.testRunner)
+    testRunner.notifyDone();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/secure-input/resources/password-frame.html
+++ b/LayoutTests/editing/secure-input/resources/password-frame.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<input id="password" type=password>
+</body>
+</html>

--- a/LayoutTests/editing/secure-input/subframe-commit-preserves-secure-input-expected.txt
+++ b/LayoutTests/editing/secure-input/subframe-commit-preserves-secure-input-expected.txt
@@ -1,0 +1,15 @@
+Verify that committing a load in a subframe does not disable secure input state while the main frame's password input is focused.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+A password input in the main frame is focused:
+PASS testRunner.secureEventInputIsEnabled is true
+
+The subframe commits a new document:
+PASS document.activeElement is input
+PASS testRunner.secureEventInputIsEnabled is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/secure-input/subframe-commit-preserves-secure-input.html
+++ b/LayoutTests/editing/secure-input/subframe-commit-preserves-secure-input.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../http/tests/secure-input/resources/secure-input-helper.js"></script>
+</head>
+<body>
+<input id="input" type=password>
+<iframe id="iframe" src="about:blank"></iframe>
+<script>
+jsTestIsAsync = true;
+
+description("Verify that committing a load in a subframe does not disable secure input state while the main frame's password input is focused.");
+
+window.addEventListener("load", async () => {
+    debug("A password input in the main frame is focused:");
+    input.focus();
+
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("testRunner.secureEventInputIsEnabled", "true");
+
+    debug("\nThe subframe commits a new document:");
+    iframe.src = "resources/empty-frame.html";
+    await waitForIframeLoad(iframe);
+
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("document.activeElement", "input");
+    shouldBe("testRunner.secureEventInputIsEnabled", "true");
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/secure-input/subframe-navigation-from-focused-password-resets-secure-input-expected.txt
+++ b/LayoutTests/editing/secure-input/subframe-navigation-from-focused-password-resets-secure-input-expected.txt
@@ -1,0 +1,18 @@
+Verify that navigating a subframe away from a focused password input in that subframe disables secure event input state.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Initial state, no password focused:
+PASS testRunner.secureEventInputIsEnabled is false
+
+A password input in the subframe is focused:
+PASS iframe.contentDocument.activeElement is iframePassword
+PASS testRunner.secureEventInputIsEnabled is true
+
+The subframe navigates away to a document without a password input:
+PASS testRunner.secureEventInputIsEnabled is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/secure-input/subframe-navigation-from-focused-password-resets-secure-input.html
+++ b/LayoutTests/editing/secure-input/subframe-navigation-from-focused-password-resets-secure-input.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../http/tests/secure-input/resources/secure-input-helper.js"></script>
+</head>
+<body>
+<iframe id="iframe" src="resources/password-frame.html"></iframe>
+<script>
+jsTestIsAsync = true;
+
+description("Verify that navigating a subframe away from a focused password input in that subframe disables secure event input state.");
+
+var iframePassword;
+
+window.addEventListener("load", async () => {
+    debug("Initial state, no password focused:");
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("testRunner.secureEventInputIsEnabled", "false");
+
+    debug("\nA password input in the subframe is focused:");
+    iframePassword = iframe.contentDocument.getElementById("password");
+    iframePassword.focus();
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("iframe.contentDocument.activeElement", "iframePassword");
+    shouldBe("testRunner.secureEventInputIsEnabled", "true");
+
+    debug("\nThe subframe navigates away to a document without a password input:");
+    iframe.src = "resources/empty-frame.html";
+    await waitForIframeLoad(iframe);
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("testRunner.secureEventInputIsEnabled", "false");
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/secure-input/subframe-navigation-to-autofocus-password-preserves-secure-input-expected.txt
+++ b/LayoutTests/editing/secure-input/subframe-navigation-to-autofocus-password-preserves-secure-input-expected.txt
@@ -1,0 +1,19 @@
+Verify that navigating a subframe from a focused password input to a new document with an autofocused password input keeps secure event input state enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Initial state, no password focused:
+PASS testRunner.secureEventInputIsEnabled is false
+
+A password input in the subframe is focused:
+PASS iframe.contentDocument.activeElement is iframePassword
+PASS testRunner.secureEventInputIsEnabled is true
+
+The subframe navigates to a new document with an autofocused password input:
+PASS iframe.contentDocument.activeElement is newIframePassword
+PASS testRunner.secureEventInputIsEnabled is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/secure-input/subframe-navigation-to-autofocus-password-preserves-secure-input.html
+++ b/LayoutTests/editing/secure-input/subframe-navigation-to-autofocus-password-preserves-secure-input.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../http/tests/secure-input/resources/secure-input-helper.js"></script>
+</head>
+<body>
+<iframe id="iframe" src="resources/password-frame.html"></iframe>
+<script>
+jsTestIsAsync = true;
+
+description("Verify that navigating a subframe from a focused password input to a new document with an autofocused password input keeps secure event input state enabled.");
+
+var iframePassword;
+var newIframePassword;
+
+window.addEventListener("load", async () => {
+    debug("Initial state, no password focused:");
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("testRunner.secureEventInputIsEnabled", "false");
+
+    debug("\nA password input in the subframe is focused:");
+    iframePassword = iframe.contentDocument.getElementById("password");
+    iframePassword.focus();
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("iframe.contentDocument.activeElement", "iframePassword");
+    shouldBe("testRunner.secureEventInputIsEnabled", "true");
+
+    debug("\nThe subframe navigates to a new document with an autofocused password input:");
+    iframe.src = "resources/autofocus-password-frame.html";
+    await waitForIframeLoad(iframe);
+    await UIHelper.ensurePresentationUpdate();
+    newIframePassword = iframe.contentDocument.getElementById("password");
+    shouldBe("iframe.contentDocument.activeElement", "newIframePassword");
+    shouldBe("testRunner.secureEventInputIsEnabled", "true");
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/secure-input/cross-origin-subframe-commit-preserves-secure-input-expected.txt
+++ b/LayoutTests/http/tests/secure-input/cross-origin-subframe-commit-preserves-secure-input-expected.txt
@@ -1,0 +1,15 @@
+Verify that committing a load in a cross-origin subframe does not disable secure input state while the main frame's password input is focused.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+A password input in the main frame is focused:
+PASS testRunner.secureEventInputIsEnabled is true
+
+The cross-origin subframe commits a new document:
+PASS document.activeElement is input
+PASS testRunner.secureEventInputIsEnabled is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/secure-input/cross-origin-subframe-commit-preserves-secure-input.html
+++ b/LayoutTests/http/tests/secure-input/cross-origin-subframe-commit-preserves-secure-input.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="resources/secure-input-helper.js"></script>
+</head>
+<body>
+<input id="input" type=password>
+<iframe id="iframe" src="about:blank"></iframe>
+<script>
+jsTestIsAsync = true;
+
+description("Verify that committing a load in a cross-origin subframe does not disable secure input state while the main frame's password input is focused.");
+
+window.addEventListener("load", async () => {
+    debug("A password input in the main frame is focused:");
+    input.focus();
+
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("testRunner.secureEventInputIsEnabled", "true");
+
+    debug("\nThe cross-origin subframe commits a new document:");
+    let loadPromise = waitForIframeLoad(iframe);
+    iframe.src = "http://localhost:8000/secure-input/resources/cross-origin-empty-frame.html";
+    await loadPromise;
+
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("document.activeElement", "input");
+    shouldBe("testRunner.secureEventInputIsEnabled", "true");
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/secure-input/cross-origin-subframe-navigation-from-focused-password-resets-secure-input-expected.txt
+++ b/LayoutTests/http/tests/secure-input/cross-origin-subframe-navigation-from-focused-password-resets-secure-input-expected.txt
@@ -1,0 +1,17 @@
+Verify that navigating a cross-origin subframe away from a focused password input in that subframe disables secure event input state.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Initial state, no password focused:
+PASS testRunner.secureEventInputIsEnabled is false
+
+A password input in the cross-origin subframe is focused:
+PASS testRunner.secureEventInputIsEnabled is true
+
+The cross-origin subframe navigates away to a document without a password input:
+PASS testRunner.secureEventInputIsEnabled is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/secure-input/cross-origin-subframe-navigation-from-focused-password-resets-secure-input.html
+++ b/LayoutTests/http/tests/secure-input/cross-origin-subframe-navigation-from-focused-password-resets-secure-input.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="resources/secure-input-helper.js"></script>
+</head>
+<body>
+<iframe id="iframe" src="http://localhost:8000/secure-input/resources/cross-origin-password-frame.html"></iframe>
+<script>
+jsTestIsAsync = true;
+
+description("Verify that navigating a cross-origin subframe away from a focused password input in that subframe disables secure event input state.");
+
+window.addEventListener("load", async () => {
+    debug("Initial state, no password focused:");
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("testRunner.secureEventInputIsEnabled", "false");
+
+    debug("\nA password input in the cross-origin subframe is focused:");
+    await focusCrossOriginIframePassword(iframe);
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("testRunner.secureEventInputIsEnabled", "true");
+
+    debug("\nThe cross-origin subframe navigates away to a document without a password input:");
+    let loadPromise = waitForIframeLoad(iframe);
+    iframe.src = "http://localhost:8000/secure-input/resources/cross-origin-empty-frame.html";
+    await loadPromise;
+    await UIHelper.ensurePresentationUpdate();
+    shouldBe("testRunner.secureEventInputIsEnabled", "false");
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/secure-input/mainframe-navigation-with-focused-cross-origin-subframe-password-resets-secure-input-expected.txt
+++ b/LayoutTests/http/tests/secure-input/mainframe-navigation-with-focused-cross-origin-subframe-password-resets-secure-input-expected.txt
@@ -1,0 +1,10 @@
+Verify that a main-frame navigation away from a page that has a focused password input in a cross-origin subframe disables secure event input state.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS testRunner.secureEventInputIsEnabled is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/secure-input/mainframe-navigation-with-focused-cross-origin-subframe-password-resets-secure-input.html
+++ b/LayoutTests/http/tests/secure-input/mainframe-navigation-with-focused-cross-origin-subframe-password-resets-secure-input.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="resources/secure-input-helper.js"></script>
+</head>
+<body>
+<iframe id="iframe" src="http://localhost:8000/secure-input/resources/cross-origin-password-frame.html"></iframe>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+window.addEventListener("load", async () => {
+    if (testRunner.secureEventInputIsEnabled) {
+        debug("FAIL: Secure event input was enabled before focusing the cross-origin subframe password input");
+        testRunner.notifyDone();
+        return;
+    }
+
+    await focusCrossOriginIframePassword(iframe);
+    await UIHelper.ensurePresentationUpdate();
+    if (!testRunner.secureEventInputIsEnabled) {
+        debug("FAIL: Secure event input was not enabled after focusing the cross-origin subframe password input");
+        testRunner.notifyDone();
+        return;
+    }
+
+    location = "resources/mainframe-navigation-with-focused-cross-origin-subframe-password-target.html";
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/secure-input/reset-state-on-process-swap-navigation-expected.txt
+++ b/LayoutTests/http/tests/secure-input/reset-state-on-process-swap-navigation-expected.txt
@@ -1,0 +1,10 @@
+Verify that a cross-origin process-swap navigation away from a page with a focused password input disables secure event input state.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS testRunner.secureEventInputIsEnabled is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/secure-input/reset-state-on-process-swap-navigation.html
+++ b/LayoutTests/http/tests/secure-input/reset-state-on-process-swap-navigation.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html><!-- webkit-test-runner [ enableProcessSwapOnNavigation=true ] -->
+<html>
+<head>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<input type=password>
+<script>
+    
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+var passwordInput = document.getElementsByTagName("input")[0];
+
+passwordInput.focus();
+UIHelper.ensurePresentationUpdate().then(() => {
+    if (testRunner.secureEventInputIsEnabled) {
+        location = "http://localhost:8000/secure-input/resources/reset-state-on-process-swap-navigation-target.html";
+        return;
+    }
+
+    debug("FAIL: Secure event input is not enabled after focusing a password input");
+    testRunner.notifyDone();
+    return;  
+})
+        
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/secure-input/resources/cross-origin-empty-frame.html
+++ b/LayoutTests/http/tests/secure-input/resources/cross-origin-empty-frame.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Cross-origin subframe used by secure-input tests.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/secure-input/resources/cross-origin-password-frame.html
+++ b/LayoutTests/http/tests/secure-input/resources/cross-origin-password-frame.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+html, body { margin: 0; padding: 0; width: 100%; height: 100%; }
+#password { width: 100%; height: 100%; box-sizing: border-box; }
+</style>
+</head>
+<body>
+<input id="password" type=password>
+<script>
+const password = document.getElementById("password");
+password.addEventListener("focus", () => parent.postMessage("password-focused", "*"));
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/secure-input/resources/mainframe-navigation-with-focused-cross-origin-subframe-password-target.html
+++ b/LayoutTests/http/tests/secure-input/resources/mainframe-navigation-with-focused-cross-origin-subframe-password-target.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+
+description("Verify that a main-frame navigation away from a page that has a focused password input in a cross-origin subframe disables secure event input state.");
+
+shouldBe("testRunner.secureEventInputIsEnabled", "false");
+
+if (window.testRunner)
+    testRunner.notifyDone();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/secure-input/resources/reset-state-on-process-swap-navigation-target.html
+++ b/LayoutTests/http/tests/secure-input/resources/reset-state-on-process-swap-navigation-target.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+
+description("Verify that a cross-origin process-swap navigation away from a page with a focused password input disables secure event input state.");
+
+shouldBe("testRunner.secureEventInputIsEnabled", "false");
+
+if (window.testRunner)
+    testRunner.notifyDone();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/secure-input/resources/secure-input-helper.js
+++ b/LayoutTests/http/tests/secure-input/resources/secure-input-helper.js
@@ -1,0 +1,20 @@
+function waitForIframeLoad(iframe) {
+    return new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+}
+
+function waitForMessage(expectedData) {
+    return new Promise(resolve => {
+        window.addEventListener("message", function handler(event) {
+            if (event.data !== expectedData)
+                return;
+            window.removeEventListener("message", handler);
+            resolve();
+        });
+    });
+}
+
+async function focusCrossOriginIframePassword(iframe) {
+    let focusedPromise = waitForMessage("password-focused");
+    await UIHelper.activateElement(iframe);
+    await focusedPromise;
+}

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -588,9 +588,12 @@ webkit.org/b/165799 fast/mediastream/device-change-event-2.html [ Skip ]
 # AutoFill button is not supported
 fast/forms/auto-fill-button/mouse-down-input-mouse-release-auto-fill-button.html
 
+# SecureEventInput is not supported on iOS.
+editing/secure-input [ Skip ]
+http/tests/secure-input [ Skip ]
+
 # Mouse events are not supported on iOS
 editing/deleting/smart-delete-across-editable-boundaries-2.html [ Skip ]
-editing/secure-input/password-input-focusing-to-different-frame.html [ Skip ]
 editing/selection/4895428-1.html [ Skip ]
 editing/selection/4895428-4.html [ Skip ]
 editing/selection/5195166-1.html [ Skip ]
@@ -5351,10 +5354,6 @@ editing/inserting/insert-tab-001.html [ Failure ]
 editing/inserting/insert-tab-002.html [ Failure ]
 editing/inserting/insert-tab-004.html [ Failure ]
 editing/inserting/typing-around-br-001.html [ Failure ]
-editing/secure-input/password-input-changed-type.html [ Failure ]
-editing/secure-input/password-input-focusing.html [ Failure ]
-editing/secure-input/removed-password-input.html [ Failure ]
-editing/secure-input/reset-state-on-navigation.html [ Failure ]
 editing/selection/caret-in-empty-inline-1.html [ Failure ]
 editing/selection/caret-in-empty-inline-2.html [ Failure ]
 editing/selection/click-in-margins-inside-editable-div.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -17,6 +17,7 @@ http/tests/security/referrer-policy-header-unsafe-url.html [ Crash ]
 #######################
 # Tests that time out #
 #######################
+editing/secure-input/bfcache-restore-preserves-secure-input.html [ Skip ]
 fast/events/pageshow-pagehide-on-back-cached-with-frames.html [ Timeout ]
 fast/events/pageshow-pagehide-on-back-cached.html [ Timeout ]
 fast/history/back-from-page-with-focused-iframe.html [ Timeout ]
@@ -52,6 +53,8 @@ http/tests/media/media-stream/speech-recognition-iframe-allow-attribute.html [ F
 http/tests/misc/will-send-request-returns-null-on-redirect.html [ Failure ]
 http/tests/navigation/cross-origin-navigation-fires-onload.html [ Failure ]
 http/tests/navigation/page-cache-xhr-in-loading-iframe.html [ Failure ]
+http/tests/secure-input/cross-origin-subframe-navigation-from-focused-password-resets-secure-input.html [ Failure ]
+http/tests/secure-input/mainframe-navigation-with-focused-cross-origin-subframe-password-resets-secure-input.html [ Failure ]
 http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Pass ]

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8723,9 +8723,19 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
     }
 
 #if USE(APPKIT)
-    // FIXME (bug 59111): didCommitLoadForFrame comes too late when restoring a page from b/f cache, making us disable secure event mode in password fields.
-    // FIXME: A load going on in one frame shouldn't affect text editing in other frames on the page.
-    protectedPageClient->resetSecureInputState();
+    for (RefPtr ancestor = focusedOrMainFrame(); ancestor; ancestor = ancestor->parentFrame()) {
+        if (ancestor == frame) {
+            protectedPageClient->resetSecureInputState();
+            // FIXME: <rdar://175390893> WebPageProxy::didUpdateEditorState only updates
+            // the secure input state if `isInPasswordField` changed across EditorStates, or
+            // if the select type is `None`. If a frame autofocuses a password input,
+            // `isInPasswordField` may be true for both the old and new state and the selection
+            // type may be `None` and thus fail to update the state even though we just reset it.
+            // We force a reevaluation as a workaround.
+            internals().forceNeedsSecureInputReevaluation = true;
+            break;
+        }
+    }
 #endif
 
     frame->didCommitLoad(mimeType, containsPluginDocument, WTF::move(documentSecurityPolicy), WTF::move(cspOriginsThatUpgradeInsecureNavigations));

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -432,6 +432,8 @@ public:
     WebCore::CornerRadii scrollbarAvoidanceCornerRadii;
 #endif
 
+    bool forceNeedsSecureInputReevaluation { false };
+
     explicit Internals(WebPageProxy&, bool processInheritedFromOpener);
 
 #if ENABLE(SPEECH_SYNTHESIS)

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -795,6 +795,16 @@ CGRect WebPageProxy::boundsOfLayerInLayerBackedWindowCoordinates(CALayer *layer)
 void WebPageProxy::didUpdateEditorState(const EditorState& oldEditorState, const EditorState& newEditorState)
 {
     bool couldChangeSecureInputState = newEditorState.isInPasswordField != oldEditorState.isInPasswordField || oldEditorState.selectionType == WebCore::SelectionType::None;
+
+    // FIXME: <rdar://175390893> WebPageProxy::didUpdateEditorState only updates
+    // the secure input state if `isInPasswordField` changed across EditorStates, or
+    // if the select type is `None`. If a frame autofocuses a password input,
+    // `isInPasswordField` may be true for both the old and new state and the selection
+    // type may be `None` and thus fail to update the state even though we just reset it.
+    // We force a reevaluation as a workaround.
+    if (std::exchange(internals().forceNeedsSecureInputReevaluation, false))
+        couldChangeSecureInputState = true;
+
     // Selection being none is a temporary state when editing. Flipping secure input state too quickly was causing trouble (not fully understood).
     if (couldChangeSecureInputState && newEditorState.selectionType != WebCore::SelectionType::None) {
         if (RefPtr pageClient = this->pageClient())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1774,6 +1774,10 @@ void WebLocalFrameLoaderClient::transitionToCommittedForNewPage(InitializingIfra
 void WebLocalFrameLoaderClient::didRestoreFromBackForwardCache()
 {
     m_frameCameFromBackForwardCache = true;
+
+    // Schedule a full editor state update in case the secure input state needs to be updated.
+    if (RefPtr webPage = m_frame->page())
+        webPage->scheduleFullEditorStateUpdate();
 }
 
 void WebLocalFrameLoaderClient::didCacheBackForwardItem(BackForwardItemIdentifier itemID, BackForwardFrameItemIdentifier frameItemID)


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://184744718 to main. [808715aa71af] caused a merge conflict. 

```
Cherry-pick c58993a9e655. rdar://174172292

    Subframe disables SecureEventInput during password entry, can allow for malicious keylogging
    rdar://174172292

    Reviewed by Wenson Hsieh, Abrar Rahman Protyasha, and Aditya Keerthi.

    When a password input has focus, a subframe can make document commits
    to disable SecureEventInput. `WebPageProxy::didCommitLoadForFrame`
    gets called after the subframe makes a commit, where we then call
    `protectedPageClient->resetSecureInputState()` regardless of which
    frame actually made the commit.

    Resolve this issue by only calling `resetSecureInputState()` if
    the frame which made the commit is the focused frame or an ancestor
    of the focused frame. Additionally, mark
    `internals().forceNeedsSecureInputReevaluation` as true and check
    for the value in `WebPageProxy::didUpdateEditorState` to ensure
    that we reenable the SecureEventInput state if a page with an
    autofocused password input navigates to another page with an
    autofocused password input.

    Also address the issue where bfcache restoration fails to update
    the state accordingly by scheduling a full editor state update in
    `WebLocalFrameLoaderClient::didRestoreFromBackForwardCache`.

    Tests: editing/secure-input/bfcache-restore-preserves-secure-input.html
           editing/secure-input/mainframe-navigation-with-focused-subframe-password-resets-secure-input.html
           editing/secure-input/reload-preserves-secure-input.html
           editing/secure-input/reload-without-focus-resets-secure-input.html
           editing/secure-input/subframe-commit-preserves-secure-input.html
           editing/secure-input/subframe-navigation-from-focused-password-resets-secure-input.html
           editing/secure-input/subframe-navigation-to-autofocus-password-preserves-secure-input.html
           http/tests/secure-input/cross-origin-subframe-commit-preserves-secure-input.html
           http/tests/secure-input/cross-origin-subframe-navigation-from-focused-password-resets-secure-input.html
           http/tests/secure-input/mainframe-navigation-with-focused-cross-origin-subframe-password-resets-secure-input.html
           http/tests/secure-input/reset-state-on-process-swap-navigation.html

    * LayoutTests/editing/secure-input/bfcache-restore-preserves-secure-input-expected.txt: Added.
    * LayoutTests/editing/secure-input/bfcache-restore-preserves-secure-input.html: Added.
    * LayoutTests/editing/secure-input/mainframe-navigation-with-focused-subframe-password-resets-secure-input-expected.txt: Added.
    * LayoutTests/editing/secure-input/mainframe-navigation-with-focused-subframe-password-resets-secure-input.html: Added.
    * LayoutTests/editing/secure-input/reload-preserves-secure-input-expected.txt: Added.
    * LayoutTests/editing/secure-input/reload-preserves-secure-input.html: Added.
    * LayoutTests/editing/secure-input/reload-without-focus-resets-secure-input-expected.txt: Added.
    * LayoutTests/editing/secure-input/reload-without-focus-resets-secure-input.html: Added.
    * LayoutTests/editing/secure-input/resources/autofocus-password-frame.html: Added.
    * LayoutTests/editing/secure-input/resources/empty-frame.html: Added.
    * LayoutTests/editing/secure-input/resources/mainframe-navigation-with-focused-subframe-password-target.html: Added.
    * LayoutTests/editing/secure-input/resources/password-frame.html: Added.
    * LayoutTests/editing/secure-input/subframe-commit-preserves-secure-input-expected.txt: Added.
    * LayoutTests/editing/secure-input/subframe-commit-preserves-secure-input.html: Added.
    * LayoutTests/editing/secure-input/subframe-navigation-from-focused-password-resets-secure-input-expected.txt: Added.
    * LayoutTests/editing/secure-input/subframe-navigation-from-focused-password-resets-secure-input.html: Added.
    * LayoutTests/editing/secure-input/subframe-navigation-to-autofocus-password-preserves-secure-input-expected.txt: Added.
    * LayoutTests/editing/secure-input/subframe-navigation-to-autofocus-password-preserves-secure-input.html: Added.
    * LayoutTests/http/tests/secure-input/cross-origin-subframe-commit-preserves-secure-input-expected.txt: Added.
    * LayoutTests/http/tests/secure-input/cross-origin-subframe-commit-preserves-secure-input.html: Added.
    * LayoutTests/http/tests/secure-input/cross-origin-subframe-navigation-from-focused-password-resets-secure-input-expected.txt: Added.
    * LayoutTests/http/tests/secure-input/cross-origin-subframe-navigation-from-focused-password-resets-secure-input.html: Added.
    * LayoutTests/http/tests/secure-input/mainframe-navigation-with-focused-cross-origin-subframe-password-resets-secure-input-expected.txt: Added.
    * LayoutTests/http/tests/secure-input/mainframe-navigation-with-focused-cross-origin-subframe-password-resets-secure-input.html: Added.
    * LayoutTests/http/tests/secure-input/reset-state-on-process-swap-navigation-expected.txt: Added.
    * LayoutTests/http/tests/secure-input/reset-state-on-process-swap-navigation.html: Added.
    * LayoutTests/http/tests/secure-input/resources/cross-origin-empty-frame.html: Added.
    * LayoutTests/http/tests/secure-input/resources/cross-origin-password-frame.html: Added.
    * LayoutTests/http/tests/secure-input/resources/mainframe-navigation-with-focused-cross-origin-subframe-password-target.html: Added.
    * LayoutTests/http/tests/secure-input/resources/reset-state-on-process-swap-navigation-target.html: Added.
    * LayoutTests/http/tests/secure-input/resources/secure-input-helper.js: Added.
    (waitForIframeLoad):
    (waitForMessage.return.new.Promise):
    (async focusCrossOriginIframePassword):
    * LayoutTests/platform/ios/TestExpectations:
    * LayoutTests/platform/mac-site-isolation/TestExpectations:
    * Source/WebKit/UIProcess/WebPageProxy.cpp:
    (WebKit::WebPageProxy::didCommitLoadForFrame):
    * Source/WebKit/UIProcess/WebPageProxyInternals.h:
    * Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
    (WebKit::WebPageProxy::didUpdateEditorState):
    * Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
    (WebKit::WebLocalFrameLoaderClient::didRestoreFromBackForwardCache):

    Identifier: 305413.732@safari-7624-branch

Originally-landed-as: 305413.985@safari-7624.5-branch (808715aa71af). rdar://184744718


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edb14c6f6d88781405690523ae47dcec51a4339e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144764 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54104 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140731 "Found 4 new test failures: http/tests/secure-input/cross-origin-subframe-commit-preserves-secure-input.html http/tests/secure-input/cross-origin-subframe-navigation-from-focused-password-resets-secure-input.html http/tests/secure-input/mainframe-navigation-with-focused-cross-origin-subframe-password-resets-secure-input.html http/tests/secure-input/reset-state-on-process-swap-navigation.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97478 "1 flakes 8 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121183 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43068 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41351 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41027 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1813 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192589 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161016 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150092 "Found 4 new test failures: http/tests/secure-input/cross-origin-subframe-commit-preserves-secure-input.html http/tests/secure-input/cross-origin-subframe-navigation-from-focused-password-resets-secure-input.html http/tests/secure-input/mainframe-navigation-with-focused-cross-origin-subframe-password-resets-secure-input.html http/tests/secure-input/reset-state-on-process-swap-navigation.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54742 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149815 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44437 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127005 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122167 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53259 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16016 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52641 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52706 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->