### PR TITLE
Verify used (not computed) value of user-select in modern-media-controls tests

### DIFF
--- a/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section-expected.txt
+++ b/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section-expected.txt
@@ -4,9 +4,14 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS !!document.querySelector('.placard') became true
-PASS window.getComputedStyle(document.querySelector('.title')).webkitUserSelect is "none"
+PASS selectedText.includes("text selection is turned off") is true
+PASS document.querySelector('.title').textContent is "AirPlay"
+PASS document.querySelector('.title').getClientRects().length > 0 is true
+PASS selectedText.includes("AirPlay") is false
 PASS window.getComputedStyle(document.querySelector('.title')).cursor is "default"
-PASS window.getComputedStyle(document.querySelector('.description')).webkitUserSelect is "none"
+PASS document.querySelector('.description').textContent is "This video is playing on the TV."
+PASS document.querySelector('.description').getClientRects().length > 0 is true
+PASS selectedText.includes("This video is playing on the TV.") is false
 PASS window.getComputedStyle(document.querySelector('.description')).cursor is "default"
 
 PASS successfullyParsed is true

--- a/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section.html
+++ b/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section.html
@@ -13,9 +13,18 @@ mediaControls.placard = mediaControls.airplayPlacard;
 document.body.appendChild(mediaControls.element);
 
 shouldBecomeEqual("!!document.querySelector('.placard')", "true", () => {
-    shouldBeEqualToString("window.getComputedStyle(document.querySelector('.title')).webkitUserSelect", "none");
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.selectAllChildren(document.body);
+    window.selectedText = selection.toString();
+    shouldBeTrue('selectedText.includes("text selection is turned off")');
+    shouldBeEqualToString("document.querySelector('.title').textContent", "AirPlay");
+    shouldBeTrue("document.querySelector('.title').getClientRects().length > 0");
+    shouldBeFalse('selectedText.includes("AirPlay")');
     shouldBeEqualToString("window.getComputedStyle(document.querySelector('.title')).cursor", "default");
-    shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).webkitUserSelect", "none");
+    shouldBeEqualToString("document.querySelector('.description').textContent", "This video is playing on the TV.");
+    shouldBeTrue("document.querySelector('.description').getClientRects().length > 0");
+    shouldBeFalse('selectedText.includes("This video is playing on the TV.")');
     shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).cursor", "default");
 
     mediaControls.element.remove();

--- a/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section-expected.txt
+++ b/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section-expected.txt
@@ -3,7 +3,10 @@ Testing that text selection is turned off for PiPPlacard.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS window.getComputedStyle(document.querySelector('.description')).webkitUserSelect is "none"
+PASS selectedText.includes("text selection is turned off") is true
+PASS document.querySelector('.description').textContent is "This video is playing in picture in picture."
+PASS document.querySelector('.description').getClientRects().length > 0 is true
+PASS selectedText.includes("This video is playing in picture in picture.") is false
 PASS window.getComputedStyle(document.querySelector('.description')).cursor is "default"
 
 PASS successfullyParsed is true

--- a/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section.html
+++ b/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section.html
@@ -14,7 +14,14 @@ document.body.appendChild(mediaControls.element);
 
 scheduler.frameDidFire = function()
 {
-    shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).webkitUserSelect", "none");
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.selectAllChildren(document.body);
+    window.selectedText = selection.toString();
+    shouldBeTrue('selectedText.includes("text selection is turned off")');
+    shouldBeEqualToString("document.querySelector('.description').textContent", "This video is playing in picture in picture.");
+    shouldBeTrue("document.querySelector('.description').getClientRects().length > 0");
+    shouldBeFalse('selectedText.includes("This video is playing in picture in picture.")');
     shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).cursor", "default");
 
     mediaControls.element.remove();

--- a/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection-expected.txt
+++ b/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection-expected.txt
@@ -3,7 +3,10 @@ Testing that text selection is turned off for StatusLabel.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS window.getComputedStyle(mediaControls.statusLabel.element).webkitUserSelect is "none"
+PASS selectedText.includes("text selection is turned off") is true
+PASS mediaControls.statusLabel.element.textContent is "Hello"
+PASS mediaControls.statusLabel.element.getClientRects().length > 0 is true
+PASS selectedText.includes("Hello") is false
 PASS window.getComputedStyle(mediaControls.statusLabel.element).cursor is "default"
 
 PASS successfullyParsed is true

--- a/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection.html
+++ b/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection.html
@@ -16,7 +16,14 @@ document.body.appendChild(mediaControls.element);
 
 scheduler.frameDidFire = function()
 {
-    shouldBeEqualToString("window.getComputedStyle(mediaControls.statusLabel.element).webkitUserSelect", "none");
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.selectAllChildren(document.body);
+    window.selectedText = selection.toString();
+    shouldBeTrue('selectedText.includes("text selection is turned off")');
+    shouldBeEqualToString("mediaControls.statusLabel.element.textContent", "Hello");
+    shouldBeTrue("mediaControls.statusLabel.element.getClientRects().length > 0");
+    shouldBeFalse('selectedText.includes("Hello")');
     shouldBeEqualToString("window.getComputedStyle(mediaControls.statusLabel.element).cursor", "default");
     mediaControls.element.remove();
     debug("");


### PR DESCRIPTION
#### 3ebb8e36b597779c7c883c3c50d9f4dcdab5b25c
<pre>
Verify used (not computed) value of user-select in modern-media-controls tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=321698">https://bugs.webkit.org/show_bug.cgi?id=321698</a>
<a href="https://rdar.apple.com/184843797">rdar://184843797</a>

Reviewed by Tim Nguyen.

Three media/modern-media-controls/ tests now verify selectability with
`selection.selectAllChildren()` instead of
`getComputedStyle().webkitUserSelect`. This means we now verify the
used value instead of the computed value.

While the computed and used value are in agreement today, this is not
the specced behavior for user-select, so this should simplify a
future effort to unprefix -webkit-user-select.

Spec link: <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/user-select#formal_definition.">https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/user-select#formal_definition.</a>

* LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section-expected.txt:
* LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section.html:
* LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section-expected.txt:
* LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section.html:
* LayoutTests/media/modern-media-controls/status-label/status-label-text-selection-expected.txt:
* LayoutTests/media/modern-media-controls/status-label/status-label-text-selection.html:

Canonical link: <a href="https://commits.webkit.org/319170@main">https://commits.webkit.org/319170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24a23d6b4736054cd7a49ae4d6c80afbb1e3cdab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190801 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144912 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a52b2650-be84-45ce-9d45-48a1602c2fc4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140852 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77a4419d-8e39-42f5-a021-c16037ac8506) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161628 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121304 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1947249-0667-4591-87ae-7f08e14eff02) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41481 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153603 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41157 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Passed layout tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1960 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192737 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150231 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40226 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54889 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149948 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44568 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122368 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53406 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16146 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53025 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->