### PR TITLE
Srcdoc iframes bypass SameSite Strict and Lax cookies

### DIFF
--- a/LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe-expected.txt
@@ -1,0 +1,13 @@
+Tests that SameSite=Strict and SameSite=Lax cookies for 127.0.0.1 are not sent with a fetch() initiated from a srcdoc iframe nested inside a cross-origin iframe. The srcdoc inherits its parent's origin, so a request from the srcdoc back to the top-level origin is cross-site and must not receive SameSite-restricted cookies.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Cookies sent with cross-site fetch initiated from srcdoc iframe inside cross-origin iframe:
+PASS Do not have cookie "strict".
+PASS Do not have cookie "lax".
+PASS Has cookie "implicit-default" with value 9.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="../resources/cookie-utilities.js"></script>
+</head>
+<body>
+<script>
+window.jsTestIsAsync = true;
+
+description("Tests that SameSite=Strict and SameSite=Lax cookies for 127.0.0.1 are not sent with a fetch() initiated from a srcdoc iframe nested inside a cross-origin iframe. The srcdoc inherits its parent's origin, so a request from the srcdoc back to the top-level origin is cross-site and must not receive SameSite-restricted cookies.");
+
+const kCookieValue = "9";
+
+function checkCookies(cookies)
+{
+    debug("Cookies sent with cross-site fetch initiated from srcdoc iframe inside cross-origin iframe:");
+    if (cookies.error) {
+        testFailed(`fetch from srcdoc failed: ${cookies.error}`);
+        return;
+    }
+    if (cookies.strict === undefined)
+        testPassed('Do not have cookie "strict".');
+    else
+        testFailed(`Should not have cookie "strict". But do with value ${cookies.strict}.`);
+
+    if (cookies.lax === undefined)
+        testPassed('Do not have cookie "lax".');
+    else
+        testFailed(`Should not have cookie "lax". But do with value ${cookies.lax}.`);
+
+    if (cookies["implicit-default"] === kCookieValue)
+        testPassed(`Has cookie "implicit-default" with value ${kCookieValue}.`);
+    else
+        testFailed(`Should have cookie "implicit-default" with value ${kCookieValue}. Got ${cookies["implicit-default"]}.`);
+}
+
+async function runTest()
+{
+    await resetCookies();
+    await setCookie("strict", kCookieValue, {"SameSite": "Strict", "Max-Age": 100, "path": "/"});
+    await setCookie("lax", kCookieValue, {"SameSite": "Lax", "Max-Age": 100, "path": "/"});
+    await setCookie("implicit-default", kCookieValue, {"SameSite": null, "Max-Age": 100, "path": "/"});
+
+    let cookiesPromise = new Promise((resolve) => {
+        window.addEventListener("message", (event) => {
+            if (event.data && event.data.type === "cookies-from-srcdoc")
+                resolve(event.data.cookies);
+        }, {once: true});
+    });
+
+    let attackerIframe = document.createElement("iframe");
+    attackerIframe.src = "http://localhost:8000/cookies/same-site/resources/srcdoc-creator-inside-cross-origin-iframe.html";
+    document.body.appendChild(attackerIframe);
+
+    let cookies = await cookiesPromise;
+    checkCookies(cookies);
+
+    document.body.removeChild(attackerIframe);
+
+    await resetCookies();
+    finishJSTest();
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe-expected.txt
@@ -1,0 +1,13 @@
+Tests that SameSite=Strict and SameSite=Lax cookies for 127.0.0.1 are not sent with an <img> sub-resource request initiated from a srcdoc iframe nested inside a cross-origin iframe. The srcdoc inherits its parent's origin, so the image request back to the top-level origin is cross-site and must not receive SameSite-restricted cookies.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Cookies sent with cross-site <img> request initiated from srcdoc iframe inside cross-origin iframe:
+PASS Do not have cookie "strict".
+PASS Do not have cookie "lax".
+PASS Has cookie "implicit-default" with value 9.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="../resources/cookie-utilities.js"></script>
+</head>
+<body>
+<script>
+window.jsTestIsAsync = true;
+
+description("Tests that SameSite=Strict and SameSite=Lax cookies for 127.0.0.1 are not sent with an &lt;img&gt; sub-resource request initiated from a srcdoc iframe nested inside a cross-origin iframe. The srcdoc inherits its parent's origin, so the image request back to the top-level origin is cross-site and must not receive SameSite-restricted cookies.");
+
+const kCookieValue = "9";
+const kRecorderBase = "/cookies/same-site/resources/record-image-cookies.py";
+const kToken = "srcdoc-img-test-" + Date.now();
+
+async function fetchRecordedCookies()
+{
+    let response = await fetch(`${kRecorderBase}?mode=read&token=${encodeURIComponent(kToken)}`, {credentials: "same-origin"});
+    return response.json();
+}
+
+async function resetRecordedCookies()
+{
+    await fetch(`${kRecorderBase}?mode=reset&token=${encodeURIComponent(kToken)}`, {credentials: "same-origin"});
+}
+
+function checkCookies(cookies)
+{
+    debug("Cookies sent with cross-site &lt;img&gt; request initiated from srcdoc iframe inside cross-origin iframe:");
+    if (cookies.strict === undefined)
+        testPassed('Do not have cookie "strict".');
+    else
+        testFailed(`Should not have cookie "strict". But do with value ${cookies.strict}.`);
+
+    if (cookies.lax === undefined)
+        testPassed('Do not have cookie "lax".');
+    else
+        testFailed(`Should not have cookie "lax". But do with value ${cookies.lax}.`);
+
+    // Positive control: WebKit treats a cookie with no SameSite attribute as
+    // SameSite=None (see coreSameSitePolicy() in CookieCocoa.mm), so it must
+    // still be sent on a cross-site image request that includes credentials.
+    // Without this assertion, the negative checks above could pass simply
+    // because cookies aren't being delivered at all.
+    if (cookies["implicit-default"] === kCookieValue)
+        testPassed(`Has cookie "implicit-default" with value ${kCookieValue}.`);
+    else
+        testFailed(`Should have cookie "implicit-default" with value ${kCookieValue}. Got ${cookies["implicit-default"]}.`);
+}
+
+async function runTest()
+{
+    await resetCookies();
+    await resetRecordedCookies();
+    await setCookie("strict", kCookieValue, {"SameSite": "Strict", "Max-Age": 100, "path": "/"});
+    await setCookie("lax", kCookieValue, {"SameSite": "Lax", "Max-Age": 100, "path": "/"});
+    await setCookie("implicit-default", kCookieValue, {"SameSite": null, "Max-Age": 100, "path": "/"});
+
+    let imgLoadedPromise = new Promise((resolve, reject) => {
+        window.addEventListener("message", (event) => {
+            if (!event.data)
+                return;
+            if (event.data.type === "srcdoc-img-loaded")
+                resolve();
+            else if (event.data.type === "srcdoc-img-error")
+                reject(new Error("srcdoc <img> failed to load"));
+        }, {once: false});
+    });
+
+    let attackerIframe = document.createElement("iframe");
+    attackerIframe.src = "http://localhost:8000/cookies/same-site/resources/srcdoc-creator-img-inside-cross-origin-iframe.html?token=" + encodeURIComponent(kToken);
+    document.body.appendChild(attackerIframe);
+
+    try {
+        await imgLoadedPromise;
+    } catch (e) {
+        testFailed(String(e));
+        document.body.removeChild(attackerIframe);
+        await resetCookies();
+        finishJSTest();
+        return;
+    }
+
+    let cookies = await fetchRecordedCookies();
+    checkCookies(cookies);
+
+    document.body.removeChild(attackerIframe);
+
+    await resetRecordedCookies();
+    await resetCookies();
+    finishJSTest();
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/cookies/same-site/resources/record-image-cookies.py
+++ b/LayoutTests/http/tests/cookies/same-site/resources/record-image-cookies.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#
+# Helper for img-from-srcdoc-iframe-inside-cross-origin-iframe.html
+# (rdar://175498842 / https://bugs.webkit.org/show_bug.cgi?id=313220).
+#
+# Modes:
+#   ?mode=reset&token=<id> ............ clear any previously recorded cookies for <id>
+#   ?mode=record&token=<id> ........... record incoming Cookie header to a temp file keyed by <id>; respond with a 1x1 PNG
+#   ?mode=read&token=<id> ............. respond with JSON of cookies recorded for <id>
+
+import json
+import os
+import sys
+import tempfile
+from urllib.parse import parse_qs
+
+file = __file__.split(':/cygwin')[-1]
+http_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file)))))
+sys.path.insert(0, http_root)
+
+from resources.portabilityLayer import get_cookies, get_state, set_state
+
+query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
+mode = query.get('mode', ['record'])[0]
+token = query.get('token', ['default'])[0]
+tmp_file = os.path.join(tempfile.gettempdir(), 'srcdoc-img-cookies-' + token + '.json')
+
+origin = os.environ.get('HTTP_ORIGIN', '*')
+
+if mode == 'reset':
+    set_state(tmp_file, '{}')
+    sys.stdout.write(
+        'Content-Type: text/plain\r\n'
+        'Cache-Control: no-store\r\n'
+        'Access-Control-Allow-Origin: {}\r\n'
+        'Access-Control-Allow-Credentials: true\r\n\r\n'
+        'reset'.format(origin)
+    )
+    sys.exit(0)
+
+if mode == 'read':
+    cookies_json = get_state(tmp_file, '{}')
+    sys.stdout.write(
+        'Content-Type: application/json\r\n'
+        'Cache-Control: no-store\r\n'
+        'Access-Control-Allow-Origin: {}\r\n'
+        'Access-Control-Allow-Credentials: true\r\n\r\n'
+        '{}'.format(origin, cookies_json)
+    )
+    sys.exit(0)
+
+# mode == 'record' (default): record incoming cookies and serve a 1x1 transparent PNG.
+cookies = get_cookies()
+set_state(tmp_file, json.dumps(cookies))
+
+png = bytes.fromhex(
+    '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489'
+    '0000000d4944415478da63f8ffff3f0005fe02fe2c8c5d420000000049454e44ae'
+    '426082'
+)
+sys.stdout.buffer.write(
+    ('Content-Type: image/png\r\n'
+     'Cache-Control: no-store\r\n'
+     'Content-Length: {}\r\n\r\n'.format(len(png))).encode()
+)
+sys.stdout.buffer.write(png)
+sys.exit(0)

--- a/LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-img-inside-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-img-inside-cross-origin-iframe.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Attacker iframe (cross-origin to the top-level victim) that creates a srcdoc loading an img</title>
+</head>
+<body>
+<script>
+// Loaded at http://localhost:8000 inside an iframe of a top-level page at
+// http://127.0.0.1:8000. Creates a nested srcdoc iframe; the srcdoc loads an
+// <img> back to the top-level origin and reports load completion to the top
+// frame. The top frame then reads the cookies the image request actually saw
+// from a server-side recorder.
+//
+// rdar://175498842 / https://bugs.webkit.org/show_bug.cgi?id=313220
+
+const params = new URLSearchParams(window.location.search);
+const token = params.get("token") || "default";
+const recorderURL = "http://127.0.0.1:8000/cookies/same-site/resources/record-image-cookies.py?mode=record&token=" + encodeURIComponent(token);
+
+const srcdocContent = `<!DOCTYPE html><body><script>
+let img = new Image();
+img.onload = () => window.top.postMessage({type: "srcdoc-img-loaded"}, "*");
+img.onerror = () => window.top.postMessage({type: "srcdoc-img-error"}, "*");
+img.src = ${JSON.stringify(recorderURL)};
+<\/script></body>`;
+
+let srcdocIframe = document.createElement("iframe");
+srcdocIframe.style.display = "none";
+srcdocIframe.srcdoc = srcdocContent;
+document.body.appendChild(srcdocIframe);
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-inside-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-inside-cross-origin-iframe.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Cross-origin iframe that creates a srcdoc</title>
+</head>
+<body>
+<script>
+const fetchURL = "http://127.0.0.1:8000/cookies/resources/echo-json.py";
+const srcdocContent = `<!DOCTYPE html><body><script>
+fetch(${JSON.stringify(fetchURL)}, {credentials: "include", mode: "cors"})
+    .then((response) => response.json())
+    .then((cookies) => {
+        window.top.postMessage({type: "cookies-from-srcdoc", cookies}, "*");
+    })
+    .catch((error) => {
+        window.top.postMessage({type: "cookies-from-srcdoc", cookies: {error: String(error)}}, "*");
+    });
+<\/script></body>`;
+
+let srcdocIframe = document.createElement("iframe");
+srcdocIframe.style.display = "none";
+srcdocIframe.srcdoc = srcdocContent;
+document.body.appendChild(srcdocIframe);
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1298,7 +1298,10 @@ void FrameLoader::setFirstPartyForCookies(const URL& url)
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*descendantFrame);
         if (!localFrame)
             continue;
-        if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(protect(localFrame->document())->url()) || registrableDomain.matches(protect(localFrame->document())->url()))
+        if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(protect(localFrame->document())->url())) {
+            if (RefPtr parent = dynamicDowncast<LocalFrame>(localFrame->tree().parent()))
+                protect(localFrame->document())->setSiteForCookies(parent->document()->siteForCookies());
+        } else if (registrableDomain.matches(protect(localFrame->document())->url()))
             protect(localFrame->document())->setSiteForCookies(url);
     }
 }


### PR DESCRIPTION
#### c52bbb5187e1602b26568547b57440f196bba56a
<pre>
Srcdoc iframes bypass SameSite Strict and Lax cookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=313220">https://bugs.webkit.org/show_bug.cgi?id=313220</a>
<a href="https://rdar.apple.com/175498842">rdar://175498842</a>

Reviewed by Charlie Wolfe.

When we set firstPartyForCookies on a subframe, we check if either:

1) shouldInheritSecurityOriginFromOwner is true for the current document&apos;s URL, or
2) if the current document&apos;s URL is same-registrable-domain as the top-level document URL

In the case of an iframe with srcdoc, shouldInheritSecurityOriginFromOwner
returns true (as documented), and this causes us to set the page&apos;s mainFrameURL
as the firstPartyForCookies. We need a conditional exception for
shouldInheritSecurityOriginFromOwner, but it should take nested iframes into
account. This patch adjusts the logic so we inherit the ancestor frame&apos;s
siteForCookies instead of the page&apos;s URL. The same-registrable-domain check
remains unchanged.

Test: http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe.html

* LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/cookies/same-site/fetch-in-srcdoc-iframe-inside-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/cookies/same-site/img-from-srcdoc-iframe-inside-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/cookies/same-site/resources/record-image-cookies.py: Added.
* LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-img-inside-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/cookies/same-site/resources/srcdoc-creator-inside-cross-origin-iframe.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::setFirstPartyForCookies):

Originally-landed-as: 305413.948@safari-7624.4-branch (edd74642a6ef). <a href="https://rdar.apple.com/184744188">rdar://184744188</a>
Canonical link: <a href="https://commits.webkit.org/319605@main">https://commits.webkit.org/319605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9288bdd536520e3122d683efc784aa2d8ef943d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181852 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192077 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141964 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122400 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44330 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42600 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154727 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42228 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3239 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194004 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162200 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151377 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40565 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56158 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151083 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45651 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128441 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124200 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54671 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17224 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54053 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54292 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->