### PR TITLE
In WebPageProxy::takeSnapshot(), validate IOSurface from MachSendRight

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -151,6 +151,7 @@ public:
     WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromImage(IOSurfacePool*, CGImageRef);
 
     WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromSendRight(const WTF::MachSendRight&&);
+    WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromUntrustedUncompressedWebKitSendRight(const WTF::MachSendRight&&);
     // If the colorSpace argument is non-null, it replaces any colorspace metadata on the surface.
     WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromSurface(IOSurfaceRef, std::optional<DestinationColorSpace>&&);
 

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -40,6 +40,7 @@
 #import <pal/spi/cf/CoreVideoSPI.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <wtf/Assertions.h>
+#import <wtf/CheckedArithmetic.h>
 #import <wtf/EnumTraits.h>
 #import <wtf/MachSendRight.h>
 #import <wtf/MathExtras.h>
@@ -118,6 +119,58 @@ std::unique_ptr<IOSurface> IOSurface::createFromSendRight(const MachSendRight&& 
 
     auto surface = adoptCF(IOSurfaceLookupFromMachPort(sendRight.sendRight()));
     return IOSurface::createFromSurface(surface.get(), { });
+}
+
+template <unsigned bytesPerElement>
+static std::unique_ptr<IOSurface> validateAndCreateFromUntrustedSurface(IOSurfaceRef surface)
+{
+    static_assert(bytesPerElement > 0);
+    auto width = IOSurfaceGetWidth(surface);
+    auto height = IOSurfaceGetHeight(surface);
+    auto bytesPerRow = IOSurfaceGetBytesPerRow(surface);
+    if (!width || !height || !bytesPerRow)
+        return nullptr;
+    auto maxSize = IOSurface::maximumSize();
+    if (width > size_t(maxSize.width()) || height > size_t(maxSize.height()))
+        return nullptr;
+    auto rowBytes = CheckedSize { width } * bytesPerElement;
+    if (rowBytes.hasOverflowed() || rowBytes.value() > bytesPerRow)
+        return nullptr;
+    auto totalBytes = CheckedSize { bytesPerRow } * height;
+    auto allocSize = IOSurfaceGetAllocSize(surface);
+    if (totalBytes.hasOverflowed() || totalBytes.value() > allocSize)
+        return nullptr;
+
+    return IOSurface::createFromSurface(surface, { });
+}
+
+std::unique_ptr<IOSurface> IOSurface::createFromUntrustedUncompressedWebKitSendRight(const MachSendRight&& sendRight)
+{
+    ASSERT(ProcessCapabilities::canUseAcceleratedBuffers());
+
+    auto surface = adoptCF(IOSurfaceLookupFromMachPort(sendRight.sendRight()));
+    if (!surface)
+        return nullptr;
+
+    unsigned pixelFormat = IOSurfaceGetPixelFormat(surface.get());
+    switch (pixelFormat) {
+    case kCVPixelFormatType_32BGRA:
+    case kCVPixelFormatType_32RGBA:
+#if ENABLE(PIXEL_FORMAT_RGB10)
+    case kCVPixelFormatType_30RGBLEPackedWideGamut:
+#endif
+        return validateAndCreateFromUntrustedSurface<4>(surface.get());
+
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    case kCVPixelFormatType_64RGBAHalf:
+        return validateAndCreateFromUntrustedSurface<8>(surface.get());
+#endif
+
+    default:
+        break;
+    }
+
+    return { };
 }
 
 std::unique_ptr<IOSurface> IOSurface::createFromSurface(IOSurfaceRef surface, std::optional<DestinationColorSpace>&& colorSpace)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16420,7 +16420,7 @@ void WebPageProxy::takeSnapshot(const IntRect& rect, const IntSize& bitmapSize, 
                         image = bitmap->createPlatformImage(DontCopyBackingStore);
                 }
                 , [&image] (MachSendRight& machSendRight) {
-                    if (auto surface = WebCore::IOSurface::createFromSendRight(WTF::move(machSendRight)))
+                    if (auto surface = WebCore::IOSurface::createFromUntrustedUncompressedWebKitSendRight(WTF::move(machSendRight)))
                         image = WebCore::IOSurface::sinkIntoImage(WTF::move(surface));
                 }
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm
@@ -60,6 +60,39 @@ TEST(IOSurfaceTest, CreatePlatformContext)
     EXPECT_FALSE(s1->isInUse());
 }
 
+TEST(IOSurfaceTest, createFromUntrustedUncompressedWebKitSendRightSRGB)
+{
+    auto original = WebCore::IOSurface::create(nullptr, { 5, 5 }, WebCore::DestinationColorSpace::SRGB());
+    ASSERT_NE(original, nullptr);
+
+    auto roundTripped = WebCore::IOSurface::createFromUntrustedUncompressedWebKitSendRight(original->createSendRight());
+    ASSERT_NE(roundTripped, nullptr);
+    EXPECT_EQ(roundTripped->size(), original->size());
+    EXPECT_EQ(roundTripped->colorSpace(), original->colorSpace());
+}
+
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+TEST(IOSurfaceTest, createFromUntrustedUncompressedWebKitSendRightRGBA16F)
+{
+    auto original = WebCore::IOSurface::create(nullptr, { 5, 5 }, WebCore::DestinationColorSpace::ExtendedDisplayP3(), WebCore::IOSurface::Name::Default, WebCore::IOSurface::Format::RGBA16F);
+    ASSERT_NE(original, nullptr);
+
+    auto roundTripped = WebCore::IOSurface::createFromUntrustedUncompressedWebKitSendRight(original->createSendRight());
+    ASSERT_NE(roundTripped, nullptr);
+    EXPECT_EQ(roundTripped->size(), original->size());
+    EXPECT_EQ(roundTripped->colorSpace(), original->colorSpace());
+}
+#endif // ENABLE(PIXEL_FORMAT_RGBA16F)
+
+TEST(IOSurfaceTest, createFromUntrustedUncompressedWebKitSendRightYUV422)
+{
+    auto original = WebCore::IOSurface::create(nullptr, { 5, 5 }, WebCore::DestinationColorSpace::ExtendedRec2020(), WebCore::IOSurface::Name::Default, WebCore::IOSurface::Format::YUV422);
+    ASSERT_NE(original, nullptr);
+
+    auto roundTripped = WebCore::IOSurface::createFromUntrustedUncompressedWebKitSendRight(original->createSendRight());
+    ASSERT_EQ(roundTripped, nullptr);
+}
+
 TEST(IOSurfaceTest, IOSurfaceNames)
 {
     {


### PR DESCRIPTION
#### c374428fdcece156aa09080f44a4806b7c4dceb9
<pre>
In WebPageProxy::takeSnapshot(), validate IOSurface from MachSendRight
<a href="https://rdar.apple.com/176886608">rdar://176886608</a>

Reviewed by Mike Wyrzykowski.

WebPageProxy::takeSnapshot() now uses the new
IOSurface::createFromUntrustedSendRight(), which has stronger checks of
the MachSendRight-provided IOSurface, expecting a valid IOSurface as
produced uncompressed and uni-planar from IOSurface::create().

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::validateAndCreateFromUntrustedSurface):
(WebCore::IOSurface::createFromUntrustedUncompressedWebKitSendRight):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::takeSnapshot):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm:
(TestWebKitAPI::TEST(IOSurfaceTest, createFromUntrustedUncompressedWebKitSendRightSRGB)):
(TestWebKitAPI::TEST(IOSurfaceTest, createFromUntrustedUncompressedWebKitSendRightRGBA16F)):
(TestWebKitAPI::TEST(IOSurfaceTest, createFromUntrustedUncompressedWebKitSendRightYUV422)):

Originally-landed-as: 305413.949@safari-7624.4-branch (5126b6a5a9e2). <a href="https://rdar.apple.com/184745333">rdar://184745333</a>
Canonical link: <a href="https://commits.webkit.org/319213@main">https://commits.webkit.org/319213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05d159963bfd0ceaa3f9b425924231dd4610be78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180466 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140754 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97492 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121206 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43091 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41375 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41054 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1836 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192612 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54077 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150115 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40260 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54765 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149838 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44464 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127028 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122190 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53282 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16043 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52664 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52901 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->