### PR TITLE
Cherry-pick 318892@main (c5e28398bb0c). https://bugs.webkit.org/show_bug.cgi?id=321309

### DIFF
--- a/Tools/Scripts/run-mvt-tests
+++ b/Tools/Scripts/run-mvt-tests
@@ -34,6 +34,7 @@ maybe_enter_webkit_container_sdk()
 import argparse
 import json
 import logging
+import subprocess
 import traceback
 import urllib3
 from selenium.webdriver.common.by import By
@@ -171,7 +172,7 @@ class MVTWebDriverRunner():
         if retry_if_failure_to_start:
             return self._retry_if_timeout(self.start_driver, None, False)
         # Start the service (WebDriver) in its own process group to ensure cleaning everything at stop_driver()
-        self.driver_service = self.driver_service_class(executable_path=self._run_webdriver_script_path, env=self.environ_for_test,
+        self.driver_service = self.driver_service_class(executable_path=self._run_webdriver_script_path, env=self.environ_for_test, log_output=subprocess.STDOUT,
                           service_args=[f"--{self.configuration}", f"--{self.platform}"], popen_kw={"process_group": 0})
         self.driver = self.driver_class(options=self.driver_options, service=self.driver_service)
         self.driver.maximize_window()


### PR DESCRIPTION
#### 8dd445d3da53cee377511439048534b3db9aff9d
<pre>
Cherry-pick 318892@main (c5e28398bb0c). <a href="https://bugs.webkit.org/show_bug.cgi?id=321309">https://bugs.webkit.org/show_bug.cgi?id=321309</a>

Unreviewed backport

    [Tools][WPE] run-mvt-tests: configure Selenium so the browser logs are shown by default
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321309">https://bugs.webkit.org/show_bug.cgi?id=321309</a>

    Reviewed by Nikolas Zimmermann.

    Selenium by default sends the browser stdout/stderr to /dev/null.
    This was hiding useful debug information on run-mvt-tests script.

    Fix that by telling selenium to forward the logs to the terminal.

    * Tools/Scripts/run-mvt-tests:

    Canonical link: <a href="https://commits.webkit.org/318892@main">https://commits.webkit.org/318892@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1091@webkitglib/2.52">https://commits.webkit.org/305877.1091@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/127ba98e22e25576b70b85c0236c2492502204ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180529 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/54474 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48272 "The change is no longer eligible for processing.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144851 "The change is no longer eligible for processing.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/182391 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/55772 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54190 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/190740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144851 "The change is no longer eligible for processing.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/183484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/55772 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/48272 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/55772 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54190 "The change is no longer eligible for processing.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/190740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/48272 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/55772 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48272 "The change is no longer eligible for processing.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/1899 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/54190 "The change is no longer eligible for processing.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/192676 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/54140 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/48272 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/192676 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/54828 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48272 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/192676 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27388 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/54828 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122288 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/53345 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/48272 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52727 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/52964 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52792 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->