### PR TITLE
[JSC] Rename Heap::finalize to Heap::runCollectionEpilogue

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1861,7 +1861,7 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
         m_signpostMessage = { };
     }
 
-    setNeedFinalize();
+    setNeedCollectionEpilogue();
 
     MonotonicTime now = MonotonicTime::now();
     if (m_maxEdenSizeForRateLimiting) {
@@ -1908,20 +1908,20 @@ NEVER_INLINE bool Heap::finishChangingPhase(GCConductor conn)
             if (conn == GCConductor::Collector)
                 resumeTheMutator();
             else
-                handleNeedFinalize();
+                handleNeedCollectionEpilogue();
         } else {
             RELEASE_ASSERT(!suspendedBefore);
             RELEASE_ASSERT(suspendedAfter);
             
             if (conn == GCConductor::Collector) {
-                waitWhileNeedFinalize();
+                waitWhileNeedCollectionEpilogue();
                 if (!stopTheMutator()) {
                     dataLogLnIf(HeapInternal::verbose, "Returning false.");
                     return false;
                 }
             } else {
                 sanitizeStackForVM(vm());
-                handleNeedFinalize();
+                handleNeedCollectionEpilogue();
             }
             stopThePeriphery(conn);
         }
@@ -2093,7 +2093,7 @@ void Heap::stopIfNecessarySlow()
     RELEASE_ASSERT(m_worldState.load() & hasAccessBit);
     RELEASE_ASSERT(!(m_worldState.load() & stoppedBit));
     
-    handleNeedFinalize();
+    handleNeedCollectionEpilogue();
     m_mutatorDidRun = true;
 }
 
@@ -2105,9 +2105,9 @@ bool Heap::stopIfNecessarySlow(unsigned oldState)
     RELEASE_ASSERT(oldState & hasAccessBit);
     RELEASE_ASSERT(!(oldState & stoppedBit));
     
-    // It's possible for us to wake up with finalization already requested but the world not yet
-    // resumed. If that happens, we can't run finalization yet.
-    if (handleNeedFinalize(oldState))
+    // It's possible for us to wake up with the epilogue already requested but the world not yet
+    // resumed. If that happens, we can't run the epilogue yet.
+    if (handleNeedCollectionEpilogue(oldState))
         return true;
 
     // FIXME: When entering the concurrent phase, we could arrange for this branch not to fire, and then
@@ -2210,7 +2210,7 @@ void Heap::acquireAccessSlow()
         RELEASE_ASSERT(!(oldState & stoppedBit));
         unsigned newState = oldState | hasAccessBit;
         if (m_worldState.compareExchangeWeak(oldState, newState)) {
-            handleNeedFinalize();
+            handleNeedCollectionEpilogue();
             m_mutatorDidRun = true;
             stopIfNecessary();
             return;
@@ -2231,7 +2231,7 @@ void Heap::releaseAccessSlow()
             RELEASE_ASSERT_NOT_REACHED();
         }
         
-        if (handleNeedFinalize(oldState))
+        if (handleNeedCollectionEpilogue(oldState))
             continue;
         
         unsigned newState = oldState & ~(hasAccessBit | mutatorHasConnBit);
@@ -2288,16 +2288,16 @@ void Heap::relinquishConn()
     while (relinquishConn(m_worldState.load())) { }
 }
 
-NEVER_INLINE bool Heap::handleNeedFinalize(unsigned oldState)
+NEVER_INLINE bool Heap::handleNeedCollectionEpilogue(unsigned oldState)
 {
     RELEASE_ASSERT(oldState & hasAccessBit);
     RELEASE_ASSERT(!(oldState & stoppedBit));
     
-    if (!(oldState & needFinalizeBit))
+    if (!(oldState & needCollectionEpilogueBit))
         return false;
-    if (m_worldState.compareExchangeWeak(oldState, oldState & ~needFinalizeBit)) {
-        finalize();
-        // Wake up anyone waiting for us to finalize. Note that they may have woken up already, in
+    if (m_worldState.compareExchangeWeak(oldState, oldState & ~needCollectionEpilogueBit)) {
+        runCollectionEpilogue();
+        // Wake up anyone waiting for us to run the epilogue. Note that they may have woken up already, in
         // which case they would be waiting for us to release heap access.
         ParkingLot::unparkAll(&m_worldState);
         return true;
@@ -2305,26 +2305,26 @@ NEVER_INLINE bool Heap::handleNeedFinalize(unsigned oldState)
     return true;
 }
 
-void Heap::handleNeedFinalize()
+void Heap::handleNeedCollectionEpilogue()
 {
-    while (handleNeedFinalize(m_worldState.load())) { }
+    while (handleNeedCollectionEpilogue(m_worldState.load())) { }
 }
 
-void Heap::setNeedFinalize()
+void Heap::setNeedCollectionEpilogue()
 {
-    m_worldState.exchangeOr(needFinalizeBit);
+    m_worldState.exchangeOr(needCollectionEpilogueBit);
     ParkingLot::unparkAll(&m_worldState);
     m_stopIfNecessaryTimer->scheduleSoon();
 }
 
-void Heap::waitWhileNeedFinalize()
+void Heap::waitWhileNeedCollectionEpilogue()
 {
     for (;;) {
         unsigned oldState = m_worldState.load();
-        if (!(oldState & needFinalizeBit)) {
-            // This means that either there was no finalize request or the main thread will finalize
+        if (!(oldState & needCollectionEpilogueBit)) {
+            // This means that either there was no epilogue request or the main thread will run it
             // with heap access, so a subsequent call to stopTheWorld() will return only when
-            // finalize finishes.
+            // the epilogue finishes.
             return;
         }
         ParkingLot::compareAndPark(&m_worldState, oldState);
@@ -2347,18 +2347,18 @@ void Heap::notifyThreadStopping(const AbstractLocker&)
     ParkingLot::unparkAll(&m_worldState);
 }
 
-void Heap::finalize()
+void Heap::runCollectionEpilogue()
 {
     MonotonicTime before;
     if (Options::logGC()) [[unlikely]] {
         before = MonotonicTime::now();
-        dataLog("[GC<", RawPointer(this), ">: finalize ");
+        dataLog("[GC<", RawPointer(this), ">: epilogue ");
     }
     
     {
         SweepingScope sweepingScope(*this);
         deleteSourceProviderCaches();
-        sweepInFinalize();
+        sweepEagerlyInEpilogue();
     }
     
     if (HasOwnPropertyCache* cache = vm().hasOwnPropertyCache())
@@ -2427,7 +2427,7 @@ void Heap::waitForCollection(Ticket ticket)
         });
 }
 
-void Heap::sweepInFinalize()
+void Heap::sweepEagerlyInEpilogue()
 {
     m_objectSpace.sweepPreciseAllocations();
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -739,14 +739,14 @@ private:
     JS_EXPORT_PRIVATE void acquireAccessSlow();
     JS_EXPORT_PRIVATE void releaseAccessSlow();
     
-    bool handleNeedFinalize(unsigned);
-    void handleNeedFinalize();
+    bool handleNeedCollectionEpilogue(unsigned);
+    void handleNeedCollectionEpilogue();
     
     bool relinquishConn(unsigned);
     void finishRelinquishingConn();
     
-    void setNeedFinalize();
-    void waitWhileNeedFinalize();
+    void setNeedCollectionEpilogue();
+    void waitWhileNeedCollectionEpilogue();
     
     void setMutatorWaiting();
     void clearMutatorWaiting();
@@ -794,8 +794,8 @@ private:
     void resumeCompilerThreads();
     void gatherExtraHeapData(HeapProfiler&);
     void removeDeadHeapSnapshotNodes(HeapProfiler&);
-    void finalize();
-    void sweepInFinalize();
+    void runCollectionEpilogue();
+    void sweepEagerlyInEpilogue();
     
     void sweepAllLogicallyEmptyWeakBlocks();
     bool sweepNextLogicallyEmptyWeakBlock();
@@ -997,7 +997,7 @@ private:
     static constexpr unsigned mutatorHasConnBit = 1u << 0u; // Must also be protected by threadLock.
     static constexpr unsigned stoppedBit = 1u << 1u; // Only set when !hasAccessBit
     static constexpr unsigned hasAccessBit = 1u << 2u;
-    static constexpr unsigned needFinalizeBit = 1u << 3u;
+    static constexpr unsigned needCollectionEpilogueBit = 1u << 3u;
     static constexpr unsigned mutatorWaitingBit = 1u << 4u; // Allows the mutator to use this as a condition variable.
     Atomic<unsigned> m_worldState;
     bool m_worldIsStopped { false };


### PR DESCRIPTION
#### f4da7823ee1d1dacf4b080de2986759a051003ee
<pre>
[JSC] Rename Heap::finalize to Heap::runCollectionEpilogue
<a href="https://bugs.webkit.org/show_bug.cgi?id=321689">https://bugs.webkit.org/show_bug.cgi?id=321689</a>
<a href="https://rdar.apple.com/184833847">rdar://184833847</a>

Reviewed by Keith Miller.

Heap::finalize is the mutator-side epilogue of a collection cycle, not
finalization. It flushes HasOwnPropertyCache, MegamorphicCache and the string
caches, ages the megamorphic cache, eagerly sweeps precise allocations, and runs
the embedder&apos;s end-of-GC callbacks. Nothing in it operates on a dying object.

    Heap::finalize          -&gt; Heap::runCollectionEpilogue
    needFinalizeBit         -&gt; needCollectionEpilogueBit
    setNeedFinalize         -&gt; setNeedCollectionEpilogue
    handleNeedFinalize      -&gt; handleNeedCollectionEpilogue
    waitWhileNeedFinalize   -&gt; waitWhileNeedCollectionEpilogue
    Heap::sweepInFinalize   -&gt; Heap::sweepEagerlyInEpilogue

sweepEagerlyInEpilogue says why it sweeps at this point -- precise allocations and
Wasm memory hold a lot of bytes -- rather than merely when.

The --logGC=1 phase label changes from &quot;finalize&quot; to &quot;epilogue&quot; to match. That
output has no stability contract, but anyone scraping GC logs will see it.

No behavior change.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::clearConcurrentRetainedDataIfPossible):
* Source/JavaScriptCore/heap/Heap.h:

Canonical link: <a href="https://commits.webkit.org/319134@main">https://commits.webkit.org/319134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b37d3b427d569585c78dae01d7afbc39669a925d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190776 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144887 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9147bce-3d15-4c2c-81d1-eee2f5d7a3d7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54226 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ccb4e96-d7bd-4dca-89fb-7a134325452d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121309 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e02fa0f1-5653-4390-8ac6-ba19216567da) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3276 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10100 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153585 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41144 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1935 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41839 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47136 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45719 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192712 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54176 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150208 "Failure limit exceed. At least found 483 new test failures: accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html accessibility/add-children-pseudo-element.html accessibility/adjacent-continuations-cause-assertion-failure.html accessibility/alt-tag-on-image-with-nonimage-role.html accessibility/anchor-linked-anonymous-block-crash.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54864 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149932 "Found 159 new API test failures: TestLoaderClient:/webkit/WebKitURIRequest/http-method, TestAutocleanups:/webkit/Autocleanups/web-process-autocleanups, TestWebKit.WebKit.FrameMIMETypePNG, TestLoaderClient:/webkit/WebKitWebView/user-agent, TestCookieManager:/webkit/WebKitCookieManager/persistent-storage-delete-all, TestSSL:/webkit/WebKitWebView/load-failed-with-tls-errors, TestWebKitWebView:/webkit/WebKitWebView/load-alternate-html-from-page-with-csp, TestWebViewEditor:/webkit/WebKitWebView/insert/image, TestWebKit.WebKit.AboutBlankLoad, TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/form-controls-associated-signal ... (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27403 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44552 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127128 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122343 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53381 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16133 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52763 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53000 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52828 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->