### PR TITLE
[JSC] Do not allocate `StructureRareData` for every transition just to hold the shared poly proto watchpoint

### DIFF
--- a/JSTests/stress/poly-proto-detection-through-deep-and-dictionary-structures.js
+++ b/JSTests/stress/poly-proto-detection-through-deep-and-dictionary-structures.js
@@ -1,0 +1,37 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual);
+}
+
+function isPolyProto(object) {
+    return /PolyProto offset/.test(describe(object));
+}
+
+function isDictionary(object) {
+    return /Dictionary/.test(describe(object));
+}
+
+function test(numberOfProperties, expectDictionary) {
+    let makeInstance = new Function(`
+        function C() {
+            for (let i = 0; i < ${numberOfProperties}; ++i)
+                this["p" + i] = i;
+        }
+        return new C;
+    `);
+    function access(object) { return object.p3; }
+
+    shouldBe(isDictionary(makeInstance()), expectDictionary);
+
+    for (let i = 0; i < 10; ++i) {
+        let object = makeInstance();
+        shouldBe(access(object), 3);
+        shouldBe(access(object), 3);
+    }
+    return isPolyProto(makeInstance());
+}
+
+// Poly proto opportunities are only detected by inline caches.
+let expected = !!(jscOptions().forcePolyProto || jscOptions().useJIT || jscOptions().useLLIntICs);
+shouldBe(test(100, false), expected);
+shouldBe(test(200, true), expected);

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -4641,12 +4641,9 @@ static Vector<WatchpointSet*, 3> collectAdditionalWatchpoints(VM& vm, AccessCase
     if (WatchpointSet* set  = accessCase.additionalSet())
         result.append(set);
 
-    if (structure
-        && structure->hasRareData()
-        && structure->rareData()->hasSharedPolyProtoWatchpoint()
-        && structure->rareData()->sharedPolyProtoWatchpoint()->isStillValid()) {
-        WatchpointSet* set = structure->rareData()->sharedPolyProtoWatchpoint()->inflate();
-        result.append(set);
+    if (structure) {
+        if (InlineWatchpointSet* set = structure->sharedPolyProtoWatchpoint(); set && set->isStillValid())
+            result.append(set->inflate());
     }
 
     return result;
@@ -8208,10 +8205,11 @@ AccessGenerationResult PolymorphicAccess::addCases(const GCSafeConcurrentJSLocke
                 // The reason we don't immediately fire this watchpoint is that we may be already
                 // watching the poly proto watchpoint, which if fired, would destroy us. We let
                 // the person handling the result to do a delayed fire.
-                ASSERT(a->rareData()->sharedPolyProtoWatchpoint().get() == b->rareData()->sharedPolyProtoWatchpoint().get());
-                if (a->rareData()->sharedPolyProtoWatchpoint()->isStillValid()) {
+                InlineWatchpointSet* watchpoint = a->sharedPolyProtoWatchpoint();
+                ASSERT(watchpoint == b->sharedPolyProtoWatchpoint());
+                if (watchpoint->isStillValid()) {
                     shouldReset = true;
-                    resetResult.addWatchpointToFire(*a->rareData()->sharedPolyProtoWatchpoint(), StringFireDetail("Detected poly proto optimization opportunity."));
+                    resetResult.addWatchpointToFire(*watchpoint, StringFireDetail("Detected poly proto optimization opportunity."));
                 }
             }
         };

--- a/Source/JavaScriptCore/bytecode/ObjectAllocationProfileInlines.h
+++ b/Source/JavaScriptCore/bytecode/ObjectAllocationProfileInlines.h
@@ -120,7 +120,7 @@ ALWAYS_INLINE void ObjectAllocationProfileBase<Derived>::initializeProfile(VM& v
             ASSERT(constructor);
             ASSERT(functionRareData);
             InlineWatchpointSet& polyProtoWatchpointSet = executable->ensurePolyProtoWatchpoint();
-            structure->ensureRareData(vm)->setSharedPolyProtoWatchpoint(executable->sharedPolyProtoWatchpoint());
+            structure->setSharedPolyProtoWatchpoint(vm, executable->sharedPolyProtoWatchpoint());
             if (polyProtoWatchpointSet.isStillValid() && !functionRareData->hasAllocationProfileClearingWatchpoint()) {
                 // If we happen to go poly proto in the future, we want to clear this particular
                 // object allocation profile so we can transition to allocating poly proto objects.

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
@@ -136,10 +136,11 @@ AccessGenerationResult PropertyInlineCache::upgradeForPolyProtoIfNecessary(const
                 // The reason we don't immediately fire this watchpoint is that we may be already
                 // watching the poly proto watchpoint, which if fired, would destroy us. We let
                 // the person handling the result to do a delayed fire.
-                ASSERT(a->rareData()->sharedPolyProtoWatchpoint().get() == b->rareData()->sharedPolyProtoWatchpoint().get());
-                if (a->rareData()->sharedPolyProtoWatchpoint()->isStillValid()) {
+                InlineWatchpointSet* watchpoint = a->sharedPolyProtoWatchpoint();
+                ASSERT(watchpoint == b->sharedPolyProtoWatchpoint());
+                if (watchpoint->isStillValid()) {
                     shouldReset = true;
-                    resetResult.addWatchpointToFire(*a->rareData()->sharedPolyProtoWatchpoint(), StringFireDetail("Detected poly proto optimization opportunity."));
+                    resetResult.addWatchpointToFire(*watchpoint, StringFireDetail("Detected poly proto optimization opportunity."));
                 }
             }
         };

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -752,8 +752,8 @@ LLINT_SLOW_PATH_DECL(slow_path_get_by_id_direct)
                 Structure* b = baseValue.asCell()->structure();
 
                 if (Structure::shouldConvertToPolyProto(a, b)) {
-                    ASSERT(a->rareData()->sharedPolyProtoWatchpoint().get() == b->rareData()->sharedPolyProtoWatchpoint().get());
-                    a->rareData()->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
+                    ASSERT(a->sharedPolyProtoWatchpoint() == b->sharedPolyProtoWatchpoint());
+                    a->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
                 }
             }
         }
@@ -881,8 +881,8 @@ static JSValue performLLIntGetByID(BytecodeIndex bytecodeIndex, CodeBlock* codeB
                 Structure* b = baseValue.asCell()->structure();
 
                 if (Structure::shouldConvertToPolyProto(a, b)) {
-                    ASSERT(a->rareData()->sharedPolyProtoWatchpoint().get() == b->rareData()->sharedPolyProtoWatchpoint().get());
-                    a->rareData()->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
+                    ASSERT(a->sharedPolyProtoWatchpoint() == b->sharedPolyProtoWatchpoint());
+                    a->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
                 }
             }
         }
@@ -1096,8 +1096,8 @@ LLINT_SLOW_PATH_DECL(slow_path_put_by_id)
                     b = b->previousID();
 
                 if (Structure::shouldConvertToPolyProto(a, b)) {
-                    a->rareData()->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
-                    b->rareData()->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
+                    ASSERT(a->sharedPolyProtoWatchpoint() == b->sharedPolyProtoWatchpoint());
+                    a->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
                 }
             }
         }
@@ -1269,8 +1269,8 @@ LLINT_SLOW_PATH_DECL(slow_path_get_private_name)
                 Structure* b = baseValue.asCell()->structure();
 
                 if (Structure::shouldConvertToPolyProto(a, b)) {
-                    ASSERT(a->rareData()->sharedPolyProtoWatchpoint().get() == b->rareData()->sharedPolyProtoWatchpoint().get());
-                    a->rareData()->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
+                    ASSERT(a->sharedPolyProtoWatchpoint() == b->sharedPolyProtoWatchpoint());
+                    a->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
                 }
             }
         }
@@ -1404,8 +1404,8 @@ LLINT_SLOW_PATH_DECL(slow_path_put_private_name)
                     b = b->previousID();
 
                 if (Structure::shouldConvertToPolyProto(a, b)) {
-                    a->rareData()->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
-                    b->rareData()->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
+                    ASSERT(a->sharedPolyProtoWatchpoint() == b->sharedPolyProtoWatchpoint());
+                    a->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
                 }
             }
         }

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -356,6 +356,7 @@ Structure::Structure(VM& vm, StructureVariant variant, Structure* previous)
     setDidTransition(true);
     setStaticPropertiesReified(previous->staticPropertiesReified());
     setHasBeenDictionary(previous->hasBeenDictionary());
+    setHasSharedPolyProtoWatchpoint(previous->hasSharedPolyProtoWatchpoint());
     setProtectPropertyTableWhileTransitioning(false);
     setTransitionOffset(vm, invalidOffset);
     setMaxOffset(vm, invalidOffset);
@@ -1117,6 +1118,12 @@ void Structure::pinForCaching(const AbstractLocker&, VM& vm, PropertyTable* tabl
     m_transitionPropertyName = nullptr;
 }
 
+void Structure::pinSharedPolyProtoWatchpoint(VM& vm)
+{
+    ASSERT(vm.heap.isDeferred());
+    setSharedPolyProtoWatchpoint(vm, findSharedPolyProtoWatchpoint());
+}
+
 void Structure::allocateRareData(VM& vm)
 {
     ASSERT(!hasRareData());
@@ -1713,6 +1720,7 @@ Structure* Structure::setBrandTransition(VM& vm, Structure* structure, Symbol* b
     if (existingTransition) 
         return existingTransition;
 
+    DeferGC deferGC(vm);
     Structure* transition = BrandedStructure::create(vm, structure, &brand->uid(), deferred);
     transition->setTransitionKind(TransitionKind::SetBrand);
 

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -775,6 +775,8 @@ public:
     SeenProperties seenProperties() const { return m_seenProperties; }
 
     static bool shouldConvertToPolyProto(const Structure* a, const Structure* b);
+    inline InlineWatchpointSet* sharedPolyProtoWatchpoint() const; // Defined in StructureInlines.h
+    inline void setSharedPolyProtoWatchpoint(VM&, Box<InlineWatchpointSet>); // Defined in StructureInlines.h
 
     UniquedStringImpl* transitionPropertyName() const { return m_transitionPropertyName.get(); }
 
@@ -823,6 +825,7 @@ public:
     DEFINE_BITFIELD(bool, hasNonEnumerableProperties, HasNonEnumerableProperties, 1, 6);
     DEFINE_BITFIELD(bool, hasSpecialProperties, HasSpecialProperties, 1, 7);
     DEFINE_BITFIELD(DefinitelyNonThenableState, definitelyNonThenableState, DefinitelyNonThenableState, 2, 8); // This flag can be flipped on the main thread at any timing.
+    DEFINE_BITFIELD(bool, hasSharedPolyProtoWatchpoint, HasSharedPolyProtoWatchpoint, 1, 10);
     DEFINE_BITFIELD(TransitionKind, transitionKind, TransitionKind, 5, 13);
     DEFINE_BITFIELD(bool, isWatchingReplacement, IsWatchingReplacement, 1, 18); // This flag can be fliped on the main thread at any timing.
     DEFINE_BITFIELD(bool, mayBePrototype, MayBePrototype, 1, 19);
@@ -970,6 +973,9 @@ private:
     // Keep them inlined function since they are used in the critical path of Dictionary JSObject modification.
     void pin(const AbstractLocker&, VM&, PropertyTable*);
     void pinForCaching(const AbstractLocker&, VM&, PropertyTable*);
+
+    inline const Box<InlineWatchpointSet>& findSharedPolyProtoWatchpoint() const; // Defined in StructureInlines.h
+    JS_EXPORT_PRIVATE void pinSharedPolyProtoWatchpoint(VM&);
     
     static bool isRareData(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -480,8 +480,32 @@ inline void Structure::pin(const AbstractLocker&, VM& vm, PropertyTable* table)
 {
     setIsPinnedPropertyTable(true);
     setPropertyTable(vm, table);
+    if (hasSharedPolyProtoWatchpoint() && previousID())
+        pinSharedPolyProtoWatchpoint(vm);
     clearPreviousID();
     m_transitionPropertyName = nullptr;
+}
+
+inline const Box<InlineWatchpointSet>& Structure::findSharedPolyProtoWatchpoint() const
+{
+    ASSERT(hasSharedPolyProtoWatchpoint());
+    const Structure* current = this;
+    while (!current->hasRareData() || !current->rareData()->m_polyProtoWatchpoint)
+        current = current->previousID();
+    return current->rareData()->m_polyProtoWatchpoint;
+}
+
+inline InlineWatchpointSet* Structure::sharedPolyProtoWatchpoint() const
+{
+    if (!hasSharedPolyProtoWatchpoint())
+        return nullptr;
+    return findSharedPolyProtoWatchpoint().get();
+}
+
+inline void Structure::setSharedPolyProtoWatchpoint(VM& vm, Box<InlineWatchpointSet> watchpoint)
+{
+    ensureRareData(vm)->m_polyProtoWatchpoint = WTF::move(watchpoint);
+    setHasSharedPolyProtoWatchpoint(true);
 }
 
 ALWAYS_INLINE bool Structure::shouldConvertToPolyProto(const Structure* a, const Structure* b)
@@ -496,22 +520,19 @@ ALWAYS_INLINE bool Structure::shouldConvertToPolyProto(const Structure* a, const
         return false;
 
     // We only care about objects created via a constructor's to_this. These
-    // all have Structures with rare data and a sharedPolyProtoWatchpoint.
-    if (!a->hasRareData() || !b->hasRareData())
+    // all have Structures with a sharedPolyProtoWatchpoint.
+    if (!a->hasSharedPolyProtoWatchpoint() || !b->hasSharedPolyProtoWatchpoint())
         return false;
-
-    // We only care about Structure's generated from functions that share
-    // the same executable.
-    const Box<InlineWatchpointSet>& aInlineWatchpointSet = a->rareData()->sharedPolyProtoWatchpoint();
-    const Box<InlineWatchpointSet>& bInlineWatchpointSet = b->rareData()->sharedPolyProtoWatchpoint();
-    if (!aInlineWatchpointSet || !bInlineWatchpointSet || aInlineWatchpointSet.get() != bInlineWatchpointSet.get())
-        return false;
-    ASSERT(aInlineWatchpointSet && bInlineWatchpointSet && aInlineWatchpointSet.get() == bInlineWatchpointSet.get());
 
     if (a->hasPolyProto() || b->hasPolyProto())
         return false;
 
     if (a->storedPrototype() == b->storedPrototype())
+        return false;
+
+    // We only care about Structure's generated from functions that share
+    // the same executable.
+    if (a->sharedPolyProtoWatchpoint() != b->sharedPolyProtoWatchpoint())
         return false;
 
     JSObject* aObj = a->storedPrototypeObject();
@@ -621,13 +642,6 @@ inline void StructureTransitionTable::finalizeUnconditionally(VM& vm, Collection
 inline void Structure::finishCreation(VM& vm, const Structure* previous, DeferredStructureTransitionWatchpointFire* deferred)
 {
     this->finishCreation(vm);
-    if (previous->hasRareData()) {
-        const StructureRareData* previousRareData = previous->rareData();
-        if (previousRareData->hasSharedPolyProtoWatchpoint()) {
-            ensureRareData(vm);
-            rareData()->setSharedPolyProtoWatchpoint(previousRareData->copySharedPolyProtoWatchpoint());
-        }
-    }
     previous->fireStructureTransitionWatchpoint(deferred);
 }
 

--- a/Source/JavaScriptCore/runtime/StructureRareData.h
+++ b/Source/JavaScriptCore/runtime/StructureRareData.h
@@ -100,11 +100,6 @@ public:
     JSCellButterfly* cachedPropertyNamesConcurrently(CachedPropertyNamesKind) const;
     void setCachedPropertyNames(VM&, CachedPropertyNamesKind, JSCellButterfly*);
 
-    Box<InlineWatchpointSet> copySharedPolyProtoWatchpoint() const { return m_polyProtoWatchpoint; }
-    const Box<InlineWatchpointSet>& sharedPolyProtoWatchpoint() const { return m_polyProtoWatchpoint; }
-    void setSharedPolyProtoWatchpoint(Box<InlineWatchpointSet>&& sharedPolyProtoWatchpoint) { m_polyProtoWatchpoint = WTF::move(sharedPolyProtoWatchpoint); }
-    bool hasSharedPolyProtoWatchpoint() const { return static_cast<bool>(m_polyProtoWatchpoint); }
-
     static JSCellButterfly* cachedPropertyNamesSentinel() { return std::bit_cast<JSCellButterfly*>(static_cast<uintptr_t>(1)); }
 
     static constexpr ptrdiff_t offsetOfCachedPropertyNames(CachedPropertyNamesKind kind)


### PR DESCRIPTION
#### 1636f086098d299f1226667eaf79f19a3076a5c7
<pre>
[JSC] Do not allocate `StructureRareData` for every transition just to hold the shared poly proto watchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=321659">https://bugs.webkit.org/show_bug.cgi?id=321659</a>

Reviewed by NOBODY (OOPS!).

Structures created by a constructor hold the executable&apos;s shared poly proto
watchpoint in their StructureRareData, and every transition copies it into a
new StructureRareData. So every Structure of a constructor or class instance
carries a 96 byte StructureRareData whose only content is this 8 byte Box.
The Box is only read when an IC is built, and the root Structure of the
transition chain already has it.

This patch keeps the Box on the root only. Transitions inherit a bit saying
that some Structure on the previousID() chain has it, and readers walk the
chain only when the bit is set. pin() copies the Box into its own rare data
before it cuts the chain, so dictionary structures behave as before.

After compiling with Octane&apos;s TypeScript, StructureRareData count goes from
12040 to 826 (1.16 MB to 79 KB) out of 15414 Structures. Benchmarks are
neutral; without the bit, ICs on large object literals walked long chains for
nothing and the first TypeScript iteration got 2% slower.

Test: JSTests/stress/poly-proto-detection-through-deep-and-dictionary-structures.js

* JSTests/stress/poly-proto-detection-through-deep-and-dictionary-structures.js: Added.
(shouldBe):
(isPolyProto):
(isDictionary):
(test):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::collectAdditionalWatchpoints):
(JSC::PolymorphicAccess::addCases):
* Source/JavaScriptCore/bytecode/ObjectAllocationProfileInlines.h:
(JSC::ObjectAllocationProfileBase&lt;Derived&gt;::initializeProfile):
* Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp:
(JSC::PropertyInlineCache::upgradeForPolyProtoIfNecessary):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
(JSC::LLInt::performLLIntGetByID):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::Structure):
(JSC::Structure::pinSharedPolyProtoWatchpoint):
(JSC::Structure::setBrandTransition):
* Source/JavaScriptCore/runtime/Structure.h:
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::pin):
(JSC::Structure::findSharedPolyProtoWatchpoint const):
(JSC::Structure::sharedPolyProtoWatchpoint const):
(JSC::Structure::setSharedPolyProtoWatchpoint):
(JSC::Structure::shouldConvertToPolyProto):
(JSC::Structure::finishCreation):
* Source/JavaScriptCore/runtime/StructureRareData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1636f086098d299f1226667eaf79f19a3076a5c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190702 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144812 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140786 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97519 "5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121238 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43117 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41399 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3205 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10036 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153521 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41080 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1861 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41765 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192637 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54102 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150139 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54790 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149861 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44487 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127053 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122225 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53307 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16069 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52689 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->