### PR TITLE
[git-webkit] Rebase a stack of pull requests onto the branch beneath each one

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -50,7 +50,7 @@ except ImportError:
         "See https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy"
     )
 
-version = Version(7, 0, 5)
+version = Version(7, 0, 6)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('markupsafe', Version(3, 0, 3), pypi_name='MarkupSafe', wheel=True))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -50,7 +50,7 @@ except ImportError:
         "See https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy"
     )
 
-version = Version(7, 0, 4)
+version = Version(7, 0, 5)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('markupsafe', Version(3, 0, 3), pypi_name='MarkupSafe', wheel=True))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -55,7 +55,7 @@ class Git(mocks.Subprocess):
         remote=None, tags=None,
         detached=None, default_branch='main',
         git_svn=False, remotes=None, editor=None,
-        is_worktree=False,
+        is_worktree=False, git_version='2.50.1',
     ):
         self.path = path
         self.default_branch = default_branch
@@ -63,6 +63,7 @@ class Git(mocks.Subprocess):
         self.detached = detached or False
         self.is_worktree = is_worktree
         self.push_error = None
+        self.git_version = git_version
 
         self.tags = tags or {}
 
@@ -672,9 +673,18 @@ nothing to commit, working tree clean
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self._fetch_with_refspec(args[3:]),
             ), mocks.Subprocess.Route(
+                self.executable, '--version',
+                cwd=self.path,
+                generator=lambda *args, **kwargs: mocks.ProcessCompletion(
+                    returncode=0,
+                    stdout=f'git version {self.git_version}\n',
+                ),
+            ), mocks.Subprocess.Route(
                 self.executable, 'rebase', '--onto', re.compile(r'.+'), re.compile(r'.+'), re.compile(r'.+'),
                 cwd=self.path,
-                generator=lambda *args, **kwargs: self.rebase(args[3], args[4], args[5]),
+                generator=lambda *args, **kwargs: self.rebase(
+                    args[3], args[4], args[5], update_refs='--update-refs' in args,
+                ),
             ), mocks.Subprocess.Route(
                 self.executable, 'branch', '-f', re.compile(r'.+'), re.compile(r'.+'),
                 cwd=self.path,
@@ -1315,16 +1325,28 @@ nothing to commit, working tree clean
         self.modified = {}
         return mocks.ProcessCompletion(returncode=0)
 
-    def rebase(self, target, base, head):
-        if target not in self.commits or base not in self.commits or head not in self.commits:
+    def rebase(self, target, base, head, update_refs=False):
+        target_commit = self.commits[target][-1] if target in self.commits else self.find(target)
+        if not target_commit:
+            return mocks.ProcessCompletion(returncode=1)
+        if head not in self.commits or (base not in self.commits and not self.find(base)):
             return mocks.ProcessCompletion(returncode=1)
 
-        base = self.commits[target][-1]
-        self.commits[head][0] = base
-        for commit in self.commits[head][1:]:
-            commit.branch_point = base.branch_point or base.identifier
-            if base.branch_point:
-                commit.identifier += base.identifier
+        chain = [head]
+        while update_refs:
+            parent = self.commits[chain[-1]][0].branch
+            if parent == target_commit.branch or parent not in self.commits or parent in chain:
+                break
+            chain.append(parent)
+
+        for branch in reversed(chain):
+            self.commits[branch][0] = target_commit
+            for commit in self.commits[branch][1:]:
+                commit.branch_point = target_commit.branch_point or target_commit.identifier
+                if target_commit.branch_point:
+                    commit.identifier += target_commit.identifier
+            target_commit = self.commits[branch][-1]
+        self.head = self.commits[head][-1]  # 'git rebase --onto <onto> <base> <branch>' checks out <branch>
         return mocks.ProcessCompletion(returncode=0)
 
     def pull(self, autostash=False):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -57,6 +57,7 @@ from .review import Review
 from .setup_git_svn import SetupGitSvn
 from .setup import Setup
 from .show import Show
+from .stack import Stack
 from .trace import Trace
 from .track import Track
 from .tracker_metadata import TrackerMetadata
@@ -104,7 +105,7 @@ def main(
         PullRequest, Revert, Review, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
         Pickable, CherryPick, Trace, Track, TrackerMetadata, Show, Publish,
-        Classify, InstallHooks,
+        Classify, InstallHooks, Stack,
     ] + (programs or [])
     if subversion:
         programs.append(SetupGitSvn)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py
@@ -22,8 +22,8 @@
 
 import sys
 
-from .branch import Branch
 from .command import Command
+from .stack import Stack
 from webkitcorepy import arguments
 from webkitscmpy import local
 
@@ -59,6 +59,12 @@ class Pull(Command):
                 if rmt in bp_remotes:
                     remote = rmt
                     break
+
+            if (members := Stack.members(repository, repository.branch)) is None:
+                return 1
+            if len(members) > 1:
+                return Stack.rebase(repository, remote=remote, prune=args.prune)
+
             return repository.pull(rebase=True, branch=branch_point.branch, remote=remote, prune=args.prune)
         if args.prune is not None:
             sys.stderr.write("'prune' arguments only valid for 'git' checkouts\n")

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack.py
@@ -20,12 +20,17 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
+import re
 import sys
 
+from collections import namedtuple
 from .command import Command
 
-from webkitcorepy import run
+from webkitcorepy import run, Version
 from webkitscmpy import local, log
+
+Rebase = namedtuple('Rebase', ('branch', 'onto', 'base', 'update_refs'))
 
 
 class Stack(Command):
@@ -33,10 +38,16 @@ class Stack(Command):
     help = 'Manage a stack of dependent development branches'
 
     PARENT_KEY = 'stack-parent'
+    BASE_KEY = 'stack-base'
     HEADER = 'Stacked pull requests, bottom of the stack first:'
+    UPDATE_REFS_VERSION = Version(2, 38)
 
     @classmethod
     def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            '--rebase', dest='rebase', action='store_true', default=False,
+            help='Rebase every branch in the stack onto the branch beneath it',
+        )
         parser.add_argument(
             '--on', '--stacked-on',
             dest='parent', type=str, default=None,
@@ -49,12 +60,29 @@ class Stack(Command):
         )
         parser.add_argument(
             '--remote', dest='remote', type=str, default=None,
-            help="Look for the stack's pull requests on the provided remote",
+            help='Rebase the bottom of the stack on the production branch of the provided remote',
         )
 
     @classmethod
-    def _key_for(cls, branch):
-        return f'branch.{branch}.{cls.PARENT_KEY}'
+    def _key_for(cls, branch, key=None):
+        return f'branch.{branch}.{key or cls.PARENT_KEY}'
+
+    @classmethod
+    def _base(cls, git, branch):
+        """The parent's tip as of the last time 'branch' was known to sit on top of it."""
+        return git.config().get(cls._key_for(branch, cls.BASE_KEY)) or None
+
+    @classmethod
+    def _set_base(cls, git, branch, parent):
+        if not (tip := git.commit(branch=parent, include_log=False, include_identifier=False)):
+            sys.stderr.write(f"Failed to resolve the tip of '{parent}'\n")
+            return 1
+        command = [git.executable(), 'config', cls._key_for(branch, cls.BASE_KEY), tip.hash]
+        if run(command, cwd=git.root_path, capture_output=True).returncode:
+            sys.stderr.write(f"Failed to record where '{branch}' sits on '{parent}'\n")
+            return 1
+        git.config(cached=False)
+        return 0
 
     @classmethod
     def _parent(cls, git, branch):
@@ -72,23 +100,20 @@ class Stack(Command):
 
     @classmethod
     def _set_parent(cls, git, branch, parent):
-        if run(
-            [git.executable(), 'config', cls._key_for(branch), parent],
-            cwd=git.root_path, capture_output=True,
-        ).returncode:
+        command = [git.executable(), 'config', cls._key_for(branch), parent]
+        if run(command, cwd=git.root_path, capture_output=True).returncode:
             sys.stderr.write(f"Failed to record that '{branch}' is stacked on '{parent}'\n")
             return 1
         git.config(cached=False)
-        return 0
+        return cls._set_base(git, branch, parent)
 
     @classmethod
     def _unset_parent(cls, git, branch):
-        if run(
-            [git.executable(), 'config', '--unset', cls._key_for(branch)],
-            cwd=git.root_path, capture_output=True,
-        ).returncode:
-            sys.stderr.write(f"Failed to forget which branch '{branch}' is stacked on\n")
-            return 1
+        for key in (cls.PARENT_KEY, cls.BASE_KEY):
+            command = [git.executable(), 'config', '--unset', cls._key_for(branch, key)]
+            if run(command, cwd=git.root_path, capture_output=True).returncode and key == cls.PARENT_KEY:
+                sys.stderr.write(f"Failed to forget which branch '{branch}' is stacked on\n")
+                return 1
         git.config(cached=False)
         return 0
 
@@ -149,7 +174,7 @@ class Stack(Command):
         return result
 
     @classmethod
-    def _members(cls, git, branch):
+    def members(cls, git, branch):
         if (below := cls._ancestors(git, branch)) is None:
             return None
         root = below[0] if below else branch
@@ -170,7 +195,7 @@ class Stack(Command):
 
     @classmethod
     def _describe(cls, git, branch, remote_repo=None):
-        if (members := cls._members(git, branch)) is None:
+        if (members := cls.members(git, branch)) is None:
             return None
         if len(members) < 2:
             return []
@@ -195,6 +220,99 @@ class Stack(Command):
             described = f" ({', '.join(annotations)})" if annotations else ''
             lines.append(f"{'    ' * depth[member]}- {number}{member}{described}")
         return lines
+
+    @classmethod
+    def _supports_update_refs(cls, git):
+        """git rebase --update-ref is available in 2.38."""
+        result = run([git.executable(), '--version'], cwd=git.root_path, capture_output=True, encoding='utf-8')
+        if result.returncode or not (match := re.search(r'(\d+)\.(\d+)(?:\.(\d+))?', result.stdout)):
+            return False
+        return Version(*[int(group) for group in match.groups(default='0')]) >= cls.UPDATE_REFS_VERSION
+
+    @classmethod
+    def _is_contiguous(cls, git, branch, parent):
+        """Whether 'branch' still descends from its parent's tip, so both can replay in one rebase."""
+        tip = git.commit(branch=parent, include_log=False, include_identifier=False)
+        return bool(tip) and cls._base(git, branch) == tip.hash
+
+    @classmethod
+    def _rebase_plan(cls, git, members, trunk, branch_point) -> list[Rebase]:
+        """One rebase per run of branches that can replay together, bottom of the stack first."""
+        def rebase_for(member, parent):
+            if member == members[0]:
+                return Rebase(member, trunk, branch_point.hash, False)
+            return Rebase(member, parent, cls._base(git, member) or parent, False)
+
+        result = []
+        update_refs = cls._supports_update_refs(git)
+
+        for member in members:
+            parent = cls._parent(git, member)
+            is_first_child = result and result[-1].branch == parent
+
+            if update_refs and is_first_child and cls._is_contiguous(git, member, parent):
+                result[-1] = result[-1]._replace(branch=member, update_refs=True)
+            else:
+                result.append(rebase_for(member, parent))
+        return result
+
+    @classmethod
+    def rebase(cls, git, remote=None, prune=None):
+        # CHECKS
+        if not (branch := git.branch):
+            sys.stderr.write('HEAD is not on a branch, so there is no stack to rebase\n')
+            if any(os.path.isdir(os.path.join(git.git_directory, candidate)) for candidate in ('rebase-merge', 'rebase-apply')):
+                sys.stderr.write("Finish the rebase in progress with 'git rebase --continue' or 'git rebase --abort'\n")
+            return 1
+
+        if (members := cls.members(git, branch)) is None:
+            return 1
+
+        remote = remote or git.default_remote
+        root = members[0]
+        if not (branch_point := git.branch_point(ref=root)):
+            sys.stderr.write(f"Failed to determine where '{root}' diverged from a production branch\n")
+            return 1
+
+        if git.branch != branch_point.branch and not git.is_worktree and git.fetch(
+            branch=branch_point.branch, remote=remote, prune=prune,
+        ):
+            sys.stderr.write(f"Failed to fetch '{branch_point.branch}' from '{remote}'\n")
+            return 1
+
+        # REBASE
+        trunk = f'remotes/{remote}/{branch_point.branch}'
+        plan = cls._rebase_plan(git, members, trunk, branch_point)
+        for step in plan:
+            if cls._rebase_onto(git, step):
+                return 1
+
+        for member in members[1:]:
+            if cls._set_base(git, member, cls._parent(git, member)):
+                return 1
+
+        # CLEANUP
+        command = [git.executable(), 'checkout', branch]
+        if plan[-1].branch != branch and run(command, cwd=git.root_path, capture_output=True).returncode:
+            sys.stderr.write(f"Failed to return to '{branch}'\n")
+            return 1
+        return 0
+
+    @classmethod
+    def _rebase_onto(cls, git, step):
+        log.info(f"Rebasing '{step.branch}' on '{step.onto}'...")
+        command = [git.executable(), 'rebase', '--onto', step.onto, step.base, step.branch, '--autostash']
+        if step.update_refs:
+            command.append('--update-refs')
+
+        if run(command, cwd=git.root_path).returncode:
+            sys.stderr.write(f"Failed to rebase '{step.branch}' on '{step.onto},' please resolve conflicts\n")
+            sys.stderr.write(
+                f"Then run 'git rebase --continue' followed by "
+                f"'{os.path.basename(sys.argv[0])} stack --rebase' to replay the rest of the stack\n"
+            )
+            return 1
+        return 0
 
     @classmethod
     def main(cls, args, repository, **kwargs):
@@ -231,6 +349,9 @@ class Stack(Command):
                 return 1
             print(f"'{branch}' is no longer stacked on another branch")
             return 0
+
+        if args.rebase and (result := cls.rebase(git, remote=args.remote)):
+            return result
 
         remote_repo = git.remote(name=args.remote or git.default_remote)
         if (lines := cls._describe(git, branch, remote_repo=remote_repo)) is None:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack.py
@@ -1,0 +1,242 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+from .command import Command
+
+from webkitcorepy import run
+from webkitscmpy import local, log
+
+
+class Stack(Command):
+    name = 'stack'
+    help = 'Manage a stack of dependent development branches'
+
+    PARENT_KEY = 'stack-parent'
+    HEADER = 'Stacked pull requests, bottom of the stack first:'
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            '--on', '--stacked-on',
+            dest='parent', type=str, default=None,
+            help='Record that the current development branch is stacked on the provided branch',
+        )
+        parser.add_argument(
+            '--unstack',
+            dest='unstack', action='store_true', default=False,
+            help='Forget which branch the current development branch is stacked on',
+        )
+        parser.add_argument(
+            '--remote', dest='remote', type=str, default=None,
+            help="Look for the stack's pull requests on the provided remote",
+        )
+
+    @classmethod
+    def _key_for(cls, branch):
+        return f'branch.{branch}.{cls.PARENT_KEY}'
+
+    @classmethod
+    def _parent(cls, git, branch):
+        if not isinstance(git, local.Git) or not branch:
+            return None
+
+        candidate = git.config().get(cls._key_for(branch))
+        if not candidate or candidate == branch:
+            return None
+
+        if candidate not in git.branches_for(remote=False):
+            log.warning(f"'{branch}' is stacked on '{candidate}', which no longer exists in this checkout")
+            return None
+        return candidate
+
+    @classmethod
+    def _set_parent(cls, git, branch, parent):
+        if run(
+            [git.executable(), 'config', cls._key_for(branch), parent],
+            cwd=git.root_path, capture_output=True,
+        ).returncode:
+            sys.stderr.write(f"Failed to record that '{branch}' is stacked on '{parent}'\n")
+            return 1
+        git.config(cached=False)
+        return 0
+
+    @classmethod
+    def _unset_parent(cls, git, branch):
+        if run(
+            [git.executable(), 'config', '--unset', cls._key_for(branch)],
+            cwd=git.root_path, capture_output=True,
+        ).returncode:
+            sys.stderr.write(f"Failed to forget which branch '{branch}' is stacked on\n")
+            return 1
+        git.config(cached=False)
+        return 0
+
+    @classmethod
+    def _resolve_parent(cls, git, candidate, branch=None):
+        from .branch import Branch
+
+        branches = git.branches_for(remote=False)
+        if candidate not in branches:
+            candidate = Branch.normalize_branch_name(candidate, repository=git)
+            if candidate not in branches:
+                sys.stderr.write(f"'{candidate}' does not exist in this checkout\n")
+                return None
+
+        if not git.dev_branches.match(candidate):
+            sys.stderr.write(f"'{candidate}' is not a development branch, a branch cannot be stacked on it\n")
+            return None
+
+        if candidate == branch:
+            sys.stderr.write(f"'{branch}' cannot be stacked on itself\n")
+            return None
+        return candidate
+
+    @classmethod
+    def _children(cls, git, branch):
+        prefix, suffix = 'branch.', f'.{cls.PARENT_KEY}'
+        result = []
+        for key, value in git.config().items():
+            if value != branch or not key.startswith(prefix) or not key.endswith(suffix):
+                continue
+            candidate = key[len(prefix):-len(suffix)]
+            if cls._parent(git, candidate) == branch:
+                result.append(candidate)
+        return sorted(result)
+
+    @classmethod
+    def _ancestors(cls, git, branch):
+        result = []
+        candidate = branch
+        while candidate := cls._parent(git, candidate):
+            if candidate == branch or candidate in result:
+                sys.stderr.write(f"'{candidate}' is part of a cycle of stacked branches\n")
+                return None
+            result.append(candidate)
+        return result[::-1]  # Bottom of stack to top
+
+    @classmethod
+    def _descendants(cls, git, branch):  # DFS so children come before siblings
+        result = []
+        stack = list(reversed(cls._children(git, branch)))
+        while stack:
+            candidate = stack.pop()
+            if candidate == branch or candidate in result:
+                sys.stderr.write(f"'{candidate}' is part of a cycle of stacked branches\n")
+                return None
+            result.append(candidate)
+            stack.extend(reversed(cls._children(git, candidate)))
+        return result
+
+    @classmethod
+    def _members(cls, git, branch):
+        if (below := cls._ancestors(git, branch)) is None:
+            return None
+        root = below[0] if below else branch
+        if (above := cls._descendants(git, root)) is None:
+            return None
+        return [root] + above
+
+    @classmethod
+    def _pull_request_for(cls, git, branch, remote_repo):
+        if not remote_repo or not remote_repo.pull_requests:
+            return None
+        if not git.config().get(f'branch.{branch}.target'):
+            return None
+
+        # Avoids a circular import
+        from .pull_request import PullRequest
+        return PullRequest.find_existing_pull_request(git, remote_repo, branch=branch)
+
+    @classmethod
+    def _describe(cls, git, branch, remote_repo=None):
+        if (members := cls._members(git, branch)) is None:
+            return None
+        if len(members) < 2:
+            return []
+
+        depth = {}
+        lines = [cls.HEADER]
+        for member in members:
+            depth[member] = depth.get(cls._parent(git, member), -1) + 1
+            pull_request = cls._pull_request_for(git, member, remote_repo)
+
+            annotations = []
+            if member == branch:
+                annotations.append('this pull request')
+            elif remote_repo and not pull_request:
+                annotations.append('not uploaded')
+            elif pull_request and pull_request.merged:
+                annotations.append('merged')
+            elif pull_request and pull_request.opened is False:
+                annotations.append('closed')
+
+            number = f'#{pull_request.number} ' if pull_request else ''
+            described = f" ({', '.join(annotations)})" if annotations else ''
+            lines.append(f"{'    ' * depth[member]}- {number}{member}{described}")
+        return lines
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        if not isinstance(repository, local.Git):
+            sys.stderr.write(f"Can only '{cls.name}' on a native Git repository\n")
+            return 1
+
+        git = repository
+        branch = git.branch
+        if args.parent and args.unstack:
+            sys.stderr.write(f"Cannot both set and unset the branch '{branch}' is stacked on\n")
+            return 1
+
+        if args.parent:
+            if not git.is_suitable_branch_for_pull_request(branch, args.remote or git.default_remote):
+                sys.stderr.write(f"'{branch}' is not a development branch, it cannot be stacked on another branch\n")
+                return 1
+            if not (parent := cls._resolve_parent(git, args.parent, branch=branch)):
+                return 1
+            if (descendants := cls._descendants(git, branch)) is None:
+                return 1
+            if parent in descendants:
+                sys.stderr.write(
+                    f"'{parent}' is stacked on '{branch},' stacking '{branch}' on it would create a cycle\n"
+                )
+                return 1
+            if cls._set_parent(git, branch, parent):
+                return 1
+            print(f"'{branch}' is stacked on '{parent}'")
+            return 0
+
+        if args.unstack:
+            if cls._unset_parent(git, branch):
+                return 1
+            print(f"'{branch}' is no longer stacked on another branch")
+            return 0
+
+        remote_repo = git.remote(name=args.remote or git.default_remote)
+        if (lines := cls._describe(git, branch, remote_repo=remote_repo)) is None:
+            return 1
+        if not lines:
+            print(f"'{branch}' is not part of a stack")
+            return 0
+        print('\n'.join(lines))
+        return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_unittest.py
@@ -20,6 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import os
 from unittest.mock import patch
 
@@ -71,6 +72,13 @@ class TestStack(testing.PathTestCase):
         repo.head = repo.commits['eng/child'][-1]
         return repo
 
+    @classmethod
+    def record_into(cls, recorded):
+        def capture(git, step):
+            recorded.append(step)
+            return 0
+        return capture
+
     def test_set_parent(self):
         with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
                 patch('webkitbugspy.Tracker._trackers', []), MockTime:
@@ -78,9 +86,12 @@ class TestStack(testing.PathTestCase):
             self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
             # Recording the same parent again is not an error
             self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+
+            config = local.Git(self.path).config()
+            self.assertEqual(config.get('branch.eng/child.stack-parent'), 'eng/parent')
             self.assertEqual(
-                local.Git(self.path).config().get('branch.eng/child.stack-parent'),
-                'eng/parent',
+                config.get('branch.eng/child.stack-base'),
+                repo.commits['eng/parent'][-1].hash,
             )
 
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -222,7 +233,10 @@ class TestStack(testing.PathTestCase):
             self.add_stack(repo)
             self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
             self.assertEqual(0, program.main(args=('stack', '--unstack'), path=self.path))
-            self.assertIsNone(local.Git(self.path).config().get('branch.eng/child.stack-parent'))
+
+            config = local.Git(self.path).config()
+            self.assertIsNone(config.get('branch.eng/child.stack-parent'))
+            self.assertIsNone(config.get('branch.eng/child.stack-base'))
 
         self.assertEqual(captured.stderr.getvalue(), '')
         self.assertEqual(
@@ -334,3 +348,181 @@ class TestStack(testing.PathTestCase):
             self.assertEqual(1, program.main(args=('stack',), path=self.path))
 
         self.assertIn('is part of a cycle of stacked branches\n', captured.stderr.getvalue())
+
+    def test_rebase(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+
+            landed = Commit(
+                hash='c37b6b6ba1c99f2b4c6b53c1e1a1e0c9f3f2bd3d',
+                branch='main',
+                author=CONTRIBUTOR,
+                identifier='6@main',
+                timestamp=1601670000,
+                message='[Testing] Landed on main\n',
+            )
+            repo.commits['main'].append(landed)
+            repo.remotes['origin/main'] = repo.commits['main'][:]
+
+            repo.head = repo.commits['eng/parent'][-1]
+            self.assertEqual(0, program.main(args=('stack', '--rebase', '-v'), path=self.path))
+            self.assertEqual(repo.commits['eng/parent'][0].hash, landed.hash)
+            self.assertEqual(repo.commits['eng/child'][0].hash, repo.commits['eng/parent'][-1].hash)
+
+            # The run ends on top of the stack, so the cascade has to come back
+            self.assertEqual(repo.head.branch, 'eng/parent')
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            [line for line in captured.root.log.getvalue().splitlines() if 'Mock process' not in line],
+            ["Rebasing 'eng/child' on 'remotes/origin/main'..."],
+        )
+
+    def test_rebase_falls_back_when_git_cannot_update_refs(self):
+        recorded = []
+
+        with OutputCapture(level=logging.INFO), mocks.local.Git(self.path, git_version='2.37.0') as repo, \
+                mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+
+            with patch.object(program.Stack, '_rebase_onto', self.record_into(recorded)):
+                self.assertEqual(0, program.Stack.rebase(local.Git(self.path)))
+
+        # Without '--update-refs' every branch has to be replayed on its own
+        self.assertEqual(
+            [(branch, update_refs) for branch, _, _, update_refs in recorded],
+            [('eng/parent', False), ('eng/child', False)],
+        )
+
+    def test_rebase_records_missing_base(self):
+        with OutputCapture(level=logging.INFO), mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+
+            # A stack recorded before stack-base existed, or one whose base was hand-removed
+            repo.edit_config('branch.eng/child.stack-base', None)
+            self.assertIsNone(local.Git(self.path).config().get('branch.eng/child.stack-base'))
+
+            self.assertEqual(0, program.main(args=('stack', '--rebase'), path=self.path))
+
+            self.assertEqual(
+                local.Git(self.path).config().get('branch.eng/child.stack-base'),
+                repo.commits['eng/parent'][-1].hash,
+            )
+
+    def test_rebase_uses_recorded_base(self):
+        recorded = []
+
+        with OutputCapture(level=logging.INFO), mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            base = local.Git(self.path).config().get('branch.eng/child.stack-base')
+
+            # Amending the parent rewrites its tip, so the child no longer descends from it
+            repo.commits['eng/parent'][-1] = Commit(
+                hash='9a1c0e5f4b7d2a8e3c6b1f0d9e8a7c5b4d3e2f10',
+                branch='eng/parent',
+                author=CONTRIBUTOR,
+                identifier='5.1@eng/parent',
+                timestamp=1601668500,
+                message='[Testing] Parent change, amended\n',
+            )
+
+            with patch.object(program.Stack, '_rebase_onto', self.record_into(recorded)):
+                self.assertEqual(0, program.Stack.rebase(local.Git(self.path)))
+
+            # The child replays from the parent's tip as of the last cascade rather than being swept
+            # into the parent's rebase, which is what lets an amended parent be recovered from
+            self.assertEqual(recorded[-1], ('eng/child', 'eng/parent', base, False))
+
+    def test_rebase_branches_from_the_fork_point(self):
+        recorded = []
+
+        with OutputCapture(level=logging.INFO), mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            repo.commits['eng/sibling'] = [
+                repo.commits['eng/parent'][-1],
+                Commit(
+                    hash='2f0c1cbb7e5b6f2a3ba0a4c1e0f79c1c7d4a3b12',
+                    branch='eng/sibling',
+                    author=CONTRIBUTOR,
+                    identifier='5.2@eng/sibling',
+                    timestamp=1601669500,
+                    message='[Testing] Sibling change\n',
+                ),
+            ]
+            repo.head = repo.commits['eng/sibling'][-1]
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            fork = local.Git(self.path).config().get('branch.eng/sibling.stack-base')
+
+            repo.commits['eng/nephew'] = [
+                repo.commits['eng/sibling'][-1],
+                Commit(
+                    hash='7d1e4a9c0b5f3e8a2d6c4b1f9e0a8c7b5d3f2e14',
+                    branch='eng/nephew',
+                    author=CONTRIBUTOR,
+                    identifier='5.3@eng/nephew',
+                    timestamp=1601669800,
+                    message='[Testing] Nephew change\n',
+                ),
+            ]
+            repo.head = repo.commits['eng/nephew'][-1]
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/sibling'), path=self.path))
+
+            repo.head = repo.commits['eng/child'][-1]
+            with patch.object(program.Stack, '_rebase_onto', self.record_into(recorded)):
+                self.assertEqual(0, program.Stack.rebase(local.Git(self.path)))
+
+            # The first leaf carries the shared parent with it, so the second subtree replays from
+            # where it forked rather than sweeping the parent in a second time, and then batches
+            self.assertEqual(recorded, [
+                ('eng/child', 'remotes/origin/main', repo.commits['main'][-1].hash, True),
+                ('eng/nephew', 'eng/parent', fork, True),
+            ])
+
+            repo.remotes['origin/main'] = repo.commits['main'][:]
+            self.assertEqual(0, program.Stack.rebase(local.Git(self.path)))
+
+            # The cascade ends on top of the last run, so it has to come back
+            self.assertEqual(repo.head.branch, 'eng/child')
+
+    def test_rebase_refuses_detached_head(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path, detached=True) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(1, program.main(args=('stack', '--rebase'), path=self.path))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'HEAD is not on a branch, so there is no stack to rebase\n',
+        )
+
+    def test_pull_cascades_stack(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            self.assertEqual(0, program.main(args=('pull', '-v'), path=self.path))
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            [line for line in captured.root.log.getvalue().splitlines() if 'Mock process' not in line],
+            ["Rebasing 'eng/child' on 'remotes/origin/main'..."],
+        )
+
+    def test_pull_unstacked_branch_unchanged(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_parent(repo)
+            repo.head = repo.commits['eng/parent'][-1]
+            self.assertEqual(0, program.main(args=('pull', '-v'), path=self.path))
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertNotIn('Rebasing', captured.root.log.getvalue())

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_unittest.py
@@ -1,0 +1,336 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+from unittest.mock import patch
+
+from webkitcorepy import OutputCapture, testing
+from webkitcorepy.mocks import Time as MockTime
+
+from webkitscmpy import Commit, local, mocks, program
+
+CONTRIBUTOR = {'name': 'Tim Contributor', 'emails': ['tcontributor@example.com']}
+
+
+class TestStack(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self):
+        super().setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    @classmethod
+    def add_parent(cls, repo):
+        repo.commits['eng/parent'] = [
+            repo.commits[repo.default_branch][-1],
+            Commit(
+                hash='06de5d56554e693db72313f4ca1fb969c30b8ccb',
+                branch='eng/parent',
+                author=CONTRIBUTOR,
+                identifier='5.1@eng/parent',
+                timestamp=1601668000,
+                message='[Testing] Parent change\n',
+            ),
+        ]
+        return repo
+
+    @classmethod
+    def add_stack(cls, repo):
+        cls.add_parent(repo)
+        repo.commits['eng/child'] = [
+            repo.commits['eng/parent'][-1],
+            Commit(
+                hash='b8b921baaad2fd10bc9d0cc9e97f8fa1d6e5f4a1',
+                branch='eng/child',
+                author=CONTRIBUTOR,
+                identifier='5.2@eng/child',
+                timestamp=1601669000,
+                message='[Testing] Child change\n',
+            ),
+        ]
+        repo.head = repo.commits['eng/child'][-1]
+        return repo
+
+    def test_set_parent(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            # Recording the same parent again is not an error
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            self.assertEqual(
+                local.Git(self.path).config().get('branch.eng/child.stack-parent'),
+                'eng/parent',
+            )
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "'eng/child' is stacked on 'eng/parent'\n" * 2,
+        )
+
+    def test_set_parent_missing(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(1, program.main(args=('stack', '--on', 'eng/missing'), path=self.path))
+
+        self.assertEqual(captured.stderr.getvalue(), "'eng/missing' does not exist in this checkout\n")
+
+    def test_set_parent_production(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(1, program.main(args=('stack', '--on', 'main'), path=self.path))
+            self.assertIsNone(local.Git(self.path).config().get('branch.eng/child.stack-parent'))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "'main' is not a development branch, a branch cannot be stacked on it\n",
+        )
+
+    def test_set_parent_self(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(1, program.main(args=('stack', '--on', 'eng/child'), path=self.path))
+
+        self.assertEqual(captured.stderr.getvalue(), "'eng/child' cannot be stacked on itself\n")
+
+    def test_set_parent_self_with_child(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+
+            # 'eng/parent' already has 'eng/child' stacked on it, which must not be reported
+            # in place of the branch being stacked on itself
+            repo.head = repo.commits['eng/parent'][-1]
+            self.assertEqual(1, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "'eng/parent' cannot be stacked on itself\n",
+        )
+
+    def test_set_parent_cycle(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            repo.head = repo.commits['eng/parent'][-1]
+            self.assertEqual(1, program.main(args=('stack', '--on', 'eng/child'), path=self.path))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "'eng/child' is stacked on 'eng/parent,' stacking 'eng/parent' on it would create a cycle\n",
+        )
+
+    def test_set_parent_refuses_a_cycle_above(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_parent(repo)
+            repo.commits['eng/child'] = [
+                repo.commits['eng/parent'][-1],
+                Commit(
+                    hash='b8b921baaad2fd10bc9d0cc9e97f8fa1d6e5f4a1',
+                    branch='eng/child',
+                    author=CONTRIBUTOR,
+                    identifier='5.2@eng/child',
+                    timestamp=1601669000,
+                    message='[Testing] Child change\n',
+                ),
+            ]
+            repo.commits['eng/other'] = [
+                repo.commits[repo.default_branch][-1],
+                Commit(
+                    hash='9d1a3f6c2b8e4d5a7c0f1e2b3a4d5c6e7f809123',
+                    branch='eng/other',
+                    author=CONTRIBUTOR,
+                    identifier='5.1@eng/other',
+                    timestamp=1601669500,
+                    message='[Testing] Other change\n',
+                ),
+            ]
+            repo.head = repo.commits['eng/parent'][-1]
+
+            # Hand-written config where two branches are stacked on each other. The walk up
+            # from 'eng/parent' finds the cycle before the walk down from it ever runs.
+            repo.edit_config('branch.eng/child.stack-parent', 'eng/parent')
+            repo.edit_config('branch.eng/parent.stack-parent', 'eng/child')
+
+            self.assertEqual(1, program.main(args=('stack', '--on', 'eng/other'), path=self.path))
+
+        self.assertIn('is part of a cycle of stacked branches\n', captured.stderr.getvalue())
+
+    def test_set_parent_branching(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            repo.commits['eng/sibling'] = [
+                repo.commits['eng/parent'][-1],
+                Commit(
+                    hash='2f0c1cbb7e5b6f2a3ba0a4c1e0f79c1c7d4a3b12',
+                    branch='eng/sibling',
+                    author=CONTRIBUTOR,
+                    identifier='5.2@eng/sibling',
+                    timestamp=1601669500,
+                    message='[Testing] Sibling change\n',
+                ),
+            ]
+            repo.head = repo.commits['eng/sibling'][-1]
+
+            # Two branches may be stacked on the same branch
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "'eng/child' is stacked on 'eng/parent'\n"
+            "'eng/sibling' is stacked on 'eng/parent'\n"
+            'Stacked pull requests, bottom of the stack first:\n'
+            '- eng/parent\n'
+            '    - eng/child\n'
+            '    - eng/sibling (this pull request)\n',
+        )
+
+    def test_unstack(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            self.assertEqual(0, program.main(args=('stack', '--unstack'), path=self.path))
+            self.assertIsNone(local.Git(self.path).config().get('branch.eng/child.stack-parent'))
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "'eng/child' is stacked on 'eng/parent'\n"
+            "'eng/child' is no longer stacked on another branch\n",
+        )
+
+    def test_parent_deleted(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            del repo.commits['eng/parent']
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "'eng/child' is stacked on 'eng/parent'\n"
+            "'eng/child' is not part of a stack\n",
+        )
+
+    def test_listing(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            self.assertEqual(0, program.main(args=('stack', '--on', 'eng/parent'), path=self.path))
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+            # The whole stack is listed from either end, only the marked branch moves
+            repo.head = repo.commits['eng/parent'][-1]
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "'eng/child' is stacked on 'eng/parent'\n"
+            'Stacked pull requests, bottom of the stack first:\n'
+            '- eng/parent\n'
+            '    - eng/child (this pull request)\n'
+            'Stacked pull requests, bottom of the stack first:\n'
+            '- eng/parent (this pull request)\n'
+            '    - eng/child\n',
+        )
+
+    def test_listing_not_stacked(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_parent(repo)
+            repo.head = repo.commits['eng/parent'][-1]
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.stdout.getvalue(), "'eng/parent' is not part of a stack\n")
+
+    def test_listing_nests_a_deeper_sibling(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            repo.commits['eng/grandchild'] = [
+                repo.commits['eng/child'][-1],
+                Commit(
+                    hash='7c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f60718293',
+                    branch='eng/grandchild',
+                    author=CONTRIBUTOR,
+                    identifier='5.3@eng/grandchild',
+                    timestamp=1601670000,
+                    message='[Testing] Grandchild change\n',
+                ),
+            ]
+            repo.commits['eng/sibling'] = [
+                repo.commits['eng/parent'][-1],
+                Commit(
+                    hash='2f0c1cbb7e5b6f2a3ba0a4c1e0f79c1c7d4a3b12',
+                    branch='eng/sibling',
+                    author=CONTRIBUTOR,
+                    identifier='5.2@eng/sibling',
+                    timestamp=1601669500,
+                    message='[Testing] Sibling change\n',
+                ),
+            ]
+            repo.edit_config('branch.eng/child.stack-parent', 'eng/parent')
+            repo.edit_config('branch.eng/grandchild.stack-parent', 'eng/child')
+            repo.edit_config('branch.eng/sibling.stack-parent', 'eng/parent')
+            repo.head = repo.commits['eng/parent'][-1]
+
+            self.assertEqual(0, program.main(args=('stack',), path=self.path))
+
+        # 'eng/grandchild' is deeper than 'eng/sibling', so it has to follow the branch it is
+        # stacked on rather than whichever branch was listed immediately before it
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Stacked pull requests, bottom of the stack first:\n'
+            '- eng/parent (this pull request)\n'
+            '    - eng/child\n'
+            '        - eng/grandchild\n'
+            '    - eng/sibling\n',
+        )
+
+    def test_listing_refuses_a_cycle_above(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), \
+                patch('webkitbugspy.Tracker._trackers', []), MockTime:
+            self.add_stack(repo)
+            # Hand-written config can stack two branches on each other
+            repo.edit_config('branch.eng/child.stack-parent', 'eng/parent')
+            repo.edit_config('branch.eng/parent.stack-parent', 'eng/child')
+
+            self.assertEqual(1, program.main(args=('stack',), path=self.path))
+
+        self.assertIn('is part of a cycle of stacked branches\n', captured.stderr.getvalue())


### PR DESCRIPTION
#### a4d4fbba9aeaaec3e38013549ba81b32aa8b6c43
<pre>
[git-webkit] Rebase a stack of pull requests onto the branch beneath each one
<a href="https://bugs.webkit.org/show_bug.cgi?id=321657">https://bugs.webkit.org/show_bug.cgi?id=321657</a>
<a href="https://rdar.apple.com/184785789">rdar://184785789</a>

Reviewed by NOBODY (OOPS!).

`claude` summary:

Amending or rebasing a branch in a stack rewrites its tip, which leaves every
branch above it sitting on a commit that no longer exists. Recovering means
rebasing each descendant by hand, from the bottom of the stack up, and picking
the base by eye: replaying a branch from its parent&apos;s new tip re-applies the
parent&apos;s own commits, while replaying from the parent&apos;s old tip only works
while that commit is still reachable.

Record the parent&apos;s tip in branch.&lt;name&gt;.stack-base when the parent is
recorded, and refresh it once the stack has been replayed. A branch can then be
rebased with &apos;--onto &lt;parent&gt; &lt;recorded base&gt;&apos;, which moves that branch&apos;s
commits and nothing else.

Since 2.38 git can move a stack&apos;s intermediate branch refs itself, so replay
each run of branches that are still stacked directly on each other in a single
rebase with &apos;--update-refs&apos; rather than one rebase per branch. Nothing moves
until the run finishes and a single &apos;git rebase --continue&apos; completes it, so a
conflict part way up a run no longer leaves the stack half replayed. A branch
whose recorded base no longer matches its parent&apos;s tip, which is what an
amended parent leaves behind, begins a new run so that it still replays from
the base it was stacked at instead of being swept into its parent&apos;s range along
with the commits it no longer descends from. Older versions of git fall back to
one rebase per branch.

Walk the stack depth first so a parent is always replayed before its children,
rebasing the bottom of the stack onto the production branch it diverged from,
and run the cascade from &apos;git-webkit pull&apos; so that a stacked branch is
restacked by the command already used to pull.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py:
(Pull.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack.py: Added.
(Stack):
(Stack.parser):
(Stack._key_for):
(Stack._base):
(Stack._set_base):
(Stack._parent):
(Stack._set_parent):
(Stack._unset_parent):
(Stack._resolve_parent):
(Stack._children):
(Stack._ancestors):
(Stack._descendants):
(Stack.members):
(Stack._pull_request_for):
(Stack._describe):
(Stack.rebase):
(Stack._rebase_onto):
(Stack.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_unittest.py: Added.
(TestStack):
(TestStack.setUp):
(TestStack.add_parent):
(TestStack.add_stack):
(TestStack.test_set_parent):
(TestStack.test_set_parent_missing):
(TestStack.test_set_parent_production):
(TestStack.test_set_parent_self):
(TestStack.test_set_parent_self_with_child):
(TestStack.test_set_parent_cycle):
(TestStack.test_set_parent_refuses_a_cycle_above):
(TestStack.test_set_parent_branching):
(TestStack.test_unstack):
(TestStack.test_parent_deleted):
(TestStack.test_listing):
(TestStack.test_listing_not_stacked):
(TestStack.test_listing_nests_a_deeper_sibling):
(TestStack.test_listing_refuses_a_cycle_above):
(TestStack.test_rebase):
(TestStack.test_rebase_records_missing_base):
(TestStack.test_rebase_uses_recorded_base):
(TestStack.test_rebase_uses_recorded_base.capture):
(TestStack.test_rebase_refuses_detached_head):
(TestStack.test_pull_cascades_stack):
(TestStack.test_pull_unstacked_branch_unchanged):
</pre>
----------------------------------------------------------------------
#### 628af3cd95d2771f970f5f01489d215c8121198a
<pre>
[git-webkit] Add a local model for stacked pull requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=321654">https://bugs.webkit.org/show_bug.cgi?id=321654</a>
<a href="https://rdar.apple.com/184780034">rdar://184780034</a>

Reviewed by NOBODY (OOPS!).

Nothing records that one development branch continues the work of
another, so a change split across several pull requests has to be
tracked by hand, and every descendant re-rebased by hand whenever
an ancestor changes. git-webkit should know which branch a branch
is stacked on and be able to show the resulting stack.

* Record the branch a development branch is stacked on in
  `branch.&lt;name&gt;.stack-parent`, so the relationship is known offline and
  before a pull request exists.
* Add `git-webkit stack` to set that relationship with `--stacked-on`,
  forget it with `--unstack`, and otherwise print the stack the current
  branch belongs to.
* Allow a branch to have several branches stacked on it, and print the
  result as a tree. Stacking a branch on itself, or anywhere that would
  form a cycle, is refused.
* Treat a branch whose parent no longer exists in the checkout as
  unstacked, which is what happens once a parent lands and its branch is
  deleted.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/stack.py: Added.
(Stack):
(Stack.parser):
(Stack._key_for):
(Stack.parent):
(Stack.set_parent):
(Stack.unset_parent):
(Stack.resolve_parent):
(Stack.children):
(Stack._ancestors):
(Stack._descendants):
(Stack.members):
(Stack._pull_request_for):
(Stack.describe):
(Stack.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/stack_unittest.py: Added.
(TestStack):
(TestStack.setUp):
(TestStack.add_parent):
(TestStack.add_stack):
(TestStack.test_set_parent):
(TestStack.test_set_parent_production):
(TestStack.test_set_parent_missing):
(TestStack.test_set_parent_branching):
(TestStack.test_set_parent_repeated):
(TestStack.test_set_parent_self):
(TestStack.test_set_parent_cycle):
(TestStack.test_unstack):
(TestStack.test_listing):
(TestStack.test_listing_from_bottom):
(TestStack.test_listing_not_stacked):
(TestStack.test_parent_deleted):
(TestStack.test_set_parent_self_with_child):
(TestStack.test_listing_refuses_a_cycle_above):
(TestStack.test_set_parent_refuses_a_cycle_above):
(TestStack.test_listing_nests_a_deeper_sibling):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7292becc6350d335822ed455dd8fc8ae881f2f09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146353 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142121 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98681 "3 flakes 17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45797 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162855 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicyWhenSuspendedOrHidden (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122555 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181348 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44481 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42752 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42380 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3414 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194177 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/181425 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55642 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151537 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56333 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151241 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45801 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124435 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54844 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17375 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54225 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54464 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->