### PR TITLE
[GFC] Loosen the max-width and max-height avoidance reasons

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-height-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-height-001-expected.txt
@@ -1,0 +1,3 @@
+
+PASS .grid 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-height-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-height-001.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Grid item with a fixed max-height is clamped by it.</title>
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-grid-2/#grid-item-sizing">
+<meta name="assert" content="A grid item with an automatic block size which is stretched into its grid area is clamped by its fixed max-height, so its used block size is the max-height rather than the block size of the grid area.">
+<link rel="stylesheet" href="/css/support/grid.css">
+<style>
+.grid {
+    grid-template-columns: 50px;
+    grid-template-rows: 100px;
+    /* Layout-preserving: keeps the grid on the modern grid path. */
+    justify-items: normal;
+}
+.item {
+    max-height: 50px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.grid')">
+<div id="log"></div>
+
+<div class="grid">
+    <div class="item" data-expected-height="50"></div>
+</div>
+
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-width-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-width-001-expected.txt
@@ -1,0 +1,3 @@
+
+PASS .grid 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-width-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-width-001.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Grid item with a fixed max-width is clamped by it.</title>
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-grid-2/#grid-item-sizing">
+<meta name="assert" content="A grid item with an automatic inline size which is stretched into its grid area is clamped by its fixed max-width, so its used inline size is the max-width rather than the inline size of the grid area.">
+<link rel="stylesheet" href="/css/support/grid.css">
+<style>
+.grid {
+    grid-template-columns: 100px;
+    /* Layout-preserving: keeps the grid on the modern grid path. */
+    justify-items: normal;
+}
+.item {
+    max-width: 50px;
+    height: 50px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.grid')">
+<div id="log"></div>
+
+<div class="grid">
+    <div class="item" data-expected-width="50"></div>
+</div>
+
+</body>

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -565,7 +565,11 @@ LayoutUnit inlineMaximumSize(const PlacedGridItem& gridItem, LayoutUnit borderAn
     auto& maximumSize = gridItem.inlineAxisSizes().maximumSize;
     if (maximumSize.isNone())
         return BorderBoxSize::maxSized().value;
-    return BorderBoxSize { ContentBoxSize { LayoutUnit { maximumSize.tryFixed()->resolveZoom(gridItem.usedZoom()) } }, borderAndPadding }.value;
+    if (auto fixedMaximumSize = maximumSize.tryFixed())
+        return BorderBoxSize { ContentBoxSize { LayoutUnit { fixedMaximumSize->resolveZoom(gridItem.usedZoom()) } }, borderAndPadding }.value;
+    // FIXME: Resolve percentage and calculated maximum sizes against the grid area.
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return BorderBoxSize::maxSized().value;
 }
 
 LayoutUnit blockMaximumSize(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding)
@@ -573,7 +577,11 @@ LayoutUnit blockMaximumSize(const PlacedGridItem& gridItem, LayoutUnit borderAnd
     auto& maximumSize = gridItem.blockAxisSizes().maximumSize;
     if (maximumSize.isNone())
         return BorderBoxSize::maxSized().value;
-    return BorderBoxSize { ContentBoxSize { LayoutUnit { maximumSize.tryFixed()->resolveZoom(gridItem.usedZoom()) } }, borderAndPadding }.value;
+    if (auto fixedMaximumSize = maximumSize.tryFixed())
+        return BorderBoxSize { ContentBoxSize { LayoutUnit { fixedMaximumSize->resolveZoom(gridItem.usedZoom()) } }, borderAndPadding }.value;
+    // FIXME: Resolve percentage and calculated maximum sizes against the grid area.
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return BorderBoxSize::maxSized().value;
 }
 
 // https://drafts.csswg.org/css-grid-1/#grid-item-sizing

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -69,8 +69,8 @@ enum class GridAvoidanceReason : uint8_t {
     GridHasUnsupportedMinHeight,
     GridHasUnsupportedMaxHeight,
     GridHasPercentageRowsWithIndefiniteHeight,
-    GridItemHasNonInitialMaxWidth,
-    GridItemHasNonInitialMaxHeight,
+    GridItemHasUnsupportedMaxWidth,
+    GridItemHasUnsupportedMaxHeight,
     GridItemHasMargin,
     GridItemHasBorderBoxSizing,
     GridItemHasUnsupportedWritingMode,
@@ -509,15 +509,17 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
         if (!minWidth.isFixed() && !minWidth.isAuto())
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasUnsupportedMinWidth, reasons, reasonCollectionMode);
 
-        if (!gridItemStyle->maxWidth().isNone())
-            ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasNonInitialMaxWidth, reasons, reasonCollectionMode);
+        auto& maxWidth = gridItemStyle->maxWidth();
+        if (!maxWidth.isFixed() && !maxWidth.isNone())
+            ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasUnsupportedMaxWidth, reasons, reasonCollectionMode);
 
         auto& minHeight = gridItemStyle->minHeight();
         if (!minHeight.isFixed() && !minHeight.isAuto())
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasUnsupportedMinHeight, reasons, reasonCollectionMode);
 
-        if (!gridItemStyle->maxHeight().isNone())
-            ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasNonInitialMaxHeight, reasons, reasonCollectionMode);
+        auto& maxHeight = gridItemStyle->maxHeight();
+        if (!maxHeight.isFixed() && !maxHeight.isNone())
+            ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasUnsupportedMaxHeight, reasons, reasonCollectionMode);
 
         auto gridItemHasMargins = [&] {
             return gridItemStyle->marginBox().anyOf([](const Style::MarginEdge& marginEdge) {
@@ -774,11 +776,11 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
     case GridAvoidanceReason::GridItemHasUnsupportedAutomaticBlockSizing:
         stream << "grid item has unsupported automatic block sizing";
         break;
-    case GridAvoidanceReason::GridItemHasNonInitialMaxWidth:
-        stream << "grid item has non-initial max-width";
+    case GridAvoidanceReason::GridItemHasUnsupportedMaxWidth:
+        stream << "grid item has unsupported max-width";
         break;
-    case GridAvoidanceReason::GridItemHasNonInitialMaxHeight:
-        stream << "grid item has non-initial max-height";
+    case GridAvoidanceReason::GridItemHasUnsupportedMaxHeight:
+        stream << "grid item has unsupported max-height";
         break;
     case GridAvoidanceReason::GridItemHasMargin:
         stream << "grid item has margin";


### PR DESCRIPTION
#### 53f594a61dd2b5408e66fb2c27340d03b2ed05e4
<pre>
[GFC] Loosen the max-width and max-height avoidance reasons
<a href="https://bugs.webkit.org/show_bug.cgi?id=321644">https://bugs.webkit.org/show_bug.cgi?id=321644</a>
&lt;<a href="https://rdar.apple.com/184769971">rdar://184769971</a>&gt;

Reviewed by Sammy Gill.

GFC supports fixed max-width and max-height, so we should loosen that coverage
check. Tests were written to pass our avoidance checks to properly verify that
GFC was handling these maximum sizes as expected.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-height-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-height-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-width-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-fixed-max-width-001.html: Added.
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::inlineMaximumSize):
(WebCore::Layout::GridLayoutUtils::blockMaximumSize):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::printReason):
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):

Canonical link: <a href="https://commits.webkit.org/319106@main">https://commits.webkit.org/319106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3500492f6ee8d81c237f9ff7b06b31a97b6fef1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144768 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1d7a767-55b6-43b2-8399-ff014712c853) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140735 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd772013-b8e2-4a90-9ce2-d0e4f3a8f4d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121187 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa32e380-9abc-4d46-ae3d-e014093af632) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43074 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41354 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41031 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1817 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192593 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150096 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54746 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149819 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27390 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44444 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127009 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122171 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53263 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16020 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52645 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52882 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52710 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->