### PR TITLE
Rename ConstantPropertyMap to Style::EnvironmentVariables

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1329,7 +1329,6 @@ dom/CommandEvent.cpp
 dom/Comment.cpp
 dom/ComposedTreeIterator.cpp
 dom/CompositionEvent.cpp
-dom/ConstantPropertyMap.cpp
 dom/ContainerNode.cpp @header:RenderStyleGetters
 dom/ContainerNodeAlgorithms.cpp
 dom/ContentVisibilityAutoStateChangeEvent.cpp
@@ -3303,6 +3302,7 @@ style/StyleColorResolver.cpp @header:RenderStyleGetters @cost:4
 style/StyleCustomProperty.cpp
 style/StyleCustomPropertyRegistry.cpp @header:RenderStyleGetters @cost:6
 style/StyleDifference.cpp @header:RenderStyleGetters @cost:5
+style/StyleEnvironmentVariables.cpp
 style/StyleExtractor.cpp @header:RenderStyleGetters @cost:6
 style/StyleFontSizeFunctions.cpp @header:RenderStyleGetters @cost:5
 style/StyleInterpolation.cpp @header:RenderStyleGetters @cost:6

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1183,7 +1183,7 @@
 		2D9F0E1314FF1CBF00BA0FF7 /* linearSRGB.icc in Resources */ = {isa = PBXBuildFile; fileRef = 2D9F0E1214FF1CBF00BA0FF7 /* linearSRGB.icc */; };
 		2DA397E5265C737500468F33 /* NullGraphicsContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DA397E3265C737400468F33 /* NullGraphicsContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DABFA7F2B216C68001C33D7 /* DynamicContentScalingDisplayList.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DABFA7E2B216C68001C33D7 /* DynamicContentScalingDisplayList.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2DAF343D1EA7E0F100382CD3 /* ConstantPropertyMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DAF343B1EA7E0F100382CD3 /* ConstantPropertyMap.h */; };
+		2DAF343D1EA7E0F100382CD3 /* StyleEnvironmentVariables.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DAF343B1EA7E0F100382CD3 /* StyleEnvironmentVariables.h */; };
 		2DC05CA827D80956004ED403 /* InteractionRegion.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DC05CA327D7F6B5004ED403 /* InteractionRegion.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DC8D39825F2FE9700CFCBAB /* Model.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DC8D39725F2FE9400CFCBAB /* Model.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DD5A7271EBEE47D009BA597 /* CompositionUnderline.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DD5A7261EBEE47D009BA597 /* CompositionUnderline.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -10564,8 +10564,8 @@
 		2DAAE32C19DCAF6000E002D2 /* MockPageOverlayClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MockPageOverlayClient.cpp; sourceTree = "<group>"; };
 		2DAAE32D19DCAF6000E002D2 /* MockPageOverlayClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockPageOverlayClient.h; sourceTree = "<group>"; };
 		2DABFA7E2B216C68001C33D7 /* DynamicContentScalingDisplayList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DynamicContentScalingDisplayList.h; sourceTree = "<group>"; };
-		2DAF343A1EA7E0F100382CD3 /* ConstantPropertyMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConstantPropertyMap.cpp; sourceTree = "<group>"; };
-		2DAF343B1EA7E0F100382CD3 /* ConstantPropertyMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstantPropertyMap.h; sourceTree = "<group>"; };
+		2DAF343A1EA7E0F100382CD3 /* StyleEnvironmentVariables.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StyleEnvironmentVariables.cpp; sourceTree = "<group>"; };
+		2DAF343B1EA7E0F100382CD3 /* StyleEnvironmentVariables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StyleEnvironmentVariables.h; sourceTree = "<group>"; };
 		2DC05CA327D7F6B5004ED403 /* InteractionRegion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InteractionRegion.h; sourceTree = "<group>"; };
 		2DC05CA727D80217004ED403 /* InteractionRegion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InteractionRegion.cpp; sourceTree = "<group>"; };
 		2DC8D39625F2FE9300CFCBAB /* Model.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Model.cpp; sourceTree = "<group>"; };
@@ -41479,6 +41479,8 @@
 				BC913B3C2EE88D34009E3349 /* StyleDifference.h */,
 				A1D0C50120260608000A0001 /* StyleDocumentScope.cpp */,
 				A1D0C50120260608000A0002 /* StyleDocumentScope.h */,
+				2DAF343A1EA7E0F100382CD3 /* StyleEnvironmentVariables.cpp */,
+				2DAF343B1EA7E0F100382CD3 /* StyleEnvironmentVariables.h */,
 				BCFEE3322DC6B33D00EC3901 /* StyleExtractor.cpp */,
 				BCFEE3302DC6B2C300EC3901 /* StyleExtractor.h */,
 				BCFEE32E2DC6AFEC00EC3901 /* StyleExtractorCustom.h */,
@@ -42683,8 +42685,6 @@
 				79F2F59E1091939A000D87CB /* CompositionEvent.cpp */,
 				79F2F59F1091939A000D87CB /* CompositionEvent.h */,
 				79F2F5A01091939A000D87CB /* CompositionEvent.idl */,
-				2DAF343A1EA7E0F100382CD3 /* ConstantPropertyMap.cpp */,
-				2DAF343B1EA7E0F100382CD3 /* ConstantPropertyMap.h */,
 				A81872140977D3C0005826D9 /* ContainerNode.cpp */,
 				A81872110977D3C0005826D9 /* ContainerNode.h */,
 				A7A78CD41532BA62006C21E4 /* ContainerNodeAlgorithms.cpp */,
@@ -44720,7 +44720,6 @@
 				7A7C8B5827F32EF70008E234 /* ComputedStylePropertyMapReadOnly.h in Headers */,
 				FD31608F12B026F700C1A359 /* Cone.h in Headers */,
 				65C97AF308EA908800ACD273 /* config.h in Headers */,
-				2DAF343D1EA7E0F100382CD3 /* ConstantPropertyMap.h in Headers */,
 				E7C8E13B24E2FE7E0027A27F /* ConstantSourceNode.h in Headers */,
 				E7C8E13724E2FBCE0027A27F /* ConstantSourceOptions.h in Headers */,
 				E596DD5D251BB08200C275A7 /* ContactInfo.h in Headers */,
@@ -49061,6 +49060,7 @@
 				BC5C89C02D567E31000F45B7 /* StyleDynamicRangeLimitMix.h in Headers */,
 				BC7320362E73558D00A6584F /* StyleEasingFunction.h in Headers */,
 				BCB2720B2CC1F1DB00265123 /* StyleEllipseFunction.h in Headers */,
+				2DAF343D1EA7E0F100382CD3 /* StyleEnvironmentVariables.h in Headers */,
 				BCFEE3312DC6B2C300EC3901 /* StyleExtractor.h in Headers */,
 				BCFEE32F2DC6AFEC00EC3901 /* StyleExtractorCustom.h in Headers */,
 				BCFEE3292DC6AC6800EC3901 /* StyleExtractorGenerated.h in Headers */,

--- a/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
+++ b/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
@@ -56,13 +56,13 @@ bool CSSSubstitutionParser::isValidCustomPropertyName(const CSSParserToken& toke
     return isCustomPropertyName(token.value());
 }
 
-static bool NODELETE isValidConstantName(const CSSParserToken& token)
+static bool NODELETE isValidEnvVariableName(const CSSParserToken& token)
 {
     return token.type() == IdentToken;
 }
 
 static bool isValidVariableReference(CSSParserTokenRange, const CSSParserContext&);
-static bool isValidConstantReference(CSSParserTokenRange, const CSSParserContext&);
+static bool isValidEnvReference(CSSParserTokenRange, const CSSParserContext&);
 static bool isValidDashedFunction(CSSParserTokenRange, const CSSParserContext&);
 static bool isValidAttrReference(CSSParserTokenRange, const CSSParserContext&);
 static bool isValidRandomItemReference(CSSParserTokenRange, const CSSParserContext&);
@@ -131,7 +131,7 @@ static std::optional<ClassifyBlockResult> classifyBlock(CSSParserTokenRange rang
                 continue;
             }
             if (token.functionId() == CSSValueEnv) {
-                if (!isValidConstantReference(block, parserContext))
+                if (!isValidEnvReference(block, parserContext))
                     return { };
                 result.hasSubstitutionFunctions = true;
                 continue;
@@ -254,10 +254,10 @@ bool isValidVariableReference(CSSParserTokenRange range, const CSSParserContext&
     return !!classifyBlock(range, parserContext);
 }
 
-bool isValidConstantReference(CSSParserTokenRange range, const CSSParserContext& parserContext)
+bool isValidEnvReference(CSSParserTokenRange range, const CSSParserContext& parserContext)
 {
     range.consumeWhitespace();
-    if (!isValidConstantName(range.consumeIncludingWhitespace()))
+    if (!isValidEnvVariableName(range.consumeIncludingWhitespace()))
         return false;
     if (range.atEnd())
         return true;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -62,7 +62,6 @@
 #include "ComposedTreeAncestorIterator.h"
 #include "ComposedTreeIterator.h"
 #include "CompositionEvent.h"
-#include "ConstantPropertyMap.h"
 #include "ContentSecurityPolicy.h"
 #include "ContentVisibilityDocumentState.h"
 #include "ContentfulPaintChecker.h"
@@ -10694,15 +10693,6 @@ void Document::didRemoveInDocumentShadowRoot(ShadowRoot& shadowRoot)
 {
     ASSERT(m_inDocumentShadowRoots.contains(shadowRoot));
     m_inDocumentShadowRoots.remove(shadowRoot);
-}
-
-ConstantPropertyMap& Document::constantProperties() const
-{
-    if (!m_constantPropertyMap) {
-        auto& thisDocument = const_cast<Document&>(*this);
-        thisDocument.m_constantPropertyMap = makeUnique<ConstantPropertyMap>(thisDocument);
-    }
-    return *m_constantPropertyMap;
 }
 
 void Document::orientationChanged(IntDegrees orientation)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -117,7 +117,6 @@ class CanvasRenderingContext2D;
 class CaretPosition;
 class CharacterData;
 class Comment;
-class ConstantPropertyMap;
 class ContentVisibilityDocumentState;
 class CustomElementRegistry;
 class DOMImplementation;
@@ -1847,8 +1846,6 @@ public:
     void attachToCachedFrame(CachedFrameBase&);
     void detachFromCachedFrame(CachedFrameBase&);
 
-    ConstantPropertyMap& constantProperties() const;
-
     void orientationChanged(IntDegrees orientation);
     OrientationNotifier& orientationNotifier();
 
@@ -2466,8 +2463,6 @@ private:
     bool m_deferResizeEventForVisibilityChange { false };
 
     std::optional<HashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash>> m_accessKeyCache;
-
-    std::unique_ptr<ConstantPropertyMap> m_constantPropertyMap;
 
     RenderPtr<RenderView> m_renderView;
     std::unique_ptr<Style::ComputedStyle> m_initialContainingBlockStyle;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -49,7 +49,6 @@
 #include "ChromeClient.h"
 #include "CommonAtomStrings.h"
 #include "CommonVM.h"
-#include "ConstantPropertyMap.h"
 #include "ContainerNodeInlines.h"
 #include "ContextMenuClient.h"
 #include "ContextMenuController.h"
@@ -195,6 +194,7 @@
 #include "StringCallback.h"
 #include "StyleAdjuster.h"
 #include "StyleDocumentScope.h"
+#include "StyleEnvironmentVariables.h"
 #include "StyleResolver.h"
 #include "SubframeLoader.h"
 #include "SubresourceLoader.h"
@@ -4400,7 +4400,7 @@ void Page::setUnobscuredSafeAreaInsets(const FloatBoxExtent& insets)
     m_unobscuredSafeAreaInsets = insets;
 
     forEachDocument([&] (Document& document) {
-        document.constantProperties().didChangeSafeAreaInsets();
+        document.styleScope().environmentVariables().didChangeSafeAreaInsets();
     });
 }
 
@@ -4493,7 +4493,7 @@ void Page::setFullscreenInsets(const FloatBoxExtent& insets)
     m_fullscreenInsets = insets;
 
     forEachDocument([] (Document& document) {
-        document.constantProperties().didChangeFullscreenInsets();
+        document.styleScope().environmentVariables().didChangeFullscreenInsets();
     });
 }
 
@@ -4505,7 +4505,7 @@ void Page::setFullscreenAutoHideDuration(Seconds duration)
     m_fullscreenAutoHideDuration = duration;
 
     forEachDocument([&] (Document& document) {
-        document.constantProperties().setFullscreenAutoHideDuration(duration);
+        document.styleScope().environmentVariables().setFullscreenAutoHideDuration(duration);
     });
 }
 

--- a/Source/WebCore/style/StyleDocumentScope.cpp
+++ b/Source/WebCore/style/StyleDocumentScope.cpp
@@ -50,6 +50,7 @@
 #include "ShadowRoot.h"
 #include "StyleableInlines.h"
 #include "StyleCustomPropertyRegistry.h"
+#include "StyleEnvironmentVariables.h"
 #include "StyleInvalidator.h"
 #include "StyleResolver.h"
 #include "StyleSheetContents.h"
@@ -380,6 +381,15 @@ MatchResultCache& DocumentScope::matchResultCache()
     if (!m_matchResultCache)
         m_matchResultCache = makeUnique<MatchResultCache>();
     return *m_matchResultCache;
+}
+
+EnvironmentVariables& DocumentScope::environmentVariables() const
+{
+    if (!m_environmentVariables) {
+        auto& thisScope = const_cast<DocumentScope&>(*this);
+        thisScope.m_environmentVariables = makeUnique<EnvironmentVariables>(m_document.get());
+    }
+    return *m_environmentVariables;
 }
 
 void DocumentScope::updateAnchorPositioningStateAfterStyleResolution()

--- a/Source/WebCore/style/StyleDocumentScope.h
+++ b/Source/WebCore/style/StyleDocumentScope.h
@@ -28,6 +28,8 @@ class StyleRuleKeyframes;
 
 namespace Style {
 
+class EnvironmentVariables;
+
 // Style scope for the document tree. Owns the document-level state that is shared
 // by all the tree scopes (the document scope and its descendant shadow tree scopes).
 class DocumentScope final : public Scope {
@@ -57,6 +59,8 @@ public:
     void addViewTransitionKeyframes(Ref<StyleRuleKeyframes>&&);
 
     MatchResultCache& matchResultCache() LIFETIME_BOUND;
+
+    EnvironmentVariables& environmentVariables() const LIFETIME_BOUND;
 
     struct LayoutDependencyUpdateContext {
         HashSet<CheckedRef<const Element>> invalidatedContainers;
@@ -106,6 +110,8 @@ private:
     HashMap<WeakStyleable, size_t> m_lastSuccessfulPositionOptionIndexes;
 
     std::unique_ptr<MatchResultCache> m_matchResultCache;
+
+    std::unique_ptr<EnvironmentVariables> m_environmentVariables;
 
     HashMap<ResolverSharingKey, Ref<Resolver>> m_sharedShadowTreeResolvers;
 

--- a/Source/WebCore/style/StyleEnvironmentVariables.cpp
+++ b/Source/WebCore/style/StyleEnvironmentVariables.cpp
@@ -20,12 +20,12 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
 
 #include "config.h"
-#include "ConstantPropertyMap.h"
+#include "StyleEnvironmentVariables.h"
 
 #include "CSSCustomPropertyValue.h"
 #include "CSSParserTokenRange.h"
@@ -36,22 +36,23 @@
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+namespace Style {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(ConstantPropertyMap);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EnvironmentVariables);
 
-ConstantPropertyMap::ConstantPropertyMap(Document& document)
+EnvironmentVariables::EnvironmentVariables(Document& document)
     : m_document(document)
 {
 }
 
-const ConstantPropertyMap::Values& ConstantPropertyMap::values() const
+const EnvironmentVariables::Values& EnvironmentVariables::values() const
 {
     if (!m_values)
-        const_cast<ConstantPropertyMap&>(*this).buildValues();
+        const_cast<EnvironmentVariables&>(*this).buildValues();
     return *m_values;
 }
 
-const AtomString& ConstantPropertyMap::nameForProperty(ConstantProperty property) const
+const AtomString& EnvironmentVariables::nameForVariable(UADefinedVariable variable) const
 {
     static MainThreadNeverDestroyed<const AtomString> safeAreaInsetTopName("safe-area-inset-top"_s);
     static MainThreadNeverDestroyed<const AtomString> safeAreaInsetRightName("safe-area-inset-right"_s);
@@ -63,45 +64,45 @@ const AtomString& ConstantPropertyMap::nameForProperty(ConstantProperty property
     static MainThreadNeverDestroyed<const AtomString> fullscreenInsetRightName("fullscreen-inset-right"_s);
     static MainThreadNeverDestroyed<const AtomString> fullscreenAutoHideDurationName("fullscreen-auto-hide-duration"_s);
 
-    switch (property) {
-    case ConstantProperty::SafeAreaInsetTop:
+    switch (variable) {
+    case UADefinedVariable::SafeAreaInsetTop:
         return safeAreaInsetTopName;
-    case ConstantProperty::SafeAreaInsetRight:
+    case UADefinedVariable::SafeAreaInsetRight:
         return safeAreaInsetRightName;
-    case ConstantProperty::SafeAreaInsetBottom:
+    case UADefinedVariable::SafeAreaInsetBottom:
         return safeAreaInsetBottomName;
-    case ConstantProperty::SafeAreaInsetLeft:
+    case UADefinedVariable::SafeAreaInsetLeft:
         return safeAreaInsetLeftName;
-    case ConstantProperty::FullscreenInsetTop:
+    case UADefinedVariable::FullscreenInsetTop:
         return fullscreenInsetTopName;
-    case ConstantProperty::FullscreenInsetLeft:
+    case UADefinedVariable::FullscreenInsetLeft:
         return fullscreenInsetLeftName;
-    case ConstantProperty::FullscreenInsetBottom:
+    case UADefinedVariable::FullscreenInsetBottom:
         return fullscreenInsetBottomName;
-    case ConstantProperty::FullscreenInsetRight:
+    case UADefinedVariable::FullscreenInsetRight:
         return fullscreenInsetRightName;
-    case ConstantProperty::FullscreenAutoHideDuration:
+    case UADefinedVariable::FullscreenAutoHideDuration:
         return fullscreenAutoHideDurationName;
     }
 
     return nullAtom();
 }
 
-void ConstantPropertyMap::setValueForProperty(ConstantProperty property, Ref<CSSVariableData>&& data)
+void EnvironmentVariables::setValueForVariable(UADefinedVariable variable, Ref<CSSVariableData>&& data)
 {
     if (!m_values)
         buildValues();
 
-    auto& name = nameForProperty(property);
-    m_values->set(name, Style::CustomProperty::createForVariableData(name, WTF::move(data)));
+    auto& name = nameForVariable(variable);
+    m_values->set(name, CustomProperty::createForVariableData(name, WTF::move(data)));
 }
 
-void ConstantPropertyMap::buildValues()
+void EnvironmentVariables::buildValues()
 {
     m_values = Values { };
 
-    updateConstantsForSafeAreaInsets();
-    updateConstantsForFullscreen();
+    updateSafeAreaInsetVariables();
+    updateFullscreenVariables();
 }
 
 static Ref<CSSVariableData> variableDataForPositivePixelLength(float lengthInPx)
@@ -128,45 +129,46 @@ static Ref<CSSVariableData> variableDataForPositiveDuration(Seconds durationInSe
     return CSSVariableData::create(tokenRange);
 }
 
-void ConstantPropertyMap::updateConstantsForSafeAreaInsets()
+void EnvironmentVariables::updateSafeAreaInsetVariables()
 {
     RefPtr page = m_document->page();
     FloatBoxExtent unobscuredSafeAreaInsets = page ? page->unobscuredSafeAreaInsets() : FloatBoxExtent();
-    setValueForProperty(ConstantProperty::SafeAreaInsetTop, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.top()));
-    setValueForProperty(ConstantProperty::SafeAreaInsetRight, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.right()));
-    setValueForProperty(ConstantProperty::SafeAreaInsetBottom, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.bottom()));
-    setValueForProperty(ConstantProperty::SafeAreaInsetLeft, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.left()));
+    setValueForVariable(UADefinedVariable::SafeAreaInsetTop, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.top()));
+    setValueForVariable(UADefinedVariable::SafeAreaInsetRight, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.right()));
+    setValueForVariable(UADefinedVariable::SafeAreaInsetBottom, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.bottom()));
+    setValueForVariable(UADefinedVariable::SafeAreaInsetLeft, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.left()));
 }
 
-void ConstantPropertyMap::didChangeSafeAreaInsets()
+void EnvironmentVariables::didChangeSafeAreaInsets()
 {
-    updateConstantsForSafeAreaInsets();
+    updateSafeAreaInsetVariables();
     protect(m_document)->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
 }
 
-void ConstantPropertyMap::updateConstantsForFullscreen()
+void EnvironmentVariables::updateFullscreenVariables()
 {
     RefPtr page = m_document->page();
     FloatBoxExtent fullscreenInsets = page ? page->fullscreenInsets() : FloatBoxExtent();
-    setValueForProperty(ConstantProperty::FullscreenInsetTop, variableDataForPositivePixelLength(fullscreenInsets.top()));
-    setValueForProperty(ConstantProperty::FullscreenInsetRight, variableDataForPositivePixelLength(fullscreenInsets.right()));
-    setValueForProperty(ConstantProperty::FullscreenInsetBottom, variableDataForPositivePixelLength(fullscreenInsets.bottom()));
-    setValueForProperty(ConstantProperty::FullscreenInsetLeft, variableDataForPositivePixelLength(fullscreenInsets.left()));
+    setValueForVariable(UADefinedVariable::FullscreenInsetTop, variableDataForPositivePixelLength(fullscreenInsets.top()));
+    setValueForVariable(UADefinedVariable::FullscreenInsetRight, variableDataForPositivePixelLength(fullscreenInsets.right()));
+    setValueForVariable(UADefinedVariable::FullscreenInsetBottom, variableDataForPositivePixelLength(fullscreenInsets.bottom()));
+    setValueForVariable(UADefinedVariable::FullscreenInsetLeft, variableDataForPositivePixelLength(fullscreenInsets.left()));
 
     Seconds fullscreenAutoHideDuration = page ? page->fullscreenAutoHideDuration() : 0_s;
-    setValueForProperty(ConstantProperty::FullscreenAutoHideDuration, variableDataForPositiveDuration(fullscreenAutoHideDuration));
+    setValueForVariable(UADefinedVariable::FullscreenAutoHideDuration, variableDataForPositiveDuration(fullscreenAutoHideDuration));
 }
 
-void ConstantPropertyMap::didChangeFullscreenInsets()
+void EnvironmentVariables::didChangeFullscreenInsets()
 {
-    updateConstantsForFullscreen();
+    updateFullscreenVariables();
     protect(m_document)->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
 }
 
-void ConstantPropertyMap::setFullscreenAutoHideDuration(Seconds duration)
+void EnvironmentVariables::setFullscreenAutoHideDuration(Seconds duration)
 {
-    setValueForProperty(ConstantProperty::FullscreenAutoHideDuration, variableDataForPositiveDuration(duration));
+    setValueForVariable(UADefinedVariable::FullscreenAutoHideDuration, variableDataForPositiveDuration(duration));
     protect(m_document)->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
 }
 
+}
 }

--- a/Source/WebCore/style/StyleEnvironmentVariables.h
+++ b/Source/WebCore/style/StyleEnvironmentVariables.h
@@ -41,10 +41,10 @@ class Document;
 class WeakPtrImplWithEventTargetData;
 
 namespace Style {
-class CustomProperty;
-}
 
-enum class ConstantProperty {
+class CustomProperty;
+
+enum class UADefinedVariable {
     SafeAreaInsetTop,
     SafeAreaInsetRight,
     SafeAreaInsetBottom,
@@ -56,12 +56,12 @@ enum class ConstantProperty {
     FullscreenAutoHideDuration,
 };
 
-class ConstantPropertyMap {
-    WTF_MAKE_TZONE_ALLOCATED(ConstantPropertyMap);
+class EnvironmentVariables {
+    WTF_MAKE_TZONE_ALLOCATED(EnvironmentVariables);
 public:
-    explicit ConstantPropertyMap(Document&);
+    explicit EnvironmentVariables(Document&);
 
-    using Values = HashMap<AtomString, Ref<const Style::CustomProperty>>;
+    using Values = HashMap<AtomString, Ref<const CustomProperty>>;
     const Values& values() const LIFETIME_BOUND;
 
     void didChangeSafeAreaInsets();
@@ -71,11 +71,11 @@ public:
 private:
     void buildValues();
 
-    const AtomString& nameForProperty(ConstantProperty) const;
-    void setValueForProperty(ConstantProperty, Ref<CSSVariableData>&&);
+    const AtomString& nameForVariable(UADefinedVariable) const;
+    void setValueForVariable(UADefinedVariable, Ref<CSSVariableData>&&);
 
-    void updateConstantsForSafeAreaInsets();
-    void updateConstantsForFullscreen();
+    void updateSafeAreaInsetVariables();
+    void updateFullscreenVariables();
 
 
     std::optional<Values> m_values;
@@ -83,4 +83,5 @@ private:
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
+} // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -49,7 +49,6 @@
 #include "CSSValueKeywords.h"
 #include "CSSVariableData.h"
 #include "CSSWideKeyword.h"
-#include "ConstantPropertyMap.h"
 #include "ContainerQueryEvaluator.h"
 #include "CustomFunctionRegistry.h"
 #include "Document.h"
@@ -65,6 +64,8 @@
 #include "StyleComputedStyle+SettersInlines.h"
 #include "StyleCustomProperty.h"
 #include "StyleCustomPropertyRegistry.h"
+#include "StyleDocumentScope.h"
+#include "StyleEnvironmentVariables.h"
 #include "StyleLocalPropertyRegistry.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StyleResolver.h"
@@ -143,7 +144,7 @@ SubstitutionResolver::SubstitutionResolver(Builder& builder, const CSSRegistered
 RefPtr<const CustomProperty> SubstitutionResolver::propertyValueForVariableName(const AtomString& variableName, CSSValueID functionId)
 {
     if (functionId == CSSValueEnv)
-        return m_styleBuilder.state().document().constantProperties().values().get(variableName);
+        return m_styleBuilder.state().document().styleScope().environmentVariables().values().get(variableName);
 
     // Apply this variable first, in case it is still unresolved
     m_styleBuilder.applyCustomProperty(variableName);


### PR DESCRIPTION
#### 032d7b853259a90954d3e513e9983807fc7eeca0
<pre>
Rename ConstantPropertyMap to Style::EnvironmentVariables
<a href="https://bugs.webkit.org/show_bug.cgi?id=321696">https://bugs.webkit.org/show_bug.cgi?id=321696</a>
<a href="https://rdar.apple.com/184842559">rdar://184842559</a>

Reviewed by Antti Koivisto.

ConstantPropertyMap is named after constant()/const(). This class currently
is the backing store for env() which is one per Document. We rename it
to Style::EnvironmentVariables, which maintains the same shape but more closer to the
env() concept.

The enum is renamed to UADefinedVariable rather than EnvironmentVariable so a
class and an enum in one namespace don&apos;t differ by a single letter, and because
&quot;UA-defined&quot; is the distinction that will matter once author-set variables land
alongside these. Also, we rename the two remaining constant()-era names in the env() parser.

No behavior change.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/parser/CSSSubstitutionParser.cpp:
(WebCore::isValidEnvVariableName):
(WebCore::classifyBlock):
(WebCore::isValidEnvReference):
(WebCore::isValidConstantName): Deleted.
(WebCore::isValidConstantReference): Deleted.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::styleEnvironmentVariables const):
(WebCore::Document::constantProperties const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setUnobscuredSafeAreaInsets):
(WebCore::Page::setFullscreenInsets):
(WebCore::Page::setFullscreenAutoHideDuration):
* Source/WebCore/style/StyleEnvironmentVariables.cpp: Renamed from Source/WebCore/dom/ConstantPropertyMap.cpp.
(WebCore::Style::EnvironmentVariables::EnvironmentVariables):
(WebCore::Style::EnvironmentVariables::values const):
(WebCore::Style::EnvironmentVariables::nameForVariable const):
(WebCore::Style::EnvironmentVariables::setValueForVariable):
(WebCore::Style::EnvironmentVariables::buildValues):
(WebCore::Style::variableDataForPositivePixelLength):
(WebCore::Style::variableDataForPositiveDuration):
(WebCore::Style::EnvironmentVariables::updateSafeAreaInsetVariables):
(WebCore::Style::EnvironmentVariables::didChangeSafeAreaInsets):
(WebCore::Style::EnvironmentVariables::updateFullscreenVariables):
(WebCore::Style::EnvironmentVariables::didChangeFullscreenInsets):
(WebCore::Style::EnvironmentVariables::setFullscreenAutoHideDuration):
* Source/WebCore/style/StyleEnvironmentVariables.h: Renamed from Source/WebCore/dom/ConstantPropertyMap.h.
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::propertyValueForVariableName):
* Source/WebCore/style/StyleDocumentScope.cpp:
(WebCore::Style::DocumentScope::environmentVariables const):
* Source/WebCore/style/StyleDocumentScope.h:

Canonical link: <a href="https://commits.webkit.org/319194@main">https://commits.webkit.org/319194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61c2b1c45c330e97d914aa268b68d39ee2be2074

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190953 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145063 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44980d9d-61ba-45bd-afd8-48e9587a253f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140981 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183695 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/44656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121433 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79b45226-fc25-4c49-8961-28162362e6eb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41274 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2114 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47297 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192888 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54351 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150364 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40249 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55039 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150081 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44691 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122582 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53556 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16267 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52938 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53175 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->