### PR TITLE
Add double requestAnimationFrame wait before reftest/crashtest snapshot

### DIFF
--- a/Tools/DumpRenderTree/mac/FrameLoadDelegate.mm
+++ b/Tools/DumpRenderTree/mac/FrameLoadDelegate.mm
@@ -138,7 +138,7 @@ IGNORE_WARNINGS_END
     [super dealloc];
 }
 
-- (void)dumpAfterWaitAttributeIsRemoved:(id)dummy
+- (void)dumpIfStillReady
 {
 #if PLATFORM(IOS_FAMILY)
     WebThreadLock();
@@ -147,6 +147,21 @@ IGNORE_WARNINGS_END
         [self performSelector:@selector(dumpAfterWaitAttributeIsRemoved:) withObject:nil afterDelay:0];
     else
         dump();
+}
+
+- (void)dumpAfterWaitAttributeIsRemoved:(id)dummy
+{
+#if PLATFORM(IOS_FAMILY)
+    WebThreadLock();
+#endif
+    if (WTR::hasTestWaitAttribute(mainFrame.globalContext))
+        [self performSelector:@selector(dumpAfterWaitAttributeIsRemoved:) withObject:nil afterDelay:0];
+    else {
+        RetainPtr<FrameLoadDelegate> strongSelf = self;
+        WTR::waitForDoubleRequestAnimationFrame(mainFrame.globalContext, [strongSelf] {
+            [strongSelf dumpIfStillReady];
+        });
+    }
 }
 
 - (void)readyToDumpState
@@ -176,6 +191,7 @@ IGNORE_WARNINGS_END
 - (void)resetToConsistentState
 {
     accessibilityController->resetToConsistentState();
+    WTR::cancelPendingDoubleRequestAnimationFrameWait(mainFrame.globalContext);
 }
 
 - (void)webView:(WebView *)webView locationChangeDone:(NSError *)error forDataSource:(WebDataSource *)dataSource

--- a/Tools/TestRunnerShared/WPTFunctions.cpp
+++ b/Tools/TestRunnerShared/WPTFunctions.cpp
@@ -28,6 +28,8 @@
 #include <array>
 #include <wtf/URL.h>
 #include <wtf/text/ASCIILiteral.h>
+#include <wtf/HashMap.h>
+#include <wtf/StdLibExtras.h>
 
 #include "JSBasics.h"
 
@@ -71,6 +73,56 @@ bool isWebPlatformTestURL(const URL& url)
     auto host = url.host();
     auto port = url.port().value_or(0);
     return contains(possibleHosts, host) && contains(possiblePorts, port);
+}
+
+static HashMap<JSGlobalContextRef, WTF::Function<void()>>& pendingRAFCompletions()
+{
+    static NeverDestroyed<HashMap<JSGlobalContextRef, WTF::Function<void()>>> completions;
+    return completions;
+}
+
+static JSValueRef secondRequestAnimationFrameCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    auto& map = pendingRAFCompletions();
+    auto globalContext = JSContextGetGlobalContext(context);
+    auto it = map.find(globalContext);
+    if (it != map.end()) {
+        auto completion = WTF::move(it->value);
+        map.remove(it);
+        completion();
+    }
+    return JSValueMakeUndefined(context);
+}
+
+static JSValueRef firstRequestAnimationFrameCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    // First rAF callback: schedule the second rAF
+    auto globalObject = JSContextGetGlobalObject(context);
+    auto window = objectProperty(context, globalObject, "window");
+    auto secondCallback = JSObjectMakeFunctionWithCallback(context, nullptr, secondRequestAnimationFrameCallback);
+    call(context, window, "requestAnimationFrame", { secondCallback });
+    return JSValueMakeUndefined(context);
+}
+
+void waitForDoubleRequestAnimationFrame(JSGlobalContextRef context, WTF::Function<void()>&& completionHandler)
+{
+    if (!context)
+        return;
+
+    auto& map = pendingRAFCompletions();
+    map.set(context, WTF::move(completionHandler));
+
+    auto globalObject = JSContextGetGlobalObject(context);
+    auto window = objectProperty(context, globalObject, "window");
+    auto firstCallback = JSObjectMakeFunctionWithCallback(context, nullptr, firstRequestAnimationFrameCallback);
+    call(context, window, "requestAnimationFrame", { firstCallback });
+}
+
+void cancelPendingDoubleRequestAnimationFrameWait(JSGlobalContextRef context)
+{
+    if (!context)
+        return;
+    pendingRAFCompletions().remove(context);
 }
 
 }

--- a/Tools/TestRunnerShared/WPTFunctions.h
+++ b/Tools/TestRunnerShared/WPTFunctions.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Function.h>
+
 typedef struct OpaqueJSContext* JSGlobalContextRef;
 
 namespace WTF {
@@ -36,5 +38,7 @@ namespace WTR {
 void sendTestRenderedEvent(JSGlobalContextRef);
 bool hasTestWaitAttribute(JSGlobalContextRef);
 bool isWebPlatformTestURL(const WTF::URL&);
+void waitForDoubleRequestAnimationFrame(JSGlobalContextRef, WTF::Function<void()>&& completionHandler);
+void cancelPendingDoubleRequestAnimationFrameWait(JSGlobalContextRef);
 
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -274,6 +274,8 @@ void InjectedBundlePage::resetAfterTest()
 
     InjectedBundle::singleton().resetUserScriptInjectedCount();
 
+    cancelPendingDoubleRequestAnimationFrameWait(WKBundleFrameGetJavaScriptContext(frame));
+
     m_didCommitMainFrameLoad = false;
 }
 
@@ -1060,18 +1062,25 @@ static bool hasTestWaitAttribute(WKBundlePageRef page)
     return frame && hasTestWaitAttribute(WKBundleFrameGetJavaScriptContext(frame));
 }
 
-static void dumpAfterWaitAttributeIsRemoved(WKBundlePageRef page)
+static void dumpAfterWaitAttributeIsRemoved(WKBundlePageRef);
+
+static void pollAgainAfterDelay(WKBundlePageRef page)
+{
+    WKRetain(page);
+    // Use a 1ms interval between tries to allow lower priority run loop sources with zero delays to run.
+    RunLoop::currentSingleton().dispatchAfter(1_ms, [page] {
+        WKBundlePageCallAfterTasksAndTimers(page, [] (void* typelessPage) {
+            auto page = static_cast<WKBundlePageRef>(typelessPage);
+            dumpAfterWaitAttributeIsRemoved(page);
+            WKRelease(page);
+        }, const_cast<OpaqueWKBundlePage*>(page));
+    });
+}
+
+static void dumpIfStillReady(WKBundlePageRef page)
 {
     if (hasTestWaitAttribute(page)) {
-        WKRetain(page);
-        // Use a 1ms interval between tries to allow lower priority run loop sources with zero delays to run.
-        RunLoop::currentSingleton().dispatchAfter(1_ms, [page] {
-            WKBundlePageCallAfterTasksAndTimers(page, [] (void* typelessPage) {
-                auto page = static_cast<WKBundlePageRef>(typelessPage);
-                dumpAfterWaitAttributeIsRemoved(page);
-                WKRelease(page);
-            }, const_cast<OpaqueWKBundlePage*>(page));
-        });
+        pollAgainAfterDelay(page);
         return;
     }
 
@@ -1081,6 +1090,29 @@ static void dumpAfterWaitAttributeIsRemoved(WKBundlePageRef page)
         return;
     if (auto currentPage = bundle.page(); currentPage && currentPage->page() == page)
         currentPage->dump();
+}
+
+static void dumpAfterWaitAttributeIsRemoved(WKBundlePageRef page)
+{
+    if (hasTestWaitAttribute(page)) {
+        pollAgainAfterDelay(page);
+        return;
+    }
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    auto frame = WKBundlePageGetMainFrame(page);
+    ALLOW_DEPRECATED_DECLARATIONS_END
+    auto context = frame ? WKBundleFrameGetJavaScriptContext(frame) : nullptr;
+    if (!context) {
+        dumpIfStillReady(page);
+        return;
+    }
+
+    WKRetain(page);
+    waitForDoubleRequestAnimationFrame(context, [page] {
+        dumpIfStillReady(page);
+        WKRelease(page);
+    });
 }
 
 void InjectedBundlePage::frameDidChangeLocation(WKBundleFrameRef frame)


### PR DESCRIPTION
(Very much an experimental throwaway for now, here to gather results from EWS.)<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d873679e4decedee88f5768b3da7297cb123207a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180651 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48394 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190862 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Failed to compile WebKit; Compiled WebKit (warnings); Hash d873679e for PR 71591 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144973 "Hash d873679e for PR 71591 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e9a9636-a63f-4276-af40-0c394949c558) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54312 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/190862 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Failed to compile WebKit; Compiled WebKit (warnings); Hash d873679e for PR 71591 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/144973 "Hash d873679e for PR 71591 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2386c4c4-9859-487f-9480-f2b9176f531c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183606 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44581 "Found 60 new test failures: compositing/repaint/inline-repaint-container.html compositing/visible-rect/iframe-with-layers-outside-viewport.html contact-picker/contacts-interfaces.html dom/xhtml/level2/html/HTMLFormElement10.xhtml fast/animation/request-animation-frame-in-isolated-world-with-javascript-disabled.html fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled.html fast/attachment/cocoa/wide-attachment-rendering.html fast/block/content-visisbility-and-float-crash.html fast/canvas/canvas-drawImage-detached-leak.html fast/canvas/createImageBitmap-invalid-image-blob-crash.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161674 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/190862 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Failed to compile WebKit; Compiled WebKit (warnings); Hash d873679e for PR 71591 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/179a7108-38e4-438c-b277-134babc8ce2a) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43254 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41532 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/190862 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Failed to compile WebKit; Compiled WebKit (warnings); Hash d873679e for PR 71591 does not build (failure)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153658 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41203 "Found 60 new test failures: compositing/repaint/inline-repaint-container.html compositing/visible-rect/iframe-with-layers-outside-viewport.html contact-picker/contacts-interfaces.html dom/xhtml/level2/html/HTMLFormElement10.xhtml fast/animation/request-animation-frame-in-isolated-world-with-javascript-disabled.html fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled.html fast/attachment/cocoa/wide-attachment-rendering.html fast/canvas/createImageBitmap-invalid-image-blob-crash.html fast/canvas/webgl/simulated-vertexAttrib0-invalid-indicies.html fast/dom/Document/open-triggered-by-mutation-observer-on-element-from-a-parsed-doc-crash.html ... (failure)") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2023 "Hash d873679e for PR 71591 does not build (failure)") | | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45787 "Found 60 new test failures: accessibility/mac/stale-textmarker-crash.html compositing/repaint/inline-repaint-container.html compositing/visible-rect/iframe-with-layers-outside-viewport.html contact-picker/contacts-interfaces.html dom/xhtml/level2/html/HTMLFormElement10.xhtml fast/animation/request-animation-frame-in-isolated-world-with-javascript-disabled.html fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled.html fast/attachment/cocoa/wide-attachment-rendering.html fast/canvas/createImageBitmap-invalid-image-blob-crash.html fast/canvas/webgl/simulated-vertexAttrib0-invalid-indicies.html ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192798 "Hash d873679e for PR 71591 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54262 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/192798 "Hash d873679e for PR 71591 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54950 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37820 "Found 60 new test failures: compositing/repaint/inline-repaint-container.html compositing/visible-rect/iframe-with-layers-outside-viewport.html contact-picker/contacts-interfaces.html dom/xhtml/level2/html/HTMLFormElement10.xhtml fast/animation/request-animation-frame-in-isolated-world-with-javascript-disabled.html fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled.html fast/attachment/cocoa/wide-attachment-rendering.html fast/canvas/createImageBitmap-invalid-image-blob-crash.html fast/canvas/webgl/simulated-vertexAttrib0-invalid-indicies.html fast/dom/Document/open-triggered-by-mutation-observer-on-element-from-a-parsed-doc-crash.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/192798 "Hash d873679e for PR 71591 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44617 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122431 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53467 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16196 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52849 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53086 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52914 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->