### PR TITLE
[WebCore] ASSERT(m_decodedSize >= decodedSize) in BitmapImageSource::decodedSizeReset()

### DIFF
--- a/LayoutTests/fast/images/destroy-decoded-data-accounting-expected.txt
+++ b/LayoutTests/fast/images/destroy-decoded-data-accounting-expected.txt
@@ -1,0 +1,12 @@
+Destroying the decoded data of an image must not underflow the MemoryCache size when the NativeImage's backing platform image was replaced with a larger one after it was cached.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS sizeBeforeDestroyingDecodedData > 0 is true
+PASS sizeAfterDestroyingDecodedData >= 0 is true
+PASS sizeAfterDestroyingDecodedData <= sizeBeforeDestroyingDecodedData is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/images/destroy-decoded-data-accounting.html
+++ b/LayoutTests/fast/images/destroy-decoded-data-accounting.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="400" height="400"></canvas>
+<script>
+description("Destroying the decoded data of an image must not underflow the MemoryCache size when the NativeImage's backing platform image was replaced with a larger one after it was cached.");
+
+jsTestIsAsync = true;
+
+// A grayscale PNG decodes to one byte per pixel, while the platform image the
+// GPU process substitutes for it is at least four bytes per pixel and its rows
+// are aligned. Unless the decoded-size accounting is updated when drawing
+// replaces the platform image, the subtraction when the decoded data is
+// destroyed would be several times larger than the addition and the
+// MemoryCache size would underflow.
+var image = new Image();
+image.onload = function() {
+    var context = document.getElementById("canvas").getContext("2d");
+    context.drawImage(image, 0, 0);
+
+    // Round-tripping to the GPU process flushes the drawImage() above, which is
+    // what replaces the NativeImage's platform image.
+    context.getImageData(0, 0, 1, 1);
+
+    sizeBeforeDestroyingDecodedData = internals.memoryCacheSize();
+    shouldBeTrue("sizeBeforeDestroyingDecodedData > 0");
+
+    internals.destroyDecodedDataForAllImages();
+
+    sizeAfterDestroyingDecodedData = internals.memoryCacheSize();
+    shouldBeTrue("sizeAfterDestroyingDecodedData >= 0");
+    shouldBeTrue("sizeAfterDestroyingDecodedData <= sizeBeforeDestroyingDecodedData");
+
+    finishJSTest();
+};
+
+if (window.internals) {
+    internals.clearMemoryCache();
+    image.src = "resources/mu.png";
+} else {
+    testFailed("This test requires internals.");
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/images/destroy-decoded-data-accounting-incomplete-frame-expected.txt
+++ b/LayoutTests/http/tests/images/destroy-decoded-data-accounting-incomplete-frame-expected.txt
@@ -1,0 +1,11 @@
+Destroying the decoded data of a progressively-loaded (still-incomplete) image must not corrupt the MemoryCache size when the NativeImage's backing platform image is replaced during drawing.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS encodedSize > 0 is true
+PASS sizeAfterDestroyingDecodedData <= encodedSize is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/images/destroy-decoded-data-accounting-incomplete-frame.html
+++ b/LayoutTests/http/tests/images/destroy-decoded-data-accounting-incomplete-frame.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<img id="testImage">
+<script>
+description("Destroying the decoded data of a progressively-loaded (still-incomplete) image must not corrupt the MemoryCache size when the NativeImage's backing platform image is replaced during drawing.");
+
+jsTestIsAsync = true;
+
+// mu.png is a 383x321 8-bit grayscale PNG (14793 bytes). Serving it partially and
+// stalling keeps its frame incomplete while it is drawn. A grayscale frame decodes to
+// one byte per pixel, while the platform image the GPU process substitutes for it is
+// several times larger, so drawing changes the frame's reported size. Unless that
+// change is folded into the decoded-size accounting only while the frame still owns
+// the NativeImage, drawing the incomplete frame leaves an orphaned over-count that
+// destroying the decoded data never reclaims.
+function partialGrayscalePng()
+{
+    // Unique URL per run: in stress mode this test repeats in one web process, and
+    // reusing the identical stalled URL leaves a later run's request unserviced.
+    return "http://127.0.0.1:8000/resources/load-and-stall.py"
+        + "?name=../../../fast/images/resources/mu.png&mimeType=image%2Fpng&stallAt=6000&stallFor=60"
+        + "&rand=" + Math.random();
+}
+
+var image = document.getElementById("testImage");
+
+function drawAndMeasure()
+{
+    // Accounting for the encoded data only; the image is loaded but has not been
+    // rendered, so no frame has been decoded or drawn yet.
+    encodedSize = internals.memoryCacheSize();
+    shouldBeTrue("encodedSize > 0");
+
+    // Render the still-incomplete image and force a paint through the GPU process,
+    // which replaces the NativeImage's platform image.
+    image.decoding = "sync";
+    testRunner.display();
+
+    internals.destroyDecodedDataForAllImages();
+
+    sizeAfterDestroyingDecodedData = internals.memoryCacheSize();
+
+    // With the decoded data destroyed, the accounting must fall back to the encoded
+    // size; an orphaned over-count would keep it larger.
+    shouldBeTrue("sizeAfterDestroyingDecodedData <= encodedSize");
+
+    finishJSTest();
+}
+
+function waitUntilIncompleteThenDraw()
+{
+    if (image.naturalWidth > 0 && !image.complete) {
+        drawAndMeasure();
+        return;
+    }
+    setTimeout(waitUntilIncompleteThenDraw, 10);
+}
+
+function startTest()
+{
+    internals.clearMemoryCache();
+    image.src = partialGrayscalePng();
+    waitUntilIncompleteThenDraw();
+}
+
+// Start the stalled load from a timer that runs after the document has finished
+// loading. Setting the src earlier -- during parse or inside the load event -- makes
+// the still-loading image part of the main frame's load, so the frame never finishes
+// loading and WebKitTestRunner defers notifyDone()'s dump until the test times out.
+// Once the frame is idle the stalled subresource does not re-block it, so drawing the
+// deliberately-incomplete image and then finishing dumps immediately.
+if (window.internals && window.testRunner)
+    window.addEventListener("load", function () { setTimeout(startTest, 0); });
+else {
+    testFailed("This test requires internals and testRunner.");
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/resources/load-and-stall.py
+++ b/LayoutTests/http/tests/resources/load-and-stall.py
@@ -5,6 +5,14 @@ import sys
 import time
 from urllib.parse import parse_qs
 
+# Serves `name`, but stalls after `stallAt` bytes for `stallFor` seconds, holding
+# the response open server-side to keep a resource load incomplete. Because the
+# response is held for the whole stall, a test that reuses the identical URL while
+# repeated in one web process (run-layout-tests in stress mode) can leave a later
+# run's request unserviced and time out on the EWS stress bots; append a
+# cache-busting query parameter (e.g. `"&rand=" + Math.random()`) so each run
+# requests a unique URL.
+
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
 name = query.get('name', [''])[0]
 stall_at = query.get('stallAt', [None])[0]

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -140,7 +140,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
             if (headroom == Headroom::FromImage)
                 headroom = nativeImage->headroom();
 
-            context.drawNativeImage(nativeImage, destinationRect, adjustedSourceRect, { options, orientation, headroom });
+            m_source->drawNativeImage(context, nativeImage, destinationRect, adjustedSourceRect, { options, orientation, headroom });
 #if !HAVE(SUPPORT_HDR_DISPLAY_APIS)
         }
 #endif

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -509,6 +509,27 @@ void BitmapImageSource::cacheNativeImageAtIndex(unsigned index, SubsamplingLevel
     decodedSizeIncreased(destination.sizeInBytes());
 }
 
+void BitmapImageSource::drawNativeImage(GraphicsContext& context, NativeImage& nativeImage, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions options)
+{
+    Ref protectedNativeImage { nativeImage };
+    auto sizeBeforeDrawing = protectedNativeImage->sizeInBytes();
+    context.drawNativeImage(protectedNativeImage, destinationRect, sourceRect, options);
+    auto sizeAfterDrawing = protectedNativeImage->sizeInBytes();
+
+    if (sizeBeforeDrawing == sizeAfterDrawing)
+        return;
+
+    // Only fold the change while the frame still owns this NativeImage.
+    auto& frame = frameAtIndex(currentFrameIndex());
+    if (!frame.hasNativeImage(protectedNativeImage))
+        return;
+
+    if (sizeAfterDrawing > sizeBeforeDrawing)
+        decodedSizeIncreased(static_cast<unsigned>(sizeAfterDrawing - sizeBeforeDrawing));
+    else
+        decodedSizeDecreased(static_cast<unsigned>(sizeBeforeDrawing - sizeAfterDrawing));
+}
+
 const ImageFrame& BitmapImageSource::frameAtIndex(unsigned index) const
 {
     if (index >= m_frames.size())

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -80,6 +80,8 @@ public:
     RefPtr<NativeImage> primaryNativeImageIfExists() { return frameAtIndex(primaryFrameIndex()).nativeImage(std::nullopt); }
     RefPtr<NativeImage> primaryNativeImage() final { return nativeImageAtIndex(primaryFrameIndex()); }
 
+    void drawNativeImage(GraphicsContext&, NativeImage&, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions) final;
+
     // Image Metadata
     unsigned frameCount() const final { return m_descriptor.frameCount(); }
     RepetitionCount repetitionCount() const { return m_descriptor.repetitionCount(); }

--- a/Source/WebCore/platform/graphics/ImageFrame.h
+++ b/Source/WebCore/platform/graphics/ImageFrame.h
@@ -91,6 +91,14 @@ public:
 
     bool hasNativeImage(DecodingDestination decodingDestination) const { return m_destinations[decodingDestination].hasNativeImage(); }
     bool NODELETE hasNativeImage(DecodingDestination, SubsamplingLevel) const;
+    bool hasNativeImage(const NativeImage& nativeImage) const
+    {
+        for (auto& destination : m_destinations) {
+            if (destination.nativeImage.get() == &nativeImage)
+                return true;
+        }
+        return false;
+    }
     bool NODELETE hasFullSizeNativeImage(DecodingDestination, SubsamplingLevel) const;
     std::optional<DecodingDestination> compatibleDecodingDestinationWithOptions(const DecodingOptions&, SubsamplingLevel) const;
     bool hasMetadata() const { return !size().isEmpty(); }

--- a/Source/WebCore/platform/graphics/ImageSource.cpp
+++ b/Source/WebCore/platform/graphics/ImageSource.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "ImageSource.h"
 
+#include "GraphicsContext.h"
+#include "NativeImage.h"
+
 namespace WebCore {
 
 Expected<Ref<NativeImage>, DecodingStatus> ImageSource::primaryNativeImageForDrawing(SubsamplingLevel, const DecodingOptions&)
@@ -38,6 +41,11 @@ Expected<Ref<NativeImage>, DecodingStatus> ImageSource::primaryNativeImageForDra
 Expected<Ref<NativeImage>, DecodingStatus> ImageSource::currentNativeImageForDrawing(SubsamplingLevel subsamplingLevel, const DecodingOptions& options)
 {
     return primaryNativeImageForDrawing(subsamplingLevel, options);
+}
+
+void ImageSource::drawNativeImage(GraphicsContext& context, NativeImage& nativeImage, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions options)
+{
+    context.drawNativeImage(protect(nativeImage), destinationRect, sourceRect, options);
 }
 
 bool ImageSource::hasSolidColor() const

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -38,6 +38,7 @@
 
 namespace WebCore {
 
+class FloatRect;
 class FragmentedSharedBuffer;
 
 class ImageSource : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ImageSource> {
@@ -80,6 +81,10 @@ public:
 
     virtual Expected<Ref<NativeImage>, DecodingStatus> primaryNativeImageForDrawing(SubsamplingLevel, const DecodingOptions&);
     virtual Expected<Ref<NativeImage>, DecodingStatus> currentNativeImageForDrawing(SubsamplingLevel, const DecodingOptions&);
+
+    // Overridden by BitmapImageSource to keep decoded-size accounting in step with the
+    // platform-image replacement the GPU process performs while the image is drawn.
+    virtual void drawNativeImage(GraphicsContext&, NativeImage&, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions);
 
     // Image Metadata
     virtual IntSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const = 0;


### PR DESCRIPTION
#### e1d90aba37f5ef0b38d954bf715feebb2cae92d5
<pre>
[WebCore] ASSERT(m_decodedSize &gt;= decodedSize) in BitmapImageSource::decodedSizeReset()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=321735">https://bugs.webkit.org/show_bug.cgi?id=321735</a>&gt;
&lt;<a href="https://rdar.apple.com/184788659">rdar://184788659</a>&gt;

Reviewed by Said Abou-Hallawa.

BitmapImageSource tracks its decoded size by adding a frame&apos;s
sizeInBytes() when its NativeImage is cached and subtracting the same
measurement when the frame is cleared, both read live from
NativeImage::sizeInBytes().  When drawing goes through the GPU process,
RemoteResourceCacheProxy::recordNativeImageUse() replaces the platform
image with a memory-saving ShareableBitmap of a different size, so the
size subtracted at clear time no longer matches the size added at
cache time.  When the replacement is larger, m_decodedSize underflows
and decodedSizeReset() asserts.

Route BitmapImage::draw() through a new ImageSource::drawNativeImage()
virtual.  BitmapImageSource overrides it to measure the NativeImage
around the draw and fold the difference into its decoded-size
accounting; the replacement happens synchronously as the draw is
recorded, so the running total tracks the real size and matches what
the frame subtracts when it is cleared.  The base implementation just
draws.

Fold the difference only while the current frame still owns the drawn
NativeImage.  BitmapImage::draw() reads the frame&apos;s orientation and
headroom after obtaining the image, and for a still-incomplete
(progressively-loading) frame that clears the frame and has already
dropped its size from m_decodedSize, leaving the NativeImage alive only
on the caller&apos;s stack.  Folding then would corrupt the total; while the
frame still owns the image, m_decodedSize includes its pre-draw size,
so the adjustment stays balanced against the eventual clear.

Tests: fast/images/destroy-decoded-data-accounting.html
       http/tests/images/destroy-decoded-data-accounting-incomplete-frame.html

* LayoutTests/fast/images/destroy-decoded-data-accounting-expected.txt: Add.
* LayoutTests/fast/images/destroy-decoded-data-accounting.html: Add.
* LayoutTests/http/tests/images/destroy-decoded-data-accounting-incomplete-frame-expected.txt: Add.
* LayoutTests/http/tests/images/destroy-decoded-data-accounting-incomplete-frame.html: Add.
* LayoutTests/http/tests/resources/load-and-stall.py:
- Document that a test repeated in one web process may need a
  cache-busting query parameter to avoid stalling its own later loads.
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::drawNativeImage): Add.
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/ImageFrame.h:
(WebCore::ImageFrame::hasNativeImage): Add.
* Source/WebCore/platform/graphics/ImageSource.cpp:
(WebCore::ImageSource::drawNativeImage): Add.
* Source/WebCore/platform/graphics/ImageSource.h:

Canonical link: <a href="https://commits.webkit.org/319239@main">https://commits.webkit.org/319239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb0eedf2fdd281807875ea77b13f0b2912ff39e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145238 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3ced178-65e7-4de0-83c0-4173c518217a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141144 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4088401c-866e-47ea-bb23-303df5cdc61a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121595 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48ae55af-1883-427b-b5ac-52a0104d4abf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43480 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41759 "Passed tests") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153884 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41419 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2289 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47472 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193064 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150527 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55214 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150245 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27459 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44838 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127480 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122864 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53731 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16412 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53113 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53350 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53178 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->