### PR TITLE
Shared workers reset even when they still have a tab connected to them

### DIFF
--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -150,6 +150,19 @@ bool WebSharedWorkerServer::needsContextConnectionForRegistrableDomain(const Web
     return false;
 }
 
+bool WebSharedWorkerServer::needsContextConnection(const ContextConnectionKey& key) const
+{
+    auto& [registrableDomain, coep] = key;
+    for (auto& sharedWorker : m_sharedWorkers.values()) {
+        if (registrableDomain != sharedWorker->topRegistrableDomain())
+            continue;
+        // A worker that has not finished fetching has no COEP value yet, so it may still need this connection.
+        if (!sharedWorker->didFinishFetching() || sharedWorker->fetchResult().crossOriginEmbedderPolicy.value == coep)
+            return true;
+    }
+    return false;
+}
+
 void WebSharedWorkerServer::createContextConnection(const WebCore::Site& site, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier, WebCore::CrossOriginEmbedderPolicyValue workerCrossOriginEmbedderPolicy)
 {
     ContextConnectionKey key { site.domain(), workerCrossOriginEmbedderPolicy };
@@ -222,6 +235,11 @@ void WebSharedWorkerServer::contextConnectionCreated(WebSharedWorkerServerToCont
             continue;
 
         sharedWorker->didCreateContextConnection(contextConnection);
+    }
+
+    if (contextConnection.sharedWorkerObjects().isEmpty() && !needsContextConnection({ registrableDomain, coep })) {
+        RELEASE_LOG(SharedWorker, "WebSharedWorkerServer::contextConnectionCreated(%p) is not needed by any shared worker, starting a timer to terminate it", &contextConnection);
+        contextConnection.startIdleTerminationTimerIfNeeded();
     }
 }
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -92,6 +92,7 @@ private:
     void createContextConnection(const WebCore::Site&, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier, WebCore::CrossOriginEmbedderPolicyValue);
     void forEachContextConnectionForRegistrableDomain(const WebCore::RegistrableDomain&, NOESCAPE const Function<void(WebSharedWorkerServerToContextConnection&)>&);
     bool needsContextConnectionForRegistrableDomain(const WebCore::RegistrableDomain&) const;
+    bool needsContextConnection(const ContextConnectionKey&) const;
     void contextConnectionCreated(WebSharedWorkerServerToContextConnection&);
     void didFinishFetchingSharedWorkerScript(WebSharedWorker&, WebCore::WorkerFetchResult&&, WebCore::WorkerInitializationData&&);
     void shutDownSharedWorker(const WebCore::SharedWorkerKey&);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -220,8 +220,16 @@ void WebSharedWorkerServerToContextConnection::removeSharedWorkerObject(WebCore:
     if (m_sharedWorkerObjects.isEmpty()) {
         CONTEXT_CONNECTION_RELEASE_LOG("removeSharedWorkerObject: connection is now idle, starting a timer to terminate it");
         ASSERT(!m_idleTerminationTimer.isActive());
-        m_idleTerminationTimer.startOneShot(MemoryPressureHandler::singleton().isUnderMemoryPressure() || m_shouldTerminateWhenPossible ? 0_s : idleTerminationDelay);
+        startIdleTerminationTimerIfNeeded();
     }
+}
+
+void WebSharedWorkerServerToContextConnection::startIdleTerminationTimerIfNeeded()
+{
+    if (!m_sharedWorkerObjects.isEmpty() || m_idleTerminationTimer.isActive())
+        return;
+
+    m_idleTerminationTimer.startOneShot(MemoryPressureHandler::singleton().isUnderMemoryPressure() || m_shouldTerminateWhenPossible ? 0_s : idleTerminationDelay);
 }
 
 void WebSharedWorkerServerToContextConnection::idleTerminationTimerFired()

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -90,6 +90,8 @@ public:
     void addSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier);
     void removeSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier);
 
+    void startIdleTerminationTimerIfNeeded();
+
     std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
 private:

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -138,7 +138,7 @@ bool WebProcessCache::addProcessIfPossible(Ref<WebProcessProxy>&& process)
     ASSERT(!process->pageCount());
     ASSERT(!process->provisionalPageCount());
     ASSERT(!process->suspendedPageCount());
-    ASSERT(!process->isRunningServiceWorkers());
+    ASSERT(!process->isRunningWorkers());
 
     if (!canCacheProcess(process))
         return false;
@@ -167,7 +167,7 @@ bool WebProcessCache::addProcess(Ref<CachedProcess>&& cachedProcess)
     ASSERT(!cachedProcess->process().pageCount());
     ASSERT(!cachedProcess->process().provisionalPageCount());
     ASSERT(!cachedProcess->process().suspendedPageCount());
-    ASSERT(!cachedProcess->process().isRunningServiceWorkers());
+    ASSERT(!cachedProcess->process().isRunningWorkers());
 
     Ref process = cachedProcess->process();
     if (!canCacheProcess(process))

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -506,6 +506,10 @@ void WebProcessPool::networkProcessDidTerminate(NetworkProcessProxy& networkProc
         automationSession->terminate();
 
     terminateServiceWorkers();
+
+    // Shared workers keep their hosting web process alive and only the network process knows when
+    // they are no longer needed, so losing it has to release those hosts too.
+    terminateSharedWorkers();
 }
 
 void WebProcessPool::serviceWorkerProcessCrashed(WebProcessProxy& proxy, ProcessTerminationReason reason)
@@ -1857,6 +1861,17 @@ void WebProcessPool::terminateServiceWorkers()
     });
     for (Ref serviceWorkerProcess : serviceWorkerProcesses)
         serviceWorkerProcess->disableRemoteWorkers(RemoteWorkerType::ServiceWorker);
+}
+
+void WebProcessPool::terminateSharedWorkers()
+{
+    Vector<Ref<WebProcessProxy>> sharedWorkerProcesses;
+    remoteWorkerProcesses().forEach([&](auto& process) {
+        if (process.isRunningSharedWorkers())
+            sharedWorkerProcesses.append(process);
+    });
+    for (auto& sharedWorkerProcess : sharedWorkerProcesses)
+        sharedWorkerProcess->disableRemoteWorkers(RemoteWorkerType::SharedWorker);
 }
 
 void WebProcessPool::updateAutomationCapabilities() const

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -323,6 +323,7 @@ public:
     void terminateAllWebContentProcesses(ProcessTerminationReason);
     void terminateServiceWorkersForSession(PAL::SessionID);
     void terminateServiceWorkers();
+    void terminateSharedWorkers();
 
     void setShouldMakeNextWebProcessLaunchFailForTesting(bool value) { m_shouldMakeNextWebProcessLaunchFailForTesting = value; }
     bool shouldMakeNextWebProcessLaunchFailForTesting() const { return m_shouldMakeNextWebProcessLaunchFailForTesting; }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1876,7 +1876,7 @@ void WebProcessProxy::didDestroyUserGestureToken(PageIdentifier pageID, UserGest
 
 bool WebProcessProxy::canBeAddedToWebProcessCache() const
 {
-    if (isRunningServiceWorkers()) {
+    if (isRunningWorkers()) {
         WEBPROCESSPROXY_RELEASE_LOG(Process, "canBeAddedToWebProcessCache: Not adding to process cache because the process is running workers");
         return false;
     }
@@ -1937,8 +1937,8 @@ bool WebProcessProxy::canTerminateAuxiliaryProcess()
         return false;
     }
 
-    if (isRunningServiceWorkers()) {
-        WEBPROCESSPROXY_RELEASE_LOG(Process, "canTerminateAuxiliaryProcess: returns false because process is running service workers");
+    if (isRunningWorkers()) {
+        WEBPROCESSPROXY_RELEASE_LOG(Process, "canTerminateAuxiliaryProcess: returns false because process is running workers");
         return false;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -2540,6 +2540,160 @@ TEST(ServiceWorkers, SharedWorkerReusesProcessAfterCOOPProcessSwap)
     }));
 }
 
+static constexpr auto sharedWorkerIdentityPageBytes = R"SWRESOURCE(
+<script>
+const worker = new SharedWorker("sharedWorker.js");
+worker.port.onmessage = (event) => {
+    window.workerId = event.data;
+};
+worker.port.start();
+function askWorkerId()
+{
+    window.workerId = null;
+    worker.port.postMessage("who are you?");
+}
+</script>
+)SWRESOURCE"_s;
+
+// Each time this script is evaluated (i.e. each time the worker is (re)started) it picks a new identity.
+static constexpr auto sharedWorkerIdentityScriptBytes = R"SWRESOURCE(
+const workerId = "worker-" + Math.random();
+onconnect = (e) => {
+    const port = e.ports[0];
+    port.onmessage = () => port.postMessage(workerId);
+    port.start();
+};
+)SWRESOURCE"_s;
+
+static RetainPtr<TestWKWebView> createSharedWorkerWebView(TestWebKitAPI::HTTPServer& server, WKProcessPool *processPool)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setProcessPool:processPool];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadRequest:server.request()];
+    return webView;
+}
+
+static RetainPtr<NSString> sharedWorkerIdentity(TestWKWebView *webView)
+{
+    [webView objectByEvaluatingJavaScript:@"askWorkerId()"];
+    RetainPtr<NSString> identity;
+    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] {
+        identity = [webView objectByEvaluatingJavaScript:@"window.workerId"];
+        return [identity isKindOfClass:NSString.class];
+    }));
+    return identity;
+}
+
+// Returns 0 if no web content process is currently hosting a shared worker.
+static pid_t sharedWorkerHostProcessIdentifier()
+{
+    for (_WKWebContentProcessInfo *info in [WKProcessPool _webContentProcessInfoForTesting]) {
+        if (info.runningSharedWorkers)
+            return info.pid;
+    }
+    return 0;
+}
+
+// A shared worker context connection that goes idle is terminated after 5 seconds, so tests that
+// need to observe what happens on either side of that delay have to straddle it.
+static constexpr Seconds sharedWorkerIdleTerminationDelay { 5_s };
+
+TEST(SharedWorker, KeepsRunningAfterHostingPageCloses)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { sharedWorkerIdentityPageBytes } },
+        { "/sharedWorker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, sharedWorkerIdentityScriptBytes } },
+    });
+
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    RetainPtr firstWebView = createSharedWorkerWebView(server, processPool.get());
+    RetainPtr firstIdentity = sharedWorkerIdentity(firstWebView.get());
+    EXPECT_GT([firstIdentity length], 0u);
+
+    RetainPtr secondWebView = createSharedWorkerWebView(server, processPool.get());
+    // Both pages must be talking to the same shared worker instance.
+    EXPECT_WK_STREQ(firstIdentity.get(), sharedWorkerIdentity(secondWebView.get()).get());
+
+    // The shared worker has to be hosted in the first page's process for this test to be meaningful.
+    auto firstPID = [firstWebView _webProcessIdentifier];
+    EXPECT_NE(firstPID, [secondWebView _webProcessIdentifier]);
+    EXPECT_EQ(firstPID, sharedWorkerHostProcessIdentifier());
+
+    // Close the first page ("tab"), leaving the second one as the only client of the shared worker.
+    [firstWebView _close];
+    firstWebView = nil;
+
+    // The hosting process must stay alive even though it no longer has any page, and it must still
+    // be alive after the idle termination delay has elapsed.
+    EXPECT_EQ(firstPID, sharedWorkerHostProcessIdentifier());
+    TestWebKitAPI::Util::runFor(sharedWorkerIdleTerminationDelay + 1_s);
+    EXPECT_EQ(firstPID, sharedWorkerHostProcessIdentifier());
+
+    // And the surviving page must still be talking to the very same shared worker instance.
+    EXPECT_WK_STREQ(firstIdentity.get(), sharedWorkerIdentity(secondWebView.get()).get());
+}
+
+TEST(SharedWorker, HostProcessGoesAwayWhenLastClientCloses)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { sharedWorkerIdentityPageBytes } },
+        { "/sharedWorker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, sharedWorkerIdentityScriptBytes } },
+    });
+
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    RetainPtr firstWebView = createSharedWorkerWebView(server, processPool.get());
+    RetainPtr secondWebView = createSharedWorkerWebView(server, processPool.get());
+    EXPECT_GT([sharedWorkerIdentity(secondWebView.get()) length], 0u);
+    EXPECT_EQ([firstWebView _webProcessIdentifier], sharedWorkerHostProcessIdentifier());
+
+    // Keeping the hosting process alive must not outlive the last client: once every page that was
+    // using the shared worker is gone, the process has to be released.
+    [firstWebView _close];
+    firstWebView = nil;
+    [secondWebView _close];
+    secondWebView = nil;
+
+    EXPECT_TRUE(waitUntilEvaluatesToTrue([] {
+        return !sharedWorkerHostProcessIdentifier();
+    }));
+}
+
+TEST(SharedWorker, HostProcessIsReleasedWhenNetworkProcessTerminates)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { sharedWorkerIdentityPageBytes } },
+        { "/sharedWorker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, sharedWorkerIdentityScriptBytes } },
+    });
+
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    RetainPtr firstWebView = createSharedWorkerWebView(server, processPool.get());
+    RetainPtr secondWebView = createSharedWorkerWebView(server, processPool.get());
+    EXPECT_GT([sharedWorkerIdentity(secondWebView.get()) length], 0u);
+
+    auto firstPID = [firstWebView _webProcessIdentifier];
+    EXPECT_EQ(firstPID, sharedWorkerHostProcessIdentifier());
+
+    // The hosting process now has no page of its own and is only kept alive by its shared worker.
+    [firstWebView _close];
+    firstWebView = nil;
+    EXPECT_EQ(firstPID, sharedWorkerHostProcessIdentifier());
+
+    // The network process is the only thing that tells us when a shared worker host is no longer
+    // needed, so losing it must not leave the host process pinned forever.
+    [[WKWebsiteDataStore defaultDataStore] _terminateNetworkProcess];
+
+    EXPECT_TRUE(waitUntilEvaluatesToTrue([] {
+        return !sharedWorkerHostProcessIdentifier();
+    }));
+}
+
 enum class UseSeparateServiceWorkerProcess : bool { No, Yes };
 void testSuspendServiceWorkerProcessBasedOnClientProcesses(UseSeparateServiceWorkerProcess useSeparateServiceWorkerProcess)
 {


### PR DESCRIPTION
#### 8f790888be3ae43338836d28731582fd1979adda
<pre>
Shared workers reset even when they still have a tab connected to them
<a href="https://bugs.webkit.org/show_bug.cgi?id=318873">https://bugs.webkit.org/show_bug.cgi?id=318873</a>
<a href="https://rdar.apple.com/182316624">rdar://182316624</a>

Reviewed by NOBODY (OOPS!).

A shared worker is hosted inside a regular WebContent process, preferring the
process of the page that requested it. Unlike service workers, nothing kept
that process alive once its last page went away: canTerminateAuxiliaryProcess()
and canBeAddedToWebProcessCache() only bailed out for isRunningServiceWorkers().

So closing the tab that created a shared worker, while other tabs were still
connected to it, destroyed the worker&apos;s process. WebSharedWorkerServer::
removeContextConnection() then saw the remaining clients and immediately
established a replacement context connection in a surviving client process, and
WebSharedWorker::didCreateContextConnection() re-ran the script there with a
fresh global scope, losing all of the worker&apos;s state. This was silent: the
WebSharedWorker, its SharedWorkerIdentifier and its MessagePorts were reused and
connect events re-posted on the same ports, so the page had no way to observe
it. That defeats the purpose of shared workers for coordinating state across
tabs.

Check isRunningWorkers() instead of isRunningServiceWorkers() in both places, so
a process hosting a live shared worker is neither cached nor shut down while it
still has clients. The existing release path is unchanged and still reclaims it:
once the last client goes away, the context connection&apos;s idle termination timer
fires, which disables shared workers in the process and lets it shut down.

Two things had to be fixed to make that safe. The idle termination timer was
only ever armed when the last shared worker object was removed, so a context
connection established after the objects that needed it were already gone never
armed it at all; harmless before, but now it would pin a page-less process
hosting no worker. Arm it when such a connection is created, if no shared worker
needs it. Whether it is needed is decided on the connection&apos;s exact
(registrable domain, COEP) key, matching the dispatch loop right above: a worker
that has not finished fetching its script yet has no COEP value and so counts as
a potential user of any connection for its domain. And the network process is
the only thing that reports a shared worker host as no longer needed, so losing
it has to release those hosts too, otherwise they would stay pinned
indefinitely. WebProcessPool::networkProcessDidTerminate() already does this for
service workers; it now does the same for shared workers.

This does not address the case where the host process itself dies (crash,
jetsam, memory pressure). The worker is still relaunched with a fresh global
scope there, and the page is still not notified. It should be tackled separately.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm

* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::needsContextConnection const):
(WebKit::WebSharedWorkerServer::contextConnectionCreated):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
(WebKit::WebSharedWorkerServerToContextConnection::removeSharedWorkerObject):
(WebKit::WebSharedWorkerServerToContextConnection::startIdleTerminationTimerIfNeeded):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::addProcessIfPossible):
(WebKit::WebProcessCache::addProcess):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::networkProcessDidTerminate):
(WebKit::WebProcessPool::terminateSharedWorkers):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::canBeAddedToWebProcessCache const):
(WebKit::WebProcessProxy::canTerminateAuxiliaryProcess):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm:
((SharedWorker, KeepsRunningAfterHostingPageCloses)):
((SharedWorker, HostProcessGoesAwayWhenLastClientCloses)):
((SharedWorker, HostProcessIsReleasedWhenNetworkProcessTerminates)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f790888be3ae43338836d28731582fd1979adda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146712 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12484e0f-8c7b-425a-8d8d-7fabc500ce04) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142369 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98875 "3 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bbca7ab-dc1b-49a3-b016-9f47f9e8c964) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122802 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53d59173-c034-4dc0-a593-67a0f5e988a2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44756 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43031 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155156 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42653 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3775 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194539 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56001 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151797 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56692 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151498 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46078 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128976 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124944 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55203 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17652 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54584 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54823 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54651 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->