### PR TITLE
Cherry-pick(s) 97c98b40f0a7. rdar://184744128

### DIFF
--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -41,6 +41,7 @@
 #import <pal/spi/cocoa/NetworkSPI.h>
 #import <time.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/Lock.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RobinHoodHashMap.h>
 #import <wtf/RunLoop.h>
@@ -549,6 +550,8 @@ public:
                     return;
                 }
 
+                Locker locker { listLock };
+
                 version4List().clear();
                 version6List().clear();
 
@@ -572,11 +575,12 @@ public:
         });
     }
 
-    static const TrackerAddressLookupInfo* find(const WebCore::IPAddress& address)
+    static std::optional<TrackerAddressLookupInfo> find(const WebCore::IPAddress& address)
     {
+        Locker locker { listLock };
         auto& list = address.isIPv4() ? version4List() : version6List();
         if (list.isEmpty())
-            return nullptr;
+            return std::nullopt;
 
         size_t lower = 0;
         size_t upper = list.size() - 1;
@@ -589,29 +593,31 @@ public:
                 auto middle = std::midpoint(lower, upper);
                 auto compareResult = address <=> list[middle].m_network;
                 if (is_eq(compareResult))
-                    return &list[middle];
+                    return list[middle];
                 if (is_lt(compareResult))
                     upper = middle;
                 else if (is_gt(compareResult))
                     lower = middle;
                 else {
                     ASSERT_NOT_REACHED();
-                    return nullptr;
+                    return std::nullopt;
                 }
             }
         }
 
         if (list[upper].contains(address))
-            return &list[upper];
+            return list[upper];
 
         if (upper != lower && list[lower].contains(address))
-            return &list[lower];
+            return list[lower];
 
-        return nullptr;
+        return std::nullopt;
     }
 
 private:
-    static Vector<TrackerAddressLookupInfo>& version4List()
+    static Lock listLock;
+
+    static Vector<TrackerAddressLookupInfo>& version4List() WTF_REQUIRES_LOCK(listLock)
     {
         static NeverDestroyed sharedList = [] {
             return Vector<TrackerAddressLookupInfo> { };
@@ -619,7 +625,7 @@ private:
         return sharedList.get();
     }
 
-    static Vector<TrackerAddressLookupInfo>& version6List()
+    static Vector<TrackerAddressLookupInfo>& version6List() WTF_REQUIRES_LOCK(listLock)
     {
         static NeverDestroyed sharedList = [] {
             return Vector<TrackerAddressLookupInfo> { };
@@ -638,6 +644,8 @@ private:
     CString m_host;
     CanBlock m_canBlock { CanBlock::No };
 };
+
+Lock TrackerAddressLookupInfo::listLock;
 
 class TrackerDomainLookupInfo {
 public:
@@ -729,7 +737,7 @@ void configureForAdvancedPrivacyProtections(NSURLSession *session)
 
     setTrackerLookupCallback(context.get(), ^(nw_endpoint_t endpoint, const char** hostName, const char** owner, bool* canBlock) {
         if (auto address = ipAddress(endpoint)) {
-            if (auto* info = TrackerAddressLookupInfo::find(*address)) {
+            if (auto info = TrackerAddressLookupInfo::find(*address)) {
                 *owner = info->owner().data();
                 *hostName = info->host().data();
                 *canBlock = info->canBlock() != TrackerAddressLookupInfo::CanBlock::No;


### PR DESCRIPTION
This is an automatic cherry-pick for rdar://184744128 to test against CI.
```
Crash reading process-global tracker address lists from the network resolver thread in WebPrivacyHelpers
<https://bugs.webkit.org/show_bug.cgi?id=317126>
<rdar://179437288>

Reviewed by Charlie Wolfe.

The tracker-lookup callback installed by
`configureForAdvancedPrivacyProtections()` reads the process-global
`version4List()`/`version6List()` on a network resolver dispatch thread,
but the `requestTrackerNetworkAddresses` completion handler rebuilds
those lists on every WebPrivacy update from a different thread.  Nothing
serializes the two, so an update can free a list's backing buffer while
the resolver thread is still walking it, leaving the resolver thread
reading freed memory.

`find()` now returns the matched entry by value because its caller reads
the entry's members after the lookup returns.  A borrowed pointer into
the shared buffer could not safely outlive the lock that protects it.

No new tests since this is a data race with no deterministic
reproduction.  The `WTF_REQUIRES_LOCK` annotations on the list accessors
make any access that does not hold the lock a compile error, which is
the load-bearing guarantee that the race cannot reappear.

* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::TrackerAddressLookupInfo::populateIfNeeded):
(WebKit::TrackerAddressLookupInfo::find):
(WebKit::TrackerAddressLookupInfo::version4List):
(WebKit::TrackerAddressLookupInfo::version6List):
(WebKit::configureForAdvancedPrivacyProtections):

Originally-landed-as: 305413.966@safari-7624.4-branch (97c98b40f0a7). rdar://184744128


```
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4a988b6148c2eafd35396659822500ea5842f4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144729 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140710 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97462 "4 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121162 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43040 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41333 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41006 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1778 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192554 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54019 "Built successfully") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150060 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Running run-layout-tests-in-stress-mode; 34 flakes 3 failures; Uploaded test results; 3 flakes; Running analyze-layout-tests-results") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54707 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149783 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44418 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126970 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122132 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53224 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15995 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52606 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->