### PR TITLE
[JSC] Rename HeapFinalizerCallback to GCCompletionCallback

### DIFF
--- a/Source/JavaScriptCore/API/JSHeapFinalizerPrivate.cpp
+++ b/Source/JavaScriptCore/API/JSHeapFinalizerPrivate.cpp
@@ -32,12 +32,12 @@ void JSContextGroupAddHeapFinalizer(JSContextGroupRef group, JSHeapFinalizer fin
 {
     JSC::VM* vm = toJS(group);
     JSC::JSLockHolder locker(vm);
-    vm->heap.addHeapFinalizerCallback(JSC::HeapFinalizerCallback(finalizer, userData));
+    vm->heap.addGCCompletionCallback(JSC::GCCompletionCallback(finalizer, userData));
 }
 
 void JSContextGroupRemoveHeapFinalizer(JSContextGroupRef group, JSHeapFinalizer finalizer, void *userData)
 {
     JSC::VM* vm = toJS(group);
     JSC::JSLockHolder locker(vm);
-    vm->heap.removeHeapFinalizerCallback(JSC::HeapFinalizerCallback(finalizer, userData));
+    vm->heap.removeGCCompletionCallback(JSC::GCCompletionCallback(finalizer, userData));
 }

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -818,6 +818,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     heap/FullGCActivityCallback.h
     heap/GCActivityCallback.h
     heap/GCAssertions.h
+    heap/GCCompletionCallback.h
     heap/GCConductor.h
     heap/GCDeferralContext.h
     heap/GCIncomingRefCounted.h
@@ -837,7 +838,6 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     heap/HeapCell.h
     heap/HeapCellInlines.h
     heap/HeapCellType.h
-    heap/HeapFinalizerCallback.h
     heap/HeapInlines.h
     heap/HeapIterationScope.h
     heap/HeapObserver.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -123,7 +123,7 @@
 		0F0B83A914BCF56200885B4F /* HandlerInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0B83A814BCF55E00885B4F /* HandlerInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F0B83B114BCF71800885B4F /* CallLinkInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0B83AF14BCF71400885B4F /* CallLinkInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F0CAEFC1EC4DA6B00970D12 /* JSHeapFinalizerPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0CAEFA1EC4DA6200970D12 /* JSHeapFinalizerPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0F0CAEFF1EC4DA8800970D12 /* HeapFinalizerCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0CAEFE1EC4DA8500970D12 /* HeapFinalizerCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0F0CAEFF1EC4DA8800970D12 /* GCCompletionCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0CAEFE1EC4DA8500970D12 /* GCCompletionCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F0CD4C215F1A6070032F1C0 /* PutDirectIndexMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0CD4C015F1A6040032F1C0 /* PutDirectIndexMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F10F1A31C420BF0001C07D2 /* AirCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F10F1A21C420BF0001C07D2 /* AirCustom.h */; };
 		0F12DE101979D5FD0006FF4E /* ExceptionFuzz.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F12DE0E1979D5FD0006FF4E /* ExceptionFuzz.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2892,8 +2892,8 @@
 		0F0C03A92995FB710064230A /* HasOwnPropertyCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HasOwnPropertyCache.cpp; sourceTree = "<group>"; };
 		0F0CAEF91EC4DA6200970D12 /* JSHeapFinalizerPrivate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSHeapFinalizerPrivate.cpp; sourceTree = "<group>"; };
 		0F0CAEFA1EC4DA6200970D12 /* JSHeapFinalizerPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSHeapFinalizerPrivate.h; sourceTree = "<group>"; };
-		0F0CAEFD1EC4DA8500970D12 /* HeapFinalizerCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HeapFinalizerCallback.cpp; sourceTree = "<group>"; };
-		0F0CAEFE1EC4DA8500970D12 /* HeapFinalizerCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HeapFinalizerCallback.h; sourceTree = "<group>"; };
+		0F0CAEFD1EC4DA8500970D12 /* GCCompletionCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GCCompletionCallback.cpp; sourceTree = "<group>"; };
+		0F0CAEFE1EC4DA8500970D12 /* GCCompletionCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCCompletionCallback.h; sourceTree = "<group>"; };
 		0F0CD4C015F1A6040032F1C0 /* PutDirectIndexMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PutDirectIndexMode.h; sourceTree = "<group>"; };
 		0F0CD4C315F6B6B50032F1C0 /* SparseArrayValueMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SparseArrayValueMap.cpp; sourceTree = "<group>"; };
 		0F10F1A21C420BF0001C07D2 /* AirCustom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AirCustom.h; path = b3/air/AirCustom.h; sourceTree = "<group>"; };
@@ -7641,6 +7641,8 @@
 				2AACE63A18CA5A0300ED0191 /* GCActivityCallback.cpp */,
 				2AACE63B18CA5A0300ED0191 /* GCActivityCallback.h */,
 				BCBE2CAD14E985AA000593AD /* GCAssertions.h */,
+				0F0CAEFD1EC4DA8500970D12 /* GCCompletionCallback.cpp */,
+				0F0CAEFE1EC4DA8500970D12 /* GCCompletionCallback.h */,
 				0FD0E5E71E43D3470006AB08 /* GCConductor.cpp */,
 				0FD0E5E81E43D3470006AB08 /* GCConductor.h */,
 				0FB4767C1D99AEA7008EA6CB /* GCDeferralContext.h */,
@@ -7673,8 +7675,6 @@
 				0F070A441D543A89006E7232 /* HeapCellInlines.h */,
 				0FDCE1201FAE8587006F3901 /* HeapCellType.cpp */,
 				0FDCE11F1FAE8587006F3901 /* HeapCellType.h */,
-				0F0CAEFD1EC4DA8500970D12 /* HeapFinalizerCallback.cpp */,
-				0F0CAEFE1EC4DA8500970D12 /* HeapFinalizerCallback.h */,
 				0F32BD0E1BB34F190093A57F /* HeapHelperPool.cpp */,
 				0F32BD0F1BB34F190093A57F /* HeapHelperPool.h */,
 				C2DA778218E259990066FCB6 /* HeapInlines.h */,
@@ -11799,6 +11799,7 @@
 				2AACE63D18CA5A0300ED0191 /* GCActivityCallback.h in Headers */,
 				BCBE2CAE14E985AA000593AD /* GCAssertions.h in Headers */,
 				0F766D3015A8DCE2008F363E /* GCAwareJITStubRoutine.h in Headers */,
+				0F0CAEFF1EC4DA8800970D12 /* GCCompletionCallback.h in Headers */,
 				0FD0E5EA1E43D34D0006AB08 /* GCConductor.h in Headers */,
 				0FB4767E1D99AEA9008EA6CB /* GCDeferralContext.h in Headers */,
 				0FB4767F1D99AEAD008EA6CB /* GCDeferralContextInlines.h in Headers */,
@@ -11872,7 +11873,6 @@
 				DC3D2B0A1D34316200BA918C /* HeapCell.h in Headers */,
 				0F070A491D543A93006E7232 /* HeapCellInlines.h in Headers */,
 				0FDCE1221FAE858C006F3901 /* HeapCellType.h in Headers */,
-				0F0CAEFF1EC4DA8800970D12 /* HeapFinalizerCallback.h in Headers */,
 				0F32BD111BB34F190093A57F /* HeapHelperPool.h in Headers */,
 				C2DA778318E259990066FCB6 /* HeapInlines.h in Headers */,
 				2AD8932B17E3868F00668276 /* HeapIterationScope.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -528,6 +528,7 @@ heap/FastMallocAlignedMemoryAllocator.cpp
 heap/FullGCActivityCallback.cpp
 heap/FreeList.cpp
 heap/GCActivityCallback.cpp
+heap/GCCompletionCallback.cpp
 heap/GCConductor.cpp
 heap/GCLogging.cpp
 heap/GCOwnedDataScope.cpp
@@ -537,7 +538,6 @@ heap/GigacageAlignedMemoryAllocator.cpp
 heap/Heap.cpp
 heap/HeapCell.cpp
 heap/HeapCellType.cpp
-heap/HeapFinalizerCallback.cpp
 heap/HeapHelperPool.cpp
 heap/HeapProfiler.cpp
 heap/HeapSnapshot.cpp

--- a/Source/JavaScriptCore/heap/GCCompletionCallback.cpp
+++ b/Source/JavaScriptCore/heap/GCCompletionCallback.cpp
@@ -24,19 +24,19 @@
  */
 
 #include "config.h"
-#include "HeapFinalizerCallback.h"
+#include "GCCompletionCallback.h"
 
 #include "APICast.h"
 #include "IntegrityInlines.h"
 
 namespace JSC {
 
-void HeapFinalizerCallback::dump(PrintStream& out) const
+void GCCompletionCallback::dump(PrintStream& out) const
 {
     out.print(RawPointer(m_finalizer), ":", RawPointer(m_userData));
 }
 
-void HeapFinalizerCallback::run(VM& vm) const
+void GCCompletionCallback::run(VM& vm) const
 {
     m_finalizer(toRef(&vm), m_userData);
 }

--- a/Source/JavaScriptCore/heap/GCCompletionCallback.h
+++ b/Source/JavaScriptCore/heap/GCCompletionCallback.h
@@ -32,25 +32,25 @@ namespace JSC {
 
 class VM;
 
-class HeapFinalizerCallback {
+class GCCompletionCallback {
 public:
-    HeapFinalizerCallback(JSHeapFinalizer finalizer = nullptr, void *userData = nullptr)
+    GCCompletionCallback(JSHeapFinalizer finalizer = nullptr, void *userData = nullptr)
         : m_finalizer(finalizer)
         , m_userData(userData)
     {
     }
-    
-    friend bool operator==(const HeapFinalizerCallback&, const HeapFinalizerCallback&) = default;
-    
+
+    friend bool operator==(const GCCompletionCallback&, const GCCompletionCallback&) = default;
+
     explicit operator bool() const
     {
-        return *this != HeapFinalizerCallback();
+        return *this != GCCompletionCallback();
     }
-    
+
     void dump(PrintStream&) const;
-    
+
     void run(VM&) const;
-    
+
 private:
     JSHeapFinalizer m_finalizer;
     void *m_userData;

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2383,7 +2383,7 @@ void Heap::runCollectionEpilogue()
 
     immutableButterflyToStringCache.clear();
     
-    for (const HeapFinalizerCallback& callback : m_heapFinalizerCallbacks)
+    for (const GCCompletionCallback& callback : m_gcCompletionCallbacks)
         callback.run(vm());
     
     if (shouldSweepSynchronously())
@@ -3411,14 +3411,14 @@ void Heap::performIncrement(size_t bytes)
     m_incrementBalance -= bytesVisited;
 }
 
-void Heap::addHeapFinalizerCallback(const HeapFinalizerCallback& callback)
+void Heap::addGCCompletionCallback(const GCCompletionCallback& callback)
 {
-    m_heapFinalizerCallbacks.append(callback);
+    m_gcCompletionCallbacks.append(callback);
 }
 
-void Heap::removeHeapFinalizerCallback(const HeapFinalizerCallback& callback)
+void Heap::removeGCCompletionCallback(const GCCompletionCallback& callback)
 {
-    m_heapFinalizerCallbacks.removeFirst(callback);
+    m_gcCompletionCallbacks.removeFirst(callback);
 }
 
 void Heap::setBonusVisitorTask(RefPtr<SharedTask<void(SlotVisitor&)>> task)

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -27,10 +27,10 @@
 #include <JavaScriptCore/CollectorPhase.h>
 #include <JavaScriptCore/CompleteSubspace.h>
 #include <JavaScriptCore/DeleteAllCodeEffort.h>
+#include <JavaScriptCore/GCCompletionCallback.h>
 #include <JavaScriptCore/GCConductor.h>
 #include <JavaScriptCore/GCIncomingRefCountedSet.h>
 #include <JavaScriptCore/GCRequest.h>
-#include <JavaScriptCore/HeapFinalizerCallback.h>
 #include <JavaScriptCore/HeapObserver.h>
 #include <JavaScriptCore/IsoCellSet.h>
 #include <JavaScriptCore/IsoHeapCellType.h>
@@ -604,8 +604,8 @@ public:
     
     HeapVerifier* verifier() const LIFETIME_BOUND { return m_verifier.get(); }
     
-    void addHeapFinalizerCallback(const HeapFinalizerCallback&);
-    void removeHeapFinalizerCallback(const HeapFinalizerCallback&);
+    void addGCCompletionCallback(const GCCompletionCallback&);
+    void removeGCCompletionCallback(const GCCompletionCallback&);
     
     void runTaskInParallel(RefPtr<SharedTask<void(SlotVisitor&)>>);
     
@@ -949,7 +949,7 @@ private:
 
     Vector<HeapObserver*> m_observers;
     
-    Vector<HeapFinalizerCallback> m_heapFinalizerCallbacks;
+    Vector<GCCompletionCallback> m_gcCompletionCallbacks;
     
     std::unique_ptr<HeapVerifier> m_verifier;
 

--- a/Source/WebCore/WebCorePrefix.h
+++ b/Source/WebCore/WebCorePrefix.h
@@ -342,6 +342,7 @@
 #include <JavaScriptCore/FreeList.h>
 #include <JavaScriptCore/FunctionHasExecutedCache.h>
 #include <JavaScriptCore/GCAssertions.h>
+#include <JavaScriptCore/GCCompletionCallback.h>
 #include <JavaScriptCore/GCConductor.h>
 #include <JavaScriptCore/GCIncomingRefCountedSet.h>
 #include <JavaScriptCore/GCOwnedDataScope.h>
@@ -354,7 +355,6 @@
 #include <JavaScriptCore/Heap.h>
 #include <JavaScriptCore/HeapCell.h>
 #include <JavaScriptCore/HeapCellType.h>
-#include <JavaScriptCore/HeapFinalizerCallback.h>
 #include <JavaScriptCore/HeapObserver.h>
 #include <JavaScriptCore/Identifier.h>
 #include <JavaScriptCore/ImplementationVisibility.h>


### PR DESCRIPTION
#### 62692012c98a7e0fe29e6f44d5b059c7f5ff66f9
<pre>
[JSC] Rename HeapFinalizerCallback to GCCompletionCallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=321690">https://bugs.webkit.org/show_bug.cgi?id=321690</a>
<a href="https://rdar.apple.com/184834345">rdar://184834345</a>

Reviewed by Vassili Bykov.

This is a once-per-GC embedder callback, not a finalizer: it is passed no object
and runs at the end of every collection. It is the internal half of
JSContextGroupAddHeapFinalizer.

    HeapFinalizerCallback           -&gt; GCCompletionCallback
    Heap::addHeapFinalizerCallback  -&gt; Heap::addGCCompletionCallback
    Heap::removeHeapFinalizerCallback
                                    -&gt; Heap::removeGCCompletionCallback
    m_heapFinalizerCallbacks        -&gt; m_gcCompletionCallbacks

The exported C entry points JSContextGroupAddHeapFinalizer and
JSContextGroupRemoveHeapFinalizer keep their names for binary compatibility.

No behavior change.

* Source/JavaScriptCore/API/JSHeapFinalizerPrivate.cpp:
(JSContextGroupAddHeapFinalizer):
(JSContextGroupRemoveHeapFinalizer):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/heap/GCCompletionCallback.cpp: Renamed from Source/JavaScriptCore/heap/HeapFinalizerCallback.cpp.
(JSC::GCCompletionCallback::dump const):
(JSC::GCCompletionCallback::run const):
* Source/JavaScriptCore/heap/GCCompletionCallback.h: Renamed from Source/JavaScriptCore/heap/HeapFinalizerCallback.h.
(JSC::GCCompletionCallback::GCCompletionCallback):
(JSC::GCCompletionCallback::operator bool const):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::clearConcurrentRetainedDataIfPossible):
* Source/JavaScriptCore/heap/Heap.h:
* Source/WebCore/WebCorePrefix.h:

Canonical link: <a href="https://commits.webkit.org/319140@main">https://commits.webkit.org/319140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d4c49a6a6f8ace9bc2cadfb4184560b1a465b7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144901 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9c86500-f923-4836-b2c4-aa96caebb321) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140861 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a1611ea-b05c-4051-a9f8-01a10e40f0ae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121313 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/974c8468-fdae-40d4-8dd5-b9b0ee681592) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43198 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3280 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10116 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41160 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1949 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41853 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/47142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192726 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54190 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161149 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150223 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54878 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149942 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27406 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44569 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127143 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122357 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53395 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16153 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52777 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53014 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52842 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->