### PR TITLE
[css-values-5 random-item()] auto <random-key> is not element-scoped, so every element shares one item

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt
@@ -25,6 +25,10 @@ PASS random-item() into a registered <number>
 PASS Selecting an empty item is invalid at computed-value time
 PASS random-item() selection is stable across style recalculation
 PASS Independent auto random-item() instances each resolve to a valid item
+PASS random-item() with an auto <random-key> is element-scoped
+PASS random-item() with a bare element-scoped <random-key> is not shared between elements
+PASS random-item() with a <dashed-ident> element-scoped <random-key> is not shared between elements
+PASS random-item() with a <dashed-ident> <random-key> is shared between elements
 PASS A shared dashed-ident key selects the same item across properties
 PASS random() and random-item() using auto in one declaration both resolve
 PASS A bare element-scoped key selects the same item across random-item() instances

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel="help" href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#random-caching">
 <link rel="author" title="Joanne Pan" href="https://github.com/J0pan">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -108,6 +109,56 @@ test(() => {
     assert_in_array(getComputedStyle(target).getPropertyValue('--p').trim(), set);
     assert_in_array(getComputedStyle(target).getPropertyValue('--q').trim(), set);
 }, 'Independent auto random-item() instances each resolve to a valid item');
+
+const ITEMS = ['rgb(1, 0, 0)', 'rgb(0, 1, 0)', 'rgb(0, 0, 1)', 'rgb(1, 1, 0)', 'rgb(0, 1, 1)', 'rgb(1, 0, 1)', 'rgb(1, 1, 1)', 'rgb(2, 0, 0)'];
+const ITEM_LIST = ITEMS.join(', ');
+
+function computedColorsForSiblings(key) {
+    const holder = document.createElement('div');
+    document.body.appendChild(holder);
+    try {
+        const colors = [];
+        for (let i = 0; i < 12; ++i) {
+            const element = document.createElement('div');
+            element.style.cssText = `color: random-item(${key}, ${ITEM_LIST})`;
+            holder.appendChild(element);
+            colors.push(getComputedStyle(element).color);
+        }
+        return colors;
+    } finally {
+        document.body.removeChild(holder);
+    }
+}
+
+// An element-scoped key gives each element an independent draw, so 12 elements agreeing across
+// 8 items is about 1 in 10^10.
+test(() => {
+    const colors = computedColorsForSiblings('auto');
+    for (const color of colors)
+        assert_in_array(color, ITEMS);
+    assert_greater_than(new Set(colors).size, 1, 'every element selected the same item');
+}, 'random-item() with an auto <random-key> is element-scoped');
+
+test(() => {
+    const colors = computedColorsForSiblings('element-scoped');
+    for (const color of colors)
+        assert_in_array(color, ITEMS);
+    assert_greater_than(new Set(colors).size, 1, 'every element selected the same item');
+}, 'random-item() with a bare element-scoped <random-key> is not shared between elements');
+
+test(() => {
+    const colors = computedColorsForSiblings('--per-element element-scoped');
+    for (const color of colors)
+        assert_in_array(color, ITEMS);
+    assert_greater_than(new Set(colors).size, 1, 'every element selected the same item');
+}, 'random-item() with a <dashed-ident> element-scoped <random-key> is not shared between elements');
+
+test(() => {
+    const colors = computedColorsForSiblings('--across-elements');
+    for (const color of colors)
+        assert_in_array(color, ITEMS);
+    assert_equals(new Set(colors).size, 1, 'elements selected different items');
+}, 'random-item() with a <dashed-ident> <random-key> is shared between elements');
 
 // Deterministic value-sharing: the same dashed-ident key selects the same item on two properties.
 test(() => {

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -1073,12 +1073,6 @@ std::optional<double> SubstitutionResolver::randomItemBaseValue(Vector<CSSParser
 
     auto parserState = CSS::PropertyParserState { .context = m_substitutionValue->context() };
 
-    // FIXME: § 9.4.1 turns `auto` into element-scoped property-index-scoped unconditionally, for both
-    // random() and random-item(), but this keys random-item()'s `auto` on the current property
-    // document-wide instead. This is pre-existing behavior, kept because there is no element to scope to
-    // in every substitution context (element-scoping would make the value invalid at computed-value time
-    // where there is none). Reconciling it with the spec is a follow-up.
-    //
     // FIXME: This index is counted here, at substitution time, in a separate space from random()'s
     // parse-time cssRandomFunctionCount. An auto random-item() and an auto random() in the same
     // property value can therefore land on the same RandomCachingKey and share a base value, and the
@@ -1086,7 +1080,7 @@ std::optional<double> SubstitutionResolver::randomItemBaseValue(Vector<CSSParser
     // counter is a follow-up.
     auto keySource = CSSPropertyParserHelpers::RandomKeySource {
         .property = { m_styleBuilder.state().cssPropertyID(), m_styleBuilder.state().customPropertyName() },
-        .autoElementScoped = std::nullopt
+        .autoElementScoped = CSS::Keyword::ElementScoped { }
     };
     auto sharing = CSSPropertyParserHelpers::consumeUnresolvedRandomKey(randomKeyRange, parserState, keySource, [&] {
         return m_randomItemAutoIndex++;


### PR DESCRIPTION
#### a26c23b4add22f9150f91d6eab8e5e1bb8027216
<pre>
[css-values-5 random-item()] auto &lt;random-key&gt; is not element-scoped, so every element shares one item
<a href="https://bugs.webkit.org/show_bug.cgi?id=321702">https://bugs.webkit.org/show_bug.cgi?id=321702</a>
<a href="https://rdar.apple.com/184845561">rdar://184845561</a>

Reviewed by Tim Nguyen.

An `auto` &lt;random-key&gt; simplifies to element-scoped property-index-scoped, for
both random() and random-item(). random() does this; random-item() keyed its
`auto` document-wide instead, so every element with the same declaration selected
the same item rather than choosing independently. The key is mandatory for
random-item(), so `auto` is what authors write for default behaviour.

Pass ElementScoped when resolving random-item()&apos;s `auto`, matching random().

The removed FIXME justified the document-wide key by there being no element in
every substitution context. resolveRandomBaseValue() already covers that: it
returns nullopt for element-scoped sharing when there is no element, the same
path random() takes. random-item-in-keyframe.html and
random-item-in-container-query.tentative.html are unaffected.

This makes the index collision described by the remaining FIXME reachable. Both
functions count `auto` indices from zero in separate spaces, so an auto random()
and an auto random-item() in one property value now agree on property, index and
element, and share a base value. Previously the differing scopes kept them in
separate maps and hid it. Measured over 40 samples of
`width: calc(random(auto, 0px, 400px) + random-item(auto, 0px, 1000px))`, results
consistent with sharing went from 22/40 to 40/40. Unifying the counters is
webkit.org/b/319919.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::randomItemBaseValue):

Canonical link: <a href="https://commits.webkit.org/319153@main">https://commits.webkit.org/319153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c2abb2730bac206171669ab1aa05b3ee1a5017d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190842 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144953 "Build is in progress. Recent messages:") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3952891d-621a-41f8-b2a5-0fc60c569356) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54292 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/144953 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3db418f-4d32-4f20-b8dc-4d611c48620d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183586 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44556 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed layout tests; 3 new passes 1 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121337 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b77315f-3967-4781-b31f-6b1a4ee4d866) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41193 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2002 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47185 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 27452 issues") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192778 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54242 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161182 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150262 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40218 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54930 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149980 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44600 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122410 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53447 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16186 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52829 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52894 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->