### PR TITLE
Classify address spaces beyond the ranges in the Local Network Access spec

### DIFF
--- a/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
@@ -27,123 +27,231 @@
 #include "IPAddressSpace.h"
 
 #include "DNS.h"
+#include "SecurityOrigin.h"
 #include "Site.h"
 #include <array>
+#include <optional>
+#include <span>
+#include <wtf/ASCIICType.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
-#include <wtf/Vector.h>
-#include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/StringView.h>
 
-#if OS(UNIX)
-#include <arpa/inet.h>
-#endif
-
 namespace WebCore {
 
-static IPAddressSpace classifyHost(String host)
+struct AddressRange {
+    std::array<uint8_t, 16> address;
+    uint8_t prefixLength;
+    IPAddressSpace space;
+};
+
+static bool matchesPrefix(std::span<const uint8_t> bytes, const AddressRange& range)
 {
-    if (!URL::hostIsIPAddress(host))
-        return IPAddressSpace::Public;
+    ASSERT(range.prefixLength <= bytes.size() * 8);
+    size_t wholeBytes = range.prefixLength / 8;
+    unsigned trailingBits = range.prefixLength % 8;
+    for (size_t byteIndex = 0; byteIndex < wholeBytes; ++byteIndex) {
+        if (bytes[byteIndex] != range.address[byteIndex])
+            return false;
+    }
+    if (!trailingBits)
+        return true;
+    uint8_t mask = 0xFF << (8 - trailingBits);
+    return (bytes[wholeBytes] & mask) == (range.address[wholeBytes] & mask);
+}
 
-    // Handle IPv6 addresses (check for colon to distinguish from IPv4)
-    if (host.contains(':')) {
-        // ::1/128 - IPv6 Loopback
-        if (host == "::1")
-            return IPAddressSpace::Loopback;
+static IPAddressSpace classifyAddress(std::span<const uint8_t> bytes, std::span<const AddressRange> ranges)
+{
+    for (auto& range : ranges) {
+        if (matchesPrefix(bytes, range))
+            return range.space;
+    }
+    return IPAddressSpace::Public;
+}
 
-        // fc00::/7 - Unique Local - local
-        if (host.startsWith("fc"_s) || host.startsWith("fd"_s))
-            return IPAddressSpace::Local;
+static IPAddressSpace classifyIPv4Address(std::span<const uint8_t, 4> bytes)
+{
+    static constexpr AddressRange ranges[] = {
+        { { 0, 0, 0, 0 }, 32, IPAddressSpace::Loopback },
+        { { 127 }, 8, IPAddressSpace::Loopback },
+        { { 198, 18 }, 15, IPAddressSpace::Loopback },
+        { { 0 }, 8, IPAddressSpace::Local },
+        { { 10 }, 8, IPAddressSpace::Local },
+        { { 100, 64 }, 10, IPAddressSpace::Local },
+        { { 172, 16 }, 12, IPAddressSpace::Local },
+        { { 192, 168 }, 16, IPAddressSpace::Local },
+        { { 169, 254 }, 16, IPAddressSpace::Local },
+        { { 192, 0, 0 }, 24, IPAddressSpace::Local },
+        { { 192, 0, 2 }, 24, IPAddressSpace::Local },
+        { { 192, 88, 99 }, 24, IPAddressSpace::Local },
+        { { 198, 51, 100 }, 24, IPAddressSpace::Local },
+        { { 203, 0, 113 }, 24, IPAddressSpace::Local },
+        { { 224 }, 4, IPAddressSpace::Local },
+        { { 240 }, 4, IPAddressSpace::Local },
+    };
+    return classifyAddress(bytes, ranges);
+}
 
-        // fe80::/10 - Link-Local Unicast - local
-        if (host.startsWith("fe8"_s) || host.startsWith("fe9"_s) || host.startsWith("fea"_s) || host.startsWith("feb"_s))
-            return IPAddressSpace::Local;
-        // ::ffff: - IPv4 Mapped IPv6 Addresses - format for parsing by IPv4 Algorithm.
-        if (host.startsWith("::ffff:"_s)) {
-            host = host.substring(7);
-            if (!host.contains('.')) {
-                // Parse hex representation like "c0a8:101" -> "192.168.1.1"
-                StringView hostView { host };
-                auto colonPosition = hostView.find(':');
-                if (colonPosition == notFound || hostView.find(':', colonPosition + 1) != notFound)
-                    return IPAddressSpace::Public;
+// RFC 6052 embeds an IPv4 address in the bits immediately following the prefix, skipping the octet at
+// bits 64-71 that the IPv6 addressing architecture reserves. Only the two prefixes with fixed values
+// can be recognised here; an operator's network-specific prefix is not knowable.
+static std::optional<std::array<uint8_t, 4>> nat64EmbeddedIPv4Address(std::span<const uint8_t, 16> bytes)
+{
+    // 64:ff9b::/96, the Well-Known Prefix (RFC 6052).
+    static constexpr std::array<uint8_t, 12> wellKnownPrefix { 0x00, 0x64, 0xFF, 0x9B };
+    if (equalSpans(bytes.first<12>(), std::span { wellKnownPrefix }))
+        return std::array<uint8_t, 4> { bytes[12], bytes[13], bytes[14], bytes[15] };
 
-                auto value1 = parseInteger<uint16_t>(hostView.left(colonPosition), 16);
-                auto value2 = parseInteger<uint16_t>(hostView.substring(colonPosition + 1), 16);
+    // 64:ff9b:1::/48, reserved for local use (RFC 8215), where the address straddles the reserved octet.
+    static constexpr std::array<uint8_t, 6> localUsePrefix { 0x00, 0x64, 0xFF, 0x9B, 0x00, 0x01 };
+    if (equalSpans(bytes.first<6>(), std::span { localUsePrefix }))
+        return std::array<uint8_t, 4> { bytes[6], bytes[7], bytes[9], bytes[10] };
 
-                if (!value1.has_value() || !value2.has_value())
-                    return IPAddressSpace::Public;
+    return std::nullopt;
+}
 
-                // Convert 16-bit hex values to dotted decimal IPv4 format
-                uint16_t val1 = *value1;
-                uint16_t val2 = *value2;
+static IPAddressSpace classifyIPv6Address(std::span<const uint8_t, 16> bytes)
+{
+    static constexpr AddressRange ipv4MappedRange { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF }, 96, IPAddressSpace::Public };
+    if (matchesPrefix(bytes, ipv4MappedRange))
+        return classifyIPv4Address(bytes.subspan<12, 4>());
 
-                host = makeString(
-                    static_cast<unsigned>(val1 >> 8), '.',
-                    static_cast<unsigned>(val1 & 0xFF), '.',
-                    static_cast<unsigned>(val2 >> 8), '.',
-                    static_cast<unsigned>(val2 & 0xFF)
-                );
+    if (auto embedded = nat64EmbeddedIPv4Address(bytes))
+        return classifyIPv4Address(std::span<const uint8_t, 4> { *embedded });
+
+    static constexpr AddressRange ranges[] = {
+        { { }, 128, IPAddressSpace::Loopback },
+        { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }, 128, IPAddressSpace::Loopback },
+        { { 0xFC }, 7, IPAddressSpace::Local },
+        { { 0xFE, 0x80 }, 10, IPAddressSpace::Local },
+        { { 0xFE, 0xC0 }, 10, IPAddressSpace::Local },
+        { { 0x20, 0x01, 0x0D, 0xB8 }, 32, IPAddressSpace::Local },
+        { { 0x3F, 0xFF }, 20, IPAddressSpace::Local },
+        { { 0xFF }, 8, IPAddressSpace::Local },
+        { { 0x01 }, 64, IPAddressSpace::Local },
+    };
+    return classifyAddress(bytes, ranges);
+}
+
+static std::optional<std::array<uint8_t, 4>> parseIPv4Address(StringView host)
+{
+    std::array<uint8_t, 4> bytes { };
+    size_t index = 0;
+    for (auto octet : host.split('.')) {
+        if (index >= 4)
+            return std::nullopt;
+        if (octet.isEmpty() || !isASCIIDigit(octet[0]))
+            return std::nullopt;
+        auto value = parseInteger<uint8_t>(octet);
+        if (!value)
+            return std::nullopt;
+        bytes[index++] = *value;
+    }
+    if (index != 4)
+        return std::nullopt;
+    return bytes;
+}
+
+static std::optional<std::array<uint8_t, 16>> parseIPv6Address(StringView host)
+{
+    if (auto percent = host.find('%'); percent != notFound)
+        host = host.left(percent);
+
+    if (host.isEmpty())
+        return std::nullopt;
+
+    StringView head = host;
+    StringView tail;
+    bool isCompressed = false;
+    if (auto doubleColon = host.find("::"_s); doubleColon != notFound) {
+        isCompressed = true;
+        head = host.left(doubleColon);
+        tail = host.substring(doubleColon + 2);
+        if (tail.contains("::"_s))
+            return std::nullopt;
+    }
+
+    auto parseGroups = [](StringView text, std::span<uint8_t, 16> out, size_t offset) -> std::optional<size_t> {
+        if (text.isEmpty())
+            return 0;
+        size_t written = 0;
+        for (auto group : text.split(':')) {
+            if (group.isEmpty())
+                return std::nullopt;
+            if (group.contains('.')) {
+                auto ipv4 = parseIPv4Address(group);
+                if (!ipv4 || offset + written + 4 > 16)
+                    return std::nullopt;
+                for (size_t i = 0; i < 4; ++i)
+                    out[offset + written + i] = (*ipv4)[i];
+                written += 4;
+                continue;
             }
+            if (group.length() > 4)
+                return std::nullopt;
+            auto value = parseInteger<uint16_t>(group, 16);
+            if (!value || offset + written + 2 > 16)
+                return std::nullopt;
+            out[offset + written] = static_cast<uint8_t>(*value >> 8);
+            out[offset + written + 1] = static_cast<uint8_t>(*value & 0xFF);
+            written += 2;
         }
-    }
-    if (host.contains('.')) {
-        std::array<uint8_t, 4> parts;
-        size_t i = 0;
-        for (auto octet : StringView(host).split('.')) {
-            if (i >= 4)
-                return IPAddressSpace::Public;
-            auto value = parseInteger<uint8_t>(octet);
-            if (!value)
-                return IPAddressSpace::Public;
-            parts[i++] = *value;
-        }
-        if (i != 4)
-            return IPAddressSpace::Public;
+        return written;
+    };
 
-        // Check IPv4 address blocks according to spec table:
+    std::array<uint8_t, 16> bytes { };
+    auto headBytes = parseGroups(head, bytes, 0);
+    if (!headBytes)
+        return std::nullopt;
 
-        // 127.0.0.0/8 - IPv4 Loopback
-        if (parts[0] == 127)
-            return IPAddressSpace::Loopback;
+    if (!isCompressed)
+        return *headBytes == 16 ? std::make_optional(bytes) : std::nullopt;
 
-        // 10.0.0.0/8 - Local Use - local
-        if (parts[0] == 10)
-            return IPAddressSpace::Local;
+    std::array<uint8_t, 16> tailBuffer { };
+    auto tailBytes = parseGroups(tail, tailBuffer, 0);
+    if (!tailBytes || *headBytes + *tailBytes > 16)
+        return std::nullopt;
 
-        // 100.64.0.0/10 - Carrier-Grade NAT - local
-        if (parts[0] == 100 && (parts[1] & 0xC0) == 64)
-            return IPAddressSpace::Local;
+    if (*headBytes + *tailBytes == 16)
+        return std::nullopt;
 
-        // 172.16.0.0/12 - Local Use - local
-        if (parts[0] == 172 && (parts[1] & 0xF0) == 16)
-            return IPAddressSpace::Local;
+    for (size_t i = 0; i < *tailBytes; ++i)
+        bytes[16 - *tailBytes + i] = tailBuffer[i];
 
-        // 192.168.0.0/16 - Local Use - local
-        if (parts[0] == 192 && parts[1] == 168)
-            return IPAddressSpace::Local;
+    return bytes;
+}
 
-        // 198.18.0.0/15 - Benchmarking - local
-        if (parts[0] == 198 && (parts[1] & 0xFE) == 18)
-            return IPAddressSpace::Local;
-
-        // 169.254.0.0/16 - Link Local - local
-        if (parts[0] == 169 && parts[1] == 254)
-            return IPAddressSpace::Local;
-
+static IPAddressSpace classifyHost(StringView host)
+{
+    if (host.contains(':')) {
+        if (auto bytes = parseIPv6Address(host))
+            return classifyIPv6Address(std::span<const uint8_t, 16> { *bytes });
         return IPAddressSpace::Public;
     }
+
+    if (auto bytes = parseIPv4Address(host))
+        return classifyIPv4Address(std::span<const uint8_t, 4> { *bytes });
+
     return IPAddressSpace::Public;
 }
 
 static IPAddressSpace determineIPAddressSpaceFromHost(StringView host)
 {
-    // Defined in https://wicg.github.io/local-network-access/#ip-address-space-section
     if (host.startsWith('[') && host.endsWith(']'))
         host = host.substring(1, host.length() - 2);
 
-    return classifyHost(host.toString());
+    if (host.endsWith('.'))
+        host = host.left(host.length() - 1);
+
+    // classifyHost() only parses address literals, so these reserved names need matching separately.
+    if (SecurityOrigin::isLocalhostAddress(host))
+        return IPAddressSpace::Loopback;
+
+    if (host.endsWithIgnoringASCIICase(".local"_s))
+        return IPAddressSpace::Local;
+
+    return classifyHost(host);
 }
 
 IPAddressSpace determineIPAddressSpace(const URL& url)
@@ -156,27 +264,15 @@ IPAddressSpace determineIPAddressSpace(const Site& site)
     return determineIPAddressSpaceFromHost(site.domain().string());
 }
 
-#if OS(UNIX)
 IPAddressSpace classifyIPAddressSpace(const IPAddress& address)
 {
-    char buffer[INET6_ADDRSTRLEN];
-    if (address.isIPv4()) {
-        if (!inet_ntop(AF_INET, &address.ipv4Address(), buffer, sizeof(buffer)))
-            return IPAddressSpace::Unknown;
-    } else if (address.isIPv6()) {
-        if (!inet_ntop(AF_INET6, &address.ipv6Address(), buffer, sizeof(buffer)))
-            return IPAddressSpace::Unknown;
-    } else
-        return IPAddressSpace::Unknown;
+    if (address.isIPv4())
+        return classifyIPv4Address(asByteSpan(address.ipv4Address()).first<4>());
 
-    return classifyHost(String::fromLatin1(buffer));
-}
-#else
-IPAddressSpace classifyIPAddressSpace(const IPAddress&)
-{
-    // IPAddress::fromString() is OS(UNIX)-only (see DNS.cpp), so there's no address to classify here.
+    if (address.isIPv6())
+        return classifyIPv6Address(asByteSpan(address.ipv6Address()).first<16>());
+
     return IPAddressSpace::Unknown;
 }
-#endif
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -48,9 +48,9 @@ BrowsingContextGroup::BrowsingContextGroup() = default;
 
 BrowsingContextGroup::~BrowsingContextGroup() = default;
 
-static bool isLoopbackOrLocalNetworkSite(const Site& site)
+static bool isLoopbackOrLocalNetworkSite(const Site& site, bool localNetworkAccessEnabled)
 {
-    if (determineIPAddressSpace(site) != IPAddressSpace::Public)
+    if (localNetworkAccessEnabled && determineIPAddressSpace(site) != IPAddressSpace::Public)
         return true;
     return SecurityOrigin::isLocalHostOrLoopbackIPAddress(site.domain().string());
 }
@@ -64,7 +64,7 @@ void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataSto
     if (site.isEmpty() || m_processMap.contains(site))
         return completionHandler(nullptr);
 
-    if (isLoopbackOrLocalNetworkSite(site))
+    if (isLoopbackOrLocalNetworkSite(site, preferences.localNetworkAccessEnabled()))
         return completionHandler(nullptr);
 
     if (!m_sharedProcessSites.contains(site)) {

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -244,6 +244,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/HTTPParsers.cpp
         Tests/WebCore/IDBKeyData.cpp
         Tests/WebCore/IDBSerializationTest.cpp
+        Tests/WebCore/IPAddressSpaceTests.cpp
         Tests/WebCore/ImageBufferTests.cpp
         Tests/WebCore/IntPointTests.cpp
         Tests/WebCore/IntRectTests.cpp

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
@@ -93,14 +93,12 @@ TEST(IPAddressSpace, IPv4LinkLocal)
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://169.255.0.1/"_s)), WebCore::IPAddressSpace::Public);
 }
 
-// Test Benchmarking addresses (198.18.0.0/15)
 TEST(IPAddressSpace, IPv4Benchmarking)
 {
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.18.0.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://198.18.100.50:443/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.18.0.1/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://198.18.100.50:443/"_s)), WebCore::IPAddressSpace::Loopback);
 
-    // Edge cases - should NOT be local
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.17.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.20.0.1/"_s)), WebCore::IPAddressSpace::Public);
 }
@@ -146,7 +144,109 @@ TEST(IPAddressSpace, IPv6LinkLocal)
 
     // Edge cases - should NOT be local
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fe7f::1]/"_s)), WebCore::IPAddressSpace::Public);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fec0::1]/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+TEST(IPAddressSpace, IPv6SiteLocal)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fec0::1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[feff::1]/"_s)), WebCore::IPAddressSpace::Local);
+}
+
+TEST(IPAddressSpace, UnspecifiedAddresses)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://0.0.0.0/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::]/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://0/"_s)), WebCore::IPAddressSpace::Loopback);
+
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://0.1.2.3/"_s)), WebCore::IPAddressSpace::Local);
+}
+
+TEST(IPAddressSpace, DocumentationRanges)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[2001:db8::1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[3fff::1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[3fff:0fff::1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.0.2.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.51.100.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://203.0.113.1/"_s)), WebCore::IPAddressSpace::Local);
+
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[3fff:1000::1]/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+TEST(IPAddressSpace, NonGloballyRoutableRanges)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://224.0.0.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://239.255.255.250/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[ff02::1]/"_s)), WebCore::IPAddressSpace::Local);
+
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://240.0.0.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://255.255.255.255/"_s)), WebCore::IPAddressSpace::Local);
+
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.0.0.1/"_s)), WebCore::IPAddressSpace::Local);
+
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.88.99.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.88.98.255/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.88.100.0/"_s)), WebCore::IPAddressSpace::Public);
+
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[2001:0:1::1]/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[2002::1]/"_s)), WebCore::IPAddressSpace::Public);
+
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[100::1]/"_s)), WebCore::IPAddressSpace::Local);
+}
+
+// The URL parser canonicalises non-dotted IPv4 hosts before classification sees them, so these
+// spellings all reach determineIPAddressSpace() as 127.0.0.1. Asserted because classifyHost() only
+// parses dotted quads, and would return Public for any form the parser stopped normalising.
+TEST(IPAddressSpace, IPv4AlternateHostFormats)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://2130706433/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://0x7f000001/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://017700000001/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.1/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.1/"_s)), WebCore::IPAddressSpace::Loopback);
+
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://3232235777/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://0xc0a80101/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.168.257/"_s)), WebCore::IPAddressSpace::Local);
+
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://134744072/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://0x08080808/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// NAT64 (RFC 6052) embeds an IPv4 address in an IPv6 one, so a translated address is only as public as
+// the IPv4 address it carries. Without this a public page could reach a private host through a NAT64
+// prefix with no permission at all.
+TEST(IPAddressSpace, NAT64WellKnownPrefix)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b::192.168.1.1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b::c0a8:101]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b::10.0.0.1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b::127.0.0.1]/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b::169.254.169.254]/"_s)), WebCore::IPAddressSpace::Local);
+
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b::8.8.8.8]/"_s)), WebCore::IPAddressSpace::Public);
+
+    // 64:ff9b:1::/48 is a different prefix and must not be read with the /96 layout.
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9c::192.168.1.1]/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// At /48 the embedded address straddles the octet at bits 64-71 that the addressing architecture
+// reserves: two bytes before it and two after. 64:ff9b:1:c0a8:1:100:: therefore carries 192.168.1.1,
+// and reading it with the /96 layout would see 0.0.0.0 instead.
+TEST(IPAddressSpace, NAT64LocalUsePrefix)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b:1:c0a8:1:100::]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b:1:a00:0:100::]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b:1:7f00:0:100::]/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b:1:a9fe:a9:fe00::]/"_s)), WebCore::IPAddressSpace::Local);
+
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b:1:808:8:800::]/"_s)), WebCore::IPAddressSpace::Public);
+
+    // Trailing bytes after the embedded address are suffix and must not affect the result.
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b:1:c0a8:1:100:dead:beef]/"_s)), WebCore::IPAddressSpace::Local);
+
+    // 64:ff9b:2::/48 is not the local-use prefix.
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[64:ff9b:2:c0a8:1:100::]/"_s)), WebCore::IPAddressSpace::Public);
 }
 
 // Test IPv4-Mapped IPv6 addresses (::ffff:0:0/96) with dotted decimal notation
@@ -185,7 +285,6 @@ TEST(IPAddressSpace, IPv6PublicAddresses)
 {
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[2001:4860:4860::8888]/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[2606:4700:4700::1111]/"_s)), WebCore::IPAddressSpace::Public);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[2001:db8::1]:443/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::2]/"_s)), WebCore::IPAddressSpace::Public);
 }
 
@@ -194,9 +293,18 @@ TEST(IPAddressSpace, HostnameAddresses)
 {
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://example.com/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://www.google.com/"_s)), WebCore::IPAddressSpace::Public);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://localhost/"_s)), WebCore::IPAddressSpace::Public);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://internal.company.local:8080/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("ftp://ftp.example.org/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://localhost/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://internal.company.local:8080/"_s)), WebCore::IPAddressSpace::Local);
+}
+
+TEST(IPAddressSpace, FullyQualifiedNames)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://printer.local./"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://localhost./"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://dev.localhost./"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1./"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://example.com./"_s)), WebCore::IPAddressSpace::Public);
 }
 
 // Test edge cases and malformed addresses
@@ -281,9 +389,8 @@ TEST(IPAddressSpace, IPv4BoundaryConditions)
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.63.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.128.0.0/"_s)), WebCore::IPAddressSpace::Public);
 
-    // Test exact boundaries for 198.18.0.0/15
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.18.0.0/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.18.0.0/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Loopback);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.17.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.20.0.0/"_s)), WebCore::IPAddressSpace::Public);
 }
@@ -329,11 +436,27 @@ TEST(IPAddressSpace, SiteMatchesURLForIPLiterals)
     EXPECT_EQ(WebCore::determineIPAddressSpace(WebCore::Site(URL("https://example.com/"_s))), WebCore::IPAddressSpace::Public);
 }
 
-TEST(IPAddressSpace, SiteDoesNotSpecialCaseLocalhostName)
+TEST(IPAddressSpace, ClassifiesLocalhostNameAsLoopback)
 {
-    // determineIPAddressSpace currently only classifies IP literals.
-    EXPECT_EQ(WebCore::determineIPAddressSpace(WebCore::Site(URL("http://localhost/"_s))), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://localhost/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://localhost:8000/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://LOCALHOST/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://foo.localhost/"_s)), WebCore::IPAddressSpace::Loopback);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(WebCore::Site(URL("http://localhost/"_s))), WebCore::IPAddressSpace::Loopback);
+}
+
+TEST(IPAddressSpace, ClassifiesMDNSNameAsLocal)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://printer.local/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://PRINTER.LOCAL/"_s)), WebCore::IPAddressSpace::Local);
+}
+
+TEST(IPAddressSpace, DoesNotOvermatchReservedNames)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://notlocalhost/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://localhost.example.com/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://mylocal/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://local.example.com/"_s)), WebCore::IPAddressSpace::Public);
 }
 
 }
-


### PR DESCRIPTION
#### c7a6160aac237c2d5392fe0fcc5ba8920d002e4a
<pre>
Classify address spaces beyond the ranges in the Local Network Access spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=321725">https://bugs.webkit.org/show_bug.cgi?id=321725</a>
<a href="https://rdar.apple.com/184859143">rdar://184859143</a>

Reviewed by Pascoe.

Widens IP address space classification beyond the ranges the Local Network Access spec
enumerates, and replaces string comparison on the host with a prefix-table match over raw
address bytes. See <a href="https://wicg.github.io/local-network-access/#ip-address-space-section">https://wicg.github.io/local-network-access/#ip-address-space-section</a> and
<a href="https://github.com/WICG/local-network-access/issues/6">https://github.com/WICG/local-network-access/issues/6</a>, /issues/13 and /issues/15.

The previous implementation compared host strings (`host == &quot;::1&quot;`, `host.contains(&apos;:&apos;)`),
which missed equivalent spellings of the same address -- `::1` and `0:0:0:0:0:0:0:1` are the
same host. Parsing to bytes and matching a prefix table classifies all spellings of an
address identically.

Classifying a range as public is the permissive answer here: the check fires only when the
target is less public than the client, so a range left public is reachable from a public page
with no permission at all. None of the ranges below can host a publicly-served site.

Ranges added beyond the spec, each covered by a test:
  - as loopback: 0.0.0.0/32 (this host, RFC 1122), 198.18.0.0/15 (benchmarking, RFC 2544),
    ::/128 (IPv6 unspecified, RFC 4291)
  - as local: 0.0.0.0/8 (this network, RFC 791), 100.64.0.0/10 (carrier-grade NAT, RFC 6598),
    192.0.0.0/24 (IETF protocol assignments, RFC 6890), 192.0.2.0/24, 198.51.100.0/24,
    203.0.113.0/24 (documentation, RFC 5737), 192.88.99.0/24 (deprecated 6to4 relay anycast,
    RFC 7526), 224.0.0.0/4 (multicast), 240.0.0.0/4 (reserved, RFC 1112)
  - as local, IPv6: fec0::/10 (deprecated site-local, RFC 3879), 2001:db8::/32 and 3fff::/20
    (documentation, RFC 3849 and RFC 9637), ff00::/8 (multicast, RFC 4291), 0100::/64
    (discard-only, RFC 6666)
  - IPv4-mapped IPv6 forms, which now classify as their embedded IPv4 address does
  - NAT64 (RFC 6052), which likewise classifies as the IPv4 address it carries: the Well-Known
    Prefix 64:ff9b::/96, and 64:ff9b:1::/48 reserved for local use (RFC 8215). Without this a
    public page could reach a private host through a NAT64 prefix with no permission. At /48 the
    embedded address straddles the octet at bits 64-71 that the addressing architecture reserves,
    so 64:ff9b:1:c0a8:1:100:: carries 192.168.1.1. An operator&apos;s network-specific prefix cannot be
    recognised here, so only these two fixed prefixes are handled.

Also recognises localhost and .local by name, which the previous host-string path did not.

Non-dotted IPv4 hosts are canonicalised by the URL parser before classification sees them, so
<a href="http://2130706433/">http://2130706433/</a> and <a href="http://0x7f000001/">http://0x7f000001/</a> arrive as 127.0.0.1. Asserted rather than assumed, since
classifyHost() only parses dotted quads and would return Public for any form the parser stopped
normalising.

Adds Tests/WebCore/IPAddressSpaceTests.cpp to Tools/TestWebKitAPI/CMakeLists.txt. It was never
listed, so every CMake port has been skipping these tests entirely.

Also gates BrowsingContextGroup&apos;s shared-process exclusion on the LocalNetworkAccessEnabled
preference. Widening the classifier changes what isLoopbackOrLocalNetworkSite() returns, and
without the gate that would alter site-isolation process placement for embedders with the
feature off. Ordinary hostnames are unaffected either way: classifyHost() returns Public for
anything that is not an address literal, so only literals, localhost and .local names are
excluded from the shared process.

Two entry points share the tables: determineIPAddressSpace(URL/Site), used before any
connection exists by fetch()&apos;s targetAddressSpace derivation and site-isolation process
placement; and classifyIPAddressSpace(IPAddress), used for a resolved peer address.

No behaviour change with LocalNetworkAccessEnabled off.

* Source/WebCore/Modules/fetch/IPAddressSpace.cpp:
(WebCore::matchesPrefix):
(WebCore::classifyAddress):
(WebCore::classifyIPv4Address):
(WebCore::nat64EmbeddedIPv4Address):
(WebCore::classifyIPv6Address):
(WebCore::determineIPAddressSpaceFromHost):
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::isLoopbackOrLocalNetworkSite):
(WebKit::BrowsingContextGroup::sharedProcessForSite):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp:

Canonical link: <a href="https://commits.webkit.org/319918@main">https://commits.webkit.org/319918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78f7bcb343aac133b7e704d4b12e3eeff64a9616

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193389 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56829 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46701 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45392 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43269 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4563 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/49741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195330 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56763 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152453 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40849 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57468 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152149 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46701 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125889 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55976 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18280 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55347 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55585 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55414 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->