### PR TITLE
Crash in libwebrtc.dylib:  void absl::internal_any_invocable::LocalInvoker<false, void, webrtc::MethodCall<webrtc::PeerConnectionInterface, void, webrtc::CreateSessionDescriptionObserver*

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/event.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/event.cc
@@ -17,6 +17,7 @@
 
 #include "api/units/time_delta.h"
 #include "rtc_base/checks.h"
+#include "rtc_base/logging.h"
 #include "rtc_base/synchronization/yield_policy.h"
 #include "rtc_base/system/warn_current_thread_is_deadlocked.h"
 
@@ -161,9 +162,30 @@ bool Event::Wait(TimeDelta give_up_after, TimeDelta warn_after) {
   ScopedYieldPolicy::YieldExecution();
   pthread_mutex_lock(&event_mutex_);
 
+  bool has_logged_error = false;
   // Wait for `event_cond_` to trigger and `event_status_` to be set, with the
   // given timeout (or without a timeout if none is given).
   const auto wait = [&](const std::optional<timespec> timeout_ts) {
+#if WEBRTC_WEBKIT_BUILD
+    while (!event_status_) {
+      if (timeout_ts == std::nullopt) {
+        auto result = pthread_cond_wait(&event_cond_, &event_mutex_);
+        if (result && result != ETIMEDOUT && !has_logged_error) {
+          has_logged_error = true;
+          RTC_LOG(LS_ERROR) << "Event::Wait pthread_cond_wait failed with error " << result;
+        }
+      } else {
+        auto result = pthread_cond_timedwait(&event_cond_, &event_mutex_, &*timeout_ts);
+        if (result == ETIMEDOUT) {
+          return ETIMEDOUT;
+        } else if (result && !has_logged_error) {
+          has_logged_error = true;
+          RTC_LOG(LS_ERROR) << "Event::Wait pthread_cond_timedwait failed with error " << result;
+        }
+      }
+    }
+    return 0;
+#else
     int error = 0;
     while (!event_status_ && error == 0) {
       if (timeout_ts == std::nullopt) {
@@ -179,6 +201,7 @@ bool Event::Wait(TimeDelta give_up_after, TimeDelta warn_after) {
       }
     }
     return error;
+#endif
   };
 
   int error;


### PR DESCRIPTION
#### d1ce9f5c801df2fe914a578b6c8b51e7f6aa0220
<pre>
Crash in libwebrtc.dylib:  void absl::internal_any_invocable::LocalInvoker&lt;false, void, webrtc::MethodCall&lt;webrtc::PeerConnectionInterface, void, webrtc::CreateSessionDescriptionObserver*
<a href="https://rdar.apple.com/181124228">rdar://181124228</a>

Reviewed by Jean-Yves Avenard and David Kilzer.

We are seeing crashes when calling Event::Wait(kForever) with the following principles:
- Event::Wait(kForever) is returning earlier than expected as the main thread should be blocked on the executing of the event task.
- Event::Wait(kForever) is doing a 3 seconds wait, then, if not yet settled, a forever wait, but only in case the 3 seconds wait is ETIMEDOUT.
- Some crashes show that the process lifetime was less than 3 seconds, which shows that the 3 seconds wait is returning earlier than 3 seconds, so not as ETIMEDOUT.

To prevent this, we change how wait is done.
Instead of returning once pthread_cond_timedwait returns, we now only return if pthread_cond_timedwait returns ETIMEDOUT.
Any other returned value will trigger a new pthread_cond_timedwait call so that we wait for the actual timeout (3 seconds or forever for instance) or for the task being executed.
We add some logging as this may help further investigations.

Looking at Chromium code, they override the webrtc::Event class with their own version.
As a follow-up, we should probably do the same and use a simple BinarySemaphore approach (at least for forever calls).

* Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/event.cc:

Originally-landed-as: 305413.1104@safari-7624.5-branch (3c99db1f1186). <a href="https://rdar.apple.com/184745065">rdar://184745065</a>
Canonical link: <a href="https://commits.webkit.org/319098@main">https://commits.webkit.org/319098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc2799eda28ea646a2725a249f2caa07441aa85f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144706 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140695 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97451 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121147 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43025 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41320 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41000 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1755 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192531 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53996 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150048 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40191 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54684 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149776 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44408 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122109 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53201 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15989 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52583 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->