### PR TITLE
[Text Extraction] adobe.com: sometimes unable to click on "Change Password" button in account settings page

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt
@@ -20,3 +20,6 @@ root
         'User Profile'
         'Username:'
         input uid=… label=Username:
+        form autocomplete=on name=signup
+            input uid=… placeholder=Email name=email
+            button uid=… 'Sign up'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids.html
@@ -74,6 +74,10 @@ canvas {
             <label for="username">Username:</label>
             <input type="text" id="username" />
         </div>
+        <form name="signup" autocomplete="on">
+            <input name="email" placeholder="Email" />
+            <button>Sign up</button>
+        </form>
     </section>
 </main>
 <script>

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -37,6 +37,12 @@ root
                 input range uid=… name=volume value=42
                 input button uid=… name=cancel value=Cancel
                 input uid=… name=submit value='Sign Up Now'
+            button 'Change'
+            button 'Add passkey'
+            form autocomplete=on name=two-step
+                button 'Turn on'
+            form label='Delete account' autocomplete=on
+                button 'Delete'
             select uid=…
                 option value=one 'Number 1'
                 option value=two 'Number 2'
@@ -108,6 +114,14 @@ root
                 <input type='range' uid=… name='volume' value='42'>
                 <input type='button' uid=… name='cancel' value='Cancel'>
                 <input type='submit' uid=… name='submit' value='Sign Up Now'>
+            </form>
+            <button>Change</button>
+            <button>Add passkey</button>
+            <form autocomplete='on' name='two-step'>
+                <button>Turn on</button>
+            </form>
+            <form aria-label='Delete account' autocomplete='on'>
+                <button>Delete</button>
             </form>
             <select uid=…>
                 <option value='one'>Number 1</option>
@@ -470,6 +484,62 @@ root
                   "controlType": "submit",
                   "name": "submit",
                   "value": "Sign Up Now"
+                }
+              ]
+            },
+            {
+              "type": "button",
+              "nodeName": "button",
+              "children": [
+                {
+                  "type": "text",
+                  "content": "Change"
+                }
+              ]
+            },
+            {
+              "type": "button",
+              "nodeName": "button",
+              "children": [
+                {
+                  "type": "text",
+                  "content": "Add passkey"
+                }
+              ]
+            },
+            {
+              "type": "form",
+              "nodeName": "form",
+              "autocomplete": "on",
+              "name": "two-step",
+              "children": [
+                {
+                  "type": "button",
+                  "nodeName": "button",
+                  "children": [
+                    {
+                      "type": "text",
+                      "content": "Turn on"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "form",
+              "nodeName": "form",
+              "aria-label": "Delete account",
+              "autocomplete": "on",
+              "children": [
+                {
+                  "type": "button",
+                  "nodeName": "button",
+                  "children": [
+                    {
+                      "type": "text",
+                      "content": "Delete"
+                    }
+                  ]
                 }
               ]
             },

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
@@ -78,6 +78,18 @@
             <input name="cancel" type="button" value="Cancel" />
             <input name="submit" type="submit" value="Sign Up Now" />
         </form>
+        <form autocomplete="on">
+            <button>Change</button>
+        </form>
+        <form autocomplete="on">
+            <div><button>Add passkey</button></div>
+        </form>
+        <form name="two-step" autocomplete="on">
+            <button>Turn on</button>
+        </form>
+        <form autocomplete="on" role="group" aria-label="Delete account">
+            <button>Delete</button>
+        </form>
         <select>
             <option value="one">Number 1</option>
             <option value="two">Number 2</option>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -882,7 +882,7 @@ static inline bool shouldIncludeNodeIdentifier(NodeIdentifierInclusion inclusion
     case None:
         return false;
     case AllContainers:
-        return !std::holds_alternative<TextItemData>(data);
+        return !std::holds_alternative<TextItemData>(data) && !std::holds_alternative<FormData>(data);
     default:
         break;
     }
@@ -923,6 +923,9 @@ static inline bool shouldIncludeNodeIdentifier(NodeIdentifierInclusion inclusion
         },
         [](const SelectData&) {
             return true;
+        },
+        [](const FormData&) {
+            return false;
         },
         [inclusion](const ScrollableItemData& scrollableData) {
             if (scrollableData.isRoot)
@@ -1435,6 +1438,42 @@ static void pruneEmptyContainersRecursive(Item& item)
     });
 }
 
+static bool isRedundantFormWrapper(const Item& item)
+{
+    if (!std::holds_alternative<FormData>(item.data))
+        return false;
+
+    if (!std::get<FormData>(item.data).name.isEmpty())
+        return false;
+
+    if (!item.eventListeners.isEmpty() || !item.ariaAttributes.isEmpty() || !item.clientAttributes.isEmpty())
+        return false;
+
+    if (!item.accessibilityRole.isEmpty() || !item.title.isEmpty())
+        return false;
+
+    if (item.children.size() != 1)
+        return false;
+
+    auto& child = item.children.first();
+    if (!std::holds_alternative<ContainerType>(child.data))
+        return false;
+
+    return std::get<ContainerType>(child.data) == ContainerType::Button;
+}
+
+static void collapseRedundantFormWrappersRecursive(Item& item)
+{
+    for (auto& child : item.children) {
+        collapseRedundantFormWrappersRecursive(child);
+        if (!isRedundantFormWrapper(child))
+            continue;
+
+        auto button = WTF::move(child.children.first());
+        child = WTF::move(button);
+    }
+}
+
 static Node* NODELETE nodeFromJSHandle(JSHandleIdentifier identifier)
 {
     auto* object = WebKitJSHandle::objectForIdentifier(identifier);
@@ -1662,6 +1701,7 @@ Result extractItem(Request&& request, LocalFrame& frame)
 
     pruneWhitespaceRecursive(root);
     pruneEmptyContainersRecursive(root);
+    collapseRedundantFormWrappersRecursive(root);
 
     return { WTF::move(root), visibleTextLength };
 }


### PR DESCRIPTION
#### 8127f106827268c8e9c89c1048bc54a7a76856bd
<pre>
[Text Extraction] adobe.com: sometimes unable to click on &quot;Change Password&quot; button in account settings page
<a href="https://bugs.webkit.org/show_bug.cgi?id=321687">https://bugs.webkit.org/show_bug.cgi?id=321687</a>
<a href="https://rdar.apple.com/184832424">rdar://184832424</a>

Reviewed by Abrar Rahman Protyasha.

Adjust heuristics around extracting `form` elements, to make it easier for agents to figure out how
to interact with the &quot;Change&quot; button in the password section on adobe.com:

-   Avoid adding `uid` for forms.
-   Elide parent `form` elements altogether, in the case where the element lacks relevant
    accessibility attributes and only contains a single `button` element.

* LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::shouldIncludeNodeIdentifier):
(WebCore::TextExtraction::isRedundantFormWrapper):
(WebCore::TextExtraction::collapseRedundantFormWrappersRecursive):
(WebCore::TextExtraction::extractItem):

Canonical link: <a href="https://commits.webkit.org/319129@main">https://commits.webkit.org/319129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5a704be9ebadfdb041fea0082eb15b3e20f1d01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190779 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144890 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e2e65d3-5e6b-4e1c-b93b-9c0b3b8429f8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140834 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44822546-be72-4813-8c94-bde6d2b3bb10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121286 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea9f3882-02e8-4d88-82eb-2e8bdd8f3994) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41138 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1938 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192715 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150213 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40211 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54867 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149923 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44547 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127131 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122346 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53384 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16127 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52766 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53003 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52831 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->