### PR TITLE
Find-in-page video matches doesn't seek on sites that handle their own playback

### DIFF
--- a/LayoutTests/media/track/text-track-find-seek-expected.txt
+++ b/LayoutTests/media/track/text-track-find-seek-expected.txt
@@ -1,0 +1,24 @@
+
+RUN(video.src = findMediaFile("video", "../content/test"))
+EVENT(loadeddata)
+Test that seekToFindMatch seeks the media element directly when no "seekto" media session action handler is registered, and defers to the handler when one is.
+
+** With no "seekto" handler, seekToFindMatch seeks the element directly.
+RUN(video.currentTime = 0)
+EXPECTED (video.currentTime == '0') OK
+RUN(internals.seekMediaElementToFindMatch(video, 3))
+EXPECTED (video.currentTime == '3') OK
+RUN(internals.seekMediaElementToFindMatch(video, 0))
+EXPECTED (video.currentTime == '0') OK
+
+** With a "seekto" handler registered, seekToFindMatch invokes the handler instead of seeking.
+RUN(internals.seekMediaElementToFindMatch(video, 3))
+ACTION: seekto, seekTime: 3
+EXPECTED (video.currentTime == '0') OK
+
+** After clearing the handler, seekToFindMatch seeks directly again.
+RUN(internals.seekMediaElementToFindMatch(video, 3))
+EXPECTED (video.currentTime == '3') OK
+
+END OF TEST
+

--- a/LayoutTests/media/track/text-track-find-seek.html
+++ b/LayoutTests/media/track/text-track-find-seek.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>text-track-find-seek</title>
+    <script src="../video-test.js"></script>
+    <script src="../media-file.js"></script>
+    <script>
+
+    async function runTest() {
+        if (!window.internals) {
+            failTest('This test requires Internals');
+            return;
+        }
+
+        findMediaElement();
+        run('video.src = findMediaFile("video", "../content/test")');
+        await waitFor(video, 'loadeddata');
+
+        consoleWrite('Test that seekToFindMatch seeks the media element directly when no "seekto" media session action handler is registered, and defers to the handler when one is.');
+
+        consoleWrite('<br>** With no "seekto" handler, seekToFindMatch seeks the element directly.');
+        run('video.currentTime = 0');
+        testExpected("video.currentTime", 0);
+        run('internals.seekMediaElementToFindMatch(video, 3)');
+        testExpected("video.currentTime", 3);
+        run('internals.seekMediaElementToFindMatch(video, 0)');
+        testExpected("video.currentTime", 0);
+
+        consoleWrite('<br>** With a "seekto" handler registered, seekToFindMatch invokes the handler instead of seeking.');
+        navigator.mediaSession.setActionHandler("seekto", actionDetails => {
+            consoleWrite(`ACTION: ${actionDetails.action}, seekTime: ${actionDetails.seekTime}`);
+        });
+        run('internals.seekMediaElementToFindMatch(video, 3)');
+        testExpected("video.currentTime", 0);
+
+        consoleWrite('<br>** After clearing the handler, seekToFindMatch seeks directly again.');
+        navigator.mediaSession.setActionHandler("seekto", null);
+        run('internals.seekMediaElementToFindMatch(video, 3)');
+        testExpected("video.currentTime", 3);
+
+        consoleWrite("");
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    <video controls preload='auto'></video>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -102,6 +102,7 @@
 #include "MediaQueryEvaluator.h"
 #include "MediaResourceLoader.h"
 #include "MediaSession.h"
+#include "MediaSessionActionDetails.h"
 #include "MessageClientForTesting.h"
 #include "Navigator.h"
 #include "NavigatorMediaDevices.h"
@@ -4314,6 +4315,28 @@ void HTMLMediaElement::setCurrentTime(const MediaTime& time)
         return;
 
     seekInternal(time);
+}
+
+void HTMLMediaElement::seekToFindMatch(const MediaTime& time)
+{
+#if ENABLE(MEDIA_SESSION)
+    // Some sites ignore direct seeking, so prefer their "seekto" handler when available.
+    if (RefPtr window = document().window()) {
+        RefPtr navigator = window->optionalNavigator();
+        RefPtr session = navigator ? NavigatorMediaSession::mediaSessionIfExists(*navigator) : nullptr;
+        if (session && session->hasActionHandler(MediaSessionAction::Seekto)) {
+            RefPtr active = session->activeMediaElement();
+            if (!active || active == this) {
+                MediaSessionActionDetails details;
+                details.action = MediaSessionAction::Seekto;
+                details.seekTime = time.toDouble();
+                if (session->callActionHandler(details, MediaSession::TriggerGestureIndicator::Yes))
+                    return;
+            }
+        }
+    }
+#endif
+    setCurrentTime(time);
 }
 
 ExceptionOr<void> HTMLMediaElement::setCurrentTimeForBindings(double time)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -427,6 +427,7 @@ public:
 
     Vector<MediaTime> findCueMatches(const String& target, FindOptions);
     void clearFindCaptionTrack();
+    WEBCORE_EXPORT void seekToFindMatch(const MediaTime&);
 
     virtual void didAddTextTrack(HTMLTrackElement&);
     virtual void didRemoveTextTrack(HTMLTrackElement&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6570,6 +6570,11 @@ double Internals::privatePlayerCurrentTime(HTMLMediaElement& media)
     return media.mediaPlayerCurrentTime();
 }
 
+void Internals::seekMediaElementToFindMatch(HTMLMediaElement& media, double time)
+{
+    media.seekToFindMatch(MediaTime::createWithDouble(time));
+}
+
 #endif
 
 ExceptionOr<void> Internals::setIsPlayingToBluetoothOverride(std::optional<bool> isPlaying)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -871,6 +871,7 @@ public:
     double privatePlayerVolume(const HTMLMediaElement&);
     bool privatePlayerMuted(const HTMLMediaElement&);
     double privatePlayerCurrentTime(HTMLMediaElement&);
+    void seekMediaElementToFindMatch(HTMLMediaElement&, double);
     bool isMediaElementHidden(const HTMLMediaElement&);
     double elementEffectivePlaybackRate(const HTMLMediaElement&);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1040,6 +1040,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] double privatePlayerVolume(HTMLMediaElement media);
     [Conditional=VIDEO] boolean privatePlayerMuted(HTMLMediaElement media);
     [Conditional=VIDEO] unrestricted double privatePlayerCurrentTime(HTMLMediaElement media);
+    [Conditional=VIDEO] undefined seekMediaElementToFindMatch(HTMLMediaElement element, unrestricted double time);
     [Conditional=VIDEO] boolean isMediaElementHidden(HTMLMediaElement media);
     [Conditional=VIDEO] undefined setOverridePreferredDynamicRangeMode(HTMLMediaElement media, DOMString mode);
     [Conditional=VIDEO] double elementEffectivePlaybackRate(HTMLMediaElement media);

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -307,7 +307,7 @@ std::optional<FrameIdentifier> FindController::applyFindMatch(const FindMatch& m
         // Clear any prior text selection so it isn't left highlighted while parked on the video.
         if (RefPtr selectedFrame = frameWithSelection(protect(webPage->corePage()).get()))
             protect(selectedFrame->selection())->clear();
-        media->setCurrentTime(cue.seekTime.toDouble());
+        media->seekToFindMatch(cue.seekTime);
         media->scrollIntoViewIfNeeded();
     }
     return frame->frameID();

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -306,7 +306,7 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
         if (auto* cueData = std::get_if<WebFoundTextRange::CueData>(&range.data)) {
             m_highlightedRange = range;
             if (RefPtr mediaElement = mediaElementForCueRange(range))
-                mediaElement->setCurrentTime(Seconds::fromMilliseconds(cueData->seekTimeMilliseconds).seconds());
+                mediaElement->seekToFindMatch(MediaTime(cueData->seekTimeMilliseconds, 1000));
         }
     }
 #endif


### PR DESCRIPTION
#### 6ad38ada0001bf8fbb7c50f5af7b0df2ebe498e5
<pre>
Find-in-page video matches doesn&apos;t seek on sites that handle their own playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=321695">https://bugs.webkit.org/show_bug.cgi?id=321695</a>
<a href="https://rdar.apple.com/184841739">rdar://184841739</a>

Reviewed by NOBODY (OOPS!).

Find-in-page can navigate a video&apos;s caption matches and seek the video to the
matched cue&apos;s time. It did this by calling HTMLMediaElement::setCurrentTime()
directly. Some sites (e.g. Netflix) drive playback themselves and ignore direct
seeks on the media element, so selecting a caption match on those sites did
nothing.

This routes find-in-video seeking through a new HTMLMediaElement::seekToFindMatch().
When the page has registered a MediaSession &quot;seekto&quot; action handler, and the
session&apos;s active media element is this element or unset, it instead invokes that handler
with the cue time instead of seeking directly, letting the site perform the seek
its own way. With no &quot;seekto&quot; handler registered it falls back to seeking the
element directly.

Both find-in-video seek call sites now use seekToFindMatch() instead of
setCurrentTime() in `FindController` and `WebFoundTextRangeController`

Test: media/track/text-track-find-seek.html
Adds internals.seekMediaElementToFindMatch() and verifies that with no &quot;seekto&quot;
handler the element seeks directly, with a handler registered the seek defers to
the handler, and after clearing the handler it seeks directly again.

* LayoutTests/media/track/text-track-find-seek-expected.txt: Added.
* LayoutTests/media/track/text-track-find-seek.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::seekToFindMatch):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::seekMediaElementToFindMatch):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::applyFindMatch):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ad38ada0001bf8fbb7c50f5af7b0df2ebe498e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144905 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140847 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97586 "2 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121299 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43194 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41478 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41158 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1953 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192730 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150222 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54882 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37773 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149955 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44560 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127147 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122361 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53399 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16151 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52846 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->