### PR TITLE
[Site Isolation] UI process crashes in WebFrameProxy::broadcastFrameTreeSyncData when a remote web process terminates while loading cross-site iframes in private browsing

### DIFF
--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -849,7 +849,9 @@ void WebFrameProxy::remoteProcessDidTerminate(WebProcessProxy& process, ClearFra
 {
     // Only clear the FrameTreeSyncData on all child processes once, when handling the main frame.
     // No point in clearing it multiple times in a tight loop.
-    if (clearFrameTreeSyncData == ClearFrameTreeSyncData::Yes)
+    // Site isolation may have been disabled after this remote page was created.
+    RefPtr webPage = page();
+    if (clearFrameTreeSyncData == ClearFrameTreeSyncData::Yes && webPage && protect(webPage->preferences())->siteIsolationEnabled())
         broadcastFrameTreeSyncData(FrameTreeSyncData::create());
 
     for (Ref child : m_childFrames)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -414,15 +414,20 @@ std::pair<std::unique_ptr<InstanceMethodSwizzler>, std::unique_ptr<InstanceMetho
 
 namespace TestWebKitAPI {
 
-static void enableFeature(WKWebViewConfiguration *configuration, NSString *featureName)
+static void setFeatureEnabled(WKWebViewConfiguration *configuration, NSString *featureName, bool enabled)
 {
     auto preferences = [configuration preferences];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:featureName]) {
-            [preferences _setEnabled:YES forFeature:feature];
+            [preferences _setEnabled:enabled forFeature:feature];
             break;
         }
     }
+}
+
+static void enableFeature(WKWebViewConfiguration *configuration, NSString *featureName)
+{
+    setFeatureEnabled(configuration, featureName, true);
 }
 
 static void enableSiteIsolation(WKWebViewConfiguration *configuration)
@@ -6144,6 +6149,34 @@ TEST(SiteIsolation, ProcessTerminationReason)
     while (server.totalRequests() < 5u)
         Util::spinRunLoop();
     EXPECT_EQ(server.totalRequests(), 5u);
+}
+
+TEST(SiteIsolation, RemoteProcessTerminationAfterDisablingSiteIsolation)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/iframe'></iframe>"_s } },
+        { "/iframe"_s, { "hi"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    pid_t iframePID = [webView firstChildFrame]._processIdentifier;
+    EXPECT_NE(iframePID, 0);
+    EXPECT_NE(iframePID, [webView mainFrame].info._processIdentifier);
+
+    // The remote page for the iframe process outlives the preference change, so its
+    // termination must not try to broadcast FrameTreeSyncData.
+    setFeatureEnabled(configuration, @"SiteIsolationEnabled", false);
+
+    kill(iframePID, 9);
+    while (processStillRunning(iframePID))
+        Util::spinRunLoop();
+
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"location.host"], "example.com");
 }
 
 #if defined(NDEBUG) && PLATFORM(MAC)


### PR DESCRIPTION
#### 884d0116ea09545d3bebd0d91a834ecc23ab6c31
<pre>
[Site Isolation] UI process crashes in WebFrameProxy::broadcastFrameTreeSyncData when a remote web process terminates while loading cross-site iframes in private browsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=321633">https://bugs.webkit.org/show_bug.cgi?id=321633</a>
<a href="https://rdar.apple.com/184724123">rdar://184724123</a>

Reviewed by Abrar Rahman Protyasha.

broadcastFrameTreeSyncData has a RELEASE_ASSERT that site isolation is enabled.
Four of its five callers check the preference first; the one in
remoteProcessDidTerminate does not. 7e7db43cb121 added the assert, the guarded
callsite in didCommitLoad, and this unguarded one, all in the same commit.

siteIsolationEnabled is a mutable preference, and nothing tears down a
RemotePageProxy or removes a page from its BrowsingContextGroup when it is turned
off on a live page - WebPreferences::update() only calls
WebPageProxy::preferencesDidChange(). So a remote page created while site
isolation was enabled outlives the preference change, and when its process later
terminates, RemotePageProxy::processDidTerminate reaches
remoteProcessDidTerminate, which broadcasts unconditionally and the release
assert kills the UI process.

Check the preference at the callsite, the way didCommitLoad does.

The test kills the iframe process and waits for it to exit rather than waiting on
-waitForWebContentProcessDidTerminate. An iframe process is not the page&apos;s
siteIsolatedProcess(), so WebProcessProxy::terminationReason() reports
NonMainFrameWebContentProcessCrash, and
NavigationState::NavigationClient::processDidTerminate returns early for that reason
without invoking the delegate. Waiting on it never completes, so the test times out
instead of failing.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::remoteProcessDidTerminate):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::setFeatureEnabled):
(TestWebKitAPI::enableFeature):

Canonical link: <a href="https://commits.webkit.org/319406@main">https://commits.webkit.org/319406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42769ffdb1ed2d894b804d4182525f6a6c0bce38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145449 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141334 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98034 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121785 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43675 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41957 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41615 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2501 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193275 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54737 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150724 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40433 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55425 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150449 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45031 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127693 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/123240 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53942 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16611 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53324 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->