### PR TITLE
WebCodecsImageDecoder should not inherit from EventTarget

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any-expected.txt
@@ -258,14 +258,10 @@ PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfe
 PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "fullRange" with the proper type
 PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "toJSON()" with the proper type
 PASS VideoColorSpace interface: default toJSON operation on new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true})
-FAIL ImageDecoder interface: existence and properties of interface object assert_equals: prototype of self's property "ImageDecoder" is not Function.prototype expected function "function () {
-    [native code]
-}" but got function "function EventTarget() {
-    [native code]
-}"
+PASS ImageDecoder interface: existence and properties of interface object
 PASS ImageDecoder interface object length
 PASS ImageDecoder interface object name
-FAIL ImageDecoder interface: existence and properties of interface prototype object assert_equals: prototype of ImageDecoder.prototype is not Object.prototype expected object "[object Object]" but got object "[object EventTarget]"
+PASS ImageDecoder interface: existence and properties of interface prototype object
 PASS ImageDecoder interface: existence and properties of interface prototype object's "constructor" property
 PASS ImageDecoder interface: existence and properties of interface prototype object's @@unscopables property
 PASS ImageDecoder interface: attribute type

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any.worker-expected.txt
@@ -258,14 +258,10 @@ PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfe
 PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "fullRange" with the proper type
 PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "toJSON()" with the proper type
 PASS VideoColorSpace interface: default toJSON operation on new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true})
-FAIL ImageDecoder interface: existence and properties of interface object assert_equals: prototype of self's property "ImageDecoder" is not Function.prototype expected function "function () {
-    [native code]
-}" but got function "function EventTarget() {
-    [native code]
-}"
+PASS ImageDecoder interface: existence and properties of interface object
 PASS ImageDecoder interface object length
 PASS ImageDecoder interface object name
-FAIL ImageDecoder interface: existence and properties of interface prototype object assert_equals: prototype of ImageDecoder.prototype is not Object.prototype expected object "[object Object]" but got object "[object EventTarget]"
+PASS ImageDecoder interface: existence and properties of interface prototype object
 PASS ImageDecoder interface: existence and properties of interface prototype object's "constructor" property
 PASS ImageDecoder interface: existence and properties of interface prototype object's @@unscopables property
 PASS ImageDecoder interface: attribute type

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,26 +39,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCodecsBase);
 
-WebCodecsBase::WebCodecsBase(ScriptExecutionContext& context)
-    : ActiveDOMObject(&context)
-{
-}
-
-WebCodecsBase::~WebCodecsBase() = default;
-
 ScriptExecutionContext* WebCodecsBase::scriptExecutionContext() const
 {
-    return ActiveDOMObject::scriptExecutionContext();
-}
-
-void WebCodecsBase::queueControlMessageAndProcess(WebCodecsControlMessage&& message)
-{
-    if (m_isMessageQueueBlocked) {
-        m_controlMessageQueue.append(WTF::move(message));
-        return;
-    }
-    m_controlMessageQueue.append(WTF::move(message));
-    processControlMessageQueue();
+    return WebCodecsControlMessageQueue::scriptExecutionContext();
 }
 
 void WebCodecsBase::queueCodecControlMessageAndProcess(WebCodecsControlMessage&& message)
@@ -73,77 +56,31 @@ void WebCodecsBase::queueCodecControlMessageAndProcess(WebCodecsControlMessage&&
     } });
 }
 
-void WebCodecsBase::scheduleDequeueEvent()
+void WebCodecsBase::clearControlMessageQueueAndMaybeScheduleDequeueEvent()
 {
-    if (m_dequeueEventScheduled)
-        return;
-
-    m_dequeueEventScheduled = true;
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [](auto& codecs) mutable {
-        codecs.dispatchEvent(Event::create(eventNames().dequeueEvent, Event::CanBubble::No, Event::IsCancelable::No));
-        codecs.m_dequeueEventScheduled = false;
-    });
-}
-
-void WebCodecsBase::processControlMessageQueue()
-{
-    while (!m_isMessageQueueBlocked && !m_controlMessageQueue.isEmpty()) {
-        auto& frontMessage = m_controlMessageQueue.first();
-        auto outcome = frontMessage();
-        if (outcome == WebCodecsControlMessageOutcome::NotProcessed)
-            break;
-        m_controlMessageQueue.removeFirst();
+    clearControlMessageQueue();
+    if (codecQueueSize()) {
+        resetCodecQueueSize();
+        scheduleDequeueEvent();
     }
-}
-
-void WebCodecsBase::incrementCodecQueueSize()
-{
-    m_codecControlMessagesPending++;
 }
 
 // Equivalent to spec's "Decrement [[encodeQueueSize]] or "Decrement [[decodeQueueSize]]" and run the Schedule Dequeue Event algorithm"
 void WebCodecsBase::decrementCodecQueueSizeAndScheduleDequeueEvent()
 {
-    m_codecControlMessagesPending--;
+    decrementCodecQueueSize();
     scheduleDequeueEvent();
 }
 
-void WebCodecsBase::decrementCodecOperationCountAndMaybeProcessControlMessageQueue()
+void WebCodecsBase::scheduleDequeueEvent()
 {
-    ASSERT(m_codecOperationsPending > 0);
-    m_codecOperationsPending--;
-    if (!isCodecSaturated())
-        processControlMessageQueue();
-}
+    if (std::exchange(m_dequeueEventScheduled, true))
+        return;
 
-void WebCodecsBase::clearControlMessageQueue()
-{
-    m_controlMessageQueue.clear();
-}
-
-void WebCodecsBase::clearControlMessageQueueAndMaybeScheduleDequeueEvent()
-{
-    clearControlMessageQueue();
-    if (m_codecControlMessagesPending) {
-        m_codecControlMessagesPending = 0;
-        scheduleDequeueEvent();
-    }
-}
-
-void WebCodecsBase::blockControlMessageQueue()
-{
-    m_isMessageQueueBlocked = true;
-}
-
-void WebCodecsBase::unblockControlMessageQueue()
-{
-    m_isMessageQueueBlocked = false;
-    processControlMessageQueue();
-}
-
-bool WebCodecsBase::virtualHasPendingActivity() const
-{
-    return m_codecControlMessagesPending || m_isMessageQueueBlocked;
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [](auto& codec) mutable {
+        codec.dispatchEvent(Event::create(eventNames().dequeueEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        codec.m_dequeueEventScheduled = false;
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,74 +27,40 @@
 
 #if ENABLE(WEB_CODECS)
 
-#include "WebCodecsCodecState.h"
-#include <WebCore/ActiveDOMObject.h>
-#include <WebCore/EventTarget.h>
-#include <wtf/Deque.h>
-#include <wtf/TZoneMalloc.h>
-#include <wtf/ThreadSafeWeakPtr.h>
+#include "EventTarget.h"
+#include "WebCodecsControlMessageQueue.h"
 
 namespace WebCore {
 
-class WebCodecsControlMessage;
-
-// WebCodecsBase implements the "Control Message Queue"
-// as per https://w3c.github.io/webcodecs/#control-message-queue-slot
-// And handle "Codec Saturation"
-// as per https://w3c.github.io/webcodecs/#saturated
 class WebCodecsBase
-    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCodecsBase>
-    , public ActiveDOMObject
+    : public WebCodecsControlMessageQueue
     , public EventTarget {
     WTF_MAKE_TZONE_ALLOCATED(WebCodecsBase);
 public:
-    virtual ~WebCodecsBase();
-
-    WebCodecsCodecState state() const { return m_state; }
-
     // ActiveDOMObject.
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
-    bool NODELETE virtualHasPendingActivity() const final;
+    void ref() const final { WebCodecsControlMessageQueue::ref(); }
+    void deref() const final { WebCodecsControlMessageQueue::deref(); }
+
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
 protected:
-    WebCodecsBase(ScriptExecutionContext&);
+    using WebCodecsControlMessageQueue::WebCodecsControlMessageQueue;
+
     ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
 
-    void setState(WebCodecsCodecState state) { m_state = state; }
-
-    size_t codecQueueSize() const { return m_codecControlMessagesPending; }
-    void queueControlMessageAndProcess(WebCodecsControlMessage&&);
     void queueCodecControlMessageAndProcess(WebCodecsControlMessage&&);
-    void processControlMessageQueue();
-    void clearControlMessageQueue();
     void clearControlMessageQueueAndMaybeScheduleDequeueEvent();
-    void NODELETE blockControlMessageQueue();
-    void unblockControlMessageQueue();
-
-    virtual size_t maximumCodecOperationsEnqueued() const { return 1; }
-    void incrementCodecOperationCount() { m_codecOperationsPending++; };
-    void decrementCodecOperationCountAndMaybeProcessControlMessageQueue();
 
 private:
     // EventTarget
-    void refEventTarget() final { ref(); }
-    void derefEventTarget() final { deref(); }
+    void refEventTarget() final { WebCodecsControlMessageQueue::ref(); }
+    void derefEventTarget() final { WebCodecsControlMessageQueue::deref(); }
 
-    // Equivalent to spec's "Increment [[encodeQueueSize]]." or "Increment [[decodeQueueSize]]"
-    void NODELETE incrementCodecQueueSize();
     // Equivalent to spec's "Decrement [[encodeQueueSize]] or "Decrement [[decodeQueueSize]]" and run the Schedule Dequeue Event algorithm"
     void decrementCodecQueueSizeAndScheduleDequeueEvent();
-    bool isCodecSaturated() const { return m_codecOperationsPending >= maximumCodecOperationsEnqueued(); }
     void scheduleDequeueEvent();
 
-    bool m_isMessageQueueBlocked { false };
-    size_t m_codecControlMessagesPending { 0 };
-    size_t m_codecOperationsPending { 0 };
     bool m_dequeueEventScheduled { false };
-    Deque<WebCodecsControlMessage> m_controlMessageQueue;
-    WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsControlMessage.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsControlMessage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +27,7 @@
 
 #if ENABLE(WEB_CODECS)
 
-#include "WebCodecsBase.h"
+#include "WebCodecsControlMessageQueue.h"
 #include <wtf/Function.h>
 
 namespace WebCore {
@@ -39,8 +39,8 @@ enum class WebCodecsControlMessageOutcome : bool {
 
 class WebCodecsControlMessage final {
 public:
-    WebCodecsControlMessage(WebCodecsBase& codec, Function<WebCodecsControlMessageOutcome()>&& message)
-        : m_pendingActivity(codec.makePendingActivity(codec))
+    WebCodecsControlMessage(WebCodecsControlMessageQueue& codecQueue, Function<WebCodecsControlMessageOutcome()>&& message)
+        : m_pendingActivity(codecQueue.makePendingActivity(codecQueue))
         , m_message(WTF::move(message))
     {
     }
@@ -57,7 +57,7 @@ public:
     }
 
 private:
-    Ref<ActiveDOMObject::PendingActivity<WebCodecsBase>> m_pendingActivity;
+    Ref<ActiveDOMObject::PendingActivity<WebCodecsControlMessageQueue>> m_pendingActivity;
     Function<WebCodecsControlMessageOutcome()> m_message;
 };
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsControlMessageQueue.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsControlMessageQueue.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCodecsControlMessageQueue.h"
+
+#if ENABLE(WEB_CODECS)
+
+#include "WebCodecsControlMessage.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCodecsControlMessageQueue);
+
+WebCodecsControlMessageQueue::WebCodecsControlMessageQueue(ScriptExecutionContext& context)
+    : ActiveDOMObject(&context)
+{
+}
+
+WebCodecsControlMessageQueue::~WebCodecsControlMessageQueue() = default;
+
+void WebCodecsControlMessageQueue::queueControlMessageAndProcess(WebCodecsControlMessage&& message)
+{
+    m_controlMessageQueue.append(WTF::move(message));
+    if (!m_isMessageQueueBlocked)
+        processControlMessageQueue();
+}
+
+void WebCodecsControlMessageQueue::queueCodecControlMessageAndProcess(WebCodecsControlMessage&& message)
+{
+    incrementCodecQueueSize();
+    // message holds a strong ref to ourselves already.
+    queueControlMessageAndProcess({ *this, [this, message = WTF::move(message)]() mutable {
+        if (isCodecSaturated())
+            return WebCodecsControlMessageOutcome::NotProcessed;
+        decrementCodecQueueSize();
+        return message();
+    } });
+}
+
+void WebCodecsControlMessageQueue::processControlMessageQueue()
+{
+    while (!m_isMessageQueueBlocked && !m_controlMessageQueue.isEmpty()) {
+        auto& frontMessage = m_controlMessageQueue.first();
+        auto outcome = frontMessage();
+        if (outcome == WebCodecsControlMessageOutcome::NotProcessed)
+            break;
+        m_controlMessageQueue.removeFirst();
+    }
+}
+
+void WebCodecsControlMessageQueue::incrementCodecQueueSize()
+{
+    m_codecControlMessagesPending++;
+}
+
+// Equivalent to spec's "Decrement [[encodeQueueSize]] or "Decrement [[decodeQueueSize]]".
+void WebCodecsControlMessageQueue::decrementCodecQueueSize()
+{
+    m_codecControlMessagesPending--;
+}
+
+void WebCodecsControlMessageQueue::resetCodecQueueSize()
+{
+    m_codecControlMessagesPending = 0;
+}
+
+void WebCodecsControlMessageQueue::decrementCodecOperationCountAndMaybeProcessControlMessageQueue()
+{
+    ASSERT(m_codecOperationsPending > 0);
+    m_codecOperationsPending--;
+    if (!isCodecSaturated())
+        processControlMessageQueue();
+}
+
+void WebCodecsControlMessageQueue::clearControlMessageQueue()
+{
+    m_controlMessageQueue.clear();
+}
+
+void WebCodecsControlMessageQueue::blockControlMessageQueue()
+{
+    m_isMessageQueueBlocked = true;
+}
+
+void WebCodecsControlMessageQueue::unblockControlMessageQueue()
+{
+    m_isMessageQueueBlocked = false;
+    processControlMessageQueue();
+}
+
+bool WebCodecsControlMessageQueue::virtualHasPendingActivity() const
+{
+    return m_codecControlMessagesPending || m_isMessageQueueBlocked;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsControlMessageQueue.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsControlMessageQueue.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "WebCodecsCodecState.h"
+#include <WebCore/ActiveDOMObject.h>
+#include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+namespace WebCore {
+
+class WebCodecsControlMessage;
+
+// WebCodecsControlMessageQueue implements the "Control Message Queue"
+// as per https://w3c.github.io/webcodecs/#control-message-queue-slot
+// And handle "Codec Saturation"
+// as per https://w3c.github.io/webcodecs/#saturated
+class WebCodecsControlMessageQueue
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCodecsControlMessageQueue>
+    , public ActiveDOMObject {
+    WTF_MAKE_TZONE_ALLOCATED(WebCodecsControlMessageQueue);
+public:
+    virtual ~WebCodecsControlMessageQueue();
+
+    WebCodecsCodecState state() const { return m_state; }
+
+    // ActiveDOMObject.
+    void ref() const override { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const override { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+    bool NODELETE virtualHasPendingActivity() const final;
+
+protected:
+    WebCodecsControlMessageQueue(ScriptExecutionContext&);
+
+    void setState(WebCodecsCodecState state) { m_state = state; }
+
+    size_t codecQueueSize() const { return m_codecControlMessagesPending; }
+    void queueControlMessageAndProcess(WebCodecsControlMessage&&);
+    void queueCodecControlMessageAndProcess(WebCodecsControlMessage&&);
+    void processControlMessageQueue();
+    void NODELETE blockControlMessageQueue();
+    void unblockControlMessageQueue();
+
+    // Equivalent to spec's "Increment [[encodeQueueSize]]." or "Increment [[decodeQueueSize]]"
+    void NODELETE incrementCodecQueueSize();
+    // Equivalent to spec's "Decrement [[encodeQueueSize]] or "Decrement [[decodeQueueSize]]"
+    void NODELETE decrementCodecQueueSize();
+    void NODELETE resetCodecQueueSize();
+    void clearControlMessageQueue();
+
+    virtual size_t maximumCodecOperationsEnqueued() const { return 1; }
+    void incrementCodecOperationCount() { m_codecOperationsPending++; };
+    void decrementCodecOperationCountAndMaybeProcessControlMessageQueue();
+    bool isCodecSaturated() const { return m_codecOperationsPending >= maximumCodecOperationsEnqueued(); }
+
+private:
+    bool m_isMessageQueueBlocked { false };
+    size_t m_codecControlMessagesPending { 0 };
+    size_t m_codecOperationsPending { 0 };
+    Deque<WebCodecsControlMessage> m_controlMessageQueue;
+    WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "ContextDestructionObserverInlines.h"
 #include "ImageDecoder.h"
 #include "JSDOMConvertBoolean.h"
 #include "JSDOMConvertDictionary.h"
@@ -60,7 +61,7 @@ Ref<WebCodecsImageDecoder> WebCodecsImageDecoder::create(ScriptExecutionContext&
 }
 
 WebCodecsImageDecoder::WebCodecsImageDecoder(ScriptExecutionContext& context, Init&& init)
-    : WebCodecsBase(context)
+    : WebCodecsControlMessageQueue(context)
     , m_completedPromise(makeUniqueRef<CompletedPromise>())
     , m_tracks(WebCodecsImageTrackList::create())
 {
@@ -273,7 +274,7 @@ ExceptionOr<void> WebCodecsImageDecoder::resetDecoder(const Exception& exception
         return Exception { ExceptionCode::InvalidStateError, "ImageDecoder is closed"_s };
 
     // Abort any active decoding operation.
-    clearControlMessageQueueAndMaybeScheduleDequeueEvent();
+    clearControlMessageQueue();
 
     // Reject pendding decoding promises with exception.
     auto pendingDecodePromises = std::exchange(m_pendingDecodePromises, { });

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h
@@ -28,12 +28,11 @@
 #if ENABLE(WEB_CODECS)
 
 #include "DOMPromiseProxy.h"
-#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "SharedBuffer.h"
-#include "WebCodecsBase.h"
+#include "WebCodecsControlMessageQueue.h"
 #include "WebCodecsImageTrackList.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/ArrayBufferView.h>
@@ -56,7 +55,7 @@ using ImageBufferSource = Variant
     , Ref<ReadableStream>
 >;
 
-class WebCodecsImageDecoder final : public WebCodecsBase {
+class WebCodecsImageDecoder final : public WebCodecsControlMessageQueue {
     WTF_MAKE_TZONE_ALLOCATED(WebCodecsImageDecoder);
 public:
     ~WebCodecsImageDecoder();
@@ -101,9 +100,6 @@ private:
     void NODELETE suspend(ReasonForSuspension) final;
     void stop() final;
 
-    // EventTarget.
-    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsImageDecoder; }
-
     void sinkStreamToInternalDecoder(const Ref<ReadableStream>&, const String& type);
     void setInternalDecoderData(FragmentedSharedBuffer&, const String& type, bool allDataReceived);
     void establishTrackList();
@@ -134,7 +130,5 @@ private:
 };
 
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebCodecsImageDecoder)
 
 #endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.idl
@@ -35,7 +35,7 @@
     InterfaceName=ImageDecoder,
     JSCustomMarkFunction,
     SecureContext
-] interface WebCodecsImageDecoder : EventTarget {
+] interface WebCodecsImageDecoder {
     [CallWith=CurrentScriptExecutionContext] constructor(WebCodecsImageDecoderInit init);
 
     readonly attribute DOMString type;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -538,6 +538,7 @@ Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
 Modules/webcodecs/WebCodecsAudioDecoder.cpp
 Modules/webcodecs/WebCodecsAudioEncoder.cpp
 Modules/webcodecs/WebCodecsBase.cpp
+Modules/webcodecs/WebCodecsControlMessageQueue.cpp
 Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
 Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
 Modules/webcodecs/WebCodecsImageDecoder.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -14565,6 +14565,8 @@
 		724DCF1B284853650026ACF4 /* ImageBufferAllocator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferAllocator.cpp; sourceTree = "<group>"; };
 		724DCF1C284853650026ACF4 /* ImageBufferAllocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferAllocator.h; sourceTree = "<group>"; };
 		724DCF1D28485C330026ACF4 /* FilterResults.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FilterResults.cpp; sourceTree = "<group>"; };
+		724DD271302D21F200AC38E2 /* WebCodecsControlMessageQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebCodecsControlMessageQueue.h; sourceTree = "<group>"; };
+		724DD272302D21F200AC38E2 /* WebCodecsControlMessageQueue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebCodecsControlMessageQueue.cpp; sourceTree = "<group>"; };
 		724E09062901CD27000AF3EB /* GraphicsContextSwitcher.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GraphicsContextSwitcher.cpp; sourceTree = "<group>"; };
 		724E09072901CD27000AF3EB /* GraphicsContextSwitcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GraphicsContextSwitcher.h; sourceTree = "<group>"; };
 		724ED3291A3A7E5400F5F13C /* EXTBlendMinMax.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EXTBlendMinMax.cpp; sourceTree = "<group>"; };
@@ -40041,6 +40043,8 @@
 				4110A21128E3440C00321D09 /* WebCodecsCodecState.h */,
 				4110A20F28E3440C00321D09 /* WebCodecsCodecState.idl */,
 				459CBAAA2C7647410003743B /* WebCodecsControlMessage.h */,
+				724DD272302D21F200AC38E2 /* WebCodecsControlMessageQueue.cpp */,
+				724DD271302D21F200AC38E2 /* WebCodecsControlMessageQueue.h */,
 				4183870C2B679AC100AD8881 /* WebCodecsEncodedAudioChunk.cpp */,
 				9A87D9ED2A82967A00EE7A8A /* WebCodecsEncodedAudioChunk.h */,
 				4183870B2B679AC100AD8881 /* WebCodecsEncodedAudioChunk.idl */,

--- a/Source/WebCore/dom/EventTargetFactory.in
+++ b/Source/WebCore/dom/EventTargetFactory.in
@@ -75,7 +75,6 @@ WakeLockSentinel
 WebAnimation
 WebCodecsAudioDecoder conditional=WEB_CODECS
 WebCodecsAudioEncoder conditional=WEB_CODECS
-WebCodecsImageDecoder conditional=WEB_CODECS
 WebCodecsVideoDecoder conditional=WEB_CODECS
 WebCodecsVideoEncoder conditional=WEB_CODECS
 WebKitMediaKeySession conditional=LEGACY_ENCRYPTED_MEDIA


### PR DESCRIPTION
#### 2e6b976d8f8364f0cb569ace2a5416f98aeb20a4
<pre>
WebCodecsImageDecoder should not inherit from EventTarget
<a href="https://bugs.webkit.org/show_bug.cgi?id=321640">https://bugs.webkit.org/show_bug.cgi?id=321640</a>
<a href="https://rdar.apple.com/184767470">rdar://184767470</a>

Reviewed by Jean-Yves Avenard.

Per the spec[1], WebCodecsImageDecoder should not inherit from any base class,
but it still needs to implement the [[control message queue]] behavior.

This PR splits WebCodecsBase into two classes: a new WebCodecsControlMessageQueue,
which holds the control-message-queue logic and does not inherit EventTarget,
and WebCodecsBase itself, which now inherits both WebCodecsControlMessageQueue
and EventTarget and exposes Event-dispatching methods to the other web codec
decoders/encoders.

WebCodecsImageDecoder can now inherit WebCodecsControlMessageQueue directly,
without pulling in EventTarget. Other web codec decoders/encoders still inherit
WebCodecsBase without any change.

[1] <a href="https://w3c.github.io/webcodecs/#imagedecoder-interface">https://w3c.github.io/webcodecs/#imagedecoder-interface</a>

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp:
(WebCore::WebCodecsBase::scriptExecutionContext const):
(WebCore::WebCodecsBase::clearControlMessageQueueAndMaybeScheduleDequeueEvent):
(WebCore::WebCodecsBase::decrementCodecQueueSizeAndScheduleDequeueEvent):
(WebCore::WebCodecsBase::scheduleDequeueEvent):
(WebCore::WebCodecsBase::WebCodecsBase): Deleted.
(WebCore::WebCodecsBase::queueControlMessageAndProcess): Deleted.
(WebCore::WebCodecsBase::processControlMessageQueue): Deleted.
(WebCore::WebCodecsBase::incrementCodecQueueSize): Deleted.
(WebCore::WebCodecsBase::decrementCodecOperationCountAndMaybeProcessControlMessageQueue): Deleted.
(WebCore::WebCodecsBase::clearControlMessageQueue): Deleted.
(WebCore::WebCodecsBase::blockControlMessageQueue): Deleted.
(WebCore::WebCodecsBase::unblockControlMessageQueue): Deleted.
(WebCore::WebCodecsBase::virtualHasPendingActivity const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsBase.h:
(WebCore::WebCodecsBase::state const): Deleted.
(WebCore::WebCodecsBase::setState): Deleted.
(WebCore::WebCodecsBase::codecQueueSize const): Deleted.
(WebCore::WebCodecsBase::maximumCodecOperationsEnqueued const): Deleted.
(WebCore::WebCodecsBase::incrementCodecOperationCount): Deleted.
(WebCore::WebCodecsBase::isCodecSaturated const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsControlMessage.h:
* Source/WebCore/Modules/webcodecs/WebCodecsControlMessageQueue.cpp: Copied from Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp.
(WebCore::WebCodecsControlMessageQueue::WebCodecsControlMessageQueue):
(WebCore::WebCodecsControlMessageQueue::queueControlMessageAndProcess):
(WebCore::WebCodecsControlMessageQueue::queueCodecControlMessageAndProcess):
(WebCore::WebCodecsControlMessageQueue::processControlMessageQueue):
(WebCore::WebCodecsControlMessageQueue::incrementCodecQueueSize):
(WebCore::WebCodecsControlMessageQueue::decrementCodecQueueSize):
(WebCore::WebCodecsControlMessageQueue::resetCodecQueueSize):
(WebCore::WebCodecsControlMessageQueue::decrementCodecOperationCountAndMaybeProcessControlMessageQueue):
(WebCore::WebCodecsControlMessageQueue::clearControlMessageQueue):
(WebCore::WebCodecsControlMessageQueue::blockControlMessageQueue):
(WebCore::WebCodecsControlMessageQueue::unblockControlMessageQueue):
(WebCore::WebCodecsControlMessageQueue::virtualHasPendingActivity const):
* Source/WebCore/Modules/webcodecs/WebCodecsControlMessageQueue.h: Copied from Source/WebCore/Modules/webcodecs/WebCodecsBase.h.
(WebCore::WebCodecsControlMessageQueue::state const):
(WebCore::WebCodecsControlMessageQueue::setState):
(WebCore::WebCodecsControlMessageQueue::codecQueueSize const):
(WebCore::WebCodecsControlMessageQueue::maximumCodecOperationsEnqueued const):
(WebCore::WebCodecsControlMessageQueue::incrementCodecOperationCount):
(WebCore::WebCodecsControlMessageQueue::isCodecSaturated const):
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp:
(WebCore::WebCodecsImageDecoder::WebCodecsImageDecoder):
(WebCore::WebCodecsImageDecoder::resetDecoder):
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/EventTargetFactory.in:

Canonical link: <a href="https://commits.webkit.org/319102@main">https://commits.webkit.org/319102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/932ba099022ecb19324b186437234d88e090e129

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190708 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144818 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d3947c9-936b-41db-86ed-a08db1961cc8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140783 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2683b134-df9f-4a19-a8ee-82b0a188d533) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121235 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38db0f7f-a15f-41da-8edc-9b87492a8a2f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41081 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1867 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192643 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54108 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150143 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40194 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54796 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149865 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44492 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127059 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122231 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53313 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16070 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52695 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52932 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52760 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->