### PR TITLE
Sync alignment, padding, specificity, changes for appearance: base-select styling

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
@@ -4,7 +4,7 @@ SIBLING
 FAIL UA styles of base appearance <select>. assert_equals: border expected "1px solid rgb(255, 0, 0)" but got "1px solid oklab(0.627955 0.224863 0.125846 / 0.5)"
 FAIL UA styles of base appearance select::picker-icon. assert_equals: content expected "counter(fake-counter-name, disclosure-open)" but got "\"⌵\" / \"\""
 FAIL UA styles of base appearance ::picker(select) assert_equals: margin expected "0px" but got "4px 0px"
-FAIL UA styles of base appearance <option>. assert_equals: padding-block-start expected "0px" but got "12px"
+FAIL UA styles of base appearance <option>. assert_equals: padding-block-start expected "0px" but got "5.2px"
 FAIL UA styles of base appearance option::checkmark. assert_equals: font-family expected "monospace" but got "system-ui"
 PASS UA styles of base appearance <optgroup>.
 FAIL UA styles of base appearance <legend>. assert_equals: padding-inline expected "12px" but got "15.299999px"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/update.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/update.css
@@ -34,15 +34,15 @@ select,
   box-sizing: border-box;
   border: 1px solid color-mix(currentColor 50%);
   border-radius: 4px;
-  padding-block: 0.4em;
+  padding-block: 0.4lh;
   padding-inline: 1em 0.7em;
   color: inherit;
   font: inherit;
   background-color: light-dark(transparent, color-mix(currentColor 4%));
-  align-items: unset;
+  align-items: center;
   white-space: nowrap;
   cursor: default;
-  gap: 0.5em;
+  gap: 0.65em;
   min-block-size: 24px;
   min-inline-size: 4em;
   overflow: clip;
@@ -58,7 +58,7 @@ select:not([popover]),
   display: inline-flex;
 }
 
-select:enabled:hover:not(:user-invalid),
+select:hover,
 .customizable-select-button.hover {
   border-color: color-mix(currentColor 70%);
 }
@@ -71,9 +71,13 @@ select:enabled:hover:not(:user-invalid),
   background-color: light-dark(transparent, color-mix(currentColor 4%));
 }
 
-select:enabled:active,
+select:active,
 .customizable-select-button.active {
   background-color: color-mix(currentColor 8%);
+}
+
+select:user-invalid {
+  border-color: light-dark(#dc3545, oklch(from #db2a37 calc(l + 0.17) c h));
 }
 
 select:disabled,
@@ -82,10 +86,6 @@ select:disabled,
   color: color-mix(currentColor 55%);
   border-color: color-mix(currentColor 25%);
   cursor: not-allowed;
-}
-
-select:user-invalid {
-  border-color: light-dark(#dc3545, oklch(from #db2a37 calc(l + 0.17) c h));
 }
 
 select:not([multiple]) > button:first-child {
@@ -107,13 +107,11 @@ select selectedcontent,
 select::picker-icon,
 .customizable-select-button::after {
   content: "\2335" / "";
-  font-family: system-ui;
-  font-style: normal;
+  font: 100% system-ui;
   text-orientation: sideways;
-  padding-inline: 0.3em 0.15em;
+  padding-inline: 0.15em;
   margin-inline-start: auto;
   margin-block-start: -0.25em;
-  align-self: center;
 }
 
 /* ---- Picker popover ---- */
@@ -156,7 +154,7 @@ select option,
 .customizable-select-option {
   min-inline-size: 24px;
   min-block-size: max(24px, 1lh);
-  padding-block: 0.5em;
+  padding-block: 0.4lh;
   padding-inline: 0.75em 1.1em;
   display: flex;
   align-items: center;
@@ -166,26 +164,26 @@ select option,
   outline-offset: inset;
 }
 
-select option:enabled:hover,
-select option:enabled:focus-visible {
+select option:hover,
+select option:focus-visible {
   background-color: color-mix(currentColor 10%);
 }
 
-select option:enabled:active {
+select option:active {
   background-color: color-mix(currentColor 15%);
 }
 
 select option:disabled,
 .customizable-select-option.disabled {
   color: color-mix(currentColor 55%);
+  background: transparent;
   cursor: not-allowed;
 }
 
 select option::checkmark,
 .customizable-select-option::before {
   content: "\2713" / "";
-  font-family: system-ui;
-  font-style: normal;
+  font: 100% system-ui;
 }
 
 select option:not(:checked)::checkmark,

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
@@ -49,9 +49,9 @@ PASS <option>1 (in <select multiple="">) - margin-top
 PASS <option>1 (in <select multiple="">) - margin-right
 PASS <option>1 (in <select multiple="">) - margin-bottom
 PASS <option>1 (in <select multiple="">) - margin-left
-FAIL <option>1 (in <select multiple="">) - padding-top assert_equals: expected "0px" but got "5.5px"
+FAIL <option>1 (in <select multiple="">) - padding-top assert_equals: expected "0px" but got "5.2px"
 FAIL <option>1 (in <select multiple="">) - padding-right assert_equals: expected "0px" but got "12.1px"
-FAIL <option>1 (in <select multiple="">) - padding-bottom assert_equals: expected "0px" but got "5.5px"
+FAIL <option>1 (in <select multiple="">) - padding-bottom assert_equals: expected "0px" but got "5.2px"
 FAIL <option>1 (in <select multiple="">) - padding-left assert_equals: expected "0px" but got "8.25px"
 PASS <option>1 (in <select multiple="">) - letter-spacing
 PASS <option>1 (in <select multiple="">) - word-spacing
@@ -141,9 +141,9 @@ PASS <option>3 (in <select multiple=""><optgroup label="2">) - margin-top
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - margin-right
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - margin-bottom
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - margin-left
-FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-top assert_equals: expected "0px" but got "5.5px"
+FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-top assert_equals: expected "0px" but got "5.2px"
 FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-right assert_equals: expected "0px" but got "12.1px"
-FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-bottom assert_equals: expected "0px" but got "5.5px"
+FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-bottom assert_equals: expected "0px" but got "5.2px"
 FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-left assert_equals: expected "0px" but got "8.25px"
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - letter-spacing
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - word-spacing

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1060,11 +1060,11 @@ select:-internal-uses-menulist {
     background-color: -internal-auto-base(Canvas, light-dark(transparent, color-mix(currentColor 4%)));
     font: -internal-auto-base(-webkit-small-control, inherit);
 #endif /* defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY */
-    padding-block: -internal-auto-base(0, 0.4em);
-    align-items: -internal-auto-base(center, unset);
+    padding-block: -internal-auto-base(0, 0.4lh);
+    align-items: center;
     white-space: -internal-auto-base(pre, nowrap);
     cursor: default;
-    gap: -internal-auto-base(initial, 0.5em);
+    gap: -internal-auto-base(initial, 0.65em);
     min-block-size: -internal-auto-base(revert-rule, 24px);
     min-inline-size: -internal-auto-base(revert-rule, 4em);
     overflow: -internal-auto-base(revert-rule, clip);
@@ -1076,12 +1076,16 @@ select:-internal-uses-menulist {
     word-spacing: -internal-auto-base(normal, inherit);
 }
 
-select:-internal-uses-menulist:enabled:hover:not(:user-invalid) {
+select:-internal-uses-menulist:hover {
     border-color: -internal-auto-base(revert-rule, color-mix(currentColor 70%));
 }
 
-select:-internal-uses-menulist:enabled:active {
+select:-internal-uses-menulist:active {
     background-color: -internal-auto-base(revert-rule, color-mix(currentColor 8%));
+}
+
+select:-internal-uses-menulist:user-invalid {
+    border-color: -internal-auto-base(revert-rule, light-dark(#dc3545, oklch(from #db2a37 calc(l + 0.17) c h)));
 }
 
 select:-internal-uses-menulist:disabled {
@@ -1094,10 +1098,6 @@ select:-internal-uses-menulist:disabled {
 #endif
     border-color: -internal-auto-base(revert-rule, color-mix(currentColor 25%));
     cursor: -internal-auto-base(revert-rule, not-allowed);
-}
-
-select:-internal-uses-menulist:user-invalid {
-    border-color: -internal-auto-base(revert-rule, light-dark(#dc3545, oklch(from #db2a37 calc(l + 0.17) c h)));
 }
 
 select:-internal-uses-menulist:not([popover]) {
@@ -1127,13 +1127,11 @@ select selectedcontent {
 
 select::picker-icon {
     content: "\2335" / "";
-    font-family: system-ui;
-    font-style: normal;
+    font: 100% system-ui;
     text-orientation: sideways;
-    padding-inline: 0.3em 0.15em;
+    padding-inline: 0.15em;
     margin-inline-start: auto;
     margin-block-start: -0.25em;
-    align-self: center;
 }
 
 :-internal-select-popover {
@@ -1168,7 +1166,7 @@ select::picker-icon {
 select:-internal-uses-menulist option {
     min-inline-size: 24px;
     min-block-size: max(24px, 1lh);
-    padding-block: 0.5em;
+    padding-block: 0.4lh;
     padding-inline: 0.75em 1.1em;
     display: flex;
     align-items: center;
@@ -1181,24 +1179,24 @@ select option {
     outline-offset: inset;
 }
 
-select option:enabled:hover,
-select option:enabled:focus-visible {
+select option:hover,
+select option:focus-visible {
     background-color: color-mix(currentColor 10%);
 }
 
-select option:enabled:active {
+select option:active {
     background-color: color-mix(currentColor 15%);
 }
 
 select option:disabled {
     color: color-mix(currentColor 55%);
+    background: transparent;
     cursor: not-allowed;
 }
 
 select option::checkmark {
     content: "\2713" / "";
-    font-family: system-ui;
-    font-style: normal;
+    font: 100% system-ui;
 }
 
 select option:not(:checked)::checkmark {
@@ -1241,7 +1239,7 @@ select optgroup legend {
         border-color: CanvasText;
     }
 
-    select option:enabled:is(:hover, :focus-visible, :active) {
+    select option:is(:hover, :focus-visible, :active) {
         background-color: SelectedItem;
         color: SelectedItemText;
     }

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -59,28 +59,10 @@ struct SameSizeAsComputedStyle : CanMakeCheckedPtr<SameSizeAsComputedStyle> {
     WTF_MAKE_TZONE_ALLOCATED(SameSizeAsComputedStyle);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SameSizeAsComputedStyle);
     struct NonInheritedFlags {
-        unsigned display : 5;
-        unsigned originalDisplay : 5;
-        unsigned overflowX : 3;
-        unsigned overflowY : 3;
-        unsigned clear : 3;
-        unsigned position : 3;
-        unsigned unicodeBidi : 3;
-        unsigned floating : 3;
-        bool usesViewportUnits : 1;
-        bool isContainerDependent : 1;
-        bool useTreeCountingFunctions : 1;
-        bool hasExplicitlyInheritedProperties : 1;
-        bool disallowsFastPathInheritance : 1;
-        bool firstChildState : 1;
-        bool lastChildState : 1;
-        bool isLink : 1;
-        unsigned pseudoElementType : 5;
-        unsigned pseudoBits : 19;
-        unsigned textDecorationLine : 5;
+        uint32_t m_bitfields[3];
     } m_nonInheritedFlags;
     struct InheritedFlags {
-        unsigned m_bitfields[2];
+        uint32_t m_bitfields[2];
     } m_inheritedFlags;
     void* nonInheritedDataRefs[1];
     void* inheritedDataRefs[2];


### PR DESCRIPTION
#### 3a999a1a45ed3cf451677c24ee47f18bd3ce7e65
<pre>
Sync alignment, padding, specificity, changes for appearance: base-select styling
<a href="https://bugs.webkit.org/show_bug.cgi?id=321699">https://bugs.webkit.org/show_bug.cgi?id=321699</a>
<a href="https://rdar.apple.com/184843832">rdar://184843832</a>

Reviewed by Tim Nguyen.

This ports over the following updates from the demo:
- Switching padding-block to use lh units, so it scales with line-height.
- Applying align-items: center to the select itself, so the button content
  is also centered (not just the ::picker-icon).
- Specificity clean-up by simplifying and reordering style rules.

Also switches ::picker-icon and ::checkmark rule to using the &apos;font&apos; shorthand
per <a href="https://github.com/w3c/csswg-drafts/issues/14250">https://github.com/w3c/csswg-drafts/issues/14250</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/update.css:
(select,):
(select:hover,):
(select:active,):
(select:user-invalid):
(select::picker-icon,):
(select option,):
(select option:hover,):
(select option:active):
(select option:disabled,):
(select option::checkmark,):
(select:enabled:hover:not(:user-invalid),): Deleted.
(select:enabled:active,): Deleted.
(select option:enabled:hover,): Deleted.
(select option:enabled:active): Deleted.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt:
* Source/WebCore/css/html.css:
(select:-internal-uses-menulist):
(select:-internal-uses-menulist:hover):
(select:-internal-uses-menulist:active):
(select:-internal-uses-menulist:user-invalid):
(select::picker-icon):
(select:-internal-uses-menulist option):
(select option:hover,):
(select option:active):
(select option:disabled):
(select option::checkmark):
(@media (prefers-contrast) select option:is(:hover, :focus-visible, :active)):
(select:-internal-uses-menulist:enabled:hover:not(:user-invalid)): Deleted.
(select:-internal-uses-menulist:enabled:active): Deleted.
(select option:enabled:hover,): Deleted.
(select option:enabled:active): Deleted.
(@media (prefers-contrast) select option:enabled:is(:hover, :focus-visible, :active)): Deleted.
* Source/WebCore/style/computed/StyleComputedStyle.cpp:

Canonical link: <a href="https://commits.webkit.org/319816@main">https://commits.webkit.org/319816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7e22baeb40ce4ac0b3025b6e2fa6b800045a8ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192940 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147013 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/83c4ce7e-e17f-41cc-9074-53a83cd48906) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142602 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f32cf39-38f0-4555-8920-5614fbd98aca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123037 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fabc56fe-87ee-41e1-bab8-7266d738b46f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45015 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43267 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155413 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42895 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4113 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194884 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56318 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152056 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40768 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57022 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151756 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46327 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129290 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125320 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55530 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17898 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54902 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55140 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54968 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->