### PR TITLE
AX: AXRangeForLine and AXLineForIndex don't count lines consistently in contenteditables

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/range-for-line-with-block-line-breaks-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/range-for-line-with-block-line-breaks-expected.txt
@@ -1,0 +1,61 @@
+Asserts AXRangeForLine and AXLineForIndex for multi-line text controls whose lines are separated by block boundaries rather than <br> elements.
+
+two block-separated lines: value "one two\nthree"
+PASS: axField.numberOfCharacters === 13
+PASS: lineRange === "{0, 7}"
+PASS: axField.stringForRange(0, 7) === "one two"
+PASS: lineRange === "{8, 5}"
+PASS: axField.stringForRange(8, 5) === "three"
+PASS: lineIndexes.join(',') === "0,0,0,0,0,0,0,0,1,1,1,1,1,-1"
+
+four block-separated lines: value "aaa\nbbb\nccc\nddd"
+PASS: axField.numberOfCharacters === 15
+PASS: lineRange === "{0, 3}"
+PASS: axField.stringForRange(0, 3) === "aaa"
+PASS: lineRange === "{4, 3}"
+PASS: axField.stringForRange(4, 3) === "bbb"
+PASS: lineRange === "{8, 3}"
+PASS: axField.stringForRange(8, 3) === "ccc"
+PASS: lineRange === "{12, 3}"
+PASS: axField.stringForRange(12, 3) === "ddd"
+PASS: lineIndexes.join(',') === "0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,-1"
+
+four <br>-separated lines: value "aaa\nbbb\nccc\nddd"
+PASS: axField.numberOfCharacters === 15
+PASS: lineRange === "{0, 4}"
+PASS: axField.stringForRange(0, 4) === "aaa\n"
+PASS: lineRange === "{4, 4}"
+PASS: axField.stringForRange(4, 4) === "bbb\n"
+PASS: lineRange === "{8, 4}"
+PASS: axField.stringForRange(8, 4) === "ccc\n"
+PASS: lineRange === "{12, 3}"
+PASS: axField.stringForRange(12, 3) === "ddd"
+PASS: lineIndexes.join(',') === "0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,-1"
+
+textarea, newlines in the value: value "aaa\nbbb\nccc\nddd"
+PASS: axField.numberOfCharacters === 15
+PASS: lineRange === "{0, 4}"
+PASS: axField.stringForRange(0, 4) === "aaa\n"
+PASS: lineRange === "{4, 4}"
+PASS: axField.stringForRange(4, 4) === "bbb\n"
+PASS: lineRange === "{8, 4}"
+PASS: axField.stringForRange(8, 4) === "ccc\n"
+PASS: lineRange === "{12, 3}"
+PASS: axField.stringForRange(12, 3) === "ddd"
+PASS: lineIndexes.join(',') === "0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,-1"
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+one two
+three
+aaa
+bbb
+ccc
+ddd
+aaa
+bbb
+ccc
+ddd
+

--- a/LayoutTests/accessibility/isolated-tree/mac/range-for-line-with-block-line-breaks.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/range-for-line-with-block-line-breaks.html
@@ -1,0 +1,112 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- AXRangeForLine and AXLineForIndex speak the same character index space as AXStringForRange, so
+     every character of the value occupies an index in it. When lines are separated by block
+     boundaries rather than <br> elements — which is what pressing Return in a contenteditable
+     produces — the newline between two lines is synthesized at the boundary and belongs to neither
+     line's own range. The isolated tree built these answers by summing each line's own length, so it
+     lost one character per boundary and the drift accumulated down the control: line N's location
+     came back N characters short, and AXStringForRange on that range returned text shifted off the
+     line ("\nbb" instead of "bbb"). The <br> cases are here to hold the line that already agreed. -->
+<div id="pair" contenteditable role="textbox" aria-multiline="true" style="width: 300px"></div>
+<div id="blocks" contenteditable role="textbox" aria-multiline="true" style="width: 300px"></div>
+<div id="brs" contenteditable role="textbox" aria-multiline="true" style="width: 300px"></div>
+<textarea id="ta" style="width: 300px; height: 90px"></textarea>
+
+<script>
+var output = "Asserts AXRangeForLine and AXLineForIndex for multi-line text controls whose lines are separated by block boundaries rather than <br> elements.\n\n";
+
+// Each case's markup is set before the accessibility tree is first built, so no case depends on the
+// isolated tree observing a mutation. `lineStrings` are the expected AXStringForRange results for
+// the corresponding `ranges`, and are what actually catch a location in the wrong index space --
+// a shifted range still has a plausible length. `lines` is the expected AXLineForIndex for every
+// index from 0 through the value's length inclusive, so the past-the-end answer is covered too.
+var cases = [
+    {
+        id: "pair",
+        label: "two block-separated lines",
+        html: "<div>one two </div><div>three</div>",
+        value: "one two\nthree",
+        ranges: ["{0, 7}", "{8, 5}"],
+        lineStrings: ["one two", "three"],
+        lines: [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, -1],
+    },
+    {
+        id: "blocks",
+        label: "four block-separated lines",
+        html: "<div>aaa</div><div>bbb</div><div>ccc</div><div>ddd</div>",
+        value: "aaa\nbbb\nccc\nddd",
+        ranges: ["{0, 3}", "{4, 3}", "{8, 3}", "{12, 3}"],
+        lineStrings: ["aaa", "bbb", "ccc", "ddd"],
+        lines: [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, -1],
+    },
+    {
+        id: "brs",
+        label: "four <br>-separated lines",
+        html: "aaa<br>bbb<br>ccc<br>ddd",
+        value: "aaa\nbbb\nccc\nddd",
+        ranges: ["{0, 4}", "{4, 4}", "{8, 4}", "{12, 3}"],
+        lineStrings: ["aaa\n", "bbb\n", "ccc\n", "ddd"],
+        lines: [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, -1],
+    },
+    {
+        id: "ta",
+        label: "textarea, newlines in the value",
+        value: "aaa\nbbb\nccc\nddd",
+        ranges: ["{0, 4}", "{4, 4}", "{8, 4}", "{12, 3}"],
+        lineStrings: ["aaa\n", "bbb\n", "ccc\n", "ddd"],
+        lines: [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, -1],
+    },
+];
+
+for (var testCase of cases) {
+    var field = document.getElementById(testCase.id);
+    if (testCase.html !== undefined)
+        field.innerHTML = testCase.html;
+    else
+        field.value = testCase.value;
+    // Force layout so the value is laid out before the accessibility tree is built.
+    field.offsetHeight;
+}
+
+// expect() evaluates its expressions in its own scope, so the values it reads are globals.
+var axField, lineRange, lineIndexes;
+
+if (window.accessibilityController) {
+    for (var testCase of cases) {
+        axField = accessibilityController.accessibleElementById(testCase.id);
+        output += `${testCase.label}: value ${JSON.stringify(testCase.value)}\n`;
+        if (!axField) {
+            output += `FAIL: no accessibility element for #${testCase.id}\n\n`;
+            continue;
+        }
+
+        output += expect("axField.numberOfCharacters", `${testCase.value.length}`);
+
+        for (var line = 0; line < testCase.ranges.length; ++line) {
+            lineRange = axField.rangeForLine(line);
+            output += expect("lineRange", JSON.stringify(testCase.ranges[line]));
+            // Read the range back as text: a location in the wrong index space yields a range of
+            // the right length holding the wrong characters, which only this catches.
+            var bounds = JSON.parse(testCase.ranges[line].replace("{", "[").replace("}", "]"));
+            output += expect(`axField.stringForRange(${bounds[0]}, ${bounds[1]})`, JSON.stringify(testCase.lineStrings[line]));
+        }
+
+        lineIndexes = [];
+        for (var i = 0; i <= testCase.value.length; ++i)
+            lineIndexes.push(axField.lineForIndex(i));
+        output += expect("lineIndexes.join(',')", JSON.stringify(testCase.lines.join(",")));
+        output += "\n";
+    }
+
+    debugEscaped(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/range-for-line-with-block-line-breaks-expected.txt
+++ b/LayoutTests/accessibility/mac/range-for-line-with-block-line-breaks-expected.txt
@@ -1,0 +1,61 @@
+Asserts AXRangeForLine and AXLineForIndex for multi-line text controls whose lines are separated by block boundaries rather than <br> elements.
+
+two block-separated lines: value "one two\nthree"
+PASS: axField.numberOfCharacters === 13
+PASS: lineRange === "{0, 7}"
+PASS: axField.stringForRange(0, 7) === "one two"
+PASS: lineRange === "{8, 5}"
+PASS: axField.stringForRange(8, 5) === "three"
+PASS: lineIndexes.join(',') === "0,0,0,0,0,0,0,0,1,1,1,1,1,-1"
+
+four block-separated lines: value "aaa\nbbb\nccc\nddd"
+PASS: axField.numberOfCharacters === 15
+PASS: lineRange === "{0, 3}"
+PASS: axField.stringForRange(0, 3) === "aaa"
+PASS: lineRange === "{4, 3}"
+PASS: axField.stringForRange(4, 3) === "bbb"
+PASS: lineRange === "{8, 3}"
+PASS: axField.stringForRange(8, 3) === "ccc"
+PASS: lineRange === "{12, 3}"
+PASS: axField.stringForRange(12, 3) === "ddd"
+PASS: lineIndexes.join(',') === "0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,-1"
+
+four <br>-separated lines: value "aaa\nbbb\nccc\nddd"
+PASS: axField.numberOfCharacters === 15
+PASS: lineRange === "{0, 4}"
+PASS: axField.stringForRange(0, 4) === "aaa\n"
+PASS: lineRange === "{4, 4}"
+PASS: axField.stringForRange(4, 4) === "bbb\n"
+PASS: lineRange === "{8, 4}"
+PASS: axField.stringForRange(8, 4) === "ccc\n"
+PASS: lineRange === "{12, 3}"
+PASS: axField.stringForRange(12, 3) === "ddd"
+PASS: lineIndexes.join(',') === "0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,-1"
+
+textarea, newlines in the value: value "aaa\nbbb\nccc\nddd"
+PASS: axField.numberOfCharacters === 15
+PASS: lineRange === "{0, 4}"
+PASS: axField.stringForRange(0, 4) === "aaa\n"
+PASS: lineRange === "{4, 4}"
+PASS: axField.stringForRange(4, 4) === "bbb\n"
+PASS: lineRange === "{8, 4}"
+PASS: axField.stringForRange(8, 4) === "ccc\n"
+PASS: lineRange === "{12, 3}"
+PASS: axField.stringForRange(12, 3) === "ddd"
+PASS: lineIndexes.join(',') === "0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,-1"
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+one two
+three
+aaa
+bbb
+ccc
+ddd
+aaa
+bbb
+ccc
+ddd
+

--- a/LayoutTests/accessibility/mac/range-for-line-with-block-line-breaks.html
+++ b/LayoutTests/accessibility/mac/range-for-line-with-block-line-breaks.html
@@ -1,0 +1,112 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- AXRangeForLine and AXLineForIndex speak the same character index space as AXStringForRange, so
+     every character of the value occupies an index in it. When lines are separated by block
+     boundaries rather than <br> elements — which is what pressing Return in a contenteditable
+     produces — the newline between two lines is synthesized at the boundary and belongs to neither
+     line's own range. The isolated tree built these answers by summing each line's own length, so it
+     lost one character per boundary and the drift accumulated down the control: line N's location
+     came back N characters short, and AXStringForRange on that range returned text shifted off the
+     line ("\nbb" instead of "bbb"). The <br> cases are here to hold the line that already agreed. -->
+<div id="pair" contenteditable role="textbox" aria-multiline="true" style="width: 300px"></div>
+<div id="blocks" contenteditable role="textbox" aria-multiline="true" style="width: 300px"></div>
+<div id="brs" contenteditable role="textbox" aria-multiline="true" style="width: 300px"></div>
+<textarea id="ta" style="width: 300px; height: 90px"></textarea>
+
+<script>
+var output = "Asserts AXRangeForLine and AXLineForIndex for multi-line text controls whose lines are separated by block boundaries rather than <br> elements.\n\n";
+
+// Each case's markup is set before the accessibility tree is first built, so no case depends on the
+// isolated tree observing a mutation. `lineStrings` are the expected AXStringForRange results for
+// the corresponding `ranges`, and are what actually catch a location in the wrong index space --
+// a shifted range still has a plausible length. `lines` is the expected AXLineForIndex for every
+// index from 0 through the value's length inclusive, so the past-the-end answer is covered too.
+var cases = [
+    {
+        id: "pair",
+        label: "two block-separated lines",
+        html: "<div>one two </div><div>three</div>",
+        value: "one two\nthree",
+        ranges: ["{0, 7}", "{8, 5}"],
+        lineStrings: ["one two", "three"],
+        lines: [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, -1],
+    },
+    {
+        id: "blocks",
+        label: "four block-separated lines",
+        html: "<div>aaa</div><div>bbb</div><div>ccc</div><div>ddd</div>",
+        value: "aaa\nbbb\nccc\nddd",
+        ranges: ["{0, 3}", "{4, 3}", "{8, 3}", "{12, 3}"],
+        lineStrings: ["aaa", "bbb", "ccc", "ddd"],
+        lines: [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, -1],
+    },
+    {
+        id: "brs",
+        label: "four <br>-separated lines",
+        html: "aaa<br>bbb<br>ccc<br>ddd",
+        value: "aaa\nbbb\nccc\nddd",
+        ranges: ["{0, 4}", "{4, 4}", "{8, 4}", "{12, 3}"],
+        lineStrings: ["aaa\n", "bbb\n", "ccc\n", "ddd"],
+        lines: [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, -1],
+    },
+    {
+        id: "ta",
+        label: "textarea, newlines in the value",
+        value: "aaa\nbbb\nccc\nddd",
+        ranges: ["{0, 4}", "{4, 4}", "{8, 4}", "{12, 3}"],
+        lineStrings: ["aaa\n", "bbb\n", "ccc\n", "ddd"],
+        lines: [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, -1],
+    },
+];
+
+for (var testCase of cases) {
+    var field = document.getElementById(testCase.id);
+    if (testCase.html !== undefined)
+        field.innerHTML = testCase.html;
+    else
+        field.value = testCase.value;
+    // Force layout so the value is laid out before the accessibility tree is built.
+    field.offsetHeight;
+}
+
+// expect() evaluates its expressions in its own scope, so the values it reads are globals.
+var axField, lineRange, lineIndexes;
+
+if (window.accessibilityController) {
+    for (var testCase of cases) {
+        axField = accessibilityController.accessibleElementById(testCase.id);
+        output += `${testCase.label}: value ${JSON.stringify(testCase.value)}\n`;
+        if (!axField) {
+            output += `FAIL: no accessibility element for #${testCase.id}\n\n`;
+            continue;
+        }
+
+        output += expect("axField.numberOfCharacters", `${testCase.value.length}`);
+
+        for (var line = 0; line < testCase.ranges.length; ++line) {
+            lineRange = axField.rangeForLine(line);
+            output += expect("lineRange", JSON.stringify(testCase.ranges[line]));
+            // Read the range back as text: a location in the wrong index space yields a range of
+            // the right length holding the wrong characters, which only this catches.
+            var bounds = JSON.parse(testCase.ranges[line].replace("{", "[").replace("}", "]"));
+            output += expect(`axField.stringForRange(${bounds[0]}, ${bounds[1]})`, JSON.stringify(testCase.lineStrings[line]));
+        }
+
+        lineIndexes = [];
+        for (var i = 0; i <= testCase.value.length; ++i)
+            lineIndexes.push(axField.lineForIndex(i));
+        output += expect("lineIndexes.join(',')", JSON.stringify(testCase.lines.join(",")));
+        output += "\n";
+    }
+
+    debugEscaped(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -858,7 +858,6 @@ CharacterRange AXTextMarker::characterRangeForLine(unsigned lineIndex) const
     if (!textRunMarker.isValid())
         return { };
 
-    unsigned precedingLength = 0;
     // Use IncludeTrailingLineBreak::Yes to match AccessibilityRenderObject::doAXRangeForLine, which behaves this way (specifically):
     //   if (isHardLineBreak(lineEnd))
     //     ++lineEndIndex;
@@ -866,12 +865,21 @@ CharacterRange AXTextMarker::characterRangeForLine(unsigned lineIndex) const
     // meaning we will compute a different length between these two APIs for the same logical range.
     auto currentLineRange = textRunMarker.lineRange(LineRangeType::Current, IncludeTrailingLineBreak::Yes);
     while (lineIndex && currentLineRange) {
-        precedingLength += currentLineRange.length();
         currentLineRange = nextLineRange(currentLineRange, IncludeTrailingLineBreak::Yes, stopAtID);
         --lineIndex;
     }
     if (!currentLineRange)
         return { };
+
+    // Measure the location by walking from the control's first text position to this line's start,
+    // rather than by summing the preceding lines' own lengths. Text emitted between two lines — the
+    // newline synthesized at a block boundary, as in <div>one</div><div>two</div> — occupies a
+    // character index but sits outside either line's range, so summing line lengths falls one
+    // character short per boundary and yields a location in a different index space than the one
+    // AXStringForRange indexes with. A <br> line break leaves no such gap (the newline is part of
+    // the preceding line's range), which is why only block-separated lines were affected.
+    unsigned precedingLength = AXTextMarkerRange { textRunMarker, currentLineRange.start() }.length();
+
     // Report the trailing blank line of a value ending in a line break as an empty range at the
     // document end, so it reads as an empty line rather than a line whose content is a newline.
     unsigned lineLength = currentLineRange.length();
@@ -917,7 +925,14 @@ int AXTextMarker::lineNumberForIndex(unsigned index) const
     auto currentLineRange = textRunMarker.lineRange(LineRangeType::Current, IncludeTrailingLineBreak::Yes);
     while (currentLineRange) {
         unsigned lineLength = currentLineRange.length();
-        if (index < lineStart + lineLength) {
+        auto nextRange = nextLineRange(currentLineRange, IncludeTrailingLineBreak::Yes, stopAtID);
+        // A line occupies the index space up to the start of the next line, which is not the same as
+        // the length of its own range: the newline synthesized at a block boundary belongs to no
+        // line's range but still occupies an index, and the non-isolated AccessibilityRenderObject
+        // path attributes that index to the preceding line. Walking start-to-start counts it, and
+        // keeps this API's line boundaries aligned with characterRangeForLine's locations.
+        unsigned lineSpan = nextRange ? AXTextMarkerRange { currentLineRange.start(), nextRange.start() }.length() : lineLength;
+        if (index < lineStart + lineSpan) {
             // Report an index on the trailing blank line of a value ending in a line break as
             // out of range, matching the non-isolated AccessibilityRenderObject path: that line
             // sits at the document end and is surfaced by characterRangeForLine (an empty range)
@@ -926,8 +941,10 @@ int AXTextMarker::lineNumberForIndex(unsigned index) const
                 return -1;
             return static_cast<int>(lineNumber);
         }
-        lineStart += lineLength;
-        currentLineRange = nextLineRange(currentLineRange, IncludeTrailingLineBreak::Yes, stopAtID);
+        if (!nextRange)
+            break;
+        lineStart += lineSpan;
+        currentLineRange = WTF::move(nextRange);
         ++lineNumber;
     }
     return -1;


### PR DESCRIPTION
#### 6e28d9c0c7722d99f7ecde619c47f8652601bc14
<pre>
AX: AXRangeForLine and AXLineForIndex don&apos;t count lines consistently in contenteditables
<a href="https://bugs.webkit.org/show_bug.cgi?id=321681">https://bugs.webkit.org/show_bug.cgi?id=321681</a>
<a href="https://rdar.apple.com/184826408">rdar://184826408</a>

Reviewed by Tyler Wilcock.

AXRangeForLine and AXLineForIndex weren&apos;t consistent in how they counted block boundaries and
emitted newlines, leading to bugs when VoiceOver round-trips from a position to a line index
to a line range.

Tests: accessibility/isolated-tree/mac/range-for-line-with-block-line-breaks.html
       accessibility/mac/range-for-line-with-block-line-breaks.html

* LayoutTests/accessibility/isolated-tree/mac/range-for-line-with-block-line-breaks-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/range-for-line-with-block-line-breaks.html: Added.
* LayoutTests/accessibility/mac/range-for-line-with-block-line-breaks-expected.txt: Added.
* LayoutTests/accessibility/mac/range-for-line-with-block-line-breaks.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::characterRangeForLine const):
(WebCore::AXTextMarker::lineNumberForIndex const):

Canonical link: <a href="https://commits.webkit.org/319221@main">https://commits.webkit.org/319221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5d64a20442ffa612e000860dc9d759c4e971a75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54724 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48522 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190992 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145102 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/464c2dec-ddb3-4434-befe-182e02fcd15f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54440 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141013 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed layout tests; 8 flakes 2 failures; Uploaded test results; layout-tests; Running analyze-layout-tests-results") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f175242a-9d3c-4e1b-908b-11fff52d2b88) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121465 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a3f267b-df01-4773-977f-93525b1b55be) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41636 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41296 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2153 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192927 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54390 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161285 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Running run-layout-tests-in-stress-mode") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150397 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed layout tests; 26 flakes; Uploaded test results; layout-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40265 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55078 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150114 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44708 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127344 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122630 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53595 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16289 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52977 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53042 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->