### PR TITLE
Confirming an IME composition can remove its containing positioned element

### DIFF
--- a/LayoutTests/editing/mac/input/ime-commit-preserves-empty-positioned-block-expected.txt
+++ b/LayoutTests/editing/mac/input/ime-commit-preserves-empty-positioned-block-expected.txt
@@ -1,0 +1,19 @@
+Committing an IME composition should preserve the empty positioned block that received the composition.
+
+Before composition:
+| <div>
+|   id="target"
+|   style="position: relative; min-height: 1px;"
+|   <#selection-caret>
+
+During composition:
+| <div>
+|   id="target"
+|   style="position: relative; min-height: 1px;"
+|   "日本語<#selection-caret>"
+
+After committing composition:
+| <div>
+|   id="target"
+|   style="position: relative; min-height: 1px;"
+|   "日本語<#selection-caret>"

--- a/LayoutTests/editing/mac/input/ime-commit-preserves-empty-positioned-block.html
+++ b/LayoutTests/editing/mac/input/ime-commit-preserves-empty-positioned-block.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="../../../resources/dump-as-markup.js"></script>
+<div id="editor" contenteditable="true"><div id="target" style="position: relative; min-height: 1px;"></div></div>
+<script>
+Markup.description("Committing an IME composition should preserve the empty positioned block that received the composition.");
+
+const target = document.getElementById("target");
+getSelection().setPosition(target, 0);
+Markup.dump("editor", "Before composition");
+
+if (window.textInputController) {
+    textInputController.setMarkedText("日本語", 3, 0);
+    Markup.dump("editor", "During composition");
+    textInputController.insertText("日本語");
+    Markup.dump("editor", "After committing composition");
+}
+</script>

--- a/LayoutTests/editing/mac/input/ime-recomposition-preserves-positioned-block-expected.txt
+++ b/LayoutTests/editing/mac/input/ime-recomposition-preserves-positioned-block-expected.txt
@@ -1,0 +1,19 @@
+Starting an IME recomposition should preserve the positioned block containing the selected text.
+
+Before recomposition:
+| <div>
+|   id="target"
+|   style="position: relative;"
+|   "<#selection-anchor>日本語<#selection-focus>"
+
+During recomposition:
+| <div>
+|   id="target"
+|   style="position: relative;"
+|   "<#selection-anchor>日本語<#selection-focus>"
+
+After committing recomposition:
+| <div>
+|   id="target"
+|   style="position: relative;"
+|   "日本語<#selection-caret>"

--- a/LayoutTests/editing/mac/input/ime-recomposition-preserves-positioned-block.html
+++ b/LayoutTests/editing/mac/input/ime-recomposition-preserves-positioned-block.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="../../../resources/dump-as-markup.js"></script>
+<div id="editor" contenteditable="true"><div id="target" style="position: relative;">日本語</div></div>
+<script>
+Markup.description("Starting an IME recomposition should preserve the positioned block containing the selected text.");
+
+const target = document.getElementById("target");
+getSelection().setBaseAndExtent(target.firstChild, 0, target.firstChild, 3);
+Markup.dump("editor", "Before recomposition");
+
+if (window.textInputController) {
+    textInputController.setMarkedText("日本語", 0, 3);
+    Markup.dump("editor", "During recomposition");
+    textInputController.insertText("日本語");
+    Markup.dump("editor", "After committing recomposition");
+}
+</script>

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -926,7 +926,8 @@ void TypingCommand::deleteSelection(bool smartDelete)
     if (!willAddTypingToOpenCommand(Type::DeleteSelection, TextGranularity::CharacterGranularity))
         return;
 
-    CompositeEditCommand::deleteSelection(smartDelete);
+    bool expandForSpecialElements = m_compositionType == TextCompositionType::None;
+    CompositeEditCommand::deleteSelection(smartDelete, /* mergeBlocksAfterDelete */ true, /* replace */ false, expandForSpecialElements);
     typingAddedToOpenCommand(Type::DeleteSelection);
 }
 


### PR DESCRIPTION
#### fefaaed9dfdeba70532cb1fe804847743dce4398
<pre>
Confirming an IME composition can remove its containing positioned element
<a href="https://bugs.webkit.org/show_bug.cgi?id=321674">https://bugs.webkit.org/show_bug.cgi?id=321674</a>

Reviewed by Ryosuke Niwa.

When confirming a composition, WebKit deletes the pending composition
text before inserting the finalized text. WebKit also deletes selected
text when starting a recomposition.

These deletions used the normal selection deletion behavior, which may
expand the selection to include a containing special element. Since
positioned elements are treated as special elements, this could remove
the element containing the composition and reinsert its text into a
styled span.

Disable special-element expansion when deleting composition text,
including pending composition text and text selected for recomposition.
Normal user-initiated selection deletion behavior remains unchanged.

Tests: editing/mac/input/ime-commit-preserves-empty-positioned-block.html
       editing/mac/input/ime-recomposition-preserves-positioned-block.html

* LayoutTests/editing/mac/input/ime-commit-preserves-empty-positioned-block-expected.txt: Added.
* LayoutTests/editing/mac/input/ime-commit-preserves-empty-positioned-block.html: Added.
* LayoutTests/editing/mac/input/ime-recomposition-preserves-positioned-block-expected.txt: Added.
* LayoutTests/editing/mac/input/ime-recomposition-preserves-positioned-block.html: Added.
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::deleteSelection):
Do not expand composition text deletion to containing special elements.

Canonical link: <a href="https://commits.webkit.org/319167@main">https://commits.webkit.org/319167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22cdc739cf8bd45b1fa74a6fafda7df3c63b3b6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144865 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140820 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121272 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43158 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41444 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41117 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1913 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192690 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150187 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40228 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54842 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37732 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/cookies/same-site/popup-same-site-with-post-form.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/do-not-block-top-level-navigation-redirect.html, http/tests/security/cached-svg-image-with-css-cross-domain.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/report-same-origin-with-cookies.py, http/tests/security/mixedContent/redirect-http-to-https-script-in-iframe-UpgradeMixedContent.html, http/tests/site-isolation/inspector/network/resource-timing-cross-origin-page-navigation.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149908 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44529 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127106 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122312 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53359 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16106 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->