### PR TITLE
GPU process crash in WebCore::ControlFactoryMac::servicesRolloverButtonCell() drawing image controls

### DIFF
--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -53,6 +53,7 @@
 #import <pal/spi/mac/NSServicesRolloverButtonCellSPI.h>
 #import <pal/spi/mac/NSViewSPI.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/Lock.h>
 #import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -168,7 +169,18 @@ NSPopUpButtonCell *ControlFactoryMac::popUpButtonCell() const
 NSServicesRolloverButtonCell *ControlFactoryMac::servicesRolloverButtonCell() const
 {
     if (!m_servicesRolloverButtonCell) {
-        m_servicesRolloverButtonCell = [NSServicesRolloverButtonCell serviceRolloverButtonCellForStyle:NSSharingServicePickerStyleRollover];
+        // +serviceRolloverButtonCellForStyle: returns a process-wide shared cell, so give
+        // each ControlFactory a private copy rather than configuring and drawing one cell
+        // across RemoteRenderingBackend work-queue threads. The copy must be serialized by
+        // a process-wide lock because -[NSButtonCell copyWithZone:] transiently mutates its
+        // source; drawing the private copy needs no lock. (-[NSServicesRolloverButtonCell
+        // initWithStyle:] would avoid the shared cell and the lock, but it is not declared
+        // in any AppKit header.)
+        static Lock copyLock;
+        {
+            Locker locker { copyLock };
+            m_servicesRolloverButtonCell = adoptNS([[NSServicesRolloverButtonCell serviceRolloverButtonCellForStyle:NSSharingServicePickerStyleRollover] copy]);
+        }
         [m_servicesRolloverButtonCell setBezelStyle:NSBezelStyleRoundedDisclosure];
         [m_servicesRolloverButtonCell setButtonType:NSButtonTypePushOnPushOff];
         [m_servicesRolloverButtonCell setImagePosition:NSImageOnly];


### PR DESCRIPTION
#### 4c7a59d2a5e1c7ecd6b137cf3a02ba24c422b44f
<pre>
GPU process crash in WebCore::ControlFactoryMac::servicesRolloverButtonCell() drawing image controls
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=316849">https://bugs.webkit.org/show_bug.cgi?id=316849</a>&gt;
&lt;<a href="https://rdar.apple.com/177901870">rdar://177901870</a>&gt;

Reviewed by Simon Fraser.

The GPU process can crash while drawing the image-controls (services
rollover) button on its per-connection RemoteRenderingBackend work
queues.  Each RemoteGraphicsContext installs its own per-context
ControlFactory override for the duration of a draw, so the factory
itself is not shared across work-queue threads.

`ControlFactoryMac::servicesRolloverButtonCell()` is the one cell
accessor that defeats that isolation.  It caches the cell returned by
`+[NSServicesRolloverButtonCell serviceRolloverButtonCellForStyle:]`,
which is a process-wide singleton, so every per-context factory ends up
caching and drawing the SAME AppKit cell.  Configuring that shared cell
on one work-queue thread races with drawing it on another, and `NSCell`
is not thread-safe.

Give each factory a private copy of the cell, so it is only ever touched
by that factory&apos;s single work-queue thread.  `-[NSButtonCell
copyWithZone:]` gives the copy a nil visual provider -- the state whose
concurrent mutation crashes -- so the copy shares nothing mutable with
the shared cell, and drawing it needs no lock.

The copy itself must be serialized under a process-wide lock because
`-[NSButtonCell copyWithZone:]` transiently mutates its source, so
concurrent first-access copies of the shared cell would otherwise race.

No new tests since this change is not directly testable.

* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::servicesRolloverButtonCell const):

Originally-landed-as: 305413.939@safari-7624.4-branch (4620ee2b5925). <a href="https://rdar.apple.com/184744679">rdar://184744679</a>
Canonical link: <a href="https://commits.webkit.org/319097@main">https://commits.webkit.org/319097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01999d52407c5a142792669b1659c519fff7b862

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144691 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140691 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43014 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41313 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40992 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1740 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192516 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53981 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150039 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40190 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54669 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149761 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44393 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126932 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122094 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53186 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15981 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->