### PR TITLE
[JSC] Make Air Liveness computation faster

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -1263,7 +1263,6 @@ private:
         CompilerTimingScope timingScope("Air"_s, "GreedyRegAlloc::buildLiveRanges"_s);
         UnifiedTmpLiveness liveness(m_code);
         TmpMap<Point> activeEnds(m_code);
-        TmpMap<Point> liveAtTailMarkers(m_code, std::numeric_limits<Point>::max());
 #if ASSERT_ENABLED
         UnifiedTmpLiveness::LiveAtHead assertOnlyLiveAtHead = liveness.liveAtHead();
 #endif
@@ -1414,21 +1413,28 @@ private:
                 dataLog("  positionOfTail = ", positionOfTail, "\n");
             }
 
-            for (Tmp tmp : liveness.liveAtTail(block)) {
-                markUse(tmp, positionOfTail);
-                liveAtTailMarkers[tmp] = positionOfTail;
-            }
             if (blockAfter) {
+                // On entry activeEnds is open for exactly the Tmps live at the head of blockAfter,
+                // so the only Tmps whose state changes at this boundary are the two differences
+                // between that set and the set live at this block's tail.
+
+                // If tmp was live at the head of the next block but not live at the
+                // tail of the current block, close the interval.
                 Point blockAfterPositionOfHead = this->positionOfHead(blockAfter);
-                for (Tmp tmp : liveness.liveAtHead(blockAfter)) {
-                    ASSERT(activeEnds[tmp]);
-                    // If tmp was live at the head of the next block but not live at the
-                    // tail of the current block, close the interval.
-                    if (liveAtTailMarkers[tmp] > positionOfTail) {
+                liveness.forEachLiveAtHeadNotLiveAtTail(blockAfter, block,
+                    [&](Tmp tmp) {
                         if (activeEnds[tmp]) [[likely]]
                             markDef(tmp, blockAfterPositionOfHead);
-                    }
-                }
+                    });
+                liveness.forEachLiveAtTailNotLiveAtHead(block, blockAfter,
+                    [&](Tmp tmp) {
+                        markUse(tmp, positionOfTail);
+                    });
+            } else {
+                liveness.forEachLiveAtTail(block,
+                    [&](Tmp tmp) {
+                        markUse(tmp, positionOfTail);
+                    });
             }
             assertPinnedRegsAreLive();
 
@@ -1501,8 +1507,10 @@ private:
         }
         if (blockAfter) {
             Point firstBlockPositionOfHead = this->positionOfHead(blockAfter);
-            for (Tmp tmp : liveness.liveAtHead(blockAfter))
-                markDef(tmp, firstBlockPositionOfHead);
+            liveness.forEachLiveAtHead(blockAfter,
+                [&](Tmp tmp) {
+                    markDef(tmp, firstBlockPositionOfHead);
+                });
         }
         assertPinnedRegsAreLive();
         // Pinned registers are never killed, so markDef never completes their live-range. Do it now.

--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -340,6 +340,42 @@ public:
         return Iterable(*this, { }, &sparseTail(block->index()), Storage::Sparse);
     }
 
+    void forEachLiveAtHead(typename CFG::Node block, const Invocable<void(const Thing&)> auto& func)
+    {
+        if (m_storage == Storage::Dense) {
+            forEachInDense(denseHeadSlice(block->index()), func);
+            return;
+        }
+        forEachInSparse(sparseHead(block->index()), func);
+    }
+
+    void forEachLiveAtTail(typename CFG::Node block, const Invocable<void(const Thing&)> auto& func)
+    {
+        if (m_storage == Storage::Dense) {
+            forEachInDense(denseTailSlice(block->index()), func);
+            return;
+        }
+        forEachInSparse(sparseTail(block->index()), func);
+    }
+
+    void forEachLiveAtHeadNotLiveAtTail(typename CFG::Node headBlock, typename CFG::Node tailBlock, const Invocable<void(const Thing&)> auto& func)
+    {
+        if (m_storage == Storage::Dense) {
+            forEachInDenseDifference(denseHeadSlice(headBlock->index()), denseTailSlice(tailBlock->index()), func);
+            return;
+        }
+        forEachInSparseDifference(sparseHead(headBlock->index()), sparseTail(tailBlock->index()), func);
+    }
+
+    void forEachLiveAtTailNotLiveAtHead(typename CFG::Node tailBlock, typename CFG::Node headBlock, const Invocable<void(const Thing&)> auto& func)
+    {
+        if (m_storage == Storage::Dense) {
+            forEachInDenseDifference(denseTailSlice(tailBlock->index()), denseHeadSlice(headBlock->index()), func);
+            return;
+        }
+        forEachInSparseDifference(sparseTail(tailBlock->index()), sparseHead(headBlock->index()), func);
+    }
+
     class LiveAtHead {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(LiveAtHead);
     public:
@@ -399,7 +435,7 @@ protected:
         Vector<uint64_t> genStore(matrixWords);
         Vector<uint64_t> killStore(matrixWords);
         // Vector's sized constructor does not zero POD storage, and the dataflow ORs into these.
-        std::ranges::fill(genStore, 0);
+        // gen is initialized with a value, zero initialization is not necessary (costly).
         std::ranges::fill(killStore, 0);
         std::span<uint64_t> store = m_denseStore.mutableSpan();
         std::span<uint64_t> liveInMatrix = store.subspan(0, matrixWords);
@@ -426,21 +462,22 @@ protected:
             auto genSet = setFor(genMatrix, blockIndex);
             auto liveOutSet = setFor(liveOutMatrix, blockIndex);
 
-            for (size_t boundary = 0; boundary <= Adapter::blockSize(block); ++boundary) {
-                Adapter::forEachDef(block, boundary, [&] (unsigned index) {
-                    setBit(killSet, index);
-                });
-            }
-
             // gen = transfer function applied to an empty live-out: the uses exposed at the head.
             // The fixpoint below works purely on gen/kill/liveOut, so this is the only place that
-            // walks instructions.
+            // walks instructions. This sweep reaches boundary blockSize down to 1 and then boundary
+            // 0, which is every boundary, so it collects kill as well.
             m_workset.clear();
             for (size_t instIndex = Adapter::blockSize(block); instIndex--;) {
-                Adapter::forEachDef(block, instIndex + 1, [&] (unsigned index) { m_workset.remove(index); });
+                Adapter::forEachDef(block, instIndex + 1, [&] (unsigned index) {
+                    m_workset.remove(index);
+                    setBit(killSet, index);
+                });
                 Adapter::forEachUse(block, instIndex, [&] (unsigned index) { m_workset.add(index); });
             }
-            Adapter::forEachDef(block, 0, [&] (unsigned index) { m_workset.remove(index); });
+            Adapter::forEachDef(block, 0, [&] (unsigned index) {
+                m_workset.remove(index);
+                setBit(killSet, index);
+            });
             std::span<const uint64_t> worksetSpan = m_workset.denseSpan();
             for (size_t i = 0; i < m_wordsPerSet; ++i)
                 genSet[i] = worksetSpan[i];
@@ -584,6 +621,47 @@ private:
     friend class LocalCalc::Iterable;
     friend class Iterable;
     friend class LiveAtHead;
+
+    void forEachInDense(std::span<const uint64_t> set, const Invocable<void(const Thing&)> auto& func)
+    {
+        for (size_t wordIndex = 0; wordIndex < m_wordsPerSet; ++wordIndex) {
+            uint64_t word = set[wordIndex];
+            while (word) {
+                unsigned bit = std::countr_zero(word);
+                word &= word - 1;
+                func(this->indexToValue(static_cast<unsigned>(wordIndex * wordBits + bit)));
+            }
+        }
+    }
+
+    void forEachInSparse(const SparseBitVector<>& set, const Invocable<void(const Thing&)> auto& func)
+    {
+        set.forEachSetBit(
+            [&](auto index) {
+                func(this->indexToValue(static_cast<unsigned>(index)));
+            });
+    }
+
+    void forEachInDenseDifference(std::span<const uint64_t> a, std::span<const uint64_t> b, const Invocable<void(const Thing&)> auto& func)
+    {
+        for (size_t wordIndex = 0; wordIndex < m_wordsPerSet; ++wordIndex) {
+            uint64_t word = a[wordIndex] & ~b[wordIndex];
+            while (word) {
+                unsigned bit = std::countr_zero(word);
+                word &= word - 1;
+                func(this->indexToValue(static_cast<unsigned>(wordIndex * wordBits + bit)));
+            }
+        }
+    }
+
+    void forEachInSparseDifference(const SparseBitVector<>& a, const SparseBitVector<>& b, const Invocable<void(const Thing&)> auto& func)
+    {
+        a.forEachSetBit(
+            [&](auto index) {
+                if (!b.contains(index))
+                    func(this->indexToValue(static_cast<unsigned>(index)));
+            });
+    }
 
     size_t denseHalfWords() const { return m_denseStore.size() / 2; }
     std::span<const uint64_t> denseHeadSlice(unsigned blockIndex) const LIFETIME_BOUND


### PR DESCRIPTION
#### 4a10860dc35cd5fd9f388244773c119a687b6313
<pre>
[JSC] Make Air Liveness computation faster
<a href="https://bugs.webkit.org/show_bug.cgi?id=321628">https://bugs.webkit.org/show_bug.cgi?id=321628</a>
<a href="https://rdar.apple.com/184756552">rdar://184756552</a>

Reviewed by Yijia Huang.

This patch makes Air Liveness computation faster via two changes.

1. Tighten WTF::Liveness

Let&apos;s avoid iterating blocks unnecessarily. We do not need to have
boundary iteration since normal iteration is also iterating the exact
same set of Insts. Also, avoid zeroing genStore as we are not relying on
the zero-ed values in genStore.

2. Liveness::forEachLiveAtHeadNotLiveAtTail / Liveness::forEachLiveAtTailNotLiveAtHead

Because Liveness is maintaining head and tail liveness, it is very
efficient for them to generate difference between these two set.
These two new interfaces generate the sets, which is very useful in
AirAllocateRegistersByGreedy. We use this quick scanning of set to
update live range information in AirAllocateRegistersByGreedy. Like,
GreedyRegAlloc::buildLiveRanges is getting 17% reduction of time.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::validateAssignments):
(JSC::B3::Air::Greedy::GreedyAllocator::buildLiveRanges):
* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::forEachLiveAtHead):
(WTF::Liveness::forEachLiveAtTail):
(WTF::Liveness::forEachLiveAtHeadNotLiveAtTail):
(WTF::Liveness::forEachLiveAtTailNotLiveAtHead):
(WTF::Liveness::computeDense):
(WTF::Liveness::forEachInDense):
(WTF::Liveness::forEachInSparse):
(WTF::Liveness::forEachInDenseDifference):
(WTF::Liveness::forEachInSparseDifference):

Canonical link: <a href="https://commits.webkit.org/319081@main">https://commits.webkit.org/319081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afcc9d58e3b718a2c7bf13ee75e6289fcf93b9c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144723 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6ecae06-cc01-4d67-a2b2-a58971625f87) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140703 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aaf2d4ea-6be5-4817-bdc2-5a696201128c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121155 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35d3f8b1-7157-4426-bd80-9833acdd4a87) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3122 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9972 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41016 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1772 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41676 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46946 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192548 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54013 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150063 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54701 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149786 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27377 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44417 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126964 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122126 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53218 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16005 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52600 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52665 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->