### PR TITLE
[Site Isolation] Fix page identifier confusion for some mechanisms driven by UI process API

### DIFF
--- a/Source/WebKit/UIProcess/API/APIUserStyleSheet.cpp
+++ b/Source/WebKit/UIProcess/API/APIUserStyleSheet.cpp
@@ -26,12 +26,23 @@
 #include "config.h"
 #include "APIUserStyleSheet.h"
 
+#include "WebPageProxy.h"
+
 namespace API {
 
-UserStyleSheet::UserStyleSheet(WebCore::UserStyleSheet userStyleSheet, API::ContentWorld& world)
+UserStyleSheet::UserStyleSheet(WebCore::UserStyleSheet userStyleSheet, API::ContentWorld& world, WebKit::WebPageProxy* page)
     : m_userStyleSheet(userStyleSheet)
     , m_world(world)
+    , m_page(page)
+    , m_isPageScoped(!!page)
 {
+}
+
+UserStyleSheet::~UserStyleSheet() = default;
+
+WebKit::WebPageProxy* UserStyleSheet::page() const
+{
+    return m_page.get();
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIUserStyleSheet.h
+++ b/Source/WebKit/UIProcess/API/APIUserStyleSheet.h
@@ -30,19 +30,37 @@
 #include "UserStyleSheetIdentifier.h"
 #include <WebCore/UserStyleSheet.h>
 #include <wtf/Identified.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+class WebPageProxy;
+}
 
 namespace API {
 
 class UserStyleSheet final : public ObjectImpl<Object::Type::UserStyleSheet>, public Identified<WebKit::UserStyleSheetIdentifier> {
 public:
-    static Ref<UserStyleSheet> create(WebCore::UserStyleSheet userStyleSheet, API::ContentWorld& world)
+    static Ref<UserStyleSheet> create(WebCore::UserStyleSheet userStyleSheet, API::ContentWorld& world, WebKit::WebPageProxy* page = nullptr)
     {
-        return adoptRef(*new UserStyleSheet(WTF::move(userStyleSheet), world));
+        return adoptRef(*new UserStyleSheet(WTF::move(userStyleSheet), world, page));
     }
 
-    UserStyleSheet(WebCore::UserStyleSheet, API::ContentWorld&);
+    UserStyleSheet(WebCore::UserStyleSheet, API::ContentWorld&, WebKit::WebPageProxy* = nullptr);
+    ~UserStyleSheet();
 
     const WebCore::UserStyleSheet& userStyleSheet() const LIFETIME_BOUND { return m_userStyleSheet; }
+
+    // The page this sheet is scoped to, or null if it applies to every page using the controller.
+    // Deliberately not a WebCore::PageIdentifier: that names a WebPage in one web content process, and
+    // under site isolation a page has one per process. The identifier is derived from this page for
+    // each destination process in WebUserContentControllerProxy::dataFromUserStyleSheet().
+    WebKit::WebPageProxy* page() const;
+
+    // True if this sheet was created for a specific page. Distinct from page() being non-null: once that
+    // page goes away the sheet must not be sent at all, because a sheet carrying no page identifier means
+    // "apply to every page" to the web process (see ExtensionStyleSheets::updateInjectedStyleSheetCache).
+    bool isPageScoped() const { return m_isPageScoped; }
+    bool isOrphaned() const { return m_isPageScoped && !page(); }
 
     ContentWorld& contentWorld() { return m_world; }
     const ContentWorld& contentWorld() const { return m_world; }
@@ -50,6 +68,8 @@ public:
 private:
     WebCore::UserStyleSheet m_userStyleSheet;
     Ref<ContentWorld> m_world;
+    WeakPtr<WebKit::WebPageProxy> m_page;
+    bool m_isPageScoped { false };
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
@@ -56,7 +56,7 @@
 
     WebKit::InitializeWebKit2();
 
-    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, baseURL, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, WebCore::UserContentMatchParentFrame::Never, API::toWebCoreUserStyleLevel(level), webView ? std::optional<WebCore::PageIdentifier>([webView _page]->webPageIDInMainFrameProcess()) : std::nullopt }, Ref { contentWorld ? *contentWorld->_contentWorld : API::ContentWorld::pageContentWorldSingleton() });
+    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, baseURL, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, WebCore::UserContentMatchParentFrame::Never, API::toWebCoreUserStyleLevel(level), std::nullopt }, Ref { contentWorld ? *contentWorld->_contentWorld : API::ContentWorld::pageContentWorldSingleton() }, webView ? [webView _page].get() : nullptr);
 
     return self;
 }

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -161,14 +161,14 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
             return HashSet<Ref<RemotePageProxy>> { };
         }).iterator->value;
         Ref newRemotePage = RemotePageProxy::create(page, processProxy, site);
-        newRemotePage->injectPageIntoNewProcess();
 #if ASSERT_ENABLED
         for (auto& existingPage : set) {
             ASSERT(existingPage->process().coreProcessIdentifier() != newRemotePage->process().coreProcessIdentifier() || existingPage->site() != newRemotePage->site());
             ASSERT(existingPage->page() == newRemotePage->page());
         }
 #endif
-        set.add(WTF::move(newRemotePage));
+        set.add(newRemotePage.copyRef());
+        newRemotePage->injectPageIntoNewProcess();
     };
 
     if (process.isSharedProcess()) {
@@ -272,14 +272,14 @@ void BrowsingContextGroup::addPage(WebPageProxy& page)
             return false;
         Ref processProxy = process->process();
         Ref newRemotePage = RemotePageProxy::create(page, processProxy, site);
-        newRemotePage->injectPageIntoNewProcess();
 #if ASSERT_ENABLED
         for (auto& existingPage : set) {
             ASSERT(existingPage->process().coreProcessIdentifier() != newRemotePage->process().coreProcessIdentifier() || existingPage->site() != newRemotePage->site());
             ASSERT(existingPage->page() == newRemotePage->page());
         }
 #endif
-        set.add(WTF::move(newRemotePage));
+        set.add(newRemotePage.copyRef());
+        newRemotePage->injectPageIntoNewProcess();
         return false;
     });
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm
@@ -75,13 +75,9 @@ void WebExtensionContext::offscreenCreateDocument(const WebExtensionOffscreenDoc
     m_offscreenWebView.get().inspectable = m_inspectable;
 
     Ref offscreenPage = *m_offscreenWebView.get()._page;
-    Ref offscreenProcess = offscreenPage->siteIsolatedProcess();
 
     constexpr ASCIILiteral activityName = "Web Extension offscreen document"_s;
-    if (protect(offscreenPage->preferences())->siteIsolationEnabled())
-        m_offscreenWebViewActivity = protect(offscreenPage->activityGroupContext())->foregroundProcessActivityGroup(activityName);
-    else
-        m_offscreenWebViewActivity = protect(offscreenProcess->throttler())->foregroundActivity(activityName);
+    m_offscreenWebViewActivity = protect(offscreenPage->activityGroupContext())->foregroundProcessActivityGroup(activityName);
 
     [m_offscreenWebView loadRequest:[NSURLRequest requestWithURL:documentURL.createNSURL().get()]];
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -53,7 +53,7 @@ namespace WebKit {
 void WebExtensionContext::runtimeGetBackgroundPage(CompletionHandler<void(Expected<std::optional<WebCore::PageIdentifier>, WebExtensionError>&&)>&& completionHandler)
 {
     wakeUpBackgroundContentIfNecessary([this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
-        completionHandler(backgroundPageIdentifier());
+        completionHandler(backgroundPageIdentifierInOwnProcess());
     });
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1645,8 +1645,7 @@ void WebExtensionContext::didCommitLoadForFrame(WebPageProxyIdentifier pageID, c
         // FIXME: <https://webkit.org/b/262491> There is currently no way to inject CSS in specific frames based on ID's.
         Ref userContentController = page.get()->userContentController();
         m_dynamicallyInjectedUserStyleSheets.removeAllMatching([&](auto& styleSheet) {
-            auto styleSheetPageID = styleSheet->userStyleSheet().pageID();
-            if (!styleSheetPageID || styleSheetPageID.value() != page->webPageIDInMainFrameProcess())
+            if (styleSheet->page() != page.get())
                 return false;
 
             userContentController->removeUserStyleSheet(styleSheet);
@@ -2334,16 +2333,30 @@ void WebExtensionContext::clearUserGesture(WebExtensionTab& tab)
         permissionsDidChange(PermissionNotification::GrantedPermissionMatchPatternsWereRemoved, MatchPatternSet { *oldTemporaryPermissionMatchPattern });
 }
 
-std::optional<WebCore::PageIdentifier> WebExtensionContext::backgroundPageIdentifier() const
+std::optional<WebCore::PageIdentifier> WebExtensionContext::backgroundPageIdentifier(WebProcessProxy& destinationProcess) const
 {
     if (!m_backgroundWebView || protect(extension())->backgroundContentIsServiceWorker())
         return std::nullopt;
 
-    return m_backgroundWebView.get()._page->webPageIDInMainFrameProcess();
+    Ref backgroundPage = *m_backgroundWebView.get()._page;
+    return backgroundPage->webPageIDInProcess(destinationProcess);
+}
+
+std::optional<WebCore::PageIdentifier> WebExtensionContext::backgroundPageIdentifierInOwnProcess() const
+{
+    if (!m_backgroundWebView || protect(extension())->backgroundContentIsServiceWorker())
+        return std::nullopt;
+
+    Ref backgroundPage = *m_backgroundWebView.get()._page;
+    RefPtr mainFrame = backgroundPage->mainFrame();
+    if (!mainFrame)
+        return std::nullopt;
+
+    return mainFrame->webPageIDInCurrentProcess();
 }
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
-Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::inspectorBackgroundPageIdentifiers() const
+Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::inspectorBackgroundPageIdentifiers(WebProcessProxy& destinationProcess) const
 {
     Vector<PageIdentifierTuple> result;
 
@@ -2355,13 +2368,14 @@ Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::inspectorB
         auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
 
         auto *webView = entry.value.backgroundWebView.get();
-        result.append({ webView._page->webPageIDInMainFrameProcess(), tabIdentifier, windowIdentifier });
+        Ref page = *webView._page;
+        result.append({ page->webPageIDInProcess(destinationProcess), tabIdentifier, windowIdentifier });
     }
 
     return result;
 }
 
-Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::inspectorPageIdentifiers() const
+Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::inspectorPageIdentifiers(WebProcessProxy& destinationProcess) const
 {
     Vector<PageIdentifierTuple> result;
 
@@ -2372,18 +2386,20 @@ Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::inspectorP
         auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
 
         Ref protectedInspector = inspector;
-        result.append({ protectedInspector->inspectorPage()->webPageIDInMainFrameProcess(), tabIdentifier, windowIdentifier });
+        if (RefPtr inspectorPage = protectedInspector->inspectorPage())
+            result.append({ inspectorPage->webPageIDInProcess(destinationProcess), tabIdentifier, windowIdentifier });
     }
 
     return result;
 }
 #endif // ENABLE(INSPECTOR_EXTENSIONS)
 
-Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::popupPageIdentifiers() const
+Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::popupPageIdentifiers(WebProcessProxy& destinationProcess) const
 {
     Vector<PageIdentifierTuple> result;
 
     for (auto entry : m_popupPageActionMap) {
+        Ref page = entry.key;
         Ref value = entry.value;
         RefPtr tab = value->tab();
         RefPtr window = tab ? tab->window() : value->window();
@@ -2391,13 +2407,13 @@ Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::popupPageI
         auto tabIdentifier = tab ? std::optional(tab->identifier()) : std::nullopt;
         auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
 
-        result.append({ entry.key.webPageIDInMainFrameProcess(), tabIdentifier, windowIdentifier });
+        result.append({ page->webPageIDInProcess(destinationProcess), tabIdentifier, windowIdentifier });
     }
 
     return result;
 }
 
-Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::tabPageIdentifiers() const
+Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::tabPageIdentifiers(WebProcessProxy& destinationProcess) const
 {
     Vector<PageIdentifierTuple> result;
 
@@ -2406,10 +2422,11 @@ Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::tabPageIde
         if (!tab)
             continue;
 
+        Ref page = entry.key;
         RefPtr window = tab->window();
         auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
 
-        result.append({ entry.key.webPageIDInMainFrameProcess(), tab->identifier(), windowIdentifier });
+        result.append({ page->webPageIDInProcess(destinationProcess), tab->identifier(), windowIdentifier });
     }
 
     return result;
@@ -2629,19 +2646,16 @@ void WebExtensionContext::loadBackgroundWebView()
     m_backgroundContentLoadError = nullptr;
 
     Ref backgroundPage = *m_backgroundWebView.get()._page;
-    Ref backgroundProcess = backgroundPage->siteIsolatedProcess();
 
-    bool siteIsolationEnabled = protect(backgroundPage->preferences())->siteIsolationEnabled();
     constexpr ASCIILiteral activityName = "Web Extension background content"_s;
 
     // Use foreground activity to keep background content responsive to events.
-    if (siteIsolationEnabled)
-        m_backgroundWebViewActivity = protect(backgroundPage->activityGroupContext())->foregroundProcessActivityGroup(activityName);
-    else
-        m_backgroundWebViewActivity = protect(backgroundProcess->throttler())->foregroundActivity(activityName);
+    m_backgroundWebViewActivity = protect(backgroundPage->activityGroupContext())->foregroundProcessActivityGroup(activityName);
 
     if (!protect(extension())->backgroundContentIsServiceWorker()) {
-        backgroundProcess->send(Messages::WebExtensionContextProxy::SetBackgroundPageIdentifier(backgroundPage->webPageIDInMainFrameProcess()), identifier());
+        backgroundPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+            webProcess.send(Messages::WebExtensionContextProxy::SetBackgroundPageIdentifier(pageID), identifier());
+        });
 
         [m_backgroundWebView loadRequest:[NSURLRequest requestWithURL:backgroundContentURL().createNSURL().get()]];
         return;
@@ -3055,8 +3069,21 @@ HashSet<Ref<WebProcessProxy>> WebExtensionContext::processes(const API::Inspecto
     ASSERT(m_inspectorContextMap.contains(*inspectorProxy));
 
     const auto& inspectorContext = m_inspectorContextMap.get(*inspectorProxy);
-    if (auto *backgroundWebView = inspectorContext.backgroundWebView.get())
-        result.add(backgroundWebView._page->siteIsolatedProcess());
+    if (auto *backgroundWebView = inspectorContext.backgroundWebView.get()) {
+        Ref backgroundPage = *backgroundWebView._page;
+        backgroundPage->forEachWebContentProcess([&](auto& webProcess, auto) {
+            result.addVoid(webProcess);
+        });
+    }
+
+    // Extension panels are hosted by the Inspector's frontend page, not by the devtools background page,
+    // and with site isolation those are no longer forced into the same process. Panels listen for these
+    // events too, so the frontend page's processes have to be included or the panels never hear them.
+    if (RefPtr inspectorFrontendPage = inspectorProxy->inspectorPage()) {
+        inspectorFrontendPage->forEachWebContentProcess([&](auto& webProcess, auto) {
+            result.addVoid(webProcess);
+        });
+    }
 
     return result;
 }
@@ -3218,16 +3245,10 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
         inspectorExtension->setClient(makeUniqueRef<InspectorExtensionClient>(inspectorExtension, *this));
 
         // Use foreground activity to keep background content responsive to events.
-        Ref inspectorPage = *inspectorBackgroundWebView._page;
-        Ref process = inspectorPage->legacyMainFrameProcess();
+        Ref inspectorBackgroundPage = *inspectorBackgroundWebView._page;
 
-        Variant<std::monostate, Ref<ProcessThrottlerActivity>, Ref<ProcessActivityGroup>> inspectorBackgroundWebViewActivity;
         constexpr ASCIILiteral activityName = "Web Extension Inspector background content"_s;
-
-        if (siteIsolationEnabled)
-            inspectorBackgroundWebViewActivity = protect(inspectorPage->activityGroupContext())->foregroundProcessActivityGroup(activityName);
-        else
-            inspectorBackgroundWebViewActivity = protect(process->throttler())->foregroundActivity(activityName);
+        Variant<std::monostate, Ref<ProcessThrottlerActivity>, Ref<ProcessActivityGroup>> inspectorBackgroundWebViewActivity = protect(inspectorBackgroundPage->activityGroupContext())->foregroundProcessActivityGroup(activityName);
 
         InspectorContext inspectorContext {
             tab->identifier(),
@@ -3243,10 +3264,22 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
 
         auto appearance = protect(inspector->inspectorPage())->useDarkAppearance() ? Inspector::ExtensionAppearance::Dark : Inspector::ExtensionAppearance::Light;
 
-        ASSERT(siteIsolationEnabled || inspectorWebView._page->legacyMainFrameProcess() == process);
-        process->send(Messages::WebExtensionContextProxy::AddInspectorPageIdentifier(inspectorWebView._page->webPageIDInMainFrameProcess(), tab->identifier(), windowIdentifier), identifier());
-        process->send(Messages::WebExtensionContextProxy::AddInspectorBackgroundPageIdentifier(inspectorBackgroundWebView._page->webPageIDInMainFrameProcess(), tab->identifier(), windowIdentifier), identifier());
-        process->send(Messages::WebExtensionContextProxy::DispatchDevToolsPanelsThemeChangedEvent(appearance), identifier());
+        // The Inspector frontend page and the extension's devtools background page are two different
+        // pages, and when site isolation is enabled they are no longer forced into a single process by
+        // setAlwaysUseRelatedPageProcess above. Each identifier therefore has to be delivered to the
+        // processes that actually host the page it names, carrying that process's own identifier for the
+        // page. Sending the frontend page's identifier to the background page's process leaves
+        // m_inspectorPageMap empty, which makes devtools.inspectedWindow.tabId fail in extension panels.
+        Ref inspectorFrontendPage = *inspectorWebView._page;
+        inspectorFrontendPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+            webProcess.send(Messages::WebExtensionContextProxy::AddInspectorPageIdentifier(pageID, tab->identifier(), windowIdentifier), identifier());
+        });
+
+        inspectorBackgroundPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+            webProcess.send(Messages::WebExtensionContextProxy::AddInspectorBackgroundPageIdentifier(pageID, tab->identifier(), windowIdentifier), identifier());
+        });
+
+        sendToProcesses(processes(inspectorExtension.get()), Messages::WebExtensionContextProxy::DispatchDevToolsPanelsThemeChangedEvent(appearance));
 
         [inspectorBackgroundWebView loadRequest:[NSURLRequest requestWithURL:inspectorBackgroundPageURL().createNSURL().get()]];
     });

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -367,7 +367,12 @@ void WebExtensionController::unloadAll()
 
 void WebExtensionController::dispatchDidLoad(WebExtensionContext& context)
 {
-    sendToAllProcesses(Messages::WebExtensionControllerProxy::Load(context.parameters(WebExtensionContext::IncludePrivilegedIdentifier::No)), identifier());
+    for (Ref process : allProcesses()) {
+        if (!process->canSendMessage())
+            continue;
+
+        process->send(Messages::WebExtensionControllerProxy::Load(context.parameters(WebExtensionContext::IncludePrivilegedIdentifier::No, process)), identifier());
+    }
 }
 
 void WebExtensionController::addPage(WebPageProxy& page)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -178,10 +178,12 @@ void executeScript(const SourcePairs& scriptPairs, WKWebView *webView, API::Cont
 void injectStyleSheets(const SourcePairs& styleSheetPairs, WKWebView *webView, API::ContentWorld& executionWorld, WebCore::UserStyleLevel styleLevel, WebCore::UserContentInjectedFrames injectedFrames, WebExtensionContext& context)
 {
     auto page = webView._page;
-    auto pageID = page->webPageIDInMainFrameProcess();
 
     for (auto& styleSheet : styleSheetPairs) {
-        auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.first, styleSheet.second, { }, { }, injectedFrames, WebCore::UserContentMatchParentFrame::Never, styleLevel, pageID }, executionWorld);
+        // Scope the sheet to this page by handing the API object the page itself. The PageIdentifier each
+        // web content process needs is derived from it per destination when the sheet is sent, so the
+        // sheet also reaches the processes hosting cross-site frames under site isolation.
+        auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.first, styleSheet.second, { }, { }, injectedFrames, WebCore::UserContentMatchParentFrame::Never, styleLevel, std::nullopt }, executionWorld, page.get());
 
         Ref controller = page.get()->userContentController();
         controller->addUserStyleSheet(userStyleSheet);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -1671,7 +1671,7 @@ bool WebExtensionContext::isPrivilegedMessage(IPC::Decoder& message) const
     return m_privilegedIdentifier.value().toRawValue() == message.destinationID();
 }
 
-WebExtensionContextParameters WebExtensionContext::parameters(IncludePrivilegedIdentifier includePrivilegedIdentifier) const
+WebExtensionContextParameters WebExtensionContext::parameters(IncludePrivilegedIdentifier includePrivilegedIdentifier, WebProcessProxy& destinationProcess) const
 {
     RefPtr extension = m_extension;
 
@@ -1687,13 +1687,13 @@ WebExtensionContextParameters WebExtensionContext::parameters(IncludePrivilegedI
         extension->manifestVersion(),
         m_storageAccessLevels,
         extensionController()->configuration().defaultWebsiteDataStore().sessionID(),
-        backgroundPageIdentifier(),
+        backgroundPageIdentifier(destinationProcess),
 #if ENABLE(INSPECTOR_EXTENSIONS)
-        inspectorPageIdentifiers(),
-        inspectorBackgroundPageIdentifiers(),
+        inspectorPageIdentifiers(destinationProcess),
+        inspectorBackgroundPageIdentifiers(destinationProcess),
 #endif
-        popupPageIdentifiers(),
-        tabPageIdentifiers()
+        popupPageIdentifiers(destinationProcess),
+        tabPageIdentifiers(destinationProcess)
     };
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -345,7 +345,7 @@ public:
 
     WebExtensionContextIdentifier NODELETE privilegedIdentifier() const;
 
-    WebExtensionContextParameters parameters(IncludePrivilegedIdentifier) const;
+    WebExtensionContextParameters parameters(IncludePrivilegedIdentifier, WebProcessProxy& destinationProcess) const;
 
     bool operator==(const WebExtensionContext& other) const { return (this == &other); }
 
@@ -643,13 +643,16 @@ public:
 
     UserStyleSheetVector& dynamicallyInjectedUserStyleSheets() LIFETIME_BOUND { return m_dynamicallyInjectedUserStyleSheets; };
 
-    std::optional<WebCore::PageIdentifier> backgroundPageIdentifier() const;
+    // Maps page identifiers appropriately, even with site isolation enabled.
+    std::optional<WebCore::PageIdentifier> backgroundPageIdentifier(WebProcessProxy& destinationProcess) const;
+    std::optional<WebCore::PageIdentifier> backgroundPageIdentifierInOwnProcess() const;
+
 #if ENABLE(INSPECTOR_EXTENSIONS)
-    Vector<PageIdentifierTuple> inspectorBackgroundPageIdentifiers() const;
-    Vector<PageIdentifierTuple> inspectorPageIdentifiers() const;
+    Vector<PageIdentifierTuple> inspectorBackgroundPageIdentifiers(WebProcessProxy& destinationProcess) const;
+    Vector<PageIdentifierTuple> inspectorPageIdentifiers(WebProcessProxy& destinationProcess) const;
 #endif
-    Vector<PageIdentifierTuple> popupPageIdentifiers() const;
-    Vector<PageIdentifierTuple> tabPageIdentifiers() const;
+    Vector<PageIdentifierTuple> popupPageIdentifiers(WebProcessProxy& destinationProcess) const;
+    Vector<PageIdentifierTuple> tabPageIdentifiers(WebProcessProxy& destinationProcess) const;
 
     void addExtensionTabPage(WebPageProxy&, WebExtensionTab&);
     void addPopupPage(WebPageProxy&, WebExtensionAction&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -90,7 +90,7 @@ WebExtensionController::~WebExtensionController()
     unloadAll();
 }
 
-WebExtensionControllerParameters WebExtensionController::parameters(const API::PageConfiguration& pageConfiguration) const
+WebExtensionControllerParameters WebExtensionController::parameters(const API::PageConfiguration& pageConfiguration, WebProcessProxy& destinationProcess) const
 {
     return {
         .identifier = identifier(),
@@ -98,7 +98,7 @@ WebExtensionControllerParameters WebExtensionController::parameters(const API::P
         .contextParameters = WTF::map(extensionContexts(), [&](auto& context) {
             bool isForThisExtension = context->isURLForThisExtension(pageConfiguration.requiredWebExtensionBaseURL());
             auto includePrivilegedIdentifier = isForThisExtension ? WebExtensionContext::IncludePrivilegedIdentifier::Yes : WebExtensionContext::IncludePrivilegedIdentifier::No;
-            return context->parameters(includePrivilegedIdentifier);
+            return context->parameters(includePrivilegedIdentifier, destinationProcess);
         })
     };
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -112,7 +112,7 @@ public:
     enum class ForPrivateBrowsing { No, Yes };
 
     WebExtensionControllerConfiguration& configuration() const LIFETIME_BOUND { return m_configuration.get(); }
-    WebExtensionControllerParameters parameters(const API::PageConfiguration&) const;
+    WebExtensionControllerParameters parameters(const API::PageConfiguration&, WebProcessProxy& destinationProcess) const;
 
     bool operator==(const WebExtensionController& other) const { return (this == &other); }
 

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -134,9 +134,19 @@ WebCoreUserScriptData WebUserContentControllerProxy::dataFromUserScript(const We
     return { cachedTransferString(script.source()), script.url(), script.allowlist(), script.blocklist(), script.injectionTime(), script.injectedFrames(), script.matchParentFrame() };
 }
 
-WebCoreUserStyleSheetData WebUserContentControllerProxy::dataFromUserStyleSheet(const WebCore::UserStyleSheet& sheet) const
+WebCoreUserStyleSheetData WebUserContentControllerProxy::dataFromUserStyleSheet(const API::UserStyleSheet& userStyleSheet, WebProcessProxy& process) const
 {
-    return { cachedTransferString(sheet.source()), sheet.url(), sheet.allowlist(), sheet.blocklist(), sheet.injectedFrames(), sheet.matchParentFrame(), sheet.level(), sheet.pageID() };
+    auto& sheet = userStyleSheet.userStyleSheet();
+
+    // A page-scoped sheet is stored against its WebPageProxy rather than a PageIdentifier, because an
+    // identifier only names a WebPage in a single web content process and a site-isolated page has one
+    // per process. Derive the identifier the destination process knows this page by; the receiver
+    // resolves it with WebProcess::webPage() before injecting the sheet.
+    std::optional<WebCore::PageIdentifier> pageID;
+    if (RefPtr page = userStyleSheet.page())
+        pageID = page->webPageIDInProcess(process);
+
+    return { cachedTransferString(sheet.source()), sheet.url(), sheet.allowlist(), sheet.blocklist(), sheet.injectedFrames(), sheet.matchParentFrame(), sheet.level(), pageID };
 }
 
 UserContentControllerParameters WebUserContentControllerProxy::parametersForProcess(WebProcessProxy& process) const
@@ -148,8 +158,13 @@ UserContentControllerParameters WebUserContentControllerProxy::parametersForProc
         userScripts.append({ userScript->identifier(), Ref { userScript->contentWorld() }->worldDataForProcess(process), dataFromUserScript(userScript->userScript()) });
 
     Vector<WebUserStyleSheetData> userStyleSheets;
-    for (RefPtr userStyleSheet : m_userStyleSheets->elementsOfType<API::UserStyleSheet>())
-        userStyleSheets.append({ userStyleSheet->identifier(), Ref { userStyleSheet->contentWorld() }->worldDataForProcess(process), dataFromUserStyleSheet(userStyleSheet->userStyleSheet()) });
+    for (RefPtr userStyleSheet : m_userStyleSheets->elementsOfType<API::UserStyleSheet>()) {
+        // Skip a page-scoped sheet whose page is gone. Sending it with no identifier would make the web
+        // process treat it as applying to every page.
+        if (userStyleSheet->isOrphaned())
+            continue;
+        userStyleSheets.append({ userStyleSheet->identifier(), Ref { userStyleSheet->contentWorld() }->worldDataForProcess(process), dataFromUserStyleSheet(*userStyleSheet, process) });
+    }
 
     Vector<WebJSBufferData> buffers;
     for (auto& [pair, buffer] : m_buffers) {
@@ -262,8 +277,13 @@ void WebUserContentControllerProxy::addUserStyleSheet(API::UserStyleSheet& userS
 
     m_userStyleSheets->elements().append(&userStyleSheet);
 
+    // See parametersForProcess(): a page-scoped sheet whose page is already gone must not be sent, or the
+    // web process would apply it to every page.
+    if (userStyleSheet.isOrphaned())
+        return;
+
     for (Ref process : m_processes)
-        process->send(Messages::WebUserContentController::AddUserStyleSheets({ { userStyleSheet.identifier(), world->worldDataForProcess(process), dataFromUserStyleSheet(userStyleSheet.userStyleSheet()) } }), identifier());
+        process->send(Messages::WebUserContentController::AddUserStyleSheets({ { userStyleSheet.identifier(), world->worldDataForProcess(process), dataFromUserStyleSheet(userStyleSheet, process) } }), identifier());
 }
 
 void WebUserContentControllerProxy::removeUserStyleSheet(API::UserStyleSheet& userStyleSheet)

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -115,7 +115,7 @@ public:
 #else
     void removeAllUserStyleSheets();
 #endif
-    WebCoreUserStyleSheetData dataFromUserStyleSheet(const WebCore::UserStyleSheet&) const;
+    WebCoreUserStyleSheetData dataFromUserStyleSheet(const API::UserStyleSheet&, WebProcessProxy&) const;
 
     void addJSBuffer(Ref<WebCore::SharedMemory>&&, API::ContentWorld&, const String&);
     void removeJSBuffer(API::ContentWorld&, const String&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14346,10 +14346,10 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 
 #if ENABLE(WK_WEB_EXTENSIONS) && PLATFORM(COCOA)
     if (RefPtr webExtensionController = m_webExtensionController)
-        parameters.webExtensionControllerParameters = webExtensionController->parameters(m_configuration);
+        parameters.webExtensionControllerParameters = webExtensionController->parameters(m_configuration, process);
 
     if (RefPtr weakWebExtensionController = m_weakWebExtensionController.get())
-        parameters.webExtensionControllerParameters = weakWebExtensionController->parameters(m_configuration);
+        parameters.webExtensionControllerParameters = weakWebExtensionController->parameters(m_configuration, process);
 #endif
 
     // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
@@ -169,6 +169,20 @@ void performWithAppearance(Appearance, void (^block)(void));
 
 #endif
 
+// TestWebExtensionManager creates its web views lazily: when the manager itself is created, when a
+// window or tab is opened, and when a tab navigates to a URL that needs a different configuration.
+// That makes site isolation awkward to pass in as an argument at the point a test wants it. Declare
+// this at the top of a test body instead, and every web view the manager creates while it is in
+// scope gets `_siteIsolationEnabled` set.
+class SiteIsolationScope {
+public:
+    SiteIsolationScope();
+    ~SiteIsolationScope();
+
+    SiteIsolationScope(const SiteIsolationScope&) = delete;
+    SiteIsolationScope& operator=(const SiteIsolationScope&) = delete;
+};
+
 RetainPtr<TestWebExtensionManager> parseExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil, BOOL usesEnhancedSecurity = NO);
 RetainPtr<TestWebExtensionManager> loadExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil, BOOL usesEnhancedSecurity = NO);
 void loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil);

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
@@ -44,7 +44,15 @@
 #import <wtf/darwin/DispatchExtras.h>
 
 // Enable this to test all web extension tests with site isolation.
-static constexpr BOOL shouldEnableSiteIsolation = NO;
+static constexpr BOOL shouldEnableSiteIsolationForAllTests = NO;
+
+// Set for the duration of a TestWebKitAPI::Util::SiteIsolationScope, so a single test can opt in.
+static BOOL shouldEnableSiteIsolationForCurrentTest = NO;
+
+static BOOL shouldEnableSiteIsolation()
+{
+    return shouldEnableSiteIsolationForAllTests || shouldEnableSiteIsolationForCurrentTest;
+}
 
 @interface TestWebExtensionManager () <WKWebExtensionControllerDelegatePrivate>
 @end
@@ -75,7 +83,7 @@ static constexpr BOOL shouldEnableSiteIsolation = NO;
     if (!configuration)
         configuration = WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
 
-    configuration.webViewConfiguration.preferences._siteIsolationEnabled = shouldEnableSiteIsolation;
+    configuration.webViewConfiguration.preferences._siteIsolationEnabled = shouldEnableSiteIsolation();
 
     _extension = extension;
     _context = [[WKWebExtensionContext alloc] initForExtension:extension];
@@ -462,7 +470,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         configuration.userContentController = userContentController(usingPrivateBrowsing);
 
         auto *preferences = configuration.preferences;
-        preferences._siteIsolationEnabled = shouldEnableSiteIsolation;
+        preferences._siteIsolationEnabled = shouldEnableSiteIsolation();
         preferences._developerExtrasEnabled = YES;
 
         if (_window.usingEnhancedSecurity) {
@@ -524,7 +532,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     configuration.userContentController = userContentController(usingPrivateBrowsing);
 
     auto *preferences = configuration.preferences;
-    preferences._siteIsolationEnabled = shouldEnableSiteIsolation;
+    preferences._siteIsolationEnabled = shouldEnableSiteIsolation();
     preferences._developerExtrasEnabled = YES;
 
     _webView = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration];
@@ -1015,6 +1023,16 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 namespace TestWebKitAPI {
 namespace Util {
+
+SiteIsolationScope::SiteIsolationScope()
+{
+    shouldEnableSiteIsolationForCurrentTest = YES;
+}
+
+SiteIsolationScope::~SiteIsolationScope()
+{
+    shouldEnableSiteIsolationForCurrentTest = NO;
+}
 
 RetainPtr<TestWebExtensionManager> parseExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration *configuration, BOOL usesEnhancedSecurity)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm
@@ -679,6 +679,73 @@ TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToDevToolsBackground)
     [manager run];
 }
 
+// With site isolation enabled, WebExtensionContext::loadInspectorBackgroundPage deliberately skips
+// setAlwaysUseRelatedPageProcess (WebExtensionContextCocoa.mm), so the Web Inspector frontend page and
+// the extension's devtools background page no longer share a web content process — the ASSERT directly
+// above the sends documents exactly that divergence. It then sends AddInspectorPageIdentifier carrying
+// the *frontend* page's webPageIDInMainFrameProcess() to the *background* page's process. Web-process
+// side, WebExtensionContextProxy::addInspectorPageIdentifier resolves it with
+// WebProcess::singleton().webPage(pageIdentifier), which misses and silently no-ops, so
+// m_inspectorPageMap is never populated.
+//
+// A devtools panel resolves its tab through that map (WebExtensionContextProxy::tabIdentifier, reached
+// from WebExtensionAPIDevToolsInspectedWindow::tabId), so devtools.inspectedWindow.tabId comes back as
+// WebExtensionTabConstants::None (-1) instead of the inspected tab. Note that the devtools_page itself
+// is unaffected: AddInspectorBackgroundPageIdentifier sends the background page's own identifier to the
+// background page's own process, which is self-consistent either way.
+TEST(WKWebExtensionAPIDevTools, InspectedWindowTabIdFromPanel)
+{
+    Util::SiteIsolationScope siteIsolationScope;
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *devToolsScript = Util::constructScript(@[
+        @"let panel = await browser.devtools.panels.create('Test Panel', 'icon.svg', 'panel.html')",
+        @"browser.test.assertEq(typeof panel, 'object', 'Panel should be created successfully')",
+
+        // The devtools_page resolves through m_inspectorBackgroundPageMap, which is populated
+        // correctly, so this half should hold with or without site isolation.
+        @"browser.test.assertTrue(browser.devtools.inspectedWindow.tabId > 0, 'inspectedWindow.tabId should identify the inspected tab from the devtools page')",
+
+        @"browser.test.sendMessage('Panel Created')",
+    ]);
+
+    auto *panelScript = Util::constructScript(@[
+        @"const tabId = browser.devtools.inspectedWindow.tabId",
+        @"browser.test.assertEq(typeof tabId, 'number', 'inspectedWindow.tabId should be a number in a panel')",
+        @"browser.test.assertTrue(tabId > 0, 'inspectedWindow.tabId should identify the inspected tab from a panel, not be the none value')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *iconSVG = @"<svg width='16' height='16' xmlns='http://www.w3.org/2000/svg'><circle cx='8' cy='8' r='8' fill='red' /></svg>";
+
+    auto *resources = @{
+        @"background.js": @"// This script is intentionally left blank.",
+        @"devtools.html": @"<script type='module' src='devtools.js'></script>",
+        @"devtools.js": devToolsScript,
+        @"panel.html": @"<script type='module' src='panel.js'></script>",
+        @"panel.js": panelScript,
+        @"icon.svg": iconSVG,
+    };
+
+    auto manager = Util::loadExtension(devToolsManifest, resources);
+
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
+
+    [manager runUntilTestMessage:@"Panel Created"];
+
+    auto *extensionIdentifier = [NSString stringWithFormat:@"WebExtensionTab-%@-1", manager.get().context.uniqueIdentifier];
+    [manager.get().defaultTab.webView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
+        EXPECT_NULL(error);
+    }];
+
+    [manager run];
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
@@ -610,6 +610,107 @@ TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSS)
     [manager run];
 }
 
+// The main frame is served from 127.0.0.1 and the subframe from localhost. Those are different sites,
+// so with site isolation enabled the subframe is hosted by its own web content process.
+//
+// injectStyleSheets() stamps page->webPageIDInMainFrameProcess() into every UserStyleSheet
+// (WebExtensionDynamicScriptsCocoa.mm). WebUserContentControllerProxy::addUserStyleSheet then
+// correctly delivers the sheet to every enrolled process, but each receiver resolves the sheet's
+// pageID with WebProcess::singleton().webPage(*pageID) before injecting it
+// (WebUserContentController::addUserStyleSheetInternal). A PageIdentifier naming a WebPage in the
+// main frame's process names nothing in the subframe's process, so the lookup misses and the sheet
+// is not injected there. The non-page-specific path doesn't pick it up either, because
+// ExtensionStyleSheets::updateInjectedStyleSheetCache skips any sheet carrying a pageID. The sheet
+// is silently dropped, which is exactly the third-party-iframe case content blockers exist for.
+TEST(WKWebExtensionAPIScripting, InsertCSSInAllFramesWithCrossSiteFrame)
+{
+    Util::SiteIsolationScope siteIsolationScope;
+
+    // Unlike scriptingManifest, this needs access to both of the sites the test serves.
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Scripting Test",
+        @"description": @"Scripting Test",
+        @"version": @"1",
+
+        @"permissions": @[ @"scripting" ],
+        @"host_permissions": @[ @"*://localhost/*", @"*://127.0.0.1/*" ],
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<script>onload = () => { const frame = document.createElement('iframe'); frame.src = 'http://localhost:' + window.location.port + '/frame.html'; document.body.appendChild(frame); }</script>"_s } },
+        { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"const pinkValue = 'rgb(255, 192, 203)'",
+        @"const blueValue = 'rgb(0, 0, 255)'",
+
+        @"function getBackgroundColor() { return window.getComputedStyle(document.body).getPropertyValue('background-color') }",
+
+        @"function readAllFrames(tabId) {",
+        @"  return browser.scripting.executeScript({ target: { tabId, allFrames: true }, func: getBackgroundColor })",
+        @"}",
+
+        // The subframe is appended from script and is cross-site, so it is not loaded yet when the
+        // main frame reaches 'complete'. Poll until both frames are visible to executeScript.
+        @"async function readBothFrames(tabId) {",
+        @"  for (let attempt = 0; attempt < 200; ++attempt) {",
+        @"    const results = await readAllFrames(tabId)",
+        @"    if (results.length === 2)",
+        @"      return results",
+        @"    await new Promise((resolve) => setTimeout(resolve, 50))",
+        @"  }",
+        @"  browser.test.notifyFail('Timed out waiting for the cross-site subframe to appear')",
+        @"}",
+
+        @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
+        @"  if (tab.status !== 'complete')",
+        @"    return",
+
+        // Sanity check that the subframe really is the blue localhost document, and that reading from
+        // it works. executeScript is frame-routed, so it is unaffected by this bug.
+        @"  let results = await readBothFrames(tabId)",
+        @"  browser.test.assertTrue(results.some((result) => result.result === blueValue), 'The cross-site subframe should start out blue')",
+
+        @"  await browser.scripting.insertCSS({ target: { tabId, allFrames: true }, css: 'body { background-color: pink !important }' })",
+
+        @"  results = await readAllFrames(tabId)",
+        @"  browser.test.assertEq(results.length, 2, 'Both frames should be reachable')",
+
+        @"  for (const result of results)",
+        @"    browser.test.assertEq(result.result, pinkValue, `Frame ${result.frameId} should be styled by insertCSS with allFrames`)",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')",
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    auto *urlRequest = server.request();
+
+    // The extension needs access to both sites, since it styles a frame on each.
+    for (NSURL *url in @[ urlRequest.URL, server.requestWithLocalhost().URL ]) {
+        auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
+        [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+    }
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
 TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSSWithFrameIds)
 {
     TestWebKitAPI::HTTPServer server({

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
@@ -3915,6 +3915,99 @@ TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInAllFrames)
     [manager run];
 }
 
+// browser.tabs.insertCSS shares injectStyleSheets() with browser.scripting.insertCSS, so it inherits
+// the same defect: the sheet carries the main frame process's PageIdentifier, which resolves to
+// nothing in a cross-site subframe's process. See
+// WKWebExtensionAPIScripting.InsertCSSInAllFramesWithCrossSiteFrame for the full mechanism.
+//
+// The main frame is served from 127.0.0.1 and the subframe from localhost, so with site isolation
+// enabled the subframe gets its own web content process.
+TEST(WKWebExtensionAPITabs, InsertCSSInAllFramesWithCrossSiteFrame)
+{
+    Util::SiteIsolationScope siteIsolationScope;
+
+    auto *manifest = @{
+        @"manifest_version": @2,
+
+        @"name": @"Tabs Test",
+        @"description": @"Tabs Test",
+        @"version": @"1",
+
+        @"permissions": @[ @"*://localhost/*", @"*://127.0.0.1/*" ],
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<script>onload = () => { const frame = document.createElement('iframe'); frame.src = 'http://localhost:' + window.location.port + '/frame.html'; document.body.appendChild(frame); }</script>"_s } },
+        { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"const pinkValue = 'rgb(255, 192, 203)'",
+        @"const blueValue = 'rgb(0, 0, 255)'",
+        @"const readBackgroundColor = \"window.getComputedStyle(document.body).getPropertyValue('background-color')\"",
+
+        @"function readAllFrames(tabId) {",
+        @"  return browser.tabs.executeScript(tabId, { allFrames: true, code: readBackgroundColor })",
+        @"}",
+
+        // The subframe is appended from script and is cross-site, so it is not loaded yet when the
+        // main frame reaches 'complete'. Poll until both frames are visible to executeScript.
+        @"async function readBothFrames(tabId) {",
+        @"  for (let attempt = 0; attempt < 200; ++attempt) {",
+        @"    const result = await readAllFrames(tabId)",
+        @"    if (result.length === 2)",
+        @"      return result",
+        @"    await new Promise((resolve) => setTimeout(resolve, 50))",
+        @"  }",
+        @"  browser.test.notifyFail('Timed out waiting for the cross-site subframe to appear')",
+        @"}",
+
+        @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
+        @"  if (tab.status !== 'complete')",
+        @"    return",
+
+        // Sanity check that the subframe really is the blue localhost document, and that reading from
+        // it works. executeScript is frame-routed, so it is unaffected by this bug.
+        @"  let result = await readBothFrames(tabId)",
+        @"  browser.test.assertTrue(result.includes(blueValue), 'The cross-site subframe should start out blue')",
+
+        @"  await browser.tabs.insertCSS(tabId, { allFrames: true, code: 'body { background-color: pink !important }' })",
+
+        @"  result = await readAllFrames(tabId)",
+        @"  browser.test.assertEq(result.length, 2, 'Both frames should be reachable')",
+
+        @"  for (const value of result)",
+        @"    browser.test.assertEq(value, pinkValue, 'Every frame should be styled by insertCSS with allFrames')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')",
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    RetainPtr crossSiteURLRequest = server.request();
+
+    // The extension needs access to both sites, since it styles a frame on each.
+    for (NSURL *url in @[ crossSiteURLRequest.get().URL, server.requestWithLocalhost().URL ]) {
+        auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
+        [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+    }
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:crossSiteURLRequest.get()];
+
+    [manager run];
+}
+
 TEST(WKWebExtensionAPITabs, CSSUserOrigin)
 {
     TestWebKitAPI::HTTPServer server({


### PR DESCRIPTION
#### 21b1c6bcd1048ccbaf827328fe779e8c28fb45a5
<pre>
[Site Isolation] Fix page identifier confusion for some mechanisms driven by UI process API
<a href="https://rdar.apple.com/184785701">rdar://184785701</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321658">https://bugs.webkit.org/show_bug.cgi?id=321658</a>

Reviewed by NOBODY (OOPS!).

With site isolation enabled, a single page is backed by several web content processes, each of which has its own
PageIdentifier representing that page. Several API reachable code paths passed the main frame process&apos;s PageIdentifier
to every process, so the receiving process couldn&apos;t resolve it.

First we do some reordering of calls in BrowsingContextGroup so that the properties we add to creationParameters
resolve correctly in injectPageIntoNewProcess()

Then we clean up at least some of the web extensions, user content controller, and web inspector mechanisms that
are reachable through API.

Not all of these fixes are directly *observable* through API, and therefore are untestable. But for the others we add:

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm

* Source/WebKit/UIProcess/API/APIUserStyleSheet.cpp:
(API::UserStyleSheet::UserStyleSheet):
(API::UserStyleSheet::page const):
* Source/WebKit/UIProcess/API/APIUserStyleSheet.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm:
(-[_WKUserStyleSheet initWithSource:forWKWebView:forMainFrameOnly:includeMatchPatternStrings:excludeMatchPatternStrings:baseURL:level:contentWorld:]):
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::addFrameProcessAndInjectPageContextIf):
(WebKit::BrowsingContextGroup::addPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm:
(WebKit::WebExtensionContext::offscreenCreateDocument):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeGetBackgroundPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::didCommitLoadForFrame):
(WebKit::WebExtensionContext::backgroundPageIdentifier const):
(WebKit::WebExtensionContext::backgroundPageIdentifierInOwnProcess const):
(WebKit::WebExtensionContext::inspectorBackgroundPageIdentifiers const):
(WebKit::WebExtensionContext::inspectorPageIdentifiers const):
(WebKit::WebExtensionContext::popupPageIdentifiers const):
(WebKit::WebExtensionContext::tabPageIdentifiers const):
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::processes const):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::dispatchDidLoad):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::injectStyleSheets):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::parameters const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::dataFromUserStyleSheet const):
(WebKit::WebUserContentControllerProxy::parametersForProcess const):
(WebKit::WebUserContentControllerProxy::addUserStyleSheet):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm:
(shouldEnableSiteIsolation):
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:usesEnhancedSecurity:]):
(-[TestWebExtensionTab initWithWindow:extensionController:]):
(-[TestWebExtensionTab changeWebViewIfNeededForURL:forExtensionContext:]):
(TestWebKitAPI::Util::SiteIsolationScope::SiteIsolationScope):
(TestWebKitAPI::Util::SiteIsolationScope::~SiteIsolationScope):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToDevToolsBackground)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, InspectedWindowTabIdFromPanel)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSS)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, InsertCSSInAllFramesWithCrossSiteFrame)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, InsertCSSInAllFramesWithCrossSiteFrame)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21b1c6bcd1048ccbaf827328fe779e8c28fb45a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191040 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145149 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6aa4601-5b6c-4bef-8cf7-9ad2578abd39) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141062 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97762 "1 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee107c17-28fb-4a68-bca0-a4b35c844df0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121514 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/793aa8e9-0612-4485-a569-899ac8feec66) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43399 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41678 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41341 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2200 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47383 "Found 1 new failure in UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192975 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54437 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150444 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55125 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150162 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44753 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127391 "Found 1 new failure in UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122691 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53642 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16334 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53024 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53261 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53089 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->