### PR TITLE
[JSC] FTL OSR exit: handle DataFormatStorage in reboxAccordingToFormat

### DIFF
--- a/JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js
+++ b/JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js
@@ -1,0 +1,40 @@
+//@ runDefault("--forceEagerCompilation=1")
+
+let total = 0;
+function check(v3) {
+    if (++total > 10000)
+        quit(0);
+    transferArrayBuffer(v3);
+}
+noInline(check);
+
+function main() {
+    function v2(v3) {
+        for (let v9 = 0; v9 < 1024; v9 = v9 + 1) {
+            try {
+                check(v3);
+            } catch {
+                const x = (() => {
+                    const a = new Array(8);
+                    a[0] = {}, a[1] = {}, a[2] = {}, a[3] = {}, a[0] = {}, a[5] = {}, a[6] = {}, a[7] = {};
+                    return a;
+                })();
+                const y = (() => {
+                    const r = [];
+                    for (let i = 0; i < 16; i++) { }
+                })();
+                try {
+                    for (let i = 0; i < 16; i++) {
+                        const o = {};
+                        try {
+                            main(o);
+                            x.__proto__ = Math.LN2;
+                        } catch { }
+                    }
+                } catch { }
+            }
+        }
+    }
+    const v11 = v2();
+}
+main();

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -81,7 +81,8 @@ static void reboxAccordingToFormat(
         break;
     }
 
-    case DataFormatJS: {
+    case DataFormatJS:
+    case DataFormatStorage: {
         // Done already!
         break;
     }


### PR DESCRIPTION
#### a02f99629f76ee4bc721eb5f16a1bdf7286792c3
<pre>
[JSC] FTL OSR exit: handle DataFormatStorage in reboxAccordingToFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=314579">https://bugs.webkit.org/show_bug.cgi?id=314579</a>
<a href="https://rdar.apple.com/176131036">rdar://176131036</a>

Reviewed by Marcus Plutowski.

300523@main relaxed validation so that PhantomNewArrayWithButterfly may
reference a non-phantom NewButterflyWithSize, and taught
FTLLowerDFGToB3::exitValueForNode to emit an ExitArgument with
DataFormatStorage for the live butterfly. However, the FTL OSR exit
compiler&apos;s reboxAccordingToFormat() was never updated, so when such an
exit is compiled it falls into RELEASE_ASSERT_NOT_REACHED().

The recovered storage value is the raw butterfly pointer that
operationMaterializeObjectInOSR(PhantomNewArrayWithButterfly) consumes
via std::bit_cast&lt;Butterfly*&gt;, so no boxing is required; treat it the
same as DataFormatJS and pass it through unchanged.

Test: JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js

* JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js: Added.
(check):
(main.v2):
(main):
* Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:
(JSC::FTL::reboxAccordingToFormat):

Originally-landed-as: 305413.922@safari-7624.4-branch (883cc7576689). <a href="https://rdar.apple.com/184744946">rdar://184744946</a>
Canonical link: <a href="https://commits.webkit.org/319094@main">https://commits.webkit.org/319094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df4f9ec99619f4310bbb7e8936042be6cd053bab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190590 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144700 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140690 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121142 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43018 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41317 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3109 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9950 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153422 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40994 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1749 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41653 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53990 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150043 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40188 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54678 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149765 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44403 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126941 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122103 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53195 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15983 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52642 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->