### PR TITLE
WebGPU: stage writeBuffer uploads on the compute channel, not standalone blit command buffers

### DIFF
--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -107,6 +107,8 @@ public:
     id<MTLIndirectCommandBuffer> trimICB(id<MTLIndirectCommandBuffer> dest, id<MTLIndirectCommandBuffer> src, NSUInteger newSize);
     id<MTLDevice> _Nullable metalDevice() const;
     std::pair<id<MTLBuffer>, uint64_t> newTemporaryBufferWithBytes(std::span<uint8_t> data, bool noCopy);
+    void stageBufferWrite(id<MTLBuffer>, uint64_t bufferOffset, std::span<uint8_t> data);
+    void encodeStagedCopy(id<MTLBuffer> temporaryBuffer, uint64_t temporaryBufferOffset, id<MTLBuffer>, uint64_t bufferOffset, uint64_t size, bool finalizeAfterCopy);
 
 private:
     Queue(id<MTLCommandQueue>, Adapter&, Device&);
@@ -118,6 +120,8 @@ private:
 
     bool NODELETE isIdle() const;
     bool isSchedulingIdle() const { return m_submittedCommandBufferCount == m_scheduledCommandBufferCount; }
+    id<MTLComputeCommandEncoder> _Nullable ensureStagedCopyEncoder();
+    id<MTLComputePipelineState> _Nullable stagedCopyPipelineState();
     void removeMTLCommandBufferInternal(id<MTLCommandBuffer>);
     void clearTextureIfNeeded(Texture&, uint32_t mipLevelCount, uint32_t arrayLayerCount, uint32_t baseMipLevel, uint32_t baseArrayLayer);
 
@@ -126,6 +130,9 @@ private:
     id<MTLCommandQueue> _Nullable m_commandQueue { nil };
     id<MTLCommandBuffer> _Nullable m_commandBuffer { nil };
     id<MTLBlitCommandEncoder> _Nullable m_blitCommandEncoder { nil };
+    id<MTLComputeCommandEncoder> _Nullable m_stagedCopyEncoder { nil };
+    id<MTLComputePipelineState> _Nullable m_stagedCopyPipelineState { nil };
+    bool m_stagedCopyPipelineCreationFailed { false };
     ThreadSafeWeakPtr<Device> m_device; // The only kind of queues that exist right now are default queues, which are owned by Devices.
     uint64_t m_submittedCommandBufferCount { 0 };
     uint64_t m_completedCommandBufferCount { 0 };

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -77,8 +77,11 @@ Queue::~Queue()
     // that would cause them to be committed, which ends up retaining this in the completed handler.
     // It's actually fine, though, because we can just drop any pending copies on the floor.
     // If the queue is being destroyed, this is unobservable.
-    if (m_blitCommandEncoder)
-        endEncoding(m_blitCommandEncoder, m_commandBuffer);
+    id<MTLCommandEncoder> stagingEncoder = m_blitCommandEncoder;
+    if (!stagingEncoder)
+        stagingEncoder = m_stagedCopyEncoder;
+    if (stagingEncoder)
+        endEncoding(stagingEncoder, m_commandBuffer);
 }
 
 id<MTLBlitCommandEncoder> Queue::ensureBlitCommandEncoder()
@@ -86,22 +89,127 @@ id<MTLBlitCommandEncoder> Queue::ensureBlitCommandEncoder()
     if (m_blitCommandEncoder && m_blitCommandEncoder == encoderForBuffer(m_commandBuffer))
         return m_blitCommandEncoder;
 
+    if (m_stagedCopyEncoder && m_stagedCopyEncoder == encoderForBuffer(m_commandBuffer)) {
+        // Switch encoder types on the open staging command buffer rather than minting a second one.
+        endEncoding(m_stagedCopyEncoder, m_commandBuffer);
+        m_stagedCopyEncoder = nil;
+        m_blitCommandEncoder = [m_commandBuffer blitCommandEncoder];
+        if (!m_blitCommandEncoder) {
+            // See ensureStagedCopyEncoder(): committing beats orphaning the work already encoded.
+            commitMTLCommandBuffer(m_commandBuffer);
+            m_commandBuffer = nil;
+            return nil;
+        }
+        setEncoderForBuffer(m_commandBuffer, m_blitCommandEncoder);
+        return m_blitCommandEncoder;
+    }
+
     auto *commandBufferDescriptor = [MTLCommandBufferDescriptor new];
     auto blitCommandBuffer = commandBufferWithDescriptor(commandBufferDescriptor);
     m_commandBuffer = blitCommandBuffer;
+    m_stagedCopyEncoder = nil;
     m_blitCommandEncoder = [m_commandBuffer blitCommandEncoder];
     setEncoderForBuffer(m_commandBuffer, m_blitCommandEncoder);
     return m_blitCommandEncoder;
 }
 
+id<MTLComputeCommandEncoder> Queue::ensureStagedCopyEncoder()
+{
+    if (m_stagedCopyEncoder && m_stagedCopyEncoder == encoderForBuffer(m_commandBuffer))
+        return m_stagedCopyEncoder;
+
+    if (m_blitCommandEncoder && m_blitCommandEncoder == encoderForBuffer(m_commandBuffer)) {
+        // Switch encoder types on the open staging command buffer rather than minting a second one.
+        endEncoding(m_blitCommandEncoder, m_commandBuffer);
+        m_blitCommandEncoder = nil;
+        m_stagedCopyEncoder = [m_commandBuffer computeCommandEncoder];
+        if (!m_stagedCopyEncoder) {
+            // Encoder creation failed after the previous encoder was ended, so the staging command
+            // buffer now holds real work with nothing open on it. finalizeBlitCommandEncoder() keys
+            // off the encoders, so leaving it here would orphan it and drop that work; commit it.
+            commitMTLCommandBuffer(m_commandBuffer);
+            m_commandBuffer = nil;
+            return nil;
+        }
+        setEncoderForBuffer(m_commandBuffer, m_stagedCopyEncoder);
+        return m_stagedCopyEncoder;
+    }
+
+    auto *commandBufferDescriptor = [MTLCommandBufferDescriptor new];
+    auto stagingCommandBuffer = commandBufferWithDescriptor(commandBufferDescriptor);
+    m_commandBuffer = stagingCommandBuffer;
+    m_blitCommandEncoder = nil;
+    m_stagedCopyEncoder = [m_commandBuffer computeCommandEncoder];
+    setEncoderForBuffer(m_commandBuffer, m_stagedCopyEncoder);
+    return m_stagedCopyEncoder;
+}
+
 void Queue::finalizeBlitCommandEncoder()
 {
-    if (m_blitCommandEncoder) {
-        endEncoding(m_blitCommandEncoder, m_commandBuffer);
+    // Finalizes the queue-owned staging command buffer, whichever encoder type is
+    // currently open on it (blit, or the compute staged-copy encoder).
+    if (m_blitCommandEncoder || m_stagedCopyEncoder) {
+        id<MTLCommandEncoder> stagingEncoder = m_blitCommandEncoder;
+        if (!stagingEncoder)
+            stagingEncoder = m_stagedCopyEncoder;
+        endEncoding(stagingEncoder, m_commandBuffer);
         commitMTLCommandBuffer(m_commandBuffer);
         m_blitCommandEncoder = nil;
+        m_stagedCopyEncoder = nil;
+        m_commandBuffer = nil;
+    } else if (m_commandBuffer) {
+        // A staging command buffer with no encoder open: reachable if encoder creation failed. Its
+        // already-encoded work must still reach the GPU in order, so commit rather than drop.
+        commitMTLCommandBuffer(m_commandBuffer);
         m_commandBuffer = nil;
     }
+}
+
+// Host mirror of the MSL `WebKitStagedCopyArgs` declared in the kernel source below. The two
+// declarations are adjacent deliberately: they are a hand-maintained ABI, and getting the field
+// widths wrong produces silently wrong offsets rather than a compile error. MSL `ulong` is 64-bit,
+// so the static_asserts below pin size and every offset.
+struct StagedCopyArguments {
+    uint64_t sourceWordOffset;
+    uint64_t destinationWordOffset;
+    uint64_t wordCount;
+};
+static_assert(sizeof(StagedCopyArguments) == 24, "StagedCopyArguments must match MSL WebKitStagedCopyArgs (3 x ulong)");
+static_assert(!offsetof(StagedCopyArguments, sourceWordOffset), "sourceWordOffset must be at offset 0");
+static_assert(offsetof(StagedCopyArguments, destinationWordOffset) == 8, "destinationWordOffset must be at offset 8");
+static_assert(offsetof(StagedCopyArguments, wordCount) == 16, "wordCount must be at offset 16");
+
+id<MTLComputePipelineState> Queue::stagedCopyPipelineState()
+{
+    if (m_stagedCopyPipelineState || m_stagedCopyPipelineCreationFailed)
+        return m_stagedCopyPipelineState;
+
+    auto device = m_device.get();
+    id<MTLDevice> mtlDevice = device ? device->device() : nil;
+    if (!mtlDevice)
+        return nil;
+
+    NSError *error = nil;
+    /* NOLINT */ id<MTLLibrary> library = [mtlDevice newLibraryWithSource:@R"(#include <metal_stdlib>
+using namespace metal;
+struct WebKitStagedCopyArgs {
+    ulong sourceWordOffset;
+    ulong destinationWordOffset;
+    ulong wordCount;
+};
+[[kernel]] void csStagedBufferCopy(device const uint* source [[buffer(0)]], device uint* destination [[buffer(1)]], constant WebKitStagedCopyArgs& args [[buffer(2)]], uint threadIndex [[thread_position_in_grid]], uint threadsPerGrid [[threads_per_grid]])
+{
+    for (ulong i = threadIndex; i < args.wordCount; i += threadsPerGrid)
+        destination[args.destinationWordOffset + i] = source[args.sourceWordOffset + i];
+})" options:nil error:&error];
+    id<MTLFunction> function = error ? nil : [library newFunctionWithName:@"csStagedBufferCopy"];
+    if (function)
+        m_stagedCopyPipelineState = [mtlDevice newComputePipelineStateWithFunction:function error:&error];
+    if (!m_stagedCopyPipelineState) {
+        m_stagedCopyPipelineCreationFailed = true;
+        WTFLogAlways("WebGPU: staged-copy compute pipeline creation failed (%@); staged writes will fall back to blit", error); // NOLINT
+    }
+    return m_stagedCopyPipelineState;
 }
 
 void Queue::endEncoding(id<MTLCommandEncoder> commandEncoder, id<MTLCommandBuffer> commandBuffer) const
@@ -625,11 +733,15 @@ void Queue::writeBuffer(id<MTLBuffer> buffer, uint64_t bufferOffset, std::span<u
     }
 #endif
 
+    stageBufferWrite(buffer, bufferOffset, data);
+}
+
+void Queue::stageBufferWrite(id<MTLBuffer> buffer, uint64_t bufferOffset, std::span<uint8_t> data)
+{
     auto device = m_device.get();
-    if (!device)
+    if (!device || !buffer || data.empty())
         return;
 
-    ensureBlitCommandEncoder();
     bool noCopy = data.size() >= largeBufferSize;
     auto bufferWithOffset = newTemporaryBufferWithBytes(data, noCopy);
     id<MTLBuffer> temporaryBuffer = bufferWithOffset.first;
@@ -639,14 +751,70 @@ void Queue::writeBuffer(id<MTLBuffer> buffer, uint64_t bufferOffset, std::span<u
         return;
     }
 
+    encodeStagedCopy(temporaryBuffer, temporaryBufferOffset, buffer, bufferOffset, data.size(), noCopy);
+}
+
+// Encodes an already-staged copy, choosing the channel it rides. Split out from stageBufferWrite so
+// the Swift entry point can share the channel decision without converting spans across the language
+// boundary (Queue.swift).
+//
+// Encode the staged copy on the compute channel when possible. Standalone blit-only staging command
+// buffers interleaved with user compute submissions intermittently deadlock the AGX blit/DMA channel
+// (the driver reports kIOGPUCommandBufferCallbackErrorHang on the staging command buffer and
+// discards neighboring command buffers as innocent victims), losing the device. Encoding the same
+// copies as compute dispatches keeps the commit points, queue ordering, and hazard tracking
+// identical while keeping the per-frame hot path off the blit channel entirely. GPUQueue.writeBuffer
+// validation guarantees 4-byte alignment of both offset and size, and the staging suballocator is
+// 64-byte aligned, so the word-copy kernel covers every spec-reachable write; the blit encoder
+// remains as the fallback (and for writeTexture, clearBuffer, and internal copies).
+void Queue::encodeStagedCopy(id<MTLBuffer> temporaryBuffer, uint64_t temporaryBufferOffset, id<MTLBuffer> buffer, uint64_t bufferOffset, uint64_t size, bool finalizeAfterCopy)
+{
+    if (!temporaryBuffer || !buffer || !size)
+        return;
+
+    // The copy kernel's loop is bounded by wordCount alone, so a bad range would write out of
+    // bounds rather than fault. Check both sides here, by subtraction so the sums cannot overflow.
+    if (bufferOffset > buffer.length || size > buffer.length - bufferOffset)
+        return;
+    if (temporaryBufferOffset > temporaryBuffer.length || size > temporaryBuffer.length - temporaryBufferOffset)
+        return;
+
+    bool wordAligned = !(bufferOffset % sizeof(uint32_t)) && !(size % sizeof(uint32_t)) && !(temporaryBufferOffset % sizeof(uint32_t));
+    id<MTLComputePipelineState> pipelineState = wordAligned ? stagedCopyPipelineState() : nil;
+    // A null encoder here means creation failed, not that compute is unavailable; fall through to
+    // the blit encoder rather than dropping the copy, which would leave the destination stale.
+    id<MTLComputeCommandEncoder> stagedCopyEncoder = pipelineState ? ensureStagedCopyEncoder() : nil;
+    if (stagedCopyEncoder) {
+        StagedCopyArguments args {
+            temporaryBufferOffset / sizeof(uint32_t),
+            bufferOffset / sizeof(uint32_t),
+            size / sizeof(uint32_t)
+        };
+        [stagedCopyEncoder setComputePipelineState:pipelineState];
+        [stagedCopyEncoder setBuffer:temporaryBuffer offset:0 atIndex:0];
+        [stagedCopyEncoder setBuffer:buffer offset:0 atIndex:1];
+        [stagedCopyEncoder setBytes:&args length:sizeof(args) atIndex:2];
+        auto threadsPerThreadgroup = std::min<uint64_t>(256, pipelineState.maxTotalThreadsPerThreadgroup);
+        auto threadgroups = std::min<uint64_t>((args.wordCount + threadsPerThreadgroup - 1) / threadsPerThreadgroup, 2048);
+        [stagedCopyEncoder dispatchThreadgroups:MTLSizeMake(static_cast<NSUInteger>(threadgroups), 1, 1) threadsPerThreadgroup:MTLSizeMake(static_cast<NSUInteger>(threadsPerThreadgroup), 1, 1)];
+
+        if (finalizeAfterCopy)
+            finalizeBlitCommandEncoder();
+        return;
+    }
+
+    ensureBlitCommandEncoder();
+    if (!m_blitCommandEncoder)
+        return;
+
     [m_blitCommandEncoder
         copyFromBuffer:temporaryBuffer
         sourceOffset:temporaryBufferOffset
         toBuffer:buffer
         destinationOffset:bufferOffset
-        size:data.size()];
+        size:size];
 
-    if (noCopy)
+    if (finalizeAfterCopy)
         finalizeBlitCommandEncoder();
 }
 
@@ -662,7 +830,7 @@ void Queue::clearBuffer(id<MTLBuffer> buffer, NSUInteger offset, NSUInteger size
 
 bool Queue::isIdle() const
 {
-    return m_submittedCommandBufferCount == m_completedCommandBufferCount && !m_blitCommandEncoder;
+    return m_submittedCommandBufferCount == m_completedCommandBufferCount && !m_blitCommandEncoder && !m_stagedCopyEncoder;
 }
 
 NSString* Queue::errorValidatingWriteTexture(const WGPUImageCopyTexture& destination, const WGPUTextureDataLayout& dataLayout, const WGPUExtent3D& size, size_t dataByteSize, const Texture& texture) const

--- a/Source/WebGPU/WebGPU/Queue.swift
+++ b/Source/WebGPU/WebGPU/Queue.swift
@@ -38,10 +38,6 @@ extension WebGPU.Queue {
             return
         }
 
-        guard let blitCommandEncoder = ensureBlitCommandEncoder() else {
-            return
-        }
-
         let count = data.count
         let noCopy = data.count >= largeBufferSize
         // FIXME: 'bufferWithOffset' may extend the lifetime of 'data', but we drop that information here.
@@ -54,16 +50,11 @@ extension WebGPU.Queue {
             return
         }
 
-        blitCommandEncoder.copy(
-            from: temporaryBuffer,
-            sourceOffset: Int(temporaryBufferOffset),
-            to: buffer,
-            destinationOffset: Int(bufferOffset),
-            size: count
-        )
-
-        if noCopy {
-            finalizeBlitCommandEncoder()
-        }
+        // Shared channel decision with the C++ backend (Queue::encodeStagedCopy): the staged copy
+        // is encoded on the compute channel when possible, because standalone blit-only staging
+        // command buffers interleaved with user compute submissions intermittently deadlock the
+        // AGX blit/DMA channel. See Queue.mm for the full rationale. Passing the staging buffer
+        // and byte offsets keeps this call free of span interop, so it needs no 'unsafe'.
+        encodeStagedCopy(temporaryBuffer, temporaryBufferOffset, buffer, bufferOffset, UInt64(count), noCopy)
     }
 }


### PR DESCRIPTION
#### 5fec87731f0c6d4370f2dc4cc96bc637ccb3fe61
<pre>
WebGPU: stage writeBuffer uploads on the compute channel, not standalone blit command buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321676">https://bugs.webkit.org/show_bug.cgi?id=321676</a>
<a href="https://rdar.apple.com/184823819">rdar://184823819</a>

Reviewed by Mike Wyrzykowski

GPUQueue.writeBuffer stages uploads by encoding copies into a queue-owned,
blit-only MTLCommandBuffer that is committed standalone at each flush point
(Queue::finalizeBlitCommandEncoder, called from submit()). A page that
interleaves writeBuffer bursts with compute submits therefore commits a
per-frame pattern of C,SB,C,SB,C,SB,C,R (SB = staging blit CB). On Apple
silicon the AGX driver intermittently deadlocks the blit/DMA channel under
this cross-channel interleave: the newest SB completes with
kIOGPUCommandBufferCallbackErrorHang (IOGPUCommandQueueError Code=3, encoder
state Affected, Metal validation clean, queue drained between frames) and its
neighbors are discarded as innocent victims, losing the device. Traced 4/4 in
a worker+OffscreenCanvas repro (48 writes + 4 compute submits + present per
frame); coalescing the app&apos;s writes to one blit per frame measured 0/7 deaths
against an 8/10 control, implicating the standalone staging-blit interleave.

The staging command buffer&apos;s commit points cannot move: burst-k copies must be
GPU-ordered after the submit that precedes them (anti-hazard on the
destination) and before the submit that follows (true dependency), and user
command buffers arrive pre-encoded, so the copies cannot be prepended into
them either. What can move is the engine the copies run on. This change
encodes staged writeBuffer copies as dispatches of a trivial word-copy compute
kernel in the same queue-owned staging command buffer, at the same commit
points, with the same (tracked) hazard semantics - taking the per-frame hot
path off the blit/DMA channel entirely. writeBuffer&apos;s validation guarantees
4-byte alignment of offset and size and the staging suballocator is 64-byte
aligned, so the kernel covers every spec-reachable write.

The blit encoder path remains for writeTexture, clearBuffer, texture clears,
ICB trims, managed-buffer synchronization, and as a fallback if the copy
pipeline cannot be created; mixed bursts share one staging command buffer,
switching encoder types in place. Both writeBuffer backends share the channel
decision: the C++ path reaches it through Queue::stageBufferWrite, and the
Swift path, which allocates its own staging buffer, hands the resulting buffer
and byte offsets to the same Queue::encodeStagedCopy. Passing scalars rather
than a std::span keeps the Swift call free of span interop, so it introduces no
new use of &apos;unsafe&apos;.

Two safety properties the staging path did not previously hold. Switching
encoder types ends the open encoder before creating the replacement, so a null
result left both encoder pointers nil while the staging command buffer still
held encoded work; finalizeBlitCommandEncoder() keys off the encoders and would
have dropped it. Encoder creation failure now commits that command buffer
instead of orphaning it, finalize commits a live staging buffer with no encoder
open, and a null compute encoder falls through to the blit encoder rather than
returning and leaving the destination stale.

The copy kernel&apos;s loop is bounded by wordCount alone, so its argument block is a
hand-maintained ABI with no compile-time link to the MSL struct. It is now a
named StagedCopyArguments with static_asserts pinning its size and every field
offset against the MSL declaration beside it, and encodeStagedCopy bounds-checks
both source and destination ranges by subtraction before dispatching.

Measured on that repro (30 s exposures, trunk f3f75e99, M3 Max, macOS 26.3):
device loss falls from 8/10 and 4/4 in controls to 2 in 21 exposures. The
remaining failures blame the staging compute command buffer with the identical
signature, so this is a mitigation and not a fix: the hazard is the standalone
per-burst staging command buffer itself, on either channel. Removing it
entirely needs deferred encoding of staged copies into the next user command
buffer, or per-resource idle tracking to widen the existing direct-memcpy fast
path. writeTexture still mints per-burst staging blits and is unchanged here.

This contribution was funded by Spawn

Canonical link: <a href="https://commits.webkit.org/319291@main">https://commits.webkit.org/319291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/384d8e08826bdb63e8d049bf7f6a978477da3db5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191296 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145404 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141297 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121748 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43634 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41918 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154038 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41575 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2455 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193230 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54692 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150684 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40313 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55380 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150400 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44993 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127646 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123188 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53897 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16570 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53279 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->