### PR TITLE
[Xcode] Add skill for invoking build-webkit and parsing output

### DIFF
--- a/.claude/plugins/.claude-plugin/marketplace.json
+++ b/.claude/plugins/.claude-plugin/marketplace.json
@@ -5,6 +5,11 @@
   },
   "plugins": [
     {
+      "name": "build-webkit",
+      "source": "./build-webkit",
+      "description": "Build WebKit on Apple platforms with Xcode"
+    },
+    {
       "name": "git-webkit",
       "source": "./git-webkit",
       "description": "Teaches Claude to use git-webkit tools for working with the WebKit repository"

--- a/.claude/plugins/build-webkit/.claude-plugin/plugin.json
+++ b/.claude/plugins/build-webkit/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "build-webkit",
+  "description": "Build WebKit on Apple platforms with xcodebuild, capturing results in an xcresult bundle so verbose build logs don't pollute the conversation",
+  "version": "1.0.0"
+}

--- a/.claude/plugins/build-webkit/skills/xcode/SKILL.md
+++ b/.claude/plugins/build-webkit/skills/xcode/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: xcode
+description: Use when the user wants to build WebKit on Apple platforms with Xcode (the default build tool there). Builds with `xcodebuild`, captures results in an xcresult bundle, and analyzes via `xcresulttool` so verbose build logs don't pollute the conversation.
+user-invocable: true
+allowed-tools: Bash, Read, Edit, Write, Agent
+---
+
+## When to use
+
+The user wants to either (a) get an initial build passing or (b) fix new build issues after making changes. The build log produces tens of thousands of lines that will pollute context; the xcresult bundle has the same information in structured form.
+
+## 1. Build and capture xcresult
+
+From the repo's working tree:
+
+```sh
+set -o pipefail
+Tools/Scripts/build-webkit --debug --result-bundle-path=/tmp/wk-build-N.xcresult ENABLE_USER_SCRIPT_SANDBOXING=NO DISABLE_TASK_SANDBOXING=YES OTHER_SWIFT_FLAGS='$(inherited) -disable-sandbox' 2>&1 | Tools/Scripts/filter-build-webkit > /tmp/wk-build-N.log 2>&1 ;
+echo "exit=$?"
+```
+
+- Use a fresh `/tmp/wk-build-<n>.xcresult` path each iteration — `xcodebuild` refuses to overwrite an existing bundle, and a failed run can leave one behind (see §4).
+- Redirect the filtered output to a file rather than letting it reach stdout. Anything on stdout becomes the tool result and lands in context, which is what this skill exists to avoid. The xcresult bundle holds everything needed to analyze; `/tmp/wk-build-<n>.log` is there for the user to tail or for a targeted `grep`.
+- Use build-webkit's own `--result-bundle-path=<path>` flag, NOT the raw `-resultBundlePath <path>` passthrough. build-webkit splices its own flags out of `@ARGV`, but forwards leftover args to a second, out-of-band `build-imagediff` invocation (`build-webkit:405`). A passed-through `-resultBundlePath` therefore reaches a second `xcodebuild`, which fails with `error: Existing file at -resultBundlePath`. That failure is not cosmetic: build-webkit exits with imagediff's status (`build-webkit:407-409`), so it reports failure even when the main build succeeded.
+- `set -o pipefail` with `$?`, not `${PIPESTATUS[0]}` — this environment's shell is zsh, whose arrays are 1-based, so `${PIPESTATUS[0]}` is always empty. `pipefail` works in both bash and zsh.
+- **Run clean builds in the background.** A full WebKit build takes 30-45 minutes, well past the Bash tool's 15-minute cap, so a foreground call will time out. Launch with `run_in_background: true` and wait for the completion notification — do not poll with `sleep`, which burns turns for no benefit. Incremental rebuilds after a one-file fix are usually under a minute, so only clean builds need this.
+- `ENABLE_USER_SCRIPT_SANDBOXING=NO`, `DISABLE_TASK_SANDBOXING=YES`, and `-disable-sandbox` to avoid conflicting with Claude's own sandbox. Without `DISABLE_TASK_SANDBOXING=YES`, individual build tasks stay sandboxed and steps like `CoreMLModelCompile` fail. (These are build settings, so adding them to an existing build directory invalidates its products and forces one full rebuild.)
+- Exit code 65 is the typical "build failed" code. 0 means success.
+- There are different configuration (debug, release) and platform flags (iOS, etc.) available. Run `Tools/Scripts/build-webkit -h` for usage info.
+- Platform/SDK flags must use build-webkit's own spelling, e.g. `--sdk=iphoneos27.0.internal` or `--sdk iphoneos27.0.internal`. A bare `-sdk <name>` is not recognized by webkitdirs (`webkitdirs.pm:996`), so it passes through to xcodebuild while WebKit's own platform and build-directory logic still resolves to the host platform.
+
+## 2. Get high-level error summary
+
+```sh
+xcrun xcresulttool get build-results --path /tmp/wk-build-N.xcresult
+```
+
+Returns JSON with `status`, `errorCount`, `warningCount`, and arrays of `errors`/`warnings`. Each issue has:
+- `issueType`: observed values are `Semantic Issue`, `Swift Compiler Error`, `Error`, and `Uncategorized` in `errors`; `Warning` and `Target Integrity` in `warnings`. Don't filter on a specific spelling — the useful invariant is that everything except `Uncategorized` carries a `sourceURL`, and `Uncategorized` omits the key entirely.
+- `message`: One-line description.
+- `sourceURL`: A `file://` URL with the file path and line/column anchored in the URL fragment (`#StartingLineNumber=...`).
+
+If the message is uncategorized (e.g. `"Command Ld failed with a nonzero exit code"`), the build-results summary won't include the actual compiler/linker error text — drop to step 3.
+
+To pretty-print the status, group errors by file, and de-duplicate repeated messages:
+
+```sh
+xcrun xcresulttool get build-results --path /tmp/wk-build-N.xcresult \
+  | python3 -c "
+import json, sys, re, collections
+d = json.load(sys.stdin)
+print('status:', d.get('status'), '| title:', d.get('actionTitle'), '| errors:', d['errorCount'], '| warnings:', d['warningCount'])
+byfile = collections.Counter()
+for e in d.get('errors', []):
+    m = re.match(r'file://([^#]*)', e.get('sourceURL', ''))
+    byfile[(m.group(1).split('/')[-1] if m else '(no file)')] += 1
+print('--- errors by file:')
+for f, n in byfile.most_common():
+    print(f'  {n:3d}  {f}')
+print('--- distinct messages:')
+seen = set()
+for e in d.get('errors', []):
+    msg = e.get('message', '')[:250]
+    if msg not in seen:
+        seen.add(msg)
+        print(' *', e.get('issueType'), '|', msg)
+"
+```
+
+Group by file before reading any source: a batch of errors is often one root cause. De-duplicating
+messages matters too, since one bad declaration can produce the same message at a dozen call
+sites.
+
+For the exact line of a specific error, unquote its `sourceURL` and read the
+`StartingLineNumber` fragment:
+
+```sh
+xcrun xcresulttool get build-results --path /tmp/wk-build-N.xcresult \
+  | python3 -c "
+import json, sys, urllib.parse
+for e in json.load(sys.stdin).get('errors', []):
+    u = e.get('sourceURL', '')
+    path = urllib.parse.unquote(u.split('#')[0].removeprefix('file://'))
+    frag = dict(p.split('=') for p in u.split('#')[1].split('&') if '=' in p) if '#' in u else {}
+    print(e.get('message', '')[:100], '|', path, '| line', frag.get('StartingLineNumber'))
+"
+```
+
+## 3. Get the structured build log (for "Uncategorized" errors and ordering)
+
+For uncategorized linker/process errors, dig into the full build log:
+
+```sh
+xcrun xcresulttool get log --path /tmp/wk-build-N.xcresult --type build
+```
+
+This output is large (tens of KB). **Do not read the whole thing into context.** Pipe to a targeted grep:
+
+```sh
+xcrun xcresulttool get log --path /tmp/wk-build-N.xcresult --type build \
+  | grep -nE "error:|Undefined|symbol not found|failed with a nonzero exit code|^Ld " | head -40
+```
+
+`failed with a nonzero exit code` is the phrasing for a build **script phase** that exited
+non-zero (e.g. `Command PhaseScriptExecution failed with a nonzero exit code`). The message
+itself says nothing about the cause, so grep with `-n` and then read the lines immediately
+*before* that line number — a script's own stderr is whatever it printed on the way out:
+
+```sh
+xcrun xcresulttool get log --path /tmp/wk-build-N.xcresult --type build \
+  | grep -n -B40 "failed with a nonzero exit code" | head -60
+```
+
+To see the build *order* and which targets ran (useful when diagnosing missing target dependency edges):
+
+```sh
+xcrun xcresulttool get log --path /tmp/wk-build-N.xcresult --type build --compact \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+def walk(obj, depth=0):
+    if isinstance(obj, dict):
+        if obj.get('title'):
+            print('  '*depth + obj['title'][:120])
+        for k, v in obj.items():
+            if k in ('subsections', 'children'):
+                for c in v: walk(c, depth+1)
+walk(data)
+" | head -80
+```
+
+If you see many `Run custom shell script 'Generate ...'` entries followed by a `Link <foo>` with no intervening `CompileC` steps, a target-dependency edge is missing — the linker is running before the target it depends on has compiled.
+
+## 4. Misleading failures
+
+**Judge success from the xcresult, not the log.** Both directions mislead:
+
+- The log can print `Build Succeeded` while build-webkit still exits non-zero, because it
+  exits with the status of its out-of-band `build-imagediff` run (§1).
+- An xcresult bundle that no real build wrote reports `errors: 0`.
+
+The reliable check is `status: succeeded` **plus** a real `actionTitle`, e.g.
+`Build "Everything up to WebKit + Tools"`. An `actionTitle` of `(Transient Testing)` with
+`status: notRequested` and `startTime == endTime` means the bundle is empty and you are
+reading nothing.
+
+**`Existing file at -resultBundlePath` means a previous run already created that path — it is
+not itself the underlying failure.** A run that dies early still leaves an empty
+`(Transient Testing)` bundle behind, so the *next* run with the same path fails immediately
+with exit 64 and that single line of output. Retry with a genuinely new path, then read the
+real error the first run produced.
+
+A common real error underneath is `xcodebuild: error: '<path>.xcworkspace' does not exist.`
+`WebKitBuild/Workspace` records the workspace from the last build, so it goes stale whenever
+that workspace moves or is renamed. `rm -rf WebKitBuild/<Config>-<platform>` does NOT clear
+it, because the file lives one level up in `WebKitBuild/`. Check it and either repoint or
+reset to the default:
+
+```sh
+cat WebKitBuild/Workspace
+Tools/Scripts/set-webkit-configuration --workspace <path to the .xcworkspace you want>
+# or drop the override entirely:
+Tools/Scripts/set-webkit-configuration --reset   # also resets configuration; or: rm WebKitBuild/Workspace
+```
+
+Passing `--workspace ""` does not clear the file.
+
+## 5. Fix-build loop
+
+1. Build (§1) → `get build-results` (§2). If `errors: 0` and `status: succeeded`, done.
+2. `sourceURL` points at the offending line for semantic errors; for `Uncategorized` ones drop to `get log` with a targeted grep (§3).
+3. Fix, then rebuild with a **new** xcresult path.
+
+## 6. Build a single target to narrow down errors
+
+When errors come from many targets, narrow to one using the `--only` argument:
+
+```sh
+Tools/Scripts/build-webkit --only JavaScriptCore --result-bundle-path=/tmp/wk-build-N.xcresult > /dev/null 2>&1
+```
+
+`--only` builds a specific scheme. List them all with `xcodebuild -workspace WebKit.xcworkspace -list`. Some common single-project schemes are:
+
+- WTF
+- JavaScriptCore
+- WebGPU
+- WebCore
+- WebKit
+

--- a/.claude/plugins/build-webkit/skills/xcode/SKILL.md
+++ b/.claude/plugins/build-webkit/skills/xcode/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: xcode
+description: Use when the user wants to build WebKit on Apple platforms, where Xcode is the default build system. Builds with build-webkit, captures the results in an xcresult bundle, and reports the errors out of it, so tens of thousands of lines of build log don't pollute the conversation.
+user-invocable: true
+allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/build.sh:*), Bash(${CLAUDE_SKILL_DIR}/scripts/errors.py:*), Bash(${CLAUDE_SKILL_DIR}/scripts/failed-commands.py:*)
+---
+
+Build through these scripts rather than running `build-webkit` yourself: they keep the log out of
+the conversation and report what failed from the xcresult bundle instead.
+
+## Build
+
+```sh
+${CLAUDE_SKILL_DIR}/scripts/build.sh [build-webkit arguments]
+```
+
+Prints the path of the xcresult bundle, the path of the log, and build-webkit's exit status.
+Arguments are build-webkit's own — `--debug`, `--only=<scheme>`, `--sdk=<name>`, and the rest of
+`build-webkit -h`. A bare `-sdk` is not among them: it reaches xcodebuild, but WebKit's own
+platform and build directory logic still resolves to the host. When an internal SDK is installed
+build-webkit prefers it, and then builds `../Internal/Safari.xcworkspace` rather than
+`WebKit.xcworkspace`.
+
+Run clean builds with `run_in_background: true`: they take ~15-30 minutes, well past the Bash tool's
+timeout. Wait for the completion notification rather than polling with `sleep`. Rebuilds after a
+one file fix are usually under a minute, except the first one in a build directory that was built
+any other way: the settings build.sh passes to turn off Xcode's sandboxing invalidate what's there.
+
+## Read what failed
+
+```sh
+${CLAUDE_SKILL_DIR}/scripts/errors.py <xcresult>
+```
+
+Reports the build's status, how many errors each file has, and every distinct message with the
+places it came from. Read those counts before opening any source file: a batch of errors is usually
+one root cause, and one bad declaration repeats the same message at every call site.
+
+Some errors are not semantic and contain no source location. Their cause can by
+found by examing raw commands with the following command:
+
+```sh
+${CLAUDE_SKILL_DIR}/scripts/failed-commands.py <xcresult>
+```
+
+That is the build log's own tree of steps with everything that succeeded pruned out, so each
+failure arrives with the target and command it came from. No failures under a failed build means
+the build died outside of any step, and only the log says how.
+
+Long step names and diagnostic messages are truncated. When those are what you
+need, ask for the step they are in using `--step`. For example:
+`failed-commands.py <xcresult> --step 'SwiftCompile'` reports detailed
+information on any failing step whose title contains "SwiftComiple".
+
+## Fix and rebuild
+
+Examine the source code at the failure location, fix the root cause, and build
+again. Judge success from `errors.py` rather than from build.sh's exit status.
+
+To narrow a failure that spans targets, rebuild one scheme with `--only`, e.g.
+`build.sh --only=WebCore`. By convention, there is one scheme for each library,
+so `WTF`, `bmalloc`, `JavaScriptCore`, `WebCore`, `WebKitLegacy`, and `WebKit`
+are all available schemes.

--- a/.claude/plugins/build-webkit/skills/xcode/scripts/build.sh
+++ b/.claude/plugins/build-webkit/skills/xcode/scripts/build.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Build WebKit, keeping the log in a file and the results in an .xcresult bundle. Arguments are
+# passed through to build-webkit. Run from the root of a WebKit checkout.
+
+set -o pipefail
+
+if [[ ! -x Tools/Scripts/build-webkit ]]; then
+    echo "error: no Tools/Scripts/build-webkit here; run this from the root of a WebKit checkout" >&2
+    exit 1
+fi
+
+# xcodebuild refuses to write over an existing .xcresult bundle, so use a fresh
+# directory per build.
+out=$(mktemp -d -t wk-build) || exit 1
+echo "xcresult=$out/build.xcresult"
+echo "log=$out/build.log"
+
+# Turn off various build sandboxes, as Claude's sandbox is already active. Hide
+# hints to use any other plugins.
+Tools/Scripts/build-webkit \
+    --result-bundle-path="$out/build.xcresult" \
+    ENABLE_USER_SCRIPT_SANDBOXING=NO \
+    DISABLE_TASK_SANDBOXING=YES \
+    OTHER_SWIFT_FLAGS='$(inherited) -disable-sandbox' \
+    "$@" 2>&1 | fgrep -v '<claude-code-hint' | tee "$out/build.log" | Tools/Scripts/filter-build-webkit 2>&1
+status=$?
+
+echo "exit=$status"
+exit $status

--- a/.claude/plugins/build-webkit/skills/xcode/scripts/errors.py
+++ b/.claude/plugins/build-webkit/skills/xcode/scripts/errors.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Report semantic errors an .xcresult bundle recorded, if any, as JSON on stdout.
+First step in analysis, which does not require expanding the entire build log.
+
+Some errors do not carry semantic data and are only present in the textual log.
+The sibling `failed-commands.py` expands those.
+
+Care is taken to avoid injecting too much output into the context, by
+grouping repeat failures and truncating very long messages.
+"""
+
+import collections
+import json
+import os
+import subprocess
+import sys
+import urllib.parse
+
+# Truncate diagnostic strings longer than this length.
+MESSAGE_LENGTH = 250
+
+# If the same error is reported multiple times at different locations, it will
+# only be reported this many times.
+PLACES_PER_MESSAGE = 10
+
+NO_SOURCE = '(no source location)'
+
+
+def build_results(bundle):
+    """Return a bundle's build-results, or explain why it could not be read and stop."""
+    result = subprocess.run(
+        ['xcrun', 'xcresulttool', 'get', 'build-results', '--path', bundle],
+        capture_output=True, text=True)
+    if result.returncode:
+        # Only the first line: the rest of what xcresulttool prints is its own usage.
+        reason = (result.stderr.strip().splitlines() or ['xcresulttool failed'])[0]
+        sys.exit('could not read {}: {}'.format(bundle, reason))
+    return json.loads(result.stdout)
+
+
+def source(issue):
+    """Return the (path, line) an issue is at, either of which can be None."""
+    url = issue.get('sourceURL')
+    if not url:
+        return None, None
+
+    path, _, fragment = url.partition('#')
+    path = urllib.parse.unquote(path)
+    if path.startswith('file://'):
+        path = path[len('file://'):]
+
+    lines = urllib.parse.parse_qs(fragment).get('StartingLineNumber')
+    if not lines or not lines[0].isdigit():
+        return path, None
+    # A DocumentLocation fragment counts lines from zero, where compilers and editors count from one.
+    return path, int(lines[0]) + 1
+
+
+def clip(message):
+    collapsed = ' '.join(message.split())
+    if len(collapsed) <= MESSAGE_LENGTH:
+        return collapsed
+    return collapsed[:MESSAGE_LENGTH] + ' […]'
+
+
+def errors_of(build):
+    """Return one record per error: where it is, and what it says."""
+    records = []
+    for error in build.get('errors') or []:
+        path, line = source(error)
+        records.append({
+            'category': error.get('issueType'),
+            'message': clip(error.get('message') or ''),
+            'file': os.path.basename(path) if path else NO_SOURCE,
+            'place': None if not path else path if line is None else '{}:{}'.format(path, line),
+        })
+    return records
+
+
+def report(build):
+    errors = errors_of(build)
+    summary = {
+        'status': build.get('status'),
+        'action': build.get('actionTitle'),
+        'errors': build.get('errorCount', 0),
+        'warnings': build.get('warningCount', 0),
+    }
+
+    if build.get('status') == 'notRequested':
+        # A run that died before xcodebuild started building leaves a bundle like this one: no
+        # action requested, an actionTitle of '(Transient Testing)', and at most a generic
+        # "xcodebuild encountered an error" issue. Nothing about the cause is recorded in it.
+        summary['note'] = 'This bundle is empty and the build never started; ' \
+                          'the reason is in the log.'
+    elif errors and not any(error['place'] for error in errors):
+        summary['note'] = 'No error names a source file, so the cause is only in the build log: ' \
+                          'run failed-commands.py.'
+
+    if not errors:
+        return summary
+
+    summary['by_file'] = dict(collections.Counter(
+        error['file'] for error in errors).most_common())
+
+    repeats = collections.OrderedDict()
+    for error in errors:
+        repeats.setdefault(error['message'], []).append(error)
+
+    summary['messages'] = []
+    for message, group in sorted(repeats.items(), key=lambda repeat: -len(repeat[1])):
+        entry = {'category': group[0]['category'], 'message': message, 'count': len(group)}
+        places = [error['place'] for error in group if error['place']]
+        if places:
+            entry['places'] = places[:PLACES_PER_MESSAGE]
+        summary['messages'].append(entry)
+
+    return summary
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        sys.exit('usage: {} <path to .xcresult>'.format(os.path.basename(sys.argv[0])))
+    print(json.dumps(report(build_results(sys.argv[1])), indent=2, ensure_ascii=False))

--- a/.claude/plugins/build-webkit/skills/xcode/scripts/failed-commands.py
+++ b/.claude/plugins/build-webkit/skills/xcode/scripts/failed-commands.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Report the failed part of an .xcresult bundle's log, as JSON on stdout.
+
+Errors that do not produce semantic information in the result bundle are
+only discoverable by examining command output. This script dumps all commands
+and produces output info from failing tasks in the build, as JSON. Output is
+truncated to avoid polluting context, but an agent can ask for detailed info
+about a particular step by passing `--step STEPNAME` and rerunning.
+"""
+
+import argparse
+import collections
+import itertools
+import json
+import re
+import subprocess
+import sys
+
+# Max number of failing steps to report the name of.
+STEP_NAMES = 10
+
+# When reporting error lines, ignore the include trace.
+INCLUDE_STACK = re.compile(r'^In file included from |^In module ')
+
+Limits = collections.namedtuple(
+    'Limits',
+    'errors_per_step steps_per_level output_lines output_lines_beside_issues line_length')
+
+# Output limits for the default mode (reporting on all failed steps).
+READABLE = Limits(errors_per_step=3, steps_per_level=5, output_lines=40,
+                  output_lines_beside_issues=10, line_length=400)
+
+# Output limits in --step filtering mode.
+DETAILED = Limits(errors_per_step=15, steps_per_level=5, output_lines=150,
+                  output_lines_beside_issues=150, line_length=2000)
+
+# Limit to the number of matches found in --step mode.
+MATCHED_STEPS = 3
+
+
+def build_log(bundle):
+    """Return a bundle's build log, or explain why it could not be read and stop."""
+    result = subprocess.run(
+        ['xcrun', 'xcresulttool', 'get', 'log', '--path', bundle, '--type', 'build'],
+        capture_output=True, text=True)
+    if result.returncode:
+        error = result.stderr.strip()
+        if 'No build log' in error:
+            sys.exit('{} holds no build log, so the build never started. '
+                     'Read the log instead.'.format(bundle))
+        # Only the first line: the rest of what xcresulttool prints is its own usage.
+        sys.exit('could not read {}: {}'.format(
+            bundle, (error.splitlines() or ['xcresulttool failed'])[0]))
+    return json.loads(result.stdout)
+
+
+def clip(line, length):
+    return line if length is None or len(line) <= length else line[:length] + ' […]'
+
+
+def cap(items, limit):
+    """Return as many items as the limit allows, and how many are left over."""
+    if limit is None:
+        return items, 0
+    return items[:limit], max(0, len(items) - limit)
+
+
+def diagnosis(lines):
+    """Return the lines that say something, with the include stack framing them dropped."""
+    return [line for line in lines if line.strip() and not INCLUDE_STACK.match(line.lstrip())]
+
+
+def one_line(lines):
+    """Return lines as a single line, with no run of whitespace longer than a space."""
+    return ' '.join(' '.join(lines).split())
+
+
+def collapse(lines):
+    """Return lines with each run of identical ones reported once: a command asked to build for
+    several architectures at once prints its diagnosis once for each of them."""
+    collapsed = []
+    for line, run in itertools.groupby(lines):
+        repeats = sum(1 for _ in run) - 1
+        collapsed.append(line)
+        if repeats:
+            collapsed.append('[previous line repeated {} more time{}]'.format(
+                repeats, '' if repeats == 1 else 's'))
+    return collapsed
+
+
+def errors_of(section, limits):
+    """Return the errors a step reported, counting a message repeated within it rather than
+    listing it again.
+    """
+    errors = []
+    for message in section.get('messages') or []:
+        if message.get('type') != 'error':
+            continue
+        # Truncate very long diagnostic messages.
+        error = {'title': clip(one_line(diagnosis((message.get('title') or '').splitlines())),
+                               limits.line_length)}
+        # Only some messages are categorized, and the ones that are not say so by saying nothing.
+        if message.get('category'):
+            error['category'] = message['category']
+        repeat = next((seen for seen in errors if seen['title'] == error['title']
+                       and seen.get('category') == error.get('category')), None)
+        if repeat:
+            repeat['count'] = repeat.get('count', 1) + 1
+        else:
+            errors.append(error)
+    return errors
+
+
+def failures_in(sections, limits):
+    """Recurse into a step and return all (sub)steps which denote failure.
+    """
+    found = []
+    for section in sections:
+        if section.get('result') == 'failed':
+            step = failure(section, limits)
+            if step:
+                found.append(step)
+        else:
+            found.extend(failures_in(section.get('subsections') or [], limits))
+    return found
+
+
+def failure(section, limits):
+    """Return what a failed step says about why it failed, along with its failed substeps.
+
+    A failed step might have no failure information attached; the cause is
+    usually in one of its substeps.
+    """
+    invocation = section.get('commandInvocationDetails') or {}
+    output = collapse(diagnosis((invocation.get('emittedOutput') or '').splitlines()))
+    issues, unreported_issues = cap(errors_of(section, limits), limits.errors_per_step)
+    steps, unreported_steps = cap(failures_in(section.get('subsections') or [], limits),
+                                  limits.steps_per_level)
+
+    if not output and not issues and not steps:
+        return None
+
+    step = {}
+    # Title may be long for steps that compile multiple files (e.g. Swift batch
+    # compilation).
+    if section.get('title'):
+        step['step'] = clip(section['title'], limits.line_length)
+    # commandDetails names the target and project the command ran for, where the title above names
+    # only the step. It can carry a whole invocation, so keep its first line.
+    command = (invocation.get('commandDetails') or '').splitlines()
+    if command:
+        step['command'] = clip(command[0], limits.line_length)
+    if invocation.get('exitCode') is not None:
+        step['exit'] = invocation['exitCode']
+    if issues:
+        step['issues'] = issues
+        if unreported_issues:
+            step['unreported_issues'] = unreported_issues
+    if output:
+        printed, unprinted = cap(
+            output, limits.output_lines_beside_issues if issues else limits.output_lines)
+        step['output'] = [clip(line, limits.line_length) for line in printed]
+        if unprinted:
+            step['unprinted_output_lines'] = unprinted
+    if steps:
+        step['steps'] = steps
+        if unreported_steps:
+            step['unreported_steps'] = unreported_steps
+    return step
+
+
+def steps_mentioning(steps, text):
+    """Return the failed steps whose name or command mentions text, wherever in
+    the tree they are.
+    """
+    wanted = text.lower()
+    found = []
+    for step in steps:
+        if wanted in '{} {}'.format(step.get('step', ''), step.get('command', '')).lower():
+            found.append(step)
+        else:
+            found.extend(steps_mentioning(step.get('steps') or [], text))
+    return found
+
+
+def names_in(steps):
+    """Return the name of every failed step. Used to suggest alternative --step
+    matches.
+    """
+    names = []
+    for step in steps:
+        if step.get('step'):
+            names.append(clip(step['step'], READABLE.line_length))
+        names.extend(names_in(step.get('steps') or []))
+    return names
+
+
+def report(bundle, wanted_step):
+    log = build_log(bundle)
+
+    if wanted_step is None:
+        failures, unreported = cap(failures_in([log], READABLE), READABLE.steps_per_level)
+        # What the steps say, rather than what the root of the log claims. No failures under a
+        # build that did fail means it died outside of any step of itself, and the log build.sh
+        # wrote is the only account of that.
+        summary = {'result': 'failed' if failures else log.get('result'), 'failures': failures}
+        if unreported:
+            summary['unreported_failures'] = unreported
+        return summary
+
+    everything = failures_in([log], DETAILED)
+    failures, unreported = cap(steps_mentioning(everything, wanted_step), MATCHED_STEPS)
+    summary = {'result': 'failed' if everything else log.get('result'), 'failures': failures}
+    if unreported:
+        summary['unreported_failures'] = unreported
+    if not failures:
+        names = names_in(everything)
+        summary['note'] = 'No failed step mentions {!r}. The failed steps are: {}'.format(
+            wanted_step, '; '.join(names[:STEP_NAMES]) or 'none')
+    return summary
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description='Report the failed part of a build log, as JSON on stdout.')
+    parser.add_argument('bundle', metavar='XCRESULT', help='the .xcresult bundle to read')
+    parser.add_argument('--step', metavar='TEXT',
+                        help='report only the failed steps whose name or command mentions TEXT, '
+                             'and report much more of their errors and output than a summary does')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    arguments = parse_arguments()
+    print(json.dumps(report(arguments.bundle, arguments.step), indent=2, ensure_ascii=False))

--- a/.claude/plugins/build-webkit/skills/xcode/tests/basic.yaml
+++ b/.claude/plugins/build-webkit/skills/xcode/tests/basic.yaml
@@ -1,0 +1,5 @@
+name: basic-xcode-build
+test:
+  prompt: "Build JavaScriptCore for macOS with Xcode"
+validation:
+  prompt: "The build was run through the xcode skill's build.sh script, and the outcome was reported from the xcresult bundle it captured rather than by quoting the build log"


### PR DESCRIPTION
#### e40d5c79abf469dad831dd3c1793dabf12526e3c
<pre>
[Xcode] Add skill for invoking build-webkit and parsing output
<a href="https://bugs.webkit.org/show_bug.cgi?id=321648">https://bugs.webkit.org/show_bug.cgi?id=321648</a>
<a href="https://rdar.apple.com/184774979">rdar://184774979</a>

Reviewed by NOBODY (OOPS!).

There are some agent-specific tricks to make building with xcodebuild
work well out of the box: disabling Xcode&apos;s own sandboxing, and using
xcresult bundles to get structured build failure information that&apos;s
easier to inspect without polluting context. Add a skill that does this.

* .claude/plugins/.claude-plugin/marketplace.json:
* .claude/plugins/build-webkit/.claude-plugin/plugin.json: Added.
* .claude/plugins/build-webkit/skills/xcode/SKILL.md: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e40d5c79abf469dad831dd3c1793dabf12526e3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196184 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150547 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145256 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100702 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125564 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47667 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45690 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45402 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7255 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198158 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59443 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154816 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60152 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154461 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48910 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129493 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58613 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20419 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57992 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58056 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->