### PR TITLE
[JSC] Rename finalizeUnconditionally to reconcileWeakReferencesAtGCEnd

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -1491,7 +1491,7 @@ void CodeBlock::determineLiveness(const ConcurrentJSLocker&, Visitor& visitor)
 template void CodeBlock::determineLiveness(const ConcurrentJSLocker&, AbstractSlotVisitor&);
 template void CodeBlock::determineLiveness(const ConcurrentJSLocker&, SlotVisitor&);
 
-void CodeBlock::finalizeLLIntInlineCaches()
+void CodeBlock::reconcileLLIntInlineCachesAtGCEnd()
 {
     VM& vm = *m_vm;
 
@@ -1746,7 +1746,7 @@ void CodeBlock::finalizeLLIntInlineCaches()
 }
 
 #if ENABLE(JIT)
-void CodeBlock::finalizeJITInlineCaches()
+void CodeBlock::reconcileJITInlineCachesAtGCEnd()
 {
 #if ENABLE(DFG_JIT)
     if (JSC::JITCode::isOptimizingJIT(jitType())) {
@@ -1769,17 +1769,17 @@ void CodeBlock::finalizeJITInlineCaches()
 }
 #endif
 
-void CodeBlock::finalizeUnconditionally(VM& vm, CollectionScope)
+void CodeBlock::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
 {
     UNUSED_PARAM(vm);
 
-    // CodeBlock::finalizeUnconditionally is called for all live CodeBlocks.
+    // Called for all live CodeBlocks.
     // We do not need to call updateAllPredictions for DFG / FTL since the same thing happens in LLInt / Baseline CodeBlock for them.
     if (JITCode::isBaselineCode(jitType()))
         updateAllPredictions();
 
     if (JITCode::couldBeInterpreted(jitType())) {
-        finalizeLLIntInlineCaches();
+        reconcileLLIntInlineCachesAtGCEnd();
         // If the CodeBlock is DFG or FTL, CallLinkInfo in metadata is not related.
         forEachLLIntOrBaselineCallLinkInfo([&](DataOnlyCallLinkInfo& callLinkInfo) {
             callLinkInfo.visitWeak(vm);
@@ -1788,17 +1788,17 @@ void CodeBlock::finalizeUnconditionally(VM& vm, CollectionScope)
 
 #if ENABLE(JIT)
     if (!!jitCode())
-        finalizeJITInlineCaches();
+        reconcileJITInlineCachesAtGCEnd();
 #endif
 
 #if ENABLE(DFG_JIT)
     if (JSC::JITCode::isOptimizingJIT(jitType())) {
         DFG::CommonData* dfgCommon = m_jitCode->dfgCommon();
         if (auto* statuses = dfgCommon->recordedStatuses.get())
-            statuses->finalize(vm);
+            statuses->reconcileWeakReferences(vm);
 
         if (auto* jitData = dfgJITData())
-            jitData->finalizeUnconditionally();
+            jitData->reconcileWeakReferencesAtGCEnd();
     }
 #endif // ENABLE(DFG_JIT)
 
@@ -1982,6 +1982,10 @@ void CodeBlock::stronglyVisitStrongReferences(const ConcurrentJSLocker& locker, 
 #endif
 }
 
+// Runs from visitChildren, so the CodeBlock is already known live. It is live either
+// because something marked it directly, for instance a conservative stack scan finding
+// it running, or because all of its code dependencies are still live. In the former case
+// we need to ensure those dependencies stay alive, and that is what happens here.
 template<typename Visitor>
 void CodeBlock::stronglyVisitWeakReferences(const ConcurrentJSLocker&, Visitor& visitor)
 {
@@ -3097,6 +3101,9 @@ void CodeBlock::updateAllArrayAllocationProfilePredictions()
     });
 }
 
+// Folds each profile's sampled value into a pointer-free SpeculatedType and clears the sample.
+// The samples are untraced JSValues and StructureIDs, so this only runs while they are still
+// readable: after marking, before sweep.
 void CodeBlock::updateAllPredictions()
 {
     {

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -247,7 +247,7 @@ public:
 
     static size_t estimatedSize(JSCell*, VM&);
     static void destroy(JSCell*);
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
     void notifyLexicalBindingUpdate();
 
@@ -890,9 +890,9 @@ public:
     double optimizationThresholdScalingFactor() const;
 
 protected:
-    void finalizeLLIntInlineCaches();
+    void reconcileLLIntInlineCachesAtGCEnd();
 #if ENABLE(JIT)
-    void finalizeJITInlineCaches();
+    void reconcileJITInlineCachesAtGCEnd();
 #endif
 #if ENABLE(DFG_JIT)
     void tallyFrequentExitSites();

--- a/Source/JavaScriptCore/bytecode/RecordedStatuses.cpp
+++ b/Source/JavaScriptCore/bytecode/RecordedStatuses.cpp
@@ -123,32 +123,32 @@ void RecordedStatuses::markIfCheap(Visitor& visitor)
 template void RecordedStatuses::markIfCheap(AbstractSlotVisitor&);
 template void RecordedStatuses::markIfCheap(SlotVisitor&);
 
-void RecordedStatuses::finalizeWithoutDeleting(VM& vm)
+void RecordedStatuses::reconcileWeakReferencesWithoutDeleting(VM& vm)
 {
-    // This variant of finalize gets called from within graph safepoints -- so there may be DFG IR in
+    // Called from within graph safepoints -- so there may be DFG IR in
     // some compiler thread that points to the statuses. That thread is stopped at a safepoint so
     // it's OK to edit its data structure, but it's not OK to delete them. Hence we don't remove
     // anything from the vector or delete the unique_ptrs.
-    
-    auto finalize = [&] (auto& vector) {
+
+    auto reconcile = [&] (auto& vector) {
         for (auto& pair : vector) {
             if (!pair.second->finalize(vm))
                 *pair.second = { };
         }
     };
-    forEachVector(finalize);
+    forEachVector(reconcile);
 }
 
-void RecordedStatuses::finalize(VM& vm)
+void RecordedStatuses::reconcileWeakReferences(VM& vm)
 {
-    auto finalize = [&] (auto& vector) {
+    auto reconcile = [&] (auto& vector) {
         vector.removeAllMatching(
             [&] (auto& pair) -> bool {
                 return !*pair.second || !pair.second->finalize(vm);
             });
         vector.shrinkToFit();
     };
-    forEachVector(finalize);
+    forEachVector(reconcile);
 }
 
 void RecordedStatuses::shrinkToFit()

--- a/Source/JavaScriptCore/bytecode/RecordedStatuses.h
+++ b/Source/JavaScriptCore/bytecode/RecordedStatuses.h
@@ -51,8 +51,8 @@ struct RecordedStatuses {
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
     
-    void finalizeWithoutDeleting(VM&);
-    void finalize(VM&);
+    void reconcileWeakReferencesWithoutDeleting(VM&);
+    void reconcileWeakReferences(VM&);
     
     void shrinkToFit();
     

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -312,7 +312,7 @@ UnlinkedFunctionExecutable::RareData& UnlinkedFunctionExecutable::ensureRareData
     return *m_rareData;
 }
 
-void UnlinkedFunctionExecutable::finalizeUnconditionally(VM& vm, CollectionScope)
+void UnlinkedFunctionExecutable::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
 {
     if (codeBlockEdgeMayBeWeak()) {
         bool isCleared = false;

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -227,7 +227,7 @@ public:
         ensureRareData().m_sourceMappingURLDirective = sourceMappingURL;
     }
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
     struct ClassElementDefinition {
         WTF_MAKE_STRUCT_TZONE_ALLOCATED(ClassElementDefinition);

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -209,7 +209,7 @@ public:
 
     explicit JITData(unsigned propertyCacheSize, unsigned poolSize, const JITCode&, ExitVector&&);
 
-    void finalizeUnconditionally()
+    void reconcileWeakReferencesAtGCEnd()
     {
         m_dummyArrayProfile.clear();
     }

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -155,11 +155,11 @@ size_t Plan::codeSize() const
     return m_finalizer->codeSize();
 }
 
-void Plan::finalizeInGC()
+void Plan::reconcileWeakReferencesAtGCEnd()
 {
     ASSERT(m_vm);
     if (m_recordedStatuses)
-        m_recordedStatuses->finalizeWithoutDeleting(*m_vm);
+        m_recordedStatuses->reconcileWeakReferencesWithoutDeleting(*m_vm);
 }
 
 void Plan::notifyReady()

--- a/Source/JavaScriptCore/dfg/DFGPlan.h
+++ b/Source/JavaScriptCore/dfg/DFGPlan.h
@@ -64,7 +64,7 @@ public:
     ~Plan();
 
     size_t codeSize() const final;
-    void finalizeInGC() final;
+    void reconcileWeakReferencesAtGCEnd() final;
     CompilationResult finalize() override;
 
     void notifyReady() final;

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -774,65 +774,69 @@ void Heap::addReference(JSCell* cell, ArrayBuffer* buffer)
 }
 
 template<typename CellType, typename CellSet>
-void Heap::finalizeMarkedUnconditionalFinalizers(CellSet& cellSet, CollectionScope collectionScope)
+void Heap::reconcileWeakReferencesInMarkedCells(CellSet& cellSet, CollectionScope collectionScope)
 {
     cellSet.forEachMarkedCell(
         [&] (HeapCell* cell, HeapCell::Kind) {
-            static_cast<CellType*>(cell)->finalizeUnconditionally(vm(), collectionScope);
+            static_cast<CellType*>(cell)->reconcileWeakReferencesAtGCEnd(vm(), collectionScope);
         });
 }
 
-void Heap::finalizeUnconditionalFinalizers()
+// Weak reference reconciliation: settle every untraced pointer against the liveness that
+// marking just established. Must run after marking, because isMarked() only means "dead"
+// once the closure is complete, and before sweeping, because a dying referent may still
+// need to be identified or read.
+void Heap::reconcileWeakReferencesAtGCEnd()
 {
     CollectionScope collectionScope = this->collectionScope().value_or(CollectionScope::Full);
 
     {
-        // We run this before CodeBlock's unconditional finalizer since CodeBlock looks at the owner executable's installed CodeBlock in its finalizeUnconditionally.
+        // Executables go before CodeBlock, since CodeBlock::reconcileWeakReferencesAtGCEnd looks at the owner executable's installed CodeBlock.
 
-        // FunctionExecutable requires all live instances to run finalizers. Thus, we do not use finalizer set.
-        finalizeMarkedUnconditionalFinalizers<FunctionExecutable>(functionExecutableSpaceAndSet.space, collectionScope);
+        // FunctionExecutable requires all live instances to be processed, so iterate the whole space rather than a tracking set.
+        reconcileWeakReferencesInMarkedCells<FunctionExecutable>(functionExecutableSpaceAndSet.space, collectionScope);
 
-        finalizeMarkedUnconditionalFinalizers<ProgramExecutable>(programExecutableSpaceAndSet.finalizerSet, collectionScope);
+        reconcileWeakReferencesInMarkedCells<ProgramExecutable>(programExecutableSpaceAndSet.weakReconciliationSet, collectionScope);
         if (m_evalExecutableSpace)
-            finalizeMarkedUnconditionalFinalizers<EvalExecutable>(m_evalExecutableSpace->finalizerSet, collectionScope);
+            reconcileWeakReferencesInMarkedCells<EvalExecutable>(m_evalExecutableSpace->weakReconciliationSet, collectionScope);
         if (m_moduleProgramExecutableSpace)
-            finalizeMarkedUnconditionalFinalizers<ModuleProgramExecutable>(m_moduleProgramExecutableSpace->finalizerSet, collectionScope);
+            reconcileWeakReferencesInMarkedCells<ModuleProgramExecutable>(m_moduleProgramExecutableSpace->weakReconciliationSet, collectionScope);
     }
 
-    finalizeMarkedUnconditionalFinalizers<SymbolTable>(symbolTableSpace, collectionScope);
+    reconcileWeakReferencesInMarkedCells<SymbolTable>(symbolTableSpace, collectionScope);
 
     forEachCodeBlockSpace(
         [&] (auto& space) {
-            this->finalizeMarkedUnconditionalFinalizers<CodeBlock>(space.set, collectionScope);
+            this->reconcileWeakReferencesInMarkedCells<CodeBlock>(space.set, collectionScope);
         });
     if (collectionScope == CollectionScope::Full) {
-        finalizeMarkedUnconditionalFinalizers<Structure>(structureSpace, collectionScope);
-        finalizeMarkedUnconditionalFinalizers<BrandedStructure>(brandedStructureSpace, collectionScope);
+        reconcileWeakReferencesInMarkedCells<Structure>(structureSpace, collectionScope);
+        reconcileWeakReferencesInMarkedCells<BrandedStructure>(brandedStructureSpace, collectionScope);
 #if ENABLE(WEBASSEMBLY)
-        finalizeMarkedUnconditionalFinalizers<WebAssemblyGCStructure>(webAssemblyGCStructureSpace, collectionScope);
+        reconcileWeakReferencesInMarkedCells<WebAssemblyGCStructure>(webAssemblyGCStructureSpace, collectionScope);
 #endif
     }
-    finalizeMarkedUnconditionalFinalizers<StructureRareData>(structureRareDataSpace, collectionScope);
-    finalizeMarkedUnconditionalFinalizers<UnlinkedFunctionExecutable>(unlinkedFunctionExecutableSpaceAndSet.set, collectionScope);
+    reconcileWeakReferencesInMarkedCells<StructureRareData>(structureRareDataSpace, collectionScope);
+    reconcileWeakReferencesInMarkedCells<UnlinkedFunctionExecutable>(unlinkedFunctionExecutableSpaceAndSet.set, collectionScope);
     if (m_weakSetSpace)
-        finalizeMarkedUnconditionalFinalizers<JSWeakSet>(*m_weakSetSpace, collectionScope);
+        reconcileWeakReferencesInMarkedCells<JSWeakSet>(*m_weakSetSpace, collectionScope);
     if (m_weakMapSpace)
-        finalizeMarkedUnconditionalFinalizers<JSWeakMap>(*m_weakMapSpace, collectionScope);
+        reconcileWeakReferencesInMarkedCells<JSWeakMap>(*m_weakMapSpace, collectionScope);
     if (m_weakObjectRefSpace)
-        finalizeMarkedUnconditionalFinalizers<JSWeakObjectRef>(*m_weakObjectRefSpace, collectionScope);
+        reconcileWeakReferencesInMarkedCells<JSWeakObjectRef>(*m_weakObjectRefSpace, collectionScope);
     if (m_errorInstanceSpace)
-        finalizeMarkedUnconditionalFinalizers<ErrorInstance>(*m_errorInstanceSpace, collectionScope);
+        reconcileWeakReferencesInMarkedCells<ErrorInstance>(*m_errorInstanceSpace, collectionScope);
 
     // FinalizationRegistries currently rely on serial finalization because they can post tasks to the deferredWorkTimer, which normally expects tasks to only be posted by the API lock holder.
     if (m_finalizationRegistrySpace)
-        finalizeMarkedUnconditionalFinalizers<JSFinalizationRegistry>(*m_finalizationRegistrySpace, collectionScope);
+        reconcileWeakReferencesInMarkedCells<JSFinalizationRegistry>(*m_finalizationRegistrySpace, collectionScope);
 
 #if ENABLE(WEBASSEMBLY)
     if (m_webAssemblyInstanceSpace)
-        finalizeMarkedUnconditionalFinalizers<JSWebAssemblyInstance>(*m_webAssemblyInstanceSpace, collectionScope);
+        reconcileWeakReferencesInMarkedCells<JSWebAssemblyInstance>(*m_webAssemblyInstanceSpace, collectionScope);
 #endif
 
-    vm().finalizeUnconditionally();
+    vm().reconcileWeakReferencesAtGCEnd();
 }
 
 void Heap::willStartIterating()
@@ -1805,7 +1809,7 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
         pruneStaleEntriesFromWeakGCHashTables();
         sweepArrayBuffers();
         snapshotUnswept();
-        finalizeUnconditionalFinalizers(); // We rely on these unconditional finalizers running before clearCurrentlyExecuting since CodeBlock's finalizer relies on querying currently executing.
+        reconcileWeakReferencesAtGCEnd(); // Must precede clearCurrentlyExecuting: CodeBlock::reconcileWeakReferencesAtGCEnd queries which CodeBlocks are currently executing.
         removeDeadCompilerWorklistEntries();
         deleteUnmarkedCompiledCode();
     }

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -782,9 +782,9 @@ private:
     void harvestWeakReferences();
 
     template<typename CellType, typename CellSet>
-    void finalizeMarkedUnconditionalFinalizers(CellSet&, CollectionScope);
+    void reconcileWeakReferencesInMarkedCells(CellSet&, CollectionScope);
 
-    void finalizeUnconditionalFinalizers();
+    void reconcileWeakReferencesAtGCEnd();
 
     void deleteUnmarkedCompiledCode();
     JS_EXPORT_PRIVATE void addToRememberedSet(const JSCell*);
@@ -1215,14 +1215,14 @@ public:
         IsoSubspace space;
         IsoCellSet clearableCodeSet;
         IsoCellSet outputConstraintsSet;
-        IsoCellSet finalizerSet;
+        IsoCellSet weakReconciliationSet;
 
         template<typename... Arguments>
         ScriptExecutableSpaceAndSets(Arguments&&... arguments)
             : space(std::forward<Arguments>(arguments)...)
             , clearableCodeSet(space)
             , outputConstraintsSet(space)
-            , finalizerSet(space)
+            , weakReconciliationSet(space)
         {
         }
 
@@ -1235,7 +1235,7 @@ public:
 
         static IsoCellSet& clearableCodeSetFor(Subspace& space) { return setAndSpaceFor(space).clearableCodeSet; }
         static IsoCellSet& outputConstraintsSetFor(Subspace& space) { return setAndSpaceFor(space).outputConstraintsSet; }
-        static IsoCellSet& finalizerSetFor(Subspace& space) { return setAndSpaceFor(space).finalizerSet; }
+        static IsoCellSet& weakReconciliationSetFor(Subspace& space) { return setAndSpaceFor(space).weakReconciliationSet; }
     };
 
     DYNAMIC_SPACE_AND_SET_DEFINE_MEMBER(evalExecutableSpace, ScriptExecutableSpaceAndSets)

--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.h
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.h
@@ -109,7 +109,7 @@ public:
         return result;
     }
 
-    void finalizeUnconditionally(VM& vm)
+    void reconcileWeakReferencesAtGCEnd(VM& vm)
     {
         for (auto& entry : m_entries)
             entry.visitWeak(vm);

--- a/Source/JavaScriptCore/jit/JITPlan.h
+++ b/Source/JavaScriptCore/jit/JITPlan.h
@@ -85,7 +85,7 @@ public:
 
     virtual CompilationResult finalize() = 0;
 
-    virtual void finalizeInGC() { }
+    virtual void reconcileWeakReferencesAtGCEnd() { }
 
     void notifyCompiling();
     virtual void notifyReady();

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -338,7 +338,7 @@ void JITWorklist::removeDeadPlans(VM& vm)
     removeMatchingPlansForVM(vm, [&](JITPlan& plan) {
         if (!plan.isKnownToBeLiveAfterGC())
             return true;
-        plan.finalizeInGC();
+        plan.reconcileWeakReferencesAtGCEnd();
         return false;
     });
 

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -275,7 +275,7 @@ String ErrorInstance::tryGetMessageForDebugging()
     return emptyString();
 }
 
-void ErrorInstance::finalizeUnconditionally(VM& vm, CollectionScope)
+void ErrorInstance::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
 {
     if (!m_stackTrace)
         return;
@@ -283,6 +283,8 @@ void ErrorInstance::finalizeUnconditionally(VM& vm, CollectionScope)
     // We don't want to keep our stack traces alive forever if the user doesn't access the stack trace.
     // If we did, we might end up keeping functions (and their global objects) alive that happened to
     // get caught in a trace.
+    // Since the frames are weak, a dead one means the trace can no longer be reconstructed, so
+    // materialize it into strings while it is still readable.
     for (const auto& frame : *m_stackTrace.get()) {
         if (!frame.isMarked(vm)) {
             computeErrorInfo(vm);

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -114,7 +114,7 @@ public:
             m_stackPropertyAlreadyMaterialized = true;
     }
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
 protected:
     JS_EXPORT_PRIVATE explicit ErrorInstance(VM&, Structure*, ErrorType);

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
@@ -94,7 +94,7 @@ void FunctionExecutable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
         }
     }
 
-    // Since FunctionExecutable's finalizer always needs to be run, we do not track FunctionExecutable via finalizerSet.
+    // Every live FunctionExecutable needs reconciling, so it is not tracked via weakReconciliationSet.
     auto* codeBlockForCall = thisObject->m_codeBlockForCall.get();
     if (codeBlockForCall)
         visitCodeBlockEdge(visitor, codeBlockForCall);

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.h
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.h
@@ -262,7 +262,7 @@ public:
 
     TemplateObjectMap& ensureTemplateObjectMap(VM&);
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
     JSString* toString(JSGlobalObject*);
     JSString* asStringConcurrently() const

--- a/Source/JavaScriptCore/runtime/FunctionExecutableInlines.h
+++ b/Source/JavaScriptCore/runtime/FunctionExecutableInlines.h
@@ -44,11 +44,11 @@ inline void FunctionExecutable::notifyCreation(VM& vm, JSFunction* function, con
         m_unlinkedExecutable->setSingletonHasBeenInvalidated();
 }
 
-inline void FunctionExecutable::finalizeUnconditionally(VM& vm, CollectionScope collectionScope)
+inline void FunctionExecutable::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope collectionScope)
 {
-    m_singleton.finalizeUnconditionally(vm, collectionScope);
-    finalizeCodeBlockEdge(vm, m_codeBlockForCall);
-    finalizeCodeBlockEdge(vm, m_codeBlockForConstruct);
+    m_singleton.reconcileWeakReferencesAtGCEnd(vm, collectionScope);
+    jettisonCodeBlockEdgeIfDead(vm, m_codeBlockForCall);
+    jettisonCodeBlockEdgeIfDead(vm, m_codeBlockForConstruct);
     vm.heap.functionExecutableSpaceAndSet.outputConstraintsSet.remove(this);
 }
 

--- a/Source/JavaScriptCore/runtime/GlobalExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/GlobalExecutable.cpp
@@ -44,11 +44,11 @@ void GlobalExecutable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
     if (auto* codeBlock = executable->codeBlock()) {
         // If CodeBlocks is not marked yet, we will run output-constraints.
-        // We maintain the invariant that, whenever we see unmarked CodeBlock, then we must run finalizer.
-        // And whenever we set a bit on outputConstraintsSet, we must already set a bit in finalizerSet.
+        // We maintain the invariant that, whenever we see an unmarked CodeBlock, we must reconcile.
+        // And whenever we set a bit on outputConstraintsSet, we must already set a bit in weakReconciliationSet.
         visitCodeBlockEdge(visitor, codeBlock);
         if (!visitor.isMarked(codeBlock)) {
-            Heap::ScriptExecutableSpaceAndSets::finalizerSetFor(*executable->subspace()).add(executable);
+            Heap::ScriptExecutableSpaceAndSets::weakReconciliationSetFor(*executable->subspace()).add(executable);
             Heap::ScriptExecutableSpaceAndSets::outputConstraintsSetFor(*executable->subspace()).add(executable);
         }
     }
@@ -77,11 +77,11 @@ CodeBlock* GlobalExecutable::replaceCodeBlockWith(VM& vm, CodeBlock* newCodeBloc
     return oldCodeBlock;
 }
 
-void GlobalExecutable::finalizeUnconditionally(VM& vm, CollectionScope)
+void GlobalExecutable::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
 {
-    finalizeCodeBlockEdge(vm, m_codeBlock);
+    jettisonCodeBlockEdgeIfDead(vm, m_codeBlock);
     Heap::ScriptExecutableSpaceAndSets::outputConstraintsSetFor(*subspace()).remove(this);
-    Heap::ScriptExecutableSpaceAndSets::finalizerSetFor(*subspace()).remove(this);
+    Heap::ScriptExecutableSpaceAndSets::weakReconciliationSetFor(*subspace()).remove(this);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/GlobalExecutable.h
+++ b/Source/JavaScriptCore/runtime/GlobalExecutable.h
@@ -50,7 +50,7 @@ public:
     DECLARE_VISIT_CHILDREN;
     DECLARE_VISIT_OUTPUT_CONSTRAINTS;
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
 protected:
     friend class ScriptExecutable;

--- a/Source/JavaScriptCore/runtime/InferredValue.h
+++ b/Source/JavaScriptCore/runtime/InferredValue.h
@@ -123,7 +123,7 @@ public:
         notifyWriteSlow(vm, owner, value, reason);
     }
     
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
 private:
     class InferredValueWatchpointSet final : public WatchpointSet {

--- a/Source/JavaScriptCore/runtime/InferredValueInlines.h
+++ b/Source/JavaScriptCore/runtime/InferredValueInlines.h
@@ -30,7 +30,7 @@
 namespace JSC {
 
 template<typename JSCellType>
-void InferredValue<JSCellType>::finalizeUnconditionally(VM& vm, CollectionScope)
+void InferredValue<JSCellType>::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
 {
     JSCellType* value = inferredValue();
 

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
@@ -57,8 +57,8 @@ void JSFinalizationRegistry::finishCreation(VM& vm, JSGlobalObject* globalObject
         Base::internalField(index).setWithoutWriteBarrier(values[index]);
     internalField(Field::Callback).setWithoutWriteBarrier(callback);
 
-    // Make sure we init the DOM wrapper for our document since it must be allocated before finalizeUnconditionally is called. finalizeUnconditionally,
-    // is called during the GC flip so no JS objects can be allocated there. This only works because we no longer weakly hold on to DOM wrappers.
+    // Init the DOM wrapper for our document now: reconciliation runs during the GC flip, where no
+    // JS objects can be allocated. This only works because we no longer weakly hold DOM wrappers.
     globalObject->globalObjectMethodTable()->currentScriptExecutionOwner(globalObject);
 }
 
@@ -97,7 +97,7 @@ void JSFinalizationRegistry::destroy(JSCell* table)
     static_cast<JSFinalizationRegistry*>(table)->~JSFinalizationRegistry();
 }
 
-void JSFinalizationRegistry::finalizeUnconditionally(VM& vm, CollectionScope)
+void JSFinalizationRegistry::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
 {
     Locker locker { cellLock() };
 

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
@@ -69,7 +69,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
     DECLARE_VISIT_CHILDREN;
     static void destroy(JSCell*);
     static constexpr DestructionMode needsDestruction = NeedsDestruction;

--- a/Source/JavaScriptCore/runtime/JSWeakObjectRef.cpp
+++ b/Source/JavaScriptCore/runtime/JSWeakObjectRef.cpp
@@ -54,7 +54,7 @@ void JSWeakObjectRef::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 DEFINE_VISIT_CHILDREN(JSWeakObjectRef);
 
-void JSWeakObjectRef::finalizeUnconditionally(VM& vm, CollectionScope)
+void JSWeakObjectRef::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
 {
     if (m_value && !vm.heap.isMarked(m_value.get()))
         m_value.clear();

--- a/Source/JavaScriptCore/runtime/JSWeakObjectRef.h
+++ b/Source/JavaScriptCore/runtime/JSWeakObjectRef.h
@@ -61,7 +61,7 @@ public:
         return vm.weakObjectRefSpace<mode>();
     }
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
     DECLARE_VISIT_CHILDREN;
 
 private:

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.h
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.h
@@ -150,7 +150,7 @@ protected:
     static void runConstraint(const ConcurrentJSLocker&, Visitor&, CodeBlock*);
     template<typename Visitor>
     static void visitCodeBlockEdge(Visitor&, CodeBlock*);
-    void finalizeCodeBlockEdge(VM&, WriteBarrier<CodeBlock>&);
+    void jettisonCodeBlockEdgeIfDead(VM&, WriteBarrier<CodeBlock>&);
 
     SourceCode m_source;
     Intrinsic m_intrinsic { NoIntrinsic };

--- a/Source/JavaScriptCore/runtime/ScriptExecutableInlines.h
+++ b/Source/JavaScriptCore/runtime/ScriptExecutableInlines.h
@@ -30,7 +30,7 @@
 
 namespace JSC {
 
-inline void ScriptExecutable::finalizeCodeBlockEdge(VM& vm, WriteBarrier<CodeBlock>& codeBlockEdge)
+inline void ScriptExecutable::jettisonCodeBlockEdgeIfDead(VM& vm, WriteBarrier<CodeBlock>& codeBlockEdge)
 {
     for (;;) {
         auto* codeBlock = codeBlockEdge.get();

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1742,9 +1742,9 @@ void DeferredStructureTransitionWatchpointFire::fireAllSlow()
     watchpointsToFire().fireAll(m_vm, detail);
 }
 
-void Structure::finalizeUnconditionally(VM& vm, CollectionScope collectionScope)
+void Structure::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope collectionScope)
 {
-    m_transitionTable.finalizeUnconditionally(vm, collectionScope);
+    m_transitionTable.reconcileWeakReferencesAtGCEnd(vm, collectionScope);
 }
 
 void dumpTransitionKind(PrintStream& out, TransitionKind kind)

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -874,7 +874,7 @@ public:
         return numberOfSlotsForMaxOffset(maxOffset(), m_inlineCapacity);
     }
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
 protected:
     Structure(VM&, StructureVariant, Structure* previous); // Branded/Normal only

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -610,7 +610,7 @@ inline Structure* StructureTransitionTable::get(PointerKey rep, unsigned attribu
     return map()->get(StructureTransitionTable::Hash::createKey(rep, attributes, transitionKind));
 }
 
-inline void StructureTransitionTable::finalizeUnconditionally(VM& vm, CollectionScope)
+inline void StructureTransitionTable::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
 {
     if (auto* transition = trySingleTransition()) {
         if (!vm.heap.isMarked(transition))

--- a/Source/JavaScriptCore/runtime/StructureRareData.cpp
+++ b/Source/JavaScriptCore/runtime/StructureRareData.cpp
@@ -237,7 +237,7 @@ void StructureRareData::clearCachedSpecialProperty(CachedSpecialPropertyKey key)
         cache.m_value.clear();
 }
 
-void StructureRareData::finalizeUnconditionally(VM& vm, CollectionScope)
+void StructureRareData::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
 {
     if (m_specialPropertyCache) {
         auto clearCacheIfInvalidated = [&](CachedSpecialPropertyKey key) {

--- a/Source/JavaScriptCore/runtime/StructureRareData.h
+++ b/Source/JavaScriptCore/runtime/StructureRareData.h
@@ -129,7 +129,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
     static constexpr uintptr_t cachedPropertyNameEnumeratorIsValidatedViaTraversingFlag = 1;
     static constexpr uintptr_t cachedPropertyNameEnumeratorMask = ~static_cast<uintptr_t>(1);

--- a/Source/JavaScriptCore/runtime/StructureTransitionTable.h
+++ b/Source/JavaScriptCore/runtime/StructureTransitionTable.h
@@ -279,7 +279,7 @@ public:
 
     Structure* trySingleTransition() const;
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
 private:
     friend class SingleSlotTransitionWeakOwner;

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -704,7 +704,7 @@ public:
     bool hasScopedWatchpointSet(WatchpointSet*);
 #endif
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
     void dump(PrintStream&) const;
 
     struct SymbolTableRareData {

--- a/Source/JavaScriptCore/runtime/SymbolTableInlines.h
+++ b/Source/JavaScriptCore/runtime/SymbolTableInlines.h
@@ -36,9 +36,9 @@ inline Structure* SymbolTable::createStructure(VM& vm, JSGlobalObject* globalObj
     return Structure::create(vm, globalObject, prototype, TypeInfo(CellType, StructureFlags), info());
 }
 
-inline void SymbolTable::finalizeUnconditionally(VM& vm, CollectionScope collectionScope)
+inline void SymbolTable::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope collectionScope)
 {
-    m_singleton.finalizeUnconditionally(vm, collectionScope);
+    m_singleton.reconcileWeakReferencesAtGCEnd(vm, collectionScope);
 }
 
 inline void SymbolTable::notifyCreation(VM& vm, JSScope* scope, const char* reason)

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1879,9 +1879,9 @@ void VM::beginMarking()
     });
 }
 
-void VM::finalizeUnconditionally()
+void VM::reconcileWeakReferencesAtGCEnd()
 {
-    m_syncResumeCallCache->finalizeUnconditionally(*this);
+    m_syncResumeCallCache->reconcileWeakReferencesAtGCEnd(*this);
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1109,7 +1109,7 @@ public:
 #endif
 
     void beginMarking();
-    void finalizeUnconditionally();
+    void reconcileWeakReferencesAtGCEnd();
     DECLARE_VISIT_AGGREGATE;
 
     void NODELETE addDebugger(Debugger&);

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.h
@@ -356,7 +356,7 @@ public:
     }
 
     template<typename Visitor> static void visitOutputConstraints(JSCell*, Visitor&);
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
 private:
     template<typename Visitor>

--- a/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
@@ -106,7 +106,7 @@ ALWAYS_INLINE void WeakMapImpl<WeakMapBucket>::addBucket(VM& vm, JSCell* key, JS
 
 // Note that this function can be executed in parallel as long as the mutator stops.
 template<typename WeakMapBucket>
-void WeakMapImpl<WeakMapBucket>::finalizeUnconditionally(VM& vm, CollectionScope)
+void WeakMapImpl<WeakMapBucket>::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
 {
     auto* buffer = this->buffer();
     for (uint32_t index = 0; index < m_capacity; ++index) {
@@ -130,7 +130,7 @@ void WeakMapImpl<WeakMapBucket>::finalizeUnconditionally(VM& vm, CollectionScope
 template<typename WeakMapBucket>
 void WeakMapImpl<WeakMapBucket>::rehash(RehashMode mode)
 {
-    // Since shrinking is done just after GC runs (finalizeUnconditionally), WeakMapImpl::rehash()
+    // Since shrinking is done just after GC runs (reconcileWeakReferencesAtGCEnd), WeakMapImpl::rehash()
     // function must not touch any GC related features. This is why we do not allocate WeakMapBuffer
     // in auxiliary buffer.
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -411,7 +411,7 @@ void JSWebAssemblyInstance::clearJSCallICs(VM& vm)
     }
 }
 
-void JSWebAssemblyInstance::finalizeUnconditionally(VM& vm, CollectionScope)
+void JSWebAssemblyInstance::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
 {
     for (unsigned index = 0; index < numImportFunctions(); ++index) {
         auto* info = importFunctionInfo(index);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -169,7 +169,7 @@ public:
     const Wasm::ModuleInformation& moduleInformation() const { return m_moduleInformation.get(); }
 
     void clearJSCallICs(VM&);
-    void finalizeUnconditionally(VM&, CollectionScope);
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope);
 
     static constexpr ptrdiff_t offsetOfJSModule() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_jsModule); }
     static constexpr ptrdiff_t offsetOfVM() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_vm); }


### PR DESCRIPTION
#### a53d011599e7726daa97e9fd8f233b0cc95aaed5
<pre>
[JSC] Rename finalizeUnconditionally to reconcileWeakReferencesAtGCEnd
<a href="https://bugs.webkit.org/show_bug.cgi?id=321688">https://bugs.webkit.org/show_bug.cgi?id=321688</a>
<a href="https://rdar.apple.com/184832952">rdar://184832952</a>

Reviewed by Keith Miller.

This runs during the End phase on every marked, surviving cell and settles its
untraced pointers against the liveness that marking just established.

Typically finalizers are called for each dead object, so this dispatches in the
opposite direction. The &quot;unconditionally&quot; qualifier is also ambiguous.

So, make the following renames:

    T::finalizeUnconditionally              -&gt; T::reconcileWeakReferencesAtGCEnd
    Heap::finalizeUnconditionalFinalizers   -&gt; Heap::reconcileWeakReferencesAtGCEnd
    Heap::finalizeMarkedUnconditionalFinalizers
                                            -&gt; Heap::reconcileWeakReferencesInMarkedCells
    IsoCellSet finalizerSet / finalizerSetFor
                                            -&gt; weakReconciliationSet / weakReconciliationSetFor

&quot;Reconcile&quot; names what the survivor does, which fits that direction, and covers the
range of resolutions, e.g.:

    clear the pointer         JSWeakObjectRef, UnlinkedFunctionExecutable,
                                LLInt/JIT inline caches
    prune a container entry   WeakMapImpl, StructureTransitionTable
    salvage derived state     ErrorInstance stringifies its stack trace while the
                                weak frames are still readable, then drops them
    invalidate a dependent    InferredValue fires a watchpoint; StructureRareData
                                drops a cached special property
    notify an owner           JSFinalizationRegistry moves registrations to a dead
                                list and posts a cleanup job

The leaf helpers reached from here are renamed to match:

    CodeBlock::finalizeLLIntInlineCaches  -&gt; reconcileLLIntInlineCachesAtGCEnd
    CodeBlock::finalizeJITInlineCaches    -&gt; reconcileJITInlineCachesAtGCEnd
    RecordedStatuses::finalize            -&gt; reconcileWeakReferences
    RecordedStatuses::finalizeWithoutDeleting
                                            -&gt; reconcileWeakReferencesWithoutDeleting
    JITPlan::finalizeInGC                 -&gt; reconcileWeakReferencesAtGCEnd
    ScriptExecutable::finalizeCodeBlockEdge
                                            -&gt; jettisonCodeBlockEdgeIfDead

The suffix is dropped where the caller is adjacent and the timing is obvious.

CodeBlock reconciles in multiple ways. Its inline caches are cleared outright, while
updateAllPredictions salvages: ValueProfile::computeUpdatedPrediction and
ArrayProfile::computeUpdatedPrediction each read an untraced EncodedJSValue or
StructureID, fold it into a pointer-free SpeculatedType, then clear the slot.
Neither can run after sweep. updateActivity and the per-cycle flag reset are the
only work in there that is not reconciliation.

Also documents stronglyVisitWeakReferences, which is easy to mistake for part of
this pass. A CodeBlock is live either because something marked it directly, such
as a conservative stack scan finding it running, or because all of its code
dependencies are still live. In the former case those dependencies have not been
checked by anything, and that function is what keeps them alive.

No behavior change.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::reconcileLLIntInlineCachesAtGCEnd):
(JSC::CodeBlock::reconcileJITInlineCachesAtGCEnd):
(JSC::CodeBlock::reconcileWeakReferencesAtGCEnd):
(JSC::CodeBlock::finalizeLLIntInlineCaches): Deleted.
(JSC::CodeBlock::finalizeJITInlineCaches): Deleted.
(JSC::CodeBlock::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/RecordedStatuses.cpp:
(JSC::RecordedStatuses::reconcileWeakReferencesWithoutDeleting):
(JSC::RecordedStatuses::reconcileWeakReferences):
(JSC::RecordedStatuses::finalizeWithoutDeleting): Deleted.
(JSC::RecordedStatuses::finalize): Deleted.
* Source/JavaScriptCore/bytecode/RecordedStatuses.h:
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::UnlinkedFunctionExecutable::reconcileWeakReferencesAtGCEnd):
(JSC::UnlinkedFunctionExecutable::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
* Source/JavaScriptCore/dfg/DFGJITCode.h:
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::reconcileWeakReferencesAtGCEnd):
(JSC::DFG::Plan::finalizeInGC): Deleted.
* Source/JavaScriptCore/dfg/DFGPlan.h:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::reconcileWeakReferencesInMarkedCells):
(JSC::Heap::reconcileWeakReferencesAtGCEnd):
(JSC::Heap::clearConcurrentRetainedDataIfPossible):
(JSC::Heap::finalizeMarkedUnconditionalFinalizers): Deleted.
(JSC::Heap::finalizeUnconditionalFinalizers): Deleted.
* Source/JavaScriptCore/heap/Heap.h:
(JSC::Heap::ScriptExecutableSpaceAndSets::ScriptExecutableSpaceAndSets):
(JSC::Heap::ScriptExecutableSpaceAndSets::weakReconciliationSetFor):
(JSC::Heap::ScriptExecutableSpaceAndSets::finalizerSetFor): Deleted.
* Source/JavaScriptCore/interpreter/MicrotaskCall.h:
* Source/JavaScriptCore/jit/JITPlan.h:
(JSC::JITPlan::reconcileWeakReferencesAtGCEnd):
(JSC::JITPlan::finalizeInGC): Deleted.
* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::removeDeadPlans):
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::reconcileWeakReferencesAtGCEnd):
(JSC::ErrorInstance::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/runtime/ErrorInstance.h:
* Source/JavaScriptCore/runtime/FunctionExecutable.cpp:
(JSC::FunctionExecutable::visitChildrenImpl):
* Source/JavaScriptCore/runtime/FunctionExecutable.h:
* Source/JavaScriptCore/runtime/FunctionExecutableInlines.h:
(JSC::FunctionExecutable::reconcileWeakReferencesAtGCEnd):
(JSC::FunctionExecutable::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/runtime/GlobalExecutable.cpp:
(JSC::GlobalExecutable::visitChildrenImpl):
(JSC::GlobalExecutable::reconcileWeakReferencesAtGCEnd):
(JSC::GlobalExecutable::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/runtime/GlobalExecutable.h:
* Source/JavaScriptCore/runtime/InferredValue.h:
* Source/JavaScriptCore/runtime/InferredValueInlines.h:
(JSC::InferredValue&lt;JSCellType&gt;::reconcileWeakReferencesAtGCEnd):
(JSC::InferredValue&lt;JSCellType&gt;::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp:
(JSC::JSFinalizationRegistry::finishCreation):
(JSC::JSFinalizationRegistry::reconcileWeakReferencesAtGCEnd):
(JSC::JSFinalizationRegistry::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/runtime/JSFinalizationRegistry.h:
* Source/JavaScriptCore/runtime/JSWeakObjectRef.cpp:
(JSC::JSWeakObjectRef::reconcileWeakReferencesAtGCEnd):
(JSC::JSWeakObjectRef::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/runtime/JSWeakObjectRef.h:
* Source/JavaScriptCore/runtime/ScriptExecutable.h:
* Source/JavaScriptCore/runtime/ScriptExecutableInlines.h:
(JSC::ScriptExecutable::jettisonCodeBlockEdgeIfDead):
(JSC::ScriptExecutable::finalizeCodeBlockEdge): Deleted.
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::reconcileWeakReferencesAtGCEnd):
(JSC::Structure::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/runtime/Structure.h:
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::StructureTransitionTable::reconcileWeakReferencesAtGCEnd):
(JSC::StructureTransitionTable::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/runtime/StructureRareData.cpp:
(JSC::StructureRareData::reconcileWeakReferencesAtGCEnd):
(JSC::StructureRareData::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/runtime/StructureRareData.h:
* Source/JavaScriptCore/runtime/StructureTransitionTable.h:
* Source/JavaScriptCore/runtime/SymbolTable.h:
* Source/JavaScriptCore/runtime/SymbolTableInlines.h:
(JSC::SymbolTable::reconcileWeakReferencesAtGCEnd):
(JSC::SymbolTable::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::reconcileWeakReferencesAtGCEnd):
(JSC::VM::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/runtime/WeakMapImpl.h:
* Source/JavaScriptCore/runtime/WeakMapImplInlines.h:
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::reconcileWeakReferencesAtGCEnd):
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::rehash):
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::reconcileWeakReferencesAtGCEnd):
(JSC::JSWebAssemblyInstance::finalizeUnconditionally): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Canonical link: <a href="https://commits.webkit.org/319132@main">https://commits.webkit.org/319132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c6848aa1f578643d7718da332a4784b7304ebdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190771 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144882 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3db5a1b6-b26a-4dcf-9ea3-8f8eb1ebff1c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54221 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16a47d1e-4aca-4023-8fdd-517967b7948d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121306 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9126cabd-4660-4452-b4ae-8430855475dc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3273 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10098 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41142 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1930 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41834 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192707 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54171 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150206 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54859 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149926 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27402 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44551 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127123 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122337 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53376 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16131 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52758 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52995 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52823 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->