### PR TITLE
Changing the projection attribute on a playing video does not update the spatial video renderer (experimental)

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/spatial-video-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/spatial-video-support.js
@@ -41,7 +41,7 @@ class SpatialVideoSupport extends MediaControllerSupport
 
     get mediaEvents()
     {
-        return ["loadedmetadata", "resize"];
+        return ["loadedmetadata", "resize", "webkitprojectionchanged"];
     }
 
     get tracksToMonitor()
@@ -72,7 +72,7 @@ class SpatialVideoSupport extends MediaControllerSupport
     _maybeEnable()
     {
         const media = this.mediaController.media;
-        if (this._active || !(media instanceof HTMLVideoElement))
+        if (!(media instanceof HTMLVideoElement))
             return;
 
         const host = this.mediaController.host;
@@ -80,8 +80,21 @@ class SpatialVideoSupport extends MediaControllerSupport
             return;
 
         const resolved = this._resolveProjection(media, host);
-        if (!resolved)
+        if (!resolved) {
+            if (this._active)
+                this._teardown();
             return;
+        }
+
+        if (this._active) {
+            if (resolved.projection === this._projection && resolved.fovDegrees === this._fovDegrees)
+                return;
+            this._projection = resolved.projection;
+            this._fovDegrees = resolved.fovDegrees;
+            this._buildMesh(this._projection);
+            return;
+        }
+
         this._projection = resolved.projection;
         this._fovDegrees = resolved.fovDegrees;
 

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -324,6 +324,7 @@
     "webkitnetworkinfochange": { },
     "webkitplaybacktargetavailabilitychanged": { },
     "webkitpresentationmodechanged": { },
+    "webkitprojectionchanged": { },
     "webkitremovesourcebuffer": { },
     "webkitsourceclose": { },
     "webkitsourceended": { },

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -463,4 +463,5 @@ x-apple-data-detectors-type
 x-apple-pdf-annotation
 x-itunes-inherit-uri-query-component
 x-webkit-airplay
+x-webkit-projection
 x-webkit-wirelessvideoplaybackdisabled

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -239,6 +239,9 @@ void HTMLVideoElement::attributeChanged(const QualifiedName& name, const AtomStr
     } else {
         HTMLMediaElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
+        if (name == webkitprojectionAttr && oldValue != newValue && document().settings().spatialVideoRenderingEnabled())
+            scheduleEvent(eventNames().webkitprojectionchangedEvent);
+
 #if PLATFORM(IOS_FAMILY) && ENABLE(WIRELESS_PLAYBACK_TARGET)
         if (name == webkitairplayAttr)
             protect(mediaSession())->setWirelessVideoPlaybackDisabled(isWirelessPlaybackTargetDisabled());

--- a/Source/WebCore/html/HTMLVideoElement.idl
+++ b/Source/WebCore/html/HTMLVideoElement.idl
@@ -39,6 +39,7 @@
     [CEReactions=NotNeeded, Reflect] attribute boolean playsInline;
 
     // Non-standard
+    [CEReactions=NotNeeded, Reflect="webkitprojection", EnabledBySetting=SpatialVideoRenderingEnabled] attribute DOMString projection;
     readonly attribute boolean webkitSupportsFullscreen;
     readonly attribute boolean webkitDisplayingFullscreen;
 


### PR DESCRIPTION
#### 980c70c85a474a9dfa0404174ee002ca75ba3b3c
<pre>
Changing the projection attribute on a playing video does not update the spatial video renderer (experimental)
<a href="https://bugs.webkit.org/show_bug.cgi?id=321703">https://bugs.webkit.org/show_bug.cgi?id=321703</a>
<a href="https://rdar.apple.com/184845771">rdar://184845771</a>

Reviewed by Jer Noble.

x-webkit-projection was read with getAttribute() and was not a registered attribute, so nothing
notified the renderer when it changed. Setting it on a video that was already rendering did nothing
until the next loadedmetadata or resize, and there was no reflected IDL attribute, so the
projection could only be declared in markup and never read back.

Register the attribute so it generates webkitprojectionAttr, reflect it on HTMLVideoElement as
projection behind SpatialVideoRenderingEnabled, and schedule a webkitprojectionchanged event when
its value changes. SpatialVideoSupport listens for that event and re-resolves the projection.

Resolving while active no longer requires tearing down the WebGL context: _buildMesh() producesthe
mesh and the feather amount, and the draw loop binds the mesh each frame, so a changed projection
only needs the mesh rebuilt. An unchanged result is a no-op, and a projection that resolves to
nothing tears the renderer down so the video returns to being presented as-is.

* Source/WebCore/Modules/modern-media-controls/media/spatial-video-support.js:
(SpatialVideoSupport.prototype.get mediaEvents):
(SpatialVideoSupport.prototype._maybeEnable):
* Source/WebCore/dom/EventNames.json:
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::attributeChanged):
* Source/WebCore/html/HTMLVideoElement.idl:

Canonical link: <a href="https://commits.webkit.org/319383@main">https://commits.webkit.org/319383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40fe9368dc991eeeee157a62f313231cb43b2e50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [⏳ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | ⏳ 🛠 vision-apple 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40420 "Built successfully and passed tests") | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->