### PR TITLE
[git-webkit] Add a local model for stacked pull requests

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -50,7 +50,7 @@ except ImportError:
         "See https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy"
     )
 
-version = Version(7, 0, 5)
+version = Version(7, 0, 6)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('markupsafe', Version(3, 0, 3), pypi_name='MarkupSafe', wheel=True))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -539,7 +539,10 @@ nothing to commit, working tree clean
                 generator=lambda *args, **kwargs:
                     mocks.ProcessCompletion(
                         returncode=0,
-                        stdout='\n'.join(['{} {}'.format(key, value) for key, value in self.config().items() if key.startswith(args[3])])
+                        stdout='\n'.join([
+                            f'{key} {value}' for key, value in self.config().items()
+                            if re.match(args[3], key)
+                        ])
                     ),
             ), mocks.Subprocess.Route(
                 self.executable, 'config', LIST_OPTION, '--file', re.compile(r'.+'),
@@ -992,6 +995,20 @@ nothing to commit, working tree clean
             return mocks.ProcessCompletion(returncode=0, stdout='Updated 1 path from the index')
 
         commit = self.find(source)
+        if create and source != something:
+            if not commit or (something in self.commits and not force):
+                return False
+
+            # Copy source's commits and append the new one
+            self.commits[something] = (self.commits[source][:] if source in self.commits else [])
+            self.commits[something].append(Commit.from_json(Commit.Encoder().default(commit)))
+
+            self.head = self.commits[something][-1]
+            setattr(self.head, 'bridge_commit', True)
+            self.head.branch = something
+            self.detached = False
+            return True
+
         if commit and source in self.commits:
             self.commits[something] = self.commits[source]
 
@@ -1009,9 +1026,6 @@ nothing to commit, working tree clean
                         return True
                 else:
                     return False
-            elif source != something:
-                # Source was explicitly provided but doesn't exist: fail
-                return False
             self.commits[something] = [Commit.from_json(Commit.Encoder().default(self.head))]
             # Copy one more to create a bridge commit
             self.commits[something].append(Commit.from_json(Commit.Encoder().default(self.head)))
@@ -1677,7 +1691,6 @@ nothing to commit, working tree clean
             self.remotes[remote_ref] = list(reversed(self.rev_list(value)))
         return mocks.ProcessCompletion(returncode=0)
 
-
     def add_remote(self, name):
         for existing in list(self.remotes.keys()):
             remote, branch = existing.split('/', 1)
@@ -1709,7 +1722,7 @@ nothing to commit, working tree clean
                     (
                         fnmatch.translate(pattern),
                         re.escape(pattern) + r'\Z',
-                        re.escape(pattern) + '/',
+                        re.escape(pattern.rstrip('/')) + '/',
                     )
                     for pattern in patterns
                 )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -57,6 +57,7 @@ from .review import Review
 from .setup_git_svn import SetupGitSvn
 from .setup import Setup
 from .show import Show
+from .stack import Stack
 from .trace import Trace
 from .track import Track
 from .tracker_metadata import TrackerMetadata
@@ -104,7 +105,7 @@ def main(
         PullRequest, Revert, Review, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
         Pickable, CherryPick, Trace, Track, TrackerMetadata, Show, Publish,
-        Classify, InstallHooks,
+        Classify, InstallHooks, Stack,
     ] + (programs or [])
     if subversion:
         programs.append(SetupGitSvn)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack.py
@@ -1,0 +1,185 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+from argparse import ArgumentParser, Namespace
+from typing import Optional
+
+from .command import Command
+from .stack_metadata import StackMetadata
+
+from webkitscmpy import local, log
+
+
+class Stack(Command):
+    name = 'stack'
+    help = 'Manage a stack of dependent development branches'
+
+    HEADER = 'Stacked pull requests, bottom of the stack first:'
+
+    @classmethod
+    def parser(cls, parser: ArgumentParser, loggers: Optional[list] = None) -> None:
+        parser.add_argument(
+            '--on', '--stacked-on',
+            dest='parent', type=str, default=None,
+            help='Record that the current development branch is stacked on the provided branch',
+        )
+        parser.add_argument(
+            '--unstack',
+            dest='unstack', action='store_true', default=False,
+            help='Forget which branch the current development branch is stacked on',
+        )
+
+    @classmethod
+    def _recorded_parent(cls, git: local.Git, branch: Optional[str]) -> Optional[str]:
+        """The branch a change claims to be stacked on, whether or not this checkout has it."""
+        metadata = StackMetadata.for_branch(git, branch)
+        return metadata.parent if metadata else None
+
+    @classmethod
+    def parent(cls, git: local.Git, branch: Optional[str]) -> Optional[str]:
+        """The branch a change is stacked on, or None when this checkout does not have it."""
+        if not (candidate := cls._recorded_parent(git, branch)):
+            return None
+        if candidate not in git.branches_for(remote=False):
+            log.warning(f"'{branch}' is stacked on '{candidate}', which no longer exists in this checkout")
+            return None
+        return candidate
+
+    @classmethod
+    def _children(cls, git: local.Git, branch: str) -> list[str]:
+        return sorted(
+            candidate for candidate, parent in list(StackMetadata.stacked(git))
+            if parent == branch and cls.parent(git, candidate) == branch
+        )
+
+    @classmethod
+    def _ancestors(cls, git: local.Git, branch: str) -> Optional[list[str]]:
+        result = []
+        candidate = branch
+        while candidate := cls.parent(git, candidate):
+            if candidate == branch or candidate in result:
+                sys.stderr.write(f"'{candidate}' is part of a cycle of stacked branches\n")
+                return None
+            result.append(candidate)
+        return result[::-1]  # Bottom of stack to top
+
+    @classmethod
+    def _descendants(cls, git: local.Git, branch: str) -> Optional[list[str]]:  # DFS so children come before siblings
+        result = []
+        stack = list(reversed(cls._children(git, branch)))
+        while stack:
+            candidate = stack.pop()
+            if candidate == branch or candidate in result:
+                sys.stderr.write(f"'{candidate}' is part of a cycle of stacked branches\n")
+                return None
+            result.append(candidate)
+            stack.extend(reversed(cls._children(git, candidate)))
+        return result
+
+    @classmethod
+    def members(cls, git: local.Git, branch: str) -> Optional[list[str]]:
+        if (below := cls._ancestors(git, branch)) is None:
+            return None
+        root = below[0] if below else branch
+        if (above := cls._descendants(git, root)) is None:
+            return None
+        return [root] + above
+
+    @classmethod
+    def describe(cls, git: local.Git, branch: str) -> Optional[list[str]]:
+        if (members := cls.members(git, branch)) is None:
+            return None
+        if len(members) < 2:
+            return []
+
+        depth = {}
+        lines = [cls.HEADER]
+        for member in members:
+            depth[member] = depth.get(cls.parent(git, member), -1) + 1
+            described = ' (this pull request)' if member == branch else ''
+            lines.append(f"{'    ' * depth[member]}- {member}{described}")
+        return lines
+
+    @classmethod
+    def resolve(cls, git: local.Git, argument: str, branch: Optional[str] = None) -> Optional[str]:
+        """The branch in this checkout a name refers to, expanding development-branch shorthand."""
+        from .branch import Branch
+
+        branches = git.branches_for(remote=False)
+        candidate = argument if argument in branches else Branch.normalize_branch_name(argument, repository=git)
+
+        if candidate not in branches:
+            sys.stderr.write(f"Could not find '{argument}' as a branch in this checkout\n")
+            return None
+        if not git.dev_branches.match(candidate):
+            sys.stderr.write(f"'{candidate}' is not a development branch, a branch cannot be stacked on it\n")
+            return None
+        if candidate == branch:
+            sys.stderr.write(f"'{branch}' cannot be stacked on itself\n")
+            return None
+        return candidate
+
+    @classmethod
+    def main(cls, args: Namespace, repository, **kwargs) -> int:
+        if not isinstance(repository, local.Git):
+            sys.stderr.write(f"Can only '{cls.name}' on a native Git repository\n")
+            return 1
+
+        git = repository
+        branch = git.branch
+        if args.parent and args.unstack:
+            sys.stderr.write(f"Cannot both set and unset the branch '{branch}' is stacked on\n")
+            return 1
+
+        if args.parent:
+            if not git.is_suitable_branch_for_pull_request(branch, git.default_remote):
+                sys.stderr.write(f"'{branch}' is not a development branch, it cannot be stacked on another branch\n")
+                return 1
+            if not (parent := cls.resolve(git, args.parent, branch=branch)):
+                return 1
+            if (descendants := cls._descendants(git, branch)) is None:
+                return 1
+            if parent in descendants:
+                sys.stderr.write(
+                    f"'{parent}' is stacked on '{branch},' stacking '{branch}' on it would create a cycle\n"
+                )
+                return 1
+            if StackMetadata(git, branch).write({'parent': parent}):
+                return 1
+            print(f"'{branch}' is stacked on '{parent}'")
+            return 0
+
+        if args.unstack:
+            if StackMetadata(git, branch).clear():
+                return 1
+            print(f"'{branch}' is no longer stacked on another branch")
+            return 0
+
+        if (lines := cls.describe(git, branch)) is None:
+            return 1
+        if not lines:
+            print(f"'{branch}' is not part of a stack")
+            return 0
+        print('\n'.join(lines))
+        return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack_metadata.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack_metadata.py
@@ -1,0 +1,104 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+from typing import Callable, Iterator, NamedTuple, Optional
+
+from webkitcorepy import run
+from webkitscmpy import local
+
+
+class MetadataKey(NamedTuple):
+    config: str
+    describe: Callable[[str], str]
+
+
+class StackMetadata:
+    """Where a branch sits in its stack, as this checkout records it."""
+
+    KEYS = {
+        'parent': MetadataKey('stack-parent', lambda branch: f"which branch '{branch}' is stacked on"),
+    }
+
+    @classmethod
+    def for_branch(cls, git: local.Git, branch: Optional[str]) -> Optional['StackMetadata']:
+        """None for any repository or branch which cannot carry a stack at all."""
+        return cls(git, branch) if isinstance(git, local.Git) and branch else None
+
+    @classmethod
+    def key_for(cls, branch: str, name: str) -> str:
+        return f'branch.{branch}.{cls.KEYS[name].config}'
+
+    @classmethod
+    def stacked(cls, git: local.Git) -> Iterator[tuple[str, str]]:
+        """Every branch this checkout records a parent for, whether or not it has that parent."""
+        prefix, suffix = 'branch.', f".{cls.KEYS['parent'].config}"
+        for key, value in git.config().items():
+            if key.startswith(prefix) and key.endswith(suffix):
+                yield key[len(prefix):-len(suffix)], value
+
+    def __init__(self, git: local.Git, branch: str) -> None:
+        self.git = git
+        self.branch = branch
+
+    @property
+    def recorded(self) -> dict[str, str]:
+        """Everything this checkout records about where the branch sits."""
+        config = self.git.config()
+        return {
+            name: value for name in self.KEYS
+            if (value := config.get(self.key_for(self.branch, name)))
+        }
+
+    @property
+    def parent(self) -> Optional[str]:
+        """The branch this one claims to be stacked on, whether or not this checkout has it."""
+        candidate = self.recorded.get('parent')
+        return None if candidate == self.branch else candidate
+
+    def write(self, metadata: dict[str, Optional[str]]) -> int:
+        """Write the keys named, unsetting those given no value and leaving any not named alone."""
+        for name, spec in self.KEYS.items():
+            if name not in metadata:
+                continue
+
+            value = metadata[name]
+            key = self.key_for(self.branch, name)
+            command = [self.git.executable(), 'config', key, value] if value else [
+                self.git.executable(), 'config', '--unset', key,
+            ]
+            if not run(command, cwd=self.git.root_path, capture_output=True).returncode:
+                continue
+
+            # Unsetting a key which was never set fails, and only an unforgotten parent still stacks a branch
+            if value:
+                sys.stderr.write(f'Failed to record {spec.describe(self.branch)}\n')
+                return 1
+            if name == 'parent':
+                sys.stderr.write(f'Failed to forget {spec.describe(self.branch)}\n')
+                return 1
+        self.git.config(cached=False)
+        return 0
+
+    def clear(self) -> int:
+        return self.write(dict.fromkeys(self.KEYS))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_metadata_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_metadata_unittest.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+
+from webkitcorepy import testing
+
+from webkitscmpy import local, mocks
+from webkitscmpy.program.stack_metadata import StackMetadata
+
+
+class TestStackMetadata(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self) -> None:
+        super().setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def test_key_for(self) -> None:
+        self.assertEqual(StackMetadata.key_for('eng/child', 'parent'), 'branch.eng/child.stack-parent')
+
+    def test_a_branch_which_is_not_stacked_records_nothing(self) -> None:
+        with mocks.local.Git(self.path):
+            metadata = StackMetadata(local.Git(self.path), 'eng/child')
+            self.assertEqual(metadata.recorded, {})
+            self.assertIsNone(metadata.parent)
+
+    def test_write_records_a_parent(self) -> None:
+        with mocks.local.Git(self.path):
+            metadata = StackMetadata(local.Git(self.path), 'eng/child')
+            self.assertEqual(0, metadata.write({'parent': 'eng/parent'}))
+            self.assertEqual(metadata.recorded, {'parent': 'eng/parent'})
+            self.assertEqual(metadata.parent, 'eng/parent')
+
+    def test_a_recorded_parent_outlives_the_object_which_wrote_it(self) -> None:
+        with mocks.local.Git(self.path):
+            self.assertEqual(0, StackMetadata(local.Git(self.path), 'eng/child').write({'parent': 'eng/parent'}))
+            self.assertEqual(
+                local.Git(self.path).config().get('branch.eng/child.stack-parent'),
+                'eng/parent',
+            )
+
+    def test_a_branch_recorded_on_itself_has_no_parent(self) -> None:
+        with mocks.local.Git(self.path):
+            metadata = StackMetadata(local.Git(self.path), 'eng/child')
+            self.assertEqual(0, metadata.write({'parent': 'eng/child'}))
+            self.assertEqual(metadata.recorded, {'parent': 'eng/child'})
+            self.assertIsNone(metadata.parent)
+
+    def test_clear_forgets_the_parent(self) -> None:
+        with mocks.local.Git(self.path):
+            metadata = StackMetadata(local.Git(self.path), 'eng/child')
+            self.assertEqual(0, metadata.write({'parent': 'eng/parent'}))
+            self.assertEqual(0, metadata.clear())
+            self.assertEqual(metadata.recorded, {})
+
+    def test_stacked_names_every_branch_with_a_recorded_parent(self) -> None:
+        with mocks.local.Git(self.path):
+            git = local.Git(self.path)
+            self.assertEqual(0, StackMetadata(git, 'eng/child').write({'parent': 'eng/parent'}))
+            self.assertEqual(0, StackMetadata(git, 'eng/grandchild').write({'parent': 'eng/child'}))
+            self.assertEqual(
+                dict(StackMetadata.stacked(git)),
+                {'eng/child': 'eng/parent', 'eng/grandchild': 'eng/child'},
+            )
+
+    def test_stacked_ignores_branch_config_which_is_not_a_stack(self) -> None:
+        with mocks.local.Git(self.path) as repo:
+            repo.edit_config('branch.eng/child.merge', 'refs/heads/main')
+            git = local.Git(self.path)
+            self.assertEqual(0, StackMetadata(git, 'eng/other').write({'parent': 'eng/parent'}))
+            self.assertEqual(dict(StackMetadata.stacked(git)), {'eng/other': 'eng/parent'})
+
+    def test_a_detached_head_cannot_carry_a_stack(self) -> None:
+        with mocks.local.Git(self.path):
+            self.assertIsNone(StackMetadata.for_branch(local.Git(self.path), None))
+
+    def test_a_checkout_which_is_not_git_cannot_carry_a_stack(self) -> None:
+        with mocks.local.Svn(self.path):
+            self.assertIsNone(StackMetadata.for_branch(local.Svn(self.path), 'eng/child'))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_unittest.py
@@ -1,0 +1,311 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+from contextlib import contextmanager
+from typing import Iterator, NamedTuple, Optional
+from unittest.mock import patch
+
+from webkitcorepy import OutputCapture, testing
+from webkitcorepy.mocks import ProcessCompletion, Time as MockTime
+
+from webkitscmpy import Commit, local, mocks, program
+from webkitscmpy.program import stack_metadata
+
+CONTRIBUTOR = {'name': 'Tim Contributor', 'emails': ['tcontributor@example.com']}
+
+
+class MockCommit(NamedTuple):
+    hash: str
+    timestamp: int
+
+
+COMMITS = {
+    'eng/parent': MockCommit('06de5d56554e693db72313f4ca1fb969c30b8ccb', 1601668000),
+    'eng/child': MockCommit('b8b921baaad2fd10bc9d0cc9e97f8fa1d6e5f4a1', 1601669000),
+    'eng/sibling': MockCommit('2f0c1cbb7e5b6f2a3ba0a4c1e0f79c1c7d4a3b12', 1601669500),
+    'eng/other': MockCommit('9d1a3f6c2b8e4d5a7c0f1e2b3a4d5c6e7f809123', 1601669500),
+    'eng/grandchild': MockCommit('7c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f60718293', 1601670000),
+}
+
+
+class TestStack(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self) -> None:
+        super().setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    @contextmanager
+    def checkout(self) -> Iterator[tuple[mocks.local.Git, OutputCapture]]:
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            yield repo, captured
+
+    @classmethod
+    def add_branch(cls, repo: mocks.local.Git, branch: str, on: Optional[str] = None) -> mocks.local.Git:
+        mock = COMMITS[branch]
+        base = repo.commits[on or repo.default_branch][-1]
+        repo.commits[branch] = [
+            base,
+            Commit(
+                hash=mock.hash,
+                branch=branch,
+                author=CONTRIBUTOR,
+                identifier=base.identifier + 1 if base.branch_point else 1,
+                branch_point=base.branch_point or base.identifier,
+                timestamp=mock.timestamp,
+                message=f"[Testing] {branch.split('/')[-1].capitalize()} change\n",
+            ),
+        ]
+        return repo
+
+    @classmethod
+    def add_stack(cls, repo: mocks.local.Git) -> mocks.local.Git:
+        cls.add_branch(repo, 'eng/parent')
+        cls.add_branch(repo, 'eng/child', on='eng/parent')
+        repo.head = repo.commits['eng/child'][-1]
+        return repo
+
+    def test_set_parent(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            # Recording the same parent again is not an error
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+
+            config = local.Git(self.path).config()
+            self.assertEqual(config.get('branch.eng/child.stack-parent'), 'eng/parent')
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "'eng/child' is stacked on 'eng/parent'\n" * 2,
+        )
+
+    def test_set_parent_missing(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.assertEqual(1, program.main(args=('stack', '--on', 'eng/missing'), path=self.path))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "Could not find 'eng/missing' as a branch in this checkout\n",
+        )
+
+    def test_set_parent_production(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.assertEqual(1, program.main(args=('stack', '--on', 'main'), path=self.path))
+            self.assertIsNone(local.Git(self.path).config().get('branch.eng/child.stack-parent'))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "'main' is not a development branch, a branch cannot be stacked on it\n",
+        )
+
+    def test_set_parent_self(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.assertEqual(1, program.main(args=('stack', '--on', 'eng/child'), path=self.path))
+
+        self.assertEqual(captured.stderr.getvalue(), "'eng/child' cannot be stacked on itself\n")
+
+    def test_set_parent_self_with_child(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+
+            # 'eng/parent' already has 'eng/child' stacked on it, which must not be reported
+            # in place of the branch being stacked on itself
+            repo.head = repo.commits['eng/parent'][-1]
+            self.assertEqual(1, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "'eng/parent' cannot be stacked on itself\n",
+        )
+
+    def test_set_parent_cycle(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            repo.head = repo.commits['eng/parent'][-1]
+            self.assertEqual(1, program.main(args=('stack', '--on', 'eng/child'), path=self.path))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "'eng/child' is stacked on 'eng/parent,' stacking 'eng/parent' on it would create a cycle\n",
+        )
+
+    def test_set_parent_refuses_a_cycle_above(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_branch(repo, 'eng/parent')
+            self.add_branch(repo, 'eng/child', on='eng/parent')
+            self.add_branch(repo, 'eng/other')
+            repo.head = repo.commits['eng/parent'][-1]
+
+            # Hand-written config where two branches are stacked on each other. The walk up
+            # from 'eng/parent' finds the cycle before the walk down from it ever runs.
+            repo.edit_config('branch.eng/child.stack-parent', 'eng/parent')
+            repo.edit_config('branch.eng/parent.stack-parent', 'eng/child')
+
+            self.assertEqual(1, program.main(args=('stack', '--on', 'eng/other'), path=self.path))
+
+        self.assertIn('is part of a cycle of stacked branches\n', captured.stderr.getvalue())
+
+    def test_a_parent_git_refuses_to_forget_is_reported(self) -> None:
+        real = stack_metadata.run
+
+        def refuse(command: list, **kwargs: object) -> object:
+            if '--unset' in command and 'stack-parent' in ' '.join(command):
+                return ProcessCompletion(returncode=1)
+            return real(command, **kwargs)
+
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+
+            # A branch whose parent was not forgotten is still stacked on it, whatever it was told
+            with patch.object(stack_metadata, 'run', refuse):
+                self.assertEqual(1, program.main(args=('stack', '--unstack'), path=self.path))
+
+        self.assertIn(
+            "Failed to forget which branch 'eng/child' is stacked on",
+            captured.stderr.getvalue(),
+        )
+
+    def test_set_parent_branching(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            self.add_branch(repo, 'eng/sibling', on='eng/parent')
+            repo.head = repo.commits['eng/sibling'][-1]
+
+            # Two branches may be stacked on the same branch
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "'eng/child' is stacked on 'eng/parent'\n"
+            "'eng/sibling' is stacked on 'eng/parent'\n"
+            'Stacked pull requests, bottom of the stack first:\n'
+            '- eng/parent\n'
+            '    - eng/child\n'
+            '    - eng/sibling (this pull request)\n',
+        )
+
+    def test_unstack(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            self.assertEqual(0, program.main(args=('stack', '--unstack'), path=self.path))
+            self.assertIsNone(local.Git(self.path).config().get('branch.eng/child.stack-parent'))
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "'eng/child' is stacked on 'eng/parent'\n"
+            "'eng/child' is no longer stacked on another branch\n",
+        )
+
+    def test_parent_deleted(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            del repo.commits['eng/parent']
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "'eng/child' is stacked on 'eng/parent'\n"
+            "'eng/child' is not part of a stack\n",
+        )
+
+    def test_listing(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+            # The whole stack is listed from either end, only the marked branch moves
+            repo.head = repo.commits['eng/parent'][-1]
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "'eng/child' is stacked on 'eng/parent'\n"
+            'Stacked pull requests, bottom of the stack first:\n'
+            '- eng/parent\n'
+            '    - eng/child (this pull request)\n'
+            'Stacked pull requests, bottom of the stack first:\n'
+            '- eng/parent (this pull request)\n'
+            '    - eng/child\n',
+        )
+
+    def test_listing_not_stacked(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_branch(repo, 'eng/parent')
+            repo.head = repo.commits['eng/parent'][-1]
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.stdout.getvalue(), "'eng/parent' is not part of a stack\n")
+
+    def test_listing_nests_a_deeper_sibling(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            self.add_branch(repo, 'eng/grandchild', on='eng/child')
+            self.add_branch(repo, 'eng/sibling', on='eng/parent')
+            repo.edit_config('branch.eng/child.stack-parent', 'eng/parent')
+            repo.edit_config('branch.eng/grandchild.stack-parent', 'eng/child')
+            repo.edit_config('branch.eng/sibling.stack-parent', 'eng/parent')
+            repo.head = repo.commits['eng/parent'][-1]
+
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+        # 'eng/grandchild' is deeper than 'eng/sibling', so it has to follow the branch it is
+        # stacked on rather than whichever branch was listed immediately before it
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Stacked pull requests, bottom of the stack first:\n'
+            '- eng/parent (this pull request)\n'
+            '    - eng/child\n'
+            '        - eng/grandchild\n'
+            '    - eng/sibling\n',
+        )
+
+    def test_listing_refuses_a_cycle_above(self) -> None:
+        with self.checkout() as (repo, captured):
+            self.add_stack(repo)
+            # Hand-written config can stack two branches on each other
+            repo.edit_config('branch.eng/child.stack-parent', 'eng/parent')
+            repo.edit_config('branch.eng/parent.stack-parent', 'eng/child')
+
+            self.assertEqual(1, program.main(args=('stack',), path=self.path))
+
+        self.assertIn('is part of a cycle of stacked branches\n', captured.stderr.getvalue())


### PR DESCRIPTION
#### b54b3bebf635c0677de57b5553ac4106e9a72452
<pre>
[git-webkit] Add a local model for stacked pull requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=321654">https://bugs.webkit.org/show_bug.cgi?id=321654</a>
<a href="https://rdar.apple.com/184780034">rdar://184780034</a>

Reviewed by NOBODY (OOPS!).

Nothing records that one development branch continues the work of another, so a
change split across several pull requests is tracked by hand: which branch
belongs where lives in the contributor&apos;s head, and every descendant is rebased
by hand whenever an ancestor changes.

* Add `StackMetadata(git, branch)`, which owns where a branch sits in its
  stack. Today that is `branch.&lt;name&gt;.stack-parent`, so the relationship is
  known offline and before a pull request exists
* Add `git-webkit stack`, which records that relationship with `--on`, forgets
  it with `--unstack`, and otherwise prints the stack the current branch
  belongs to
* Allow several branches to be stacked on one branch and print the result as a
  tree. Stacking a branch on itself, or anywhere that would close a cycle, is
  refused
* Treat a branch whose parent this checkout does not have as unstacked, which
  is what a parent leaves behind once it lands and its branch is deleted

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(update_ref):
(for_each_ref):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack.py: Added.
(Stack):
(Stack.parser):
(Stack._recorded_parent):
(Stack.parent):
(Stack._children):
(Stack._ancestors):
(Stack._descendants):
(Stack.members):
(Stack.describe):
(Stack.resolve):
(Stack.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack_metadata.py: Added.
(MetadataKey):
(StackMetadata):
(StackMetadata.for_branch):
(StackMetadata.key_for):
(StackMetadata.stacked):
(StackMetadata.__init__):
(StackMetadata.recorded):
(StackMetadata.parent):
(StackMetadata.write):
(StackMetadata.clear):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_metadata_unittest.py: Added.
(TestStackMetadata):
(TestStackMetadata.setUp):
(TestStackMetadata.test_key_for):
(TestStackMetadata.test_a_branch_which_is_not_stacked_records_nothing):
(TestStackMetadata.test_write_records_a_parent):
(TestStackMetadata.test_a_recorded_parent_outlives_the_object_which_wrote_it):
(TestStackMetadata.test_a_branch_recorded_on_itself_has_no_parent):
(TestStackMetadata.test_clear_forgets_the_parent):
(TestStackMetadata.test_stacked_names_every_branch_with_a_recorded_parent):
(TestStackMetadata.test_stacked_ignores_branch_config_which_is_not_a_stack):
(TestStackMetadata.test_a_detached_head_cannot_carry_a_stack):
(TestStackMetadata.test_a_checkout_which_is_not_git_cannot_carry_a_stack):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_unittest.py: Added.
(TestStack):
(TestStack.setUp):
(TestStack.add_parent):
(TestStack.add_stack):
(TestStack.test_set_parent):
(TestStack.test_set_parent_missing):
(TestStack.test_set_parent_production):
(TestStack.test_set_parent_self):
(TestStack.test_set_parent_self_with_child):
(TestStack.test_set_parent_cycle):
(TestStack.test_set_parent_refuses_a_cycle_above):
(TestStack.test_a_parent_git_refuses_to_forget_is_reported):
(TestStack.test_a_parent_git_refuses_to_forget_is_reported.refuse):
(TestStack.test_set_parent_branching):
(TestStack.test_unstack):
(TestStack.test_parent_deleted):
(TestStack.test_listing):
(TestStack.test_listing_not_stacked):
(TestStack.test_listing_nests_a_deeper_sibling):
(TestStack.test_listing_refuses_a_cycle_above):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/179c16191076f80c99d47d01337bb72c7f7e7de8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147503 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56872 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143001 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99307 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123428 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182541 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45425 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43672 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5398 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12228 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43288 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4606 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44484 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195373 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182618 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163253 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152490 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57511 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39908 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152186 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46735 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129781 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126090 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56019 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18299 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55390 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->