### PR TITLE
When captured as a video frame, canvas has to be tainted if cross-origin image are drawn into it

### DIFF
--- a/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame-expected.html
+++ b/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame-expected.html
@@ -1,0 +1,20 @@
+<style>
+    .box {
+        width: 100px;
+        height: 100px;
+        margin: 10px;
+        display: inline-block;
+    }
+    .image, .tainted-canvas {
+        background-color: lime;
+    }
+    .image-capture-canvas {
+        background-color: red;
+    }
+</style>
+<body>
+    <h3>The third box has to be red. It is canvas draws an image capture from another tainted canavas.</h3>
+    <div class="image box"></div>
+    <div class="tainted-canvas box"></div>
+    <div class="image-capture-canvas box"></div>
+</body>

--- a/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame.html
+++ b/LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame.html
@@ -1,0 +1,17 @@
+<style>
+    img {
+        margin: 10px;
+        width: 100px;
+        height: 100px;
+    }
+    iframe {
+        margin: 10px;
+        width: 250px;
+        height: 100px;
+    }
+</style>
+<body>
+    <h3>The third box has to be red. It is canvas draws an image capture from another tainted canavas.</h3>
+    <img src="http://localhost:8000/canvas/resources/100x100-lime-rect.svg">
+    <iframe src="http://127.0.0.1:8000/canvas/resources/cross-origin-image-capture-video-frame.html" frameborder=0></iframe>
+</body>

--- a/LayoutTests/http/tests/canvas/resources/cross-origin-image-capture-video-frame.html
+++ b/LayoutTests/http/tests/canvas/resources/cross-origin-image-capture-video-frame.html
@@ -1,0 +1,54 @@
+<style>
+    body {
+        margin: 0;
+        padding: 0;
+        overflow: clip;
+    }
+    canvas {
+        width: 100px;
+        height: 100px;
+        margin-left: 0;
+        margin-right: 20px;
+        background: red;
+    }
+</style>
+<body>
+    <canvas id="src"></canvas>
+    <canvas id="dest"></canvas>
+    <script>
+        (async () => {
+            var srcCanvas = document.getElementById('src');
+            srcCanvas.width = 100;
+            srcCanvas.height = 100;
+
+            var destCanvas = document.getElementById('dest');
+            destCanvas.width = 100;
+            destCanvas.height = 100;
+
+            // 1. Capture the stream of the source canvas while it is still origin-clean.
+            var stream = srcCanvas.captureStream(0);
+            var track = stream.getVideoTracks()[0];
+            track.requestFrame();
+
+            // 2. Load the cross-origin image.
+            var img = new Image();
+            img.src = 'http://localhost:8000/canvas/resources/100x100-lime-rect.svg';
+            await new Promise(function(ok, fail) {
+                img.onload = ok;
+            });
+
+            // 3. Draw the the cross-origin image onto the canvas — this taints it; direct reads are now blocked.
+            var srcCtx = srcCanvas.getContext('2d');
+            srcCtx.drawImage(img, 0, 0);
+
+            // 4. grabFrame() snapshots the tainted canvas.
+            var bmp = await new ImageCapture(track).grabFrame();
+
+            // 5. Draw the frame to a fresh canvas - nothing should be drawn from the tainted canvas.
+            var destCtx = destCanvas.getContext('2d');
+            destCtx.drawImage(bmp, 0, 0);
+
+            window.parent.postMessage("onload", "*");
+        })();
+    </script>
+</body>

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -201,6 +201,9 @@ RefPtr<VideoFrame> CanvasCaptureMediaStreamTrack::Source::grabFrame()
     if (!canvas)
         return nullptr;
 
+    if (!canvas->originClean())
+        return nullptr;
+
 #if ENABLE(WEBGL)
     if (RefPtr gl = dynamicDowncast<WebGLRenderingContextBase>(canvas->renderingContext()))
         return gl->surfaceBufferToVideoFrame(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
@@ -221,16 +224,7 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
         m_shouldEmitFrame = false;
     }
 
-    if (!canvas->originClean())
-        return;
-
-    RefPtr videoFrame = [&]() -> RefPtr<VideoFrame> {
-#if ENABLE(WEBGL)
-        if (RefPtr gl = dynamicDowncast<WebGLRenderingContextBase>(canvas->renderingContext()))
-            return gl->surfaceBufferToVideoFrame(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
-#endif
-        return canvas->toVideoFrame();
-    }();
+    RefPtr videoFrame = grabFrame();
     if (!videoFrame)
         return;
 


### PR DESCRIPTION
#### 9391ef101e6d253ddb0dd0f8764eeb13d856a0bb
<pre>
When captured as a video frame, canvas has to be tainted if cross-origin image are drawn into it
<a href="https://bugs.webkit.org/show_bug.cgi?id=316594">https://bugs.webkit.org/show_bug.cgi?id=316594</a>
<a href="https://rdar.apple.com/171846032">rdar://171846032</a>

Reviewed by Simon Fraser.

HTMLCanvasElement::captureStream() allows streaming a canvas&apos;s output to a &lt;video&gt;
element. The track frames of this video is obtained from CanvasCaptureMediaStreamTrack
::grabFrame(). This function unconditionally gets a VideoFrame by calling
HTMLCanvasElement::toVideoFrame().

If cross-origin images are drawn into the canvas, this canvas has to be tainted.
So no getImageData() can see the pixels of the cross-origin images.

* LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame-expected.html: Added.
* LayoutTests/http/tests/canvas/canvas-tainted-image-capture-video-frame.html: Added.
* LayoutTests/http/tests/canvas/resources/cross-origin-image-capture-video-frame.html: Added.
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
(WebCore::CanvasCaptureMediaStreamTrack::Source::grabFrame):
(WebCore::CanvasCaptureMediaStreamTrack::Source::captureCanvas):

Originally-landed-as: 305413.925@safari-7624.4-branch (723dbeacf061). <a href="https://rdar.apple.com/184744428">rdar://184744428</a>
Canonical link: <a href="https://commits.webkit.org/319101@main">https://commits.webkit.org/319101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e618de4520136125ac6fe0c91a89e67f258410be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144702 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140694 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121146 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43021 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41316 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40998 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1751 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192527 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/160987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150044 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40193 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54680 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149766 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44400 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126943 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122105 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53197 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15987 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52579 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52816 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->