### PR TITLE
[site-isolation] AudioSession category should be calculated synchronously and not wait for the UI process

### DIFF
--- a/LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash.html
+++ b/LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash.html
@@ -23,6 +23,7 @@ const skippedInternalFunctions = [
   "setVP9DecoderDisabledForTesting",
   "setVP9ScreenSizeAndScaleForTesting",
   "storeRegistrationsOnDisk",
+  "systemAudioSessionCategory", // Calls IPC method behind AllowTestOnlyIPC which this test doesn't set.
   "terminateWebContentProcess",
 ];
 

--- a/LayoutTests/http/tests/site-isolation/audio-session-category-capture-and-playback-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-category-capture-and-playback-expected.txt
@@ -1,0 +1,15 @@
+Under site isolation, when one process plays audible media and another captures the microphone, the real audio session resolves to PlayAndRecord. Each process computes the category for its own sessions only, so this checks that the process owning the session reconciles them: MediaPlayback from the playing process, PlayAndRecord from the capturing process, and the higher priority of the two wins.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS playingProcessCategory is "MediaPlayback"
+PASS the real audio session's category is MediaPlayback while only media is playing
+PASS capturingProcessCategory is "PlayAndRecord"
+PASS playingProcessCategoryWhileCapturing is "MediaPlayback"
+PASS the real audio session's category is PlayAndRecord once one process captures
+PASS the real audio session's category is MediaPlayback again once capture stops
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/audio-session-category-capture-and-playback.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-category-capture-and-playback.html
@@ -1,0 +1,77 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/media-resources/utilities.js"></script>
+</head>
+<body>
+<video id="video" src="/media-resources/content/test.mp4"></video>
+<script>
+description("Under site isolation, when one process plays audible media and another captures the microphone, the real audio session resolves to PlayAndRecord. Each process computes the category for its own sessions only, so this checks that the process owning the session reconciles them: MediaPlayback from the playing process, PlayAndRecord from the capturing process, and the higher priority of the two wins.");
+jsTestIsAsync = true;
+
+onload = async () => {
+    try {
+        // The main frame's own process plays audible media, and computes MediaPlayback for itself.
+        await new Promise(resolve => {
+            video.addEventListener("canplaythrough", resolve, { once: true });
+            video.load();
+        });
+        internals.withUserGesture(() => video.play());
+        await new Promise(resolve => video.addEventListener("playing", resolve, { once: true }));
+
+        // Wait for the category rather than sampling it at the 'playing' event, which does not
+        // guarantee that the element's session has reached the state the category is computed from.
+        await waitForAudioSessionCategory("MediaPlayback");
+        playingProcessCategory = internals.audioSessionCategory();
+        shouldBeEqualToString("playingProcessCategory", "MediaPlayback");
+        await waitForSystemAudioSessionCategory("MediaPlayback");
+        testPassed("the real audio session's category is MediaPlayback while only media is playing");
+
+        // localhost and 127.0.0.1 are different sites, so the iframe captures in its own process.
+        capturingProcessCategory = await new Promise((resolve, reject) => {
+            window.onmessage = event => {
+                if (event.origin !== "http://localhost:8000") {
+                    reject(new Error(`unexpected origin ${event.origin}`));
+                    return;
+                }
+                resolve(event.data);
+            };
+            const iframe = document.createElement("iframe");
+            iframe.allow = "microphone";
+            iframe.src = "http://localhost:8000/site-isolation/resources/audio-session-capture-frame.html";
+            document.body.appendChild(iframe);
+        });
+
+        shouldBeEqualToString("capturingProcessCategory", "PlayAndRecord");
+
+        // The playing process has no capture source of its own, so its own category is unchanged.
+        playingProcessCategoryWhileCapturing = internals.audioSessionCategory();
+        shouldBeEqualToString("playingProcessCategoryWhileCapturing", "MediaPlayback");
+
+        // The real session takes the higher priority of the two.
+        await waitForSystemAudioSessionCategory("PlayAndRecord");
+        testPassed("the real audio session's category is PlayAndRecord once one process captures");
+
+        // Stopping capture releases the category the capturing process asked for, leaving the playing
+        // process's. PlayAndRecord is exempt from the delay before a category is dropped, so this does
+        // not wait out that timer.
+        await new Promise(resolve => {
+            window.onmessage = event => {
+                if (event.data === "stopped")
+                    resolve();
+            };
+            frames[0].postMessage("stop", "http://localhost:8000");
+        });
+        await waitForSystemAudioSessionCategory("MediaPlayback");
+        testPassed("the real audio session's category is MediaPlayback again once capture stops");
+    } catch (e) {
+        testFailed(e.message);
+    }
+
+    finishJSTest();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/audio-session-category-override-after-playback-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-category-override-after-playback-expected.txt
@@ -1,0 +1,18 @@
+A navigator.audioSession.type override set while another frame of the same page is already playing audible media replaces the audio session's category, both when it is lower than what that frame computes and when it is higher. The sibling test covers a frame that joins a page whose type is already set, which travels a different path: this one changes the type afterwards, so the other frame's process learns about it from the per-field DocumentSyncData broadcast rather than from the state it was created with. This test deliberately does not enable site isolation, so the site-isolated run is compared against the same expectations.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS playingFrameCategory is "MediaPlayback"
+PASS the real audio session's category is MediaPlayback before the override is set
+PASS navigator.audioSession.type is "ambient"
+PASS playingFrameCategoryAfterOverride is "AmbientSound"
+PASS overridingFrameCategory is "AmbientSound"
+PASS the real audio session's category is AmbientSound once the override is set
+PASS playingFrameState is "playing"
+PASS playingFrameCategoryAfterRaise is "PlayAndRecord"
+PASS the real audio session's category is PlayAndRecord once the override is raised
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/audio-session-category-override-after-playback.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-category-override-after-playback.html
@@ -1,0 +1,82 @@
+<!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/media-resources/utilities.js"></script>
+</head>
+<body>
+<script>
+description("A navigator.audioSession.type override set while another frame of the same page is already playing audible media replaces the audio session's category, both when it is lower than what that frame computes and when it is higher. The sibling test covers a frame that joins a page whose type is already set, which travels a different path: this one changes the type afterwards, so the other frame's process learns about it from the per-field DocumentSyncData broadcast rather than from the state it was created with. This test deliberately does not enable site isolation, so the site-isolated run is compared against the same expectations.");
+jsTestIsAsync = true;
+
+function nextFrameMessage()
+{
+    return new Promise((resolve, reject) => {
+        window.onmessage = event => {
+            if (event.origin !== "http://localhost:8000") {
+                reject(new Error(`unexpected origin ${event.origin}`));
+                return;
+            }
+            resolve(event.data);
+        };
+    });
+}
+
+onload = async () => {
+    try {
+        // localhost and 127.0.0.1 are different sites, so with site isolation the iframe plays in its
+        // own process. No override is set yet, so it computes MediaPlayback for itself.
+        const playing = nextFrameMessage();
+        const iframe = document.createElement("iframe");
+        iframe.src = "http://localhost:8000/site-isolation/resources/audio-session-playback-frame.html";
+        document.body.appendChild(iframe);
+
+        playingFrameCategory = await playing;
+        shouldBeEqualToString("playingFrameCategory", "MediaPlayback");
+        await waitForSystemAudioSessionCategory("MediaPlayback");
+        testPassed("the real audio session's category is MediaPlayback before the override is set");
+
+        // Setting the type now has to reach the already-playing frame's process.
+        const lowered = nextFrameMessage();
+        navigator.audioSession.type = "ambient";
+        shouldBeEqualToString("navigator.audioSession.type", "ambient");
+        frames[0].postMessage("AmbientSound", "http://localhost:8000");
+
+        playingFrameCategoryAfterOverride = await lowered;
+        shouldBeEqualToString("playingFrameCategoryAfterOverride", "AmbientSound");
+
+        overridingFrameCategory = internals.audioSessionCategory();
+        shouldBeEqualToString("overridingFrameCategory", "AmbientSound");
+
+        await waitForSystemAudioSessionCategory("AmbientSound");
+        testPassed("the real audio session's category is AmbientSound once the override is set");
+
+        // A lowered category on the real session only means the override reached the playing frame if
+        // that frame still has something to play. Had its media ended, its own category would have
+        // dropped without any override.
+        const stillPlaying = nextFrameMessage();
+        frames[0].postMessage("playing?", "http://localhost:8000");
+        playingFrameState = await stillPlaying;
+        shouldBeEqualToString("playingFrameState", "playing");
+
+        // An override replaces the computed category in either direction, so it raises it just as well:
+        // PlayAndRecord over the MediaPlayback the playing frame computes, with nothing capturing.
+        const raised = nextFrameMessage();
+        navigator.audioSession.type = "play-and-record";
+        frames[0].postMessage("PlayAndRecord", "http://localhost:8000");
+
+        playingFrameCategoryAfterRaise = await raised;
+        shouldBeEqualToString("playingFrameCategoryAfterRaise", "PlayAndRecord");
+
+        await waitForSystemAudioSessionCategory("PlayAndRecord");
+        testPassed("the real audio session's category is PlayAndRecord once the override is raised");
+    } catch (e) {
+        testFailed(e.message);
+    }
+
+    finishJSTest();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/audio-session-category-override-and-playback-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-category-override-and-playback-expected.txt
@@ -1,0 +1,13 @@
+A navigator.audioSession.type override set by one frame applies to audible media played by another frame of the same page, and lowers the audio session's category. This test deliberately does not enable site isolation, so that the site-isolated run is compared against the same expectations: with site isolation the two frames are in separate processes and the type reaches the playing one through DocumentSyncData, without it they share a process and its audio session, and both must reach AmbientSound.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS navigator.audioSession.type is "ambient"
+PASS playingFrameCategory is "AmbientSound"
+PASS overridingFrameCategory is "AmbientSound"
+PASS the real audio session's category is AmbientSound
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/audio-session-category-override-and-playback.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-category-override-and-playback.html
@@ -1,0 +1,54 @@
+<!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/media-resources/utilities.js"></script>
+</head>
+<body>
+<script>
+description("A navigator.audioSession.type override set by one frame applies to audible media played by another frame of the same page, and lowers the audio session's category. This test deliberately does not enable site isolation, so that the site-isolated run is compared against the same expectations: with site isolation the two frames are in separate processes and the type reaches the playing one through DocumentSyncData, without it they share a process and its audio session, and both must reach AmbientSound.");
+jsTestIsAsync = true;
+
+onload = async () => {
+    try {
+        // "ambient" maps to the AmbientSound category, which is lower priority than the MediaPlayback
+        // the playing frame would compute on its own.
+        navigator.audioSession.type = "ambient";
+        shouldBeEqualToString("navigator.audioSession.type", "ambient");
+
+        // localhost and 127.0.0.1 are different sites, so with site isolation the iframe plays in its
+        // own process.
+        playingFrameCategory = await new Promise((resolve, reject) => {
+            window.onmessage = event => {
+                if (event.origin !== "http://localhost:8000") {
+                    reject(new Error(`unexpected origin ${event.origin}`));
+                    return;
+                }
+                resolve(event.data);
+            };
+            const iframe = document.createElement("iframe");
+            iframe.src = "http://localhost:8000/site-isolation/resources/audio-session-playback-frame.html";
+            document.body.appendChild(iframe);
+        });
+
+        // The playing frame's process has the override even though it did not set it.
+        shouldBeEqualToString("playingFrameCategory", "AmbientSound");
+
+        overridingFrameCategory = internals.audioSessionCategory();
+        shouldBeEqualToString("overridingFrameCategory", "AmbientSound");
+
+        // The override replaces the category each process computes, so every process of the page reports
+        // AmbientSound. The process owning the real session picks the highest priority category its
+        // clients reported, so it only reaches AmbientSound because none of them reported higher.
+        await waitForSystemAudioSessionCategory("AmbientSound");
+        testPassed("the real audio session's category is AmbientSound");
+    } catch (e) {
+        testFailed(e.message);
+    }
+
+    finishJSTest();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/audio-session-category-override-does-not-affect-another-page-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/audio-session-category-override-does-not-affect-another-page-expected.txt
@@ -1,0 +1,14 @@
+Under site isolation, a navigator.audioSession.type override applies to the page that set it and not to another page in a different process. This page sets "ambient" and plays nothing, the opened page plays audible media: the opened page still computes MediaPlayback, and the real audio session takes the higher priority of the two.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS navigator.audioSession.type is "ambient"
+PASS thisPageCategory is "AmbientSound"
+PASS the real audio session's category is MediaPlayback
+PASS openedPageCategory is "MediaPlayback"
+PASS thisPageCategoryWhileOtherPagePlays is "AmbientSound"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/audio-session-category-override-does-not-affect-another-page.html
+++ b/LayoutTests/http/tests/site-isolation/audio-session-category-override-does-not-affect-another-page.html
@@ -1,0 +1,71 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/media-resources/utilities.js"></script>
+</head>
+<body>
+<script>
+description("Under site isolation, a navigator.audioSession.type override applies to the page that set it and not to another page in a different process. This page sets \"ambient\" and plays nothing, the opened page plays audible media: the opened page still computes MediaPlayback, and the real audio session takes the higher priority of the two.");
+jsTestIsAsync = true;
+
+let openedWindow;
+
+function nextMessage(type)
+{
+    return new Promise(resolve => {
+        window.addEventListener("message", function listener(event) {
+            if (event.data.type !== type)
+                return;
+            window.removeEventListener("message", listener);
+            resolve(event.data);
+        });
+    });
+}
+
+onload = async () => {
+    if (!window.internals) {
+        testFailed("This test requires the Internals API");
+        finishJSTest();
+        return;
+    }
+
+    try {
+        navigator.audioSession.type = "ambient";
+        shouldBeEqualToString("navigator.audioSession.type", "ambient");
+
+        thisPageCategory = internals.audioSessionCategory();
+        shouldBeEqualToString("thisPageCategory", "AmbientSound");
+
+        // localhost and 127.0.0.1 are different sites, so the opened page runs in a different process.
+        const playing = nextMessage("playing");
+        openedWindow = window.open("http://localhost:8000/site-isolation/resources/report-video-element-audio-session-category.html");
+        await playing;
+
+        // The opened page computes MediaPlayback for its own element, so the real session takes
+        // MediaPlayback over this page's AmbientSound.
+        await waitForSystemAudioSessionCategory("MediaPlayback");
+        testPassed("the real audio session's category is MediaPlayback");
+
+        // Sampled after the real session has settled, so an override reaching the opened page would
+        // already have been applied there.
+        const reported = nextMessage("category");
+        openedWindow.postMessage("category?", "*");
+        openedPageCategory = (await reported).category;
+        shouldBeEqualToString("openedPageCategory", "MediaPlayback");
+
+        // This page has no media of its own, so its category is still the override.
+        thisPageCategoryWhileOtherPagePlays = internals.audioSessionCategory();
+        shouldBeEqualToString("thisPageCategoryWhileOtherPagePlays", "AmbientSound");
+    } catch (e) {
+        testFailed(e.message);
+    }
+
+    if (openedWindow)
+        openedWindow.close();
+    finishJSTest();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/audio-session-capture-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/audio-session-capture-frame.html
@@ -1,0 +1,25 @@
+<script src="/media-resources/utilities.js"></script>
+<script>
+// Captures microphone audio and reports the category its own process computed, then stops capturing
+// when asked. Used by the test that checks the real audio session's category while one process plays
+// audio and another captures, and once capture stops.
+window.onmessage = event => {
+    if (event.data !== "stop")
+        return;
+    window.stream.getTracks().forEach(track => track.stop());
+    window.parent.postMessage("stopped", "*");
+};
+
+async function captureAndReport()
+{
+    try {
+        window.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        await waitForAudioSessionActiveState(true);
+        window.parent.postMessage(internals.audioSessionCategory(), "*");
+    } catch (e) {
+        window.parent.postMessage(`error: ${e.message}`, "*");
+    }
+}
+
+captureAndReport();
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/audio-session-playback-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/audio-session-playback-frame.html
@@ -1,0 +1,44 @@
+<script src="/media-resources/utilities.js"></script>
+<video id="video" loop src="/media-resources/content/test.mp4"></video>
+<script>
+// Plays audible media and reports the category its own process computed, then reports again once that
+// process reaches a category the parent asks for. Used by the tests that check a
+// navigator.audioSession.type override set by another frame of the same page reaches this process.
+// "playing?" reports whether the media is still playing, which the parent needs to tell a category it
+// computed from an override apart from one it computed from having nothing left to play.
+window.onmessage = async event => {
+    try {
+        if (event.data === "playing?") {
+            window.parent.postMessage(video.ended ? "ended" : video.paused ? "paused" : "playing", "*");
+            return;
+        }
+        await waitForAudioSessionCategory(event.data);
+        window.parent.postMessage(internals.audioSessionCategory(), "*");
+    } catch (e) {
+        window.parent.postMessage(`error: ${e.message}`, "*");
+    }
+};
+
+async function playAndReport()
+{
+    try {
+        await new Promise(resolve => {
+            video.addEventListener("canplaythrough", resolve, { once: true });
+            video.load();
+        });
+        internals.withUserGesture(() => video.play());
+        await new Promise(resolve => video.addEventListener("playing", resolve, { once: true }));
+
+        // Wait for the category rather than sampling it at the 'playing' event. Which category it is
+        // depends on whether the page has a navigator.audioSession.type override, so wait for any but None.
+        for (let tries = 0; internals.audioSessionCategory() === "None" && tries < 200; ++tries)
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+        window.parent.postMessage(internals.audioSessionCategory(), "*");
+    } catch (e) {
+        window.parent.postMessage(`error: ${e.message}`, "*");
+    }
+}
+
+playAndReport();
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/report-video-element-audio-session-category.html
+++ b/LayoutTests/http/tests/site-isolation/resources/report-video-element-audio-session-category.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/media-resources/utilities.js"></script>
+<script>
+let video;
+
+// Reports the category this process computed for its own sessions, on request rather than as soon as it
+// changes, so the opener can sample it at a point of its choosing.
+window.addEventListener("message", (event) => {
+    if (event.data === "category?")
+        window.opener.postMessage({ type: "category", category: internals.audioSessionCategory() }, "*");
+});
+
+window.addEventListener("load", async () => {
+    if (!window.opener || !window.internals)
+        return;
+
+    video = document.querySelector("video");
+    video.src = "/media/resources/test.mp4";
+    video.loop = true;
+    video.volume = 0.001;
+    playIgnoringAbort(video);
+
+    await new Promise(resolve => video.addEventListener("playing", resolve, { once: true }));
+    window.opener.postMessage({ type: "playing" }, "*");
+});
+</script>
+</head>
+<body>
+<video></video>
+This page plays a near-silent &lt;video&gt; on a loop and reports the audio session category its own process computed to its opener.
+</body>
+</html>

--- a/LayoutTests/media/audioSession/audioSessionType.html
+++ b/LayoutTests/media/audioSession/audioSessionType.html
@@ -6,24 +6,11 @@
         <script src="../../resources/testharnessreport.js"></script>
         <script src="../media-file.js"></script>
         <script src="../video-test.js"></script>
+        <script src="../utilities.js"></script>
     </head>
     <body>
         <audio id="audio"></audio>
         <script>
-async function ensureCategory(expected, counter)
-{
-    if (internals.audioSessionCategory() == expected)
-        return "";
-
-    if (!counter)
-        counter = 0;
-    else if (counter > 100)
-        return `ensureCategory failed, expected was ${expected} and current value is ${internals.audioSessionCategory()}`;
-
-    await new Promise(resolve => setTimeout(resolve, 20));
-    return ensureCategory(expected, ++counter);
-}
-
 promise_test(async (test) => {
     assert_equals(navigator.audioSession.type, "auto");
     assert_equals(AudioSession.prototype.state, undefined);
@@ -37,7 +24,7 @@ promise_test(async (test) => {
 
 
     assert_equals(navigator.audioSession.type, "auto");
-    assert_equals(await ensureCategory("MediaPlayback"), "", "initial MediaPlayback");
+    await waitForAudioSessionCategory("MediaPlayback", "initial");
 
     navigator.audioSession.type = "ambient";
     assert_equals(internals.audioSessionCategory(), "AmbientSound");
@@ -55,7 +42,7 @@ promise_test(async (test) => {
     assert_equals(internals.audioSessionCategory(), "SoloAmbientSound");
 
     navigator.audioSession.type = "auto";
-    assert_equals(await ensureCategory("MediaPlayback"), "", "final MediaPlayback");
+    await waitForAudioSessionCategory("MediaPlayback", "final");
 }, "AudioSession type");
         </script>
     </body>

--- a/LayoutTests/media/utilities.js
+++ b/LayoutTests/media/utilities.js
@@ -164,3 +164,35 @@ function waitForAudioSessionActiveState(active) {
         check();
     });
 }
+
+// Waits for the category applied to the real audio session, which the process owning it derives from
+// what every web process reported, so it can lag this process asking for its own category.
+async function waitForSystemAudioSessionCategory(category) {
+    if (!window.internals)
+        throw new Error("waitForSystemAudioSessionCategory requires window.internals");
+
+    let observed;
+    for (let tries = 0; tries < 200; ++tries) {
+        observed = await internals.systemAudioSessionCategory();
+        if (observed === category)
+            return;
+        await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    throw new Error(`system audio session category is "${observed}", expected "${category}"`);
+}
+
+// Waits for the category this process computed for its own sessions. The category is applied from a
+// task, so a caller that has just changed what a session reports has to wait for it.
+async function waitForAudioSessionCategory(category, description) {
+    if (!window.internals)
+        throw new Error("waitForAudioSessionCategory requires window.internals");
+
+    let observed;
+    for (let tries = 0; tries < 200; ++tries) {
+        observed = internals.audioSessionCategory();
+        if (observed === category)
+            return;
+        await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    throw new Error(`audio session category is "${observed}", expected "${category}"${description ? ` (${description})` : ""}`);
+}

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -110,6 +110,11 @@ ExceptionOr<void> DOMAudioSession::setType(Type type)
     return { };
 }
 
+void DOMAudioSession::applyTypeToAudioSessionCategoryOverride(Type type)
+{
+    AudioSession::singleton().setCategoryOverride(fromDOMAudioSessionType(type));
+}
+
 DOMAudioSession::Type DOMAudioSession::type() const
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -58,6 +58,11 @@ public:
 
     ExceptionOr<void> setType(Type);
     Type type() const;
+
+    // Applies the category override a type implies to this process's audio session. Called when the
+    // type set by another process's document arrives through DocumentSyncData, so that every process
+    // of the page computes its category with the same override.
+    static void applyTypeToAudioSessionCategoryOverride(Type);
     State state() const;
 
     void topDocumentAudioSessionStateChanged();

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -549,10 +549,14 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
         return;
 
     bool muted = m_private->muted();
-    Ref categoryApplied = GenericPromise::createAndResolve();
+    RefPtr<GenericPromise> sessionActivated;
     if (isAudio() && isCaptureTrack()) {
-        if (RefPtr manager = mediaSessionManager())
-            categoryApplied = manager->audioCaptureSourceStateChanged(muted ? MediaSessionManagerInterface::IsCaptureStarting::No : MediaSessionManagerInterface::IsCaptureStarting::Yes);
+        if (RefPtr manager = mediaSessionManager()) {
+            Ref stateChanged = manager->audioCaptureSourceStateChanged(muted ? MediaSessionManagerInterface::IsCaptureStarting::No : MediaSessionManagerInterface::IsCaptureStarting::Yes);
+            // Only unmuting has something to wait for: muting requests deactivation without waiting.
+            if (!muted)
+                sessionActivated = WTF::move(stateChanged);
+        }
     }
 
     Function<void()> updateMuted = [this, protectedThis = Ref { *this }, muted] {
@@ -575,12 +579,14 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
 
     if (m_shouldFireMuteEventImmediately)
         updateMuted();
-    else {
-        // Under site isolation the audio session category is applied to this process asynchronously
-        // (via IPC reply). Delay the mute/unmute event until it has been applied so listeners observe
-        // the up-to-date category. In the non-isolated case categoryApplied is already resolved, so
-        // this is equivalent to queueing the event on the event loop as before.
-        context->enqueueTaskWhenSettled(WTF::move(categoryApplied), TaskSource::Networking, [updateMuted = WTF::move(updateMuted)](auto&&) mutable {
+    else if (sessionActivated) {
+        // Unmuting an audio capture track activates the audio session asynchronously. Delay the event
+        // until it has, so listeners observe an active session.
+        context->enqueueTaskWhenSettled(sessionActivated.releaseNonNull(), TaskSource::Networking, [updateMuted = WTF::move(updateMuted)](auto&&) mutable {
+            updateMuted();
+        });
+    } else {
+        queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [updateMuted = WTF::move(updateMuted)](auto&) {
             updateMuted();
         });
     }

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -205,12 +205,12 @@ void UserMediaRequest::allow(CaptureDevice&& audioDevice, CaptureDevice&& videoD
                 return;
             }
 
-            Ref categoryApplied = GenericPromise::createAndResolve();
+            RefPtr<GenericPromise> sessionActivated;
             if (RefPtr audioTrack = stream->getFirstAudioTrack()) {
 #if USE(AUDIO_SESSION)
                 if (RefPtr page = document.page()) {
                     if (RefPtr manager = page->mediaSessionManager())
-                        categoryApplied = manager->audioCaptureSourceStateChanged(MediaSessionManagerInterface::IsCaptureStarting::Yes);
+                        sessionActivated = manager->audioCaptureSourceStateChanged(MediaSessionManagerInterface::IsCaptureStarting::Yes);
                 }
 #endif
                 if (std::holds_alternative<MediaTrackConstraints>(protectedThis->m_audioConstraints))
@@ -224,12 +224,15 @@ void UserMediaRequest::allow(CaptureDevice&& audioDevice, CaptureDevice&& videoD
             ASSERT(document.isCapturing());
             document.setHasCaptureMediaStreamTrack();
 
-            // Under site isolation the audio session category is applied to this process asynchronously
-            // (via IPC reply). Delay resolving the getUserMedia promise until it has been applied, so
-            // callers observe the up-to-date category (e.g. "PlayAndRecord"). In the non-isolated case
-            // (or without an audio track) categoryApplied is already resolved.
+            if (!sessionActivated) {
+                protectedThis->m_promise->resolve(WTF::move(stream));
+                return;
+            }
+
+            // Audio session activation completes asynchronously. Delay resolving the getUserMedia
+            // promise until it has, so callers observe an active session.
             RefPtr context = protectedThis->scriptExecutionContext();
-            context->enqueueTaskWhenSettled(WTF::move(categoryApplied), TaskSource::UserInteraction, [protectedThis, stream = WTF::move(stream)](auto&&) mutable {
+            context->enqueueTaskWhenSettled(sessionActivated.releaseNonNull(), TaskSource::UserInteraction, [protectedThis, stream = WTF::move(stream)](auto&&) mutable {
                 protectedThis->m_promise->resolve(WTF::move(stream));
             });
         };

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5105,15 +5105,6 @@ void HTMLMediaElement::routingContextUIDDidChange(const AudioSession& session)
     });
 }
 
-void HTMLMediaElement::categoryDidChange(const AudioSession& session)
-{
-    if (paused())
-        return;
-
-    m_categoryAtMostRecentPlayback = session.category();
-    m_modeAtMostRecentPlayback = session.mode();
-}
-
 #endif // USE(AUDIO_SESSION)
 
 void HTMLMediaElement::togglePlayState()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1117,7 +1117,6 @@ private:
     void hardwareMutedStateDidChange(const AudioSession&) final;
 #endif
     void routingContextUIDDidChange(const AudioSession&) final;
-    void categoryDidChange(const AudioSession&) final;
 #endif
 
     bool NODELETE hasMediaSource() const;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1004,12 +1004,15 @@ void Page::updateTopDocumentSyncData(const DocumentSyncSerializationData& data)
     case DocumentSyncDataType::IsAutofocusProcessed:
     case DocumentSyncDataType::IsClosing:
     case DocumentSyncDataType::UserDidInteractWithPage:
-#if ENABLE(DOM_AUDIO_SESSION)
-    case DocumentSyncDataType::AudioSessionType:
-#endif
         protect(m_topDocumentSyncData)->update(data);
         break;
 #if ENABLE(DOM_AUDIO_SESSION)
+    case DocumentSyncDataType::AudioSessionType:
+        protect(m_topDocumentSyncData)->update(data);
+        // The type was set by a document in another process. Each process computes its own audio
+        // session category, so apply the override the type implies here too.
+        DOMAudioSession::applyTypeToAudioSessionCategoryOverride(m_topDocumentSyncData->audioSessionType);
+        break;
     case DocumentSyncDataType::AudioSessionState:
         protect(m_topDocumentSyncData)->update(data);
         forEachDocument([](Document& document) {
@@ -1028,6 +1031,12 @@ void Page::updateTopDocumentSyncData(const DocumentSyncSerializationData& data)
 void Page::updateTopDocumentSyncData(Ref<DocumentSyncData>&& data)
 {
     m_topDocumentSyncData = WTF::move(data);
+
+#if ENABLE(DOM_AUDIO_SESSION)
+    // This path carries the whole state at once, when a remote page is set up in this process. Apply
+    // the override the type implies, as the per-field path does for later changes.
+    DOMAudioSession::applyTypeToAudioSessionCategoryOverride(m_topDocumentSyncData->audioSessionType);
+#endif
 }
 
 void Page::setMainFrameURLFragment(String&& fragment)

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -70,7 +70,6 @@ public:
     virtual void bufferSizeDidChange(const AudioSession&) { }
     virtual void sampleRateDidChange(const AudioSession&) { }
     virtual void routingContextUIDDidChange(const AudioSession&) { }
-    virtual void categoryDidChange(const AudioSession&) { }
 };
 
 class WEBCORE_EXPORT AudioSession : public AbstractThreadSafeRefCountedAndCanMakeWeakPtr {
@@ -128,6 +127,10 @@ public:
 
     virtual void beginInterruptionForTesting() { beginInterruption(); }
     virtual void endInterruptionForTesting() { endInterruption(MayResume::Yes); }
+
+    // The category applied to the real audio session.
+    using CategoryPromise = NativePromise<AudioSessionCategory, void>;
+    virtual Ref<CategoryPromise> systemCategoryForTesting() { return CategoryPromise::createAndResolve(category()); }
     virtual void clearInterruptionFlagForTesting() { }
 
     static void addInterruptionObserver(AudioSessionInterruptionObserver&);

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -726,28 +726,21 @@ void MediaSessionManagerInterface::removeAudioCaptureSource(AudioCaptureSource& 
 
 Ref<GenericPromise> MediaSessionManagerInterface::audioCaptureSourceStateChanged(IsCaptureStarting isCaptureStarting)
 {
-    Ref categoryApplied = updateSessionState();
+    updateSessionState();
 #if USE(AUDIO_SESSION)
     // Activation and deactivation are requested synchronously, so a caller that does not wait on the
-    // returned promise observes AudioSession::isActive() as soon as this returns (RemoteAudioSession
-    // reflects the requested state optimistically). navigator.mediaSession.setMicrophoneActive() for
-    // instance resolves its promise from the UIProcess ValidateCaptureStateUpdate reply, which does not
-    // wait for the UpdateMediaSessionStates round-trip that applies the category under site isolation.
-    // The returned promise settles once both the category has been applied and the activation has
-    // completed, so a caller that does wait — the getUserMedia promise, the track mute/unmute events —
-    // sees a session that is both categorised and active.
-    if (isCaptureStarting == IsCaptureStarting::Yes) {
-        GenericPromise::Producer producer;
-        Ref promise = producer.promise();
-        GenericPromise::all({ WTF::move(categoryApplied), maybeActivateAudioSession() })->chainTo(WTF::move(producer));
-        return promise;
-    }
+    // returned promise still observes AudioSession::isActive() as soon as this returns
+    // (RemoteAudioSession reflects the requested state optimistically). The promise settles once the
+    // activation has completed, for callers that need an active session — the getUserMedia promise and
+    // the track unmute event.
+    if (isCaptureStarting == IsCaptureStarting::Yes)
+        return maybeActivateAudioSession();
 
     maybeDeactivateAudioSession();
 #else
     UNUSED_PARAM(isCaptureStarting);
 #endif
-    return categoryApplied;
+    return GenericPromise::createAndResolve();
 }
 
 int MediaSessionManagerInterface::countActiveAudioCaptureSources()
@@ -959,11 +952,6 @@ void MediaSessionManagerInterface::scheduleUpdateSessionState()
         updateSessionState();
         m_hasScheduledSessionStateUpdate = false;
     });
-}
-
-Ref<GenericPromise> MediaSessionManagerInterface::updateSessionState()
-{
-    return GenericPromise::createAndResolve();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -208,12 +208,7 @@ protected:
     bool computeSupportsSeeking() const;
 
     void scheduleUpdateSessionState();
-    // Applies the computed audio session category for the current set of sessions/capture sources.
-    // The returned promise settles once the category has been applied to AudioSession::singleton() in
-    // this process — synchronously for in-process managers (already-resolved promise), asynchronously
-    // for RemoteMediaSessionManager which applies it from an IPC reply. Callers that don't need to
-    // observe completion may ignore the result.
-    virtual Ref<GenericPromise> updateSessionState();
+    virtual void updateSessionState() { }
 
     std::optional<PageIdentifier> pageIdentifier() const { return m_pageIdentifier; }
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -64,7 +64,7 @@ public:
 protected:
     explicit MediaSessionManagerCocoa(std::optional<PageIdentifier>);
 
-    Ref<GenericPromise> updateSessionState() override;
+    void updateSessionState() override;
     void beginInterruption(PlatformMediaSession::InterruptionType) final;
 
     bool hasActiveNowPlayingSession() const final { return m_nowPlayingActive; }

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -99,7 +99,7 @@ MediaSessionManagerCocoa::MediaSessionManagerCocoa(std::optional<PageIdentifier>
 {
 }
 
-Ref<GenericPromise> MediaSessionManagerCocoa::updateSessionState()
+void MediaSessionManagerCocoa::updateSessionState()
 {
     constexpr auto delayBeforeSettingCategoryNone = 2_s;
     int videoCount = 0;
@@ -174,7 +174,7 @@ Ref<GenericPromise> MediaSessionManagerCocoa::updateSessionState()
     sharedSession->setPreferredBufferSize(bufferSize);
 
     if (!DeprecatedGlobalSettings::shouldManageAudioSessionCategory())
-        return GenericPromise::createAndResolve();
+        return;
 
     auto category = AudioSession::CategoryType::None;
     auto mode = AudioSession::Mode::Default;
@@ -220,8 +220,6 @@ Ref<GenericPromise> MediaSessionManagerCocoa::updateSessionState()
     forEachSession([&] (auto& session) {
         session.audioSessionCategoryChanged(category, mode, policy);
     });
-
-    return GenericPromise::createAndResolve();
 }
 
 void MediaSessionManagerCocoa::possiblyChangeAudioCategory()

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7029,6 +7029,22 @@ auto Internals::audioSessionCategory() const -> AudioSessionCategory
 #endif
 }
 
+void Internals::systemAudioSessionCategory(DOMPromiseDeferred<IDLEnumeration<AudioSessionCategory>>&& promise)
+{
+#if USE(AUDIO_SESSION)
+    AudioSession::singleton().systemCategoryForTesting()->whenSettled(RunLoop::mainSingleton(),
+        [promise = WTF::move(promise)](auto&& result) mutable {
+            if (!result) {
+                promise.reject(Exception { ExceptionCode::InvalidStateError, "Could not read the system audio session category"_s });
+                return;
+            }
+            promise.resolve(*result);
+        });
+#else
+    promise.resolve(AudioSessionCategory::None);
+#endif
+}
+
 auto Internals::audioSessionMode() const -> AudioSessionMode
 {
 #if USE(AUDIO_SESSION)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1151,6 +1151,7 @@ public:
 
     bool NODELETE supportsAudioSession() const;
     AudioSessionCategory audioSessionCategory() const;
+    void systemAudioSessionCategory(DOMPromiseDeferred<IDLEnumeration<AudioSessionCategory>>&&);
     AudioSessionMode audioSessionMode() const;
     RouteSharingPolicy routeSharingPolicy() const;
 #if ENABLE(VIDEO)

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1315,6 +1315,7 @@ enum ContentsFormat {
 
     readonly attribute boolean supportsAudioSession;
     AudioSessionCategory audioSessionCategory();
+    Promise<AudioSessionCategory> systemAudioSessionCategory();
     AudioSessionMode audioSessionMode();
     [Conditional=VIDEO] AudioSessionCategory categoryAtMostRecentPlayback(HTMLMediaElement element);
     [Conditional=VIDEO] AudioSessionMode modeAtMostRecentPlayback(HTMLMediaElement element);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -195,6 +195,13 @@ RemoteAudioSessionProxyManager& RemoteAudioSessionProxy::audioSessionManager()
     return m_gpuConnection.get()->gpuProcess().audioSessionManager();
 }
 
+void RemoteAudioSessionProxy::systemCategoryForTesting(CompletionHandler<void(WebCore::AudioSessionCategory)>&& completionHandler)
+{
+    // The category the GPU process applied to the real session, after reconciling what every web
+    // process reported. Each process's own AudioSession only knows the value it asked for.
+    completionHandler(AudioSession::singleton().category());
+}
+
 void RemoteAudioSessionProxy::triggerBeginInterruptionForTesting()
 {
     AudioSession::singleton().beginInterruptionForTesting();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -102,6 +102,7 @@ private:
     void tryToSetActive(bool, SetActiveCompletion&&);
     void tryToSetActiveSync(bool, SetActiveCompletion&&);
     void setIsPlayingToBluetoothOverride(std::optional<bool>&& value);
+    void systemCategoryForTesting(CompletionHandler<void(WebCore::AudioSessionCategory)>&&);
     void triggerBeginInterruptionForTesting();
     void triggerEndInterruptionForTesting();
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
@@ -39,6 +39,7 @@ messages -> RemoteAudioSessionProxy {
 
     [EnabledBy=AllowTestOnlyIPC] TriggerBeginInterruptionForTesting()
     [EnabledBy=AllowTestOnlyIPC] TriggerEndInterruptionForTesting()
+    [EnabledBy=AllowTestOnlyIPC] SystemCategoryForTesting() -> (enum:uint8_t WebCore::AudioSessionCategory category)
 
     BeginInterruptionRemote()
     EndInterruptionRemote(enum:bool WebCore::AudioSessionMayResume flags)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -37,7 +37,6 @@
 #include "SharedPreferencesForWebProcess.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
-#include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/MediaSessionManagerClient.h>
 #include <WebCore/PlatformMediaSessionInterface.h>
 #include <WebCore/PlatformMediaSessionManager.h>
@@ -165,10 +164,6 @@ RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy()
     setClient(makeUnique<RemoteMediaSessionManagerProxyClient>(*this));
 #endif
 
-#if PLATFORM(IOS_FAMILY) || ENABLE(ROUTING_ARBITRATION)
-    WebCore::DeprecatedGlobalSettings::setShouldManageAudioSessionCategory(true);
-#endif
-
 #if PLATFORM(COCOA)
     WebCore::AudioHardwareListener::setCreationFunction([protectedThis = Ref { *this }] (WebCore::AudioHardwareListener::Client& client) {
         return protectedThis->ensureAudioHardwareListenerProxy(client);
@@ -180,7 +175,7 @@ RemoteMediaSessionManagerProxy::~RemoteMediaSessionManagerProxy()
 {
 }
 
-void RemoteMediaSessionManagerProxy::addMediaSession(IPC::Connection& connection, RemoteMediaSessionState&& state, CompletionHandler<void(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&& completionHandler)
+void RemoteMediaSessionManagerProxy::addMediaSession(IPC::Connection& connection, RemoteMediaSessionState&& state)
 {
     Ref process = WebProcessProxy::fromConnection(connection);
 
@@ -193,12 +188,6 @@ void RemoteMediaSessionManagerProxy::addMediaSession(IPC::Connection& connection
         session->updateState(state);
 
     REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::addSession(session);
-
-#if USE(AUDIO_SESSION)
-    completionHandler(m_category, m_mode, m_routeSharingPolicy);
-#else
-    completionHandler(WebCore::AudioSessionCategory::None, WebCore::AudioSessionMode::Default, WebCore::RouteSharingPolicy::Default);
-#endif
 }
 
 void RemoteMediaSessionManagerProxy::removeMediaSession(IPC::Connection& connection, RemoteMediaSessionState&& state)
@@ -252,12 +241,6 @@ void RemoteMediaSessionManagerProxy::webProcessWillShutDown(WebCore::ProcessIden
         updateSessionState();
 
 #if USE(AUDIO_SESSION)
-    // Drop any override that process had set, so it no longer affects the category.
-    if (m_categoryOverridesByPage.removeIf([processIdentifier](auto& entry) {
-        return entry.key.processIdentifier() == processIdentifier;
-    }))
-        updateSessionState();
-
     // The process is gone; drop the activation state we tracked for it (keyed by ProcessIdentifier, so a
     // reused process starts clean). The pending activations' waiters are AutoRejectProducers, so removing the
     // entry rejects any still-pending promises as it is destroyed. setAudioSessionActiveForProcess() relies on
@@ -281,7 +264,7 @@ void RemoteMediaSessionManagerProxy::refreshSessionStates(IPC::Connection& conne
     }
 }
 
-void RemoteMediaSessionManagerProxy::updateMediaSessionStates(IPC::Connection& connection, WebCore::PageIdentifier pageIdentifier, Vector<RemoteMediaSessionState>&& sessions, uint64_t audioCaptureSourceCount, WebCore::AudioSessionCategory categoryOverride, CompletionHandler<void(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&& completionHandler)
+void RemoteMediaSessionManagerProxy::updateMediaSessionStates(IPC::Connection& connection, WebCore::PageIdentifier pageIdentifier, Vector<RemoteMediaSessionState>&& sessions, uint64_t audioCaptureSourceCount)
 {
     refreshSessionStates(connection, sessions);
 
@@ -296,19 +279,6 @@ void RemoteMediaSessionManagerProxy::updateMediaSessionStates(IPC::Connection& c
         m_audioCaptureSourceCountsByPage.set(key, audioCaptureSourceCount);
 
 #if USE(AUDIO_SESSION)
-    // Each page reports its own override. Keep them separate so that a page without one does not clear
-    // the override another page has set.
-    if (categoryOverride == WebCore::AudioSessionCategory::None)
-        m_categoryOverridesByPage.remove(key);
-    else
-        m_categoryOverridesByPage.set(key, categoryOverride);
-#else
-    UNUSED_PARAM(categoryOverride);
-#endif
-
-    updateSessionState();
-
-#if USE(AUDIO_SESSION)
     // Drive audio-session activation for this process's audio capture: activeAudioSessionRequired() can't see
     // capture from the UI process (only the count is forwarded, not the AudioCaptureSource objects), so key off
     // the capture-count transition -- activate when it starts, deactivate when it stops and nothing else needs it.
@@ -316,10 +286,6 @@ void RemoteMediaSessionManagerProxy::updateMediaSessionStates(IPC::Connection& c
         enqueueAudioSessionActivation(process, true)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
     else if (!audioCaptureSourceCount && previousPageCaptureCount && !processRequiresAudioSession(process))
         enqueueAudioSessionActivation(process, false)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
-
-    completionHandler(m_category, m_mode, m_routeSharingPolicy);
-#else
-    completionHandler(WebCore::AudioSessionCategory::None, WebCore::AudioSessionMode::Default, WebCore::RouteSharingPolicy::Default);
 #endif
 }
 
@@ -350,22 +316,11 @@ void RemoteMediaSessionManagerProxy::setCurrentSession(WebCore::PlatformMediaSes
     REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::setCurrentSession(session);
 }
 
-void RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback(IPC::Connection& connection, RemoteMediaSessionState&& state, CompletionHandler<void(bool, WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&& completionHandler)
+void RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback(IPC::Connection& connection, RemoteMediaSessionState&& state, CompletionHandler<void(bool)>&& completionHandler)
 {
-    // Reply with the current audio session category so the WebContent process applies it before
-    // resuming playback. This makes the play() promise observe the up-to-date category — the
-    // capture count has already been folded in via a prior UpdateMediaSessionStates round-trip.
-    auto reply = [protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)](bool granted) mutable {
-#if USE(AUDIO_SESSION)
-        completionHandler(granted, protectedThis->m_category, protectedThis->m_mode, protectedThis->m_routeSharingPolicy);
-#else
-        completionHandler(granted, WebCore::AudioSessionCategory::None, WebCore::AudioSessionMode::Default, WebCore::RouteSharingPolicy::Default);
-#endif
-    };
-
     RefPtr session = findAndUpdateSession(connection, state);
     if (!session) {
-        reply(false);
+        completionHandler(false);
         return;
     }
 
@@ -382,7 +337,7 @@ void RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback(IPC::Connecti
     AudioSession::setActive(it != m_activationByProcess.end() && it->value.active);
 #endif
 
-    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionWillBeginPlayback(*session, WTF::move(reply));
+    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionWillBeginPlayback(*session, WTF::move(completionHandler));
 }
 
 void RemoteMediaSessionManagerProxy::addMediaSessionRestriction(WebCore::PlatformMediaSessionMediaType type, WebCore::MediaSessionRestrictions restrictions)
@@ -401,16 +356,6 @@ void RemoteMediaSessionManagerProxy::resetMediaSessionRestrictions()
 }
 
 #if USE(AUDIO_SESSION)
-WebCore::AudioSessionCategory RemoteMediaSessionManagerProxy::categoryOverride() const
-{
-    // Use the override of any page that has set one. Pages without an override have no entry here.
-    for (auto category : m_categoryOverridesByPage.values()) {
-        if (category != WebCore::AudioSessionCategory::None)
-            return category;
-    }
-    return WebCore::AudioSessionCategory::None;
-}
-
 void RemoteMediaSessionManagerProxy::remoteAudioConfigurationChanged(RemoteAudioSessionConfiguration&& configuration)
 {
     // configuration.isActive is NOT trusted for the activation gate: it is relayed by the (untrusted)
@@ -438,24 +383,6 @@ void RemoteMediaSessionManagerProxy::setAudioSessionActiveForProcess(WebCore::Pr
     if (state.ipcInFlight || !state.pendingChain.isEmpty())
         return;
     state.active = active;
-}
-
-void RemoteMediaSessionManagerProxy::setCategory(CategoryType type, Mode mode, WebCore::RouteSharingPolicy policy)
-{
-#if PLATFORM(COCOA)
-    if (type == m_category && mode == m_mode && policy == m_routeSharingPolicy)
-        return;
-
-    m_category = type;
-    m_mode = mode;
-    m_routeSharingPolicy = policy;
-
-    for (Ref session : m_sessionProxies.values())
-        session->send(Messages::RemoteMediaSessionManager::SetAudioSessionCategory(type, mode, policy));
-#else
-    UNUSED_PARAM(type);
-    UNUSED_PARAM(policy);
-#endif
 }
 
 Ref<WebCore::AudioSession::SetActivePromise> RemoteMediaSessionManagerProxy::tryToSetActiveInternal(bool active)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -115,12 +115,16 @@ private:
     RemoteMediaSessionManagerProxy();
 
     // Messages
-    void addMediaSession(IPC::Connection&, RemoteMediaSessionState&&, CompletionHandler<void(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&&);
+    void addMediaSession(IPC::Connection&, RemoteMediaSessionState&&);
     void removeMediaSession(IPC::Connection&, RemoteMediaSessionState&&);
     void setCurrentMediaSession(IPC::Connection&, RemoteMediaSessionState&&);
-    void updateMediaSessionStates(IPC::Connection&, WebCore::PageIdentifier, Vector<RemoteMediaSessionState>&&, uint64_t audioCaptureSourceCount, WebCore::AudioSessionCategory categoryOverride, CompletionHandler<void(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&&);
+    void updateMediaSessionStates(IPC::Connection&, WebCore::PageIdentifier, Vector<RemoteMediaSessionState>&&, uint64_t audioCaptureSourceCount);
     void mediaSessionStateChanged(IPC::Connection&, WebKit::RemoteMediaSessionState&&);
-    void mediaSessionWillBeginPlayback(IPC::Connection&, RemoteMediaSessionState&&, CompletionHandler<void(bool, WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy)>&&);
+    void mediaSessionWillBeginPlayback(IPC::Connection&, RemoteMediaSessionState&&, CompletionHandler<void(bool)>&&);
+
+    // The audio session category is computed by each content process for its own sessions; the GPU
+    // process reconciles them. Nothing is computed here.
+    void updateSessionState() final { }
 
     void setCurrentSession(WebCore::PlatformMediaSessionInterface&) final;
 
@@ -142,11 +146,6 @@ private:
     void remoteProcessDidResume(IPC::Connection&);
 
     // AudioSession
-    void setCategory(CategoryType, Mode, WebCore::RouteSharingPolicy) final;
-    CategoryType category() const final { return m_category; }
-    Mode mode() const final { return m_mode; }
-
-    WebCore::RouteSharingPolicy routeSharingPolicy() const final { return m_routeSharingPolicy; }
     String routingContextUID() const final { return m_audioConfiguration.routingContextUID; }
 
     float sampleRate() const final { return m_audioConfiguration.sampleRate; }
@@ -166,7 +165,6 @@ private:
     size_t preferredBufferSize() const final { return m_audioConfiguration.preferredBufferSize; }
     void setPreferredBufferSize(size_t) final;
 
-    CategoryType categoryOverride() const final;
 #endif
 
     RefPtr<WebCore::PlatformMediaSessionInterface> findAndUpdateSession(IPC::Connection&, const RemoteMediaSessionState&);
@@ -181,18 +179,12 @@ private:
 
     HashMap<WebCore::ProcessQualified<WebCore::MediaSessionIdentifier>, Ref<RemoteMediaSessionProxy>> m_sessionProxies;
     HashMap<WebCore::ProcessQualified<WebCore::PageIdentifier>, uint64_t> m_audioCaptureSourceCountsByPage;
-#if USE(AUDIO_SESSION)
-    HashMap<WebCore::ProcessQualified<WebCore::PageIdentifier>, WebCore::AudioSessionCategory> m_categoryOverridesByPage;
-#endif
 
 #if PLATFORM(COCOA)
     RefPtr<RemoteMediaSessionManagerAudioHardwareListener> m_audioHardwareListenerProxy;
 #endif
 
 #if USE(AUDIO_SESSION)
-    CategoryType m_category { CategoryType::None };
-    Mode m_mode { Mode::Default };
-    WebCore::RouteSharingPolicy m_routeSharingPolicy { WebCore::RouteSharingPolicy::Default };
     mutable RemoteAudioSessionConfiguration m_audioConfiguration;
 
     struct PendingActivation {

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
@@ -29,8 +29,8 @@
     EnabledBy=RemoteMediaSessionManagerEnabled || SiteIsolationEnabled
 ]
 messages -> RemoteMediaSessionManagerProxy {
-    UpdateMediaSessionStates(WebCore::PageIdentifier pageIdentifier, Vector<WebKit::RemoteMediaSessionState> sessions, uint64_t audioCaptureSourceCount, enum:uint8_t WebCore::AudioSessionCategory categoryOverride) -> (enum:uint8_t WebCore::AudioSessionCategory category, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
-    AddMediaSession(struct WebKit::RemoteMediaSessionState session) -> (enum:uint8_t WebCore::AudioSessionCategory category, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
+    void UpdateMediaSessionStates(WebCore::PageIdentifier pageIdentifier, Vector<WebKit::RemoteMediaSessionState> sessions, uint64_t audioCaptureSourceCount)
+    void AddMediaSession(struct WebKit::RemoteMediaSessionState session)
     void RemoveMediaSession(struct WebKit::RemoteMediaSessionState session);
     void SetCurrentMediaSession(struct WebKit::RemoteMediaSessionState session);
     void MediaSessionStateChanged(struct WebKit::RemoteMediaSessionState session);
@@ -39,7 +39,7 @@ messages -> RemoteMediaSessionManagerProxy {
     void RemoveMediaSessionRestriction(enum:uint8_t WebCore::PlatformMediaSessionMediaType type, WebCore::MediaSessionRestrictions restrictions);
     void ResetMediaSessionRestrictions();
 
-    MediaSessionWillBeginPlayback(struct WebKit::RemoteMediaSessionState session) -> (bool granted, enum:uint8_t WebCore::AudioSessionCategory category, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
+    MediaSessionWillBeginPlayback(struct WebKit::RemoteMediaSessionState session) -> (bool granted)
 
 #if PLATFORM(COCOA)
     void RemoteAudioHardwareDidBecomeActive();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -105,19 +105,12 @@ void RemoteAudioSession::setCategory(CategoryType type, Mode mode, RouteSharingP
     if (type == m_category && mode == m_mode && policy == m_routeSharingPolicy && !m_isPlayingToBluetoothOverrideChanged)
         return;
 
-    bool categoryOrModeChanged = type != m_category || mode != m_mode;
     m_category = type;
     m_mode = mode;
     m_routeSharingPolicy = policy;
     m_isPlayingToBluetoothOverrideChanged = false;
 
     protect(ensureConnection())->send(Messages::RemoteAudioSessionProxy::SetCategory(type, mode, policy), { });
-
-    if (categoryOrModeChanged) {
-        m_configurationChangeObservers.forEach([this](auto& observer) {
-            observer.categoryDidChange(*this);
-        });
-    }
 #else
     UNUSED_PARAM(type);
     UNUSED_PARAM(policy);
@@ -316,6 +309,16 @@ void RemoteAudioSession::beginAudioSessionInterruption()
 void RemoteAudioSession::endAudioSessionInterruption(MayResume mayResume)
 {
     protect(ensureConnection())->send(Messages::RemoteAudioSessionProxy::EndInterruptionRemote(mayResume), { });
+}
+
+Ref<AudioSession::CategoryPromise> RemoteAudioSession::systemCategoryForTesting()
+{
+    return protect(ensureConnection())->sendWithPromisedReply(Messages::RemoteAudioSessionProxy::SystemCategoryForTesting())->whenSettled(RunLoop::mainSingleton(),
+        [](auto&& result) -> Ref<CategoryPromise> {
+            if (!result)
+                return CategoryPromise::createAndReject();
+            return CategoryPromise::createAndResolve(*result);
+        });
 }
 
 void RemoteAudioSession::beginInterruptionForTesting()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -98,6 +98,7 @@ private:
 
     void beginInterruptionForTesting() final;
     void endInterruptionForTesting() final;
+    Ref<CategoryPromise> systemCategoryForTesting() final;
     void clearInterruptionFlagForTesting() final { m_isInterruptedForTesting = false; }
 
     void setSceneIdentifier(const String&) final;

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
@@ -87,16 +87,7 @@ RemoteMediaSessionManager::~RemoteMediaSessionManager()
 void RemoteMediaSessionManager::addSession(WebCore::PlatformMediaSessionInterface& session)
 {
     REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::addSession(session);
-    sendWithAsyncReply(Messages::RemoteMediaSessionManagerProxy::AddMediaSession(currentSessionState(session)),
-        [](WebCore::AudioSessionCategory category, WebCore::AudioSessionMode mode, WebCore::RouteSharingPolicy policy) {
-#if USE(AUDIO_SESSION)
-            WebCore::AudioSession::singleton().setCategory(category, mode, policy);
-#else
-            UNUSED_PARAM(category);
-            UNUSED_PARAM(mode);
-            UNUSED_PARAM(policy);
-#endif
-        });
+    send(Messages::RemoteMediaSessionManagerProxy::AddMediaSession(currentSessionState(session)));
 }
 
 void RemoteMediaSessionManager::removeSession(WebCore::PlatformMediaSessionInterface& session)
@@ -133,14 +124,7 @@ void RemoteMediaSessionManager::sessionWillBeginPlayback(WebCore::PlatformMediaS
     // by the GPU process (the source of truth); this process does not send its own view, which the proxy
     // could not trust.
     sendWithAsyncReply(Messages::RemoteMediaSessionManagerProxy::MediaSessionWillBeginPlayback(currentSessionState(session)),
-        [protectedThis = Ref { *this }, sessionWasAlreadyInterrupted, completionHandler = WTF::move(completionHandler)](bool granted, WebCore::AudioSessionCategory category, WebCore::AudioSessionMode mode, WebCore::RouteSharingPolicy policy) mutable {
-#if USE(AUDIO_SESSION)
-            WebCore::AudioSession::singleton().setCategory(category, mode, policy);
-#else
-            UNUSED_PARAM(category);
-            UNUSED_PARAM(mode);
-            UNUSED_PARAM(policy);
-#endif
+        [protectedThis = Ref { *this }, sessionWasAlreadyInterrupted, completionHandler = WTF::move(completionHandler)](bool granted) mutable {
             if (granted && sessionWasAlreadyInterrupted && protectedThis->isInterrupted())
                 protectedThis->endInterruption(WebCore::PlatformMediaSessionEndInterruptionFlags::NoFlags);
             completionHandler(granted);
@@ -165,7 +149,7 @@ void RemoteMediaSessionManager::resetRestrictions()
     REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::resetRestrictions();
 }
 
-Ref<GenericPromise> RemoteMediaSessionManager::updateSessionState()
+void RemoteMediaSessionManager::updateSessionState()
 {
     auto liveSessions = copySessionsToVector();
     Vector<RemoteMediaSessionState> sessions(liveSessions.size(), [&](size_t i) -> std::optional<RemoteMediaSessionState> {
@@ -175,24 +159,11 @@ Ref<GenericPromise> RemoteMediaSessionManager::updateSessionState()
         return currentSessionState(*session);
     });
 
-    // navigator.audioSession.type sets the override on this process's AudioSession, but the category is
-    // computed in the UI process, which has no audio session of its own to read it from.
-#if USE(AUDIO_SESSION)
-    auto categoryOverride = WebCore::AudioSession::singleton().categoryOverride();
-#else
-    auto categoryOverride = WebCore::AudioSessionCategory::None;
-#endif
+    // The UI process needs the session states and the capture count for the work it still owns:
+    // playback admission and audio session activation.
+    send(Messages::RemoteMediaSessionManagerProxy::UpdateMediaSessionStates(m_webPageID, WTF::move(sessions), countActiveAudioCaptureSources()));
 
-    return sendWithPromisedReply(Messages::RemoteMediaSessionManagerProxy::UpdateMediaSessionStates(m_webPageID, WTF::move(sessions), countActiveAudioCaptureSources(), categoryOverride))->whenSettled(RunLoop::mainSingleton(),
-        [](auto&& result) -> Ref<GenericPromise> {
-            if (!result)
-                return GenericPromise::createAndReject();
-#if USE(AUDIO_SESSION)
-            auto [category, mode, policy] = WTF::move(*result);
-            WebCore::AudioSession::singleton().setCategory(category, mode, policy);
-#endif
-            return GenericPromise::createAndResolve();
-        });
+    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::updateSessionState();
 }
 
 void RemoteMediaSessionManager::sessionStateChanged(WebCore::PlatformMediaSessionInterface& session)
@@ -299,11 +270,6 @@ void RemoteMediaSessionManager::audioOutputDeviceChanged()
 #endif
 
 #if USE(AUDIO_SESSION)
-void RemoteMediaSessionManager::setAudioSessionCategory(WebCore::AudioSessionCategory type, WebCore::AudioSessionMode mode, WebCore::RouteSharingPolicy policy)
-{
-    WebCore::AudioSession::singleton().setCategory(type, mode, policy);
-}
-
 void RemoteMediaSessionManager::setAudioSessionPreferredBufferSize(uint64_t preferredBufferSize)
 {
     WebCore::AudioSession::singleton().setPreferredBufferSize(preferredBufferSize);

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h
@@ -76,7 +76,6 @@ protected:
     void setCurrentMediaSession(std::optional<WebCore::MediaSessionIdentifier>);
 
 #if USE(AUDIO_SESSION)
-    void setAudioSessionCategory(WebCore::AudioSessionCategory, WebCore::AudioSessionMode, WebCore::RouteSharingPolicy);
     void setAudioSessionPreferredBufferSize(uint64_t);
 #endif
 
@@ -97,7 +96,7 @@ private:
     void removeSession(WebCore::PlatformMediaSessionInterface&) final;
     void setCurrentSession(WebCore::PlatformMediaSessionInterface&) final;
     void sessionWillBeginPlayback(WebCore::PlatformMediaSessionInterface&, CompletionHandler<void(bool)>&&) final;
-    Ref<GenericPromise> updateSessionState() final;
+    void updateSessionState() final;
     void sessionStateChanged(WebCore::PlatformMediaSessionInterface&) final;
     void processWillSuspend() final;
     void processDidResume() final;

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.messages.in
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.messages.in
@@ -36,7 +36,6 @@ messages -> RemoteMediaSessionManager {
     void SetCurrentMediaSession(std::optional<WebCore::MediaSessionIdentifier> identifier);
 
 #if USE(AUDIO_SESSION)
-    void SetAudioSessionCategory(enum:uint8_t WebCore::AudioSessionCategory type, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
     void SetAudioSessionPreferredBufferSize(uint64_t preferredBufferSize)
 #endif
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetDisplayMediaWindowAndScreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetDisplayMediaWindowAndScreen.mm
@@ -133,22 +133,6 @@ static constexpr unsigned stateChangeQueryMaxCount = 30;
 
 namespace TestWebKitAPI {
 
-// media-session-capture.html records MediaSession action handler calls, track mute/unmute events and
-// setXXXActive() promise resolutions into a single list. Those are delivered asynchronously, so a test
-// that triggers several operations at once has no guaranteed interleaving between them — arm a wait
-// before triggering an operation and await it before triggering the next.
-static void armActionState(TestWKWebView *webView, NSString *state)
-{
-    [webView objectByCallingAsyncFunction:@"return armActionState(state)" withArguments:@{ @"state": state }];
-}
-
-static void waitForActionState(TestWKWebView *webView, NSString *state)
-{
-    NSError *error = nil;
-    [webView objectByCallingAsyncFunction:@"return awaitActionState(state)" withArguments:@{ @"state": state } error:&error];
-    EXPECT_NULL(error);
-}
-
 TEST(WebKit2, GetDisplayMediaWindowAndScreenPrompt)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -330,13 +314,11 @@ TEST(WebKit2, ToggleScreenshare)
 
     // Mute capture.
     __block bool completionCalled = false;
-    armActionState(webView.get(), @"muting screenshare");
     [webView _setDisplayCaptureState:WKDisplayCaptureStateMuted completionHandler:^() {
         completionCalled = true;
     }];
     TestWebKitAPI::Util::run(&completionCalled);
     EXPECT_EQ([webView _displayCaptureState], WKDisplayCaptureStateMuted);
-    waitForActionState(webView.get(), @"muting screenshare");
 
     [delegate resetWasPrompted];
     [delegate setGetDisplayMediaDecision:WKDisplayCapturePermissionDecisionDeny];
@@ -354,13 +336,11 @@ TEST(WebKit2, ToggleScreenshare)
 
     // Unmute via MediaSession.
     messageReceived = false;
-    armActionState(webView.get(), @"unmuting screenshare");
     [webView stringByEvaluatingJavaScript:@"setScreenshareActive(true, true)"];
     TestWebKitAPI::Util::run(&messageReceived);
 
     EXPECT_EQ([webView _displayCaptureState], WKDisplayCaptureStateActive);
     EXPECT_TRUE([delegate wasPrompted]);
-    waitForActionState(webView.get(), @"unmuting screenshare");
 
     // Validate handlers/events order.
     messageReceived = false;
@@ -371,23 +351,19 @@ TEST(WebKit2, ToggleScreenshare)
 
     // Mute via MediaSession.
     messageReceived = false;
-    armActionState(webView.get(), @"muting screenshare");
     [webView stringByEvaluatingJavaScript:@"setScreenshareActive(false, true)"];
     TestWebKitAPI::Util::run(&messageReceived);
 
     EXPECT_EQ([webView _displayCaptureState], WKDisplayCaptureStateMuted);
     EXPECT_FALSE([delegate wasPrompted]);
-    waitForActionState(webView.get(), @"muting screenshare");
 
     // Unmute via MediaSession.
     messageReceived = false;
-    armActionState(webView.get(), @"unmuting screenshare");
     [webView stringByEvaluatingJavaScript:@"setScreenshareActive(true, true)"];
     TestWebKitAPI::Util::run(&messageReceived);
 
     EXPECT_EQ([webView _displayCaptureState], WKDisplayCaptureStateActive);
     EXPECT_FALSE([delegate wasPrompted]);
-    waitForActionState(webView.get(), @"unmuting screenshare");
 
     // Validate handlers/events order.
     messageReceived = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetUserMedia.mm
@@ -1700,9 +1700,9 @@ TEST(WebKit2, DoNotUnmuteWhenTakingAThumbnail)
 
 #if WK_HAVE_C_SPI
 // media-session-capture.html records MediaSession action handler calls, track mute/unmute events and
-// setXXXActive() promise resolutions into a single list. Those are delivered asynchronously, so a test
-// that triggers several operations at once has no guaranteed interleaving between them — arm a wait
-// before triggering an operation and await it before triggering the next.
+// setXXXActive() promise resolutions into a single list. Unmuting an audio capture track waits on the
+// audio session activation, so arm a wait before triggering it and await it before triggering the next
+// operation.
 static void armActionState(TestWKWebView *webView, NSString *state)
 {
     [webView objectByCallingAsyncFunction:@"return armActionState(state)" withArguments:@{ @"state": state }];
@@ -1837,23 +1837,18 @@ TEST(WebKit2, ToggleCameraCaptureWhenRestarting)
     EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateActive));
     EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateActive));
 
-    // Mute capture, one device at a time: the mute event is dispatched asynchronously, so muting both
-    // and then expecting a particular interleaving of the two would be assuming an ordering that isn't
-    // guaranteed.
+    // Mute capture.
     cameraCaptureStateChange = false;
     microphoneCaptureStateChange = false;
 
-    armActionState(webView.get(), @"muting camera");
     [webView setCameraCaptureState:WKMediaCaptureStateMuted completionHandler:nil];
-    EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateMuted));
-    waitForActionState(webView.get(), @"muting camera");
-
-    armActionState(webView.get(), @"muting microphone");
     [webView setMicrophoneCaptureState:WKMediaCaptureStateMuted completionHandler:nil];
-    EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateMuted));
-    waitForActionState(webView.get(), @"muting microphone");
 
-    // Unmute via MediaSession.
+    EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateMuted));
+    EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateMuted));
+
+    // Unmute via MediaSession. Unmuting waits on the audio session activation, so arm a wait before
+    // triggering it and await it before checking the recorded order.
     cameraCaptureStateChange = false;
     done = false;
     armActionState(webView.get(), @"unmuting camera");
@@ -1911,23 +1906,18 @@ TEST(WebKit2, ToggleMicrophoneCaptureWhenRestarting)
     EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateActive));
     EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateActive));
 
-    // Mute capture, one device at a time: the mute event is dispatched asynchronously, so muting both
-    // and then expecting a particular interleaving of the two would be assuming an ordering that isn't
-    // guaranteed.
+    // Mute capture.
     cameraCaptureStateChange = false;
     microphoneCaptureStateChange = false;
 
-    armActionState(webView.get(), @"muting camera");
     [webView setCameraCaptureState:WKMediaCaptureStateMuted completionHandler:nil];
-    EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateMuted));
-    waitForActionState(webView.get(), @"muting camera");
-
-    armActionState(webView.get(), @"muting microphone");
     [webView setMicrophoneCaptureState:WKMediaCaptureStateMuted completionHandler:nil];
-    EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateMuted));
-    waitForActionState(webView.get(), @"muting microphone");
 
-    // Unmute via MediaSession.
+    EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateMuted));
+    EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateMuted));
+
+    // Unmute via MediaSession. Unmuting waits on the audio session activation, so arm a wait before
+    // triggering it and await it before checking the recorded order.
     cameraCaptureStateChange = false;
     microphoneCaptureStateChange = false;
     done = false;


### PR DESCRIPTION
#### eca8e2cf2518a805495f9ce2ad0fce1c57b75eb1
<pre>
[site-isolation] AudioSession category should be calculated synchronously and not wait for the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=321642">https://bugs.webkit.org/show_bug.cgi?id=321642</a>
<a href="https://rdar.apple.com/184769561">rdar://184769561</a>

Reviewed by Eric Carlson.

301864@main removed the audio session category calculation from the content process. 303417@main made
RemoteMediaSessionManagerProxy a MediaSessionManagerCocoa and a WebCore::AudioSession without
overriding updateSessionState(), so the UI process computed the category and pushed it back, and
317396@main made that proxy a singleton, so one category covered every page of every process. The
content process learned its category from an asynchronous IPC reply, which caused two classes of
problem.

1) Scripts read a stale category, since internals.audioSessionCategory() reads this process&apos;s
AudioSession and could run before the reply arrived. Every path reading it after an await needed
its own fix: play(), getUserMedia, track mute/unmute, the audioTracks change event, the
navigator.audioSession.type override, and the category recorded at the most recent playback.

2) Operations with no reason to be asynchronous became asynchronous to accommodate it:
updateSessionState() returned a GenericPromise, three IPC replies carried (category, mode, policy),
the proxy pushed the category to every process, and the getUserMedia resolution and the mute/unmute
event dispatch were gated on a promise waiting on getting the new category.

The UI process has no information of a kind the content process lacks: the calculation reads no
AVAudioSession, no audio route, and no interruption or application state, only media session
bookkeeping. Its only advantage was breadth, the sessions of other content processes, and the GPU
process already reconciles that by collecting the category each process reports and applying the
highest priority one. Every branch of the calculation tests whether at least one session is doing
something, so a process seeing only its own sessions lands at or below the correct category and never
above it, which makes the highest-priority pick equivalent to calculating over every process&apos;s
sessions.

RemoteMediaSessionManager::updateSessionState() chains to MediaSessionManagerCocoa, applying the
category in the same turn, and sends the session states and the capture count to the UI process
without waiting for a reply as the UI process still needs them for playback admission and activation.
The proxy computes no category of its own: its updateSessionState() does nothing, and the category in
the AddMediaSession, UpdateMediaSessionStates and MediaSessionWillBeginPlayback replies, the
SetAudioSessionCategory push, and the per-page override tracking are all removed. updateSessionState()
can now return void.

DocumentSyncData already synchronized navigator.audioSession.type to every process of the page. Each
process converts that type into a category override and applies it in its own calculation, so every
process of a page computes with the same override.

This removes a difference that existed only with site isolation enabled. The UI process used the
override of any page that had set one, so navigator.audioSession.type in one page lowered the category
for unrelated pages in other processes. Without site isolation the override lives on the web process&apos;s
own AudioSession and never reached a page in another process, and the GPU process&apos;s pick can only
raise, so an override there has never lowered another process&apos;s category. The two configurations now
behave the same.

The tests read the category applied to the real audio session with a new
internals.systemAudioSessionCategory(), which returns a promise because that category lives in the
process owning the session, over IPC gated on AllowTestOnlyIPC.
http/tests/site-isolation/audio-session-category-override-does-not-affect-another-page.html covers the
paragraph above: this page sets the type and plays nothing, a page opened in another process plays
audible media, and that page still computes MediaPlayback while the real session takes it. Before this
change both pages took the category the UI process computed from the override, so both read
AmbientSound.

audio-session-category-override-and-playback.html and
audio-session-category-override-after-playback.html cover the two ways the type reaches another process
of the same page, the state that process is created with and the per-field DocumentSyncData broadcast,
and assert that the override replaces the computed category in both directions. Neither enables site
isolation, so the site-isolated run is compared against the same expectations as the ordinary one: with
site isolation the frames are in separate processes and the type reaches the playing one through
DocumentSyncData, without it they share a process and its audio session.

audio-session-category-capture-and-playback.html covers the reconciliation this change relies on: one
process plays audible media, another captures the microphone, each computes the category for its own
sessions, and the real audio session resolves to PlayAndRecord.

playPlayer() reads the category directly, as setState(State::Playing) notifies the manager and
sessionStateChanged() calls updateSessionState() synchronously before clientWillBeginPlayback()&apos;s
completion reaches updatePlayState().

The wait in UserMediaRequest::allow() and on the track unmute event stays and now covers the audio
session activation alone: 318776@main added it for activation, which failed at 45% without site
isolation, and activation remains asynchronous. The API tests keep their waits around unmuting for the
same reason, and lose those around muting and around screen capture.

Reverted in full: 317945@main.
Reverted in part: 301864@main, 303417@main, 317760@main, 318099@main, 318537@main, 318776@main,
318865@main, 319003@main.

* LayoutTests/http/tests/site-isolation/audio-session-category-capture-and-playback-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-category-capture-and-playback.html: Added.
* LayoutTests/http/tests/site-isolation/audio-session-category-override-after-playback-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-category-override-after-playback.html: Added.
* LayoutTests/http/tests/site-isolation/audio-session-category-override-and-playback-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-category-override-and-playback.html: Added.
* LayoutTests/http/tests/site-isolation/audio-session-category-override-does-not-affect-another-page-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/audio-session-category-override-does-not-affect-another-page.html: Added.
* LayoutTests/http/tests/site-isolation/resources/audio-session-capture-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/audio-session-playback-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/report-video-element-audio-session-category.html: Added.
* LayoutTests/media/audioSession/audioSessionType.html: Use waitForAudioSessionCategory() instead of a
local copy.
* LayoutTests/media/utilities.js: Added waitForAudioSessionCategory() and
waitForSystemAudioSessionCategory().
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::applyTypeToAudioSessionCategoryOverride): Added. Apply the category
override a type implies to this process&apos;s audio session.
* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::trackMutedChanged): Wait for the audio session activation only when
unmuting an audio capture track, and queue the event directly otherwise.
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::allow): Wait for the audio session activation instead of the category.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::categoryDidChange): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateTopDocumentSyncData): Apply the category override implied by a synchronized
audio session type, on both the per-field and the whole-state path.
* Source/WebCore/platform/audio/AudioSession.h:
(WebCore::AudioSessionConfigurationChangeObserver::categoryDidChange): Deleted.
(WebCore::AudioSession::systemCategoryForTesting): Added. Return the category of this process&apos;s audio
session, overridden where that session lives in another process.
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::audioCaptureSourceStateChanged): Return a promise covering the
activation.
(WebCore::MediaSessionManagerInterface::updateSessionState): Deleted; the empty body moves back to the
header.
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState): Return void.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::systemAudioSessionCategory): Added.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::systemCategoryForTesting): Added. Reply with the category applied to
the real audio session.
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy): Don&apos;t set
shouldManageAudioSessionCategory; the UI process computes no category.
(WebKit::RemoteMediaSessionManagerProxy::addMediaSession): Don&apos;t reply with the category.
(WebKit::RemoteMediaSessionManagerProxy::webProcessWillShutDown): Drop the per-page override cleanup.
(WebKit::RemoteMediaSessionManagerProxy::updateMediaSessionStates): Don&apos;t track the override, compute
the category or reply with it.
(WebKit::RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback): Reply with the admission
decision only.
(WebKit::RemoteMediaSessionManagerProxy::categoryOverride): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::setCategory): Deleted.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::setCategory): Don&apos;t notify the configuration change observers.
(WebKit::RemoteAudioSession::systemCategoryForTesting): Added. Ask the process owning the session.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp:
(WebKit::RemoteMediaSessionManager::addSession): Send without a reply.
(WebKit::RemoteMediaSessionManager::sessionWillBeginPlayback): Take the admission decision only.
(WebKit::RemoteMediaSessionManager::updateSessionState): Compute the category in this process.
(WebKit::RemoteMediaSessionManager::setAudioSessionCategory): Deleted.
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h:
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetDisplayMediaWindowAndScreen.mm:
(TestWebKitAPI::armActionState): Deleted.
(TestWebKitAPI::waitForActionState): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetUserMedia.mm:

Canonical link: <a href="https://commits.webkit.org/319230@main">https://commits.webkit.org/319230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fcbf9474df4aeaf7371e3ead47d6e47a762e074

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180882 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145205 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fcd19a89-08a3-4284-82b3-70b55877d07f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141114 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b7aed3d7-705e-4972-ae93-336b99528188) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121565 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b50c6616-2794-41da-b8e6-781a9d1bfd65) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41387 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2256 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193031 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150495 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40268 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55181 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150214 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44806 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127447 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122774 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53698 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16380 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53080 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53317 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53145 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->