### PR TITLE
[Interop] Correct focus restore behavior to match spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-showModal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-showModal-expected.txt
@@ -7,6 +7,6 @@ PASS when opening multiple dialogs, only the newest one is non-inert
 PASS opening dialog without focusable children
 PASS opening dialog with multiple focusable children
 PASS opening dialog with multiple focusable children, one having the autofocus attribute
-FAIL when opening multiple dialogs, the most recently opened is rendered on top assert_equals: expected Element node <dialog id="d10" open=""></dialog> but got Element node <dialog id="d11" open=""></dialog>
+PASS when opening multiple dialogs, the most recently opened is rendered on top
 PASS When the document is not attached to any pages, showModal() should throw.
 OK

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Hit-testing doesn't reach contents of an inert SVG
-FAIL Hit-testing can reach contents of a no longer inert SVG assert_true: target is active expected true got false
+PASS Hit-testing can reach contents of a no longer inert SVG
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
@@ -43,6 +43,7 @@ promise_test(async function() {
         .pointerMove(wrapperRect.x + 1, wrapperRect.y + 1, { origin: "viewport" })
         .pointerDown()
         .send();
+    this.add_cleanup(() => test_driver.click(document.body));
 
     assert_false(target.matches(":active"), "target is not active");
     assert_false(target.matches(":hover"), "target is not hovered");
@@ -61,6 +62,7 @@ promise_test(async function() {
         .pointerMove(0, 0, { origin: wrapper })
         .pointerDown()
         .send();
+    this.add_cleanup(() => test_driver.click(document.body));
 
     assert_true(target.matches(":active"), "target is active");
     assert_true(reachedTarget, "target got event");

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Hit-testing doesn't reach contents of an inert SVG
+FAIL Hit-testing can reach contents of a no longer inert SVG assert_true: target is active expected true got false
+

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -210,8 +210,12 @@ ExceptionOr<void> HTMLDialogElement::showModal(Element* source)
         if (renderer)
             containingBlockBeforeStyleResolution = renderer->containingBlock();
 
-        if (!isInTopLayer())
-            addToTopLayer();
+        // Remove before adding, so we always add at the end of the top layer. A dialog can still
+        // be in the top layer here if its open attribute was removed directly rather than by
+        // close(), and showing it again must promote it above the dialogs opened since.
+        if (isInTopLayer())
+            removeFromTopLayer();
+        addToTopLayer();
 
         RenderElement::markRendererDirtyAfterTopLayerChange(renderer.get(), containingBlockBeforeStyleResolution.get());
     }
@@ -252,6 +256,11 @@ void HTMLDialogElement::close(const String& result, Element* source)
     if (!result.isNull())
         m_returnValue = result;
 
+    // FIXME: Focus should only be restored when the document's focused element is still inside
+    // this dialog, or when the dialog was modal. Adding that condition requires show() to run the
+    // dialog focusing steps reliably first: focusability is determined from a possibly stale
+    // computed style, so for a dialog that was previously shown and closed no candidate looks
+    // focusable and focus never enters the dialog. See webkit.org/b/321623.
     if (RefPtr element = std::exchange(m_previouslyFocusedElement, nullptr).get()) {
         FocusOptions options;
         options.preventScroll = true;


### PR DESCRIPTION
#### 61d9a441f90ea63b76127680b19c0d11df7a3bc5
<pre>
[Interop] Correct focus restore behavior to match spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=321623">https://bugs.webkit.org/show_bug.cgi?id=321623</a>
<a href="https://rdar.apple.com/184751412">rdar://184751412</a>

Reviewed by Tim Nguyen.

showModal() skipped the top layer insertion when the dialog was already in the top layer,
so a dialog whose open attribute was removed directly rather than via close() kept its old
stacking position when shown again. Per css-position-4, adding an element to the top layer
removes it first and re-appends it, making it topmost. This matches DocumentFullscreen&apos;s
existing behavior for fullscreen elements.

Note Chrome does not yet match this behavior.

This change also fixes a WPT test issue that caused our ports to fail. A button click
cleanup step that is present in other similar tests appears to have been lost when
the-dialog-element/inert-svg-hittest.html was adapted from inert/inert-svg-hittest.html.
This creates a cross-test state leak that may have affected other things (besides causing
this individual failure). This should be pushed upstream once this PR lands.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-showModal-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt.
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::showModal):
(WebCore::HTMLDialogElement::close):

Canonical link: <a href="https://commits.webkit.org/319173@main">https://commits.webkit.org/319173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5826550ef950a680eceae849f18564bdb3250a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144958 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e182016-7080-4b0f-8839-d7319cd03928) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140889 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a94fca2-e14f-49b1-969b-74e6ba810e9f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121341 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42eba250-2d75-4557-af60-852f50b5dd7b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41520 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153641 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41196 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Passed layout tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2007 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192783 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150272 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54935 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149987 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27431 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44601 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127200 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122415 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53452 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16189 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52834 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53071 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52899 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->