### PR TITLE
[CMake] Mac build fails to resolve the WebCore_Private module when ENABLE_BACK_FORWARD_LIST_SWIFT is off

### DIFF
--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -1672,8 +1672,8 @@ add_dependencies(WebCore WebCore_CopyBundleResources)
 
 # Stage the in-tree WebCore_Private module map into the framework bundle so the
 # Swift Clang importer finds it as a real module via -F (as JavaScriptCore does,
-# and as iOS does in PlatformIOS.cmake).
-if (ENABLE_BACK_FORWARD_LIST_SWIFT)
+# and as iOS does below).
+if (SWIFT_REQUIRED)
     set(_webcore_modules_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebCore.framework/Versions/A/Modules")
     add_custom_command(
         OUTPUT "${_webcore_modules_dir}/module.private.modulemap"


### PR DESCRIPTION
#### ba82b6ab43cece22292e3912cc6e5c985b36b9c8
<pre>
[CMake] Mac build fails to resolve the WebCore_Private module when ENABLE_BACK_FORWARD_LIST_SWIFT is off
<a href="https://bugs.webkit.org/show_bug.cgi?id=321684">https://bugs.webkit.org/show_bug.cgi?id=321684</a>
<a href="https://rdar.apple.com/184829371">rdar://184829371</a>

Reviewed by Zak Ridouh.

A macOS CMake build configured with --no-swift-back-forward-list fails with:

    Source/WebKit/SwiftPrewarmMac.swift:27:8: error: unable to resolve module dependency: &apos;WebCore_Private&apos;
    import WebCore_Private
           ^
    note: a dependency of main module &apos;SwiftPrewarmMac&apos;

319083@main added unconditional imports of the WebKit stack&apos;s own modules to
SwiftPrewarmMac.swift, including WebCore_Private. Staging the in-tree
WebCore_Private module map into the WebCore framework bundle -- where the Swift
Clang importer finds it via -F -- was gated on ENABLE_BACK_FORWARD_LIST_SWIFT,
so with that feature off WebCore.framework/Modules is left empty and the module
cannot be resolved.

The prewarm target is not gated on that feature: SWIFT_REQUIRED is
unconditionally ON for Cocoa, and Source/WebKit/CMakeLists.txt adds the target
for SWIFT_REQUIRED AND WEBKIT_SDK_IS_MACOS. Gate the staging on SWIFT_REQUIRED
instead, which matches the iOS path in the same file (it stages the map
unconditionally).

No new tests (build fix, no behavior change).

* Source/WebCore/PlatformCocoa.cmake:

Canonical link: <a href="https://commits.webkit.org/319166@main">https://commits.webkit.org/319166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d77f9529dd765df9cce2383b46291a7d1c96ecd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144876 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe47e592-3e2a-4222-919c-4f46d029876b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140827 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9988dc76-500e-4dfb-8411-3cb44c8b1667) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121279 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b722f31d-1a48-4b8f-85ad-b11017829d49) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43167 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41453 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41129 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1924 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192701 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54165 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150196 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40224 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54853 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149916 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44537 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127117 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122325 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53370 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16118 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52752 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52989 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52817 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->