### PR TITLE
[Navigation API] precommitHandler-traverse.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traversal-window-stop-before-commit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traversal-window-stop-before-commit-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL precommitHandler traversal is not aborted by window.stop() before commit assert_equals: expected "#2" but got "#1"
+PASS precommitHandler traversal is not aborted by window.stop() before commit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traverse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traverse-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL precommitHandler for a traverse navigation, reject before commit assert_equals: expected object "Error: assert_equals: hash after first async step expected "#4" but got """ but got object "Error: boo!"
-FAIL precommitHandler for a traverse navigation, reject after commit assert_equals: hash after first async step expected "" but got "#1"
-FAIL precommitHandler for a traverse navigation, success assert_equals: hash after first async step expected "#1" but got "#3"
+PASS precommitHandler for a traverse navigation, reject before commit
+PASS precommitHandler for a traverse navigation, reject after commit
+PASS precommitHandler for a traverse navigation, success
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4636,6 +4636,21 @@ void FrameLoader::loadSameDocumentItem(HistoryItem& item)
         history->restoreScrollPositionAndViewState();
 }
 
+void FrameLoader::clearDeferredTraversal()
+{
+    m_deferredTraversalItem = nullptr;
+}
+
+void FrameLoader::resumeDeferredTraversal()
+{
+    RefPtr item = std::exchange(m_deferredTraversalItem, nullptr);
+    if (!item)
+        return;
+
+    m_loadType = m_deferredTraversalLoadType;
+    loadSameDocumentItem(*item);
+}
+
 // FIXME: This function should really be split into a couple pieces, some of
 // which should be methods of HistoryController and some of which should be
 // methods of FrameLoader.
@@ -4789,8 +4804,17 @@ void FrameLoader::loadItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadTy
             // https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-traverse-navigate-event
             if (RefPtr window = frame().document()->window()) {
                 if (RefPtr navigation = window->navigation(); navigation->frame()) {
-                    if (navigation->dispatchTraversalNavigateEvent(item) == Navigation::DispatchResult::Aborted)
+                    auto dispatchResult = navigation->dispatchTraversalNavigateEvent(item);
+                    if (dispatchResult == Navigation::DispatchResult::Aborted)
                         return;
+                    if (dispatchResult == Navigation::DispatchResult::DeferredCommit) {
+                        // A precommit handler is still pending, so the traverse history step must
+                        // not be applied yet. Navigation resumes it once the precommit handler
+                        // promises fulfill, and discards it if the navigation is aborted before.
+                        m_deferredTraversalItem = &item;
+                        m_deferredTraversalLoadType = loadType;
+                        return;
+                    }
                     // In case the event detached the frame.
                     if (!navigation->frame())
                         return;

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -365,6 +365,9 @@ public:
 
     void updateURLAndHistory(const URL&, RefPtr<SerializedScriptValue>&& stateObject, NavigationHistoryBehavior = NavigationHistoryBehavior::Replace);
 
+    void clearDeferredTraversal();
+    void resumeDeferredTraversal();
+
     WEBCORE_EXPORT void NODELETE setPendingAsyncBackForwardNavigation();
     WEBCORE_EXPORT void cancelPendingAsyncBackForwardNavigation();
     bool asyncBackForwardNavigationWasCancelled() const { return m_asyncBackForwardNavigationState == AsyncBackForwardNavigationState::Cancelled; }
@@ -580,6 +583,8 @@ private:
     bool m_doNotAbortNavigationAPI { false };
     bool m_isDispatchingPageSwapEvent { false };
     RefPtr<HistoryItem> m_pendingNavigationAPIItem;
+    RefPtr<HistoryItem> m_deferredTraversalItem;
+    FrameLoadType m_deferredTraversalLoadType { FrameLoadType::IndexedBackForward };
     uint64_t m_requiredCookiesVersion { 0 };
 
     const Ref<DocumentPrefetcher> m_documentPrefetcher;

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1016,12 +1016,28 @@ auto Navigation::registerAbortHandler() -> Ref<AbortHandler>
     return abortHandler;
 }
 
+void Navigation::clearDeferredTraversalIfNeeded()
+{
+    if (RefPtr localFrame = frame())
+        localFrame->loader().clearDeferredTraversal();
+}
+
+void Navigation::resumeDeferredTraversalIfNeeded()
+{
+    if (RefPtr localFrame = frame())
+        localFrame->loader().resumeDeferredTraversal();
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#abort-the-ongoing-navigation
 void Navigation::abortOngoingNavigation(NavigateEvent& event)
 {
     m_abortHandlers.forEach([](auto& abortHandler) {
         abortHandler.markAsAborted();
     });
+
+    // A traverse history step deferred by a pending precommit handler must never be applied
+    // once the navigation is aborted.
+    clearDeferredTraversalIfNeeded();
 
     RefPtr scriptExecutionContext = this->scriptExecutionContext();
     auto* globalObject = scriptExecutionContext->globalObject();
@@ -1253,97 +1269,77 @@ std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigati
     if (navigationType == NavigationNavigationType::Traverse && event.wasIntercepted() && apiMethodTracker && !apiMethodTracker->hasCommitted())
         notifyCommittedToEntry(apiMethodTracker, protect(currentEntry()).get(), navigationType);
 
-    if (!event.wasIntercepted() && !apiMethodTracker) {
-        // For non-intercepted same-document navigations without a JS-initiated tracker
-        // (e.g., BFCache restorations, fragment navigations via link clicks), use a queued
-        // task instead of PromiseSettlementObserver. This avoids creating JS heap objects
-        // (DeferredPromise, DOMPromise) during commitProvisionalLoad, which can interfere
-        // with plugin initialization (e.g., UnifiedPDF during BFCache restoration).
-        RefPtr scriptExecutionContext = this->scriptExecutionContext();
-        protect(scriptExecutionContext->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { this }, abortController = Ref { abortController }]() {
+    // https://webidl.spec.whatwg.org/#wait-for-all
+    auto successSteps = [navigationType, weakThis = WeakPtr { this }, abortController = Ref { abortController }, document = Ref { document }, apiMethodTracker = RefPtr { apiMethodTracker }]() mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
+            return;
+
+        auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
+        protect(protectedThis->ongoingNavigateEvent())->finish(document, InterceptionHandlersDidFulfill::Yes, focusChanged);
+        protectedThis->m_ongoingNavigateEvent = nullptr;
+
+        auto dispatchSuccess = [weakThis, abortController, document, apiMethodTracker]() mutable {
             RefPtr protectedThis = weakThis.get();
-            if (!protectedThis || abortController->signal().aborted())
-                return;
-            RefPtr document = dynamicDowncast<Document>(protectedThis->scriptExecutionContext());
-            if (!document || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
+            if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive())
                 return;
 
-            protectedThis->m_ongoingNavigateEvent = nullptr;
             protectedThis->dispatchEvent(Event::create(eventNames().navigatesuccessEvent, { }));
-        });
-    } else {
-        // https://webidl.spec.whatwg.org/#wait-for-all
-        auto successSteps = [navigationType, weakThis = WeakPtr { this }, abortController = Ref { abortController }, document = Ref { document }, apiMethodTracker = RefPtr { apiMethodTracker }]() mutable {
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
-                return;
 
-            auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
-            protect(protectedThis->ongoingNavigateEvent())->finish(document, InterceptionHandlersDidFulfill::Yes, focusChanged);
-            protectedThis->m_ongoingNavigateEvent = nullptr;
-
-            auto dispatchSuccess = [weakThis, abortController, document, apiMethodTracker]() mutable {
-                RefPtr protectedThis = weakThis.get();
-                if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive())
-                    return;
-
-                protectedThis->dispatchEvent(Event::create(eventNames().navigatesuccessEvent, { }));
-
-                if (apiMethodTracker)
-                    protectedThis->resolveFinishedPromise(apiMethodTracker.get());
-
-                if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
-                    transition->resolvePromise();
-            };
-
-            // For traverse navigations the committed-to entry is notified earlier (see notifyCommittedToEntry),
-            // so the committed promise reactions must run before navigatesuccess.
-            // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm
-            if (navigationType == NavigationNavigationType::Traverse)
-                protect(document->eventLoop())->queueMicrotask(document->vm(), WTF::move(dispatchSuccess));
-            else
-                dispatchSuccess();
-        };
-
-        auto failureSteps = [weakThis = WeakPtr { this }, abortController = Ref { abortController }, document = Ref { document }, apiMethodTracker = RefPtr { apiMethodTracker }](JSC::JSValue result) mutable {
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
-                return;
-
-            auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
-            protect(protectedThis->ongoingNavigateEvent())->finish(document, InterceptionHandlersDidFulfill::No, focusChanged);
-
-            abortController->signal().signalAbort(result);
-
-            protectedThis->m_ongoingNavigateEvent = nullptr;
-
-            ErrorInformation errorInformation;
-            String errorMessage;
-            if (auto* errorInstance = dynamicDowncast<JSC::ErrorInstance>(result)) {
-                if (auto extracted = extractErrorInformationFromErrorInstance(protect(protectedThis->scriptExecutionContext())->globalObject(), *errorInstance)) {
-                    errorInformation = WTF::move(*extracted);
-                    errorMessage = makeString("Uncaught "_s, errorInformation.errorTypeString, ": "_s, errorInformation.message);
-                }
-            }
-
-            auto* navGlobalObject = protect(protectedThis->scriptExecutionContext())->globalObject();
-            protectedThis->dispatchEvent(ErrorEvent::create(*navGlobalObject, eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { navGlobalObject->vm(), result }));
-
-            if (apiMethodTracker) {
-                apiMethodTracker->rejectFinished(result);
-                protectedThis->m_methodTrackers.unregister(*apiMethodTracker);
-            }
+            if (apiMethodTracker)
+                protectedThis->resolveFinishedPromise(apiMethodTracker.get());
 
             if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
-                transition->rejectPromise(result);
+                transition->resolvePromise();
         };
 
-        PromiseSettlementObserver::waitForAll(document, promiseList, WTF::move(successSteps), WTF::move(failureSteps));
+        // For traverse navigations the committed-to entry is notified earlier (see notifyCommittedToEntry),
+        // so the committed promise reactions must run before navigatesuccess.
+        // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm
+        if (navigationType == NavigationNavigationType::Traverse)
+            protect(document->eventLoop())->queueMicrotask(document->vm(), WTF::move(dispatchSuccess));
+        else
+            dispatchSuccess();
+    };
 
-        // If a new event has been dispatched in our event handler then we were aborted above.
-        if (m_ongoingNavigateEvent != &event)
-            return DispatchResult::Aborted;
-    }
+    auto failureSteps = [weakThis = WeakPtr { this }, abortController = Ref { abortController }, document = Ref { document }, apiMethodTracker = RefPtr { apiMethodTracker }](JSC::JSValue result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
+            return;
+
+        auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
+        protect(protectedThis->ongoingNavigateEvent())->finish(document, InterceptionHandlersDidFulfill::No, focusChanged);
+
+        abortController->signal().signalAbort(result);
+
+        protectedThis->m_ongoingNavigateEvent = nullptr;
+
+        ErrorInformation errorInformation;
+        String errorMessage;
+        if (auto* errorInstance = dynamicDowncast<JSC::ErrorInstance>(result)) {
+            if (auto extracted = extractErrorInformationFromErrorInstance(protect(protectedThis->scriptExecutionContext())->globalObject(), *errorInstance)) {
+                errorInformation = WTF::move(*extracted);
+                errorMessage = makeString("Uncaught "_s, errorInformation.errorTypeString, ": "_s, errorInformation.message);
+            }
+        }
+
+        auto* navGlobalObject = protect(protectedThis->scriptExecutionContext())->globalObject();
+        protectedThis->dispatchEvent(ErrorEvent::create(*navGlobalObject, eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { navGlobalObject->vm(), result }));
+
+        if (apiMethodTracker) {
+            apiMethodTracker->rejectFinished(result);
+            protectedThis->m_methodTrackers.unregister(*apiMethodTracker);
+        }
+
+        if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
+            transition->rejectPromise(result);
+    };
+
+    PromiseSettlementObserver::waitForAll(document, promiseList, WTF::move(successSteps), WTF::move(failureSteps));
+
+    // If a new event has been dispatched in our event handler then we were aborted above.
+    if (m_ongoingNavigateEvent != &event)
+        return DispatchResult::Aborted;
 
     return std::nullopt;
 }
@@ -1376,10 +1372,12 @@ void Navigation::runNavigatePrecommitHandlers(NavigateEvent& event, NavigationAP
             return;
 
         protectedThis->setupInterceptionState(event.get(), event->navigationType(), event->destination(), document.get(), classicHistoryAPIState.get());
-        // This runs asynchronously after innerDispatchNavigateEvent() has already returned
-        // DispatchResult::Intercepted to its caller, so there is no caller left to report the
-        // DispatchResult to. Discarding the return value here is intentional.
-        protectedThis->handleSameDocumentNavigation(event.get(), event->navigationType(), apiMethodTracker.get(), abortController.get(), document.get());
+
+        auto dispatchResult = protectedThis->handleSameDocumentNavigation(event.get(), event->navigationType(), apiMethodTracker.get(), abortController.get(), document.get());
+        if (dispatchResult == DispatchResult::Aborted)
+            return;
+
+        protectedThis->resumeDeferredTraversalIfNeeded();
     };
 
     auto failureSteps = [weakThis = WeakPtr { this }, event = Ref { event }, apiMethodTracker = RefPtr { apiMethodTracker }, abortController = Ref { abortController }, document = Ref { document }](JSC::JSValue result) mutable {
@@ -1390,6 +1388,10 @@ void Navigation::runNavigatePrecommitHandlers(NavigateEvent& event, NavigationAP
         // The navigation has not been committed yet (interception state is still "intercepted"), so unlike
         // an intercept handler failure we must not call NavigateEvent::finish() here.
         abortController->signal().signalAbort(result);
+
+        // This path does not go through abortOngoingNavigation(), so discard the deferred traverse
+        // history step here.
+        protectedThis->clearDeferredTraversalIfNeeded();
 
         protectedThis->m_ongoingNavigateEvent = nullptr;
 
@@ -1544,7 +1546,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
         if (m_ongoingNavigateEvent != event.ptr())
             return DispatchResult::Aborted;
 
-        return DispatchResult::Intercepted;
+        return DispatchResult::DeferredCommit;
     }
 
     // Step 32:

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -156,7 +156,7 @@ public:
 
     ExceptionOr<void> updateCurrentEntry(UpdateCurrentEntryOptions&&);
 
-    enum class DispatchResult : uint8_t { Completed, Aborted, Intercepted };
+    enum class DispatchResult : uint8_t { Completed, Aborted, Intercepted, DeferredCommit };
     DispatchResult dispatchTraversalNavigateEvent(HistoryItem&);
     bool dispatchPushReplaceReloadNavigateEvent(const URL&, NavigationNavigationType, bool isSameDocument, FormState*, SerializedScriptValue* classicHistoryAPIState = nullptr, Element* sourceElement = nullptr);
     bool dispatchDownloadNavigateEvent(const URL&, const String& downloadFilename, Element* sourceElement = nullptr);
@@ -286,6 +286,9 @@ private:
 
     void disposeOfForwardEntriesInParents(BackForwardItemIdentifier);
     void recursivelyDisposeOfForwardEntriesInParents(BackForwardItemIdentifier, LocalFrame* navigatedFrame);
+
+    void clearDeferredTraversalIfNeeded();
+    void resumeDeferredTraversalIfNeeded();
 
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api-method-tracker
     class MethodTrackerRegistry {


### PR DESCRIPTION
#### 6ee1aef89dac209e9afdfda943d5585b5ac291e6
<pre>
[Navigation API] precommitHandler-traverse.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=321694">https://bugs.webkit.org/show_bug.cgi?id=321694</a>
<a href="https://rdar.apple.com/184840625">rdar://184840625</a>

Reviewed by Chris Dumez.

The test builds five history entries in a single document, then runs three subtests.
The first subtest rejectBeforeCommit traverses back four steps to entries[0],
intercepts with a precommit handler, and has that handler reject.

It fails the assertion in the precommit handler which checks that the URL/hash
haven&apos;t changed yet (they must only change once the precommit handler is done
and the navigation has committed. Them changing is part of the commit):
FAIL ... &quot;Error: assert_equals: hash after first async step expected &quot;#4&quot; but got &quot;&quot;&quot;

So our issue is that part of the commit is happening too early.

When the navigation happens, FrameLoader::loadItem() is run and it does:

if (sameDocumentNavigation) {
    ...
        if (navigation-&gt;dispatchTraversalNavigateEvent(item) == Navigation::DispatchResult::Aborted))
            return;
        ...
    }
}
...
if (sameDocumentNavigation) {
    ...
    loadSameDocumentItem(item);     // ← runs for Intercepted too
}

Navigation::dispatchTraversalNavigateEvent() is the part that fires the navigate
event, waits for the precommit handlers to finish running, and then finally calls
Navigation::setupInterceptionState(), which is the Navigation API commit that
updates the URL.

FrameLoader::loadSameDocumentItem() is the normal &quot;apply the history step&quot; which also
changes the URL. The issue is that when a precommit handler exists,
innerDispatchNavigateEvent() returns &quot;Intercepted&quot; without actually committing.

This is wrong, the spec expects us to defer the history step when the navigation is
intercepted and then actually apply the history step as part of committing:

The traverse navigate event is fired from &quot;check if unloading is canceled&quot;
(<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#checking-if-unloading-is-canceled)">https://html.spec.whatwg.org/multipage/browsing-the-web.html#checking-if-unloading-is-canceled)</a>:

&gt; Let navigateEventResult be the result of firing a traverse navigate event ...
  If navigateEventResult is false, return [a non continue status]

Fire a traverse navigate event returns false whenever the event was intercepted
(<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-traverse-navigate-event)">https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-traverse-navigate-event)</a>

Apply the history step then bails on that result
(<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step)">https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step)</a>

&gt; The result of checking if unloading is canceled is not continue, then early return.

Commit a navigate event then picks it back up
(<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#commit-a-navigate-event)">https://html.spec.whatwg.org/multipage/nav-history-apis.html#commit-a-navigate-event)</a>

&gt; Resume applying the traverse history step.

So we fix this by implementing this deferred commit. When the navigate event is
firing, if it is intercepted and has precommit handlers, innerDispatchNavigateEvent()
will return &quot;DeferredCommit&quot; instead of &quot;Intercepted&quot;, which lets FrameLoader::loadItem()
know that it should stash this item so the history step can be resumed later when we
commit after the precommit handlers are done running.

After we make this change, the subtest progresses but still fails:

FAIL ... reject before commit  assert_false: navigatesuccess fired expected false got true

When tracing the rejectBeforeCommit, we see that both promises are indeed rejected
and a navigate success is not actually coming from it. It&apos;s coming from the initial setup:

There are 4 history.pushState() calls back to back, each one cancels the navigate event
of the one before it, except the last one, whose navigate success event is not cancelled
since there is no subsequent pushState().

The issue is that this navigate success arrives a whole task late.
Navigation::handleSameDocumentNavigation() special-cased exactly pushState&apos;s shape —
not intercepted, no API method tracker — and scheduled it with
queueTask(TaskSource::DOMManipulation, ...) instead of a microtask.

For a same document navigation (like pushState), the spec says to run the intercept
commit handler steps, which fire the navigate success from wait-for-all whcih uses
a microtask:
(<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#update-the-navigation-api-entries-for-a-same-document-navigation).">https://html.spec.whatwg.org/multipage/nav-history-apis.html#update-the-navigation-api-entries-for-a-same-document-navigation).</a>

This special case was initially added by 310748@main which had concerns about creating
a wrapper DeferredPromise which looks to have been resolved by 317203@main. So we
fix this by removing the special case that uses a task, so that a microtask is used
as per spec. The tests added in those two commits still pass after this change.

This makes the rejectBeforeCommit test pass, as well as other tests.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traversal-window-stop-before-commit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/precommit-handler/precommitHandler-traverse-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::clearDeferredTraversal):
(WebCore::FrameLoader::resumeDeferredTraversal):
(WebCore::FrameLoader::loadItem):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::clearDeferredTraversalIfNeeded):
(WebCore::Navigation::resumeDeferredTraversalIfNeeded):
(WebCore::Navigation::abortOngoingNavigation):
(WebCore::Navigation::setupInterceptionState):
(WebCore::Navigation::handleSameDocumentNavigation):
(WebCore::Navigation::runNavigatePrecommitHandlers):
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/319196@main">https://commits.webkit.org/319196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/748b34a86a91b5cbb486713e542f6c0d1e07d8bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190807 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144918 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e586da8b-bab2-4715-a91e-aaf77ae16e4c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140860 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/618185e4-1978-4ed7-82f8-f4d227a2328c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121312 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d60db52a-6a27-406d-9f0a-4a2f648cf11f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43204 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41487 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41164 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1966 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192743 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54207 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150236 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54895 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37781 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Skipped layout-tests; 343 new passes 11 flakes 4 failures; Uploaded test results; Running re-run-layout-tests; layout-tests; Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149953 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27439 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44573 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127160 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122374 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53412 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16157 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52794 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53031 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52859 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->