### PR TITLE
[JSC][Intl] Compute the "Before Hijra" year from the calendar, not ICU's rendered text

### DIFF
--- a/JSTests/stress/intl-datetimeformat.js
+++ b/JSTests/stress/intl-datetimeformat.js
@@ -353,11 +353,18 @@ shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-rgsa', { timeZone: 'America/Los_An
     // islamic-civil/islamic-umalqura epoch is ISO 622-07-19T07:52:58.000Z; islamic-tbla's is one
     // day earlier. A date in February 622 is before both real epochs but was previously missed by
     // an overly early hardcoded threshold, so it incorrectly reported "Anno Hegirae".
-    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-islamic-civil', opts).format(Date.UTC(622, 1, 1)), ['Before Hijra 0', '0 Before Hijra']);
+    // Year is 1 - year (no year zero), matching Temporal's eraYear; used to show the raw ICU year (0).
+    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-islamic-civil', opts).format(Date.UTC(622, 1, 1)), ['Before Hijra 1', '1 Before Hijra']);
+    // Well before the epoch, not just at the boundary -- the only case that distinguishes "1 - year" from other conventions.
+    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-islamic-civil', opts).format(Date.UTC(300, 0, 1)), ['Before Hijra 333', '333 Before Hijra']);
+    // year:"2-digit": the flip must use the true year, not ICU's already-truncated 2-digit text
+    // (raw year -199 renders as "-99" under 2-digit; flipping -99 gives 100, not the correct
+    // 00 = (1 - (-199)) mod 100).
+    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-islamic-civil', { year: '2-digit', era: 'long', timeZone: 'UTC' }).format(Date.UTC(429, 0, 1)), ['Before Hijra 00', '00 Before Hijra']);
     // ICU < 78 has no distinct long-form "Anno Hegirae" era string for islamic-civil in this locale and falls back to the short form ("AH").
     shouldBeOneOfForICUVersion(78, Intl.DateTimeFormat('en-u-ca-islamic-civil', opts).format(Date.UTC(650, 0, 1)), ['Anno Hegirae 29', '29 Anno Hegirae']);
-    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-islamic-tbla', opts).format(Date.UTC(622, 1, 1)), ['Before Hijra 0', '0 Before Hijra']);
-    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-islamic-umalqura', opts).format(Date.UTC(622, 1, 1)), ['Before Hijra 0', '0 Before Hijra']);
+    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-islamic-tbla', opts).format(Date.UTC(622, 1, 1)), ['Before Hijra 1', '1 Before Hijra']);
+    shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-islamic-umalqura', opts).format(Date.UTC(622, 1, 1)), ['Before Hijra 1', '1 Before Hijra']);
     // coptic AM epoch is ISO 284-08-29T07:52:58.000Z.
     shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-coptic', opts).format(Date.UTC(200, 0, 1)), ['Anno Martyrum 85', '85 Anno Martyrum']);
     // ICU < 78 has no distinct long-form "Anno Martyrum" era string for coptic in this locale and falls back to the generic "ERA1" placeholder.
@@ -384,6 +391,11 @@ shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-rgsa', { timeZone: 'America/Los_An
         const eraPart = Intl.DateTimeFormat('en-u-ca-islamic-civil', { ...base, era: width }).formatToParts(pre).find(p => p.type === 'era');
         shouldBe(eraPart && eraPart.value, 'Before Hijra');
     }
+
+    // The year part's VALUE must also be flipped -- formatToParts is a separate codepath from
+    // format()'s string splicing, with its own copy of this logic.
+    const yearPart = Intl.DateTimeFormat('en-u-ca-islamic-civil', { ...base, era: 'long' }).formatToParts(pre).find(p => p.type === 'year');
+    shouldBe(yearPart && yearPart.value, '1');
 
     // Locale ignored: ja gets the English text glued onto Japanese-formatted output.
     const ja = Intl.DateTimeFormat('ja-u-ca-islamic-civil', { ...base, era: 'long' }).format(pre);

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -1398,33 +1398,61 @@ static void NODELETE replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(Contain
 // (architecturally locked to one); Coptic has a second era but never selects it.
 // Substitute CLDR's "Before Hijra"/"Anno Martyrum" text ourselves. islamic-tbla's
 // epoch differs from civil/umalqura's by a day, hence the separate branch.
+// needsYearFlip: islamic's raw year has no year-zero skip, unlike Gregorian's native "Before
+// Christ" or Temporal's own eraYear for this era (both use `1 - year`). Coptic's year is already correct.
 // FIXME: doesn't cover formatRange()/formatRangeToParts(); wait for ICU
 // to fix era selection natively rather than extending this further.
-static ASCIILiteral proposalEraOverrideString(const String& calendar, double epochMs)
+struct EraOverride {
+    ASCIILiteral text;
+    bool needsYearFlip { false };
+};
+static std::optional<EraOverride> proposalEraOverrideString(const String& calendar, double epochMs)
 {
     if (calendar == "islamic-civil"_s || calendar == "islamic-umalqura"_s) {
         constexpr double islamicEpoch = -42521558822000.0; // ISO 622-07-19T07:52:58.000Z
         if (epochMs < islamicEpoch)
-            return "Before Hijra"_s;
-        return { };
+            return EraOverride { "Before Hijra"_s, true };
+        return std::nullopt;
     }
     if (calendar == "islamic-tbla"_s) {
         constexpr double islamicTblaEpoch = -42521645222000.0; // ISO 622-07-18T07:52:58.000Z
         if (epochMs < islamicTblaEpoch)
-            return "Before Hijra"_s;
-        return { };
+            return EraOverride { "Before Hijra"_s, true };
+        return std::nullopt;
     }
     if (calendar == "coptic"_s) {
         constexpr double copticEpoch = -53184182822000.0; // ISO 284-08-29T07:52:58.000Z
         if (epochMs < copticEpoch)
-            return "Anno Martyrum"_s;
-        return { };
+            return EraOverride { "Anno Martyrum"_s };
+        return std::nullopt;
     }
-    return { };
+    return std::nullopt;
+}
+
+// ICU4C-WORKAROUND: rdar://182953351 - the flipped "Before Hijra" year (1 - year, matching
+// Temporal's eraYear and ICU's native "Before Christ"), read from a clone of the format's own
+// calendar rather than parsed from ICU's rendered text -- under year:"2-digit" that text is
+// already lossily truncated, so flipping it instead of the real value would be wrong.
+static std::optional<String> flippedEraOverrideYear(UDateFormat* format, double value, bool yearIsTwoDigit)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    auto calendar = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_clone(udat_getCalendar(format), &status));
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    ucal_setMillis(calendar.get(), value, &status);
+    int32_t year = ucal_get(calendar.get(), UCAL_YEAR, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    int32_t flipped = 1 - year;
+    if (!yearIsTwoDigit)
+        return String::number(flipped);
+    int32_t twoDigit = ((flipped % 100) + 100) % 100;
+    auto digits = String::number(twoDigit);
+    return digits.length() < 2 ? makeString('0', digits) : digits;
 }
 
 // ICU4C-WORKAROUND: rdar://182953351 - see proposalEraOverrideString. Shared by both format() overloads.
-static JSValue formatWithEraOverride(JSGlobalObject* globalObject, UDateFormat* format, double value, ASCIILiteral eraOverride)
+static JSValue formatWithEraOverride(JSGlobalObject* globalObject, UDateFormat* format, double value, const EraOverride& eraOverride, bool yearIsTwoDigit)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1438,8 +1466,10 @@ static JSValue formatWithEraOverride(JSGlobalObject* globalObject, UDateFormat* 
     if (U_FAILURE(fieldsStatus)) [[unlikely]]
         return throwTypeError(globalObject, scope, "failed to format date value"_s);
     replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(result);
-    // Splice: replace the era field's substring with override, or append if missing.
+
+    // Find the era field, and (only if needed) the year field, so both splice in one pass.
     int32_t eraBegin = -1, eraEnd = -1;
+    int32_t yearBegin = -1, yearEnd = -1;
     int32_t beginIndex = 0, endIndex = 0;
     while (true) {
         auto fieldType = ufieldpositer_next(fields.get(), &beginIndex, &endIndex);
@@ -1448,23 +1478,52 @@ static JSValue formatWithEraOverride(JSGlobalObject* globalObject, UDateFormat* 
         if (fieldType == UDAT_ERA_FIELD) {
             eraBegin = beginIndex;
             eraEnd = endIndex;
-            break;
+        } else if (eraOverride.needsYearFlip && fieldType == UDAT_YEAR_FIELD) {
+            yearBegin = beginIndex;
+            yearEnd = endIndex;
         }
     }
-    StringBuilder builder;
-    if (eraBegin >= 0) {
-        builder.append(StringView(result.span()).substring(0, eraBegin));
-        builder.append(String(eraOverride));
-        builder.append(StringView(result.span()).substring(eraEnd, result.size() - eraEnd));
-    } else {
+
+    StringView resultView(result.span());
+    if (eraBegin < 0) {
         // ICU can already leave a trailing space where the empty era slot would go;
         // only add our own separator if one isn't already there.
-        StringView resultView(result.span());
+        StringBuilder builder;
         builder.append(resultView);
         if (resultView.isEmpty() || !WTF::isUnicodeWhitespace(resultView[resultView.length() - 1]))
             builder.append(' ');
-        builder.append(String(eraOverride));
+        builder.append(String(eraOverride.text));
+        return jsString(vm, builder.toString());
     }
+
+    // Replace the era field, and the year field too when needsYearFlip (see struct above).
+    String yearReplacement;
+    if (yearBegin >= 0) {
+        if (auto flipped = flippedEraOverrideYear(format, value, yearIsTwoDigit))
+            yearReplacement = *flipped;
+    }
+
+    struct ReplacedSpan {
+        int32_t begin;
+        int32_t end;
+        String replacement;
+    };
+    ReplacedSpan spans[2] = { { eraBegin, eraEnd, String(eraOverride.text) }, { -1, -1, { } } };
+    if (!yearReplacement.isNull())
+        spans[1] = { yearBegin, yearEnd, yearReplacement };
+    if (spans[1].begin >= 0 && spans[1].begin < spans[0].begin)
+        std::swap(spans[0], spans[1]);
+
+    StringBuilder builder;
+    int32_t cursor = 0;
+    for (auto& span : spans) {
+        if (span.begin < 0)
+            continue;
+        builder.append(resultView.substring(cursor, span.begin - cursor));
+        builder.append(span.replacement);
+        cursor = span.end;
+    }
+    builder.append(resultView.substring(cursor, resultView.length() - cursor));
     return jsString(vm, builder.toString());
 }
 
@@ -1480,9 +1539,9 @@ JSValue IntlDateTimeFormat::format(JSGlobalObject* globalObject, double value) c
         return throwRangeError(globalObject, scope, "date value is not finite in DateTimeFormat format()"_s);
 
     // ICU4C-WORKAROUND: rdar://182953351 - see proposalEraOverrideString; only when era requested.
-    auto eraOverride = m_impl->m_era != Era::None ? proposalEraOverrideString(m_impl->m_calendar, value) : ASCIILiteral { };
-    if (!eraOverride.isNull())
-        RELEASE_AND_RETURN(scope, formatWithEraOverride(globalObject, m_impl->m_dateFormat.get(), value, eraOverride));
+    auto eraOverride = m_impl->m_era != Era::None ? proposalEraOverrideString(m_impl->m_calendar, value) : std::nullopt;
+    if (eraOverride)
+        RELEASE_AND_RETURN(scope, formatWithEraOverride(globalObject, m_impl->m_dateFormat.get(), value, *eraOverride, m_impl->m_year == Year::TwoDigit));
 
     Vector<char16_t, 32> result;
     auto status = callBufferProducingFunction(udat_format, m_impl->m_dateFormat.get(), value, result, nullptr);
@@ -1556,7 +1615,7 @@ static ASCIILiteral partTypeString(UDateFormatField field)
     return "unknown"_s;
 }
 
-static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFormat* format, double value, JSString* sourceType, ASCIILiteral eraOverride = { })
+static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFormat* format, double value, JSString* sourceType, std::optional<EraOverride> eraOverride = std::nullopt, bool yearIsTwoDigit = false)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1607,9 +1666,13 @@ static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFo
             JSString* valueStr;
             {
                 // ICU4C-WORKAROUND: rdar://182953351 - replace era field text with override for islamic-* pre-Hijra / coptic pre-AM.
-                if (!eraOverride.isNull() && fieldType == UDAT_ERA_FIELD) {
-                    valueStr = jsNontrivialString(vm, String(eraOverride));
+                if (eraOverride && fieldType == UDAT_ERA_FIELD) {
+                    valueStr = jsNontrivialString(vm, String(eraOverride->text));
                     sawEra = true;
+                } else if (eraOverride && eraOverride->needsYearFlip && fieldType == UDAT_YEAR_FIELD) {
+                    // ICU4C-WORKAROUND: rdar://182953351 - flip the year the same way formatWithEraOverride does.
+                    auto flipped = flippedEraOverrideYear(format, value, yearIsTwoDigit);
+                    valueStr = flipped ? jsString(vm, *flipped) : jsString(vm, resultStringView.substring(beginIndex, endIndex - beginIndex));
                 } else
                     valueStr = jsString(vm, resultStringView.substring(beginIndex, endIndex - beginIndex));
             }
@@ -1623,7 +1686,7 @@ static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFo
 
     {
         // ICU4C-WORKAROUND: rdar://182953351 - append era override as a distinct part when ICU emitted no era field (coptic pre-AM).
-        if (!eraOverride.isNull() && !sawEra) {
+        if (eraOverride && !sawEra) {
             if (resultStringView.isEmpty() || !WTF::isUnicodeWhitespace(resultStringView[resultLength - 1])) {
                 auto separator = jsSingleCharacterString(vm, static_cast<char16_t>(' '));
                 JSObject* separatorPart = sourceType
@@ -1633,7 +1696,7 @@ static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFo
                 RETURN_IF_EXCEPTION(scope, { });
             }
             auto type = jsNontrivialString(vm, "era"_s);
-            auto valueStr = jsNontrivialString(vm, String(eraOverride));
+            auto valueStr = jsNontrivialString(vm, String(eraOverride->text));
             JSObject* part = sourceType
                 ? createIntlPartObjectWithSource(globalObject, type, valueStr, sourceType)
                 : createIntlPartObject(globalObject, type, valueStr);
@@ -2514,9 +2577,9 @@ JSValue IntlDateTimeFormat::format(JSGlobalObject* globalObject, JSValue x) cons
         return throwTypeError(globalObject, scope, "DateTimeFormat has no fields applicable to this Temporal type"_s);
 
     // ICU4C-WORKAROUND: rdar://182953351 - see proposalEraOverrideString; only when era requested.
-    auto eraOverride = m_impl->m_era != Era::None ? proposalEraOverrideString(m_impl->m_calendar, record.value) : ASCIILiteral { };
-    if (!eraOverride.isNull())
-        RELEASE_AND_RETURN(scope, formatWithEraOverride(globalObject, tempFormat, record.value, eraOverride));
+    auto eraOverride = m_impl->m_era != Era::None ? proposalEraOverrideString(m_impl->m_calendar, record.value) : std::nullopt;
+    if (eraOverride)
+        RELEASE_AND_RETURN(scope, formatWithEraOverride(globalObject, tempFormat, record.value, *eraOverride, m_impl->m_year == Year::TwoDigit));
 
     Vector<char16_t, 32> result;
     auto fmtStatus = callBufferProducingFunction(udat_format, tempFormat, record.value, result, nullptr);
@@ -2548,8 +2611,8 @@ JSValue IntlDateTimeFormat::formatToParts(JSGlobalObject* globalObject, JSValue 
     }
 
     // ICU4C-WORKAROUND: rdar://182953351 - see proposalEraOverrideString; only when era requested.
-    auto eraOverride = m_impl->m_era != Era::None ? proposalEraOverrideString(m_impl->m_calendar, record.value) : ASCIILiteral { };
-    RELEASE_AND_RETURN(scope, buildFormattedDateTimeParts(globalObject, fmt, record.value, nullptr, eraOverride));
+    auto eraOverride = m_impl->m_era != Era::None ? proposalEraOverrideString(m_impl->m_calendar, record.value) : std::nullopt;
+    RELEASE_AND_RETURN(scope, buildFormattedDateTimeParts(globalObject, fmt, record.value, nullptr, eraOverride, m_impl->m_year == Year::TwoDigit));
 }
 
 std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter>


### PR DESCRIPTION
#### 171864159318a3d0c4c344f0775ab26210e841b9
<pre>
[JSC][Intl] Compute the &quot;Before Hijra&quot; year from the calendar, not ICU&apos;s rendered text
<a href="https://bugs.webkit.org/show_bug.cgi?id=321713">https://bugs.webkit.org/show_bug.cgi?id=321713</a>
<a href="https://rdar.apple.com/184853584">rdar://184853584</a>

Reviewed by Sosuke Suzuki.

Islamic calendars have only one ICU era value, so pre-Hijra dates come back as a negative raw
year under it instead of a distinct era. The existing workaround detects the
epoch boundary and substitutes &quot;Before Hijra&quot; text, but left the year untouched, so a pre-Hijra
date rendered as e.g. &quot;-332 Before Hijra&quot; — double-negative, and inconsistent with how Gregorian&apos;s
native &quot;Before Christ&quot; and Temporal&apos;s own eraYear for this exact era both read (1 - year, no year
zero: &quot;333 Before Hijra&quot;).

Fixes the year to match that convention. The value comes from a clone of the format&apos;s own calendar
(cloned and given its own millis, same pattern already used by createCalendarForDate in this file)
rather than by parsing ICU&apos;s already-rendered year text — parsing would be wrong under
year:&quot;2-digit&quot;, since ICU truncates to two digits before this code ever sees the string, and
flipping an already-truncated number does not equal truncating the correctly-flipped one.

EraOverride now carries a needsYearFlip flag (true for islamic-civil/tbla/umalqura, false for
coptic — ICU already renders coptic&apos;s year correctly on its own) instead of a bare era string, and
the flip is computed once in a shared helper used by both format() and formatToParts(), which
previously would have needed the identical logic written out twice.

Test: JSTests/stress/intl-datetimeformat.js
Canonical link: <a href="https://commits.webkit.org/319172@main">https://commits.webkit.org/319172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/492fd21d022b0ecbc5229cd4e7665520ebee9300

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144932 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1b2df9e-5b0a-4524-992b-c06d2b5a4f7a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140872 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50626a86-9f16-4760-8a4a-ac5896464cfc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121324 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5fd1bb9-f0b2-4cd6-9ee9-3d6bfcf55ba0) 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43218 "An unexpected error occured. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; 1 new passes 3 flakes; Uploaded test results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41500 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3291 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10136 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41180 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1981 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41884 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192757 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54221 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150245 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54909 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149963 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27430 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44586 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127174 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122389 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53426 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16173 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52808 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53045 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52873 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->