### PR TITLE
[JSC][Wasm] Prefer lowest function index for concurrent CompileError

### DIFF
--- a/JSTests/wasm/stress/consistent-compile-error-function-index.js
+++ b/JSTests/wasm/stress/consistent-compile-error-function-index.js
@@ -1,0 +1,75 @@
+// Concurrent function validation should report the CompileError for the lowest
+// failing function index, not whichever worker finishes first.
+// https://bugs.webkit.org/show_bug.cgi?id=283476
+//@ requireOptions("--useConcurrentJIT=true")
+
+import * as assert from "../assert.js";
+
+function leb(value) {
+    let bytes = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value)
+            byte |= 0x80;
+        bytes.push(byte);
+    } while (value);
+    return bytes;
+}
+
+function section(id, payload) {
+    return [id, ...leb(payload.length), ...payload];
+}
+
+// Many invalid functions. Function 0 is large (slow to validate) so a higher-index
+// worker is likely to finish first under concurrent compilation. The reported
+// error must still be for function 0.
+function invalidModuleBytes() {
+    const types = [0x01, 0x60, 0x00, 0x00];
+    const functionCount = 16;
+    const functions = [functionCount, ...Array(functionCount).fill(0x00)];
+
+    // Function 0: many nops then empty-stack i32.add (fails late).
+    const body0 = [0x00];
+    for (let i = 0; i < 8000; ++i)
+        body0.push(0x01); // nop
+    body0.push(0x6a, 0x0b); // i32.add end
+
+    // Functions 1..N: immediate empty-stack f32.add (fails quickly).
+    const bodyFast = [0x00, 0x92, 0x0b];
+
+    const codePayload = [functionCount, ...leb(body0.length), ...body0];
+    for (let i = 1; i < functionCount; ++i)
+        codePayload.push(...leb(bodyFast.length), ...bodyFast);
+
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        ...section(1, types),
+        ...section(3, functions),
+        ...section(10, codePayload),
+    ]);
+}
+
+const bytes = invalidModuleBytes();
+const iterations = 80;
+
+for (let i = 0; i < iterations; ++i) {
+    let message;
+    try {
+        new WebAssembly.Module(bytes);
+        throw new Error("expected CompileError");
+    } catch (error) {
+        assert.truthy(error instanceof WebAssembly.CompileError, `expected CompileError, got ${error}`);
+        message = String(error);
+    }
+    assert.truthy(
+        message.includes("function at index 0"),
+        `iteration ${i}: expected error for function 0, got: ${message}`
+    );
+    for (let j = 1; j < 16; ++j) {
+        assert.truthy(
+            !message.includes(`function at index ${j}`),
+            `iteration ${i}: should not report function ${j} when function 0 also fails: ${message}`
+        );
+    }
+}

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -273,6 +273,14 @@ bool EntryPlan::failIfMixedExceptionHandlingProposals()
     return false;
 }
 
+void EntryPlan::failFunctionCompilation(FunctionCodeIndex functionIndex, String&& errorMessage, CompilationError error)
+{
+    failAtFunction(functionIndex, WTF::move(errorMessage), error);
+    m_currentIndex = m_numberOfFunctions;
+    if (hasWork())
+        moveToState(State::Compiled);
+}
+
 bool EntryPlan::completeSyncIfPossible()
 {
     Locker locker { m_lock };

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -118,6 +118,10 @@ protected:
     void complete() WTF_REQUIRES_LOCK(m_lock) override;
 
     bool failIfMixedExceptionHandlingProposals() WTF_REQUIRES_LOCK(m_lock);
+    // Records a function validation error (lowest index wins) and stops assigning more work.
+    // Completion is deferred to ThreadCountHolder / completeInStreaming so concurrent
+    // workers can still report a lower-index failure.
+    void failFunctionCompilation(FunctionCodeIndex, String&& errorMessage, CompilationError = CompilationError::Default) WTF_REQUIRES_LOCK(m_lock);
 
     virtual bool prepareImpl() = 0;
     virtual void compileFunction(FunctionCodeIndex functionIndex) = 0;

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -97,11 +97,7 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
 
     if (!parseAndCompileResult) [[unlikely]] {
         Locker locker { m_lock };
-        if (!m_errorMessage) {
-            // Multiple compiles could fail simultaneously. We arbitrarily choose the first.
-            fail(makeString(parseAndCompileResult.error(), ", in function at index "_s, functionIndex.rawIndex())); // FIXME make this an Expected.
-        }
-        m_currentIndex = m_moduleInformation->functions.size();
+        failFunctionCompilation(functionIndex, makeString(parseAndCompileResult.error(), ", in function at index "_s, functionIndex.rawIndex()));
         return;
     }
 
@@ -117,7 +113,7 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
 
         if (usesSIMD && !Options::useBBQJIT() && !Options::useWasmIPIntSIMD()) {
             Locker locker { m_lock };
-            Base::fail(makeString("JIT is disabled, but the entrypoint for "_s, functionIndex.rawIndex(), " requires JIT"_s));
+            failFunctionCompilation(functionIndex, makeString("JIT is disabled, but the entrypoint for "_s, functionIndex.rawIndex(), " requires JIT"_s));
             return;
         }
 

--- a/Source/JavaScriptCore/wasm/WasmPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmPlan.cpp
@@ -127,6 +127,18 @@ void Plan::fail(String&& errorMessage, CompilationError error)
     complete();
 }
 
+void Plan::failAtFunction(FunctionCodeIndex functionIndex, String&& errorMessage, CompilationError error)
+{
+    ASSERT(errorMessage);
+    // Non-function failures (OOM, parse, cancel) win over function validation errors.
+    if (failed() && (!m_errorFunctionIndex || *m_errorFunctionIndex <= functionIndex))
+        return;
+    dataLogLnIf(WasmPlanInternal::verbose, "failing function ", functionIndex, " with message: ", errorMessage);
+    m_errorMessage = WTF::move(errorMessage);
+    m_errorFunctionIndex = functionIndex;
+    m_error = error;
+}
+
 Plan::~Plan() = default;
 
 CString Plan::signpostMessage(CompilationMode compilationMode, uint32_t functionIndexSpace) const

--- a/Source/JavaScriptCore/wasm/WasmPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmPlan.h
@@ -32,6 +32,7 @@
 #include "WasmJS.h"
 #include "WasmModuleInformation.h"
 #include "WasmOMGIRGenerator.h"
+#include <optional>
 #include <wtf/Bag.h>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/SharedTask.h>
@@ -81,6 +82,7 @@ public:
 protected:
     void runCompletionTasks() WTF_REQUIRES_LOCK(m_lock);
     void fail(String&& errorMessage, CompilationError = CompilationError::Default) WTF_REQUIRES_LOCK(m_lock);
+    void failAtFunction(FunctionCodeIndex, String&& errorMessage, CompilationError = CompilationError::Default) WTF_REQUIRES_LOCK(m_lock);
 
     virtual bool isComplete() const = 0;
     virtual void complete() WTF_REQUIRES_LOCK(m_lock) = 0;
@@ -100,6 +102,7 @@ protected:
     Vector<std::pair<VM*, CompletionTask>, 1> m_completionTasks;
 
     String m_errorMessage;
+    std::optional<FunctionCodeIndex> m_errorFunctionIndex;
     CompilationError m_error { CompilationError::Default };
 };
 


### PR DESCRIPTION
#### b7afce9416a9ef663661eb59613768529ea65101
<pre>
[JSC][Wasm] Prefer lowest function index for concurrent CompileError
<a href="https://bugs.webkit.org/show_bug.cgi?id=283476">https://bugs.webkit.org/show_bug.cgi?id=283476</a>

Reviewed by Yusuke Suzuki.

When multiple functions fail validation under concurrent compilation,
keep the error message for the lowest function index instead of
whichever worker finishes first. Function-scoped failures record the
error without completing the plan immediately so later lower-index
failures can replace it. Non-function failures such as OOM are not
replaced by later function errors. EntryPlan stops assigning more work
and ThreadCountHolder completes when active workers drain.

* Source/JavaScriptCore/wasm/WasmPlan.h:
* Source/JavaScriptCore/wasm/WasmPlan.cpp:
* Source/JavaScriptCore/wasm/WasmEntryPlan.h:
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
* JSTests/wasm/stress/consistent-compile-error-function-index.js: Added.

Canonical link: <a href="https://commits.webkit.org/319430@main">https://commits.webkit.org/319430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caa48824d625fcdc921e72beb092695217d0c0fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190984 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145094 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141008 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97720 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121460 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43347 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41629 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3427 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10244 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41288 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2145 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42045 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192919 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54382 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150392 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55070 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37906 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150109 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27552 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44701 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127336 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122622 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53587 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16281 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53206 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->