### PR TITLE
[AppKit Gestures] Certain diagonal scrolls should be able to bypass directional locking

### DIFF
--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -1367,9 +1367,10 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         gestureDelta = { };
 
     auto pinnedState = [webView _protectedPage]->pinnedStateIncludingAncestorsAtPoint(locationInView);
+    bool prefersUnlockedScroll = [self prefersUnlockedScroll:_panGestureRecognizer];
     bool canScrollHorizontally = [_panGestureRecognizer _canPanHorizontally] && !(pinnedState.left() && pinnedState.right());
     bool canScrollVertically = [_panGestureRecognizer _canPanVertically] && !(pinnedState.top() && pinnedState.bottom());
-    gestureDelta = WebCore::FloatSize { _directionalScrollLockTracker->update(gestureDelta, canScrollHorizontally, canScrollVertically, [gesture timestamp]) };
+    gestureDelta = WebCore::FloatSize { _directionalScrollLockTracker->update(gestureDelta, canScrollHorizontally, canScrollVertically, prefersUnlockedScroll, [gesture timestamp]) };
 
     auto wheelTicks { gestureDelta.scaled(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep())) };
     auto granularity = WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
@@ -1428,7 +1429,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     // Continue the scroll along the same axis the drag was locked to rather than reintroducing
     // diagonal drift; also keeps _fastScrollTracker's velocity heuristics off-axis-clean.
-    auto velocity = WebCore::FloatSize { _directionalScrollLockTracker->filterVelocity(unfilteredVelocity) };
+    auto velocity = WebCore::FloatSize { _directionalScrollLockTracker->filterVelocity(unfilteredVelocity, [self prefersUnlockedScroll:gesture]) };
 
     static constexpr float minimumVelocityForMomentum = 20;
 

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKDirectionalScrollLockTracker.swift
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKDirectionalScrollLockTracker.swift
@@ -44,7 +44,13 @@ struct WKDirectionalScrollLockTracker {
 
     // Takes one incremental (per-event) gesture delta and returns it with the locked-out axis zeroed,
     // or unchanged while unlocked.
-    mutating func update(delta: CGSize, canScrollHorizontally: Bool, canScrollVertically: Bool, time: TimeInterval) -> CGSize {
+    mutating func update(
+        delta: CGSize,
+        canScrollHorizontally: Bool,
+        canScrollVertically: Bool,
+        prefersUnlocked: Bool,
+        time: TimeInterval
+    ) -> CGSize {
         // A long gap between events without mouse up re-opens the axis decision, but deliberately
         // leaves any existing lock in place until a new definite axis replaces it below.
         if lastEventTime != 0, time - lastEventTime >= Constants.pauseInterval {
@@ -83,13 +89,13 @@ struct WKDirectionalScrollLockTracker {
             }
         }
 
-        return Self.apply(lockedAxis, to: delta)
+        return Self.apply(prefersUnlocked ? nil : lockedAxis, to: delta)
     }
 
     // Applies the current lock to a velocity vector without mutating state, so a locked drag continues
     // its scroll on the locked axis rather than reintroducing diagonal drift.
-    func filterVelocity(_ velocity: CGSize) -> CGSize {
-        Self.apply(lockedAxis, to: velocity)
+    func filterVelocity(_ velocity: CGSize, prefersUnlocked: Bool) -> CGSize {
+        Self.apply(prefersUnlocked ? nil : lockedAxis, to: velocity)
     }
 
     // A fresh gesture re-decides its axis, seeded from the previous drag's axis if it caught that

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -1405,6 +1405,34 @@ extension AppKitGesturesTests.Basic {
         #expect(abs(end.y - start.y) < 1)
     }
 
+    @Test(
+        .bug("https://webkit.org/b/321650", "Certain diagonal scrolls should be able to bypass directional locking")
+    )
+    func diagonallySwipingBetweenSpacesScrollsBothAxes() async throws {
+        try await loadScrollableGrid()
+        await page.waitForNextPresentationUpdate()
+
+        try await page.callJavaScript { "window.scrollTo(2000, 8000);" }
+        await page.waitForNextPresentationUpdate()
+        let start = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+
+        let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
+        await recap.play { composer in
+            composer._wk_scroll(
+                withStart: center,
+                end: CGPoint(x: center.x - 250, y: center.y - 80),
+                duration: .seconds(0.3),
+                multiFinger: true
+            )
+        }
+        await page.waitForNextPresentationUpdate()
+
+        let end = try await settledScrollPosition()
+
+        #expect(end.x - start.x > 20)
+        #expect(end.y - start.y > 20)
+    }
+
     @Test
     func steepScrollLocksToVerticalAxis() async throws {
         try await loadScrollableGrid()


### PR DESCRIPTION
#### e29b63174052d82929fcc8e1081f06573ffb9583
<pre>
[AppKit Gestures] Certain diagonal scrolls should be able to bypass directional locking
<a href="https://bugs.webkit.org/show_bug.cgi?id=321650">https://bugs.webkit.org/show_bug.cgi?id=321650</a>
<a href="https://rdar.apple.com/184776089">rdar://184776089</a>

Reviewed by Tim Horton.

318029@main introduced support for directional scroll locking for
diagonal scrolls. This is generally the mode in which we want to
propagate gesture-driven scroll deltas. However, certain flows
necessitate that we opt out of locking. WKDirectionalScrollTracker does
not offer any API escape hatch for these cases, though, so that is what
we teach it in this patch.

Test: AppKitGesturesTests/Basic/diagonallySwipingBetweenSpacesScrollsBothAxes()

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController sendWheelEventForGesture:]):
(-[WKAppKitGestureController startMomentumIfNeededForGesture:]):
* Source/WebKit/UIProcess/mac/WKDirectionalScrollLockTracker.swift:
(WKDirectionalScrollLockTracker.update(_:canScrollHorizontally:canScrollVertically:prefersUnlocked:time:)):
(WKDirectionalScrollLockTracker.filterVelocity(_:prefersUnlocked:)):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/319143@main">https://commits.webkit.org/319143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f51e75daf7744d4d410e9770bb82917031aded24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54553 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190819 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6060660d-a0ae-4eff-9fcd-de751adbadd4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54269 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9637688-8bcd-4d09-a34e-c4bebd4a4c0b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44543 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/121321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c686aca-8d1c-4785-99f9-cab022a8059a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153620 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/41177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1979 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/47162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192755 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/54219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/161166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54907 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/149964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27409 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/44585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122387 "Failed to checkout and rebase branch from PR 71522") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53424 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/16170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52871 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->