### PR TITLE
[JSC] Add a fast path to Parser::useVariable

### DIFF
--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -650,6 +650,13 @@ public:
     void useVariable(UniquedStringImpl* impl, bool isEval)
     {
         m_usesEval |= isEval;
+        if (impl == m_lastAddedUsedVariable) {
+            // A failure indicates that m_usedVariables was changed (a set added or removed)
+            // without clearing m_lastAddedUsedVariable.
+            ASSERT(m_usedVariables.last().contains(impl));
+            return;
+        }
+        m_lastAddedUsedVariable = impl;
         m_usedVariables.last().add(impl);
     }
     void usePrivateName(const Identifier& ident)
@@ -659,9 +666,17 @@ public:
 
     void setUsesImportMeta() { m_usesImportMeta = true; }
 
-    void pushUsedVariableSet() { m_usedVariables.append(UniquedStringImplPtrSet()); }
+    void pushUsedVariableSet()
+    {
+        m_usedVariables.append(UniquedStringImplPtrSet());
+        m_lastAddedUsedVariable = nullptr;
+    }
     size_t currentUsedVariablesSize() { return m_usedVariables.size(); }
-    void revertToPreviousUsedVariables(size_t size) { m_usedVariables.resize(size); }
+    void revertToPreviousUsedVariables(size_t size)
+    {
+        m_usedVariables.resize(size);
+        m_lastAddedUsedVariable = nullptr;
+    }
 
     void setNeedsFullActivation() { m_needsFullActivation = true; }
     bool needsFullActivation() const { return m_needsFullActivation; }
@@ -1031,6 +1046,7 @@ private:
     EvalContextType m_evalContextType { EvalContextType::None };
     DerivedContextType m_derivedContextType { DerivedContextType::None };
 
+    UniquedStringImpl* m_lastAddedUsedVariable { nullptr };
     Vector<UniquedStringImplPtrSet, 6> m_usedVariables;
 
     static void verifyLayout();


### PR DESCRIPTION
#### 9f770b1bd5958779d19eec644e05c3c183103e0d
<pre>
[JSC] Add a fast path to Parser::useVariable
<a href="https://bugs.webkit.org/show_bug.cgi?id=321716">https://bugs.webkit.org/show_bug.cgi?id=321716</a>
<a href="https://rdar.apple.com/184855343">rdar://184855343</a>

Reviewed by Yijia Huang.

Parser::useVariable adds a variable to the top set of the m_usedVariables stack.
It&apos;s not uncommon for the same variable to be added repeatedly, so it helps
to remember the last added variable and skip the extra work if it gets added again.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/319191@main">https://commits.webkit.org/319191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4db6a36447eac977b3af7aef17a1ec1b6b6c7c3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190825 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144936 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a30020b0-8663-4050-8b07-4e81c6e07d9e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140875 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b76cdd5a-32db-45b8-848c-ce7159b6b59b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121327 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d55d1bb-3d2a-44a5-807f-808836a06e07) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41503 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3294 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10137 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41181 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1985 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41888 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192761 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54225 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150253 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40243 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54913 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37798 "Too many flaky failures: http/tests/cookies/same-site/user-load-cross-site-redirect.py, http/tests/media/track-in-band-hls-metadata-removecue-non-datacue-crash.html, http/tests/misc/slow-preload-cancel.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/omit-document-referrer-nested-third-party-iframe-ephemeral.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/storageAccess/deny-without-prompt-preserves-gesture.html, http/tests/websocket/tests/hybi/handshake-error.html, http/tests/xmlhttprequest/abort-should-cancel-load.html, http/wpt/background-fetch/background-fetch-persistency.window.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149971 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44589 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127178 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122393 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53430 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16174 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52812 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53049 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52877 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->