### PR TITLE
Fix '#import' in cross-platform headers

### DIFF
--- a/Source/WTF/wtf/MachSendRightAnnotated.h
+++ b/Source/WTF/wtf/MachSendRightAnnotated.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#import <wtf/Platform.h>
+#include <wtf/Platform.h>
 
 #if PLATFORM(COCOA)
 

--- a/Source/WebKit/Modules/Internal/WebKitInternalCxx.h
+++ b/Source/WebKit/Modules/Internal/WebKitInternalCxx.h
@@ -25,4 +25,4 @@
 
 // Add project-level C++ header files here to be able to access them from within Swift sources.
 
-#import "IPCTesterReceiverMessages.h"
+#include "IPCTesterReceiverMessages.h"

--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -72,13 +72,13 @@ module WebKit_Internal [system] {
     }
 
     module WKObject {
-        requires cplusplus20
+        requires cplusplus20,objc
         header "../../Shared/Cocoa/WKObject.h"
         export *
     }
 
     module WKTextSelectionController {
-        requires cplusplus20
+        requires cplusplus20,objc
         header "../../UIProcess/mac/WKTextSelectionController.h"
         export *
     }
@@ -102,12 +102,13 @@ module WebKit_Internal [system] {
     }
 
     module WKTextSelectionRect {
-        requires cplusplus20
+        requires cplusplus20,objc
         header "../../UIProcess/Cocoa/WKTextSelectionRect.h"
         export *
     }
 
     module WKWebViewIOS {
+        requires objc
         header "../../UIProcess/API/ios/WKWebViewIOS.h"
         export *
     }
@@ -399,7 +400,7 @@ module WebKit_Internal [system] {
     }
 
     module WKAppKitGestureController {
-        requires cplusplus20
+        requires cplusplus20,objc
         header "../../UIProcess/mac/AppKitGestures/WKAppKitGestureController.h"
         export *
     }


### PR DESCRIPTION
#### 390e2c91dca558e7f3ae701d21f400d6905bf27a
<pre>
Fix &apos;#import&apos; in cross-platform headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321678">https://bugs.webkit.org/show_bug.cgi?id=321678</a>
<a href="https://rdar.apple.com/184825762">rdar://184825762</a>

Reviewed by Ian Grunert.

A variety of WebKit headers contained #import yet were included as
cross-platform within the modulemaps that were imported by Swift. This caused
difficulties under Windows where #import means something different.

* Source/WTF/wtf/MachSendRightAnnotated.h:
* Source/WebKit/Modules/Internal/WebKitInternalCxx.h:
* Source/WebKit/Modules/Internal/module.modulemap:

Canonical link: <a href="https://commits.webkit.org/319436@main">https://commits.webkit.org/319436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa6d5e0f259796abe28071cc550e0324ebbfb0ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145379 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0bce4a9-e447-4d27-b80b-71bb932ee872) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141276 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97966 "1 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec835bb6-f3e9-4fd6-aae9-c8730e8dec07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121727 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57fb8512-121a-4584-8b2e-616a4f2dfd8a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43612 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41894 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3692 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10506 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154016 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41550 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2430 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42330 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193205 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54667 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150859 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40449 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55355 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150377 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44970 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127621 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123153 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53872 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16546 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53254 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53319 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->