### PR TITLE
Suppress the NoDeleteChecker warning on IDBRequestData::isolatedCopy()

### DIFF
--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
@@ -79,7 +79,8 @@ IDBRequestData::IDBRequestData(const IDBRequestData& that, IsolatedCopyTag)
 }
 
 
-IDBRequestData IDBRequestData::isolatedCopy() const
+// FIXME: SUPPRESS_NODELETE shouldn't be necessary (webkit.org/b/321500).
+SUPPRESS_NODELETE IDBRequestData IDBRequestData::isolatedCopy() const
 {
     return { *this, IsolatedCopy };
 }


### PR DESCRIPTION
#### 4087bd7152027907454a2b7586d21d8069c6f1d4
<pre>
Suppress the NoDeleteChecker warning on IDBRequestData::isolatedCopy()

<a href="https://bugs.webkit.org/show_bug.cgi?id=321500">https://bugs.webkit.org/show_bug.cgi?id=321500</a>

Reviewed by Ryosuke Niwa.

isolatedCopy() is annotated NODELETE and alpha.webkit.NoDeleteChecker objects to it. The
constructor it calls assigns to members that have already been default-constructed, and each
of those assignments destroys the previous empty value, so the checker sees a possible
destruction inside the body. Nothing meaningful is destroyed, but a constructor cannot itself
be marked NODELETE, so the annotation stays and the checker is suppressed on the definition
instead. Callers keep the NODELETE guarantee and do not need to take a ref.

Canonical link: <a href="https://commits.webkit.org/319261@main">https://commits.webkit.org/319261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7556814b501ecd5e9e164312dd29fb35f1b7400

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144799 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a6f7df3-af45-4b0d-8a5a-4511c8ff642a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140765 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97506 "4 flakes 4 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1884f114-1ff6-4c3f-be28-66e5f64e37d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121217 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33b6dc4b-e578-4171-9b65-3066cca2fe0f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43101 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41389 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153505 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41063 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1848 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192624 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54089 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150127 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40291 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54777 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149849 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44473 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127040 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122208 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53294 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16052 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52676 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52741 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->