### PR TITLE
[Navigation API] Implement NavigationTransition's to property

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7130,7 +7130,6 @@ imported/w3c/web-platform-tests/navigation-api/navigate-event/dangling-navigate-
 imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-infinite.optional.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-history-pushState.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-multiple-location.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to.html [ Skip ]
 
 # Require enabling CSS Scroll Anchoring
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reload.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.transition.to matches the navigate event's destination Test timed out
+PASS navigation.transition.to matches the navigate event's destination
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1178,7 +1178,7 @@ bool Navigation::createTransitionForInterception(NavigateEvent& event, Navigatio
     Ref committedPromise = DeferredPromise::create(domGlobalObject, DeferredPromise::Mode::RetainPromiseOnResolve).releaseNonNull();
     Ref finishedPromise = DeferredPromise::create(domGlobalObject, DeferredPromise::Mode::RetainPromiseOnResolve).releaseNonNull();
 
-    m_transition = NavigationTransition::create(navigationType, *fromNavigationHistoryEntry, WTF::move(committedPromise), WTF::move(finishedPromise));
+    m_transition = NavigationTransition::create(navigationType, *fromNavigationHistoryEntry, event.destination(), WTF::move(committedPromise), WTF::move(finishedPromise));
     return true;
 }
 

--- a/Source/WebCore/page/NavigationTransition.cpp
+++ b/Source/WebCore/page/NavigationTransition.cpp
@@ -34,14 +34,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationTransition);
 
-Ref<NavigationTransition> NavigationTransition::create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Ref<NavigationTransition> NavigationTransition::create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<NavigationDestination>&& destination, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    return adoptRef(*new NavigationTransition(type, WTF::move(fromEntry), WTF::move(committed), WTF::move(finished)));
+    return adoptRef(*new NavigationTransition(type, WTF::move(fromEntry), WTF::move(destination), WTF::move(committed), WTF::move(finished)));
 }
 
-NavigationTransition::NavigationTransition(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+NavigationTransition::NavigationTransition(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<NavigationDestination>&& destination, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
     : m_navigationType(type)
     , m_from(WTF::move(fromEntry))
+    , m_destination(WTF::move(destination))
     , m_committed(WTF::move(committed))
     , m_finished(WTF::move(finished))
 {

--- a/Source/WebCore/page/NavigationTransition.h
+++ b/Source/WebCore/page/NavigationTransition.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "JSDOMPromise.h"
+#include "NavigationDestination.h"
 #include "NavigationHistoryEntry.h"
 #include "NavigationNavigationType.h"
 
@@ -38,10 +39,11 @@ class Exception;
 class NavigationTransition final : public RefCounted<NavigationTransition> {
     WTF_MAKE_TZONE_ALLOCATED(NavigationTransition);
 public:
-    static Ref<NavigationTransition> create(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
+    static Ref<NavigationTransition> create(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry, Ref<NavigationDestination>&&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
 
     NavigationNavigationType navigationType() { return m_navigationType; };
     NavigationHistoryEntry& from() { return m_from; };
+    NavigationDestination& to() { return m_destination; };
     DOMPromise& committed();
     DOMPromise& finished();
 
@@ -51,11 +53,12 @@ public:
     void rejectPromise(JSC::JSValue exceptionObject);
 
 private:
-    explicit NavigationTransition(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
+    explicit NavigationTransition(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry, Ref<NavigationDestination>&&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
 
     NavigationNavigationType m_navigationType;
     bool m_committedSettled { false };
     const Ref<NavigationHistoryEntry> m_from;
+    const Ref<NavigationDestination> m_destination;
     const Ref<DeferredPromise> m_committed;
     const Ref<DeferredPromise> m_finished;
     RefPtr<DOMPromise> m_committedDOMPromise;

--- a/Source/WebCore/page/NavigationTransition.idl
+++ b/Source/WebCore/page/NavigationTransition.idl
@@ -4,6 +4,7 @@
 ] interface NavigationTransition {
   readonly attribute NavigationNavigationType navigationType;
   readonly attribute NavigationHistoryEntry from;
+  readonly attribute NavigationDestination to;
   readonly attribute Promise<undefined> committed;
   readonly attribute Promise<undefined> finished;
 };


### PR DESCRIPTION
#### cd40dc9c0d7265e263eb3204d763b5d510d953df
<pre>
[Navigation API] Implement NavigationTransition&apos;s to property
<a href="https://bugs.webkit.org/show_bug.cgi?id=321664">https://bugs.webkit.org/show_bug.cgi?id=321664</a>
<a href="https://rdar.apple.com/184792753">rdar://184792753</a>

Reviewed by Jessica Lee.

The spec says that NavigationTransition must have a property called &quot;to&quot;
which represents the NavigationDestination of a navigation.
<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationtransition">https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationtransition</a>

This patch implements this property. This is tested by a WPT test:
navigation-api/ordering-and-transition/transition-to.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-to-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::createTransitionForInterception):
* Source/WebCore/page/NavigationTransition.cpp:
(WebCore::NavigationTransition::create):
(WebCore::NavigationTransition::NavigationTransition):
* Source/WebCore/page/NavigationTransition.h:
* Source/WebCore/page/NavigationTransition.idl:

Canonical link: <a href="https://commits.webkit.org/319142@main">https://commits.webkit.org/319142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2051b88cf9b5083b25c92a3177b2e048f5dd2e66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190714 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144824 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bdd9e0bf-c602-4349-8ffb-2a32ec271206) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140779 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121231 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9509a494-307e-4b98-b946-e89c656fdc16) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43126 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41410 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153530 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41084 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1873 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192649 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150150 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54802 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37699 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/cookies/same-site/post-from-cross-site-popup.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/privateClickMeasurement/store-private-click-measurement.html, http/tests/resourceLoadStatistics/grandfathering.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/image-blocked-alt-text.html, http/tests/security/mixedContent/redirect-http-to-https-script-in-iframe-UpgradeMixedContent.html, http/tests/site-isolation/find-string-with-cross-page-focused-frame-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149872 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27408 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44495 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127065 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122238 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53319 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16073 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52701 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52938 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52766 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->