### PR TITLE
[Navigation API] traverseTo-detach-between-navigate-and-navigatesuccess.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-detach-between-navigate-and-navigatesuccess-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-detach-between-navigate-and-navigatesuccess-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Detach a window between when a traverseTo() fires navigate and navigatesuccess Test timed out
+PASS Detach a window between when a traverseTo() fires navigate and navigatesuccess
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3434,6 +3434,13 @@ void FrameLoader::frameDetached()
     // Calling stopAllLoadersAndCheckCompleteness() can cause the frame to be deallocated, including the frame loader.
     Ref frame = m_frame.get();
 
+    // https://html.spec.whatwg.org/multipage/document-sequences.html#destroy-a-child-navigable
+    // Step 4: Inform the navigation API about child navigable destruction
+    if (RefPtr document = frame->document(); document && document->settings().navigationAPIEnabled()) {
+        if (RefPtr window = document->window())
+            protect(window->navigation())->informAboutChildNavigableDestruction();
+    }
+
     if (m_checkTimer.isActive()) {
         m_checkTimer.stop();
         checkCompletenessNow();

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -924,6 +924,15 @@ NavigationAPIMethodTracker* Navigation::MethodTrackerRegistry::upcomingTraverse(
     return m_upcomingTraverse.get(key);
 }
 
+Vector<Ref<NavigationAPIMethodTracker>> Navigation::MethodTrackerRegistry::upcomingTraverseTrackers() const
+{
+    assertIsMainThread();
+    Locker locker { m_lock };
+    return WTF::map(m_upcomingTraverse.values(), [](auto& tracker) {
+        return Ref { tracker };
+    });
+}
+
 NavigationAPIMethodTracker* Navigation::MethodTrackerRegistry::ongoing() const
 {
     assertIsMainThread();
@@ -1607,6 +1616,19 @@ void Navigation::abortOngoingNavigationIfNeeded()
 {
     if (RefPtr ongoingNavigateEvent = m_ongoingNavigateEvent)
         abortOngoingNavigation(*ongoingNavigateEvent);
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#inform-the-navigation-api-about-child-navigable-destruction
+void Navigation::informAboutChildNavigableDestruction()
+{
+    RefPtr context = scriptExecutionContext();
+    if (!context || context->activeDOMObjectsAreSuspended() || context->activeDOMObjectsAreStopped())
+        return;
+
+    abortOngoingNavigationIfNeeded();
+
+    for (Ref tracker : m_methodTrackers.upcomingTraverseTrackers())
+        rejectFinishedPromise(tracker.ptr());
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-session-history-entries-for-the-navigation-api

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -166,6 +166,8 @@ public:
 
     RefPtr<NavigationActivation> createForPageswapEvent(HistoryItem* newItem, DocumentLoader*, bool fromBackForwardCache);
 
+    void informAboutChildNavigableDestruction();
+
     void abortOngoingNavigationIfNeeded();
 
     NavigationHistoryEntry* findEntryByKey(const String&) const;
@@ -291,6 +293,7 @@ private:
         void setUpcomingNonTraverse(Ref<NavigationAPIMethodTracker>&&) WTF_EXCLUDES_LOCK(m_lock);
         void addUpcomingTraverse(const String& key, Ref<NavigationAPIMethodTracker>&&) WTF_EXCLUDES_LOCK(m_lock);
         NavigationAPIMethodTracker* upcomingTraverse(const String& key) const WTF_EXCLUDES_LOCK(m_lock);
+        Vector<Ref<NavigationAPIMethodTracker>> upcomingTraverseTrackers() const WTF_EXCLUDES_LOCK(m_lock);
         NavigationAPIMethodTracker* ongoing() const WTF_EXCLUDES_LOCK(m_lock);
 
         RefPtr<NavigationAPIMethodTracker> takeUpcomingNonTraverseIfEquals(NavigationAPIMethodTracker&) WTF_EXCLUDES_LOCK(m_lock);


### PR DESCRIPTION
#### ec445d2204215668407ddbdc65c1d4d35327e9eb
<pre>
[Navigation API] traverseTo-detach-between-navigate-and-navigatesuccess.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=321639">https://bugs.webkit.org/show_bug.cgi?id=321639</a>
<a href="https://rdar.apple.com/184766408">rdar://184766408</a>

Reviewed by Charlie Wolfe.

This test tests that if an iframe uses the Navigation API to traverse but gets
removed after committing but before finishing, then NavigateSuccess is not
fired, but NavigateError is and the finished promise rejects.

Currently, the test times out because NavigateError is not fired at all.

The spec says that when an iframe is destroyed, we must notify the iframe&apos;s
navigation object so that it can abort the ongoing navigation and reject
the finished promises of all the upcoming traverse trackers.

Spec:
<a href="https://html.spec.whatwg.org/multipage/document-sequences.html#destroy-a-child-navigable">https://html.spec.whatwg.org/multipage/document-sequences.html#destroy-a-child-navigable</a>
has Step 4: Inform the navigation API about child navigable destruction given navigable
<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#inform-the-navigation-api-about-child-navigable-destruction">https://html.spec.whatwg.org/multipage/nav-history-apis.html#inform-the-navigation-api-about-child-navigable-destruction</a>

We currently don&apos;t implement this. So we fix the test by implementing it.

It is possible that informAboutChildNavigableDestruction() gets called when
the frames of a back/forward cache entry are disconnected when the entry is
being destroyed (see CachedFrame::destroy()). In that case the document is
suspended or stopped and can&apos;t dispatch events or settle promises. So we guard
against this case. Multiple tests were crashing without this guard.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::frameDetached):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::MethodTrackerRegistry::upcomingTraverseTrackers const):
(WebCore::Navigation::informAboutChildNavigableDestruction):
* Source/WebCore/page/Navigation.h:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-detach-between-navigate-and-navigatesuccess-expected.txt:

Canonical link: <a href="https://commits.webkit.org/319183@main">https://commits.webkit.org/319183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ab71162c4c4817b5a9fbc6ed758f1a41c11e3a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190682 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144792 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d6b04e8d-2188-4ec3-8113-086ae1d41a1c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140759 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97505 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b509fa9f-6837-42bc-9884-bc57166db429) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121211 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1676259b-9455-4aa0-b02b-e8f320c68ab9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43096 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41380 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41055 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1841 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192617 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54082 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150120 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54770 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149843 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27434 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44465 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127033 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122196 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53287 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16044 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52669 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52906 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52734 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->