### PR TITLE
[JSC][Temporal] Delete constrainMonthCodeInternal and inline constrainMonthCodeGivenContainment

### DIFF
--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -1580,10 +1580,15 @@ TemporalResult<bool> yearContainsMonthCode(CalendarID calendarId, int32_t year, 
 }
 
 // https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-constrainmonthcode
-static TemporalResult<ParsedMonthCode> constrainMonthCodeGivenContainment(CalendarID calendarId, ParsedMonthCode monthCode, bool contained, TemporalOverflow overflow)
+TemporalResult<ParsedMonthCode> constrainMonthCode(CalendarID calendarId, int32_t year, ParsedMonthCode monthCode, TemporalOverflow overflow)
 {
+    // Step 1: Assert IsValidMonthCodeForCalendar.
+    ASSERT(isValidMonthCodeForCalendar(calendarId, monthCode));
+    auto contained = yearContainsMonthCode(calendarId, year, monthCode);
+    if (!contained) [[unlikely]]
+        return makeUnexpected(contained.error());
     // Step 2: If YearContainsMonthCode, return monthCode.
-    if (contained)
+    if (*contained)
         return monthCode;
     // Step 3: If overflow is ~reject~, throw RangeError.
     if (overflow == TemporalOverflow::Reject)
@@ -1596,30 +1601,6 @@ static TemporalResult<ParsedMonthCode> constrainMonthCodeGivenContainment(Calend
     // Step 8: hebrew row → ~skip-forward~ → assert "M05L" (8.a), return "M06" (8.b).
     ASSERT(monthCode.monthNumber == 5 && monthCode.isLeapMonth);
     return ParsedMonthCode { 6, false };
-}
-TemporalResult<ParsedMonthCode> constrainMonthCode(CalendarID calendarId, int32_t year, ParsedMonthCode monthCode, TemporalOverflow overflow)
-{
-    // Step 1: Assert IsValidMonthCodeForCalendar.
-    ASSERT(isValidMonthCodeForCalendar(calendarId, monthCode));
-    // Steps 2-8: delegate to algorithm extract with cursor-computed containment.
-    auto contained = yearContainsMonthCode(calendarId, year, monthCode);
-    if (!contained) [[unlikely]]
-        return makeUnexpected(contained.error());
-    return constrainMonthCodeGivenContainment(calendarId, monthCode, *contained, overflow);
-}
-static TemporalResult<ParsedMonthCode> constrainMonthCodeInternal(UCalendar* cal, CalendarID calendarId, ParsedMonthCode monthCode, TemporalOverflow overflow)
-{
-    // Step 1: Assert IsValidMonthCodeForCalendar.
-    ASSERT(isValidMonthCodeForCalendar(calendarId, monthCode));
-    UErrorCode status = U_ZERO_ERROR;
-    int32_t year = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    // Steps 2-8: delegate to algorithm extract with cursor-computed containment.
-    auto contained = yearContainsMonthCodeInternal(cal, calendarId, year, monthCode);
-    if (!contained) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    return constrainMonthCodeGivenContainment(calendarId, monthCode, *contained, overflow);
 }
 
 // https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-monthcodetoordinal
@@ -2511,29 +2492,16 @@ static void setICUCalendarYear(UCalendar* cal, CalendarID calendarId, std::optio
     ucal_set(cal, UCAL_EXTENDED_YEAR, year.value_or(0));
 }
 
-static TemporalResult<void> positionCursorAtConstrainedMonthCode(UCalendar* cal, CalendarID calendarId, const ParsedMonthCode& monthCode, TemporalOverflow overflow)
+static TemporalResult<void> positionCursorAtConstrainedMonthCode(UCalendar* cal, CalendarID calendarId, const ParsedMonthCode& monthCode)
 {
     if (!isValidMonthCodeForCalendar(calendarId, monthCode)) [[unlikely]]
         return makeUnexpected(rangeError("monthCode is not valid for this calendar"_s));
 
-    auto constrained = constrainMonthCodeInternal(cal, calendarId, monthCode, overflow);
-    if (!constrained) [[unlikely]]
-        return makeUnexpected(constrained.error());
+    ASSERT(!monthCode.isLeapMonth);
 
-    // Position the cursor at the constrained monthCode.
-    UErrorCode status = U_ZERO_ERROR;
-    if (calendarIsLunisolar(calendarId)) {
-        String targetCode = makeString("M"_s, constrained->monthNumber < 10 ? "0"_s : ""_s,
-            constrained->monthNumber, constrained->isLeapMonth ? "L"_s : ""_s);
-        auto probe = setCalendarToMonthCode(cal, calendarId, targetCode);
-        if (!probe) [[unlikely]]
-            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-        return { };
-    }
     // Non-lunisolar: direct set (M13 for coptic/ethiopic/ethioaa; M01..M12 otherwise).
-    ucal_set(cal, UCAL_MONTH, constrained->monthNumber - 1);
-    if (constrained->isLeapMonth)
-        ucal_set(cal, UCAL_IS_LEAP_MONTH, 1);
+    UErrorCode status = U_ZERO_ERROR;
+    ucal_set(cal, UCAL_MONTH, monthCode.monthNumber - 1);
     ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
     ucal_getMillis(cal, &status);
     if (U_FAILURE(status)) [[unlikely]]
@@ -2715,7 +2683,7 @@ TemporalResult<ISO8601::PlainDate> nonISOCalendarDateToISO(CalendarID calendarId
                     return makeUnexpected(rangeError("monthCode does not exist in this calendar year"_s));
             } else {
                 // Non-lunisolar with monthCode (Gregorian-based calendars).
-                if (auto r = positionCursorAtConstrainedMonthCode(cal, calendarId, *monthCode, overflow); !r)
+                if (auto r = positionCursorAtConstrainedMonthCode(cal, calendarId, *monthCode); !r)
                     return makeUnexpected(r.error());
             }
         } else {

--- a/Source/JavaScriptCore/runtime/temporal/core/TemporalEnums.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/TemporalEnums.h
@@ -104,8 +104,6 @@ enum class TemporalUnit : uint8_t {
 static constexpr unsigned numberOfTemporalUnits = 0 JSC_TEMPORAL_UNITS(JSC_COUNT_TEMPORAL_UNITS);
 static constexpr unsigned numberOfTemporalPlainDateUnits = 0 JSC_TEMPORAL_PLAIN_DATE_UNITS(JSC_COUNT_TEMPORAL_UNITS);
 static constexpr unsigned numberOfTemporalPlainTimeUnits = 0 JSC_TEMPORAL_PLAIN_TIME_UNITS(JSC_COUNT_TEMPORAL_UNITS);
-static constexpr unsigned numberOfTemporalPlainYearMonthUnits = 0 JSC_TEMPORAL_PLAIN_YEAR_MONTH_UNITS(JSC_COUNT_TEMPORAL_UNITS);
-static constexpr unsigned numberOfTemporalPlainMonthDayUnits = 0 JSC_TEMPORAL_PLAIN_MONTH_DAY_UNITS(JSC_COUNT_TEMPORAL_UNITS);
 #undef JSC_COUNT_TEMPORAL_UNITS
 
 // https://tc39.es/proposal-temporal/#table-temporal-temporaldurationlike-properties


### PR DESCRIPTION
#### e165fd1fce9a07e76b7a711c065b6ada222fdae6
<pre>
[JSC][Temporal] Delete constrainMonthCodeInternal and inline constrainMonthCodeGivenContainment
<a href="https://bugs.webkit.org/show_bug.cgi?id=321685">https://bugs.webkit.org/show_bug.cgi?id=321685</a>
<a href="https://rdar.apple.com/184829841">rdar://184829841</a>

Reviewed by Sosuke Suzuki.

constrainMonthCodeInternal re-checked ConstrainMonthCode via a live ICU cursor for its only caller,
positionCursorAtConstrainedMonthCode. That caller is only reached for non-lunisolar calendars, and a
leap monthCode is only ever valid for chinese/dangi/hebrew — exactly the lunisolar set — so the check
always resolved to &quot;contained&quot; and the whole call reduced to one wasted ICU read plus returning its
input unchanged. Deleted; the invariant is now an ASSERT instead of a runtime check, along with an
unreachable calendarIsLunisolar branch in the same function and its now-unused overflow parameter.

constrainMonthCodeGivenContainment loses its second caller in the same change, so it&apos;s inlined into
the one left (constrainMonthCode).

Also deletes two TemporalEnums.h constants with zero references tree-wide.

No behavior change.

Canonical link: <a href="https://commits.webkit.org/319162@main">https://commits.webkit.org/319162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c99db55cdda6438e1ad2063f7629608a94304622

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190764 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144875 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5770ea1-56b7-4a90-af03-252c92f2ca44) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140828 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01a3abc1-a29d-401d-911e-b96a51edd19f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44495 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121280 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70db5182-895e-4d90-9d2f-7e972ebd4fbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43168 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41454 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3247 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10088 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41132 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1923 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41827 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192700 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54164 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150197 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54852 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149917 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27420 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44538 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127116 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122324 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53369 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16121 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52751 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52988 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->