### PR TITLE
[Site Isolation] ad iframes auto-refresh after returning from ad clicks.

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1733,6 +1733,11 @@ void WebPage::reinitializeWebPage(WebPageCreationParameters&& parameters)
 
     setUseColorAppearance(parameters.useDarkAppearance, parameters.useElevatedUserInterfaceLevel);
 
+    if (auto& remotePageParameters = parameters.remotePageParameters) {
+        if (RefPtr page = m_page; page && is<RemoteFrame>(page->mainFrame()))
+            page->updateTopDocumentSyncData(Ref { remotePageParameters->topDocumentSyncData });
+    }
+
     if (auto&& provisionalFrameCreationParameters = parameters.provisionalFrameCreationParameters) {
         ASSERT(m_page->settings().siteIsolationEnabled());
         createProvisionalFrame(WTF::move(*provisionalFrameCreationParameters));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -7903,6 +7903,53 @@ TEST(SiteIsolation, UserScript)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "script ran in iframe");
 }
 
+// A window opened with no URL has an about:blank main frame that inherits the opener frame's origin.
+// Processes seeded with that origin must be told the new one once the window navigates away.
+TEST(SiteIsolation, TopOriginInRemoteProcessesAfterMainFrameProcessSwap)
+{
+    HTTPServer server({
+        { "/top"_s, { "<!DOCTYPE html><iframe src='https://widget.com/idle'></iframe><iframe src='https://opener.com/frame'></iframe>"_s } },
+        { "/idle"_s, { "<!DOCTYPE html><p>idle</p>"_s } },
+        { "/frame"_s, { "<!DOCTYPE html><script>const w = window.open(); setTimeout(() => { w.location = 'https://landing.com/landing' }, 0)</script>"_s } },
+        { "/landing"_s, { "<!DOCTYPE html><iframe src='https://widget.com/widget'></iframe>"_s } },
+        { "/widget"_s, { "<!DOCTYPE html><script>navigator.serviceWorker.register('/sw.js').then(() => { alert('registered') })</script>"_s } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, "self.addEventListener('message', () => { });"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    // The NetworkProcess terminating a Web process is reported as _WKProcessTerminationReasonCrash.
+    __block bool done = false;
+    __block bool terminatedByNetworkProcess = false;
+    navigationDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason reason) {
+        terminatedByNetworkProcess = reason == _WKProcessTerminationReasonCrash;
+        done = true;
+    };
+
+    __block auto *sharedNavigationDelegate = navigationDelegate.get();
+    __block RetainPtr<TestWKWebView> openedWebView;
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    webView.get().UIDelegate = uiDelegate.get();
+    uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *, WKFrameInfo *, void (^completionHandler)(void)) {
+        done = true;
+        completionHandler();
+    };
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 200) configuration:configuration]);
+        openedWebView.get().navigationDelegate = sharedNavigationDelegate;
+        openedWebView.get().UIDelegate = uiDelegate.get();
+        return openedWebView.get();
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://top.com/top"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    TestWebKitAPI::Util::run(&done);
+
+    EXPECT_FALSE(terminatedByNetworkProcess);
+}
+
 TEST(SiteIsolation, SharedProcessMostBasic)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 86ad754c5241dc05eefb5ce157aa0967e3dfa785
<pre>
[Site Isolation] ad iframes auto-refresh after returning from ad clicks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=321531">https://bugs.webkit.org/show_bug.cgi?id=321531</a>
<a href="https://rdar.apple.com/168602323">rdar://168602323</a>

Reviewed by Charlie Wolfe.

With site isolation enabled, it&apos;s possible for a web process to have a handle on
a Page with a stale topOrigin. Then, when the web process communicates to the
NetworkProcess, the innocent web process is wrongfully terminated.

This resulted in ads on bbc.com to go blank after clicking on a few ads on the
page.

Here&apos;s the scenario that triggers the bug:

1. Page A is bbc.com (WP1) with a google.com iframe (WP2)
2. Some user click creates a new Page B in a different process (i.e. ad.com)
3. Event though there&apos;s no google.com iframe on Page B, it still has a copy of
   Page B&apos;s state due to BrowsingContextGroup::addPage.
4. Page B&apos;s main frame navigates to ford.com (WP3). ford.com happens to have a
   google.com iframe.
5. ford.com (WP3) sends BroadcastAllDocumentSyncData to the UIProcess to inform
   it about the navigation.
5. Normally, WebPageProxy::broadcastAllDocumentSyncData will broadcast Page B&apos;s
   new top origin information to other web process. However it has an early
   return which skips this broadcast if the web process that sent
   BroadcastAllDocumentSyncData doesn&apos;t match legacyMainFrameProcess. In this
   scenario, the legacyMainFrameProcess still points to an old web process and
   didn&apos;t get updated yet to the ford.com WP3.
6. WebKit sees that ford.com has a google.com iframe and places it in WP2 (which
   was already hosting the google.com iframe on Page A).
6. Since WP2 never received the updated top origin, it has a stale view of Page
   B and gets terminated for having the wrong top origin when talking to the
   NetworkProcess.

This patch fixes this bug by keeping WP2&apos;s topOrigin for Page B in sync with the
actual main frame of page B.

The bug is that the right topOrigin doesn&apos;t get broadcasted if the sender is a
provisional page due to an early return in
WebPageProxy::broadcastAllDocumentSyncData.

Instead of dropping the broadcast, this patch updates top origin by updating
the DocumentSyncData of the web process&apos;s copy of WebPage
(during WebPage;:reinitializeWebPage).

This DocumentSyncData comes from the CreateWebPage IPC which is sent by
the UIProcess with the page&apos;s updated top origin.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::reinitializeWebPage):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, TopOriginInRemoteProcessesAfterMainFrameProcessSwap)):

Canonical link: <a href="https://commits.webkit.org/319465@main">https://commits.webkit.org/319465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c472e08d53be914139b2f9f0f9cc901d67a6b419

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145729 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6e7cba8-419b-48c9-abef-5263a0b50ba8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141577 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42767cdb-0f5c-4933-9ce5-13008ba4ed04) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122017 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7fc21e9b-f87a-4e68-9760-c82a7db64703) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43940 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42208 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154342 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41851 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2783 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193554 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55019 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150973 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40468 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55706 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150680 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45262 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127987 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123588 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54222 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16850 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53604 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53842 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53669 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->