### PR TITLE
[GLib] Add API for the HTTPS upgrade policy

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2326,7 +2326,10 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
             return;
         }
 
-        if (advancedPrivacyProtections().contains(AdvancedPrivacyProtections::HTTPSOnly)) {
+        bool isHTTPSOnlyActive = advancedPrivacyProtections().contains(AdvancedPrivacyProtections::HTTPSOnly)
+            || m_httpsByDefaultMode == HTTPSByDefaultMode::UpgradeWithUserMediatedFallback
+            || m_httpsByDefaultMode == HTTPSByDefaultMode::UpgradeAndNoFallback;
+        if (isHTTPSOnlyActive) {
             if (platformStrategies()->loaderStrategy()->isHttpNavigationWithHTTPSOnlyError(mainResourceOrError.error())) {
                 DOCUMENTLOADER_RELEASE_LOG("loadMainResource: Unable to load main resource, URL has HTTP scheme with HTTPSOnly enabled");
                 cancelMainResourceLoad(mainResourceOrError.error());

--- a/Source/WebCore/platform/network/ResourceErrorBase.h
+++ b/Source/WebCore/platform/network/ResourceErrorBase.h
@@ -38,6 +38,14 @@ class ResourceError;
 inline constexpr ASCIILiteral errorDomainWebKitInternal { "WebKitInternal"_s }; // Used for errors that won't be exposed to clients.
 inline constexpr ASCIILiteral errorDomainWebKitServiceWorker { "WebKitServiceWorker"_s }; // Used for errors that happen when loading a resource from a service worker.
 
+// Shared with API::Error in the WebKit layer, which cannot be included here.
+#if USE(GLIB)
+inline constexpr ASCIILiteral errorDomainWebKitNetwork { "WebKitNetworkError"_s };
+#else
+inline constexpr ASCIILiteral errorDomainWebKitNetwork { "WebKitErrorDomain"_s };
+#endif
+inline constexpr int errorCodeHTTPSUpgradeRedirectLoop { 304 };
+
 enum class ResourceErrorBaseType : uint8_t {
     Null,
     General,

--- a/Source/WebCore/platform/network/cocoa/ResourceErrorCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceErrorCocoa.mm
@@ -191,11 +191,8 @@ ResourceError::ErrorRecoveryMethod ResourceError::errorRecoveryMethod() const
         case NSURLErrorClientCertificateRequired:
             isRecoverableError = true;
         }
-    } else if ([nsDomain isEqualToString:@"WebKitErrorDomain"]) {
-        // FIXME: These literals should be moved into a central location that is shared with WebKit::API.
-        constexpr auto httpsUpgradeRedirectLoop { 304 };
-        isRecoverableError = m_errorCode == httpsUpgradeRedirectLoop;
-    }
+    } else if (m_domain == errorDomainWebKitNetwork)
+        isRecoverableError = m_errorCode == errorCodeHTTPSUpgradeRedirectLoop;
 
     if (isRecoverableError && m_failingURL.protocolIs("https"_s))
         return ResourceError::ErrorRecoveryMethod::HTTPFallback;

--- a/Source/WebCore/platform/network/soup/ResourceError.h
+++ b/Source/WebCore/platform/network/soup/ResourceError.h
@@ -70,7 +70,7 @@ public:
     GTlsCertificate* certificate() const { return m_certificate.get(); }
     void setCertificate(GTlsCertificate* certificate) { m_certificate = certificate; }
 
-    ErrorRecoveryMethod errorRecoveryMethod() const { return ErrorRecoveryMethod::NoRecovery; }
+    WEBCORE_EXPORT ErrorRecoveryMethod errorRecoveryMethod() const;
 
     static bool platformCompare(const ResourceError& a, const ResourceError& b);
 

--- a/Source/WebCore/platform/network/soup/ResourceErrorSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceErrorSoup.cpp
@@ -31,10 +31,13 @@
 #include "LocalizedStrings.h"
 #include "URLSoup.h"
 #include <libsoup/soup.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/glib/GUniquePtr.h>
-#include <wtf/text/CString.h>
 
 namespace WebCore {
+
+// Use the same value as in NSURLError.h
+static constexpr int errorCodeTimeout = -1001;
 
 ResourceError::ResourceError(const String& domain, int errorCode, const URL& failingURL, const String& localizedDescription, Type type, IsSanitized isSanitized)
     : ResourceErrorBase(domain, errorCode, failingURL, localizedDescription, type, isSanitized)
@@ -108,13 +111,32 @@ ResourceError ResourceError::tlsError(const URL& failingURL, unsigned tlsErrors,
 
 ResourceError ResourceError::timeoutError(const URL& failingURL)
 {
-    // FIXME: This should probably either be integrated into ErrorsGtk.h or the
-    // networking errors from that file should be moved here.
+    return ResourceError(errorDomainWebKitNetwork, errorCodeTimeout, failingURL, "Request timed out"_s, ResourceError::Type::Timeout);
+}
 
-    // Use the same value as in NSURLError.h
-    static constexpr int timeoutError = -1001;
-    static constexpr auto errorDomain = "WebKitNetworkError"_s;
-    return ResourceError(errorDomain, timeoutError, failingURL, "Request timed out"_s, ResourceError::Type::Timeout);
+ResourceError::ErrorRecoveryMethod ResourceError::errorRecoveryMethod() const
+{
+    if (!m_failingURL.protocolIs("https"_s) || isCancellation())
+        return ErrorRecoveryMethod::NoRecovery;
+
+    static const NeverDestroyed<String> ioErrorDomain = String::fromLatin1(g_quark_to_string(G_IO_ERROR));
+
+    // Only failures that suggest the host does not serve HTTPS at all are
+    // recoverable. G_TLS_ERROR is deliberately absent: a TLS failure means
+    // there is an HTTPS server, so retrying over cleartext is never right.
+    bool isRecoverableError = false;
+    if (m_domain == ioErrorDomain.get()) {
+        switch (m_errorCode) {
+        case G_IO_ERROR_CONNECTION_REFUSED:
+        case G_IO_ERROR_CONNECTION_CLOSED:
+        case G_IO_ERROR_NOT_CONNECTED:
+        case G_IO_ERROR_TIMED_OUT:
+            isRecoverableError = true;
+        }
+    } else if (m_domain == errorDomainWebKitNetwork)
+        isRecoverableError = m_errorCode == errorCodeHTTPSUpgradeRedirectLoop || m_errorCode == errorCodeTimeout;
+
+    return isRecoverableError ? ErrorRecoveryMethod::HTTPFallback : ErrorRecoveryMethod::NoRecovery;
 }
 
 void ResourceError::doPlatformIsolatedCopy(const ResourceError& other)

--- a/Source/WebKit/Shared/API/APIError.cpp
+++ b/Source/WebKit/Shared/API/APIError.cpp
@@ -39,12 +39,9 @@ const WTF::String& Error::webKitErrorDomain()
 
 const WTF::String& Error::webKitNetworkErrorDomain()
 {
-#if USE(GLIB)
-    static NeverDestroyed<WTF::String> webKitErrorDomainString(MAKE_STATIC_STRING_IMPL("WebKitNetworkError"));
-    return webKitErrorDomainString;
-#else
-    return webKitErrorDomain();
-#endif
+    static StaticStringImpl impl(WebCore::errorDomainWebKitNetwork);
+    static NeverDestroyed<WTF::String> webKitNetworkErrorDomainString(&static_cast<StringImpl&>(impl));
+    return webKitNetworkErrorDomainString;
 }
 
 const WTF::String& Error::webKitPolicyErrorDomain()

--- a/Source/WebKit/Shared/API/APIError.h
+++ b/Source/WebKit/Shared/API/APIError.h
@@ -55,7 +55,7 @@ public:
     enum Network {
         Cancelled = 302,
         FileDoesNotExist = 303,
-        HTTPSUpgradeRedirectLoop = 304,
+        HTTPSUpgradeRedirectLoop = WebCore::errorCodeHTTPSUpgradeRedirectLoop,
         HTTPNavigationWithHTTPSOnlyError = 305,
     };
     static const WTF::String& webKitNetworkErrorDomain();

--- a/Source/WebKit/UIProcess/API/glib/WebKitError.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitError.h.in
@@ -57,6 +57,11 @@ G_BEGIN_DECLS
  * @WEBKIT_NETWORK_ERROR_UNKNOWN_PROTOCOL: Load failure due to unknown protocol
  * @WEBKIT_NETWORK_ERROR_CANCELLED: Load failure due to cancellation
  * @WEBKIT_NETWORK_ERROR_FILE_DOES_NOT_EXIST: Load failure due to missing file
+ * @WEBKIT_NETWORK_ERROR_HTTPS_UPGRADE_REDIRECT_LOOP: Load failure due to a redirect
+ *     loop caused by upgrading the navigation to HTTPS. Since: 2.56
+ * @WEBKIT_NETWORK_ERROR_HTTP_NAVIGATION_WITH_HTTPS_ONLY: Load failure due to the
+ *     navigation being for a non-upgradable HTTP URI while
+ *     %WEBKIT_UPGRADE_TO_HTTPS_POLICY_ERROR_ON_FAILURE is in effect. Since: 2.56
  *
  * Enum values used to denote the various network errors.
  **/
@@ -65,7 +70,9 @@ typedef enum {
     WEBKIT_NETWORK_ERROR_TRANSPORT = 300,
     WEBKIT_NETWORK_ERROR_UNKNOWN_PROTOCOL = 301,
     WEBKIT_NETWORK_ERROR_CANCELLED = 302,
-    WEBKIT_NETWORK_ERROR_FILE_DOES_NOT_EXIST = 303
+    WEBKIT_NETWORK_ERROR_FILE_DOES_NOT_EXIST = 303,
+    WEBKIT_NETWORK_ERROR_HTTPS_UPGRADE_REDIRECT_LOOP = 304,
+    WEBKIT_NETWORK_ERROR_HTTP_NAVIGATION_WITH_HTTPS_ONLY = 305
 } WebKitNetworkError;
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp
@@ -140,6 +140,10 @@ unsigned toWebKitError(unsigned webCoreError)
         return WEBKIT_NETWORK_ERROR_CANCELLED;
     case API::Error::Network::FileDoesNotExist:
         return WEBKIT_NETWORK_ERROR_FILE_DOES_NOT_EXIST;
+    case API::Error::Network::HTTPSUpgradeRedirectLoop:
+        return WEBKIT_NETWORK_ERROR_HTTPS_UPGRADE_REDIRECT_LOOP;
+    case API::Error::Network::HTTPNavigationWithHTTPSOnlyError:
+        return WEBKIT_NETWORK_ERROR_HTTP_NAVIGATION_WITH_HTTPS_ONLY;
     case API::Error::Policy::CannotShowMIMEType:
         return WEBKIT_POLICY_ERROR_CANNOT_SHOW_MIME_TYPE;
     case API::Error::Policy::CannotShowURL:
@@ -263,6 +267,10 @@ unsigned toWebCoreError(unsigned webKitError)
         return API::Error::Network::Cancelled;
     case WEBKIT_NETWORK_ERROR_FILE_DOES_NOT_EXIST:
         return API::Error::Network::FileDoesNotExist;
+    case WEBKIT_NETWORK_ERROR_HTTPS_UPGRADE_REDIRECT_LOOP:
+        return API::Error::Network::HTTPSUpgradeRedirectLoop;
+    case WEBKIT_NETWORK_ERROR_HTTP_NAVIGATION_WITH_HTTPS_ONLY:
+        return API::Error::Network::HTTPNavigationWithHTTPSOnlyError;
     case WEBKIT_POLICY_ERROR_CANNOT_SHOW_MIME_TYPE:
         return API::Error::Policy::CannotShowMIMEType;
     case WEBKIT_POLICY_ERROR_CANNOT_SHOW_URI:

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.cpp
@@ -22,6 +22,7 @@
 
 #include "APIWebsitePolicies.h"
 #include "WebKitEnumTypes.h"
+#include <WebCore/HTTPSByDefaultMode.h>
 #include <glib/gi18n-lib.h>
 #include <wtf/glib/WTFGType.h>
 
@@ -34,7 +35,8 @@ using namespace WebKit;
  * View specific website policies.
  *
  * WebKitWebsitePolicies allows you to configure per-page policies,
- * currently only autoplay and custom user agent policies are supported.
+ * currently autoplay, custom user agent and upgrade to HTTPS policies
+ * are supported.
  *
  * Since: 2.30
  */
@@ -46,6 +48,7 @@ enum {
 
     PROP_AUTOPLAY_POLICY,
     PROP_CUSTOM_USER_AGENT,
+    PROP_UPGRADE_TO_HTTPS_POLICY,
 };
 
 struct _WebKitWebsitePoliciesPrivate {
@@ -75,6 +78,9 @@ static void webkitWebsitePoliciesGetProperty(GObject* object, guint propID, GVal
     case PROP_CUSTOM_USER_AGENT:
         g_value_set_string(value, webkit_website_policies_get_custom_user_agent(policies));
         break;
+    case PROP_UPGRADE_TO_HTTPS_POLICY:
+        g_value_set_enum(value, webkit_website_policies_get_upgrade_to_https_policy(policies));
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propID, paramSpec);
     }
@@ -97,6 +103,21 @@ void webkitWebsitePoliciesSetAutoplayPolicy(WebKitWebsitePolicies* policies, Web
     }
 }
 
+static void webkitWebsitePoliciesSetUpgradeToHTTPSPolicy(WebKitWebsitePolicies* policies, WebKitUpgradeToHTTPSPolicy policy)
+{
+    switch (policy) {
+    case WEBKIT_UPGRADE_TO_HTTPS_POLICY_KEEP_AS_REQUESTED:
+        policies->priv->websitePolicies->setHTTPSByDefault(WebCore::HTTPSByDefaultMode::Disabled);
+        break;
+    case WEBKIT_UPGRADE_TO_HTTPS_POLICY_AUTOMATIC_FALLBACK_TO_HTTP:
+        policies->priv->websitePolicies->setHTTPSByDefault(WebCore::HTTPSByDefaultMode::UpgradeWithAutomaticFallback);
+        break;
+    case WEBKIT_UPGRADE_TO_HTTPS_POLICY_ERROR_ON_FAILURE:
+        policies->priv->websitePolicies->setHTTPSByDefault(WebCore::HTTPSByDefaultMode::UpgradeAndNoFallback);
+        break;
+    }
+}
+
 static void webkitWebsitePoliciesSetProperty(GObject* object, guint propID, const GValue* value, GParamSpec* paramSpec)
 {
     WebKitWebsitePolicies* policies = WEBKIT_WEBSITE_POLICIES(object);
@@ -108,6 +129,9 @@ static void webkitWebsitePoliciesSetProperty(GObject* object, guint propID, cons
     case PROP_CUSTOM_USER_AGENT:
         if (const auto* customUserAgent = g_value_get_string(value))
             policies->priv->websitePolicies->setCustomUserAgent(String::fromUTF8(customUserAgent));
+        break;
+    case PROP_UPGRADE_TO_HTTPS_POLICY:
+        webkitWebsitePoliciesSetUpgradeToHTTPSPolicy(policies, static_cast<WebKitUpgradeToHTTPSPolicy>(g_value_get_enum(value)));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propID, paramSpec);
@@ -153,6 +177,24 @@ static void webkit_website_policies_class_init(WebKitWebsitePoliciesClass* findC
             "custom-user-agent",
             nullptr, nullptr,
             nullptr,
+            static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+
+    /**
+     * WebKitWebsitePolicies:upgrade-to-https-policy: (getter get_upgrade_to_https_policy):
+     *
+     * How HTTP navigations governed by these [class@WebsitePolicies] are
+     * upgraded to HTTPS.
+     *
+     * Since: 2.56
+     */
+    g_object_class_install_property(
+        gObjectClass,
+        PROP_UPGRADE_TO_HTTPS_POLICY,
+        g_param_spec_enum(
+            "upgrade-to-https-policy",
+            nullptr, nullptr,
+            WEBKIT_TYPE_UPGRADE_TO_HTTPS_POLICY,
+            WEBKIT_UPGRADE_TO_HTTPS_POLICY_KEEP_AS_REQUESTED,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
 }
 
@@ -259,4 +301,31 @@ const gchar* webkit_website_policies_get_custom_user_agent(WebKitWebsitePolicies
         policies->priv->customUserAgent = newCustomUserAgent.isEmpty() ? CString() : newCustomUserAgent.utf8();
     }
     return policies->priv->customUserAgent.data();
+}
+
+/**
+ * webkit_website_policies_get_upgrade_to_https_policy: (get-property upgrade-to-https-policy):
+ * @policies: a #WebKitWebsitePolicies
+ *
+ * Get the [property@WebsitePolicies:upgrade-to-https-policy] property.
+ *
+ * Returns: a [enum@UpgradeToHTTPSPolicy]
+ *
+ * Since: 2.56
+ */
+WebKitUpgradeToHTTPSPolicy webkit_website_policies_get_upgrade_to_https_policy(WebKitWebsitePolicies* policies)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEBSITE_POLICIES(policies), WEBKIT_UPGRADE_TO_HTTPS_POLICY_KEEP_AS_REQUESTED);
+
+    switch (policies->priv->websitePolicies->httpsByDefaultMode()) {
+    case WebCore::HTTPSByDefaultMode::Disabled:
+        return WEBKIT_UPGRADE_TO_HTTPS_POLICY_KEEP_AS_REQUESTED;
+    case WebCore::HTTPSByDefaultMode::UpgradeWithAutomaticFallback:
+        return WEBKIT_UPGRADE_TO_HTTPS_POLICY_AUTOMATIC_FALLBACK_TO_HTTP;
+    case WebCore::HTTPSByDefaultMode::UpgradeWithUserMediatedFallback:
+    case WebCore::HTTPSByDefaultMode::UpgradeAndNoFallback:
+        return WEBKIT_UPGRADE_TO_HTTPS_POLICY_ERROR_ON_FAILURE;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.h.in
@@ -64,6 +64,40 @@ typedef enum {
     WEBKIT_AUTOPLAY_DENY
 } WebKitAutoplayPolicy;
 
+/**
+ * WebKitUpgradeToHTTPSPolicy:
+ * @WEBKIT_UPGRADE_TO_HTTPS_POLICY_KEEP_AS_REQUESTED: Do not request an upgrade.
+ *     Note that this does not disable HSTS, which applies to every navigation.
+ * @WEBKIT_UPGRADE_TO_HTTPS_POLICY_AUTOMATIC_FALLBACK_TO_HTTP: Upgrade HTTP
+ *     navigations to HTTPS, silently falling back to HTTP if the HTTPS load
+ *     fails. Cleartext HTTP is still allowed for navigations that cannot be
+ *     upgraded.
+ * @WEBKIT_UPGRADE_TO_HTTPS_POLICY_ERROR_ON_FAILURE: Upgrade HTTP navigations to
+ *     HTTPS and never load insecurely. Navigations that cannot be upgraded, and
+ *     upgraded navigations whose HTTPS load fails, fail with
+ *     %WEBKIT_NETWORK_ERROR_HTTP_NAVIGATION_WITH_HTTPS_ONLY. This applies to
+ *     every scheme that is not registered as secure, not only HTTP, so custom
+ *     schemes need [method@SecurityManager.register_uri_scheme_as_secure] to
+ *     remain loadable.
+ *
+ * Enum values used to specify how HTTP navigations are upgraded to HTTPS.
+ *
+ * This is an optimistic upgrade attempted without any prior knowledge about the
+ * host. This is unlike and independent of HSTS which will never downgrade to
+ * HTTP.
+ *
+ * Only main frame navigations are upgraded; requests to localhost and to IP
+ * addresses are never upgraded. Falling back to HTTP is never done for TLS
+ * failures, which always fail the load.
+ *
+ * Since: 2.56
+ */
+typedef enum {
+    WEBKIT_UPGRADE_TO_HTTPS_POLICY_KEEP_AS_REQUESTED,
+    WEBKIT_UPGRADE_TO_HTTPS_POLICY_AUTOMATIC_FALLBACK_TO_HTTP,
+    WEBKIT_UPGRADE_TO_HTTPS_POLICY_ERROR_ON_FAILURE
+} WebKitUpgradeToHTTPSPolicy;
+
 WEBKIT_API WebKitWebsitePolicies *
 webkit_website_policies_new                                   (void);
 
@@ -76,5 +110,8 @@ webkit_website_policies_get_autoplay_policy                   (WebKitWebsitePoli
 
 WEBKIT_API const gchar *
 webkit_website_policies_get_custom_user_agent                 (WebKitWebsitePolicies *policies);
+
+WEBKIT_API WebKitUpgradeToHTTPSPolicy
+webkit_website_policies_get_upgrade_to_https_policy           (WebKitWebsitePolicies *policies);
 
 G_END_DECLS

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitPolicyClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitPolicyClient.cpp
@@ -23,6 +23,7 @@
 #include "LoadTrackingTest.h"
 #include "WebKitTestServer.h"
 #include "WebKitWebsitePolicies.h"
+#include <algorithm>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/CString.h>
@@ -419,6 +420,125 @@ static void testCustomUserAgentPolicy(PolicyClientTest* test, gconstpointer)
     g_assert_cmpstr(secondSeenUserAgent.data(), ==, kSiteZUserAgent);
 }
 
+static void setProxySettings(PolicyClientTest* test, WebKitNetworkProxyMode mode, WebKitNetworkProxySettings* proxySettings)
+{
+#if ENABLE(2022_GLIB_API)
+    webkit_network_session_set_proxy_settings(test->m_networkSession.get(), mode, proxySettings);
+#else
+    auto* websiteDataManager = webkit_web_context_get_website_data_manager(test->m_webContext.get());
+    webkit_website_data_manager_set_network_proxy_settings(websiteDataManager, mode, proxySettings);
+#endif
+}
+
+static void testUpgradeToHTTPSPolicy(PolicyClientTest* test, gconstpointer)
+{
+    test->m_policyDecisionTypeFilter = WEBKIT_POLICY_DECISION_TYPE_NAVIGATION_ACTION;
+
+    GRefPtr<WebKitWebsitePolicies> defaultPolicies = adoptGRef(webkit_website_policies_new());
+    g_assert_cmpint(webkit_website_policies_get_upgrade_to_https_policy(defaultPolicies.get()), ==, WEBKIT_UPGRADE_TO_HTTPS_POLICY_KEEP_AS_REQUESTED);
+
+    test->m_websitePolicies = adoptGRef(webkit_website_policies_new_with_policies("upgrade-to-https-policy", WEBKIT_UPGRADE_TO_HTTPS_POLICY_AUTOMATIC_FALLBACK_TO_HTTP, nullptr));
+    g_assert_cmpint(webkit_website_policies_get_upgrade_to_https_policy(test->m_websitePolicies.get()), ==, WEBKIT_UPGRADE_TO_HTTPS_POLICY_AUTOMATIC_FALLBACK_TO_HTTP);
+
+    // Server listens on an IP address, which is never upgraded, so the load is
+    // unaffected by the policy.
+    auto serverURI = kServer->getURIForPath("/");
+    test->m_policyDecisionResponse = PolicyClientTest::UseWithPolicy;
+    test->loadURI(serverURI.data());
+    test->waitUntilLoadFinished();
+    g_assert_false(test->m_loadFailed);
+    ASSERT_CMP_CSTRING(webkit_web_view_get_uri(test->m_webView.get()), ==, serverURI);
+    g_assert_cmpint(std::ranges::count(test->m_loadEvents, LoadTrackingTest::ProvisionalLoadStarted), ==, 1);
+
+    // Route http through server and https to a port nothing listens on, so that
+    // the upgraded navigation fails and falls back to http.
+    WebKitNetworkProxySettings* proxySettings = webkit_network_proxy_settings_new(nullptr, nullptr);
+    webkit_network_proxy_settings_add_proxy_for_scheme(proxySettings, "http", kServer->baseURL().string().utf8().data());
+    webkit_network_proxy_settings_add_proxy_for_scheme(proxySettings, "https", "http://127.0.0.1:1/");
+    setProxySettings(test, WEBKIT_NETWORK_PROXY_MODE_CUSTOM, proxySettings);
+
+    test->m_policyDecisionResponse = PolicyClientTest::UseWithPolicy;
+    test->loadURI("http://site.example/");
+    test->waitUntilLoadFinished();
+    g_assert_false(test->m_loadFailed);
+    g_assert_cmpstr(webkit_web_view_get_uri(test->m_webView.get()), ==, "http://site.example/");
+    // The HTTPS attempt and the HTTP fallback are two separate provisional loads.
+    g_assert_cmpint(std::ranges::count(test->m_loadEvents, LoadTrackingTest::ProvisionalLoadStarted), ==, 2);
+
+    setProxySettings(test, WEBKIT_NETWORK_PROXY_MODE_NO_PROXY, nullptr);
+    webkit_network_proxy_settings_free(proxySettings);
+
+    // With ERROR_ON_FAILURE an HTTP navigation that cannot be upgraded fails
+    // instead of loading over cleartext.
+    test->m_websitePolicies = adoptGRef(webkit_website_policies_new_with_policies("upgrade-to-https-policy", WEBKIT_UPGRADE_TO_HTTPS_POLICY_ERROR_ON_FAILURE, nullptr));
+    g_assert_cmpint(webkit_website_policies_get_upgrade_to_https_policy(test->m_websitePolicies.get()), ==, WEBKIT_UPGRADE_TO_HTTPS_POLICY_ERROR_ON_FAILURE);
+
+    test->m_policyDecisionResponse = PolicyClientTest::UseWithPolicy;
+    test->loadURI(serverURI.data());
+    test->waitUntilLoadFinished();
+    g_assert_true(test->m_loadFailed);
+    g_assert_error(test->m_error.get(), WEBKIT_NETWORK_ERROR, WEBKIT_NETWORK_ERROR_HTTP_NAVIGATION_WITH_HTTPS_ONLY);
+}
+
+static void policySchemeRequestCallback(WebKitURISchemeRequest* request, gpointer)
+{
+    static const char* replyHTML = "<html><body>custom scheme</body></html>";
+    GRefPtr<GInputStream> stream = adoptGRef(g_memory_input_stream_new_from_data(replyHTML, strlen(replyHTML), nullptr));
+    webkit_uri_scheme_request_finish(request, stream.get(), strlen(replyHTML), "text/html");
+}
+
+static void testUpgradeToHTTPSPolicySecureSchemes(PolicyClientTest* test, gconstpointer)
+{
+    // ERROR_ON_FAILURE rejects any scheme that is not registered as secure, not
+    // just cleartext HTTP.
+    test->m_policyDecisionTypeFilter = WEBKIT_POLICY_DECISION_TYPE_NAVIGATION_ACTION;
+    test->m_websitePolicies = adoptGRef(webkit_website_policies_new_with_policies("upgrade-to-https-policy", WEBKIT_UPGRADE_TO_HTTPS_POLICY_ERROR_ON_FAILURE, nullptr));
+
+    webkit_web_context_register_uri_scheme(test->m_webContext.get(), "policyscheme", policySchemeRequestCallback, nullptr, nullptr);
+
+    test->m_policyDecisionResponse = PolicyClientTest::UseWithPolicy;
+    test->loadURI("policyscheme:index.html");
+    test->waitUntilLoadFinished();
+    g_assert_true(test->m_loadFailed);
+    g_assert_error(test->m_error.get(), WEBKIT_NETWORK_ERROR, WEBKIT_NETWORK_ERROR_HTTP_NAVIGATION_WITH_HTTPS_ONLY);
+
+    // Once registered as secure the same navigation is allowed.
+    webkit_security_manager_register_uri_scheme_as_secure(webkit_web_context_get_security_manager(test->m_webContext.get()), "policyscheme");
+
+    test->m_policyDecisionResponse = PolicyClientTest::UseWithPolicy;
+    test->loadURI("policyscheme:index.html");
+    test->waitUntilLoadFinished();
+    g_assert_false(test->m_loadFailed);
+    g_assert_cmpstr(webkit_web_view_get_uri(test->m_webView.get()), ==, "policyscheme:index.html");
+}
+
+static void testHTTPSByDefaultSetting(PolicyClientTest* test, gconstpointer)
+{
+    // The global HTTPS-by-default feature upgrades every navigation, independently
+    // of any website policies.
+    WebKitFeatureList* features = webkit_settings_get_experimental_features();
+    WebKitFeature* httpsByDefault = webkit_feature_list_find(features, "HTTPSByDefault");
+    g_assert_nonnull(httpsByDefault);
+    webkit_settings_set_feature_enabled(webkit_web_view_get_settings(test->m_webView.get()), httpsByDefault, TRUE);
+
+    WebKitNetworkProxySettings* proxySettings = webkit_network_proxy_settings_new(nullptr, nullptr);
+    webkit_network_proxy_settings_add_proxy_for_scheme(proxySettings, "http", kServer->baseURL().string().utf8().data());
+    webkit_network_proxy_settings_add_proxy_for_scheme(proxySettings, "https", "http://127.0.0.1:1/");
+    setProxySettings(test, WEBKIT_NETWORK_PROXY_MODE_CUSTOM, proxySettings);
+
+    test->m_policyDecisionResponse = PolicyClientTest::Use;
+    test->loadURI("http://site.example/");
+    test->waitUntilLoadFinished();
+    g_assert_false(test->m_loadFailed);
+    g_assert_cmpstr(webkit_web_view_get_uri(test->m_webView.get()), ==, "http://site.example/");
+    g_assert_cmpint(std::ranges::count(test->m_loadEvents, LoadTrackingTest::ProvisionalLoadStarted), ==, 2);
+
+    setProxySettings(test, WEBKIT_NETWORK_PROXY_MODE_NO_PROXY, nullptr);
+    webkit_network_proxy_settings_free(proxySettings);
+    webkit_settings_set_feature_enabled(webkit_web_view_get_settings(test->m_webView.get()), httpsByDefault, FALSE);
+    webkit_feature_list_unref(features);
+}
+
 void beforeAll()
 {
     kServer = new WebKitTestServer();
@@ -428,6 +548,9 @@ void beforeAll()
     PolicyClientTest::add("WebKitPolicyClient", "response-policy", testResponsePolicy);
     PolicyClientTest::add("WebKitPolicyClient", "autoplay-policy", testAutoplayPolicy);
     PolicyClientTest::add("WebKitPolicyClient", "custom-user-agent-policy", testCustomUserAgentPolicy);
+    PolicyClientTest::add("WebKitPolicyClient", "upgrade-to-https-policy", testUpgradeToHTTPSPolicy);
+    PolicyClientTest::add("WebKitPolicyClient", "upgrade-to-https-policy-secure-schemes", testUpgradeToHTTPSPolicySecureSchemes);
+    PolicyClientTest::add("WebKitPolicyClient", "https-by-default-setting", testHTTPSByDefaultSetting);
     // WARNING: This test must come last, it uses racey constructs that
     // interfere nondeterminisically with any test running after it.
     // https://bugs.webkit.org/show_bug.cgi?id=213190


### PR DESCRIPTION
#### b2678ccf7efb04a68ae229eff8edfc8c98ed402e
<pre>
[GLib] Add API for the HTTPS upgrade policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=321724">https://bugs.webkit.org/show_bug.cgi?id=321724</a>

Reviewed by Michael Catanzaro and Carlos Garcia Campos.

Adds WebKitUpgradeToHTTPSPolicy and the upgrade-to-https-policy property,
mapping onto HTTPSByDefaultMode, so embedders can opt navigations into
upgrading HTTP to HTTPS. The enum values match the Cocoa port&apos;s
WKWebpagePreferencesUpgradeToHTTPSPolicy.

UpgradeWithUserMediatedFallback is not exposed which would allow a user
to choose to allow fallbacks. That can come in a later addition with
a new signal if desired.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitPolicyClient.cpp

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::loadMainResource):
* Source/WebCore/platform/network/ResourceErrorBase.h:
* Source/WebCore/platform/network/cocoa/ResourceErrorCocoa.mm:
(WebCore::ResourceError::errorRecoveryMethod const):
* Source/WebCore/platform/network/soup/ResourceError.h:
(WebCore::ResourceError::errorRecoveryMethod const): Deleted.
* Source/WebCore/platform/network/soup/ResourceErrorSoup.cpp:
(WebCore::ResourceError::timeoutError):
(WebCore::ResourceError::errorRecoveryMethod const):
* Source/WebKit/Shared/API/APIError.cpp:
(API::Error::webKitNetworkErrorDomain):
* Source/WebKit/Shared/API/APIError.h:
* Source/WebKit/UIProcess/API/glib/WebKitError.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp:
(toWebKitError):
(toWebCoreError):
* Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.cpp:
(webkitWebsitePoliciesGetProperty):
(webkitWebsitePoliciesSetUpgradeToHTTPSPolicy):
(webkitWebsitePoliciesSetProperty):
(webkit_website_policies_class_init):
(webkit_website_policies_get_upgrade_to_https_policy):
* Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.h.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestWebKitPolicyClient.cpp:
(setProxySettings):
(testUpgradeToHTTPSPolicy):
(policySchemeRequestCallback):
(testUpgradeToHTTPSPolicySecureSchemes):
(testHTTPSByDefaultSetting):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/319880@main">https://commits.webkit.org/319880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58b4774051b88a078d758fea4babd135574bcb95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147128 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142714 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123142 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45120 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43365 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43000 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4229 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194998 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56432 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152163 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40822 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57137 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151859 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46429 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129406 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125488 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55645 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18010 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->