### PR TITLE
Cherry-pick(s) 6fd41e08545c. rdar://184745432

### DIFF
--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -309,6 +309,7 @@ void StreamPipeToState::handleSignal()
                 if (!globalObject)
                     return nullptr;
 
+<<<<<<< HEAD
                 auto valueOrException = internalWritableStream->abort(*globalObject, signal->reason().getValue());
                 if (valueOrException.hasException()) {
                     auto [rejectedPromise, deferred] = createPromiseAndWrapper(*globalObject);
@@ -316,6 +317,12 @@ void StreamPipeToState::handleSignal()
                     return WTF::move(rejectedPromise);
                 }
                 auto* promise = downcast<JSC::JSPromise>(valueOrException.releaseReturnValue());
+=======
+                auto value = internalWritableStream->abort(*globalObject, signal->reason().getValue());
+                if (!value)
+                    return nullptr;
+                auto* promise = jsDynamicCast<JSC::JSPromise*>(value);
+>>>>>>> 6fd41e08545c (Crash in StreamPipeToState::errorsMustBePropagatedForward)
                 if (!promise)
                     return nullptr;
 
@@ -419,6 +426,7 @@ void StreamPipeToState::errorsMustBePropagatedForward(JSDOMGlobalObject& globalO
                     return nullptr;
 
                 Ref internalWritableStream = protectedThis->m_destination->internalWritableStream();
+<<<<<<< HEAD
                 auto valueOrException = internalWritableStream->abort(*globalObject, error.get());
                 if (valueOrException.hasException()) {
                     auto [rejectedPromise, deferred] = createPromiseAndWrapper(*globalObject);
@@ -426,6 +434,12 @@ void StreamPipeToState::errorsMustBePropagatedForward(JSDOMGlobalObject& globalO
                     return WTF::move(rejectedPromise);
                 }
                 auto* promise = dynamicDowncast<JSC::JSPromise>(valueOrException.releaseReturnValue());
+=======
+                auto value = internalWritableStream->abort(*globalObject, error.get());
+                if (!value)
+                    return nullptr;
+                auto* promise = jsDynamicCast<JSC::JSPromise*>(value);
+>>>>>>> 6fd41e08545c (Crash in StreamPipeToState::errorsMustBePropagatedForward)
                 if (!promise) {
                     auto [result, deferred] = createPromiseAndWrapper(*globalObject);
                     deferred->resolve();


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://184745432 to main. [6fd41e08545c] caused a merge conflict. 

```
Crash in StreamPipeToState::errorsMustBePropagatedForward
https://bugs.webkit.org/show_bug.cgi?id=313907
rdar://175745036

Reviewed by Youenn Fablet.

Added a nullptr check.

No new tests since we don't have a reproduction.

* Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp:
(WebCore::StreamPipeToState::handleSignal):
(WebCore::StreamPipeToState::errorsMustBePropagatedForward):

Originally-landed-as: 305413.826@safari-7624-branch (6fd41e08545c). rdar://184745432


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d74acbd376913377c7c1ec0d61075db3c1c9036

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180404 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54349 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48147 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190615 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144725 "") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182266 "") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55647 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54065 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/190615 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/144725 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183359 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/55647 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/48147 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/190615 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/55647 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/54065 "") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/190615 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/48147 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/55647 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/48147 "") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1774 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46948 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/54065 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192550 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54015 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/48147 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/192550 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54703 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/48147 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/192550 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/54703 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126966 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122128 "") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53220 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/48147 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52602 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52839 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52667 "") | | | 
<!--EWS-Status-Bubble-End-->