### PR TITLE
[JSC] AirEliminateDeadCode does not need to remove elements from Vector

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp
@@ -45,7 +45,7 @@ bool eliminateDeadCode(Code& code)
     IndexSet<StackSlot*> liveStackSlots;
     bool changed { false };
     
-    auto isArgLive = [&] (const Arg& arg) -> bool {
+    auto isArgLive = [&](const Arg& arg) -> bool {
         switch (arg.kind()) {
         case Arg::Tmp:
             if (arg.isReg())
@@ -60,7 +60,7 @@ bool eliminateDeadCode(Code& code)
         }
     };
 
-    auto isInstLiveByDefs = [&] (Inst& inst) -> bool {
+    auto isInstLiveByDefs = [&](Inst& inst) -> bool {
         // This instruction should be presumed dead, if its Args are all dead.
         bool storesToLive = false;
         inst.forEachArg(
@@ -74,11 +74,11 @@ bool eliminateDeadCode(Code& code)
         return storesToLive;
     };
 
-    auto isInstLive = [&] (Inst& inst) -> bool {
+    auto isInstLive = [&](Inst& inst) -> bool {
         return inst.hasNonArgEffects() || isInstLiveByDefs(inst);
     };
 
-    auto markArgsLive = [&] (Inst& inst) {
+    auto markArgsLive = [&](Inst& inst) {
         for (Arg& arg : inst.args()) {
             if (arg.isStack() && !arg.stackSlot()->isLocked())
                 changed |= liveStackSlots.add(arg.stackSlot());
@@ -90,7 +90,7 @@ bool eliminateDeadCode(Code& code)
         }
     };
 
-    Vector<Inst*> deadCandidatesInBackwardOrder;
+    Vector<Inst*> backingStore;
 
     for (unsigned blockIndex = code.size(); blockIndex--;) {
         BasicBlock* block = code[blockIndex];
@@ -99,42 +99,44 @@ bool eliminateDeadCode(Code& code)
         for (unsigned instIndex = block->size(); instIndex--;) {
             Inst& inst = block->at(instIndex);
             if (!isInstLive(inst))
-                deadCandidatesInBackwardOrder.append(&inst);
+                backingStore.append(&inst);
             else
                 markArgsLive(inst);
         }
     }
 
+    auto deadCandidatesInBackwardOrder = backingStore.mutableSpan();
+
     // Inst in deadCandidatesInBackwardOrder already have hasNonArgEffects() == false, invariant
     // under live-set growth, so the fixpoint skips that re-check.
-    auto handleInst = [&] (Inst& inst) -> bool {
+    auto handleInst = [&](Inst& inst) -> bool {
         if (!isInstLiveByDefs(inst))
             return false;
         markArgsLive(inst);
         return true;
     };
 
-    auto runBackward = [&] () -> bool {
+    auto runBackward = [&] -> bool {
         changed = false;
-        deadCandidatesInBackwardOrder.removeAllMatching(
+        auto [begin, end] = std::ranges::remove_if(deadCandidatesInBackwardOrder,
             [&] (Inst* inst) -> bool {
                 bool result = handleInst(*inst);
                 changed |= result;
                 return result;
             });
+        deadCandidatesInBackwardOrder = deadCandidatesInBackwardOrder.first(begin - deadCandidatesInBackwardOrder.begin());
         return changed;
     };
 
-    auto runForward = [&] () -> bool {
+    auto runForward = [&] -> bool {
         changed = false;
-        for (unsigned i = deadCandidatesInBackwardOrder.size(); i--;) {
-            bool result = handleInst(*deadCandidatesInBackwardOrder[i]);
-            if (result) {
-                deadCandidatesInBackwardOrder[i] = deadCandidatesInBackwardOrder.last();
-                deadCandidatesInBackwardOrder.removeLast();
-                changed = true;
-            }
-        }
+        auto [begin, end] = std::ranges::remove_if(deadCandidatesInBackwardOrder | std::views::reverse,
+            [&] (Inst* inst) -> bool {
+                bool result = handleInst(*inst);
+                changed |= result;
+                return result;
+            });
+        deadCandidatesInBackwardOrder = deadCandidatesInBackwardOrder.last(deadCandidatesInBackwardOrder.end() - begin.base());
         return changed;
     };
 
@@ -152,7 +154,7 @@ bool eliminateDeadCode(Code& code)
 
     // After the fixpoint, deadCandidatesInBackwardOrder holds exactly the dead Insts. Null them
     // out and sweep with the cheap !inst predicate.
-    if (deadCandidatesInBackwardOrder.isEmpty())
+    if (deadCandidatesInBackwardOrder.empty())
         return false;
 
     for (Inst* inst : deadCandidatesInBackwardOrder)


### PR DESCRIPTION
#### ae85b80e5fbe8bf0a8a942a12636dbe6ee4b4621
<pre>
[JSC] AirEliminateDeadCode does not need to remove elements from Vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=321651">https://bugs.webkit.org/show_bug.cgi?id=321651</a>
<a href="https://rdar.apple.com/184776446">rdar://184776446</a>

Reviewed by Yijia Huang.

This patch uses std::ranges::remove_if and std::views::reverse, so
Vector&lt;Inst*&gt; elements are just moved forward / backward to the
latter part of the range when it is &quot;removed&quot;. And based on that we can
just shrink the size of std::span view.

* Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp:
(JSC::B3::Air::eliminateDeadCode):

Canonical link: <a href="https://commits.webkit.org/319087@main">https://commits.webkit.org/319087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b40b7a281aee771a0697df8340f1e45902e6062

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190665 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144775 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5cb0709a-05dd-4c8b-bbaf-86898faf9b77) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140742 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f2899fb3-1e51-4dce-bf68-5205f3866d41) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121194 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75af4e9f-10c5-4412-a301-252754c1b41d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3161 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9996 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41040 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1824 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41728 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46998 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192600 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54065 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150102 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54753 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149825 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27381 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44449 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122178 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53270 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16029 "Passed tests") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52652 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52889 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52717 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->