### PR TITLE
Escape WebTransport protocol strings in network process

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -87,18 +87,13 @@ ExceptionOr<Ref<WebTransport>> WebTransport::create(ScriptExecutionContext& cont
         return Exception { ExceptionCode::NotSupportedError };
 
     HashSet<String> uniqueProtocols;
-    Vector<String> escapedProtocols;
-    escapedProtocols.reserveInitialCapacity(options.protocols.size());
     for (auto& protocol : options.protocols) {
-        auto escapedProtocol = RFC8941::escapeString(protocol);
-        if (!escapedProtocol || escapedProtocol->isEmpty() || escapedProtocol->length() > 512)
+        auto escapedLength = RFC8941::escapedStringLength(protocol);
+        if (!escapedLength || !*escapedLength || *escapedLength > 512)
             return Exception { ExceptionCode::SyntaxError };
-
-        if (!uniqueProtocols.add(*escapedProtocol).isNewEntry)
+        if (!uniqueProtocols.add(protocol).isNewEntry)
             return Exception { ExceptionCode::SyntaxError };
-        escapedProtocols.append(WTF::move(*escapedProtocol));
     }
-    options.protocols = WTF::move(escapedProtocols);
 
     auto* globalObject = context.globalObject();
     if (!globalObject) {

--- a/Source/WebCore/platform/network/RFC8941.cpp
+++ b/Source/WebCore/platform/network/RFC8941.cpp
@@ -378,14 +378,12 @@ std::optional<HashMap<String, std::pair<ItemOrInnerList, Parameters>>> parseDict
     });
 }
 
-std::optional<String> escapeString(StringView input)
+bool escapeString(StringView input, StringBuilder& builder)
 {
     // https://datatracker.ietf.org/doc/html/rfc8941#section-3.3.3
-    StringBuilder builder;
-    builder.reserveCapacity(input.length());
     for (char16_t codeUnit : input.codeUnits()) {
         if (codeUnit < 0x20 || codeUnit > 0x7E)
-            return std::nullopt;
+            return false;
         if (codeUnit == '"')
             builder.append("\\\""_s);
         else if (codeUnit == '\\')
@@ -393,7 +391,22 @@ std::optional<String> escapeString(StringView input)
         else
             builder.append(static_cast<Latin1Character>(codeUnit));
     }
-    return builder.toString();
+    return true;
+};
+
+std::optional<size_t> escapedStringLength(StringView input)
+{
+    // https://datatracker.ietf.org/doc/html/rfc8941#section-3.3.3
+    size_t length = input.length();
+    for (char16_t codeUnit : input.codeUnits()) {
+        if (codeUnit < 0x20 || codeUnit > 0x7E)
+            return std::nullopt;
+        if (codeUnit == '"')
+            length++;
+        else if (codeUnit == '\\')
+            length++;
+    }
+    return length;
 };
 
 } // namespace RFC8941

--- a/Source/WebCore/platform/network/RFC8941.h
+++ b/Source/WebCore/platform/network/RFC8941.h
@@ -67,7 +67,9 @@ using ItemOrInnerList = Variant<BareItem, InnerList>;
 WEBCORE_EXPORT std::optional<std::pair<BareItem, Parameters>> parseItemStructuredFieldValue(StringView header);
 WEBCORE_EXPORT std::optional<Vector<std::pair<ItemOrInnerList, Parameters>>> parseListStructuredFieldValue(StringView header);
 WEBCORE_EXPORT std::optional<HashMap<String, std::pair<ItemOrInnerList, Parameters>>> parseDictionaryStructuredFieldValue(StringView header);
-std::optional<String> escapeString(StringView);
+
+std::optional<size_t> escapedStringLength(StringView);
+[[nodiscard]] WEBCORE_EXPORT bool escapeString(StringView, StringBuilder&);
 
 } // namespace RFC8941
 

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -192,7 +192,8 @@ static String joinProtocolStrings(const Vector<String>& protocols)
     for (size_t i = 0; i < protocols.size(); ++i) {
         if (i)
             builder.append(", "_s);
-        builder.append('\"', protocols[i], '\"');
+        if (!RFC8941::escapeString(protocols[i], builder))
+            return { };
     }
     return builder.toString();
 }


### PR DESCRIPTION
#### 8b64d59f00b9f074a6576476aab61d1cf5a59f97
<pre>
Escape WebTransport protocol strings in network process
<a href="https://bugs.webkit.org/show_bug.cgi?id=321646">https://bugs.webkit.org/show_bug.cgi?id=321646</a>
<a href="https://rdar.apple.com/184770789">rdar://184770789</a>

Reviewed by NOBODY (OOPS!).

This was suggested by AI after looking at <a href="https://commits.webkit.org/318984@main">318984@main</a>.
It suggested a MESSAGE_CHECK, but I think ignoring any invalid protocols
from a compromised web content process is just fine.  This will prevent
a compromised web content process from sending a protocol with an unescaped
quote or slash, or non-ASCII characters in it.

* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::create):
* Source/WebCore/platform/network/RFC8941.cpp:
(RFC8941::escapeString):
(RFC8941::escapedStringLength):
* Source/WebCore/platform/network/RFC8941.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::joinProtocolStrings):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b64d59f00b9f074a6576476aab61d1cf5a59f97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190653 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144763 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34df1e3d-2bf4-4117-a7da-9c49c1e06f24) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140728 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97476 "2 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d62cb5c7-0507-4023-9364-a33ce4bd2bca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121180 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e8f304ee-10db-4a8b-a160-37894297f5ca) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43067 "Found 4 new test failures: imported/w3c/web-platform-tests/webtransport/connect.https.any.html imported/w3c/web-platform-tests/webtransport/connect.https.any.serviceworker.html imported/w3c/web-platform-tests/webtransport/connect.https.any.sharedworker.html imported/w3c/web-platform-tests/webtransport/connect.https.any.worker.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41352 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41028 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1812 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46986 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45606 "Found 4 new test failures: imported/w3c/web-platform-tests/webtransport/connect.https.any.html imported/w3c/web-platform-tests/webtransport/connect.https.any.serviceworker.html imported/w3c/web-platform-tests/webtransport/connect.https.any.sharedworker.html imported/w3c/web-platform-tests/webtransport/connect.https.any.worker.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192588 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54053 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150091 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54741 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37642 "Too many flaky failures: http/tests/cookies/same-site/popup-same-site.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/privateClickMeasurement/store-private-click-measurement-nested.html, http/tests/resourceLoadStatistics/grandfathering.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/image-blocked-alt-text.html, http/tests/security/mixedContent/redirect-https-to-http-script-in-iframe-UpgradeMixedContent.html, http/tests/site-isolation/find-string-with-cross-page-focused-frame-crash.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html, http/tests/webgpu/webgpu/api/validation/image_copy/texture_related.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149814 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44436 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127004 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122166 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53258 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16017 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52640 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52877 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->