### PR TITLE
[JSC] Rename the visitWeak family to reconcileWeakReferencesAtGCEnd

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -1399,7 +1399,7 @@ void AccessCase::dump(PrintStream& out) const
     out.print("}"_s);
 }
 
-bool AccessCase::visitWeak(VM& vm) const
+bool AccessCase::isStillLive(VM& vm) const
 {
     bool isValid = true;
     forEachDependentCell(vm, [&](JSCell* cell) {

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -390,7 +390,7 @@ private:
     void forEachDependentCell(VM&, const Functor&) const;
 
     DECLARE_VISIT_AGGREGATE_WITH_MODIFIER(const);
-    bool visitWeak(VM&) const;
+    bool isStillLive(VM&) const;
     template<typename Visitor> void propagateTransitions(Visitor&) const;
 
     AccessType m_type;

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -170,7 +170,7 @@ bool CallLinkInfo::haveLastSeenCallee() const
     return !!m_lastSeenCallee;
 }
 
-void CallLinkInfo::visitWeak(VM& vm)
+void CallLinkInfo::reconcileWeakReferencesAtGCEnd(VM& vm)
 {
     auto handleSpecificCallee = [&] (JSFunction* callee) {
         if (vm.heap.isMarked(callee->executable()))
@@ -185,7 +185,7 @@ void CallLinkInfo::visitWeak(VM& vm)
         break;
     case Mode::Polymorphic: {
         if (stub()) {
-            if (!stub()->visitWeak(vm)) {
+            if (!stub()->reconcileWeakReferencesAtGCEnd(vm)) {
                 dataLogLnIf(Options::verboseOSR(), "At ", codeOrigin(), ", ", RawPointer(this), ": clearing call stub to ", listDump(stub()->variants()), ", stub routine ", RawPointer(stub()), ".");
                 unlinkOrUpgrade(vm, nullptr, nullptr);
                 m_clearedByGC = true;
@@ -440,7 +440,7 @@ void DirectCallLinkInfo::unlinkOrUpgradeImpl(VM&, CodeBlock* oldCodeBlock, CodeB
     RELEASE_ASSERT(!isOnList());
 }
 
-void DirectCallLinkInfo::visitWeak(VM& vm)
+void DirectCallLinkInfo::reconcileWeakReferencesAtGCEnd(VM& vm)
 {
     if (m_codeBlock && !vm.heap.isMarked(m_codeBlock)) {
         dataLogLnIf(Options::verboseOSR(), "Clearing call to ", RawPointer(m_codeBlock), " (", pointerDump(m_codeBlock), ").");

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -271,7 +271,7 @@ public:
             functor(lastSeenCallee());
     }
 
-    void visitWeak(VM&);
+    void reconcileWeakReferencesAtGCEnd(VM&);
 
     Type type() const { return static_cast<Type>(m_type); }
 
@@ -394,7 +394,7 @@ public:
 
     void unlinkOrUpgradeImpl(VM&, CodeBlock* oldCodeBlock, CodeBlock* newCodeBlock);
 
-    void visitWeak(VM&);
+    void reconcileWeakReferencesAtGCEnd(VM&);
 
     CodeOrigin codeOrigin() const { return m_codeOrigin; }
     bool isDataIC() const { return m_useDataIC == UseDataIC::Yes; }

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -1751,19 +1751,19 @@ void CodeBlock::reconcileJITInlineCachesAtGCEnd()
 #if ENABLE(DFG_JIT)
     if (JSC::JITCode::isOptimizingJIT(jitType())) {
         for (auto* callLinkInfo : m_jitCode->dfgCommon()->m_callLinkInfos)
-            callLinkInfo->visitWeak(vm());
+            callLinkInfo->reconcileWeakReferencesAtGCEnd(vm());
         for (auto* callLinkInfo : m_jitCode->dfgCommon()->m_directCallLinkInfos)
-            callLinkInfo->visitWeak(vm());
+            callLinkInfo->reconcileWeakReferencesAtGCEnd(vm());
         if (auto* jitData = dfgJITData()) {
             for (auto& callLinkInfo : jitData->callLinkInfos())
-                callLinkInfo.visitWeak(vm());
+                callLinkInfo.reconcileWeakReferencesAtGCEnd(vm());
         }
     }
 #endif
 
     forEachPropertyInlineCache([&](PropertyInlineCache& propertyCache) {
         ConcurrentJSLockerBase locker(NoLockingNecessary);
-        propertyCache.visitWeak(locker, this);
+        propertyCache.reconcileWeakReferencesAtGCEnd(locker, this);
         return IterationStatus::Continue;
     });
 }
@@ -1782,7 +1782,7 @@ void CodeBlock::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope)
         reconcileLLIntInlineCachesAtGCEnd();
         // If the CodeBlock is DFG or FTL, CallLinkInfo in metadata is not related.
         forEachLLIntOrBaselineCallLinkInfo([&](DataOnlyCallLinkInfo& callLinkInfo) {
-            callLinkInfo.visitWeak(vm);
+            callLinkInfo.reconcileWeakReferencesAtGCEnd(vm);
         });
     }
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -8247,11 +8247,11 @@ AccessGenerationResult PolymorphicAccess::addCases(const GCSafeConcurrentJSLocke
     return AccessGenerationResult::Buffered;
 }
 
-bool PolymorphicAccess::visitWeak(VM& vm)
+bool PolymorphicAccess::isStillLive(VM& vm)
 {
     bool isValid = true;
     for (unsigned i = 0; i < size(); ++i)
-        isValid &= at(i).visitWeak(vm);
+        isValid &= at(i).isStillLive(vm);
     return isValid;
 }
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -134,7 +134,7 @@ public:
     DECLARE_VISIT_AGGREGATE;
 
     // If this returns false then we are requesting a reset of the owning PropertyInlineCache.
-    bool visitWeak(VM&);
+    bool isStillLive(VM&);
 
     // This returns true if it has marked everything it will ever marked. This can be used as an
     // optimization to then avoid calling this method again during the fixpoint.

--- a/Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp
@@ -246,17 +246,17 @@ void InlineCacheHandler::aboutToDie()
     m_watchpoint.reset();
 }
 
-bool InlineCacheHandler::visitWeak(VM& vm)
+bool InlineCacheHandler::reconcileWeakReferencesAtGCEnd(VM& vm)
 {
     bool isValid = true;
     if (auto* withJSCall = dynamicDowncast<InlineCacheHandlerWithJSCall>(*this))
-        withJSCall->m_callLinkInfo.visitWeak(vm);
+        withJSCall->m_callLinkInfo.reconcileWeakReferencesAtGCEnd(vm);
 
     if (m_accessCase)
-        isValid &= m_accessCase->visitWeak(vm);
+        isValid &= m_accessCase->isStillLive(vm);
 
     if (m_stubRoutine)
-        isValid &= m_stubRoutine->visitWeak(vm);
+        isValid &= m_stubRoutine->reconcileWeakReferencesAtGCEnd(vm);
 
     return isValid;
 }

--- a/Source/JavaScriptCore/bytecode/InlineCacheHandler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheHandler.h
@@ -79,7 +79,7 @@ public:
     }
 
     // If this returns false then we are requesting a reset of the owning PropertyInlineCache.
-    bool visitWeak(VM&);
+    bool reconcileWeakReferencesAtGCEnd(VM&);
 
     void dump(PrintStream&) const;
 

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
@@ -431,7 +431,7 @@ void PropertyInlineCache::visitAggregateImpl(Visitor& visitor)
 
 DEFINE_VISIT_AGGREGATE(PropertyInlineCache);
 
-void PropertyInlineCache::visitWeak(const ConcurrentJSLockerBase& locker, CodeBlock* codeBlock)
+void PropertyInlineCache::reconcileWeakReferencesAtGCEnd(const ConcurrentJSLockerBase& locker, CodeBlock* codeBlock)
 {
     VM& vm = codeBlock->vm();
     {
@@ -456,18 +456,18 @@ void PropertyInlineCache::visitWeak(const ConcurrentJSLockerBase& locker, CodeBl
 
     if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
         if (handlerIC->m_inlinedHandler)
-            isValid &= handlerIC->m_inlinedHandler->visitWeak(vm);
+            isValid &= handlerIC->m_inlinedHandler->reconcileWeakReferencesAtGCEnd(vm);
     }
     if (auto* cursor = m_handler.get()) {
         while (cursor) {
-            isValid &= cursor->visitWeak(vm);
+            isValid &= cursor->reconcileWeakReferencesAtGCEnd(vm);
             cursor = cursor->next();
         }
     }
 
     if (auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(*this)) {
         if (repatchingIC->m_stub)
-            isValid &= repatchingIC->m_stub->visitWeak(vm);
+            isValid &= repatchingIC->m_stub->isStillLive(vm);
     }
 
     if (isValid)

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
@@ -152,7 +152,7 @@ public:
 
     // Check if the stub has weak references that are dead. If it does, then it resets itself,
     // either entirely or just enough to ensure that those dead pointers don't get used anymore.
-    void visitWeak(const ConcurrentJSLockerBase&, CodeBlock*);
+    void reconcileWeakReferencesAtGCEnd(const ConcurrentJSLockerBase&, CodeBlock*);
 
     // This returns true if it has marked everything that it will ever mark.
     template<typename Visitor> void propagateTransitions(Visitor&);

--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.cpp
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.cpp
@@ -73,7 +73,7 @@ void MicrotaskCall::unlinkOrUpgradeImpl(VM&, CodeBlock* oldCodeBlock, CodeBlock*
     m_addressForCall = nullptr;
 }
 
-void MicrotaskCall::visitWeak(VM& vm)
+void MicrotaskCall::reconcileWeakReferencesAtGCEnd(VM& vm)
 {
     if ((m_functionExecutable && !vm.heap.isMarked(m_functionExecutable)) || (m_codeBlock && !vm.heap.isMarked(m_codeBlock))) {
         if (isOnList())

--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.h
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.h
@@ -68,7 +68,7 @@ public:
     void unlinkOrUpgradeImpl(VM&, CodeBlock* oldCodeBlock, CodeBlock* newCodeBlock);
     void relink(VM&, JSFunction*);
 
-    void visitWeak(VM&);
+    void reconcileWeakReferencesAtGCEnd(VM&);
 
 private:
     CodeBlock* m_codeBlock { nullptr };
@@ -112,7 +112,7 @@ public:
     void reconcileWeakReferencesAtGCEnd(VM& vm)
     {
         for (auto& entry : m_entries)
-            entry.visitWeak(vm);
+            entry.reconcileWeakReferencesAtGCEnd(vm);
     }
 
 private:

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -164,12 +164,12 @@ void PolymorphicAccessJITStubRoutine::addedToSharedJITStubSet()
     m_isInSharedJITStubSet = true;
 }
 
-bool PolymorphicAccessJITStubRoutine::visitWeakImpl(VM& vm)
+bool PolymorphicAccessJITStubRoutine::reconcileWeakReferencesAtGCEndImpl(VM& vm)
 {
     bool isValid = true;
     for (StructureID weakReference : m_weakStructures)
         isValid &= vm.heap.isMarked(weakReference.decode());
-    isValid &= Base::visitWeakImpl(vm);
+    isValid &= Base::reconcileWeakReferencesAtGCEndImpl(vm);
     return isValid;
 }
 
@@ -204,13 +204,13 @@ void MarkingGCAwareJITStubRoutine::markRequiredObjectsImpl(SlotVisitor& visitor)
     markRequiredObjectsInternalImpl(visitor);
 }
 
-bool MarkingGCAwareJITStubRoutine::visitWeakImpl(VM& vm)
+bool MarkingGCAwareJITStubRoutine::reconcileWeakReferencesAtGCEndImpl(VM& vm)
 {
     for (auto& callLinkInfo : m_callLinkInfos) {
         if (callLinkInfo)
-            callLinkInfo->visitWeak(vm);
+            callLinkInfo->reconcileWeakReferencesAtGCEnd(vm);
     }
-    return Base::visitWeakImpl(vm);
+    return Base::reconcileWeakReferencesAtGCEndImpl(vm);
 }
 
 CallLinkInfo* MarkingGCAwareJITStubRoutine::callLinkInfoAtImpl(const ConcurrentJSLocker&, unsigned index)

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -149,7 +149,7 @@ public:
             m_owners.remove(codeBlock);
     }
 
-    bool visitWeakImpl(VM&);
+    bool reconcileWeakReferencesAtGCEndImpl(VM&);
 
 protected:
     void observeZeroRefCountImpl();
@@ -173,7 +173,7 @@ public:
 
     MarkingGCAwareJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<Ref<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner, const Vector<JSCell*>&, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&&, bool isCodeImmutable);
 
-    bool visitWeakImpl(VM&);
+    bool reconcileWeakReferencesAtGCEndImpl(VM&);
     CallLinkInfo* NODELETE callLinkInfoAtImpl(const ConcurrentJSLocker&, unsigned);
 
 protected:

--- a/Source/JavaScriptCore/jit/JITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.cpp
@@ -80,11 +80,11 @@ void JITStubRoutine::observeZeroRefCount()
     });
 }
 
-bool JITStubRoutine::visitWeak(VM& vm)
+bool JITStubRoutine::reconcileWeakReferencesAtGCEnd(VM& vm)
 {
     bool result = true;
     runWithDowncast([&](auto* derived) {
-        result = derived->visitWeakImpl(vm);
+        result = derived->reconcileWeakReferencesAtGCEndImpl(vm);
     });
     return result;
 }

--- a/Source/JavaScriptCore/jit/JITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.h
@@ -126,7 +126,7 @@ public:
         return isJITPC(std::bit_cast<void*>(address));
     }
     
-    bool visitWeak(VM&);
+    bool reconcileWeakReferencesAtGCEnd(VM&);
     CallLinkInfo* callLinkInfoAt(const ConcurrentJSLocker&, unsigned);
     void markRequiredObjects(AbstractSlotVisitor&);
     void markRequiredObjects(SlotVisitor&);
@@ -149,7 +149,7 @@ protected:
     // Return true if you are still valid after. Return false if you are now invalid. If you return
     // false, you will usually not do any clearing because the idea is that you will simply be
     // destroyed.
-    ALWAYS_INLINE bool visitWeakImpl(VM&) { return true; }
+    ALWAYS_INLINE bool reconcileWeakReferencesAtGCEndImpl(VM&) { return true; }
     ALWAYS_INLINE CallLinkInfo* callLinkInfoAtImpl(const ConcurrentJSLocker&, unsigned) { return nullptr; }
 
     template<typename Func>

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -125,9 +125,9 @@ class NativeExecutable;
     macro(PutByValWithFalseKeyReplaceHandler, putByValWithFalseKeyReplaceHandler) \
 
 // VM-dependent thunks that must exist before any code runs, because they are requested from
-// contexts that cannot take a lock. In particular CallLinkInfo::visitWeak runs during GC with the
-// JIT worklist threads suspended, and reaches getCTIVirtualCall; if a suspended compiler thread held
-// the lock, taking it here would deadlock.
+// contexts that cannot take a lock. In particular CallLinkInfo::reconcileWeakReferencesAtGCEnd
+// runs during GC with the JIT worklist threads suspended, and reaches getCTIVirtualCall; if a
+// suspended compiler thread held the lock, taking it here would deadlock.
 #define JSC_FOR_EACH_VM_DEPENDENT_EAGER_COMMON_THUNK(macro) \
     macro(HandleException, handleExceptionGenerator) \
     macro(CheckException, checkExceptionGenerator) \

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
@@ -159,7 +159,7 @@ void PolymorphicCallStubRoutine::unlinkForcefully()
         callNode.unlinkForcefully();
 }
 
-bool PolymorphicCallStubRoutine::visitWeakImpl(VM& vm)
+bool PolymorphicCallStubRoutine::reconcileWeakReferencesAtGCEndImpl(VM& vm)
 {
     bool isStillLive = true;
     for (unsigned i = 0, size = std::size(trailingSpan()) - 1; i < size; ++i) {

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
@@ -124,7 +124,7 @@ private:
     void NODELETE markRequiredObjectsImpl(AbstractSlotVisitor&);
     void markRequiredObjectsImpl(SlotVisitor&);
 
-    bool visitWeakImpl(VM&);
+    bool reconcileWeakReferencesAtGCEndImpl(VM&);
 
     CallLinkInfo* m_callLinkInfo { nullptr };
     bool m_notUsingCounting : 1 { false };

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -416,7 +416,7 @@ void JSWebAssemblyInstance::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionSco
     for (unsigned index = 0; index < numImportFunctions(); ++index) {
         auto* info = importFunctionInfo(index);
         if (auto* callLinkInfo = info->callLinkInfo.get())
-            callLinkInfo->visitWeak(vm);
+            callLinkInfo->reconcileWeakReferencesAtGCEnd(vm);
     }
 }
 


### PR DESCRIPTION
#### 5602ec36107bd2d82e39b5f071f932c1241f6ac1
<pre>
[JSC] Rename the visitWeak family to reconcileWeakReferencesAtGCEnd
<a href="https://bugs.webkit.org/show_bug.cgi?id=321714">https://bugs.webkit.org/show_bug.cgi?id=321714</a>
<a href="https://rdar.apple.com/184853952">rdar://184853952</a>

Reviewed by Vassili Bykov.

Follow-on to the reconcileWeakReferencesAtGCEnd rename; these are the leaves of the same
pass. &quot;visitWeak&quot; was doubly misleading. Usually in JSC &quot;visit&quot; means trace or
mark -- visitChildren, visitAggregate, SlotVisitor::append -- but these do the opposite:
CallLinkInfo::visitWeak calls unlinkOrUpgrade and sets m_clearedByGC. And nothing in the
name said when they run; every caller sits in the GC End reconcile tree.

Returning bool does not by itself make one a predicate, so name them by what they do.
Callers of the bool form do isValid &amp;= ..., then discard the stub on false.

    reconcileWeakReferencesAtGCEnd, void
        CallLinkInfo, DirectCallLinkInfo, MicrotaskCall, PropertyInlineCache

    reconcileWeakReferencesAtGCEnd, bool &quot;still usable&quot;
        InlineCacheHandler           reconciles m_callLinkInfo, then computes isValid
        PolymorphicCallStubRoutine   clears dead slots via slot = CallSlot()
        MarkingGCAwareJITStubRoutine reconciles m_callLinkInfos
        JITStubRoutine and the ...Impl virtual, since two of the four overrides mutate
        and a caller cannot know which it dispatches to

    isStillLive, pure predicate
        AccessCase (const), PolymorphicAccess

PolymorphicAccess only aggregates AccessCase::isStillLive, so it stays a predicate despite
sitting mid-chain. isStillLive matches StructureSet::isStillAlive and
ObjectPropertyCondition::isStillLive nearby.

No behavior change.

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::isStillLive const):
(JSC::AccessCase::visitWeak const): Deleted.
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::CallLinkInfo::reconcileWeakReferencesAtGCEnd):
(JSC::DirectCallLinkInfo::reconcileWeakReferencesAtGCEnd):
(JSC::CallLinkInfo::visitWeak): Deleted.
(JSC::DirectCallLinkInfo::visitWeak): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::reconcileJITInlineCachesAtGCEnd):
(JSC::CodeBlock::reconcileWeakReferencesAtGCEnd):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::PolymorphicAccess::isStillLive):
(JSC::PolymorphicAccess::visitWeak): Deleted.
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp:
(JSC::InlineCacheHandler::reconcileWeakReferencesAtGCEnd):
(JSC::InlineCacheHandler::visitWeak): Deleted.
* Source/JavaScriptCore/bytecode/InlineCacheHandler.h:
* Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp:
(JSC::PropertyInlineCache::reconcileWeakReferencesAtGCEnd):
(JSC::PropertyInlineCache::visitWeak): Deleted.
* Source/JavaScriptCore/bytecode/PropertyInlineCache.h:
* Source/JavaScriptCore/interpreter/MicrotaskCall.cpp:
(JSC::MicrotaskCall::reconcileWeakReferencesAtGCEnd):
(JSC::MicrotaskCall::visitWeak): Deleted.
* Source/JavaScriptCore/interpreter/MicrotaskCall.h:
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::PolymorphicAccessJITStubRoutine::reconcileWeakReferencesAtGCEndImpl):
(JSC::MarkingGCAwareJITStubRoutine::reconcileWeakReferencesAtGCEndImpl):
(JSC::PolymorphicAccessJITStubRoutine::visitWeakImpl): Deleted.
(JSC::MarkingGCAwareJITStubRoutine::visitWeakImpl): Deleted.
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
* Source/JavaScriptCore/jit/JITStubRoutine.cpp:
(JSC::JITStubRoutine::reconcileWeakReferencesAtGCEnd):
(JSC::JITStubRoutine::visitWeak): Deleted.
* Source/JavaScriptCore/jit/JITStubRoutine.h:
(JSC::JITStubRoutine::reconcileWeakReferencesAtGCEndImpl):
(JSC::JITStubRoutine::visitWeakImpl): Deleted.
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp:
(JSC::PolymorphicCallStubRoutine::reconcileWeakReferencesAtGCEndImpl):
(JSC::PolymorphicCallStubRoutine::visitWeakImpl): Deleted.
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::reconcileWeakReferencesAtGCEnd):

Canonical link: <a href="https://commits.webkit.org/319150@main">https://commits.webkit.org/319150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eafd2e5e1bf22b6341e271225b723ca06b876d30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190823 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140876 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42f0f043-51c3-498c-b25f-168b78d3ced2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121328 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bcfc988c-8c3b-4ea5-8e27-790ca7561d71) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/3295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10134 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41178 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1983 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41886 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/47166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192759 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54223 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150251 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54911 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149969 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27415 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44587 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127176 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122391 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53428 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16171 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52810 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53047 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52875 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->