### PR TITLE
[LBSE] Avoid serializing the gradient and pattern transform to answer a presence check

### DIFF
--- a/LayoutTests/svg/custom/gradient-transform-empty-or-invalid-not-inherited-expected.svg
+++ b/LayoutTests/svg/custom/gradient-transform-empty-or-invalid-not-inherited-expected.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="100">
+    <defs>
+        <linearGradient id="linear-plain">
+            <stop offset="0" stop-color="green"/>
+            <stop offset="1" stop-color="blue"/>
+        </linearGradient>
+        <linearGradient id="linear-rotated" gradientTransform="rotate(90 0.5 0.5)">
+            <stop offset="0" stop-color="green"/>
+            <stop offset="1" stop-color="blue"/>
+        </linearGradient>
+        <linearGradient id="linear-translated" gradientTransform="translate(0.5 0)">
+            <stop offset="0" stop-color="green"/>
+            <stop offset="1" stop-color="blue"/>
+        </linearGradient>
+        <radialGradient id="radial-plain">
+            <stop offset="0" stop-color="yellow"/>
+            <stop offset="1" stop-color="red"/>
+        </radialGradient>
+    </defs>
+
+    <rect x="10" y="10" width="80" height="80" fill="url(#linear-plain)"/>
+    <rect x="110" y="10" width="80" height="80" fill="url(#linear-plain)"/>
+    <rect x="210" y="10" width="80" height="80" fill="url(#linear-rotated)"/>
+    <rect x="310" y="10" width="80" height="80" fill="url(#radial-plain)"/>
+    <rect x="410" y="10" width="80" height="80" fill="url(#linear-translated)"/>
+</svg>

--- a/LayoutTests/svg/custom/gradient-transform-empty-or-invalid-not-inherited.svg
+++ b/LayoutTests/svg/custom/gradient-transform-empty-or-invalid-not-inherited.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="500" height="100">
+    <!-- An empty or invalid gradientTransform is still a present attribute, so it has to stop the
+         transform from being inherited through xlink:href, while the stops keep being inherited. A
+         gradient carrying no gradientTransform attribute at all does inherit the transform. A
+         transform that was only ever added through the SVG DOM counts as present as well.
+         The first three squares are a green to blue gradient, the first two of them unrotated and the
+         third one rotated by 90 degrees. The fourth square is a yellow to red radial gradient. The
+         last square is a green to blue gradient shifted right by half of its bounding box. -->
+    <defs>
+        <linearGradient id="linear-base" gradientTransform="rotate(90 0.5 0.5)">
+            <stop offset="0" stop-color="green"/>
+            <stop offset="1" stop-color="blue"/>
+        </linearGradient>
+        <linearGradient id="linear-empty" xlink:href="#linear-base" gradientTransform=""/>
+        <linearGradient id="linear-invalid" xlink:href="#linear-base" gradientTransform="bogus"/>
+        <linearGradient id="linear-inherited" xlink:href="#linear-base"/>
+        <linearGradient id="linear-svgdom" xlink:href="#linear-base"/>
+
+        <radialGradient id="radial-base" gradientTransform="scale(2)">
+            <stop offset="0" stop-color="yellow"/>
+            <stop offset="1" stop-color="red"/>
+        </radialGradient>
+        <radialGradient id="radial-whitespace" xlink:href="#radial-base" gradientTransform=" "/>
+    </defs>
+
+    <rect x="10" y="10" width="80" height="80" fill="url(#linear-empty)"/>
+    <rect x="110" y="10" width="80" height="80" fill="url(#linear-invalid)"/>
+    <rect x="210" y="10" width="80" height="80" fill="url(#linear-inherited)"/>
+    <rect x="310" y="10" width="80" height="80" fill="url(#radial-whitespace)"/>
+    <rect x="410" y="10" width="80" height="80" fill="url(#linear-svgdom)"/>
+
+    <script>
+        var transform = document.documentElement.createSVGTransform();
+        transform.setTranslate(0.5, 0);
+        document.getElementById("linear-svgdom").gradientTransform.baseVal.appendItem(transform);
+    </script>
+</svg>

--- a/LayoutTests/svg/custom/pattern-transform-empty-or-invalid-not-inherited-expected.svg
+++ b/LayoutTests/svg/custom/pattern-transform-empty-or-invalid-not-inherited-expected.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="100">
+    <defs>
+        <pattern id="pattern-plain" width="20" height="20" patternUnits="userSpaceOnUse">
+            <rect width="10" height="10" fill="green"/>
+        </pattern>
+        <pattern id="pattern-rotated" width="20" height="20" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+            <rect width="10" height="10" fill="green"/>
+        </pattern>
+        <pattern id="pattern-translated" width="20" height="20" patternUnits="userSpaceOnUse" patternTransform="translate(5 0)">
+            <rect width="10" height="10" fill="green"/>
+        </pattern>
+    </defs>
+
+    <rect x="10" y="10" width="80" height="80" fill="url(#pattern-plain)"/>
+    <rect x="110" y="10" width="80" height="80" fill="url(#pattern-plain)"/>
+    <rect x="210" y="10" width="80" height="80" fill="url(#pattern-rotated)"/>
+    <rect x="310" y="10" width="80" height="80" fill="url(#pattern-translated)"/>
+</svg>

--- a/LayoutTests/svg/custom/pattern-transform-empty-or-invalid-not-inherited.svg
+++ b/LayoutTests/svg/custom/pattern-transform-empty-or-invalid-not-inherited.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="400" height="100">
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-656"/>
+    <!-- An empty or invalid patternTransform is still a present attribute, so it has to stop the
+         transform from being inherited through xlink:href, while the tile content keeps being
+         inherited. A pattern carrying no patternTransform attribute at all does inherit the transform.
+         A transform that was only ever added through the SVG DOM counts as present as well.
+         The first two squares show an upright green checkerboard, the third one shows the same
+         checkerboard rotated by 45 degrees, the last one shows it shifted right by 5 units. -->
+    <defs>
+        <pattern id="pattern-base" width="20" height="20" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+            <rect width="10" height="10" fill="green"/>
+        </pattern>
+        <pattern id="pattern-empty" xlink:href="#pattern-base" patternTransform=""/>
+        <pattern id="pattern-invalid" xlink:href="#pattern-base" patternTransform="bogus"/>
+        <pattern id="pattern-inherited" xlink:href="#pattern-base"/>
+        <pattern id="pattern-svgdom" xlink:href="#pattern-base"/>
+    </defs>
+
+    <rect x="10" y="10" width="80" height="80" fill="url(#pattern-empty)"/>
+    <rect x="110" y="10" width="80" height="80" fill="url(#pattern-invalid)"/>
+    <rect x="210" y="10" width="80" height="80" fill="url(#pattern-inherited)"/>
+    <rect x="310" y="10" width="80" height="80" fill="url(#pattern-svgdom)"/>
+
+    <script>
+        var transform = document.documentElement.createSVGTransform();
+        transform.setTranslate(5, 0);
+        document.getElementById("pattern-svgdom").patternTransform.baseVal.appendItem(transform);
+    </script>
+</svg>

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
@@ -45,7 +45,6 @@ void RenderSVGResourceLinearGradient::collectGradientAttributesIfNeeded()
         return;
 
     Ref linearGradientElement = this->linearGradientElement();
-    linearGradientElement->synchronizeAllAttributes();
 
     auto attributes = LinearGradientAttributes { };
     if (linearGradientElement->collectGradientAttributes(attributes))

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -55,8 +55,6 @@ void RenderSVGResourcePattern::collectPatternAttributesIfNeeded()
 
     RefPtr current = patternElement();
 
-    current->synchronizeAllAttributes();
-
     while (current) {
         if (!current->renderer())
             break;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
@@ -46,7 +46,6 @@ void RenderSVGResourceRadialGradient::collectGradientAttributesIfNeeded()
         return;
 
     Ref radialGradientElement = this->radialGradientElement();
-    radialGradientElement->synchronizeAllAttributes();
 
     auto attributes = RadialGradientAttributes { };
     if (radialGradientElement->collectGradientAttributes(attributes))

--- a/Source/WebCore/svg/SVGGradientElement.cpp
+++ b/Source/WebCore/svg/SVGGradientElement.cpp
@@ -24,8 +24,11 @@
 #include "config.h"
 #include "SVGGradientElement.h"
 
+#include "AffineTransform.h"
 #include "ContainerNodeInlines.h"
 #include "ElementChildIteratorInlines.h"
+#include "ElementInlines.h"
+#include "GradientAttributes.h"
 #include "LegacyRenderSVGResourceLinearGradient.h"
 #include "LegacyRenderSVGResourceRadialGradient.h"
 #include "NodeName.h"
@@ -115,6 +118,28 @@ GradientColorStops SVGGradientElement::buildStops()
         stops.addColorStop({ monotonicallyIncreasingOffset, stop->stopColorIncludingOpacity() });
     }
     return stops;
+}
+
+bool SVGGradientElement::hasGradientTransformAttribute() const
+{
+    if (!attributeWithoutSynchronization(SVGNames::gradientTransformAttr).isNull())
+        return true;
+    return !m_gradientTransform->baseVal()->isEmpty();
+}
+
+void SVGGradientElement::collectCommonGradientAttributes(GradientAttributes& attributes)
+{
+    if (!attributes.hasSpreadMethod() && hasAttribute(SVGNames::spreadMethodAttr))
+        attributes.setSpreadMethod(spreadMethod());
+
+    if (!attributes.hasGradientUnits() && hasAttribute(SVGNames::gradientUnitsAttr))
+        attributes.setGradientUnits(gradientUnits());
+
+    if (!attributes.hasGradientTransform() && hasGradientTransformAttribute())
+        attributes.setGradientTransform(gradientTransform().concatenate().value_or(identity));
+
+    if (!attributes.hasStops())
+        attributes.setStops(buildStops());
 }
 
 }

--- a/Source/WebCore/svg/SVGGradientElement.h
+++ b/Source/WebCore/svg/SVGGradientElement.h
@@ -30,6 +30,8 @@
 
 namespace WebCore {
 
+struct GradientAttributes;
+
 enum SVGSpreadMethodType {
     SVGSpreadMethodUnknown = 0,
     SVGSpreadMethodPad,
@@ -82,6 +84,7 @@ public:
     };
 
     GradientColorStops buildStops();
+    void collectCommonGradientAttributes(GradientAttributes&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGradientElement, SVGElement, SVGURIReference>;
 
@@ -104,6 +107,8 @@ protected:
 private:
     bool needsPendingResourceHandling() const override { return false; }
     void childrenChanged(const ChildChange&) override;
+
+    bool hasGradientTransformAttribute() const;
 
     const Ref<SVGAnimatedEnumeration> m_spreadMethod { SVGAnimatedEnumeration::create(this, SVGSpreadMethodPad) };
     const Ref<SVGAnimatedEnumeration> m_gradientUnits { SVGAnimatedEnumeration::create(this, SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) };

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -112,17 +112,7 @@ RenderPtr<RenderElement> SVGLinearGradientElement::createElementRenderer(Style::
 
 static void setGradientAttributes(SVGGradientElement& element, LinearGradientAttributes& attributes, bool isLinear = true)
 {
-    if (!attributes.hasSpreadMethod() && element.hasAttribute(SVGNames::spreadMethodAttr))
-        attributes.setSpreadMethod(element.spreadMethod());
-
-    if (!attributes.hasGradientUnits() && element.hasAttribute(SVGNames::gradientUnitsAttr))
-        attributes.setGradientUnits(element.gradientUnits());
-
-    if (!attributes.hasGradientTransform() && element.hasAttribute(SVGNames::gradientTransformAttr))
-        attributes.setGradientTransform(element.gradientTransform().concatenate().value_or(identity));
-
-    if (!attributes.hasStops())
-        attributes.setStops(element.buildStops());
+    element.collectCommonGradientAttributes(attributes);
 
     if (isLinear) {
         SVGLinearGradientElement& linear = downcast<SVGLinearGradientElement>(element);

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -150,6 +150,13 @@ RenderPtr<RenderElement> SVGPatternElement::createElementRenderer(Style::Compute
     return createRenderer<LegacyRenderSVGResourcePattern>(*this, WTF::move(style));
 }
 
+bool SVGPatternElement::hasPatternTransformAttribute() const
+{
+    if (!attributeWithoutSynchronization(SVGNames::patternTransformAttr).isNull())
+        return true;
+    return !m_patternTransform->baseVal()->isEmpty();
+}
+
 void SVGPatternElement::collectPatternAttributes(PatternAttributes& attributes) const
 {
     if (!attributes.hasX() && hasAttribute(SVGNames::xAttr))
@@ -176,7 +183,7 @@ void SVGPatternElement::collectPatternAttributes(PatternAttributes& attributes) 
     if (!attributes.hasPatternContentUnits() && hasAttribute(SVGNames::patternContentUnitsAttr))
         attributes.setPatternContentUnits(patternContentUnits());
 
-    if (!attributes.hasPatternTransform() && hasAttribute(SVGNames::patternTransformAttr))
+    if (!attributes.hasPatternTransform() && hasPatternTransformAttribute())
         attributes.setPatternTransform(patternTransform().concatenate().value_or(identity));
 
     if (!attributes.hasPatternContentElement() && childElementCount())

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -70,6 +70,8 @@ private:
 
     RenderPtr<RenderElement> createElementRenderer(Style::ComputedStyle&&, const RenderTreePosition&) final;
 
+    bool hasPatternTransformAttribute() const;
+
     bool isValid() const final { return SVGTests::isValid(); }
     bool needsPendingResourceHandling() const final { return false; }
     bool selfHasRelativeLengths() const final { return true; }

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -118,17 +118,7 @@ RenderPtr<RenderElement> SVGRadialGradientElement::createElementRenderer(Style::
 
 static void setGradientAttributes(SVGGradientElement& element, RadialGradientAttributes& attributes, bool isRadial = true)
 {
-    if (!attributes.hasSpreadMethod() && element.hasAttribute(SVGNames::spreadMethodAttr))
-        attributes.setSpreadMethod(element.spreadMethod());
-
-    if (!attributes.hasGradientUnits() && element.hasAttribute(SVGNames::gradientUnitsAttr))
-        attributes.setGradientUnits(element.gradientUnits());
-
-    if (!attributes.hasGradientTransform() && element.hasAttribute(SVGNames::gradientTransformAttr))
-        attributes.setGradientTransform(element.gradientTransform().concatenate().value_or(identity));
-
-    if (!attributes.hasStops())
-        attributes.setStops(element.buildStops());
+    element.collectCommonGradientAttributes(attributes);
 
     if (isRadial) {
         SVGRadialGradientElement& radial = downcast<SVGRadialGradientElement>(element);


### PR DESCRIPTION
#### cd5e57e3a9dedd146aeefa5808eb35a547297951
<pre>
[LBSE] Avoid serializing the gradient and pattern transform to answer a presence check
<a href="https://bugs.webkit.org/show_bug.cgi?id=321675">https://bugs.webkit.org/show_bug.cgi?id=321675</a>

Reviewed by Rob Buis.

collectGradientAttributes() and collectPatternAttributes() asked hasAttribute()
whether gradientTransform / patternTransform was specified. Answering that costs
a serialization of the transform list into the attribute map whenever the base
value was changed through the SVG DOM, and the serialized string is never read
back: the value itself comes from the typed accessor gradientTransform() /
patternTransform() -&gt; answer the presence check directly instead.

Move the attributes shared by &lt;linearGradient&gt; and &lt;radialGradient&gt; into
SVGGradientElement::collectCommonGradientAttributes(), so the two copies of that
code cannot drift apart.

Tests: svg/custom/gradient-transform-empty-or-invalid-not-inherited.svg
       svg/custom/pattern-transform-empty-or-invalid-not-inherited.svg

* LayoutTests/svg/custom/gradient-transform-empty-or-invalid-not-inherited-expected.svg: Added.
* LayoutTests/svg/custom/gradient-transform-empty-or-invalid-not-inherited.svg: Added.
* LayoutTests/svg/custom/pattern-transform-empty-or-invalid-not-inherited-expected.svg: Added.
* LayoutTests/svg/custom/pattern-transform-empty-or-invalid-not-inherited.svg: Added.
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp:
(WebCore::RenderSVGResourceLinearGradient::collectGradientAttributesIfNeeded):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::collectPatternAttributesIfNeeded):
* Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp:
(WebCore::RenderSVGResourceRadialGradient::collectGradientAttributesIfNeeded):
* Source/WebCore/svg/SVGGradientElement.cpp:
(WebCore::SVGGradientElement::hasGradientTransformAttribute const):
(WebCore::SVGGradientElement::collectCommonGradientAttributes):
* Source/WebCore/svg/SVGGradientElement.h:
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::setGradientAttributes):
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::hasPatternTransformAttribute const):
(WebCore::SVGPatternElement::collectPatternAttributes const):
* Source/WebCore/svg/SVGPatternElement.h:
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::setGradientAttributes):

Canonical link: <a href="https://commits.webkit.org/319280@main">https://commits.webkit.org/319280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd30340f6bdbfa45d7cd2920a5240129d5d5adf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191184 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141197 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121649 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43531 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41810 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41470 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2344 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193119 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161459 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150582 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55269 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150299 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27478 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44888 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127535 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123010 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53786 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16464 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53168 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53405 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->