### PR TITLE
[Site Isolation] Validate the source frame and origin of a cross-process postMessage

### DIFF
--- a/LayoutTests/http/tests/site-isolation/post-message-forged-source-origin-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/post-message-forged-source-origin-expected.txt
@@ -1,0 +1,11 @@
+A WebContent process must not be able to forge MessageEvent.origin with PostMessageToRemote
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS report is "done forged"
+PASS originsSeen.join() is "http://localhost:8000"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/post-message-forged-source-origin.html
+++ b/LayoutTests/http/tests/site-isolation/post-message-forged-source-origin.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("A WebContent process must not be able to forge MessageEvent.origin with PostMessageToRemote");
+jsTestIsAsync = true;
+
+let originsSeen = [];
+let report = "the iframe did not report anything";
+
+addEventListener("message", (event) => {
+    if (!event.data.startsWith("done")) {
+        originsSeen.push(event.origin);
+        return;
+    }
+
+    report = event.data;
+    if (report == "done skipped") {
+        testPassed("the IPC testing API is not enabled in this configuration");
+        finishJSTest();
+        return;
+    }
+
+    shouldBeEqualToString("report", "done forged");
+    shouldBeEqualToString("originsSeen.join()", "http://localhost:8000");
+    finishJSTest();
+});
+</script>
+<body>
+<iframe src="http://localhost:8000/site-isolation/resources/post-message-forged-source-origin-frame.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-origin-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-origin-frame.html
@@ -1,0 +1,67 @@
+<script>
+// Posting a message to the cross-site parent goes through WebPageProxy::postMessageToRemote. Capture that
+// message and send it again with the host in its sourceOrigin replaced, like a compromised process would.
+
+const realHost = "localhost";
+const forgedHost = "evil.test"; // Same length as realHost, so the encoded string stays well formed.
+
+function report(status)
+{
+    parent.postMessage("done " + status, "*");
+}
+
+// Returns how many copies of realHost were replaced, so the test fails loudly rather than silently replaying
+// an unmodified message if the encoding ever changes.
+function forgeHost(bytes)
+{
+    const encoder = new TextEncoder();
+    const realBytes = encoder.encode(realHost);
+    const forgedBytes = encoder.encode(forgedHost);
+    let replacements = 0;
+    outer: for (let i = 0; i + realBytes.length <= bytes.length; i++) {
+        for (let j = 0; j < realBytes.length; j++) {
+            if (bytes[i + j] !== realBytes[j])
+                continue outer;
+        }
+        for (let j = 0; j < forgedBytes.length; j++)
+            bytes[i + j] = forgedBytes[j];
+        replacements++;
+        i += realBytes.length - 1;
+    }
+    return replacements;
+}
+
+onload = () => {
+    if (!window.IPC) {
+        report("skipped");
+        return;
+    }
+
+    let captured = false;
+    IPC.addOutgoingMessageListener("UI", (description) => {
+        if (captured || !description || !description.buffer)
+            return;
+        if (description.name !== IPC.messages.WebPageProxy_PostMessageToRemote.name)
+            return;
+        captured = true;
+
+        const bytes = new Uint8Array(new Uint8Array(description.buffer));
+        const replacements = forgeHost(bytes);
+        if (replacements !== 1) {
+            report("unable to forge sourceOrigin, replaced " + replacements + " copies of the host");
+            return;
+        }
+
+        // slice(16) drops the message header, which IPC.sendMessage writes itself.
+        IPC.sendMessage("UI", description.destinationID, description.name, bytes.slice(16));
+        report("forged");
+    });
+
+    parent.postMessage("probe", "*");
+
+    setTimeout(() => {
+        if (!captured)
+            report("no PostMessageToRemote was captured");
+    }, 3000);
+};
+</script>

--- a/Source/WebKit/UIProcess/FrameProcess.cpp
+++ b/Source/WebKit/UIProcess/FrameProcess.cpp
@@ -31,6 +31,7 @@
 #include "WebPageProxy.h"
 #include "WebPreferences.h"
 #include "WebProcessProxy.h"
+#include <WebCore/SecurityOriginData.h>
 #include <WebCore/Site.h>
 
 namespace WebKit {
@@ -72,6 +73,20 @@ FrameProcess::~FrameProcess()
 BrowsingContextGroup* FrameProcess::browsingContextGroup() const
 {
     return m_browsingContextGroup.get();
+}
+
+bool FrameProcess::isAllowedToClaimOrigin(const WebCore::SecurityOriginData& origin) const
+{
+    // Opaque origins are exposed to script as "null", and any process can host a document with one.
+    if (origin.isOpaque())
+        return true;
+
+    // A shared process is deliberately not locked to a single site.
+    if (isSharedProcess())
+        return true;
+
+    // Site Isolation separates sites rather than origins, so any origin within the site is allowed.
+    return WebCore::Site { origin } == *m_site;
 }
 
 }

--- a/Source/WebKit/UIProcess/FrameProcess.h
+++ b/Source/WebKit/UIProcess/FrameProcess.h
@@ -51,6 +51,8 @@ public:
     const WebCore::Site& sharedProcessMainFrameSite() const LIFETIME_BOUND { ASSERT(!m_site); return m_mainFrameSite; }
     bool isArchiveProcess() const { return m_isArchiveProcess; }
 
+    bool isAllowedToClaimOrigin(const WebCore::SecurityOriginData&) const;
+
     BrowsingContextGroup* NODELETE browsingContextGroup() const;
 
     void incrementFrameCount() { m_frameCount++; }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -19088,8 +19088,18 @@ void WebPageProxy::focusRemoteFrame(IPC::Connection& connection, WebCore::FrameI
     setFocus(true);
 }
 
-void WebPageProxy::postMessageToRemote(WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts& message, std::optional<WebCore::UserGestureTokenData>&& userGestureToken)
+void WebPageProxy::postMessageToRemote(IPC::Connection& connection, WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts& message, std::optional<WebCore::UserGestureTokenData>&& userGestureToken)
 {
+    Ref process = WebProcessProxy::fromConnection(connection);
+
+    // sourceOrigin becomes MessageEvent.origin in the receiving document, so the sender must host the frame
+    // it claims to be sending from and be allowed to claim that origin. The frame can legitimately belong to
+    // another process while a process swap is in flight, so ignore the message instead of terminating.
+    RefPtr sourceFrame = WebFrameProxy::webFrame(source);
+    if (!sourceFrame || &sourceFrame->process() != process.ptr())
+        return;
+    MESSAGE_CHECK(process, sourceFrame->frameProcess().isAllowedToClaimOrigin(sourceOrigin));
+
     if (message.transferredPorts.isEmpty()) {
         sendToProcessContainingFrame(target, Messages::WebPage::RemotePostMessage(source, sourceOrigin, target, targetOrigin, message, userGestureToken));
         return;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3666,7 +3666,7 @@ private:
     void broadcastFocusedFrameToOtherProcesses(IPC::Connection&, std::optional<WebCore::FrameIdentifier>&&);
 
     void focusRemoteFrame(IPC::Connection&, WebCore::FrameIdentifier, std::optional<WebCore::UserGestureTokenIdentifier>);
-    void postMessageToRemote(WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts&, std::optional<WebCore::UserGestureTokenData>&&);
+    void postMessageToRemote(IPC::Connection&, WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts&, std::optional<WebCore::UserGestureTokenData>&&);
     void renderTreeAsTextForTesting(WebCore::FrameIdentifier, uint64_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);
     void layerTreeAsTextForTesting(WebCore::FrameIdentifier, uint64_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>, CompletionHandler<void(String&&)>&&);
     void dispatchCrossOriginBeforeUnloadCheckForFrame(WebCore::FrameIdentifier, WebCore::SecurityOriginData&&);


### PR DESCRIPTION
#### d5a35f031764c635a2ab8d0241837fc17bb81f64
<pre>
[Site Isolation] Validate the source frame and origin of a cross-process postMessage
<a href="https://bugs.webkit.org/show_bug.cgi?id=321736">https://bugs.webkit.org/show_bug.cgi?id=321736</a>
<a href="https://rdar.apple.com/175959343">rdar://175959343</a>

Reviewed by NOBODY (OOPS!).

Under Site Isolation, a cross-process window.postMessage is routed through
WebPageProxy::postMessageToRemote, which forwarded the sending process&apos;s
frame identifier and origin without validating either. The origin becomes
MessageEvent.origin in the receiving document, so a compromised WebContent
process could claim any origin and spoof a message from any site.

Require that the sending process hosts the frame it claims to be sending
from, and that the frame&apos;s process is one the UI process is willing to load
the claimed origin in. The site each process was chosen for is recorded on
FrameProcess when the UI process picks the process, so unlike
WebFrameProxy::securityOrigin() it is not derived from anything a WebContent
process reports.

Test: http/tests/site-isolation/post-message-forged-source-origin.html

* LayoutTests/http/tests/site-isolation/post-message-forged-source-origin-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/post-message-forged-source-origin.html: Added.
* LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-origin-frame.html: Added.
* Source/WebKit/UIProcess/FrameProcess.cpp:
(WebKit::FrameProcess::isAllowedToClaimOrigin const):
* Source/WebKit/UIProcess/FrameProcess.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::postMessageToRemote):
* Source/WebKit/UIProcess/WebPageProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5a35f031764c635a2ab8d0241837fc17bb81f64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190861 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144972 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41857fd3-f54c-4cd3-a94d-2dae2eddb7e7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140901 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97620 "6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb314a2f-71f2-4a8d-bfbc-39234232963f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183605 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44578 "Found 1 new test failure: http/tests/site-isolation/post-message-forged-source-origin.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121353 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1da88626-e42f-437c-a470-121f0b006bf3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43251 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41534 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153655 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41206 "Found 1 new test failure: http/tests/site-isolation/post-message-forged-source-origin.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2022 "Built successfully") | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47204 "Build is in progress. Recent messages:OS: Tahoe (26.6), Xcode: 26.5; Checked out pull request; Found 27451 issues; Found 1 new failure in UIProcess/WebPageProxy.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192797 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54261 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161195 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150283 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54949 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37823 "Found 1 new test failure: http/tests/site-isolation/post-message-forged-source-origin.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150000 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44620 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127214 "Found 1 new failure in UIProcess/WebPageProxy.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122430 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53466 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16199 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52848 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53085 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52913 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->