### PR TITLE
[AppKit Gestures] Some events are not fired when event listeners are added to `document`

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2851,8 +2851,8 @@ void Node::defaultEventHandler(Event& event)
 
 bool Node::willRespondToMouseMoveEvents() const
 {
-    // FIXME: Why is the iOS code path different from the non-iOS code path?
-#if !PLATFORM(IOS_FAMILY)
+    // FIXME: Why is the Cocoa code path different from the non-Cocoa code path?
+#if !PLATFORM(COCOA)
     auto* element = dynamicDowncast<Element>(*this);
     if (!element)
         return false;
@@ -2897,8 +2897,8 @@ bool Node::hasActivationBehavior() const
 
 bool Node::willRespondToMouseClickEventsWithEditability(Editability editability) const
 {
-    // FIXME: Why is the iOS code path different from the non-iOS code path?
-#if !PLATFORM(IOS_FAMILY)
+    // FIXME: Why is the Cocoa code path different from the non-Cocoa code path?
+#if !PLATFORM(COCOA)
     auto* element = dynamicDowncast<Element>(*this);
     if (!element)
         return false;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
@@ -270,13 +270,20 @@ extension JavaScriptMessages {
         public static var expression: String {
             """
             window.eventLog = [];
-            const target = document.getElementById(elementID);
+
+            var target = null;
+            if (element.kind === "id") {
+                target = document.getElementById(element.value);
+            } else if (element.kind === "document") {
+                target = document;
+            }
+
             for (const type of eventTypes)
                 target.addEventListener(type, event => window.eventLog.push({ "type": event.type, "detail": event.detail }));
             """
         }
 
-        private let elementID: String
+        private let element: DOMElement
         private let eventTypes: [String]
 
         /// Creates an expression that records the given event types fired on an element.
@@ -285,7 +292,16 @@ extension JavaScriptMessages {
         ///   - elementID: The `id` attribute of the element to observe.
         ///   - eventTypes: The event types to record.
         public init(in elementID: String, for eventTypes: [DOMEventType]) {
-            self.elementID = elementID
+            self.init(in: .id(elementID), for: eventTypes)
+        }
+
+        /// Creates an expression that records the given event types fired on an element.
+        ///
+        /// - Parameters:
+        ///   - element: The `id` attribute of the element to observe.
+        ///   - eventTypes: The event types to record.
+        public init(in element: DOMElement, for eventTypes: [DOMEventType]) {
+            self.element = element
             self.eventTypes = eventTypes.map(\.rawValue)
         }
 
@@ -293,7 +309,7 @@ extension JavaScriptMessages {
         // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
         public func encoded() -> [String: Any?] {
             [
-                "elementID": elementID,
+                "element": element.encoded(),
                 "eventTypes": eventTypes,
             ]
         }

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift
@@ -208,6 +208,33 @@ extension CGRect {
     }
 }
 
+/// Represents a DOM element.
+public enum DOMElement: Sendable {
+    /// The document element.
+    case document
+
+    /// An element with the specific id.
+    case id(String)
+}
+
+extension DOMElement: WebPage.JavaScriptEncodable {
+    // Protocol conformance.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public func encoded() -> [String: Any?] {
+        switch self {
+        case .id(let value):
+            [
+                "kind": "id",
+                "value": value,
+            ]
+        case .document:
+            [
+                "kind": "document"
+            ]
+        }
+    }
+}
+
 /// A coordinate position.
 public struct DOMPoint: Sendable {
     /// The x coordinate.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -90,11 +90,29 @@ extension AppKitGesturesTests.Basic {
         await page.waitForPendingMouseEvents()
         await page.waitForNextPresentationUpdate()
 
-        let eventLog = try await page.callJavaScript(JavaScriptMessages.EventLog())
+        let actual = try await page.callJavaScript(JavaScriptMessages.EventLog())
+        #expect(actual.map(\.type) == expectedEvents)
+    }
 
-        for eventType in expectedEvents {
-            #expect(eventLog.contains { $0.type == eventType })
+    @Test
+    func singleClickFiresEventsForListenersOnTheDocument() async throws {
+        try await loadHTML()
+
+        let expectedEvents: [DOMEventType] = [.pointerdown, .mousedown, .pointerup, .mouseup, .click]
+
+        try await page.callJavaScript(JavaScriptMessages.InstallEventLog(in: .document, for: expectedEvents))
+
+        let toBounds = try await screenBoundsOfText("to")
+
+        await recap.play { composer in
+            composer._wk_click(at: toBounds.center, for: .seconds(0.05))
         }
+
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+
+        let actual = try await page.callJavaScript(JavaScriptMessages.EventLog())
+        #expect(actual.map(\.type) == expectedEvents)
     }
 
     @Test(arguments: [true, false])


### PR DESCRIPTION
#### 5919411cb04f540ca591ee2d5f6f848b1cad29cc
<pre>
[AppKit Gestures] Some events are not fired when event listeners are added to `document`
<a href="https://bugs.webkit.org/show_bug.cgi?id=321730">https://bugs.webkit.org/show_bug.cgi?id=321730</a>
<a href="https://rdar.apple.com/184861414">rdar://184861414</a>

Reviewed by Abrar Rahman Protyasha.

Fix some logic to be agnostic across Cocoa platforms.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::willRespondToMouseMoveEvents const):
(WebCore::Node::willRespondToMouseClickEventsWithEditability const):
* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift:
(InstallEventLog.expression):
(InstallEventLog.encoded):
* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift:
(DOMElement.encoded):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:
(AppKitGesturesTests.singleClickFiresPointerMouseAndClickEvents(_:)):
(AppKitGesturesTests.singleClickFiresEventsForListenersOnTheDocument):

Canonical link: <a href="https://commits.webkit.org/319177@main">https://commits.webkit.org/319177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7fced8b19a664e82ca951568a165219140fe1d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144957 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8f4868a-321a-46e0-b34d-7b2b292eeb1a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140890 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f687c7a-d8ce-452f-ab0d-23c91148c761) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121342 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8346f6df-652d-44dd-85df-90a957e67061) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41518 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41195 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2006 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192782 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54246 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150268 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40238 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54934 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149986 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44602 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127199 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122414 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53451 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16188 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52833 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53070 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->