### PR TITLE
Log forwarding should not try to send after timeout

### DIFF
--- a/Source/WebKit/Platform/LogClient.h
+++ b/Source/WebKit/Platform/LogClient.h
@@ -74,6 +74,7 @@ private:
 #else
     Lock m_lock;
 #endif // ENABLE(UNFAIR_LOCK)
+    bool m_isValid WTF_GUARDED_BY_LOCK(m_lock) { true };
 #else
     const Ref<IPC::Connection> m_connection;
 #endif
@@ -84,8 +85,14 @@ void LogClient::send(T&& message)
 {
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
     Locker locker { m_lock };
-#endif
+    if (!m_isValid) [[unlikely]]
+        return;
+    auto result = m_connection->send(WTF::move(message), identifier());
+    if (result != IPC::Error::NoError) [[unlikely]]
+        m_isValid = false;
+#else
     m_connection->send(WTF::move(message), identifier());
+#endif
 }
 
 }


### PR DESCRIPTION
#### 5f85d2c6992b7c3d9e23e890ded64be4b1042fd3
<pre>
Log forwarding should not try to send after timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=321665">https://bugs.webkit.org/show_bug.cgi?id=321665</a>
<a href="https://rdar.apple.com/184798531">rdar://184798531</a>

Reviewed by NOBODY (OOPS!).

Sending a log forwarded log casues a strem send.
A stream send after a timeout causes an ASSERT.
The assert tries to log, re-entering the log forwarding.

Fix by not sending after a timeout.

* Source/WebKit/Platform/LogClient.h:
(WebKit::LogClient::send):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f85d2c6992b7c3d9e23e890ded64be4b1042fd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144832 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19ac4204-69f5-4363-8f04-8fda124af53f) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182373 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54172 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140788 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97528 "4 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0bc40091-095b-448d-96f9-fc1f4855bf22) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161564 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121240 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb8c3c63-cab7-47b9-a389-7d2750b2645e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43132 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41417 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41093 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1881 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192657 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54122 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150156 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54810 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149878 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44503 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127073 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122254 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53327 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16082 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52709 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52946 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52774 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->