### PR TITLE
[JSC] Avoid unnecessary work in JIT code generation loop

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -584,8 +584,9 @@ void GenerateAndAllocateRegisters::generate(CCallHelpers& jit)
 
     Disassembler* disassembler = m_code.disassembler();
     PCToOriginMap& pcToOriginMap = m_code.proc().pcToOriginMap();
+    bool shouldPreserveB3Origins = m_code.shouldPreserveB3Origins();
     auto addItem = [&](Inst& inst) {
-        if (!m_code.shouldPreserveB3Origins())
+        if (!shouldPreserveB3Origins)
             return;
         if (inst.origin)
             pcToOriginMap.appendItem(m_jit->labelIgnoringWatchpoints(), inst.origin->origin());
@@ -618,8 +619,7 @@ void GenerateAndAllocateRegisters::generate(CCallHelpers& jit)
         } else
             ASSERT(!m_code.isEntrypoint(block));
 
-        auto startLabel = m_jit->labelIgnoringWatchpoints();
-
+        auto startLabel = disassembler ? m_jit->labelIgnoringWatchpoints() : CCallHelpers::Label();
         {
             auto iter = m_blocksAfterTerminalPatchForSpilling.find(block);
             if (iter != m_blocksAfterTerminalPatchForSpilling.end()) {
@@ -664,7 +664,7 @@ void GenerateAndAllocateRegisters::generate(CCallHelpers& jit)
         for (size_t instIndex = 0; instIndex < block->size(); ++instIndex) {
             checkConsistency();
 
-            if (instIndex && !isReplayingSameInst)
+            if (instIndex && !isReplayingSameInst && disassembler)
                 startLabel = m_jit->labelIgnoringWatchpoints();
 
             context.indexInBlock = instIndex;
@@ -991,9 +991,8 @@ void GenerateAndAllocateRegisters::generate(CCallHelpers& jit)
                 }
             }
 
-            auto endLabel = m_jit->labelIgnoringWatchpoints();
             if (disassembler)
-                disassembler->addInst(&inst, startLabel, endLabel);
+                disassembler->addInst(&inst, startLabel, m_jit->labelIgnoringWatchpoints());
 
             ++m_globalInstIndex;
         }

--- a/Source/JavaScriptCore/b3/air/AirGenerate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirGenerate.cpp
@@ -200,8 +200,9 @@ static void generateWithAlreadyAllocatedRegisters(Code& code, CCallHelpers& jit)
     };
 
     PCToOriginMap& pcToOriginMap = code.proc().pcToOriginMap();
+    bool shouldPreserveB3Origins = code.shouldPreserveB3Origins();
     auto addItem = [&] (Inst& inst) {
-        if (!code.shouldPreserveB3Origins())
+        if (!shouldPreserveB3Origins)
             return;
         if (inst.origin)
             pcToOriginMap.appendItem(jit.labelIgnoringWatchpoints(), inst.origin->origin());
@@ -239,12 +240,11 @@ static void generateWithAlreadyAllocatedRegisters(Code& code, CCallHelpers& jit)
             context.indexInBlock = i;
             Inst& inst = block->at(i);
             addItem(inst);
-            auto start = jit.labelIgnoringWatchpoints();
+            auto start = disassembler ? jit.labelIgnoringWatchpoints() : CCallHelpers::Label();
             CCallHelpers::Jump jump = inst.generate(jit, context);
             ASSERT_UNUSED(jump, !jump.isSet());
-            auto end = jit.labelIgnoringWatchpoints();
             if (disassembler)
-                disassembler->addInst(&inst, start, end);
+                disassembler->addInst(&inst, start, jit.labelIgnoringWatchpoints());
         }
 
         context.indexInBlock = block->size() - 1;
@@ -257,20 +257,18 @@ static void generateWithAlreadyAllocatedRegisters(Code& code, CCallHelpers& jit)
             // We currently don't represent the full prologue/epilogue in Air, so we need to
             // have this override.
             addItem(block->last());
-            auto start = jit.labelIgnoringWatchpoints();
+            auto start = disassembler ? jit.labelIgnoringWatchpoints() : CCallHelpers::Label();
             code.emitEpilogue(jit);
-            auto end = jit.labelIgnoringWatchpoints();
             if (disassembler)
-                disassembler->addInst(&block->last(), start, end);
+                disassembler->addInst(&block->last(), start, jit.labelIgnoringWatchpoints());
             continue;
         }
 
         addItem(block->last());
-        auto start = jit.labelIgnoringWatchpoints();
+        auto start = disassembler ? jit.labelIgnoringWatchpoints() : CCallHelpers::Label();
         CCallHelpers::Jump jump = block->last().generate(jit, context);
-        auto end = jit.labelIgnoringWatchpoints();
         if (disassembler)
-            disassembler->addInst(&block->last(), start, end);
+            disassembler->addInst(&block->last(), start, jit.labelIgnoringWatchpoints());
 
         // The jump won't be set for patchpoints. It won't be set for Oops because then it won't have
         // any successors.

--- a/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
@@ -39,15 +39,15 @@ void lowerStackArgs(Code& code)
 {
     PhaseScope phaseScope(code, "lowerStackArgs"_s);
     
-    // Now we need to deduce how much argument area we need.
+    // Now we need to deduce how much argument area we need. We always reserve the conservative
+    // register bytes for Bank::FP because CallArgs do not record which bank they are.
+    unsigned conservativeCallArgBytes = code.usesSIMD() ? conservativeRegisterBytes(Bank::FP) : conservativeRegisterBytesWithoutVectors(Bank::FP);
     for (BasicBlock* block : code) {
         for (Inst& inst : *block) {
             for (Arg& arg : inst.args()) {
                 if (arg.isCallArg()) {
                     ASSERT(arg.offset() >= 0);
-                    // We always check the conservative register bytes for Bank::FP because
-                    // CallArgs do not store which bank they are.
-                    code.requestCallArgAreaSizeInBytes(arg.offset() + (code.usesSIMD() ? conservativeRegisterBytes(Bank::FP) : conservativeRegisterBytesWithoutVectors(Bank::FP)));
+                    code.requestCallArgAreaSizeInBytes(arg.offset() + conservativeCallArgBytes);
                 }
             }
         }
@@ -181,6 +181,19 @@ void lowerStackArgs(Code& code)
                 }
                 // Fall through to handle remainder of the original or modified inst, including potential ZDef handling.
             }
+
+            // The scan below only ever acts on Stack and CallArg operands, and after register
+            // allocation most instructions have neither. Checking that does not need the Arg roles,
+            // and iterating args() directly can only over-approximate what forEachArg reports.
+            bool mayHaveStackArg = false;
+            for (Arg& arg : inst.args()) {
+                if (arg.isStack() || arg.isCallArg()) {
+                    mayHaveStackArg = true;
+                    break;
+                }
+            }
+            if (!mayHaveStackArg)
+                continue;
 
             inst.forEachArg(
                 [&] (Arg& arg, Arg::Role role, Bank, Width width) {

--- a/Source/JavaScriptCore/b3/air/AirSimplifyCFG.cpp
+++ b/Source/JavaScriptCore/b3/air/AirSimplifyCFG.cpp
@@ -58,9 +58,10 @@ bool simplifyCFG(Code& code)
     }
 
     bool changed = false;
+    bool validateAtEachPhase = shouldValidateIRAtEachPhase();
     for (BasicBlock* block : code) {
         // We rely on predecessors being conservatively correct. Verify this here.
-        if (shouldValidateIRAtEachPhase()) {
+        if (validateAtEachPhase) [[unlikely]] {
             for (BasicBlock* block : code) {
                 for (BasicBlock* successor : block->successorBlocks())
                     RELEASE_ASSERT(successor->containsPredecessor(block));

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -190,14 +190,15 @@ void JIT::privateCompileMainPass()
             breakpoint();
         }
 
+        Label bytecodeStart = label();
         if (m_disassembler)
-            m_disassembler->setForBytecodeMainPath(m_bytecodeIndex.offset(), label());
+            m_disassembler->setForBytecodeMainPath(m_bytecodeIndex.offset(), bytecodeStart);
         const auto* currentInstruction = instructions.at(m_bytecodeIndex).ptr();
         ASSERT(currentInstruction->size());
 
-        m_pcToCodeOriginMapBuilder.appendItem(label(), CodeOrigin(m_bytecodeIndex));
+        m_pcToCodeOriginMapBuilder.appendItem(bytecodeStart, CodeOrigin(m_bytecodeIndex));
 
-        m_labels[m_bytecodeIndex.offset()] = label();
+        m_labels[m_bytecodeIndex.offset()] = bytecodeStart;
 
         if (JITInternal::verbose)
             dataLogLn("Baseline JIT emitting code for ", m_bytecodeIndex, " at offset ", (long)debugOffset());
@@ -490,7 +491,8 @@ void JIT::privateCompileSlowCases()
     for (Vector<SlowCaseEntry>::iterator iter = m_slowCases.begin(); iter != m_slowCases.end();) {
         m_bytecodeIndex = iter->to;
 
-        m_pcToCodeOriginMapBuilder.appendItem(label(), CodeOrigin(m_bytecodeIndex));
+        Label slowPathStart = label();
+        m_pcToCodeOriginMapBuilder.appendItem(slowPathStart, CodeOrigin(m_bytecodeIndex));
 
         BytecodeIndex firstTo = m_bytecodeIndex;
 
@@ -500,7 +502,7 @@ void JIT::privateCompileSlowCases()
             dataLogLn("Baseline JIT emitting slow code for ", m_bytecodeIndex, " at offset ", (long)debugOffset());
 
         if (m_disassembler)
-            m_disassembler->setForBytecodeSlowPath(m_bytecodeIndex.offset(), label());
+            m_disassembler->setForBytecodeSlowPath(m_bytecodeIndex.offset(), slowPathStart);
 
         OpcodeID opcodeID = currentInstruction->opcodeID();
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -638,8 +638,7 @@ void ControlData::fillLabels(CCallHelpers::Label label)
 }
 
 BBQJIT::BBQJIT(CompilationContext& compilationContext, const RTT& signature, Module& module, CalleeGroup& calleeGroup, IPIntCallee& profiledCallee, BBQCallee& callee, const FunctionData& function, FunctionCodeIndex functionIndex, const ModuleInformation& info, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, MemoryMode mode, InternalFunction* compilation)
-    : m_context(compilationContext)
-    , m_jit(*compilationContext.wasmEntrypointJIT)
+    : m_jit(*compilationContext.wasmEntrypointJIT)
     , m_module(module)
     , m_calleeGroup(calleeGroup)
     , m_profiledCallee(profiledCallee)
@@ -4930,10 +4929,22 @@ WasmOrigin BBQJIT::origin()
         break;
     }
     ASSERT(isValidOpType(static_cast<uint8_t>(opcodeOrigin.opcode())));
-    WasmOrigin result { CallSiteIndex(m_callSiteIndex), opcodeOrigin };
-    if (m_context.origins.isEmpty() || m_context.origins.last() != result)
-        m_context.origins.append(result);
-    return m_context.origins.last();
+    return { CallSiteIndex(m_callSiteIndex), opcodeOrigin };
+}
+
+ALWAYS_INLINE void BBQJIT::recordOpcodeOrigin()
+{
+    // Opcode origins in BBQ feed only the sampling profiler's PC map and the disassembler; exception
+    // handling instead stores call site indices into the frame as it emits them. The label is not a
+    // branch target, so use one that does not invalidate the assembler's cached scratch registers.
+    if (!m_pcToCodeOriginMapBuilder.didBuildMapping() && !m_disassembler) [[likely]]
+        return;
+
+    auto origin = this->origin();
+    auto label = m_jit.labelIgnoringWatchpoints();
+    m_pcToCodeOriginMapBuilder.appendItem(label, CodeOrigin(BytecodeIndex(origin.m_opcodeOrigin.location())));
+    if (m_disassembler)
+        m_disassembler->setOpcode(label, origin.m_opcodeOrigin);
 }
 
 ALWAYS_INLINE void BBQJIT::willParseOpcode()
@@ -4949,10 +4960,7 @@ ALWAYS_INLINE void BBQJIT::willParseOpcode()
         break;
     }
 
-    auto origin = this->origin();
-    m_pcToCodeOriginMapBuilder.appendItem(m_jit.label(), CodeOrigin(BytecodeIndex(origin.m_opcodeOrigin.location())));
-    if (m_disassembler) [[unlikely]]
-        m_disassembler->setOpcode(m_jit.label(), origin.m_opcodeOrigin);
+    recordOpcodeOrigin();
 
     m_gprAllocator.assertAllValidRegistersAreUnlocked();
     m_fprAllocator.assertAllValidRegistersAreUnlocked();
@@ -4976,10 +4984,7 @@ ALWAYS_INLINE void BBQJIT::willParseOpcode()
 
 ALWAYS_INLINE void BBQJIT::willParseExtendedOpcode()
 {
-    auto origin = this->origin();
-    m_pcToCodeOriginMapBuilder.appendItem(m_jit.label(), CodeOrigin(BytecodeIndex(origin.m_opcodeOrigin.location())));
-    if (m_disassembler) [[unlikely]]
-        m_disassembler->setOpcode(m_jit.label(), origin.m_opcodeOrigin);
+    recordOpcodeOrigin();
 
     m_gprAllocator.assertAllValidRegistersAreUnlocked();
     m_fprAllocator.assertAllValidRegistersAreUnlocked();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -2241,8 +2241,8 @@ private:
     void emitRestoreCalleeSaves();
 
     WasmOrigin origin();
+    void recordOpcodeOrigin();
 
-    CompilationContext& m_context;
     CCallHelpers& m_jit;
     Module& m_module;
     CalleeGroup& m_calleeGroup;


### PR DESCRIPTION
#### 4af3bbad9cda43c2c6a6580bc45f493fd010c161
<pre>
[JSC] Avoid unnecessary work in JIT code generation loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=321655">https://bugs.webkit.org/show_bug.cgi?id=321655</a>
<a href="https://rdar.apple.com/184783026">rdar://184783026</a>

Reviewed by Justin Michaud.

This patch removes unnecessary work done in JIT code generation main
loop in Air, BBQ, and Baseline JIT.

1. Disassembler&apos;s label creation

Creating label is not free. It is adding label entry in the
MacroAssembler&apos;s buffer. Let&apos;s avoid this when it is not necessary. We
have many labels which are only used when disassembler is enabled.

2. Move some of loop invariant values

Let&apos;s move some loop invariant values out of the hot loop in Air.

3. Quickly check whether we have Stack / CallArg args

They are relatively rare args. Let&apos;s just scan it first, before invoking
generic inst.forEachArg.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::GenerateAndAllocateRegisters::generate):
* Source/JavaScriptCore/b3/air/AirGenerate.cpp:
(JSC::B3::Air::generateWithAlreadyAllocatedRegisters):
* Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp:
(JSC::B3::Air::lowerStackArgs):
* Source/JavaScriptCore/b3/air/AirSimplifyCFG.cpp:
(JSC::B3::Air::simplifyCFG):
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::privateCompileMainPass):
(JSC::JIT::privateCompileSlowCases):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJITImpl::BBQJIT::origin):
(JSC::Wasm::BBQJITImpl::BBQJIT::recordOpcodeOrigin):
(JSC::Wasm::BBQJITImpl::BBQJIT::willParseOpcode):
(JSC::Wasm::BBQJITImpl::BBQJIT::willParseExtendedOpcode):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:

Canonical link: <a href="https://commits.webkit.org/319120@main">https://commits.webkit.org/319120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71713411fd3c1c5fc2ddf53a1fd103a8f463fab9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144796 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/711c7c36-8055-463d-beeb-f660d7b474df) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140762 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08a7c4ff-f857-4da4-9982-b274add737bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161531 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121214 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04116cd0-e926-4a63-b713-9e7f3f4d31af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43097 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41382 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3181 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10016 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153501 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41060 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1845 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41749 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192621 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/179876 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54086 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150126 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54774 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149846 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27397 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44470 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127037 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122202 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53291 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16049 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52673 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52910 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52738 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->