### PR TITLE
Make ThreadSafeWeakPtr safe to mutate from different threads

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -167,8 +167,8 @@ template<typename, typename WeakPtrImpl = DefaultWeakPtrImpl, typename = RawPtrT
 template<typename, typename = DefaultWeakPtrImpl> class WeakRef;
 template<typename T> class InlineWeakPtr;
 template<typename T> struct NoTaggingTraits;
-template<typename T, typename = NoTaggingTraits<T>> class ThreadSafeWeakPtr;
-template<typename T, typename = NoTaggingTraits<T>> class ThreadSafeWeakRef;
+template<typename T> class ThreadSafeWeakPtr;
+template<typename T> class ThreadSafeWeakRef;
 
 template <typename T>
 using SaSegmentedVector = SegmentedVector<T, 8, 0, SegmentedVectorGrowthPolicy::Constant, SequesteredArenaMalloc>;

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -136,8 +136,8 @@ public:
     {
     }
 
-    template<typename X, typename Y>
-    Ref(const ThreadSafeWeakRef<X, Y>& other) requires std::is_convertible_v<X*, T*>
+    template<typename X>
+    Ref(const ThreadSafeWeakRef<X>& other) requires std::is_convertible_v<X*, T*>
         : m_ptr(&RefDerefTraits::ref(other.get()))
     {
     }
@@ -209,8 +209,8 @@ template<typename X, typename Y> Ref(const WeakRef<X, Y>&) -> Ref<X, RawPtrTrait
 template<typename X, typename Y> Ref(WeakRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 template<typename X, typename Y> Ref(const CheckedRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 template<typename X, typename Y> Ref(CheckedRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
-template<typename X, typename Y> Ref(const ThreadSafeWeakRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
-template<typename X, typename Y> Ref(ThreadSafeWeakRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X> Ref(const ThreadSafeWeakRef<X>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X> Ref(ThreadSafeWeakRef<X>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 
 template<typename T, typename _PtrTraits, typename RefDerefTraits> Ref<T, _PtrTraits, RefDerefTraits> adoptRef(T&);
 

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -103,7 +103,7 @@ public:
     template<typename X, typename Y> RefPtr(Ref<X, Y>&&);
     template<typename X, typename Y, typename Z> RefPtr(const WeakPtr<X, Y, Z>& o) requires std::is_convertible_v<X*, T*> : m_ptr(RefDerefTraits::refIfNotNull(o.get())) { }
     template<typename X, typename Y> RefPtr(const CheckedPtr<X, Y>& o) requires std::is_convertible_v<X*, T*> : m_ptr(RefDerefTraits::refIfNotNull(o.get())) { }
-    template<typename X, typename Y> RefPtr(const ThreadSafeWeakPtr<X, Y>& o) requires std::is_convertible_v<X*, T*> : m_ptr(RefDerefTraits::refIfNotNull(o.get())) { }
+    template<typename X> RefPtr(const ThreadSafeWeakPtr<X>& o) requires std::is_convertible_v<X*, T*> : m_ptr(RefDerefTraits::refIfNotNull(o.get())) { }
 
     // Hash table deleted values, which are only constructed and never copied or destroyed.
     RefPtr(HashTableDeletedValueType) : m_ptr(PtrTraits::hashTableDeletedValue()) { }
@@ -163,8 +163,8 @@ template<typename X, typename Y, typename Z> RefPtr(const WeakPtr<X, Y, Z>&) -> 
 template<typename X, typename Y, typename Z> RefPtr(WeakPtr<X, Y, Z>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 template<typename X, typename Y> RefPtr(const CheckedPtr<X, Y>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 template<typename X, typename Y> RefPtr(CheckedPtr<X, Y>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
-template<typename X, typename Y> RefPtr(const ThreadSafeWeakPtr<X, Y>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
-template<typename X, typename Y> RefPtr(ThreadSafeWeakPtr<X, Y>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X> RefPtr(const ThreadSafeWeakPtr<X>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X> RefPtr(ThreadSafeWeakPtr<X>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 
 template<typename T, typename U, typename V>
 template<typename X, typename Y>

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -30,13 +30,12 @@
 #include <wtf/MainThread.h>
 #include <wtf/RefPtr.h>
 #include <wtf/SwiftBridging.h>
-#include <wtf/TaggedPtr.h>
 #include <wtf/WordLock.h>
 
 namespace WTF {
 
-template<typename T, typename> class ThreadSafeWeakPtr;
-template<typename T, typename> class ThreadSafeWeakRef;
+template<typename T> class ThreadSafeWeakPtr;
+template<typename T> class ThreadSafeWeakRef;
 template<typename> class ThreadSafeWeakHashSet;
 template<typename, DestructionThread> class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
 
@@ -44,6 +43,8 @@ class ThreadSafeWeakPtrControlBlock {
     WTF_MAKE_NONCOPYABLE(ThreadSafeWeakPtrControlBlock);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ThreadSafeWeakPtrControlBlock);
 public:
+    using ObjectOffset = int16_t;
+
     ThreadSafeWeakPtrControlBlock* weakRef()
     {
         Locker locker { m_lock };
@@ -118,27 +119,46 @@ public:
         }
     }
 
+    // N.B. These don't just make a strong reference to m_object because a ThreadSafeWeakPtr could be
+    // referring to some interior pointer when there is multiple inheritance.
+    // Consider:
+    // struct Cat : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Cat>;
+    // struct Dog { virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0; };
+    // struct CatDog : public Cat, public Dog {
+    //     ThreadSafeWeakPtrControlBlock& controlBlock() const { return Cat::controlBlock(); }
+    // };
+    //
+    // If we have a ThreadSafeWeakPtr<Dog> from a CatDog then we want to return the CatDog's Dog*
+    // and not m_object's CatDog* pointer.
+    template<typename U>
+    RefPtr<U> makeStrongReferenceIfPossible(ObjectOffset objectOffset) const
+    {
+        auto* object = static_cast<uint8_t*>(refObjectIfAlive());
+        if (!object)
+            return nullptr;
+        IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage")
+        return adoptRef(reinterpret_cast<U*>(object + objectOffset));
+        IGNORE_WARNINGS_END
+    }
+
     template<typename U>
     RefPtr<U> makeStrongReferenceIfPossible(const U* maybeInteriorPointer) const
     {
+        if (!refObjectIfAlive())
+            return nullptr;
+        return adoptRef(const_cast<U*>(maybeInteriorPointer));
+    }
+
+    template<typename U>
+    ObjectOffset objectOffset(const U* maybeInteriorPointer) const
+    {
         Locker locker { m_lock };
-        // N.B. We don't just return m_object here since a ThreadSafeWeakPtr could be calling with a pointer to
-        // some interior pointer when there is multiple inheritance.
-        // Consider:
-        // struct Cat : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Cat>;
-        // struct Dog { virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0; };
-        // struct CatDog : public Cat, public Dog {
-        //     ThreadSafeWeakPtrControlBlock& controlBlock() const { return Cat::controlBlock(); }
-        // };
-        //
-        // If we have a ThreadSafeWeakPtr<Dog> from a CatDog then we want to return maybeInteriorPointer's Dog*
-        // and not m_object's CatDog* pointer.
-        if (m_object) {
-            // Calling the RefPtr constructor would call strongRef() and deadlock.
-            ++m_strongReferenceCount;
-            return adoptRef(const_cast<U*>(maybeInteriorPointer));
-        }
-        return nullptr;
+        if (!m_object)
+            return 0;
+        ptrdiff_t offset = reinterpret_cast<const uint8_t*>(maybeInteriorPointer) - static_cast<const uint8_t*>(m_object);
+        auto truncatedOffset = static_cast<ObjectOffset>(offset);
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(truncatedOffset == offset);
+        return truncatedOffset;
     }
 
     // These should really only be used for debugging and shouldn't be used to guard any checks in production,
@@ -180,6 +200,17 @@ private:
 
     void setStrongReferenceCountDuringInitialization(uint32_t count) WTF_IGNORES_THREAD_SAFETY_ANALYSIS { m_strongReferenceCount = count; }
 
+    // Returns the object with its strong reference count incremented, or null if the object has started deletion.
+    void* refObjectIfAlive() const
+    {
+        Locker locker { m_lock };
+        if (!m_object)
+            return nullptr;
+        // Calling the RefPtr constructor would call strongRef() and deadlock.
+        ++m_strongReferenceCount;
+        return m_object;
+    }
+
     mutable WordLock m_lock;
     mutable uint32_t m_strongReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 1 };
     mutable uint32_t m_weakReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 0 };
@@ -201,6 +232,83 @@ struct ThreadSafeWeakPtrControlBlockRefDerefTraits {
     }
 };
 using ControlBlockRefPtr = RefPtr<ThreadSafeWeakPtrControlBlock, RawPtrTraits<ThreadSafeWeakPtrControlBlock>, ThreadSafeWeakPtrControlBlockRefDerefTraits>;
+
+class ThreadSafeWeakPtrStorage {
+    WTF_MAKE_NONCOPYABLE(ThreadSafeWeakPtrStorage);
+public:
+    using ObjectOffset = ThreadSafeWeakPtrControlBlock::ObjectOffset;
+
+    ThreadSafeWeakPtrStorage() = default;
+
+    ThreadSafeWeakPtrStorage(ThreadSafeWeakPtrControlBlock* controlBlock, ObjectOffset objectOffset)
+        : m_controlBlock(controlBlock ? controlBlock->weakRef() : nullptr)
+        , m_objectOffset(objectOffset)
+    {
+    }
+
+    ~ThreadSafeWeakPtrStorage() { clear(); }
+
+    template<typename T>
+    RefPtr<T> makeStrongReferenceIfPossible() const
+    {
+        Locker locker { m_lock };
+        if (!m_controlBlock)
+            return nullptr;
+        return m_controlBlock->makeStrongReferenceIfPossible<T>(m_objectOffset);
+    }
+
+    void set(ThreadSafeWeakPtrControlBlock* controlBlock, ObjectOffset objectOffset)
+    {
+        if (controlBlock)
+            controlBlock->weakRef();
+        adopt(controlBlock, objectOffset);
+    }
+
+    void clear() { adopt(nullptr, 0); }
+
+    void copyFrom(const ThreadSafeWeakPtrStorage& other)
+    {
+        ThreadSafeWeakPtrControlBlock* controlBlock;
+        ObjectOffset objectOffset;
+        {
+            Locker locker { other.m_lock };
+            controlBlock = other.m_controlBlock;
+            objectOffset = other.m_objectOffset;
+            if (controlBlock)
+                controlBlock->weakRef();
+        }
+        adopt(controlBlock, objectOffset);
+    }
+
+    void moveFrom(ThreadSafeWeakPtrStorage& other)
+    {
+        ThreadSafeWeakPtrControlBlock* controlBlock;
+        ObjectOffset objectOffset;
+        {
+            Locker locker { other.m_lock };
+            controlBlock = std::exchange(other.m_controlBlock, nullptr);
+            objectOffset = std::exchange(other.m_objectOffset, 0);
+        }
+        adopt(controlBlock, objectOffset);
+    }
+
+private:
+    void adopt(ThreadSafeWeakPtrControlBlock* controlBlock, ObjectOffset objectOffset)
+    {
+        ThreadSafeWeakPtrControlBlock* previous;
+        {
+            Locker locker { m_lock };
+            previous = std::exchange(m_controlBlock, controlBlock);
+            m_objectOffset = objectOffset;
+        }
+        if (previous)
+            previous->weakDeref();
+    }
+
+    ThreadSafeWeakPtrControlBlock* m_controlBlock WTF_GUARDED_BY_LOCK(m_lock) { nullptr };
+    ObjectOffset m_objectOffset WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    mutable Lock m_lock;
+};
 
 template<typename T, DestructionThread destructionThread = DestructionThread::Any>
 class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr {
@@ -337,72 +445,58 @@ private:
 #endif
     }
 
-    template<typename, typename> friend class ThreadSafeWeakPtr;
-    template<typename, typename> friend class ThreadSafeWeakRef;
+    template<typename> friend class ThreadSafeWeakPtr;
+    template<typename> friend class ThreadSafeWeakRef;
     template<typename> friend class ThreadSafeWeakHashSet;
 
     mutable Atomic<uintptr_t> m_bits { refIncrement + strongOnlyFlag };
 } SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
 
-template<typename T, typename TaggingTraits /* = NoTaggingTraits<T> */>
+template<typename T>
 class ThreadSafeWeakPtr {
 public:
-    using TagType = typename TaggingTraits::TagType;
     ThreadSafeWeakPtr() = default;
 
     ThreadSafeWeakPtr(std::nullptr_t) { }
 
-    ThreadSafeWeakPtr(const ThreadSafeWeakPtr& other)
-        : m_objectOfCorrectType(other.m_objectOfCorrectType)
-        , m_controlBlock(other.m_controlBlock)
-    { }
+    ThreadSafeWeakPtr(const ThreadSafeWeakPtr& other) { m_storage.copyFrom(other.m_storage); }
 
-    ThreadSafeWeakPtr(ThreadSafeWeakPtr&& other)
-        : m_objectOfCorrectType(std::exchange(other.m_objectOfCorrectType, nullptr))
-        , m_controlBlock(std::exchange(other.m_controlBlock, nullptr))
-    { }
+    ThreadSafeWeakPtr(ThreadSafeWeakPtr&& other) { m_storage.moveFrom(other.m_storage); }
 
     template<typename U>
         requires (!std::is_pointer_v<U>)
     ThreadSafeWeakPtr(const U& retainedReference)
-        : m_objectOfCorrectType(static_cast<const T*>(&retainedReference))
-        , m_controlBlock(controlBlock(retainedReference))
+        : ThreadSafeWeakPtr(controlBlockAndObjectOffset(retainedReference))
     { }
 
     template<typename U>
     ThreadSafeWeakPtr(const U* retainedPointer)
-        : m_objectOfCorrectType(static_cast<const T*>(retainedPointer))
-        , m_controlBlock(retainedPointer ? controlBlock(*retainedPointer) : nullptr)
+        : ThreadSafeWeakPtr(retainedPointer ? controlBlockAndObjectOffset(*retainedPointer) : ControlBlockAndObjectOffset { })
     { }
 
     template<typename U>
     ThreadSafeWeakPtr(const Ref<U>& strongReference)
-        : m_objectOfCorrectType(static_cast<const T*>(strongReference.ptr()))
-        , m_controlBlock(controlBlock(strongReference.get()))
+        : ThreadSafeWeakPtr(strongReference.get())
     { }
 
     template<typename U>
     ThreadSafeWeakPtr(const RefPtr<U>& strongReference)
-        : m_objectOfCorrectType(static_cast<const T*>(strongReference.get()))
-        , m_controlBlock(strongReference ? controlBlock(*strongReference) : nullptr)
+        : ThreadSafeWeakPtr(strongReference.get())
     { }
 
     ThreadSafeWeakPtr(ThreadSafeWeakPtrControlBlock& controlBlock, const T& objectOfCorrectType)
-        : m_objectOfCorrectType(&objectOfCorrectType)
-        , m_controlBlock(&controlBlock)
+        : m_storage(&controlBlock, controlBlock.objectOffset(&objectOfCorrectType))
     { }
 
     ThreadSafeWeakPtr& operator=(ThreadSafeWeakPtr&& other)
     {
-        m_controlBlock = std::exchange(other.m_controlBlock, nullptr);
-        m_objectOfCorrectType = std::exchange(other.m_objectOfCorrectType, nullptr);
+        m_storage.moveFrom(other.m_storage);
         return *this;
     }
 
     ThreadSafeWeakPtr& operator=(const ThreadSafeWeakPtr& other)
     {
-        m_controlBlock = other.m_controlBlock;
-        m_objectOfCorrectType = other.m_objectOfCorrectType;
+        m_storage.copyFrom(other.m_storage);
         return *this;
     }
 
@@ -410,112 +504,101 @@ public:
         requires (!std::is_pointer_v<U>)
     ThreadSafeWeakPtr& operator=(const U& retainedReference)
     {
-        m_controlBlock = controlBlock(retainedReference);
-        m_objectOfCorrectType = static_cast<const T*>(static_cast<const U*>(&retainedReference));
+        auto [controlBlock, objectOffset] = controlBlockAndObjectOffset(retainedReference);
+        m_storage.set(controlBlock, objectOffset);
         return *this;
     }
 
     template<typename U>
     ThreadSafeWeakPtr& operator=(const U* retainedPointer)
     {
-        m_controlBlock = retainedPointer ? controlBlock(*retainedPointer) : nullptr;
-        m_objectOfCorrectType = static_cast<const T*>(retainedPointer);
+        if (!retainedPointer) {
+            m_storage.clear();
+            return *this;
+        }
+        auto [controlBlock, objectOffset] = controlBlockAndObjectOffset(*retainedPointer);
+        m_storage.set(controlBlock, objectOffset);
         return *this;
     }
 
     ThreadSafeWeakPtr& operator=(std::nullptr_t)
     {
-        m_controlBlock = nullptr;
-        m_objectOfCorrectType = nullptr;
+        m_storage.clear();
         return *this;
     }
 
     template<typename U>
     ThreadSafeWeakPtr& operator=(const Ref<U>& strongReference)
     {
-        m_controlBlock = controlBlock(strongReference);
-        m_objectOfCorrectType = static_cast<const T*>(strongReference.ptr());
-        return *this;
+        return *this = strongReference.get();
     }
 
     template<typename U>
     ThreadSafeWeakPtr& operator=(const RefPtr<U>& strongReference)
     {
-        m_controlBlock = strongReference ? controlBlock(*strongReference) : nullptr;
-        m_objectOfCorrectType = static_cast<const T*>(strongReference.get());
-        return *this;
+        return *this = strongReference.get();
     }
 
-    RefPtr<T> get() const { return m_controlBlock ? m_controlBlock->template makeStrongReferenceIfPossible<T>(m_objectOfCorrectType.ptr()) : nullptr; }
-
-    void setTag(TagType tag) { m_objectOfCorrectType.setTag(tag); }
-    TagType tag() const { return m_objectOfCorrectType.tag(); }
+    RefPtr<T> get() const { return m_storage.makeStrongReferenceIfPossible<T>(); }
 
 private:
+    struct ControlBlockAndObjectOffset {
+        ThreadSafeWeakPtrControlBlock* controlBlock { nullptr };
+        ThreadSafeWeakPtrControlBlock::ObjectOffset objectOffset { 0 };
+    };
+
+    explicit ThreadSafeWeakPtr(ControlBlockAndObjectOffset pair)
+        : m_storage(pair.controlBlock, pair.objectOffset)
+    { }
+
     template<typename U>
     requires (std::is_convertible_v<U*, T*>)
-    ThreadSafeWeakPtrControlBlock* controlBlock(const U& classOrChildClass)
+    static ControlBlockAndObjectOffset controlBlockAndObjectOffset(const U& classOrChildClass)
     {
-        return &classOrChildClass.controlBlock();
+        auto& controlBlock = classOrChildClass.controlBlock();
+        return { &controlBlock, controlBlock.objectOffset(static_cast<const T*>(&classOrChildClass)) };
     }
 
     template<typename, DestructionThread> friend class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
     template<typename> friend class ThreadSafeWeakHashSet;
 
-    TaggedPtr<T, TaggingTraits> m_objectOfCorrectType;
-    // FIXME: Use CompactRefPtrTuple to reduce sizeof(ThreadSafeWeakPtr) by storing just an offset
-    // from ThreadSafeWeakPtrControlBlock::m_object and don't support structs larger than 65535.
-    // https://bugs.webkit.org/show_bug.cgi?id=283929
-    ControlBlockRefPtr m_controlBlock;
+    ThreadSafeWeakPtrStorage m_storage;
 } SWIFT_ESCAPABLE;
 
 template<class T> ThreadSafeWeakPtr(const T&) -> ThreadSafeWeakPtr<T>;
 template<class T> ThreadSafeWeakPtr(const T*) -> ThreadSafeWeakPtr<T>;
 
-template<typename T, typename TaggingTraits /* = NoTaggingTraits<T> */>
+template<typename T>
 class ThreadSafeWeakRef {
 public:
-    using TagType = typename TaggingTraits::TagType;
+    ThreadSafeWeakRef(const ThreadSafeWeakRef& other) { m_storage.copyFrom(other.m_storage); }
 
-    ThreadSafeWeakRef(const ThreadSafeWeakRef& other)
-        : m_objectOfCorrectType(other.m_objectOfCorrectType)
-        , m_controlBlock(other.m_controlBlock)
-    { }
-
-    ThreadSafeWeakRef(ThreadSafeWeakRef&& other)
-        : m_objectOfCorrectType(std::exchange(other.m_objectOfCorrectType, nullptr))
-        , m_controlBlock(std::exchange(other.m_controlBlock, nullptr))
-    { }
+    ThreadSafeWeakRef(ThreadSafeWeakRef&& other) { m_storage.moveFrom(other.m_storage); }
 
     template<typename U>
         requires (!std::is_pointer_v<U>)
     ThreadSafeWeakRef(const U& retainedReference)
-        : m_objectOfCorrectType(static_cast<const T*>(&retainedReference))
-        , m_controlBlock(controlBlock(retainedReference))
+        : ThreadSafeWeakRef(controlBlockAndObjectOffset(retainedReference))
     { }
 
     template<typename U>
     ThreadSafeWeakRef(const Ref<U>& strongReference)
-        : m_objectOfCorrectType(static_cast<const T*>(strongReference.ptr()))
-        , m_controlBlock(controlBlock(strongReference.get()))
+        : ThreadSafeWeakRef(strongReference.get())
     { }
 
     ThreadSafeWeakRef(ThreadSafeWeakPtrControlBlock& controlBlock, const T& objectOfCorrectType)
-        : m_objectOfCorrectType(&objectOfCorrectType)
-        , m_controlBlock(&controlBlock)
+        : m_storage(&controlBlock, controlBlock.objectOffset(&objectOfCorrectType))
     { }
 
     ThreadSafeWeakRef& operator=(ThreadSafeWeakRef&& other)
     {
-        m_controlBlock = std::exchange(other.m_controlBlock, nullptr);
-        m_objectOfCorrectType = std::exchange(other.m_objectOfCorrectType, nullptr);
+        m_storage.moveFrom(other.m_storage);
         return *this;
     }
 
     ThreadSafeWeakRef& operator=(const ThreadSafeWeakRef& other)
     {
-        m_controlBlock = other.m_controlBlock;
-        m_objectOfCorrectType = other.m_objectOfCorrectType;
+        m_storage.copyFrom(other.m_storage);
         return *this;
     }
 
@@ -523,58 +606,58 @@ public:
         requires (!std::is_pointer_v<U>)
     ThreadSafeWeakRef& operator=(const U& retainedReference)
     {
-        m_controlBlock = controlBlock(retainedReference);
-        m_objectOfCorrectType = static_cast<const T*>(static_cast<const U*>(&retainedReference));
+        auto [controlBlock, objectOffset] = controlBlockAndObjectOffset(retainedReference);
+        m_storage.set(controlBlock, objectOffset);
         return *this;
     }
 
     template<typename U>
     ThreadSafeWeakRef& operator=(const Ref<U>& strongReference)
     {
-        m_controlBlock = controlBlock(strongReference);
-        m_objectOfCorrectType = static_cast<const T*>(strongReference.ptr());
-        return *this;
+        return *this = strongReference.get();
     }
 
     Ref<T> get() const
     {
-        RELEASE_ASSERT(m_controlBlock);
-        RefPtr result = m_controlBlock->template makeStrongReferenceIfPossible<T>(m_objectOfCorrectType.ptr());
+        RefPtr result = m_storage.makeStrongReferenceIfPossible<T>();
         RELEASE_ASSERT(result);
         return result.releaseNonNull();
     }
 
-    void setTag(TagType tag) { m_objectOfCorrectType.setTag(tag); }
-    TagType tag() const { return m_objectOfCorrectType.tag(); }
-
 private:
+    struct ControlBlockAndObjectOffset {
+        ThreadSafeWeakPtrControlBlock* controlBlock { nullptr };
+        ThreadSafeWeakPtrControlBlock::ObjectOffset objectOffset { 0 };
+    };
+
+    explicit ThreadSafeWeakRef(ControlBlockAndObjectOffset pair)
+        : m_storage(pair.controlBlock, pair.objectOffset)
+    { }
+
     template<typename U>
     requires (std::is_convertible_v<U*, T*>)
-    ThreadSafeWeakPtrControlBlock* controlBlock(const U& classOrChildClass)
+    static ControlBlockAndObjectOffset controlBlockAndObjectOffset(const U& classOrChildClass)
     {
-        return &classOrChildClass.controlBlock();
+        auto& controlBlock = classOrChildClass.controlBlock();
+        return { &controlBlock, controlBlock.objectOffset(static_cast<const T*>(&classOrChildClass)) };
     }
 
     template<typename, DestructionThread> friend class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
     template<typename> friend class ThreadSafeWeakHashSet;
 
-    TaggedPtr<T, TaggingTraits> m_objectOfCorrectType;
-    // FIXME: Use CompactRefPtrTuple to reduce sizeof(ThreadSafeWeakPtr) by storing just an offset
-    // from ThreadSafeWeakPtrControlBlock::m_object and don't support structs larger than 65535.
-    // https://bugs.webkit.org/show_bug.cgi?id=283929
-    ControlBlockRefPtr m_controlBlock;
+    ThreadSafeWeakPtrStorage m_storage;
 } SWIFT_ESCAPABLE;
 
 template<class T> ThreadSafeWeakRef(const T&) -> ThreadSafeWeakRef<T>;
 
-template<typename T, typename TaggingTraits = NoTaggingTraits<T>>
-ALWAYS_INLINE RefPtr<T> protect(const ThreadSafeWeakPtr<T, TaggingTraits>& weakPtr)
+template<typename T>
+ALWAYS_INLINE RefPtr<T> protect(const ThreadSafeWeakPtr<T>& weakPtr)
 {
     return weakPtr.get();
 }
 
-template<typename T, typename TaggingTraits = NoTaggingTraits<T>>
-ALWAYS_INLINE Ref<T> protect(const ThreadSafeWeakRef<T, TaggingTraits>& weakRef)
+template<typename T>
+ALWAYS_INLINE Ref<T> protect(const ThreadSafeWeakRef<T>& weakRef)
 {
     return weakRef.get();
 }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -631,7 +631,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManager& GPUConnectionToWebProces
 RemoteAudioVideoRendererProxyManager& GPUConnectionToWebProcess::remoteAudioVideoRendererProxyManager()
 {
     if (!m_remoteAudioVideoRendererProxyManager)
-        lazyInitialize(m_remoteAudioVideoRendererProxyManager, makeUniqueWithoutRefCountedCheck<RemoteAudioVideoRendererProxyManager>(*this));
+        lazyInitialize(m_remoteAudioVideoRendererProxyManager, RemoteAudioVideoRendererProxyManager::create(*this));
 
     return *m_remoteAudioVideoRendererProxyManager;
 }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -384,7 +384,7 @@ private:
 #endif
     RefPtr<RemoteSharedResourceCache> m_sharedResourceCache;
 #if ENABLE(VIDEO)
-    const std::unique_ptr<RemoteAudioVideoRendererProxyManager> m_remoteAudioVideoRendererProxyManager;
+    const RefPtr<RemoteAudioVideoRendererProxyManager> m_remoteAudioVideoRendererProxyManager;
     Ref<RemoteMediaPlayerManagerProxy> m_remoteMediaPlayerManagerProxy;
 #endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -89,6 +89,11 @@ RefPtr<AudioVideoRenderer> RemoteAudioVideoRendererProxyManager::createRenderer(
 #endif
 }
 
+Ref<RemoteAudioVideoRendererProxyManager> RemoteAudioVideoRendererProxyManager::create(GPUConnectionToWebProcess& connection)
+{
+    return adoptRef(*new RemoteAudioVideoRendererProxyManager(connection));
+}
+
 RemoteAudioVideoRendererProxyManager::RemoteAudioVideoRendererProxyManager(GPUConnectionToWebProcess& connection)
     : m_videoFrameObjectHeap(connection.videoFrameObjectHeap())
     , m_gpuConnectionToWebProcess(connection)
@@ -110,21 +115,6 @@ RemoteAudioVideoRendererProxyManager::~RemoteAudioVideoRendererProxyManager()
     }
 }
 
-void RemoteAudioVideoRendererProxyManager::ref() const
-{
-    m_gpuConnectionToWebProcess.get()->ref();
-}
-
-void RemoteAudioVideoRendererProxyManager::deref() const
-{
-    m_gpuConnectionToWebProcess.get()->deref();
-}
-
-ThreadSafeWeakPtrControlBlock& RemoteAudioVideoRendererProxyManager::controlBlock() const
-{
-    return m_gpuConnectionToWebProcess.get()->controlBlock();
-}
-
 void RemoteAudioVideoRendererProxyManager::connectionToWebProcessClosed()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
@@ -141,7 +131,7 @@ std::optional<SharedPreferencesForWebProcess> RemoteAudioVideoRendererProxyManag
     return m_gpuConnectionToWebProcess.get()->sharedPreferencesForWebProcess();
 }
 
-void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdentifier identifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, CompletionHandler<void(std::optional<WebCore::SharedTimebaseHandle>)>&& completionHandler)
+void RemoteAudioVideoRendererProxyManager::createManager(RemoteAudioVideoRendererIdentifier identifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, CompletionHandler<void(std::optional<WebCore::SharedTimebaseHandle>)>&& completionHandler)
 {
     MESSAGE_CHECK(!m_renderers.contains(identifier));
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -66,15 +66,16 @@ class GPUConnectionToWebProcess;
 class RemoteVideoFrameObjectHeap;
 struct SharedPreferencesForWebProcess;
 
-class RemoteAudioVideoRendererProxyManager final : public IPC::MessageReceiver {
+// Destroyed on the main thread like the GPUConnectionToWebProcess that owns it, since it holds media
+// objects that expect to be torn down there.
+class RemoteAudioVideoRendererProxyManager final : public IPC::MessageReceiver, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioVideoRendererProxyManager, WTF::DestructionThread::Main> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteAudioVideoRendererProxyManager);
 public:
-    RemoteAudioVideoRendererProxyManager(GPUConnectionToWebProcess&);
+    static Ref<RemoteAudioVideoRendererProxyManager> create(GPUConnectionToWebProcess&);
     ~RemoteAudioVideoRendererProxyManager();
 
-    void ref() const final;
-    void deref() const final;
-    ThreadSafeWeakPtrControlBlock& controlBlock() const;
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     void connectionToWebProcessClosed();
 
@@ -89,8 +90,10 @@ public:
     RefPtr<WebCore::AudioVideoRenderer> rendererFor(std::optional<WebCore::MediaPlayerIdentifier>) const;
 
 private:
+    explicit RemoteAudioVideoRendererProxyManager(GPUConnectionToWebProcess&);
+
     // Messages
-    void create(RemoteAudioVideoRendererIdentifier, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier, CompletionHandler<void(std::optional<WebCore::SharedTimebaseHandle>)>&&);
+    void createManager(RemoteAudioVideoRendererIdentifier, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier, CompletionHandler<void(std::optional<WebCore::SharedTimebaseHandle>)>&&);
     void shutdown(RemoteAudioVideoRendererIdentifier);
 
     void setPreferences(RemoteAudioVideoRendererIdentifier, WebCore::VideoRendererPreferences);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -31,7 +31,7 @@
     DispatchedTo=GPU
 ]
 messages -> RemoteAudioVideoRendererProxyManager {
-    Create(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::MediaPlayerClientIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier) -> (std::optional<WebCore::SharedTimebaseHandle> handle)
+    CreateManager(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::MediaPlayerClientIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier) -> (std::optional<WebCore::SharedTimebaseHandle> handle)
     Shutdown(WebKit::RemoteAudioVideoRendererIdentifier identifier)
 
     SetPreferences(WebKit::RemoteAudioVideoRendererIdentifier identifier, OptionSet<WebCore::VideoRendererPreference> preferences)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -106,7 +106,7 @@ AudioVideoRendererRemote::AudioVideoRendererRemote(LoggerHelper* loggerHelper, G
     connection.connection().addWorkQueueMessageReceiver(Messages::AudioVideoRendererRemoteMessageReceiver::messageReceiverName(), queueSingleton(), m_receiver, m_identifier.toUInt64());
     connection.addClient(*this);
 
-    connection.connection().sendWithAsyncReply(Messages::RemoteAudioVideoRendererProxyManager::Create(identifier, mediaElementIdentifier, playerIdentifier), [weakThis = ThreadSafeWeakPtr { *this }](auto&& handle) {
+    connection.connection().sendWithAsyncReply(Messages::RemoteAudioVideoRendererProxyManager::CreateManager(identifier, mediaElementIdentifier, playerIdentifier), [weakThis = ThreadSafeWeakPtr { *this }](auto&& handle) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -32,6 +32,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/ListHashSet.h>
+#include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/WeakHashMap.h>
@@ -3275,6 +3276,374 @@ TEST(WTF_ThreadSafeWeakPtr, RemoveInDestructor)
             set.add(vector.last().get());
         }
     }
+}
+
+// The four tests below reproduce races in ThreadSafeWeakPtr and ThreadSafeWeakHashSet. Each runs
+// its accesses twice: once unguarded, which is where the race lives, and once with every access to
+// the shared handle under a single lock. The guarded run is the control -- if only the unguarded
+// run trips an oracle or a sanitizer, the cause is the missing synchronization rather than the
+// access pattern itself.
+enum class GuardWithLock : bool { No, Yes };
+
+template<typename Function>
+static void performWithOptionalLock(Lock& lock, GuardWithLock guard, const Function& function)
+{
+    if (guard == GuardWithLock::Yes) {
+        Locker locker { lock };
+        function();
+    } else
+        function();
+}
+
+static void testTornPairOnAssignment(GuardWithLock guard)
+{
+    constexpr unsigned iterations = 200000;
+
+    Lock lock;
+    ThreadSafeWeakPtr<ThreadSafeInstanceCounter> sharedWeak;
+    std::atomic<bool> readerShouldStop { false };
+
+    RefPtr counter = adoptRef(*new ThreadSafeInstanceCounter);
+    sharedWeak = *counter;
+
+    std::thread reader { [&] {
+        while (!readerShouldStop.load(std::memory_order_relaxed)) {
+            performWithOptionalLock(lock, guard, [&] {
+                // A torn read pairs the old control block with the new null object pointer, so it
+                // resolves to null rather than to a bad object. The damage it does is the
+                // unmatched strong reference asserted after the join.
+                RefPtr strong = sharedWeak.get();
+            });
+        }
+    } };
+
+    std::thread writer { [&] {
+        for (unsigned i = 0; i < iterations; ++i) {
+            performWithOptionalLock(lock, guard, [&] {
+                sharedWeak = nullptr;
+                sharedWeak = *counter;
+            });
+        }
+        readerShouldStop.store(true, std::memory_order_relaxed);
+    } };
+
+    writer.join();
+    reader.join();
+
+    // Only this function's RefPtr should hold a strong reference now. Any extra count is a torn
+    // read that incremented m_strongReferenceCount and returned adoptRef(nullptr).
+    EXPECT_EQ(counter->refCount(), 1u);
+
+    sharedWeak = nullptr;
+    counter = nullptr;
+    EXPECT_EQ(ThreadSafeInstanceCounter::instanceCount, 0u);
+}
+
+TEST(WTF_ThreadSafeWeakPtr, TornPairOnAssignment)
+{
+    testTornPairOnAssignment(GuardWithLock::No);
+    testTornPairOnAssignment(GuardWithLock::Yes);
+}
+
+static void testControlBlockFreedUnderReader(GuardWithLock guard)
+{
+    constexpr unsigned iterations = 200000;
+
+    Lock lock;
+    ThreadSafeWeakPtr<ThreadSafeInstanceCounter> sharedWeak;
+    std::atomic<bool> readerShouldStop { false };
+
+    std::thread reader { [&] {
+        while (!readerShouldStop.load(std::memory_order_relaxed)) {
+            performWithOptionalLock(lock, guard, [&] {
+                RefPtr strong = sharedWeak.get();
+            });
+        }
+    } };
+
+    std::thread writer { [&] {
+        for (unsigned i = 0; i < iterations; ++i) {
+            performWithOptionalLock(lock, guard, [&] {
+                {
+                    RefPtr victim = adoptRef(*new ThreadSafeInstanceCounter);
+                    sharedWeak = *victim;
+                }
+                // The pointee is gone and sharedWeak holds the last weak reference, so this
+                // assignment is the one that frees the control block.
+                sharedWeak = nullptr;
+            });
+        }
+        readerShouldStop.store(true, std::memory_order_relaxed);
+    } };
+
+    writer.join();
+    reader.join();
+
+    EXPECT_NULL(sharedWeak.get());
+    EXPECT_EQ(ThreadSafeInstanceCounter::instanceCount, 0u);
+}
+
+TEST(WTF_ThreadSafeWeakPtr, ControlBlockFreedUnderReader)
+{
+    testControlBlockFreedUnderReader(GuardWithLock::No);
+    testControlBlockFreedUnderReader(GuardWithLock::Yes);
+}
+
+TEST(WTF_ThreadSafeWeakPtr, GetRacingWithLastWeakReferenceRelease)
+{
+    constexpr unsigned iterations = 200000;
+
+    ThreadSafeWeakPtr<ThreadSafeInstanceCounter> sharedWeak;
+    std::atomic<bool> writerFinished { false };
+    std::atomic<uint64_t> resolvedCount { 0 };
+    std::atomic<uint64_t> readAttempts { 0 };
+    std::atomic<unsigned> readyThreads { 0 };
+
+    // Counts assignments published by the writer. The reader serves rounds rather than latching a
+    // generation, so it cannot miss the one the writer is in and spin against a handle that is
+    // already empty.
+    std::atomic<uint64_t> generation { 0 };
+
+    std::atomic<bool> objectAlive { false };
+    std::atomic<uint64_t> resolvedWhileLagging { 0 };
+    std::atomic<uint64_t> resolvedWhileAlive { 0 };
+    std::atomic<uint64_t> resolvedInWindow { 0 };
+    std::atomic<uint64_t> laggingAttempts { 0 };
+
+    std::thread reader { [&] {
+        readyThreads++;
+        while (readyThreads < 3) { }
+        for (uint64_t roundsServed = 0; ; ++roundsServed) {
+            while (generation.load(std::memory_order_acquire) == roundsServed) {
+                if (writerFinished.load(std::memory_order_relaxed))
+                    return;
+            }
+            readAttempts.fetch_add(1, std::memory_order_relaxed);
+            bool lagging = generation.load(std::memory_order_acquire) != roundsServed + 1;
+            if (lagging)
+                laggingAttempts.fetch_add(1, std::memory_order_relaxed);
+            bool aliveBefore = objectAlive.load(std::memory_order_acquire);
+            // Racing the writer's `sharedWeak = nullptr` below, which frees the control block this
+            // get() is about to read.
+            if (RefPtr strong = sharedWeak.get()) {
+                bool aliveAfter = objectAlive.load(std::memory_order_acquire);
+                bool staleRound = generation.load(std::memory_order_acquire) != roundsServed + 1;
+                resolvedCount.fetch_add(1, std::memory_order_relaxed);
+                if (lagging)
+                    resolvedWhileLagging.fetch_add(1, std::memory_order_relaxed);
+                if (aliveBefore || aliveAfter)
+                    resolvedWhileAlive.fetch_add(1, std::memory_order_relaxed);
+                if (!lagging && !staleRound && !aliveBefore && !aliveAfter)
+                    resolvedInWindow.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    } };
+
+    // Recycles control blocks so that one freed under the reader is likely to be reused, rather than
+    // left untouched where reading it would look harmless.
+    std::thread allocationChurn { [&] {
+        readyThreads++;
+        while (readyThreads < 3) { }
+        while (!writerFinished.load(std::memory_order_relaxed)) {
+            Ref object = adoptRef(*new ThreadSafeInstanceCounter);
+            // Forces a control block into existence, so this churns the same allocations.
+            ThreadSafeWeakPtr weak { object.get() };
+        }
+    } };
+
+    readyThreads++;
+    while (readyThreads < 3) { }
+
+    for (unsigned i = 0; i < iterations; ++i) {
+        {
+            Ref victim = adoptRef(*new ThreadSafeInstanceCounter);
+            objectAlive.store(true, std::memory_order_release);
+            sharedWeak = victim.get();
+        }
+        objectAlive.store(false, std::memory_order_release);
+        // The object is already destroyed, so sharedWeak holds the block's last weak reference and
+        // the assignment below is the one that frees it. Publishing first is what puts the reader's
+        // get() and that release in the same window.
+        generation.fetch_add(1, std::memory_order_release);
+        sharedWeak = nullptr;
+    }
+
+    writerFinished.store(true, std::memory_order_relaxed);
+    generation.fetch_add(1, std::memory_order_release);
+    reader.join();
+    allocationChurn.join();
+
+    EXPECT_GT(readAttempts.load(), 0u);
+    EXPECT_EQ(resolvedInWindow.load(), 0u);
+    EXPECT_NULL(sharedWeak.get());
+    EXPECT_EQ(ThreadSafeInstanceCounter::instanceCount, 0u);
+}
+
+static void testDoubleWeakDeref(GuardWithLock guard)
+{
+    constexpr unsigned balanceIterations = 200000;
+    constexpr unsigned hashSetIterations = 20000;
+
+    Lock lock;
+    ThreadSafeWeakPtr<ThreadSafeInstanceCounter> sharedWeak;
+    auto assignSharedWeak = [&](ThreadSafeInstanceCounter& object) {
+        performWithOptionalLock(lock, guard, [&] { sharedWeak = object; });
+    };
+    auto clearSharedWeak = [&] {
+        performWithOptionalLock(lock, guard, [&] { sharedWeak = nullptr; });
+    };
+
+    {
+        RefPtr a = adoptRef(*new ThreadSafeInstanceCounter);
+        RefPtr b = adoptRef(*new ThreadSafeInstanceCounter);
+
+        // One long-lived weak reference each, so the expected final count is exactly 1.
+        ThreadSafeWeakPtr keeperA { *a };
+        ThreadSafeWeakPtr keeperB { *b };
+
+        std::thread writerA { [&] {
+            for (unsigned i = 0; i < balanceIterations; ++i)
+                assignSharedWeak(*a);
+        } };
+        std::thread writerB { [&] {
+            for (unsigned i = 0; i < balanceIterations; ++i)
+                assignSharedWeak(*b);
+        } };
+        writerA.join();
+        writerB.join();
+
+        clearSharedWeak();
+        EXPECT_EQ(a->weakRefCount(), 1u);
+        EXPECT_EQ(b->weakRefCount(), 1u);
+    }
+
+    {
+        ThreadSafeWeakHashSet<ThreadSafeInstanceCounter> set;
+
+        // Phase 2 needs the two writers to overlap on the SAME assignment, so they are released one
+        // iteration at a time instead of running free.
+        std::atomic<unsigned> generation { 0 };
+        std::atomic<unsigned> workersDone { 0 };
+        std::atomic<bool> finished { false };
+
+        // A worker counts the rounds it has served rather than latching whichever generation it
+        // happens to observe first: main may already have published a round by the time a worker
+        // starts running, and a worker that then waited for the generation to change again would
+        // wait forever against main waiting for that same round to be served.
+        auto worker = [&] {
+            for (unsigned roundsServed = 0; ; ++roundsServed) {
+                while (generation.load(std::memory_order_acquire) == roundsServed) {
+                    if (finished.load(std::memory_order_acquire))
+                        return;
+                }
+                if (finished.load(std::memory_order_acquire))
+                    return;
+                clearSharedWeak();
+                workersDone.fetch_add(1, std::memory_order_release);
+            }
+        };
+
+        std::thread writerA { worker };
+        std::thread writerB { worker };
+
+        for (unsigned i = 0; i < hashSetIterations; ++i) {
+            {
+                RefPtr victim = adoptRef(*new ThreadSafeInstanceCounter);
+                set.add(*victim);
+                assignSharedWeak(*victim);
+            }
+            // The block now has two weak references (the set's bucket and sharedWeak) and no strong
+            // ones. Let both writers clear sharedWeak at once.
+            workersDone.store(0, std::memory_order_release);
+            generation.fetch_add(1, std::memory_order_release);
+            while (workersDone.load(std::memory_order_acquire) < 2) { }
+
+            // Drives amortizedCleanupIfNeeded() -> objectHasStartedDeletion() over the buckets.
+            EXPECT_TRUE(set.isEmptyIgnoringNullReferences());
+        }
+
+        finished.store(true, std::memory_order_release);
+        generation.fetch_add(1, std::memory_order_release);
+        writerA.join();
+        writerB.join();
+    }
+
+    EXPECT_EQ(ThreadSafeInstanceCounter::instanceCount, 0u);
+}
+
+TEST(WTF_ThreadSafeWeakPtr, DoubleWeakDeref)
+{
+    testDoubleWeakDeref(GuardWithLock::No);
+    testDoubleWeakDeref(GuardWithLock::Yes);
+}
+
+static void testWeakHashSetTimeOfCheckTimeOfUse(GuardWithLock guard)
+{
+    constexpr unsigned iterations = 200000;
+
+    Lock lock;
+    ThreadSafeWeakHashSet<ThreadSafeInstanceCounter> set;
+    ThreadSafeWeakPtr<ThreadSafeInstanceCounter> sharedWeak;
+    std::atomic<bool> shouldStop { false };
+
+    // The object outlives every thread below, so every set operation is in contract.
+    RefPtr keepAlive = adoptRef(*new ThreadSafeInstanceCounter);
+
+    std::thread setUser { [&] {
+        for (size_t i = 0; !shouldStop.load(std::memory_order_relaxed); ++i) {
+            performWithOptionalLock(lock, guard, [&] {
+                switch (i % 3) {
+                case 0:
+                    set.add(*keepAlive);
+                    break;
+                case 1:
+                    (void)set.contains(*keepAlive);
+                    break;
+                default:
+                    (void)set.remove(*keepAlive);
+                    break;
+                }
+            });
+        }
+    } };
+
+    auto churnHandle = [&](bool assignObject) {
+        for (unsigned i = 0; i < iterations; ++i) {
+            performWithOptionalLock(lock, guard, [&] {
+                if (assignObject)
+                    sharedWeak = *keepAlive;
+                else
+                    sharedWeak = nullptr;
+            });
+        }
+    };
+
+    std::thread writerA { [&] {
+        churnHandle(true);
+    } };
+    std::thread writerB { [&] {
+        churnHandle(false);
+    } };
+
+    writerA.join();
+    writerB.join();
+    shouldStop.store(true, std::memory_order_relaxed);
+    setUser.join();
+
+    // The set holds 0 or 1 weak references here and sharedWeak holds 0 or 1, so 0..2 is in range.
+    // Anything larger is a corrupted count; see the sanitizer output for the race itself.
+    EXPECT_LE(keepAlive->weakRefCount(), 2u);
+
+    sharedWeak = nullptr;
+    set.clear();
+    keepAlive = nullptr;
+    EXPECT_EQ(ThreadSafeInstanceCounter::instanceCount, 0u);
+}
+
+TEST(WTF_ThreadSafeWeakPtr, WeakHashSetTimeOfCheckTimeOfUse)
+{
+    testWeakHashSetTimeOfCheckTimeOfUse(GuardWithLock::No);
+    testWeakHashSetTimeOfCheckTimeOfUse(GuardWithLock::Yes);
 }
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DidUpdateRefCountWeakPtrImpl);


### PR DESCRIPTION
#### a90ff51d22256639ba1250a1d589f75a73c5ca9f
<pre>
Make ThreadSafeWeakPtr safe to mutate from different threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=283929">https://bugs.webkit.org/show_bug.cgi?id=283929</a>
<a href="https://rdar.apple.com/141168403">rdar://141168403</a>

Reviewed by David Kilzer.

ThreadSafeWeakPtr needs more information than just a pointer to support multiple inheritance.
This is tested in the existing test WTF_ThreadSafeWeakPtr.MultipleInheritance.
This was implemented by keeping two pointers, but that makes it so that if multiple threads
are accessing the same ThreadSafeWeakPtr from multiple threads and mutating it, there can
be inconsistent state, which leads to crashes.  See <a href="https://rdar.apple.com/184638719">rdar://184638719</a>.  ThreadSafeWeakPtr
was as safe as std::shared_ptr&lt;T&gt;, but this makes it as safe as std::atomic&lt;std::shared_ptr&lt;T&gt;&gt;.

Instead of keeping two pointers, I keep a pointer and a 16-bit offset to make room for a Lock.

RemoteAudioVideoRendererProxyManager needed to be fixed to fit into this new model.  It was
returning the control block of the GPUConnectionToWebProcess, which resulted in arbitrarily
large offsets needing to be stored because it was the difference of two pointers to two
different objects not related by inheritance.  I made RemoteAudioVideoRendererProxyManager
have its own control block to fix this.

I added some AI-generated tests that showed some threading issues before this fix.

I measured the performance of this change with this simple benchmark:

Ref counter = adoptRef(*new ThreadSafeInstanceCounter());
WallTime begin = WallTime::now();
for (size_t i = 0; i &lt; 1000000; i++) {
    ThreadSafeWeakPtr weakPtr { counter.get() };
    RefPtr getResult = weakPtr.get();
}
WallTime end = WallTime::now();
WTFLogAlways(&quot;%f ms&quot;, (end - begin).milliseconds());

The time spent before this change was about 8ms:
8.530140 ms
8.382082 ms
8.578062 ms
8.245945 ms
8.296013 ms

The time spent after this change was about 19ms:
19.480944 ms
19.495010 ms
19.415855 ms
19.705057 ms
19.248009 ms

So this does make this lightweight operation about twice as expensive, but that&apos;s the
cost of thread safety.  If this is found to be a performance bottleneck for anything,
we could either use WeakPtr or make a non-mutable version of ThreadSafeWeakPtr that
doesn&apos;t have a lock, or we could rewrite the code to not be so dependent on
ThreadSafeWeakPtr performance.

Test: Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp

* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/Ref.h:
* Source/WTF/wtf/RefPtr.h:
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::makeStrongReferenceIfPossible const):
(WTF::ThreadSafeWeakPtrControlBlock::objectOffset const):
(WTF::ThreadSafeWeakPtrControlBlock::refObjectIfAlive const):
(WTF::ThreadSafeWeakPtrStorage::ThreadSafeWeakPtrStorage):
(WTF::ThreadSafeWeakPtrStorage::~ThreadSafeWeakPtrStorage):
(WTF::ThreadSafeWeakPtrStorage::makeStrongReferenceIfPossible const):
(WTF::ThreadSafeWeakPtrStorage::set):
(WTF::ThreadSafeWeakPtrStorage::clear):
(WTF::ThreadSafeWeakPtrStorage::copyFrom):
(WTF::ThreadSafeWeakPtrStorage::moveFrom):
(WTF::ThreadSafeWeakPtrStorage::adopt):
(WTF::ThreadSafeWeakPtrStorage::WTF_GUARDED_BY_LOCK):
(WTF::ThreadSafeWeakPtr::ThreadSafeWeakPtr):
(WTF::ThreadSafeWeakPtr::operator=):
(WTF::ThreadSafeWeakPtr::get const):
(WTF::ThreadSafeWeakPtr::controlBlockAndObjectOffset):
(WTF::ThreadSafeWeakRef::ThreadSafeWeakRef):
(WTF::ThreadSafeWeakRef::operator=):
(WTF::ThreadSafeWeakRef::get const):
(WTF::ThreadSafeWeakRef::controlBlockAndObjectOffset):
(WTF::protect):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::remoteAudioVideoRendererProxyManager):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::create):
(WebKit::RemoteAudioVideoRendererProxyManager::createManager):
(WebKit::RemoteAudioVideoRendererProxyManager::ref const): Deleted.
(WebKit::RemoteAudioVideoRendererProxyManager::deref const): Deleted.
(WebKit::RemoteAudioVideoRendererProxyManager::controlBlock const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::AudioVideoRendererRemote):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::performWithOptionalLock):
(TestWebKitAPI::testTornPairOnAssignment):
(TestWebKitAPI::TEST(WTF_ThreadSafeWeakPtr, TornPairOnAssignment)):
(TestWebKitAPI::testControlBlockFreedUnderReader):
(TestWebKitAPI::TEST(WTF_ThreadSafeWeakPtr, ControlBlockFreedUnderReader)):
(TestWebKitAPI::TEST(WTF_ThreadSafeWeakPtr, GetRacingWithLastWeakReferenceRelease)):
(TestWebKitAPI::testDoubleWeakDeref):
(TestWebKitAPI::TEST(WTF_ThreadSafeWeakPtr, DoubleWeakDeref)):
(TestWebKitAPI::testWeakHashSetTimeOfCheckTimeOfUse):
(TestWebKitAPI::TEST(WTF_ThreadSafeWeakPtr, WeakHashSetTimeOfCheckTimeOfUse)):

Canonical link: <a href="https://commits.webkit.org/319915@main">https://commits.webkit.org/319915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f429f5cb4631fd232901c67a89968e56cd708710

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57099 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193394 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8ce119f-64dd-464c-b3dc-9c2c4ef10e7b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56834 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2435563e-f528-44a9-9628-ca1b70e29462) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186131 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/46716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/123414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab8df774-0255-4496-801b-9b9c3fff9c81) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/5384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12213 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/43273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4568 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44446 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49746 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195335 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56768 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/163238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57473 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152165 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27795 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46719 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125894 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55981 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/18284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55352 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55590 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55419 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->