### PR TITLE
[JSC] Rename Status/Variant finalize predicates to isStillLive

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -385,10 +385,10 @@ void CallLinkStatus::makeClosureCall()
     m_variants = despecifiedVariantList(m_variants);
 }
 
-bool CallLinkStatus::finalize(VM& vm)
+bool CallLinkStatus::isStillLive(VM& vm)
 {
     for (CallVariant& variant : m_variants) {
-        if (!variant.finalize(vm))
+        if (!variant.isStillLive(vm))
             return false;
     }
     return true;

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.h
@@ -109,7 +109,7 @@ public:
 
     unsigned maxArgumentCountIncludingThisForVarargs() const { return m_maxArgumentCountIncludingThisForVarargs; }
     
-    bool finalize(VM&);
+    bool isStillLive(VM&);
     
     void merge(const CallLinkStatus&);
     

--- a/Source/JavaScriptCore/bytecode/CallVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/CallVariant.cpp
@@ -31,7 +31,7 @@
 
 namespace JSC {
 
-bool CallVariant::finalize(VM& vm)
+bool CallVariant::isStillLive(VM& vm)
 {
     if (m_callee && !vm.heap.isMarked(m_callee))
         return false;

--- a/Source/JavaScriptCore/bytecode/CallVariant.h
+++ b/Source/JavaScriptCore/bytecode/CallVariant.h
@@ -134,7 +134,7 @@ public:
         return nullptr;
     }
     
-    bool finalize(VM&);
+    bool isStillLive(VM&);
     
     bool NODELETE merge(const CallVariant&);
     

--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp
@@ -240,10 +240,10 @@ void CheckPrivateBrandStatus::markIfCheap(Visitor& visitor)
 template void CheckPrivateBrandStatus::markIfCheap(AbstractSlotVisitor&);
 template void CheckPrivateBrandStatus::markIfCheap(SlotVisitor&);
 
-bool CheckPrivateBrandStatus::finalize(VM& vm)
+bool CheckPrivateBrandStatus::isStillLive(VM& vm)
 {
     for (auto& variant : m_variants) {
-        if (!variant.finalize(vm))
+        if (!variant.isStillLive(vm))
             return false;
     }
     return true;

--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.h
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.h
@@ -85,7 +85,7 @@ public:
 
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&);
+    bool isStillLive(VM&);
 
     bool appendVariant(const CheckPrivateBrandVariant&);
     void shrinkToFit();

--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.cpp
@@ -60,7 +60,7 @@ void CheckPrivateBrandVariant::markIfCheap(Visitor& visitor)
 template void CheckPrivateBrandVariant::markIfCheap(AbstractSlotVisitor&);
 template void CheckPrivateBrandVariant::markIfCheap(SlotVisitor&);
 
-bool CheckPrivateBrandVariant::finalize(VM& vm)
+bool CheckPrivateBrandVariant::isStillLive(VM& vm)
 {
     if (!m_structureSet.isStillAlive(vm))
         return false;

--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.h
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.h
@@ -49,7 +49,7 @@ public:
 
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&);
+    bool isStillLive(VM&);
 
     void dump(PrintStream&) const;
     void dumpInContext(PrintStream&, DumpContext*) const;

--- a/Source/JavaScriptCore/bytecode/DeleteByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/DeleteByStatus.cpp
@@ -266,10 +266,10 @@ void DeleteByStatus::markIfCheap(Visitor& visitor)
 template void DeleteByStatus::markIfCheap(AbstractSlotVisitor&);
 template void DeleteByStatus::markIfCheap(SlotVisitor&);
 
-bool DeleteByStatus::finalize(VM& vm)
+bool DeleteByStatus::isStillLive(VM& vm)
 {
     for (auto& variant : m_variants) {
-        if (!variant.finalize(vm))
+        if (!variant.isStillLive(vm))
             return false;
     }
     return true;

--- a/Source/JavaScriptCore/bytecode/DeleteByStatus.h
+++ b/Source/JavaScriptCore/bytecode/DeleteByStatus.h
@@ -84,7 +84,7 @@ public:
 
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&);
+    bool isStillLive(VM&);
 
     bool appendVariant(const DeleteByVariant&);
     void shrinkToFit();

--- a/Source/JavaScriptCore/bytecode/DeleteByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/DeleteByVariant.cpp
@@ -99,7 +99,7 @@ void DeleteByVariant::dump(PrintStream& out) const
     dumpInContext(out, nullptr);
 }
 
-bool DeleteByVariant::finalize(VM& vm)
+bool DeleteByVariant::isStillLive(VM& vm)
 {
     if (!vm.heap.isMarked(m_oldStructure))
         return false;

--- a/Source/JavaScriptCore/bytecode/DeleteByVariant.h
+++ b/Source/JavaScriptCore/bytecode/DeleteByVariant.h
@@ -64,7 +64,7 @@ public:
 
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&);
+    bool isStillLive(VM&);
 
     void dump(PrintStream&) const;
     void dumpInContext(PrintStream&, DumpContext*) const;

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -765,10 +765,10 @@ void GetByStatus::markIfCheap(Visitor& visitor)
 template void GetByStatus::markIfCheap(AbstractSlotVisitor&);
 template void GetByStatus::markIfCheap(SlotVisitor&);
 
-bool GetByStatus::finalize(VM& vm)
+bool GetByStatus::isStillLive(VM& vm)
 {
     for (GetByVariant& variant : m_variants) {
-        if (!variant.finalize(vm))
+        if (!variant.isStillLive(vm))
             return false;
     }
     if (isModuleNamespace()) {

--- a/Source/JavaScriptCore/bytecode/GetByStatus.h
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.h
@@ -143,7 +143,7 @@ public:
     
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&); // Return true if this gets to live.
+    bool isStillLive(VM&);
 
     bool appendVariant(const GetByVariant&);
     void shrinkToFit();

--- a/Source/JavaScriptCore/bytecode/GetByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByVariant.cpp
@@ -179,13 +179,13 @@ void GetByVariant::markIfCheap(Visitor& visitor)
 template void GetByVariant::markIfCheap(AbstractSlotVisitor&);
 template void GetByVariant::markIfCheap(SlotVisitor&);
 
-bool GetByVariant::finalize(VM& vm)
+bool GetByVariant::isStillLive(VM& vm)
 {
     if (!m_structureSet.isStillAlive(vm))
         return false;
     if (!m_conditionSet.areStillLive(vm))
         return false;
-    if (m_callLinkStatus && !m_callLinkStatus->finalize(vm))
+    if (m_callLinkStatus && !m_callLinkStatus->isStillLive(vm))
         return false;
     if (m_intrinsicFunction && !vm.heap.isMarked(m_intrinsicFunction))
         return false;

--- a/Source/JavaScriptCore/bytecode/GetByVariant.h
+++ b/Source/JavaScriptCore/bytecode/GetByVariant.h
@@ -82,7 +82,7 @@ public:
     
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&);
+    bool isStillLive(VM&);
     
     void dump(PrintStream&) const;
     void dumpInContext(PrintStream&, DumpContext*) const;

--- a/Source/JavaScriptCore/bytecode/InByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/InByStatus.cpp
@@ -311,10 +311,10 @@ void InByStatus::markIfCheap(Visitor& visitor)
 template void InByStatus::markIfCheap(AbstractSlotVisitor&);
 template void InByStatus::markIfCheap(SlotVisitor&);
 
-bool InByStatus::finalize(VM& vm)
+bool InByStatus::isStillLive(VM& vm)
 {
     for (InByVariant& variant : m_variants) {
-        if (!variant.finalize(vm))
+        if (!variant.isStillLive(vm))
             return false;
     }
     return true;

--- a/Source/JavaScriptCore/bytecode/InByStatus.h
+++ b/Source/JavaScriptCore/bytecode/InByStatus.h
@@ -109,7 +109,7 @@ public:
     
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&);
+    bool isStillLive(VM&);
 
     void dump(PrintStream&) const;
 

--- a/Source/JavaScriptCore/bytecode/InByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/InByVariant.cpp
@@ -120,13 +120,13 @@ void InByVariant::markIfCheap(Visitor& visitor)
 template void InByVariant::markIfCheap(AbstractSlotVisitor&);
 template void InByVariant::markIfCheap(SlotVisitor&);
 
-bool InByVariant::finalize(VM& vm)
+bool InByVariant::isStillLive(VM& vm)
 {
     if (!m_structureSet.isStillAlive(vm))
         return false;
     if (!m_conditionSet.areStillLive(vm))
         return false;
-    if (m_callLinkStatus && !m_callLinkStatus->finalize(vm))
+    if (m_callLinkStatus && !m_callLinkStatus->isStillLive(vm))
         return false;
     return true;
 }

--- a/Source/JavaScriptCore/bytecode/InByVariant.h
+++ b/Source/JavaScriptCore/bytecode/InByVariant.h
@@ -68,7 +68,7 @@ public:
     
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&);
+    bool isStillLive(VM&);
 
     void dump(PrintStream&) const;
     void dumpInContext(PrintStream&, DumpContext*) const;

--- a/Source/JavaScriptCore/bytecode/PutByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.cpp
@@ -534,10 +534,10 @@ void PutByStatus::markIfCheap(Visitor& visitor)
 template void PutByStatus::markIfCheap(AbstractSlotVisitor&);
 template void PutByStatus::markIfCheap(SlotVisitor&);
 
-bool PutByStatus::finalize(VM& vm)
+bool PutByStatus::isStillLive(VM& vm)
 {
     for (PutByVariant& variant : m_variants) {
-        if (!variant.finalize(vm))
+        if (!variant.isStillLive(vm))
             return false;
     }
     return true;

--- a/Source/JavaScriptCore/bytecode/PutByStatus.h
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.h
@@ -149,7 +149,7 @@ public:
 
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&);
+    bool isStillLive(VM&);
     
     void merge(const PutByStatus&);
     

--- a/Source/JavaScriptCore/bytecode/PutByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByVariant.cpp
@@ -370,7 +370,7 @@ void PutByVariant::markIfCheap(Visitor& visitor)
 template void PutByVariant::markIfCheap(AbstractSlotVisitor&);
 template void PutByVariant::markIfCheap(SlotVisitor&);
 
-bool PutByVariant::finalize(VM& vm)
+bool PutByVariant::isStillLive(VM& vm)
 {
     if (!m_oldStructure.isStillAlive(vm))
         return false;
@@ -378,7 +378,7 @@ bool PutByVariant::finalize(VM& vm)
         return false;
     if (!m_conditionSet.areStillLive(vm))
         return false;
-    if (m_callLinkStatus && !m_callLinkStatus->finalize(vm))
+    if (m_callLinkStatus && !m_callLinkStatus->isStillLive(vm))
         return false;
     return true;
 }

--- a/Source/JavaScriptCore/bytecode/PutByVariant.h
+++ b/Source/JavaScriptCore/bytecode/PutByVariant.h
@@ -139,7 +139,7 @@ public:
     
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&);
+    bool isStillLive(VM&);
     
     void dump(PrintStream&) const;
     void dumpInContext(PrintStream&, DumpContext*) const;

--- a/Source/JavaScriptCore/bytecode/RecordedStatuses.cpp
+++ b/Source/JavaScriptCore/bytecode/RecordedStatuses.cpp
@@ -132,7 +132,7 @@ void RecordedStatuses::reconcileWeakReferencesWithoutDeleting(VM& vm)
 
     auto reconcile = [&] (auto& vector) {
         for (auto& pair : vector) {
-            if (!pair.second->finalize(vm))
+            if (!pair.second->isStillLive(vm))
                 *pair.second = { };
         }
     };
@@ -144,7 +144,7 @@ void RecordedStatuses::reconcileWeakReferences(VM& vm)
     auto reconcile = [&] (auto& vector) {
         vector.removeAllMatching(
             [&] (auto& pair) -> bool {
-                return !*pair.second || !pair.second->finalize(vm);
+                return !*pair.second || !pair.second->isStillLive(vm);
             });
         vector.shrinkToFit();
     };

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp
@@ -248,10 +248,10 @@ void SetPrivateBrandStatus::markIfCheap(Visitor& visitor)
 template void SetPrivateBrandStatus::markIfCheap(AbstractSlotVisitor&);
 template void SetPrivateBrandStatus::markIfCheap(SlotVisitor&);
 
-bool SetPrivateBrandStatus::finalize(VM& vm)
+bool SetPrivateBrandStatus::isStillLive(VM& vm)
 {
     for (auto& variant : m_variants) {
-        if (!variant.finalize(vm))
+        if (!variant.isStillLive(vm))
             return false;
     }
     return true;

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.h
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.h
@@ -86,7 +86,7 @@ public:
 
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&);
+    bool isStillLive(VM&);
 
     bool appendVariant(const SetPrivateBrandVariant&);
     void shrinkToFit();

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.cpp
@@ -66,7 +66,7 @@ void SetPrivateBrandVariant::markIfCheap(Visitor& visitor)
 template void SetPrivateBrandVariant::markIfCheap(AbstractSlotVisitor&);
 template void SetPrivateBrandVariant::markIfCheap(SlotVisitor&);
 
-bool SetPrivateBrandVariant::finalize(VM& vm)
+bool SetPrivateBrandVariant::isStillLive(VM& vm)
 {
     if (!vm.heap.isMarked(m_oldStructure))
         return false;

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.h
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.h
@@ -49,7 +49,7 @@ public:
 
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
-    bool finalize(VM&);
+    bool isStillLive(VM&);
 
     void dump(PrintStream&) const;
     void dumpInContext(PrintStream&, DumpContext*) const;


### PR DESCRIPTION
#### 3d37c6da40ba652c58d5a6336ba61cc86ada9ba8
<pre>
[JSC] Rename Status/Variant finalize predicates to isStillLive
<a href="https://bugs.webkit.org/show_bug.cgi?id=321710">https://bugs.webkit.org/show_bug.cgi?id=321710</a>
<a href="https://rdar.apple.com/184852271">rdar://184852271</a>

Reviewed by Yijia Huang.

These don&apos;t finalize anything. They check whether the cells a status or variant refers
to are still marked and return a bool; the caller does the clearing.
RecordedStatuses::reconcileWeakReferencesWithoutDeleting zeroes the status in place,
reconcileWeakReferences drops it from the vector.

isStillLive is what they call into: StructureSet::isStillAlive,
ObjectPropertyConditionSet::areStillLive, ObjectPropertyCondition::isStillLive.
Adopt that name.

Renamed on CallLinkStatus, CheckPrivateBrandStatus, DeleteByStatus, GetByStatus,
InByStatus, PutByStatus, SetPrivateBrandStatus and each of their variants.

No behavior change.

* Source/JavaScriptCore/bytecode/CallLinkStatus.cpp:
(JSC::CallLinkStatus::isStillLive):
(JSC::CallLinkStatus::finalize): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkStatus.h:
* Source/JavaScriptCore/bytecode/CallVariant.cpp:
(JSC::CallVariant::isStillLive):
(JSC::CallVariant::finalize): Deleted.
* Source/JavaScriptCore/bytecode/CallVariant.h:
* Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp:
(JSC::CheckPrivateBrandStatus::isStillLive):
(JSC::CheckPrivateBrandStatus::finalize): Deleted.
* Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.h:
* Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.cpp:
(JSC::CheckPrivateBrandVariant::isStillLive):
(JSC::CheckPrivateBrandVariant::finalize): Deleted.
* Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.h:
* Source/JavaScriptCore/bytecode/DeleteByStatus.cpp:
(JSC::DeleteByStatus::isStillLive):
(JSC::DeleteByStatus::finalize): Deleted.
* Source/JavaScriptCore/bytecode/DeleteByStatus.h:
* Source/JavaScriptCore/bytecode/DeleteByVariant.cpp:
(JSC::DeleteByVariant::isStillLive):
(JSC::DeleteByVariant::finalize): Deleted.
* Source/JavaScriptCore/bytecode/DeleteByVariant.h:
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::isStillLive):
(JSC::GetByStatus::finalize): Deleted.
* Source/JavaScriptCore/bytecode/GetByStatus.h:
* Source/JavaScriptCore/bytecode/GetByVariant.cpp:
(JSC::GetByVariant::isStillLive):
(JSC::GetByVariant::finalize): Deleted.
* Source/JavaScriptCore/bytecode/GetByVariant.h:
* Source/JavaScriptCore/bytecode/InByStatus.cpp:
(JSC::InByStatus::isStillLive):
(JSC::InByStatus::finalize): Deleted.
* Source/JavaScriptCore/bytecode/InByStatus.h:
* Source/JavaScriptCore/bytecode/InByVariant.cpp:
(JSC::InByVariant::isStillLive):
(JSC::InByVariant::finalize): Deleted.
* Source/JavaScriptCore/bytecode/InByVariant.h:
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::isStillLive):
(JSC::PutByStatus::finalize): Deleted.
* Source/JavaScriptCore/bytecode/PutByStatus.h:
* Source/JavaScriptCore/bytecode/PutByVariant.cpp:
(JSC::PutByVariant::isStillLive):
(JSC::PutByVariant::finalize): Deleted.
* Source/JavaScriptCore/bytecode/PutByVariant.h:
* Source/JavaScriptCore/bytecode/RecordedStatuses.cpp:
(JSC::RecordedStatuses::reconcileWeakReferencesWithoutDeleting):
(JSC::RecordedStatuses::reconcileWeakReferences):
* Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp:
(JSC::SetPrivateBrandStatus::isStillLive):
(JSC::SetPrivateBrandStatus::finalize): Deleted.
* Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.h:
* Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.cpp:
(JSC::SetPrivateBrandVariant::isStillLive):
(JSC::SetPrivateBrandVariant::finalize): Deleted.
* Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.h:

Canonical link: <a href="https://commits.webkit.org/319146@main">https://commits.webkit.org/319146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e06d2019811a1478b7865460bbc2e28b148ed560

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190817 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1918cf75-9f5e-4f3f-8544-0f4720db9c39) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140871 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1571da34-20ba-42dd-be28-a73b9a621eda) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121323 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9bf7f16c-9bab-48b7-9d71-1ad3f30867b4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3290 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10132 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41176 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1977 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41880 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47160 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192753 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54217 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150247 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54905 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149965 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27412 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44584 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127170 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122385 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53422 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16169 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52804 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53041 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52869 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->