### PR TITLE
[JSC] Introduce AirInstAnalyzer

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -642,6 +642,7 @@
 		0FEC857C1BDACDC70080FF74 /* AirHandleCalleeSaves.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEC85571BDACDC70080FF74 /* AirHandleCalleeSaves.h */; };
 		0FEC857E1BDACDC70080FF74 /* AirInsertionSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEC85591BDACDC70080FF74 /* AirInsertionSet.h */; };
 		0FEC85801BDACDC70080FF74 /* AirInst.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEC855B1BDACDC70080FF74 /* AirInst.h */; };
+		B44D5339A33349BEB6C351CC /* AirInstAnalyzer.h in Headers */ = {isa = PBXBuildFile; fileRef = BD331F0A2D7C479E858667D8 /* AirInstAnalyzer.h */; };
 		0FEC85811BDACDC70080FF74 /* AirInstInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEC855C1BDACDC70080FF74 /* AirInstInlines.h */; };
 		0FEC85841BDACDC70080FF74 /* AirPhaseScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEC855F1BDACDC70080FF74 /* AirPhaseScope.h */; };
 		0FEC85881BDACDC70080FF74 /* AirSpecial.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEC85631BDACDC70080FF74 /* AirSpecial.h */; };
@@ -3771,6 +3772,7 @@
 		0FEC85591BDACDC70080FF74 /* AirInsertionSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AirInsertionSet.h; path = b3/air/AirInsertionSet.h; sourceTree = "<group>"; };
 		0FEC855A1BDACDC70080FF74 /* AirInst.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AirInst.cpp; path = b3/air/AirInst.cpp; sourceTree = "<group>"; };
 		0FEC855B1BDACDC70080FF74 /* AirInst.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AirInst.h; path = b3/air/AirInst.h; sourceTree = "<group>"; };
+		BD331F0A2D7C479E858667D8 /* AirInstAnalyzer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AirInstAnalyzer.h; path = b3/air/AirInstAnalyzer.h; sourceTree = "<group>"; };
 		0FEC855C1BDACDC70080FF74 /* AirInstInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AirInstInlines.h; path = b3/air/AirInstInlines.h; sourceTree = "<group>"; };
 		0FEC855E1BDACDC70080FF74 /* AirPhaseScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AirPhaseScope.cpp; path = b3/air/AirPhaseScope.cpp; sourceTree = "<group>"; };
 		0FEC855F1BDACDC70080FF74 /* AirPhaseScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AirPhaseScope.h; path = b3/air/AirPhaseScope.h; sourceTree = "<group>"; };
@@ -7256,6 +7258,7 @@
 				0FEC85591BDACDC70080FF74 /* AirInsertionSet.h */,
 				0FEC855A1BDACDC70080FF74 /* AirInst.cpp */,
 				0FEC855B1BDACDC70080FF74 /* AirInst.h */,
+				BD331F0A2D7C479E858667D8 /* AirInstAnalyzer.h */,
 				0FEC855C1BDACDC70080FF74 /* AirInstInlines.h */,
 				0FDF67D41D9DC43E001B9825 /* AirKind.cpp */,
 				0FDF67D51D9DC43E001B9825 /* AirKind.h */,
@@ -11064,6 +11067,7 @@
 				53C2CE9C22FCC3D6008B2853 /* AirHelpers.h in Headers */,
 				0FEC857E1BDACDC70080FF74 /* AirInsertionSet.h in Headers */,
 				0FEC85801BDACDC70080FF74 /* AirInst.h in Headers */,
+				B44D5339A33349BEB6C351CC /* AirInstAnalyzer.h in Headers */,
 				0FEC85811BDACDC70080FF74 /* AirInstInlines.h in Headers */,
 				0FDF67D71D9DC442001B9825 /* AirKind.h in Headers */,
 				2684D4381C00161C0081D663 /* AirLiveness.h in Headers */,

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -848,9 +848,44 @@ public:
         , m_spillSlotTable(FillWith { }, 1, nullptr) // Sacrifice index 0.
         , m_regRanges(Reg::maxIndex() + 1)
         , m_insertionSets(code.size())
-        , m_useCounts(m_code)
-        , m_tmpWidth(m_code)
     {
+        TmpWidth::Analyzer tmpWidthAnalyzer(m_tmpWidth);
+        UseCounts::Analyzer useCountsAnalyzer(m_useCounts);
+        analyzeCode(m_code, tmpWidthAnalyzer, useCountsAnalyzer);
+
+        if (Options::airValidateGreedRegAlloc()) [[unlikely]]
+            validateFusedAnalyses();
+    }
+
+    void validateFusedAnalyses()
+    {
+        TmpWidth referenceWidth(m_code);
+        UseCounts referenceUseCounts(m_code);
+
+        auto checkWidths = [&](Tmp tmp) {
+            RELEASE_ASSERT(m_tmpWidth.useWidth(tmp) == referenceWidth.useWidth(tmp));
+            RELEASE_ASSERT(m_tmpWidth.defWidth(tmp) == referenceWidth.defWidth(tmp));
+        };
+        m_code.forEachTmp(checkWidths);
+        RegisterSet::allRegisters().forEach([&](Reg reg) {
+            checkWidths(Tmp(reg));
+        });
+
+        for (unsigned i = 0; i < AbsoluteTmpMapper<GP>::absoluteIndex(m_code.numTmps(GP)); ++i) {
+            RELEASE_ASSERT(m_useCounts.numWarmUsesAndDefs<GP>(i) == referenceUseCounts.numWarmUsesAndDefs<GP>(i));
+            RELEASE_ASSERT(m_useCounts.isConstDef<GP>(i) == referenceUseCounts.isConstDef<GP>(i));
+            if (m_useCounts.isConstDef<GP>(i))
+                RELEASE_ASSERT(m_useCounts.constant<GP>(i) == referenceUseCounts.constant<GP>(i));
+        }
+        for (unsigned i = 0; i < AbsoluteTmpMapper<FP>::absoluteIndex(m_code.numTmps(FP)); ++i) {
+            RELEASE_ASSERT(m_useCounts.numWarmUsesAndDefs<FP>(i) == referenceUseCounts.numWarmUsesAndDefs<FP>(i));
+            RELEASE_ASSERT(m_useCounts.isConstDef<FP>(i) == referenceUseCounts.isConstDef<FP>(i));
+            if (m_useCounts.isConstDef<FP>(i)) {
+                RELEASE_ASSERT(m_useCounts.constant<FP>(i).u64x2[0] == referenceUseCounts.constant<FP>(i).u64x2[0]);
+                RELEASE_ASSERT(m_useCounts.constant<FP>(i).u64x2[1] == referenceUseCounts.constant<FP>(i).u64x2[1]);
+                RELEASE_ASSERT(m_useCounts.constantWidth<FP>(i) == referenceUseCounts.constantWidth<FP>(i));
+            }
+        }
     }
 
     void run()

--- a/Source/JavaScriptCore/b3/air/AirInstAnalyzer.h
+++ b/Source/JavaScriptCore/b3/air/AirInstAnalyzer.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+#include "AirBasicBlock.h"
+#include "AirCode.h"
+#include "AirInst.h"
+#include <array>
+
+namespace JSC { namespace B3 { namespace Air {
+
+template<typename... Analyzers>
+void analyzeCode(Code&, Analyzers&...);
+
+template<typename Derived>
+class InstAnalyzer {
+public:
+    // Runs this analysis on its own. Equivalent to analyzeCode(code, *this).
+    void run(Code& code)
+    {
+        analyzeCode(code, static_cast<Derived&>(*this));
+    }
+
+    // Called once before the walk, then once per block in code order before the block's
+    // instructions.
+    void prepare(Code&) { }
+    void startBlock(BasicBlock*) { }
+
+    // Return true if the analysis is done with this instruction and does not want to see its Tmps.
+    bool visitInst(Inst&) { return false; }
+
+    void visitTmp(Tmp&, Arg::Role, Bank, Width) { }
+
+    // Called once after the walk, for whatever the analysis cannot finish until it has seen all of
+    // the code, such as a fixpoint.
+    void finish() { }
+};
+
+template<typename... Analyzers>
+void analyzeCode(Code& code, Analyzers&... analyzers)
+{
+    (analyzers.prepare(code), ...);
+
+    for (BasicBlock* block : code) {
+        (analyzers.startBlock(block), ...);
+
+        for (Inst& inst : *block) {
+            // An analysis that handles an instruction by itself does not want its Tmps, so the
+            // enumeration below runs only for those that still do, and not at all when that is none
+            // of them.
+            std::array<bool, sizeof...(Analyzers)> needsTmps { };
+            bool anyNeedsTmps = false;
+            unsigned instIndex = 0;
+            auto reportInst = [&](auto& analyzer) {
+                bool needs = !analyzer.visitInst(inst);
+                needsTmps[instIndex++] = needs;
+                anyNeedsTmps |= needs;
+            };
+            (reportInst(analyzers), ...);
+
+            if (!anyNeedsTmps)
+                continue;
+
+            inst.forEachTmp(
+                [&] (Tmp& tmp, Arg::Role role, Bank bank, Width width) {
+                    unsigned tmpIndex = 0;
+                    auto reportTmp = [&](auto& analyzer) {
+                        if (needsTmps[tmpIndex++])
+                            analyzer.visitTmp(tmp, role, bank, width);
+                    };
+                    (reportTmp(analyzers), ...);
+                });
+        }
+    }
+
+    (analyzers.finish(), ...);
+}
+
+} } } // namespace JSC::B3::Air
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
@@ -31,7 +31,6 @@
 #include "AirCode.h"
 #include "AirInstInlines.h"
 #include "AirTmpWidthInlines.h"
-#include <optional>
 
 namespace JSC { namespace B3 { namespace Air {
 
@@ -39,177 +38,51 @@ TmpWidth::TmpWidth() = default;
 
 TmpWidth::TmpWidth(Code& code)
 {
-    recomputeBoth(code);
+    recompute(code);
 }
 
 TmpWidth::~TmpWidth() = default;
 
-template <auto bankFilter>
 void TmpWidth::recompute(Code& code)
 {
-    // Set this to true to cause this analysis to always return pessimistic results.
-    constexpr bool beCareful = false;
-    constexpr bool verbose = false;
-
-    constexpr auto shouldProcess = [](Bank bank) {
-        if constexpr (std::is_same_v<decltype(bankFilter), Bank>)
-            return bankFilter == bank;
-        else
-            return true;
-    };
-
-    if (verbose) {
-        dataLogLn("Code before TmpWidth:");
-        dataLog(code);
-    }
-
-    forEachBank([&](Bank bank) {
-        if (!shouldProcess(bank))
-            return;
-
-        auto& bankWidthsVector = widthsVector(bank);
-        switch (bank) {
-        case GP:
-            bankWidthsVector.resize(AbsoluteTmpMapper<GP>::absoluteIndex(code.numTmps(GP)));
-            break;
-        case FP:
-            bankWidthsVector.resize(AbsoluteTmpMapper<FP>::absoluteIndex(code.numTmps(FP)));
-            break;
-        }
-        bankWidthsVector.fill(Widths(bank));
-    });
-
-    auto assumeTheWorst = [&](Tmp tmp) {
-        Bank bank = Arg(tmp).bank();
-        if (!shouldProcess(bank))
-            return;
-
-        Width conservative = code.usesSIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank);
-        addWidths(tmp, { conservative, conservative });
-    };
-
-    // Assume the worst for registers.
-    RegisterSet::allRegisters().forEach([&](Reg reg) {
-        assumeTheWorst(Tmp(reg));
-    });
-
-    if (beCareful) {
-        code.forEachTmp(assumeTheWorst);
-
-        // We fall through because the fixpoint that follows can only make things even more
-        // conservative. This mode isn't meant to be fast, just safe.
-    }
-
-    // Now really analyze everything but Move's over Tmp's, but set aside those Move's so we can find
-    // them quickly during the fixpoint below. Note that we can make this analysis stronger by
-    // recognizing more kinds of Move's or anything that has Move-like behavior, though it's probably not
-    // worth it. We bucket the Move's per-bank so the fixpoint can run independently for each bank.
-    std::array<Vector<Inst*>, numBanks> moves;
-    for (BasicBlock* block : code) {
-        for (Inst& inst : *block) {
-            if (inst.kind.opcode == Move && inst.args()[1].isTmp()) {
-                Bank dstBank = Arg(inst.args()[1]).bank();
-                if (!shouldProcess(dstBank))
-                    continue;
-
-                if (inst.args()[0].isTmp()) {
-                    moves[dstBank].append(&inst);
-                    continue;
-                }
-
-                if (inst.args()[0].isImm() && inst.args()[0].value() >= 0) {
-                    Widths& tmpWidths = widths(inst.args()[1].tmp());
-                    Width maxWidth = Width64;
-                    if (inst.args()[0].value() <= std::numeric_limits<int8_t>::max())
-                        maxWidth = Width8;
-                    else if (inst.args()[0].value() <= std::numeric_limits<int16_t>::max())
-                        maxWidth = Width16;
-                    else if (inst.args()[0].value() <= std::numeric_limits<int32_t>::max())
-                        maxWidth = Width32;
-
-                    tmpWidths.def = std::max(tmpWidths.def, maxWidth);
-                    continue;
-                }
-            }
-            inst.forEachTmp(
-                [&] (Tmp& tmp, Arg::Role role, Bank tmpBank, Width width) {
-                    if (!shouldProcess(Arg(tmp).bank()))
-                        return;
-
-                    Widths& tmpWidths = widths(tmp);
-                    if (Arg::isAnyUse(role))
-                        tmpWidths.use = std::max(tmpWidths.use, width);
-
-                    if (Arg::isZDef(role))
-                        tmpWidths.def = std::max(tmpWidths.def, width);
-                    else if (Arg::isAnyDef(role))
-                        tmpWidths.def = code.usesSIMD() ? conservativeWidth(tmpBank) : conservativeWidthWithoutVectors(tmpBank);
-                });
-        }
-    }
-
-    // Finally, fixpoint over the Move's.
-    auto fixpointMoves = [&](const Vector<Inst*>& moves) {
-        bool changed = true;
-        while (changed) {
-            changed = false;
-            for (Inst* move : moves) {
-                ASSERT(move->kind.opcode == Move);
-                ASSERT(move->args()[0].isTmp());
-                ASSERT(move->args()[1].isTmp());
-
-                Widths& srcWidths = widths(move->args()[0].tmp());
-                Widths& dstWidths = widths(move->args()[1].tmp());
-
-                // Legend:
-                //
-                //     Move %src, %dst
-
-                // defWidth(%dst) is a promise about how many high bits are zero. The smaller the width, the
-                // stronger the promise. This Move may weaken that promise if we know that %src is making a
-                // weaker promise. Such forward flow is the only thing that determines defWidth().
-                if (dstWidths.def < srcWidths.def) {
-                    dstWidths.def = srcWidths.def;
-                    changed = true;
-                }
-
-                // srcWidth(%src) is a promise about how many high bits are ignored. The smaller the width,
-                // the stronger the promise. This Move may weaken that promise if we know that %dst is making
-                // a weaker promise. Such backward flow is the only thing that determines srcWidth().
-                if (srcWidths.use < dstWidths.use) {
-                    srcWidths.use = dstWidths.use;
-                    changed = true;
-                }
-            }
-        }
-    };
-    forEachBank([&](Bank bank) {
-        if (!shouldProcess(bank))
-            return;
-
-        fixpointMoves(moves[bank]);
-    });
-
-    if (verbose) {
-        forEachBank([&](Bank bank) {
-            if (!shouldProcess(bank))
-                return;
-
-            dataLogLn("bank: ", bank, ", widthsVector: ");
-            auto& vector = widthsVector(bank);
-            for (unsigned i = 0; i < vector.size(); ++i) {
-                if (bank == GP)
-                    dataLogLn("\t", AbsoluteTmpMapper<GP>::tmpFromAbsoluteIndex(i), " : ", vector[i]);
-                else
-                    dataLogLn("\t", AbsoluteTmpMapper<FP>::tmpFromAbsoluteIndex(i), " : ", vector[i]);
-            }
-        });
-    }
+    Analyzer analyzer(*this);
+    analyzer.run(code);
 }
 
-void TmpWidth::recomputeBoth(Code& code)
+void TmpWidth::fixpointMoves(const Vector<Inst*>& moves)
 {
-    recompute<std::nullopt>(code);
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (Inst* move : moves) {
+            ASSERT(move->kind.opcode == Move);
+            ASSERT(move->args()[0].isTmp());
+            ASSERT(move->args()[1].isTmp());
+
+            Widths& srcWidths = widths(move->args()[0].tmp());
+            Widths& dstWidths = widths(move->args()[1].tmp());
+
+            // Legend:
+            //
+            //     Move %src, %dst
+
+            // defWidth(%dst) is a promise about how many high bits are zero. The smaller the width, the
+            // stronger the promise. This Move may weaken that promise if we know that %src is making a
+            // weaker promise. Such forward flow is the only thing that determines defWidth().
+            if (dstWidths.def < srcWidths.def) {
+                dstWidths.def = srcWidths.def;
+                changed = true;
+            }
+
+            // srcWidth(%src) is a promise about how many high bits are ignored. The smaller the width,
+            // the stronger the promise. This Move may weaken that promise if we know that %dst is making
+            // a weaker promise. Such backward flow is the only thing that determines srcWidth().
+            if (srcWidths.use < dstWidths.use) {
+                srcWidths.use = dstWidths.use;
+                changed = true;
+            }
+        }
+    }
 }
 
 template <Bank bank>
@@ -236,10 +109,6 @@ void TmpWidth::Widths::dump(PrintStream& out) const
 {
     out.print("{use = ", use, ", def = ", def, "}");
 }
-
-template void TmpWidth::recompute<GP>(Code&);
-template void TmpWidth::recompute<FP>(Code&);
-template void TmpWidth::recompute<std::nullopt>(Code&);
 
 } } } // namespace JSC::B3::Air
 

--- a/Source/JavaScriptCore/b3/air/AirTmpWidth.h
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidth.h
@@ -33,16 +33,17 @@
 namespace JSC { namespace B3 { namespace Air {
 
 class Code;
+struct Inst;
 
 class TmpWidth {
 public:
+    class Analyzer;
+
     TmpWidth();
     TmpWidth(Code&);
     ~TmpWidth();
 
-    template<auto bankFilter>
     void recompute(Code&);
-    void recomputeBoth(Code&);
 
     // The width of a Tmp is the number of bits that you need to be able to track without some trivial
     // recovery. A Tmp may have a "subwidth" (say, Width32 on a 64-bit system) if either of the following
@@ -105,7 +106,8 @@ private:
     template <Bank bank>
     void ensureSize(Tmp);
 
-    // These are initialized at the beginning of recompute(), which is called in the constructor for both banks.
+    void fixpointMoves(const Vector<Inst*>&);
+
     Vector<Widths> m_widthGP;
     Vector<Widths> m_widthFP;
 };

--- a/Source/JavaScriptCore/b3/air/AirTmpWidthInlines.h
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidthInlines.h
@@ -27,10 +27,135 @@
 
 #if ENABLE(B3_JIT)
 
+#include "AirInstAnalyzer.h"
+#include "AirInstInlines.h"
 #include "AirTmpInlines.h"
 #include "AirTmpWidth.h"
+#include "RegisterSet.h"
 
 namespace JSC { namespace B3 { namespace Air {
+
+class TmpWidth::Analyzer final : public InstAnalyzer<TmpWidth::Analyzer> {
+public:
+    Analyzer(TmpWidth& widths)
+        : m_widths(widths)
+    {
+    }
+
+    void prepare(Code& code)
+    {
+        if (verbose)
+            dataLogLn("Code before TmpWidth:\n", code);
+
+        m_conservativeWidths[GP] = code.usesSIMD() ? conservativeWidth(GP) : conservativeWidthWithoutVectors(GP);
+        m_conservativeWidths[FP] = code.usesSIMD() ? conservativeWidth(FP) : conservativeWidthWithoutVectors(FP);
+
+        forEachBank([&](Bank bank) {
+            auto& bankWidthsVector = m_widths.widthsVector(bank);
+            switch (bank) {
+            case GP:
+                bankWidthsVector.resize(AbsoluteTmpMapper<GP>::absoluteIndex(code.numTmps(GP)));
+                break;
+            case FP:
+                bankWidthsVector.resize(AbsoluteTmpMapper<FP>::absoluteIndex(code.numTmps(FP)));
+                break;
+            }
+            bankWidthsVector.fill(Widths(bank));
+        });
+
+        // Assume the worst for registers.
+        RegisterSet::allRegisters().forEach([&](Reg reg) {
+            assumeTheWorst(Tmp(reg));
+        });
+
+        if (beCareful) {
+            code.forEachTmp([&](Tmp tmp) {
+                assumeTheWorst(tmp);
+            });
+
+            // We fall through because the fixpoint that follows can only make things even more
+            // conservative. This mode isn't meant to be fast, just safe.
+        }
+    }
+
+    // Analyzes everything but Move's over Tmp's, and sets those Move's aside so that finish() can
+    // find them quickly. Note that we can make this analysis stronger by recognizing more kinds of
+    // Move's or anything that has Move-like behavior, though it's probably not worth it.
+    bool visitInst(Inst& inst)
+    {
+        if (inst.kind.opcode != Move || !inst.args()[1].isTmp())
+            return false;
+
+        if (inst.args()[0].isTmp()) {
+            // We bucket the Move's per-bank so that the fixpoint can run independently for each bank.
+            m_moves[Arg(inst.args()[1]).bank()].append(&inst);
+            return true;
+        }
+
+        if (inst.args()[0].isImm() && inst.args()[0].value() >= 0) {
+            Widths& tmpWidths = m_widths.widths(inst.args()[1].tmp());
+            Width maxWidth = Width64;
+            if (inst.args()[0].value() <= std::numeric_limits<int8_t>::max())
+                maxWidth = Width8;
+            else if (inst.args()[0].value() <= std::numeric_limits<int16_t>::max())
+                maxWidth = Width16;
+            else if (inst.args()[0].value() <= std::numeric_limits<int32_t>::max())
+                maxWidth = Width32;
+
+            tmpWidths.def = std::max(tmpWidths.def, maxWidth);
+            return true;
+        }
+
+        return false;
+    }
+
+    void visitTmp(Tmp& tmp, Arg::Role role, Bank bank, Width width)
+    {
+        Widths& tmpWidths = m_widths.widths(tmp);
+        if (Arg::isAnyUse(role))
+            tmpWidths.use = std::max(tmpWidths.use, width);
+
+        if (Arg::isZDef(role))
+            tmpWidths.def = std::max(tmpWidths.def, width);
+        else if (Arg::isAnyDef(role))
+            tmpWidths.def = m_conservativeWidths[bank];
+    }
+
+    void finish()
+    {
+        forEachBank([&](Bank bank) {
+            m_widths.fixpointMoves(m_moves[bank]);
+        });
+
+        if (verbose) {
+            forEachBank([&](Bank bank) {
+                dataLogLn("bank: ", bank, ", widthsVector: ");
+                auto& vector = m_widths.widthsVector(bank);
+                for (unsigned i = 0; i < vector.size(); ++i) {
+                    if (bank == GP)
+                        dataLogLn("\t", AbsoluteTmpMapper<GP>::tmpFromAbsoluteIndex(i), " : ", vector[i]);
+                    else
+                        dataLogLn("\t", AbsoluteTmpMapper<FP>::tmpFromAbsoluteIndex(i), " : ", vector[i]);
+                }
+            });
+        }
+    }
+
+private:
+    // Set this to true to cause this analysis to always return pessimistic results.
+    static constexpr bool beCareful = false;
+    static constexpr bool verbose = false;
+
+    void assumeTheWorst(Tmp tmp)
+    {
+        Width conservative = m_conservativeWidths[Arg(tmp).bank()];
+        m_widths.addWidths(tmp, { conservative, conservative });
+    }
+
+    TmpWidth& m_widths;
+    std::array<Vector<Inst*>, numBanks> m_moves;
+    std::array<Width, numBanks> m_conservativeWidths;
+};
 
 inline TmpWidth::Widths& TmpWidth::widths(Tmp tmp)
 {

--- a/Source/JavaScriptCore/b3/air/AirUseCounts.h
+++ b/Source/JavaScriptCore/b3/air/AirUseCounts.h
@@ -30,6 +30,7 @@
 #include "AirArgInlines.h"
 #include "AirBlockWorklist.h"
 #include "AirCode.h"
+#include "AirInstAnalyzer.h"
 #include "AirInstInlines.h"
 #include "AirTmpInlines.h"
 #include <wtf/CommaPrinter.h>
@@ -43,125 +44,10 @@ class Code;
 // that are only reachable by rare edges is scaled by Options::rareBlockPenalty().
 class UseCounts {
 public:
-    UseCounts(Code& code)
-    {
-        // Find non-rare blocks.
-        BlockWorklist fastWorklist;
-        fastWorklist.push(code[0]);
-        while (BasicBlock* block = fastWorklist.pop()) {
-            for (FrequentedBlock& successor : block->successors()) {
-                if (!successor.isRare())
-                    fastWorklist.push(successor.block());
-            }
-        }
+    class Analyzer;
 
-
-        unsigned gpArraySize = AbsoluteTmpMapper<GP>::absoluteIndex(code.numTmps(GP));
-        m_gpNumWarmUsesAndDefs = FixedVector<float>(FillWith { }, gpArraySize, 0);
-        m_gpConstDefs.ensureSize(gpArraySize);
-        BitVector gpNonConstDefs = m_gpConstDefs;
-        m_gpConstants = FixedVector<int64_t>(FillWith { }, gpArraySize, 0);
-
-        unsigned fpArraySize = AbsoluteTmpMapper<FP>::absoluteIndex(code.numTmps(FP));
-        m_fpNumWarmUsesAndDefs = FixedVector<float>(FillWith { }, fpArraySize, 0);
-        m_fpConstDefs.ensureSize(fpArraySize);
-        BitVector fpNonConstDefs = m_fpConstDefs;
-        m_fpConstants = FixedVector<v128_t>(FillWith { }, fpArraySize, v128_t { });
-        m_fpConstantWidths = FixedVector<Width>(FillWith { }, fpArraySize, Width8);
-
-        auto extractGPConstant = [&](Air::Opcode opcode, const Air::Arg& arg) -> int64_t {
-            return opcode == Move32 ? static_cast<int64_t>(static_cast<uint64_t>(static_cast<uint32_t>(static_cast<uint64_t>(arg.value())))) : arg.value();
-        };
-
-        auto extractFPConstant = [&](Air::Opcode, Air::Arg arg) -> v128_t {
-            if (arg.isFPImm128())
-                return arg.asV128();
-
-            v128_t v { };
-            v.u64x2[0] = static_cast<uint64_t>(arg.value());
-            return v;
-        };
-
-        for (BasicBlock* block : code) {
-            double frequency = block->frequency();
-            if (!fastWorklist.saw(block))
-                frequency *= Options::rareBlockPenalty();
-            for (Inst& inst : *block) {
-                switch (inst.kind.opcode) {
-                case Move:
-                case Move32: {
-                    if (inst.args()[0].isSomeImm() && inst.args()[1].is<Tmp>()) {
-                        Tmp tmp = inst.args()[1].as<Tmp>();
-                        if (tmp.bank() == GP) {
-                            auto index = AbsoluteTmpMapper<GP>::absoluteIndex(tmp);
-                            if (!m_gpConstDefs.quickGet(index)) {
-                                m_gpConstDefs.quickSet(index);
-                                m_gpConstants[index] = extractGPConstant(inst.kind.opcode, inst.args()[0]);
-                            } else
-                                gpNonConstDefs.quickSet(index);
-                            m_gpNumWarmUsesAndDefs[index] += frequency;
-                            continue;
-                        }
-                    }
-                    break;
-                }
-                case MoveFloat:
-                case MoveDouble:
-                case MoveVector: {
-                    if (inst.args()[0].isSomeImm() && inst.args()[1].is<Tmp>()) {
-                        Tmp tmp = inst.args()[1].as<Tmp>();
-                        if (tmp.bank() == FP) {
-                            auto index = AbsoluteTmpMapper<FP>::absoluteIndex(tmp);
-                            if (!m_fpConstDefs.quickGet(index)) {
-                                m_fpConstDefs.quickSet(index);
-                                m_fpConstants[index] = extractFPConstant(inst.kind.opcode, inst.args()[0]);
-                                switch (inst.kind.opcode) {
-                                case MoveFloat:
-                                    m_fpConstantWidths[index] = Width32;
-                                    break;
-                                case MoveDouble:
-                                    m_fpConstantWidths[index] = Width64;
-                                    break;
-                                case MoveVector:
-                                    m_fpConstantWidths[index] = Width128;
-                                    break;
-                                default:
-                                    RELEASE_ASSERT_NOT_REACHED();
-                                }
-                            } else
-                                fpNonConstDefs.quickSet(index);
-                            m_fpNumWarmUsesAndDefs[index] += frequency;
-                            continue;
-                        }
-                    }
-                    break;
-                }
-                default:
-                    break;
-                }
-
-                inst.forEach<Tmp>(
-                    [&] (Tmp& tmp, Arg::Role role, Bank bank, Width) {
-                        if (Arg::isWarmUse(role) || Arg::isAnyDef(role)) {
-                            if (bank == GP) {
-                                auto index = AbsoluteTmpMapper<GP>::absoluteIndex(tmp);
-                                m_gpNumWarmUsesAndDefs[index] += frequency;
-                                if (Arg::isAnyDef(role))
-                                    gpNonConstDefs.quickSet(index);
-                            } else {
-                                auto index = AbsoluteTmpMapper<FP>::absoluteIndex(tmp);
-                                m_fpNumWarmUsesAndDefs[index] += frequency;
-                                if (Arg::isAnyDef(role))
-                                    fpNonConstDefs.quickSet(index);
-                            }
-                        }
-                    });
-            }
-        }
-
-        m_gpConstDefs.exclude(gpNonConstDefs);
-        m_fpConstDefs.exclude(fpNonConstDefs);
-    }
+    UseCounts() = default;
+    inline UseCounts(Code&);
 
     template<Bank bank>
     bool isConstDef(unsigned absoluteIndex) const
@@ -215,6 +101,158 @@ private:
     FixedVector<v128_t> m_fpConstants;
     FixedVector<Width> m_fpConstantWidths;
 };
+
+class UseCounts::Analyzer final : public InstAnalyzer<UseCounts::Analyzer> {
+public:
+    Analyzer(UseCounts& useCounts)
+        : m_useCounts(useCounts)
+    {
+    }
+
+    void prepare(Code& code)
+    {
+        // Find non-rare blocks.
+        m_fastBlocks.push(code[0]);
+        while (BasicBlock* block = m_fastBlocks.pop()) {
+            for (FrequentedBlock& successor : block->successors()) {
+                if (!successor.isRare())
+                    m_fastBlocks.push(successor.block());
+            }
+        }
+
+        unsigned gpArraySize = AbsoluteTmpMapper<GP>::absoluteIndex(code.numTmps(GP));
+        m_useCounts.m_gpNumWarmUsesAndDefs = FixedVector<float>(FillWith { }, gpArraySize, 0);
+        m_useCounts.m_gpConstDefs.ensureSize(gpArraySize);
+        m_gpNonConstDefs.ensureSize(gpArraySize);
+        m_useCounts.m_gpConstants = FixedVector<int64_t>(FillWith { }, gpArraySize, 0);
+
+        unsigned fpArraySize = AbsoluteTmpMapper<FP>::absoluteIndex(code.numTmps(FP));
+        m_useCounts.m_fpNumWarmUsesAndDefs = FixedVector<float>(FillWith { }, fpArraySize, 0);
+        m_useCounts.m_fpConstDefs.ensureSize(fpArraySize);
+        m_fpNonConstDefs.ensureSize(fpArraySize);
+        m_useCounts.m_fpConstants = FixedVector<v128_t>(FillWith { }, fpArraySize, v128_t { });
+        m_useCounts.m_fpConstantWidths = FixedVector<Width>(FillWith { }, fpArraySize, Width8);
+    }
+
+    void startBlock(BasicBlock* block)
+    {
+        m_frequency = block->frequency();
+        if (!m_fastBlocks.saw(block))
+            m_frequency *= Options::rareBlockPenalty();
+    }
+
+    // A Tmp that a constant is moved into is counted here rather than by visitTmp, because we also
+    // want to remember the constant itself.
+    bool visitInst(Inst& inst)
+    {
+        switch (inst.kind.opcode) {
+        case Move:
+        case Move32: {
+            if (inst.args()[0].isSomeImm() && inst.args()[1].is<Tmp>()) {
+                Tmp tmp = inst.args()[1].as<Tmp>();
+                if (tmp.bank() == GP) {
+                    auto index = AbsoluteTmpMapper<GP>::absoluteIndex(tmp);
+                    if (!m_useCounts.m_gpConstDefs.quickGet(index)) {
+                        m_useCounts.m_gpConstDefs.quickSet(index);
+                        m_useCounts.m_gpConstants[index] = extractGPConstant(inst.kind.opcode, inst.args()[0]);
+                    } else
+                        m_gpNonConstDefs.quickSet(index);
+                    m_useCounts.m_gpNumWarmUsesAndDefs[index] += m_frequency;
+                    return true;
+                }
+            }
+            break;
+        }
+        case MoveFloat:
+        case MoveDouble:
+        case MoveVector: {
+            if (inst.args()[0].isSomeImm() && inst.args()[1].is<Tmp>()) {
+                Tmp tmp = inst.args()[1].as<Tmp>();
+                if (tmp.bank() == FP) {
+                    auto index = AbsoluteTmpMapper<FP>::absoluteIndex(tmp);
+                    if (!m_useCounts.m_fpConstDefs.quickGet(index)) {
+                        m_useCounts.m_fpConstDefs.quickSet(index);
+                        m_useCounts.m_fpConstants[index] = extractFPConstant(inst.args()[0]);
+                        switch (inst.kind.opcode) {
+                        case MoveFloat:
+                            m_useCounts.m_fpConstantWidths[index] = Width32;
+                            break;
+                        case MoveDouble:
+                            m_useCounts.m_fpConstantWidths[index] = Width64;
+                            break;
+                        case MoveVector:
+                            m_useCounts.m_fpConstantWidths[index] = Width128;
+                            break;
+                        default:
+                            RELEASE_ASSERT_NOT_REACHED();
+                        }
+                    } else
+                        m_fpNonConstDefs.quickSet(index);
+                    m_useCounts.m_fpNumWarmUsesAndDefs[index] += m_frequency;
+                    return true;
+                }
+            }
+            break;
+        }
+        default:
+            break;
+        }
+
+        return false;
+    }
+
+    void visitTmp(Tmp& tmp, Arg::Role role, Bank bank, Width)
+    {
+        if (!Arg::isWarmUse(role) && !Arg::isAnyDef(role))
+            return;
+
+        if (bank == GP) {
+            auto index = AbsoluteTmpMapper<GP>::absoluteIndex(tmp);
+            m_useCounts.m_gpNumWarmUsesAndDefs[index] += m_frequency;
+            if (Arg::isAnyDef(role))
+                m_gpNonConstDefs.quickSet(index);
+        } else {
+            auto index = AbsoluteTmpMapper<FP>::absoluteIndex(tmp);
+            m_useCounts.m_fpNumWarmUsesAndDefs[index] += m_frequency;
+            if (Arg::isAnyDef(role))
+                m_fpNonConstDefs.quickSet(index);
+        }
+    }
+
+    void finish()
+    {
+        m_useCounts.m_gpConstDefs.exclude(m_gpNonConstDefs);
+        m_useCounts.m_fpConstDefs.exclude(m_fpNonConstDefs);
+    }
+
+private:
+    static int64_t extractGPConstant(Air::Opcode opcode, const Air::Arg& arg)
+    {
+        return opcode == Move32 ? static_cast<int64_t>(static_cast<uint64_t>(static_cast<uint32_t>(static_cast<uint64_t>(arg.value())))) : arg.value();
+    }
+
+    static v128_t extractFPConstant(const Air::Arg& arg)
+    {
+        if (arg.isFPImm128())
+            return arg.asV128();
+
+        v128_t v { };
+        v.u64x2[0] = static_cast<uint64_t>(arg.value());
+        return v;
+    }
+
+    UseCounts& m_useCounts;
+    BlockWorklist m_fastBlocks;
+    BitVector m_gpNonConstDefs;
+    BitVector m_fpNonConstDefs;
+    double m_frequency { 0 };
+};
+
+inline UseCounts::UseCounts(Code& code)
+{
+    Analyzer analyzer(*this);
+    analyzer.run(code);
+}
 
 } } } // namespace JSC::B3::Air
 


### PR DESCRIPTION
#### 5821b05faa72aa3be5a4e4af7d2e39e0339736aa
<pre>
[JSC] Introduce AirInstAnalyzer
<a href="https://bugs.webkit.org/show_bug.cgi?id=321637">https://bugs.webkit.org/show_bug.cgi?id=321637</a>
<a href="https://rdar.apple.com/184764993">rdar://184764993</a>

Reviewed by Yijia Huang.

We have several analysis which scans entire Air graph and populating the
analysis result. But scanning the graph multiple times is really costly
since typically Air graph is large so each analysis blows out the cache.

This patch decouples analysis and data and introducing Air::InstAnalyzer
mechanism. Now TmpWidth and UseCounts are having TmpWidth::Builder and
UseCounts::Builder, and each builder implements InstAnalyzer interface
e.g. visitTmp. And then analyzeCode scans the graph once and invoking
each analyzer to populate the information.

This patterns is currently designed for the analysis which does not
mutate the Air::Graph in the middle (as it is saying &quot;analyzer&quot;, not
&quot;reducer&quot; etc.).

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::m_insertionSets):
(JSC::B3::Air::Greedy::GreedyAllocator::validateFusedAnalyses):
(JSC::B3::Air::Greedy::GreedyAllocator::m_tmpWidth): Deleted.
* Source/JavaScriptCore/b3/air/AirInstAnalyzer.h: Added.
(JSC::B3::Air::InstAnalyzer::run):
(JSC::B3::Air::InstAnalyzer::prepare):
(JSC::B3::Air::InstAnalyzer::startBlock):
(JSC::B3::Air::InstAnalyzer::visitInst):
(JSC::B3::Air::InstAnalyzer::visitTmp):
(JSC::B3::Air::InstAnalyzer::finish):
(JSC::B3::Air::analyzeCode):
* Source/JavaScriptCore/b3/air/AirTmpWidth.cpp:
(JSC::B3::Air::TmpWidth::TmpWidth):
(JSC::B3::Air::TmpWidth::recompute):
(JSC::B3::Air::TmpWidth::fixpointMoves):
(JSC::B3::Air::TmpWidth::recomputeBoth): Deleted.
* Source/JavaScriptCore/b3/air/AirTmpWidth.h:
* Source/JavaScriptCore/b3/air/AirTmpWidthInlines.h:
* Source/JavaScriptCore/b3/air/AirUseCounts.h:
(JSC::B3::Air::UseCounts::UseCounts):

Canonical link: <a href="https://commits.webkit.org/319088@main">https://commits.webkit.org/319088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a6350830159bd20aa509b78615b32ba784c30b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190652 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144762 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4083a9b-e1e2-4ddf-b22e-b9eddfaac13f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140729 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39ad7069-e868-4ab0-b54b-7ce9f21ea95e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121181 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e526dc3-10e6-46af-b79d-e4a9d2807656) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3148 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9980 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41024 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1811 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41715 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46985 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192587 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54052 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150090 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54740 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149813 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27382 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44433 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127003 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122165 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53257 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16013 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52639 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52876 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->