### PR TITLE
[css-values-5] Add test coverage for the random() caching key in custom properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt
@@ -130,6 +130,12 @@ PASS Shared by property name and value index: random(property-index-scoped, a, b
 PASS Shared by property and index in list value: random(a, b)
 FAIL Nested in fixed value random() function used for custom property: 'random(a, b)' assert_false: Different custom properties on the same element should not have equal values expected false got true
 PASS random() in different custom properties on the same element should not be shared
+PASS random() in different registered <length> custom properties on the same element should not be shared
+PASS random() in a custom property should be element-scoped by default
+PASS random() in a custom property should not be shared with a non-custom property at the same index
+PASS random(property-scoped, ...) in a custom property should be equal between elements
+PASS two random() functions in the same custom property should not be shared
+PASS random() keyed on a custom property should not collide with an author <dashed-ident> naming it
 PASS Shared by name within an element: 'random(--identifier element-scoped, a, b)'
 PASS Shared by name within an element - shorthand: random(--identifier element-scoped, a, b))
 PASS Shared between elements within a property: random(property-index-scoped, a, b)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative.html
@@ -38,6 +38,26 @@
     inherits: true;
     initial-value: 3%;
   }
+  @property --len-a {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 3px;
+  }
+  @property --len-b {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 3px;
+  }
+  @property --len-list {
+    syntax: "<length>+";
+    inherits: true;
+    initial-value: 3px;
+  }
+  @property --len-scoped {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 3px;
+  }
   @property --transform-function {
     syntax: "<transform-function>";
     inherits: true;
@@ -56,6 +76,13 @@
     --y: random(0, 300000);
     --random-length-1: random(fixed random(0, 1), 0px, 100px);
     --random-length-2: random(fixed random(0, 1), 0px, 100px);
+  }
+  .randomCustomLength {
+    width: random(0px, 300000px);
+    --len-a: random(0px, 300000px);
+    --len-b: random(0px, 300000px);
+    --len-list: random(0px, 300000px) random(0px, 300000px);
+    --len-scoped: random(property-scoped, 0px, 300000px);
   }
   .randomMatchElement {
     width: random(property-index-scoped, 0px, 300000px);
@@ -625,6 +652,131 @@ test(() => {
 
   try {
     const el = document.createElement('div');
+    el.className = 'randomCustomLength';
+    holder.appendChild(el);
+
+    const computedA = getComputedStyle(el).getPropertyValue('--len-a');
+    const computedB = getComputedStyle(el).getPropertyValue('--len-b');
+
+    test_random_not_equals(computedA, computedB,
+                          "Different registered <length> custom properties on the same element should not have equal values");
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `random() in different registered <length> custom properties on the same element should not be shared`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
+    el.className = 'randomCustomLength';
+    holder.appendChild(el);
+
+    const other = document.createElement('div');
+    other.className = 'randomCustomLength';
+    holder.appendChild(other);
+
+    const elComputed = getComputedStyle(el).getPropertyValue('--len-a');
+    const otherComputed = getComputedStyle(other).getPropertyValue('--len-a');
+
+    test_random_not_equals(elComputed, otherComputed,
+                          "The same custom property on different elements should not have equal values");
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `random() in a custom property should be element-scoped by default`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
+    el.className = 'randomCustomLength';
+    holder.appendChild(el);
+
+    // Both are the first random() in their own property, so these only differ if the caching key
+    // distinguishes a custom property from a non-custom one.
+    const computedWidth = getComputedStyle(el)['width'];
+    const computedLength = getComputedStyle(el).getPropertyValue('--len-a');
+
+    test_random_not_equals(computedWidth, computedLength,
+                          "A custom property and a non-custom property should not have equal values");
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `random() in a custom property should not be shared with a non-custom property at the same index`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
+    el.className = 'randomCustomLength';
+    holder.appendChild(el);
+
+    const other = document.createElement('div');
+    other.className = 'randomCustomLength';
+    holder.appendChild(other);
+
+    const elComputed = getComputedStyle(el).getPropertyValue('--len-scoped');
+    const otherComputed = getComputedStyle(other).getPropertyValue('--len-scoped');
+
+    test_random_equals(elComputed, otherComputed);
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `random(property-scoped, ...) in a custom property should be equal between elements`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
+    el.className = 'randomCustomLength';
+    holder.appendChild(el);
+
+    const [first, second] = getComputedStyle(el).getPropertyValue('--len-list').split(' ');
+
+    test_random_not_equals(first, second,
+                          "Two random() functions in one custom property should not have equal values");
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `two random() functions in the same custom property should not be shared`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
+    el.style.setProperty('--len-a', 'random(0px, 300000px)');
+    // The author-supplied <dashed-ident> happens to name the other property. It is a separate
+    // namespace from the property a key is implicitly scoped to, so these must not collide.
+    el.style.setProperty('--len-b', 'random(--len-a, 0px, 300000px)');
+    holder.appendChild(el);
+
+    const computedA = getComputedStyle(el).getPropertyValue('--len-a');
+    const computedB = getComputedStyle(el).getPropertyValue('--len-b');
+
+    test_random_not_equals(computedA, computedB,
+                          "An implicit property scope should not collide with an author <dashed-ident> of the same name");
+  } finally {
+    document.body.removeChild(holder);
+  }
+}, `random() keyed on a custom property should not collide with an author <dashed-ident> naming it`);
+
+test(() => {
+  const holder = document.createElement('div');
+  document.body.appendChild(holder);
+
+  try {
+    const el = document.createElement('div');
     el.className = 'randomIdentifier';
     holder.appendChild(el);
 
@@ -913,8 +1065,10 @@ test(() => {
     const el = document.createElement('div');
     el.className = 'randomNoIdentifier';
     holder.appendChild(el);
-    const computedValue = getComputedStyle(el)['--random-in-initial'];
-    test_random_equals(computedValue, undefined);
+    // The initial-value is invalid, so the @property rule registers nothing and the property is
+    // left unregistered, which reads back as the empty string.
+    const computedValue = getComputedStyle(el).getPropertyValue('--random-in-initial');
+    test_random_equals(computedValue, '');
   } finally {
     document.body.removeChild(holder);
   }


### PR DESCRIPTION
#### c4182c1faa92daf4f2e654daff0eec1f3d4aa95f
<pre>
[css-values-5] Add test coverage for the random() caching key in custom properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=319266">https://bugs.webkit.org/show_bug.cgi?id=319266</a>
<a href="https://rdar.apple.com/182135083">rdar://182135083</a>

Reviewed by Tim Nguyen.

319039@main allowed random() inside a custom property and 319096@main added the
custom property name to the caching key. Nothing pinned which random() usages
are supposed to share a base value once that works, so add cases for the caching
identity: two registered &lt;length&gt; custom properties on one element, the same
custom property on two elements, a custom property against a non-custom one at
the same index, property-scoped equality across elements, two random() functions
within one custom property, and an author &lt;dashed-ident&gt; that happens to name the
property an implicit key is scoped to.

The @property initial-value case read the computed value with bracket access on
the CSSStyleDeclaration, which never resolves a custom property, so it compared
undefined to undefined and could not fail. Read it with getPropertyValue() and
assert the property is left unregistered.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative.html:

Canonical link: <a href="https://commits.webkit.org/319131@main">https://commits.webkit.org/319131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5321f29c09c52cfeaec7012ca420a4d8634c8048

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190802 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b864fa37-5a1d-46b1-b98e-e8afd36364f9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54252 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/553c8d87-f538-4725-8f07-214c1aafb87d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183546 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/44530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121308 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/285c0ba3-f21e-4a3e-a38d-4a1d33e8f5b7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41161 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1961 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192738 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161150 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40210 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54890 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149951 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44571 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122369 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53407 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16154 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52789 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52854 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->