### PR TITLE
[JSC] Add global priority queue inliner

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -40,6 +40,7 @@
 #include "CallVariantInlines.h"
 #include "CheckPrivateBrandStatus.h"
 #include "CodeBlock.h"
+#include "CodeBlockInlines.h"
 #include "CodeBlockWithJITType.h"
 #include "CommonSlowPaths.h"
 #include "DFGAbstractHeap.h"
@@ -105,6 +106,8 @@
 #include "WeakSetConstructor.h"
 #include <wtf/CommaPrinter.h>
 #include <wtf/HashMap.h>
+#include <wtf/PriorityQueue.h>
+#include <wtf/SegmentedVector.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StdLibExtras.h>
 
@@ -123,6 +126,262 @@ static constexpr bool verbose = true;
 #define VERBOSE_LOG(...) do { \
     dataLogIf(DFGByteCodeParserInternal::verbose && Options::verboseDFGBytecodeParsing(), __VA_ARGS__); \
 } while (false)
+
+// === Inlining plan ===
+//
+// The inliner decides each call site at the moment it reaches it, so an early call site claims
+// budget merely by being early. This surveys the candidates first: it walks the call sites
+// recorded in a code block's profiling, prices each one, ranks them, and hands a single
+// compilation-wide budget to the best of them.
+//
+// The survey reads profiling and bytecode costs only and builds no IR, so it costs a small
+// fraction of a parse. What it gives up is fidelity: it cannot know what the parser will make
+// of a site that becomes an intrinsic, a DOM call or a varargs frame, and it prices every site
+// as an ordinary call. So a plan is advisory. A site the survey never predicted is left to the
+// per-site heuristics exactly as if planning were off, which means a divergence between survey
+// and parse costs decision quality and never correctness.
+class InliningPlan {
+    WTF_MAKE_NONCOPYABLE(InliningPlan);
+public:
+    struct Site {
+        unsigned bytecodeOffset { 0 };
+        unsigned surveyIndex { 0 };
+        // Never dereferenced, just compared for identity
+        const ScriptExecutable* calleeIdentity { nullptr };
+        unsigned cost { 0 };
+        unsigned depth { 0 };
+        double score { 0 };
+        bool admitted { false };
+        Site* parent { nullptr };
+        Vector<Site*, 2> children;
+    };
+
+    InliningPlan() = default;
+
+    void build(CodeBlock* rootCodeBlock, JITType);
+
+    // Returns the decision for a callsite at `bytecodeOffset` within the callee that `parent` stands for,
+    // or nullptr when the survey did not predict this site at all.
+    const Site* siteFor(const Site* parent, unsigned bytecodeOffset) const
+    {
+        if (!parent)
+            return nullptr;
+        for (const Site* child : parent->children) {
+            if (child->bytecodeOffset == bytecodeOffset)
+                return child;
+        }
+        return nullptr;
+    }
+
+    bool isBuilt() const { return m_built; }
+    unsigned surveyedCount() const { return m_sites.size(); }
+    unsigned admittedCount() const { return m_admittedCount; }
+    unsigned admittedCost() const { return m_admittedCost; }
+    unsigned budget() const { return m_budget; }
+    const Site& root() const { return m_root; }
+
+private:
+    Site* addSite(Site& parent, unsigned bytecodeOffset, FunctionExecutable*, CodeSpecializationKind, unsigned cost, unsigned depth);
+    void surveyCallSites(Site& parent, CodeBlock*, unsigned depth);
+    unsigned priceCandidate(CallVariant, CodeSpecializationKind, unsigned depth, const Site& parent) const;
+
+    Site m_root;
+    SegmentedVector<Site, 16> m_sites;
+    CodeBlock* m_rootCodeBlock { nullptr };
+    JITType m_jitType { JITType::None };
+    unsigned m_budget { 0 };
+    unsigned m_budgetRemaining { 0 };
+    unsigned m_admittedCount { 0 };
+    unsigned m_admittedCost { 0 };
+    bool m_built { false };
+};
+
+// Chooses whether a callee can be inlined at all and determines what it costs to inline it.
+unsigned InliningPlan::priceCandidate(CallVariant callee, CodeSpecializationKind kind, unsigned depth, const Site& parent) const
+{
+    if (depth >= Options::maximumInliningDepth())
+        return UINT_MAX;
+
+    FunctionExecutable* executable = callee.functionExecutable();
+    if (!executable)
+        return UINT_MAX;
+
+    // Always price against the baseline block so that a callee costs the same whichever tier
+    // is asking, then let the capability level judge the tier-specific cap.
+    CodeBlock* baselineCodeBlock = executable->baselineCodeBlockFor(kind);
+    if (!baselineCodeBlock)
+        return UINT_MAX;
+
+    if (baselineCodeBlock->couldBeTainted() != m_rootCodeBlock->couldBeTainted())
+        return UINT_MAX;
+
+    CodeBlock* targetCodeBlock = baselineCodeBlock;
+    if (m_jitType == JITType::FTLJIT) {
+        if (CodeBlock* newest = executable->codeBlockFor(kind))
+            targetCodeBlock = newest;
+    }
+
+    if (!canInline(inlineFunctionForCapabilityLevel(m_jitType, targetCodeBlock, kind, callee.isClosureCall())))
+        return UINT_MAX;
+
+    if (!isSmallEnoughToInlineCodeInto(m_rootCodeBlock))
+        return UINT_MAX;
+
+    unsigned recursion = 0;
+    for (const Site* ancestor = &parent; ancestor; ancestor = ancestor->parent) {
+        if (ancestor->calleeIdentity == executable && ++recursion >= Options::maximumInliningRecursion())
+            return UINT_MAX;
+    }
+
+    return targetCodeBlock->bytecodeCost();
+}
+
+// Because call frequency data is available only for polymorphic sites and not monomorphic ones,
+// we can use callee tier as a proxy for how hot the callee is, and also for how resistant it is
+// to being jettisoned.
+static double calleeTierBonus(FunctionExecutable* executable, CodeSpecializationKind kind)
+{
+    unsigned rank = 0;
+    if (CodeBlock* codeBlock = executable->codeBlockFor(kind)) {
+        switch (codeBlock->jitType()) {
+        case JITType::FTLJIT:
+            rank = Options::inliningPlanTierBonusPowerForFTL();
+            break;
+        case JITType::DFGJIT:
+            rank = Options::inliningPlanTierBonusPowerForDFG();
+            break;
+        case JITType::BaselineJIT:
+            rank = Options::inliningPlanTierBonusPowerForBaseline();
+            break;
+        default:
+            // Hasn't been deemed worth compiling yet (still in LLInt)
+            break;
+        }
+    }
+    return std::pow(Options::inliningPlanTierBonusBase(), static_cast<double>(rank));
+}
+
+InliningPlan::Site* InliningPlan::addSite(Site& parent, unsigned bytecodeOffset, FunctionExecutable* executable, CodeSpecializationKind kind, unsigned cost, unsigned depth)
+{
+    Site& site = m_sites.alloc();
+    site.bytecodeOffset = bytecodeOffset;
+    site.surveyIndex = m_sites.size() - 1;
+    site.calleeIdentity = executable;
+    site.cost = cost;
+    site.depth = depth;
+    site.parent = &parent;
+    // Cost is just a weak logarithmic tiebreaker
+    site.score = calleeTierBonus(executable, kind) / (std::pow(Options::inliningPlanDepthPenalty(), static_cast<double>(depth)) * std::log2(4.0 + cost));
+
+    parent.children.append(&site);
+    return &site;
+}
+
+void InliningPlan::surveyCallSites(Site& parent, CodeBlock* codeBlock, unsigned depth)
+{
+    if (depth >= Options::maximumInliningDepth())
+        return;
+
+    if (m_sites.size() >= Options::maximumGlobalInliningPlanSites())
+        return;
+
+    // Call sites are read out of the interpreter/baseline profiling because that's where the parser reads them from.
+    if (!JITCode::couldBeInterpreted(codeBlock->jitType()))
+        return;
+
+    struct SurveyedCallSite {
+        unsigned bytecodeOffset { 0 };
+        CodeSpecializationKind kind { CodeSpecializationKind::CodeForCall };
+        CallLinkStatus status;
+    };
+    Vector<SurveyedCallSite, 8> callSites;
+
+    {
+        ConcurrentJSLocker locker(codeBlock->m_lock);
+        codeBlock->forEachLLIntOrBaselineCallLinkInfo([&](DataOnlyCallLinkInfo& callLinkInfo) {
+            CallLinkStatus callLinkStatus = CallLinkStatus::computeFor(locker, codeBlock, callLinkInfo);
+            if (!callLinkStatus.canOptimize())
+                return;
+            callSites.append(SurveyedCallSite {
+                callLinkInfo.codeOrigin().bytecodeIndex().offset(),
+                callLinkInfo.specializationKind(),
+                WTF::move(callLinkStatus),
+            });
+        });
+    }
+
+    for (const SurveyedCallSite& callSite : callSites) {
+        // A polymorphic site is charged for every variant it could inline and represented by the
+        // first (which is the most frequently seen because CallLinkStatus sorts variants by count).
+        unsigned cost = 0;
+        FunctionExecutable* firstExecutable = nullptr;
+        CodeBlock* firstCodeBlock = nullptr;
+        for (unsigned i = 0; i < callSite.status.size(); ++i) {
+            unsigned variantCost = priceCandidate(callSite.status[i], callSite.kind, depth, parent);
+            if (variantCost == UINT_MAX)
+                continue;
+            cost += variantCost;
+            if (!firstExecutable) {
+                FunctionExecutable* executable = callSite.status[i].functionExecutable();
+                if (CodeBlock* baselineCodeBlock = executable->baselineCodeBlockFor(callSite.kind)) {
+                    firstExecutable = executable;
+                    firstCodeBlock = baselineCodeBlock;
+                }
+            }
+        }
+
+        if (!firstExecutable)
+            continue;
+
+        Site* site = addSite(parent, callSite.bytecodeOffset, firstExecutable, callSite.kind, cost, depth);
+        surveyCallSites(*site, firstCodeBlock, depth + 1);
+    }
+}
+
+static bool isHigherPriorityInliningCandidate(InliningPlan::Site* const& left, InliningPlan::Site* const& right)
+{
+    if (left->score != right->score)
+        return left->score > right->score;
+    return left->surveyIndex < right->surveyIndex;
+}
+
+void InliningPlan::build(CodeBlock* rootCodeBlock, JITType jitType)
+{
+    m_rootCodeBlock = rootCodeBlock;
+    m_jitType = jitType;
+    m_built = true;
+    m_budget = jitType == JITType::FTLJIT
+        ? Options::globalInliningPlanBudgetForFTL()
+        : Options::globalInliningPlanBudgetForDFG();
+    m_budgetRemaining = m_budget;
+    m_root.calleeIdentity = rootCodeBlock->ownerExecutable();
+    m_root.admitted = true;
+
+    surveyCallSites(m_root, rootCodeBlock, m_root.depth + 1);
+
+    PriorityQueue<InliningPlan::Site*, isHigherPriorityInliningCandidate> queue;
+
+    auto makeAdmissible = [&](const auto& sites) {
+        for (Site* site : sites)
+            queue.enqueue(site);
+        return;
+    };
+
+    makeAdmissible(m_root.children);
+    while (!queue.isEmpty()) {
+        Site* candidate = queue.dequeue();
+
+        if (candidate->cost > m_budgetRemaining)
+            continue;
+
+        candidate->admitted = true;
+        m_budgetRemaining -= candidate->cost;
+        m_admittedCost += candidate->cost;
+        ++m_admittedCount;
+
+        makeAdmissible(candidate->children);
+    }
+}
 
 // === ByteCodeParser ===
 //
@@ -160,6 +419,11 @@ private:
 
     // Just parse from m_currentIndex to the end of the current CodeBlock.
     void parseCodeBlock();
+
+    // Survey and rank the compilation's inlining candidates before parsing, so that the budget
+    // goes to the best of them rather than to whichever call sites come first in bytecode order.
+    void planInlining();
+    bool planPermitsInlining() const;
     
     void ensureLocals(unsigned newNumLocals)
     {
@@ -1303,6 +1567,8 @@ private:
 
     UncheckedKeyHashMap<InlineCallFrame*, Vector<ArgumentPosition*>, WTF::DefaultHash<InlineCallFrame*>, WTF::NullableHashTraits<InlineCallFrame*>> m_inlineCallFrameToArgumentPositions;
 
+    InliningPlan m_inliningPlan;
+
     // The number of arguments passed to the function.
     const unsigned m_numArguments;
     // The number of locals (vars + temporaries) used by the bytecode for the function.
@@ -1360,6 +1626,10 @@ private:
 
         UncheckedKeyHashMap<BytecodeIndex, JSValue*> m_specFailValueProfileBuckets;
         
+        // The plan node this frame was inlined for, so that call sites inside it can be found
+        // by descending the plan in step with the parse. Null when planning is off, or when the
+        // survey never predicted the site this frame came from.
+        const InliningPlan::Site* m_planSite { nullptr };
         ICStatusMap m_baselineMap;
         ICStatusContext m_optimizedContext;
         
@@ -1925,8 +2195,13 @@ void ByteCodeParser::inlineCall(Node* callTargetNode, Operand result, CallVarian
     m_currentExitOrigin = currentCodeOrigin();
 
     InlineStackEntry* callerStackTop = m_inlineStackTop;
+    // Locate this call site in the plan before the frame is pushed, while m_currentIndex still
+    // refers to the caller's call instruction, so that call sites inside the callee can be found
+    // by descending from here.
+    const InliningPlan::Site* planSite = m_inliningPlan.siteFor(callerStackTop->m_planSite, m_currentIndex.offset());
     InlineStackEntry inlineStackEntry(this, codeBlock, codeBlock, callee.function(), result,
         inlineCallFrameStart.virtualRegister(), argumentCountIncludingThis, kind, continuationBlock);
+    inlineStackEntry.m_planSite = planSite;
 
     // This is where the actual inlining really happens.
     BytecodeIndex oldIndex = m_currentIndex;
@@ -2155,6 +2430,12 @@ ByteCodeParser::CallOptimizationResult ByteCodeParser::handleCallVariant(Node* c
     if (!inliningBalance)
         return CallOptimizationResult::DidNothing;
 
+    // Everything above substitutes nodes for the call rather than inlining a body and is always
+    // worth doing, so the plan gets a say only from here on. It doesn't get a say over a callee
+    // that the language requires be inlined.
+    if (inlineAttribute != InlineAttribute::Always && !planPermitsInlining())
+        return CallOptimizationResult::DidNothing;
+
     if (inlineAttribute != InlineAttribute::Always && myInliningCost > inliningBalance)
         return CallOptimizationResult::DidNothing;
 
@@ -2216,6 +2497,11 @@ bool ByteCodeParser::handleVarargsInlining(Node* callTargetNode, Operand result,
     auto [bytecodeCost, inlineAttribute] = inliningCost(callVariant, maxArgumentCountIncludingThis, kind);
     if (inlineAttribute != InlineAttribute::Always && bytecodeCost > getInliningBalance(callLinkStatus, specializationKind)) {
         VERBOSE_LOG("Bailing inlining: inlining cost too high.\n");
+        return false;
+    }
+
+    if (inlineAttribute != InlineAttribute::Always && !planPermitsInlining()) {
+        VERBOSE_LOG("Bailing inlining: the plan declined this call site.\n");
         return false;
     }
     
@@ -13842,16 +14128,45 @@ void ByteCodeParser::pruneUnreachableNodes()
         (code);                                                      \
     } while (false);                                                 \
 
+// Whether the plan wants this call site's callee body inlined. A site the survey never
+// predicted has no opinion and is left to the per-site heuristics exactly as if planning were
+// off: the survey reads bytecode profiling and cannot anticipate everything the parser makes of
+// a call site, so a gap in it should cost inlining quality rather than silently suppress
+// inlining that would otherwise have happened.
+bool ByteCodeParser::planPermitsInlining() const
+{
+    if (!m_inliningPlan.isBuilt())
+        return true;
+    const InliningPlan::Site* site = m_inliningPlan.siteFor(m_inlineStackTop->m_planSite, m_currentIndex.offset());
+    if (!site)
+        return true;
+    return site->admitted;
+}
+
+void ByteCodeParser::planInlining()
+{
+    if (!Options::useGlobalInliningPlanner())
+        return;
+    // Unlinked DFG cannot inline at all, so there is nothing to plan.
+    if (m_graph.m_plan.isUnlinked())
+        return;
+    m_inliningPlan.build(m_profiledBlock, m_graph.m_plan.jitType());
+}
+
 bool ByteCodeParser::parse()
 {
     // Set during construction.
     ASSERT(!m_currentIndex.offset());
     
     VERBOSE_LOG("Parsing ", *m_codeBlock, "\n");
-    
+
+    planInlining();
+
     InlineStackEntry inlineStackEntry(
         this, m_codeBlock, m_profiledBlock, nullptr, VirtualRegister(), VirtualRegister(),
         m_codeBlock->numParameters(), InlineCallFrame::Call, nullptr);
+    if (m_inliningPlan.isBuilt())
+        inlineStackEntry.m_planSite = &m_inliningPlan.root();
     
     parseCodeBlock();
     linkBlocks(inlineStackEntry.m_unlinkedBlocks, inlineStackEntry.m_blockLinkingTargets);

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -329,6 +329,16 @@ bool hasCapacityToUseLargeGigacage();
     /* from super long compiles that take a lot of memory. */\
     v(Unsigned, maximumInliningCallerBytecodeCost, 10000, Normal, nullptr) \
     \
+    v(Bool, useGlobalInliningPlanner, false, Normal, "Survey and rank every inlining candidate before parsing and spend one compilation-wide budget on the best of them, instead of deciding each call site in bytecode order"_s) \
+    v(Unsigned, globalInliningPlanBudgetForDFG, 2500, Normal, "Total callee bytecode cost the DFG may plan to inline in one compilation"_s) \
+    v(Unsigned, globalInliningPlanBudgetForFTL, 12000, Normal, "Total callee bytecode cost the FTL may plan to inline in one compilation"_s) \
+    v(Unsigned, maximumGlobalInliningPlanSites, 20000, Normal, "Cap on how many call sites one inlining plan will survey"_s) \
+    v(Double, inliningPlanTierBonusBase, 2.0, Normal, "Multiplicative benefit per tier the callee has reached (LLInt, Baseline, DFG, FTL) when ranking inlining candidates"_s) \
+    v(Double, inliningPlanTierBonusPowerForFTL, 3.0, Normal, "Base for the bonus multiplier for FTL callees"_s) \
+    v(Double, inliningPlanTierBonusPowerForDFG, 2.0, Normal, "Base for the bonus multiplier for DFG callees"_s) \
+    v(Double, inliningPlanTierBonusPowerForBaseline, 1.0, Normal, "Base for the bonus multiplier for Baseline callees"_s) \
+    v(Double, inliningPlanDepthPenalty, 1.5, Normal, "Divisive benefit penalty per level of inline-stack nesting when ranking inlining candidates"_s) \
+    \
     v(Unsigned, maximumVarargsForInlining, 100, Normal, nullptr) \
     \
     v(Unsigned, maximumBinaryStringSwitchCaseLength, 50, Normal, nullptr) \


### PR DESCRIPTION
#### bdb72467372c43614a9d6207ee7b789cdc9561d6
<pre>
[JSC] Add global priority queue inliner
<a href="https://bugs.webkit.org/show_bug.cgi?id=321720">https://bugs.webkit.org/show_bug.cgi?id=321720</a>
<a href="https://rdar.apple.com/184856840">rdar://184856840</a>

Reviewed by Yijia Huang.

This patch adds an option for JS inlining to globally rank all
inlining candidates prior to DFG bytecode parsing. Currently this
doesn&apos;t do much to change which candidates are inlined because the
budget remains fairly high, but with some followup work to tune
the budget, it can be used to skip inlining of less profitable
candidates.

No new tests because the new behavior isn&apos;t observable.

* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::InliningPlan::siteFor const):
(JSC::DFG::InliningPlan::isBuilt const):
(JSC::DFG::InliningPlan::surveyedCount const):
(JSC::DFG::InliningPlan::admittedCount const):
(JSC::DFG::InliningPlan::admittedCost const):
(JSC::DFG::InliningPlan::budget const):
(JSC::DFG::InliningPlan::root const):
(JSC::DFG::InliningPlan::priceCandidate const):
(JSC::DFG::calleeTierBonus):
(JSC::DFG::InliningPlan::addSite):
(JSC::DFG::InliningPlan::surveyCallSites):
(JSC::DFG::isHigherPriorityInliningCandidate):
(JSC::DFG::InliningPlan::build):
(JSC::DFG::ByteCodeParser::inlineCall):
(JSC::DFG::ByteCodeParser::handleCallVariant):
(JSC::DFG::ByteCodeParser::handleVarargsInlining):
(JSC::DFG::ByteCodeParser::planPermitsInlining const):
(JSC::DFG::ByteCodeParser::planInlining):
(JSC::DFG::ByteCodeParser::parse):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/319343@main">https://commits.webkit.org/319343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94fc9bae6cff2ef27f3e7bd4ca8fb0ece1019740

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191405 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145511 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce90c4ce-2dfe-4e29-a979-22d7b5c0e435) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141394 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/acf33429-cf2b-47a0-92a4-82e710de4450) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121845 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/391e31bf-6af6-448b-b407-37ded47ee715) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43740 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42013 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3810 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10629 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41674 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2564 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42462 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193337 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54799 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150782 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40389 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55487 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150498 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45090 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127755 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123313 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54004 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16670 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53386 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53451 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->