### PR TITLE
WebCodecsImageDecoder should return a Promise rejected if the mime type is not supported

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any-expected.txt
@@ -30,8 +30,8 @@ FAIL Test AVIF image YUV 4:2:0 decoding. assert_equals: expected "I420" but got 
 FAIL Test AVIF image YUV 4:2:2 decoding. assert_equals: expected "I422" but got "RGBA"
 FAIL Test AVIF image YUV 4:4:4 decoding. assert_equals: expected "I444" but got "RGBA"
 FAIL Test WEBP image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "RGBA"
-FAIL Test invalid mime type rejects decode() requests assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test invalid mime type rejects decodeMetadata() requests assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test invalid mime type rejects decode() requests
+PASS Test invalid mime type rejects decodeMetadata() requests
 FAIL Test out of range index returns RangeError promise_rejects_js: function "function() { throw e; }" threw object "DataError: Decoding error" ("DataError") expected instance of function "function RangeError() {
     [native code]
 }" ("RangeError")

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt
@@ -30,8 +30,8 @@ FAIL Test AVIF image YUV 4:2:0 decoding. assert_equals: expected "I420" but got 
 FAIL Test AVIF image YUV 4:2:2 decoding. assert_equals: expected "I422" but got "RGBA"
 FAIL Test AVIF image YUV 4:4:4 decoding. assert_equals: expected "I444" but got "RGBA"
 FAIL Test WEBP image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "RGBA"
-FAIL Test invalid mime type rejects decode() requests assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test invalid mime type rejects decodeMetadata() requests assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test invalid mime type rejects decode() requests
+PASS Test invalid mime type rejects decodeMetadata() requests
 FAIL Test out of range index returns RangeError promise_rejects_js: function "function() { throw e; }" threw object "DataError: Decoding error" ("DataError") expected instance of function "function RangeError() {
     [native code]
 }" ("RangeError")

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any-expected.txt
@@ -30,8 +30,8 @@ FAIL Test AVIF image YUV 4:2:0 decoding. assert_equals: expected "I420" but got 
 FAIL Test AVIF image YUV 4:2:2 decoding. assert_equals: expected "I422" but got "BGRA"
 FAIL Test AVIF image YUV 4:4:4 decoding. assert_equals: expected "I444" but got "BGRA"
 FAIL Test WEBP image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
-FAIL Test invalid mime type rejects decode() requests assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test invalid mime type rejects decodeMetadata() requests assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test invalid mime type rejects decode() requests
+PASS Test invalid mime type rejects decodeMetadata() requests
 FAIL Test out of range index returns RangeError assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test decoding a partial ArrayBuffer results in EncodingError promise_rejects_dom: function "function() { throw e; }" threw object "DataError: Decoding error" that is not a DOMException EncodingError: property "name" is equal to "DataError", expected "EncodingError"
 PASS Test completed property on fully buffered decode
@@ -74,8 +74,8 @@ FAIL Test AVIF image YUV 4:2:0 decoding. assert_equals: expected "I420" but got 
 FAIL Test AVIF image YUV 4:2:2 decoding. assert_equals: expected "I422" but got "BGRA"
 FAIL Test AVIF image YUV 4:4:4 decoding. assert_equals: expected "I444" but got "BGRA"
 FAIL Test WEBP image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
-FAIL Test invalid mime type rejects decode() requests assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test invalid mime type rejects decodeMetadata() requests assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test invalid mime type rejects decode() requests
+PASS Test invalid mime type rejects decodeMetadata() requests
 FAIL Test out of range index returns RangeError assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test decoding a partial ArrayBuffer results in EncodingError promise_rejects_dom: function "function() { throw e; }" threw object "DataError: Decoding error" that is not a DOMException EncodingError: property "name" is equal to "DataError", expected "EncodingError"
 PASS Test completed property on fully buffered decode

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt
@@ -30,8 +30,8 @@ FAIL Test AVIF image YUV 4:2:0 decoding. assert_equals: expected "I420" but got 
 FAIL Test AVIF image YUV 4:2:2 decoding. assert_equals: expected "I422" but got "BGRA"
 FAIL Test AVIF image YUV 4:4:4 decoding. assert_equals: expected "I444" but got "BGRA"
 FAIL Test WEBP image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
-FAIL Test invalid mime type rejects decode() requests assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test invalid mime type rejects decodeMetadata() requests assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test invalid mime type rejects decode() requests
+PASS Test invalid mime type rejects decodeMetadata() requests
 FAIL Test out of range index returns RangeError assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test decoding a partial ArrayBuffer results in EncodingError promise_rejects_dom: function "function() { throw e; }" threw object "DataError: Decoding error" that is not a DOMException EncodingError: property "name" is equal to "DataError", expected "EncodingError"
 PASS Test completed property on fully buffered decode

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp
@@ -62,6 +62,7 @@ Ref<WebCodecsImageDecoder> WebCodecsImageDecoder::create(ScriptExecutionContext&
 
 WebCodecsImageDecoder::WebCodecsImageDecoder(ScriptExecutionContext& context, Init&& init)
     : WebCodecsControlMessageQueue(context)
+    , m_type(init.type)
     , m_completedPromise(makeUniqueRef<CompletedPromise>())
     , m_tracks(WebCodecsImageTrackList::create())
 {
@@ -71,35 +72,35 @@ WebCodecsImageDecoder::WebCodecsImageDecoder(ScriptExecutionContext& context, In
     WTF::switchOn(init.data,
         [&](const Ref<JSC::ArrayBuffer>& data) {
             if (RefPtr buffer = SharedBuffer::create(data->span()))
-                setInternalDecoderData(*buffer, init.type, true);
+                setInternalDecoderData(*buffer, true);
         },
         [&](const Ref<JSC::ArrayBufferView>& data) {
             if (RefPtr buffer = SharedBuffer::create(data->span()))
-                setInternalDecoderData(*buffer, init.type, true);
+                setInternalDecoderData(*buffer, true);
         },
         [&](const Ref<ReadableStream>& stream) {
-            sinkStreamToInternalDecoder(stream, init.type);
+            sinkStreamToInternalDecoder(stream);
         }
     );
 }
 
 WebCodecsImageDecoder::~WebCodecsImageDecoder() = default;
 
-void WebCodecsImageDecoder::sinkStreamToInternalDecoder(const Ref<ReadableStream>& stream, const String& type)
+void WebCodecsImageDecoder::sinkStreamToInternalDecoder(const Ref<ReadableStream>& stream)
 {
-    m_sink = ReadableStreamToSharedBufferSink::create([weakThis = ThreadSafeWeakPtr { *this }, type](auto&& result) mutable {
+    m_sink = ReadableStreamToSharedBufferSink::create([weakThis = ThreadSafeWeakPtr { *this }](auto&& result) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
         WTF::switchOn(WTF::move(result),
             [&](std::nullptr_t) {
                 if (RefPtr buffer = protectedThis->m_bufferBuilder.copyBuffer())
-                    protectedThis->setInternalDecoderData(*buffer, type, true);
+                    protectedThis->setInternalDecoderData(*buffer, true);
             },
             [&](std::span<const uint8_t>&& chunk) {
                 protectedThis->m_bufferBuilder.append(chunk);
                 if (RefPtr buffer = protectedThis->m_bufferBuilder.copyBuffer())
-                    protectedThis->setInternalDecoderData(*buffer, type, false);
+                    protectedThis->setInternalDecoderData(*buffer, false);
             },
             [&](JSC::JSValue) {
                 protectedThis->closeDecoder(Exception { ExceptionCode::AbortError, "ReadableStream cancelled"_s });
@@ -112,13 +113,17 @@ void WebCodecsImageDecoder::sinkStreamToInternalDecoder(const Ref<ReadableStream
     protect(m_sink)->pipeFrom(stream);
 }
 
-void WebCodecsImageDecoder::setInternalDecoderData(FragmentedSharedBuffer& buffer, const String& type, bool allDataReceived)
+void WebCodecsImageDecoder::setInternalDecoderData(FragmentedSharedBuffer& buffer, bool allDataReceived)
 {
+    // If type is not supported, run the Close ImageDecoder algorithm with a NotSupportedError.
+    if (!isTypeSupported(m_type))
+        closeDecoder(Exception { ExceptionCode::NotSupportedError, "Type not supported"_s });
+
     if (state() == WebCodecsCodecState::Closed)
         return;
 
     if (!m_internalDecoder)
-        m_internalDecoder = ImageDecoder::create(buffer, type, AlphaOption::Premultiplied, GammaAndColorProfileOption::Applied);
+        m_internalDecoder = ImageDecoder::create(buffer, m_type, AlphaOption::Premultiplied, GammaAndColorProfileOption::Applied);
 
     if (!m_internalDecoder)
         return;
@@ -241,6 +246,11 @@ void WebCodecsImageDecoder::queuePendingDecodeRequests()
 
 void WebCodecsImageDecoder::decode(std::optional<DecodeOptions>&& options, Ref<DeferredPromise>&& promise)
 {
+    if (!isTypeSupported(m_type)) {
+        promise->reject(Exception { ExceptionCode::NotSupportedError, "Type not supported"_s });
+        return;
+    }
+
     // If state is closed, return a Promise rejected.
     if (state() == WebCodecsCodecState::Closed) {
         promise->reject(Exception { ExceptionCode::InvalidStateError, "ImageDecoder is closed"_s });
@@ -319,15 +329,18 @@ ExceptionOr<void> WebCodecsImageDecoder::close()
     return closeDecoder(Exception { ExceptionCode::AbortError, "Close called"_s });
 }
 
-void WebCodecsImageDecoder::isTypeSupported(ScriptExecutionContext&, String&& mimeType, DOMPromiseDeferred<IDLBoolean>&& promise)
+bool WebCodecsImageDecoder::isTypeSupported(const String& type)
 {
 #if USE(CG)
-    bool isTypeSupported = isSupportedImageType(UTIFromMIMEType(mimeType));
+    return isSupportedImageType(UTIFromMIMEType(type));
 #else
-    bool isTypeSupported = MIMETypeRegistry::isSupportedImageMIMEType(mimeType);
+    return MIMETypeRegistry::isSupportedImageMIMEType(type);
 #endif
+}
 
-    if (isTypeSupported)
+void WebCodecsImageDecoder::isTypeSupported(ScriptExecutionContext&, String&& type, DOMPromiseDeferred<IDLBoolean>&& promise)
+{
+    if (isTypeSupported(type))
         promise.resolve(true);
     else
         promise.reject(Exception { ExceptionCode::TypeError, "Image type is not supported"_s });

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h
@@ -91,6 +91,7 @@ public:
     ExceptionOr<void> reset();
     ExceptionOr<void> close();
 
+    static bool isTypeSupported(const String& type);
     static void isTypeSupported(ScriptExecutionContext&, String&& type, DOMPromiseDeferred<IDLBoolean>&&);
 
 private:
@@ -100,8 +101,8 @@ private:
     void NODELETE suspend(ReasonForSuspension) final;
     void stop() final;
 
-    void sinkStreamToInternalDecoder(const Ref<ReadableStream>&, const String& type);
-    void setInternalDecoderData(FragmentedSharedBuffer&, const String& type, bool allDataReceived);
+    void sinkStreamToInternalDecoder(const Ref<ReadableStream>&);
+    void setInternalDecoderData(FragmentedSharedBuffer&, bool allDataReceived);
     void establishTrackList();
 
     static WorkQueue& queueSingleton();


### PR DESCRIPTION
#### 95b3748aa99a86fa04bf625ac3b70d6def411391
<pre>
WebCodecsImageDecoder should return a Promise rejected if the mime type is not supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=321733">https://bugs.webkit.org/show_bug.cgi?id=321733</a>
<a href="https://rdar.apple.com/184864621">rdar://184864621</a>

Reviewed by Tim Nguyen.

Per the spec [1]: &quot;Calling decode() on the constructed ImageDecoder will trigger
a NotSupportedError if the User Agent does not support type.&quot;

Handling the case of unsupported mime type is not implemented in the constructor
and the decode() method.

Also the type attribute of WebCodecsImageDecoder has to return what was passed in
the type of ImageDecoderInit when it is created. Currently it always returns an
empty string.

<a href="https://w3c.github.io/webcodecs/#dom-imagedecoder-imagedecoder">https://w3c.github.io/webcodecs/#dom-imagedecoder-imagedecoder</a>

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp:
(WebCore::WebCodecsImageDecoder::WebCodecsImageDecoder):
(WebCore::WebCodecsImageDecoder::sinkStreamToInternalDecoder):
(WebCore::WebCodecsImageDecoder::setInternalDecoderData):
(WebCore::WebCodecsImageDecoder::decode):
(WebCore::WebCodecsImageDecoder::isTypeSupported):
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h:

Canonical link: <a href="https://commits.webkit.org/319171@main">https://commits.webkit.org/319171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95b1d6d87894b110d31ae9fd07727fc21c13d57a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144991 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fdf404f2-60c4-4fbf-aad6-2caa144d7277) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140918 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c516352-e407-4845-b33f-65620006053b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44591 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121370 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c21631ef-3bf6-409d-a730-600a4d831b8b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41215 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2041 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47223 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192817 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54280 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150300 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40229 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54968 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150017 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44631 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122452 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53485 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16208 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52867 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52932 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->