### PR TITLE
AX: Document scrollbar is not exposed in the isolated tree when revealing content makes the document scrollable

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/scrollbar-not-created-when-revealing-content-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/scrollbar-not-created-when-revealing-content-expected.txt
@@ -1,0 +1,9 @@
+This test ensures the document's scrollbar is exposed when revealing hidden content makes the document scrollable.
+
+PASS: scrollBarsBefore === 0
+PASS: scrollBarsAfter === 1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/scrollbar-not-created-when-revealing-content.html
+++ b/LayoutTests/accessibility/isolated-tree/scrollbar-not-created-when-revealing-content.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+/* Hidden content which, once revealed, is wider than the viewport, making the
+   document scrollable and giving the frame view a horizontal scrollbar. */
+#wide-content { display: none; position: absolute; width: 200vw; height: 20px; }
+</style>
+</head>
+<body>
+
+<div id="wide-content"></div>
+
+<script>
+var output = "This test ensures the document's scrollbar is exposed when revealing hidden content makes the document scrollable.\n\n";
+
+function scrollBarCount()
+{
+    // Scrollbars synthesized for a scroll view are direct children of it.
+    var root = accessibilityController.rootElement;
+    var count = 0;
+    for (var i = 0; i < root.childrenCount; i++) {
+        if (root.childAtIndex(i).role === "AXRole: AXScrollBar")
+            count++;
+    }
+    return count;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        // Realize the accessibility tree before revealing anything. This ordering is the point of
+        // the test: a scroll view rebuilds its children in place when a scrollbar comes or goes,
+        // and nothing about that is driven by a DOM or render tree mutation, so the children
+        // cached here have to be invalidated explicitly.
+        window.scrollBarsBefore = scrollBarCount();
+        output += expect("scrollBarsBefore", "0");
+
+        document.getElementById("wide-content").style.display = "block";
+        await waitFor(() => scrollBarCount() === 1);
+
+        window.scrollBarsAfter = scrollBarCount();
+        output += expect("scrollBarsAfter", "1");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/scrollbar-not-created-when-revealing-content-expected.txt
+++ b/LayoutTests/accessibility/scrollbar-not-created-when-revealing-content-expected.txt
@@ -1,0 +1,9 @@
+This test ensures the document's scrollbar is exposed when revealing hidden content makes the document scrollable.
+
+PASS: scrollBarsBefore === 0
+PASS: scrollBarsAfter === 1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/scrollbar-not-created-when-revealing-content.html
+++ b/LayoutTests/accessibility/scrollbar-not-created-when-revealing-content.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+/* Hidden content which, once revealed, is wider than the viewport, making the
+   document scrollable and giving the frame view a horizontal scrollbar. */
+#wide-content { display: none; position: absolute; width: 200vw; height: 20px; }
+</style>
+</head>
+<body>
+
+<div id="wide-content"></div>
+
+<script>
+var output = "This test ensures the document's scrollbar is exposed when revealing hidden content makes the document scrollable.\n\n";
+
+function scrollBarCount()
+{
+    // Scrollbars synthesized for a scroll view are direct children of it.
+    var root = accessibilityController.rootElement;
+    var count = 0;
+    for (var i = 0; i < root.childrenCount; i++) {
+        if (root.childAtIndex(i).role === "AXRole: AXScrollBar")
+            count++;
+    }
+    return count;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        // Realize the accessibility tree before revealing anything. This ordering is the point of
+        // the test: a scroll view rebuilds its children in place when a scrollbar comes or goes,
+        // and nothing about that is driven by a DOM or render tree mutation, so the children
+        // cached here have to be invalidated explicitly.
+        window.scrollBarsBefore = scrollBarCount();
+        output += expect("scrollBarsBefore", "0");
+
+        document.getElementById("wide-content").style.display = "block";
+        await waitFor(() => scrollBarCount() === 1);
+
+        window.scrollBarsAfter = scrollBarCount();
+        output += expect("scrollBarsAfter", "1");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3627,10 +3627,19 @@ void AXObjectCache::onScrollbarUpdate(ScrollView& view)
 void AXObjectCache::handleScrollbarUpdate(ScrollView& view)
 {
     // We don't want to create a scroll view from this method, only update an existing one.
-    if (RefPtr scrollViewObject = get(&view)) {
-        stopCachingComputedObjectAttributes();
-        scrollViewObject->updateChildrenIfNecessary();
-    }
+    RefPtr scrollViewObject = get(&view);
+    if (!scrollViewObject)
+        return;
+
+    stopCachingComputedObjectAttributes();
+    scrollViewObject->updateChildrenIfNecessary();
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    // AccessibilityScrollView::updateChildrenIfNecessary() rebuilds the live children
+    // but doesn't mark the scroll view as needing a children update.
+    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
+        tree->queueNodeUpdate(scrollViewObject->objectID(), NodeUpdateOptions::childrenUpdate());
+#endif
 }
 
 void AXObjectCache::handleAriaExpandedChange(Element& element)


### PR DESCRIPTION
#### 309c7e6231d9acf39c74997b692c7f37c8ed1231
<pre>
AX: Document scrollbar is not exposed in the isolated tree when revealing content makes the document scrollable
<a href="https://bugs.webkit.org/show_bug.cgi?id=321647">https://bugs.webkit.org/show_bug.cgi?id=321647</a>
<a href="https://rdar.apple.com/184773721">rdar://184773721</a>

Reviewed by Tyler Wilcock.

When a document becomes scrollable, LocalFrameView::didAddScrollbar
tells the AXObjectCache via onScrollbarUpdate, and
AXObjectCache::handleScrollbarUpdate calls
AccessibilityScrollView::updateChildrenIfNecessary, which clears and
re-adds the scroll view&apos;s children so that the synthesized AXScrollBar
child appears (or disappears).

That updates the live tree only. A scroll view has neither a node nor
a renderer, so a scrollbar coming and going is not accompanied by any
DOM or render tree mutation that would route through
AXObjectCache::childrenChanged, and nothing ever marked the scroll
view as needing a children update. The isolated tree therefore kept
serving whatever children the scroll area had when it was first built,
and the scrollbar was never exposed to an assistive technology. Note
that handleScrollbarUpdate also runs after
handleAllDeferredChildrenChanged in
AXObjectCache::performDeferredCacheUpdate, so deferring a
children-changed here would not be picked up in the same cycle.

Queue the children update on the isolated tree explicitly instead.

Tests: accessibility/isolated-tree/scrollbar-not-created-when-revealing-content.html
       accessibility/scrollbar-not-created-when-revealing-content.html

* LayoutTests/accessibility/isolated-tree/scrollbar-not-created-when-revealing-content-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/scrollbar-not-created-when-revealing-content.html: Added.
* LayoutTests/accessibility/scrollbar-not-created-when-revealing-content-expected.txt: Added.
* LayoutTests/accessibility/scrollbar-not-created-when-revealing-content.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleScrollbarUpdate):

Canonical link: <a href="https://commits.webkit.org/319127@main">https://commits.webkit.org/319127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/743149dac3bbe5fd0e757eed7f6062204af42f3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144804 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88c59777-e764-45f9-9635-2867f799db02) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182345 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55726 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140772 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f5d9cb0-7c7c-49f2-bc5b-95269b6b7aa4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121224 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9609a068-a0c3-471c-afbf-2816069471c5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43109 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41393 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153513 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41069 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1853 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192629 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150130 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40208 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54782 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149852 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44479 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127045 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122217 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53299 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16058 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52681 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52918 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52746 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->