### PR TITLE
[Custom Highlight] ::highlight() pseudo-element is not repainted after a CSS rule change.

### DIFF
--- a/LayoutTests/fast/repaint/highlight-pseudo-rule-change-document-wide-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-pseudo-rule-change-document-wide-expected.txt
@@ -1,0 +1,6 @@
+cssom
+class
+PASS CONTROL element's own outline
+PASS CSSOM edit, painted-only element, bare rule present
+PASS class change, painted-only element, bare rule present
+

--- a/LayoutTests/fast/repaint/highlight-pseudo-rule-change-document-wide.html
+++ b/LayoutTests/fast/repaint/highlight-pseudo-rule-change-document-wide.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Repaint tracking for ::highlight() changes with a document-wide rule</title>
+<style>
+  body { margin: 0; font: 40px/1.5 monospace; }
+  /* Bare rule: matches every element, so the hasPseudoStyle bits are set document-wide and a change
+     to which rules match is invisible in highlightPseudoElementTypes(). */
+  ::highlight(h) { background-color: yellow; }
+  .classy::highlight(h) { background-color: lime; }
+  #cssomTarget::highlight(h) { background-color: yellow; }
+</style>
+<div id="cssomTarget">cssom</div>
+<div id="classTarget">class</div>
+<pre id="log"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText(false);
+    testRunner.waitUntilDone();
+}
+
+const log = message => document.getElementById("log").textContent += message + "\n";
+const ruleFor = id => [...document.styleSheets[0].cssRules].find(rule => rule.selectorText && rule.selectorText.includes(id));
+const range = element => {
+    const r = new Range();
+    r.selectNodeContents(element);
+    return r;
+};
+CSS.highlights.set("h", new Highlight(range(cssomTarget), range(classTarget)));
+
+// These cases depend on the highlight pseudo styles having been resolved and cached by painting,
+// the way they are on a real page. A display with nothing dirty may not repaint the text at all, so
+// dirty the page first, otherwise there is no previous style to compare against and the test is flaky.
+async function paint() {
+    document.body.style.backgroundColor = document.body.style.backgroundColor === "white" ? "rgb(255, 255, 254)" : "white";
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    await testRunner.displayAndTrackRepaints();
+}
+
+async function check(name, mutate) {
+    await paint();
+    internals.startTrackingRepaints();
+    mutate();
+    document.body.offsetTop;
+    const rects = internals.repaintRectsAsText();
+    internals.stopTrackingRepaints();
+    // Every case here should repaint the originating element.
+    log(`${rects.trim() ? "PASS" : "FAIL (no repaint)"} ${name}`);
+}
+
+async function run() {
+    await check("CONTROL element's own outline", () => {
+        cssomTarget.style.outline = "2px solid blue";
+    });
+    await check("CSSOM edit, painted-only element, bare rule present", () => {
+        ruleFor("cssomTarget").style.backgroundColor = "red";
+    });
+    await check("class change, painted-only element, bare rule present", () => {
+        classTarget.className = "classy";
+    });
+    testRunner.notifyDone();
+}
+
+if (window.testRunner && window.internals)
+    run();
+else
+    log("needs testRunner and internals");
+</script>

--- a/LayoutTests/fast/repaint/highlight-pseudo-rule-change-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-pseudo-rule-change-expected.txt
@@ -1,0 +1,9 @@
+cssom
+class
+selection
+PASS CONTROL element's own background-color
+PASS CSSOM edit of a matching ::highlight() rule
+PASS CSSOM edit after getComputedStyle() cached the pseudo style
+PASS class change that starts matching .classy::highlight()
+FAIL (no repaint) CSSOM edit of a matching ::selection rule
+

--- a/LayoutTests/fast/repaint/highlight-pseudo-rule-change.html
+++ b/LayoutTests/fast/repaint/highlight-pseudo-rule-change.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Repaint tracking for ::highlight() and ::selection rule changes</title>
+<style>
+  body { margin: 0; font: 40px/1.5 monospace; }
+  #cssomTarget::highlight(h) { background-color: yellow; }
+  .classy::highlight(h) { background-color: lime; }
+  #selectionTarget::selection { background-color: yellow; }
+</style>
+<div id="cssomTarget">cssom</div>
+<div id="classTarget">class</div>
+<div id="selectionTarget">selection</div>
+<pre id="log"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText(false);
+    testRunner.waitUntilDone();
+}
+
+const log = message => document.getElementById("log").textContent += message + "\n";
+
+const range = element => {
+    const r = new Range();
+    r.selectNodeContents(element);
+    return r;
+};
+
+CSS.highlights.set("h", new Highlight(range(cssomTarget), range(classTarget)));
+getSelection().removeAllRanges();
+getSelection().addRange(range(selectionTarget));
+
+const ruleFor = id => [...document.styleSheets[0].cssRules].find(rule => rule.selectorText && rule.selectorText.includes(id));
+
+// A mutation confined to a highlight pseudo-element must still repaint the originating element.
+// FIXME: ::selection still reports NO REPAINT, because selectionPseudoStyle() resolves without
+// caching, so there is no previous value to compare against.
+// These cases depend on the highlight pseudo styles having been resolved and cached by painting,
+// the way they are on a real page. A display with nothing dirty may not repaint the text at all, so
+// dirty the page first, otherwise there is no previous style to compare against and the test is flaky.
+async function paint() {
+    document.body.style.backgroundColor = document.body.style.backgroundColor === "white" ? "rgb(255, 255, 254)" : "white";
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    await testRunner.displayAndTrackRepaints();
+}
+
+async function check(name, mutate) {
+    await paint();
+    internals.startTrackingRepaints();
+    mutate();
+    document.body.offsetTop;
+    const rects = internals.repaintRectsAsText();
+    internals.stopTrackingRepaints();
+    // Every case here should repaint the originating element.
+    log(`${rects.trim() ? "PASS" : "FAIL (no repaint)"} ${name}`);
+}
+
+async function run() {
+    // Control: an ordinary change to an element's own style must repaint.
+    await check("CONTROL element's own background-color", () => {
+        cssomTarget.style.outline = "2px solid blue";
+    });
+
+    await check("CSSOM edit of a matching ::highlight() rule", () => {
+        ruleFor("cssomTarget").style.backgroundColor = "red";
+    });
+
+    // Same edit, but the pseudo style has been cached on the element by a getComputedStyle() query.
+    getComputedStyle(cssomTarget, "::highlight(h)").backgroundColor;
+    await check("CSSOM edit after getComputedStyle() cached the pseudo style", () => {
+        ruleFor("cssomTarget").style.backgroundColor = "blue";
+    });
+
+    await check("class change that starts matching .classy::highlight()", () => {
+        classTarget.className = "classy";
+    });
+
+    await check("CSSOM edit of a matching ::selection rule", () => {
+        ruleFor("selectionTarget").style.backgroundColor = "red";
+    });
+    testRunner.notifyDone();
+}
+
+if (window.testRunner && window.internals)
+    run();
+else
+    log("needs testRunner and internals");
+</script>

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -111,10 +111,9 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
     Vector<MarkedText> markedTexts;
     RenderHighlight renderHighlight;
     auto& parentRenderer = *renderer.parent();
-    auto& parentStyle = parentRenderer.style();
     if (auto highlightRegistry = renderer.document().highlightRegistryIfExists()) {
         for (auto& highlightName : highlightRegistry->highlightNames()) {
-            auto renderStyle = parentRenderer.resolvePseudoElementStyle({ PseudoElementType::Highlight, highlightName }, &parentStyle);
+            CheckedPtr renderStyle = parentRenderer.lazyPseudoElementStyle({ PseudoElementType::Highlight, highlightName });
             if (!renderStyle)
                 continue;
             if (renderStyle->textDecorationLineInEffect().isNone() && phase == PaintPhase::Decoration)

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -109,8 +109,8 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
         break;
     }
     case MarkedText::Type::Highlight: {
-        auto renderStyle = renderer.parent()->resolvePseudoElementStyle({ PseudoElementType::Highlight, markedText.highlightName }, &renderer.style());
-        computeStyleForPseudoElementStyle(style, renderStyle.get(), viewportSize, paintInfo);
+        auto* renderStyle = renderer.parent()->lazyPseudoElementStyle({ PseudoElementType::Highlight, markedText.highlightName });
+        computeStyleForPseudoElementStyle(style, renderStyle, viewportSize, paintInfo);
         break;
     }
     case MarkedText::Type::SpellingError: {

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -891,6 +891,46 @@ public:
         SUPPRESS_UNCOUNTED_ARG if (changedCustomPaintWatchedProperty(a, *a.nonInheritedData().rareData, b, *b.nonInheritedData().rareData))
             return true;
 
+        if (highlightPseudoElementStyleChangeRequiresRepaint(a, b))
+            return true;
+
+        return false;
+    }
+
+    // A highlight pseudo-element has no renderer of its own, so the originating element repaints for
+    // it. https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+    static bool highlightPseudoElementStyleChangeRequiresRepaint(const Style::ComputedStyle& a, const Style::ComputedStyle& b)
+    {
+        auto highlightTypes = a.highlightPseudoElementTypes();
+        if (highlightTypes != b.highlightPseudoElementTypes())
+            return true;
+
+        auto differs = [&](const PseudoElementIdentifier& identifier) {
+            auto* aStyle = a.pseudoElementStyle(identifier);
+            auto* bStyle = b.pseudoElementStyle(identifier);
+            if (!aStyle || !bStyle)
+                return aStyle != bStyle;
+            return *aStyle != *bStyle;
+        };
+
+        for (auto type : highlightTypes) {
+            // ::highlight() is the only one with a name, so it needs the cached entries rather than
+            // a single identifier.
+            if (type != PseudoElementType::Highlight) {
+                if (differs({ type }))
+                    return true;
+                continue;
+            }
+            for (auto& identifier : a.pseudoElementStyles().keys()) {
+                if (identifier.type == PseudoElementType::Highlight && differs(identifier))
+                    return true;
+            }
+            for (auto& identifier : b.pseudoElementStyles().keys()) {
+                if (identifier.type == PseudoElementType::Highlight && !a.pseudoElementStyle(identifier))
+                    return true;
+            }
+        }
+
         return false;
     }
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -777,11 +777,23 @@ void Scope::didChangeViewportSize()
         return;
     }
 
+    // Lazily resolved pseudo-element styles are cached on the element's style and only re-resolved
+    // when the element is invalidated, so their viewport units have to be accounted for here too.
+    auto usesViewportUnits = [](const Style::ComputedStyle& style) {
+        if (style.usesViewportUnits())
+            return true;
+        for (auto& [identifier, pseudoElementStyle] : style.pseudoElementStyles()) {
+            if (pseudoElementStyle->usesViewportUnits())
+                return true;
+        }
+        return false;
+    };
+
     // FIXME: Ideally, we should save the list of elements that have viewport units and only iterate over those.
     for (RefPtr element = ElementTraversal::firstWithin(rootNode); element; element = ElementTraversal::nextIncludingPseudo(*element)) {
         bool styleableHasViewportUnitAnimation = Styleable::fromElement(*element).viewportSizeDidChange();
         auto* renderer = element->renderer();
-        if (styleableHasViewportUnitAnimation || (renderer && renderer->style().usesViewportUnits()))
+        if (styleableHasViewportUnitAnimation || (renderer && usesViewportUnits(renderer->style())))
             element->invalidateStyle();
     }
 }

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -436,8 +436,10 @@ auto TreeResolver::resolveElement(Element& element, const Style::ComputedStyle* 
     // Re-resolve any that were previously cached.
     if (existingStyle) {
         for (auto& [identifier, _] : existingStyle->pseudoElementStyles()) {
-            if (isHighlightPseudoElement(identifier.type))
-                resolveAndAddPseudoElementStyle(identifier);
+            // Highlight pseudo-elements inherit from the corresponding pseudo-element of the parent,
+            // so a change has to reach the descendants too.
+            if (isHighlightPseudoElement(identifier.type) && resolveAndAddPseudoElementStyle(identifier))
+                descendantsToResolve = DescendantsToResolve::All;
         }
     }
 


### PR DESCRIPTION
#### 85d296cb7e71cc5f936d194e7a393c56436235d5
<pre>
[Custom Highlight] ::highlight() pseudo-element is not repainted after a CSS rule change.
<a href="https://bugs.webkit.org/show_bug.cgi?id=321530">https://bugs.webkit.org/show_bug.cgi?id=321530</a>
<a href="https://rdar.apple.com/184643272">rdar://184643272</a>

Reviewed by Megan Gardner.

We were completely missing repaint code for highlight pseudo-elements.

For ::highlight() specifically we also failed to cache the styles in parent ComputedStyle so
we also couldn&apos;t compare them for changes in the new repaint code.

Tests: fast/repaint/highlight-pseudo-rule-change-document-wide.html
       fast/repaint/highlight-pseudo-rule-change.html
* LayoutTests/fast/repaint/highlight-pseudo-rule-change-document-wide-expected.txt: Added.
* LayoutTests/fast/repaint/highlight-pseudo-rule-change-document-wide.html: Added.
* LayoutTests/fast/repaint/highlight-pseudo-rule-change-expected.txt: Added.
* LayoutTests/fast/repaint/highlight-pseudo-rule-change.html: Added.

::selection still doesn&apos;t repaint since selectionPseudoStyle() doesn&apos;t cache the style.
It is left as a failing case in the test.

* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForHighlights):
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):

Use lazyPseudoElementStyle() instead of resolvePseudoElementStyle(). Lazy version
does caching in parent ComputedStyle which is needed for repainting. It is also
more efficient as we don&apos;t recompute the style unnecessarily.

* Source/WebCore/style/StyleDifference.cpp:
(WebCore::Style::DifferenceFunctions::changeRequiresRepaint):
(WebCore::Style::DifferenceFunctions::highlightPseudoElementStyleChangeRequiresRepaint):

Add repaint issuing code for highlight pseudo-elements.

* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::didChangeViewportSize):

Ensure we check viewport units in pseudo-elements too to not regress
custom-highlight-dynamic-viewport-metrics-first-line-001.html

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):

Resolve descendants when a highlight pseudo-element style changes, since they inherit from it.
Nothing did this before because nothing cached the styles, so paint just recomputed them. Needed
to not regress css-conditional/container-queries/pseudo-elements-010.html, where the style that
paints is cached on the span inside the element the changing rule matches.

Canonical link: <a href="https://commits.webkit.org/319169@main">https://commits.webkit.org/319169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d77dd26c48839a7a6539510ed20d5a694488fd63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180725 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/54670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145047 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182587 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/55968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140965 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183680 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/55968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/48468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121417 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/55968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/48468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/55968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2097 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47279 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/54386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192873 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/54336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/48468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150348 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40227 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/55024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150065 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/55024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122544 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/53541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/48468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->