### PR TITLE
[CSS] Add Style::InheritedRareData::usedUserSelect

### DIFF
--- a/LayoutTests/editing/selection/user-select-in-text-control-expected.txt
+++ b/LayoutTests/editing/selection/user-select-in-text-control-expected.txt
@@ -1,0 +1,51 @@
+
+edixtableParagraph
+
+editableParagraphWebkitUserSelectAll
+
+Verifies the used user-select value for the inner text element of a text control, and contrasts it with ordinary editable content.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+By default, a control's value is selectable.
+PASS selectTextIn("mutable") is "mutable"
+PASS selectTextIn("readOnly") is "readOnly"
+PASS selectTextIn("textarea") is "textarea"
+PASS selectTextIn("textareaReadOnly") is "textareaReadOnly"
+
+'none' makes it unselectable, but it is overridden if the text is editable.
+PASS selectTextIn("webkitUserSelectNone") is "webkitUserSelectNone"
+PASS selectTextIn("textareaWebkitUserSelectNone") is "textareaWebkitUserSelectNone"
+PASS selectTextIn("readOnlyWebkitUserSelectNone") is ""
+PASS selectTextIn("textareaReadOnlyWebkitUserSelectNone") is ""
+
+By default, a control's value is not atomically selectable (all).
+PASS extendOneCharacterIn("mutable") is "m"
+PASS extendOneCharacterIn("readOnly") is "r"
+PASS extendOneCharacterIn("textarea") is "t"
+PASS extendOneCharacterIn("textareaReadOnly") is "t"
+
+'all' makes the value atomically selectable, whether the text is editable or not.
+PASS extendOneCharacterIn("webkitUserSelectAll") is "webkitUserSelectAll"
+PASS extendOneCharacterIn("textareaWebkitUserSelectAll") is "textareaWebkitUserSelectAll"
+PASS extendOneCharacterIn("readOnlyWebkitUserSelectAll") is "readOnlyWebkitUserSelectAll"
+PASS extendOneCharacterIn("textareaReadOnlyWebkitUserSelectAll") is "textareaReadOnlyWebkitUserSelectAll"
+
+'all' removes editability from ordinary editable content
+PASS typedTextLandsAt("editableParagraph") is true
+PASS typedTextLandsAt("editableParagraphWebkitUserSelectAll") is false
+
+Exceptionally, 'all' does not remove editability from editable text controls.
+PASS typedTextLandsAt("mutable") is true
+PASS typedTextLandsAt("textarea") is true
+PASS typedTextLandsAt("readOnly") is false
+PASS typedTextLandsAt("textareaReadOnly") is false
+PASS typedTextLandsAt("webkitUserSelectAll") is true
+PASS typedTextLandsAt("textareaWebkitUserSelectAll") is true
+PASS typedTextLandsAt("readOnlyWebkitUserSelectAll") is false
+PASS typedTextLandsAt("textareaReadOnlyWebkitUserSelectAll") is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/user-select-in-text-control.html
+++ b/LayoutTests/editing/selection/user-select-in-text-control.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- A text control's value is rendered by shadow dom elements whose style is built directly
+     rather than produced by the style cascade, so the style adjuster does not run on them.
+     This test verifies that the used value of user-select is correct. -->
+
+<input id="mutable" value="mutable">
+<input id="readOnly" readonly value="readOnly">
+<textarea id="textarea">textarea</textarea>
+<textarea id="textareaReadOnly" readonly>textareaReadOnly</textarea>
+
+<input id="webkitUserSelectNone" value="webkitUserSelectNone" style="-webkit-user-select: none">
+<textarea id="textareaWebkitUserSelectNone" style="-webkit-user-select: none">textareaWebkitUserSelectNone</textarea>
+
+<input id="readOnlyWebkitUserSelectNone" readonly value="readOnlyWebkitUserSelectNone" style="-webkit-user-select: none">
+<textarea id="textareaReadOnlyWebkitUserSelectNone" readonly style="-webkit-user-select: none">textareaReadOnlyWebkitUserSelectNone</textarea>
+
+<input id="webkitUserSelectAll" value="webkitUserSelectAll" style="-webkit-user-select: all">
+<textarea id="textareaWebkitUserSelectAll" style="-webkit-user-select: all">textareaWebkitUserSelectAll</textarea>
+
+<input id="readOnlyWebkitUserSelectAll" readonly value="readOnlyWebkitUserSelectAll" style="-webkit-user-select: all">
+<textarea id="textareaReadOnlyWebkitUserSelectAll" readonly style="-webkit-user-select: all">textareaReadOnlyWebkitUserSelectAll</textarea>
+
+<p id="editableParagraph" contenteditable>editableParagraph</p>
+<p id="editableParagraphWebkitUserSelectAll" contenteditable style="-webkit-user-select: all">editableParagraphWebkitUserSelectAll</p>
+
+<div id="description"></div>
+<div id="console"></div>
+<script>
+description("Verifies the used user-select value for the inner text element of a text control, and contrasts it with ordinary editable content.");
+
+function selectTextIn(id)
+{
+    const innerText = internals.shadowRoot(document.getElementById(id)).querySelector("div[contenteditable]").firstChild;
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.setBaseAndExtent(innerText, 0, innerText, innerText.length);
+    return selection.toString();
+}
+
+function extendOneCharacterIn(id)
+{
+    const innerText = internals.shadowRoot(document.getElementById(id)).querySelector("div[contenteditable]").firstChild;
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.setPosition(innerText, 0);
+    selection.modify("extend", "forward", "character");
+    return selection.toString();
+}
+
+// Attempts to place the caret inside the element's text and type a character
+// there. This is more reliable than probing the computed value provided by
+// contenteditable/isContentEditable
+function typedTextLandsAt(id)
+{
+    const offset = 3;
+    const element = document.getElementById(id);
+    const isTextControl = element.value !== undefined;
+    const editableText = isTextControl
+        ? internals.shadowRoot(element).querySelector("div[contenteditable]").firstChild
+        : element.firstChild;
+    const textOf = () => isTextControl ? element.value : element.textContent;
+
+    const textBeforeTyping = textOf();
+    element.focus();
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.setPosition(editableText, offset);
+    document.execCommand("insertText", false, "x");
+
+    return textOf() === textBeforeTyping.slice(0, offset) + "x" + textBeforeTyping.slice(offset);
+}
+
+debug("");
+debug("By default, a control's value is selectable.");
+shouldBeEqualToString('selectTextIn("mutable")', "mutable");
+shouldBeEqualToString('selectTextIn("readOnly")', "readOnly");
+shouldBeEqualToString('selectTextIn("textarea")', "textarea");
+shouldBeEqualToString('selectTextIn("textareaReadOnly")', "textareaReadOnly");
+
+debug("");
+debug("'none' makes it unselectable, but it is overridden if the text is editable.");
+shouldBeEqualToString('selectTextIn("webkitUserSelectNone")', "webkitUserSelectNone");
+shouldBeEqualToString('selectTextIn("textareaWebkitUserSelectNone")', "textareaWebkitUserSelectNone");
+shouldBeEqualToString('selectTextIn("readOnlyWebkitUserSelectNone")', "");
+shouldBeEqualToString('selectTextIn("textareaReadOnlyWebkitUserSelectNone")', "");
+
+debug("");
+debug("By default, a control's value is not atomically selectable (all).");
+shouldBeEqualToString('extendOneCharacterIn("mutable")', 'm');
+shouldBeEqualToString('extendOneCharacterIn("readOnly")', 'r');
+shouldBeEqualToString('extendOneCharacterIn("textarea")', 't');
+shouldBeEqualToString('extendOneCharacterIn("textareaReadOnly")', 't');
+
+debug("");
+debug("'all' makes the value atomically selectable, whether the text is editable or not.");
+shouldBeEqualToString('extendOneCharacterIn("webkitUserSelectAll")', "webkitUserSelectAll");
+shouldBeEqualToString('extendOneCharacterIn("textareaWebkitUserSelectAll")', "textareaWebkitUserSelectAll");
+shouldBeEqualToString('extendOneCharacterIn("readOnlyWebkitUserSelectAll")', "readOnlyWebkitUserSelectAll");
+shouldBeEqualToString('extendOneCharacterIn("textareaReadOnlyWebkitUserSelectAll")', "textareaReadOnlyWebkitUserSelectAll");
+
+debug("");
+debug("'all' removes editability from ordinary editable content");
+shouldBeTrue('typedTextLandsAt("editableParagraph")');
+shouldBeFalse('typedTextLandsAt("editableParagraphWebkitUserSelectAll")');
+
+debug("");
+debug("Exceptionally, 'all' does not remove editability from editable text controls.");
+shouldBeTrue('typedTextLandsAt("mutable")');
+shouldBeTrue('typedTextLandsAt("textarea")');
+shouldBeFalse('typedTextLandsAt("readOnly")');
+shouldBeFalse('typedTextLandsAt("textareaReadOnly")');
+
+shouldBeTrue('typedTextLandsAt("webkitUserSelectAll")');
+shouldBeTrue('typedTextLandsAt("textareaWebkitUserSelectAll")');
+shouldBeFalse('typedTextLandsAt("readOnlyWebkitUserSelectAll")');
+shouldBeFalse('typedTextLandsAt("textareaReadOnlyWebkitUserSelectAll")');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -59,6 +59,7 @@
 #include "RenderTheme.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
+#include "StyleAdjuster.h"
 #include "StyleComputedStyle+SettersInlines.h"
 #include "StyleKeyword+Mappings.h"
 #include "Text.h"
@@ -959,6 +960,11 @@ void HTMLTextFormControlElement::adjustInnerTextStyle(const Style::ComputedStyle
                 textBlockStyle.setUserModify(fromCSSValueID<UserModify>(*value));
         }
     }
+
+    // The used value of user-select needs adjusting here because the adjuster won't run
+    // on this style later (because it was not produced by the cascade).
+    Style::Adjuster adjuster(document(), parentStyle, nullptr, nullptr);
+    adjuster.adjustUsedUserSelect(textBlockStyle);
 
     if (parentStyle.fieldSizing() == FieldSizing::Content)
         textBlockStyle.setLogicalMinWidth(Style::MinimumSize::Fixed { static_cast<float>(caretWidth()) });

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -49,6 +49,7 @@
 #include "ScriptController.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
+#include "StyleAdjuster.h"
 #include "StyleComputedStyle+SettersInlines.h"
 #include "StyleLengthResolution.h"
 #include "StyleResolver.h"
@@ -132,6 +133,11 @@ std::optional<Style::UnadjustedStyle> TextControlInnerElement::resolveCustomStyl
     newStyle->setDirection(TextDirection::LTR);
     // We don't want the shadow DOM to be editable, so we set this block to read-only in case the input itself is editable.
     newStyle->setUserModify(UserModify::ReadOnly);
+
+    // The used value of user-select needs adjusting here because the adjuster won't run
+    // on this style later (because it was not produced by the cascade).
+    Style::Adjuster adjuster(document(), *shadowHostStyle, nullptr, nullptr);
+    adjuster.adjustUsedUserSelect(*newStyle);
 
     if (isStrongPasswordTextField(shadowHost())) {
         newStyle->setFlexShrink(0);

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -826,6 +826,24 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
 #endif
 
     adjustForSiteSpecificQuirks(style);
+
+    adjustUsedUserSelect(style);
+}
+
+void Adjuster::adjustUsedUserSelect(Style::ComputedStyle& style) const
+{
+    auto value = style.webkitUserSelect();
+
+    // On editable, non-draggable content, 'none' is overridden so that the content can
+    // still be selected and carets can be placed in it.
+    if (style.userModify() != UserModify::ReadOnly && style.userDrag() != UserDrag::Element && value == UserSelect::None)
+        value = UserSelect::Text;
+
+    // 'auto' means nothing stronger was inherited, so it is handled as 'text'.
+    if (value == UserSelect::Auto)
+        value = UserSelect::Text;
+
+    style.setUsedUserSelect(value);
 }
 
 static bool NODELETE hasEffectiveDisplayNoneForDisplayContents(const Element& element)

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -53,6 +53,7 @@ public:
     static void adjustFromBuilder(Style::ComputedStyle&);
     void adjust(Style::ComputedStyle&) const;
     void adjustAnimatedStyle(Style::ComputedStyle&, OptionSet<AnimationImpact>) const;
+    void adjustUsedUserSelect(Style::ComputedStyle&) const;
 
     static void adjustVisibilityForPseudoElement(Style::ComputedStyle&, const Element& host);
     static void NODELETE adjustFirstLetterStyle(Style::ComputedStyle&);

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -801,6 +801,7 @@ public:
         return a.effectiveInert != b.effectiveInert
             || a.userModify != b.userModify
             || a.webkitUserSelect != b.webkitUserSelect
+            || a.usedUserSelect != b.usedUserSelect
             || a.appleColorFilter != b.appleColorFilter
             || a.imageRendering != b.imageRendering
             || a.accentColor != b.accentColor

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -528,11 +528,7 @@ UserSelect ComputedStyle::usedUserSelect() const
     if (effectiveInert())
         return UserSelect::None;
 
-    auto value = webkitUserSelect();
-    if (userModify() != UserModify::ReadOnly && userDrag() != UserDrag::Element)
-        return value == UserSelect::None ? UserSelect::Text : value;
-
-    return value;
+    return static_cast<UserSelect>(m_inheritedRareData->usedUserSelect);
 }
 
 WebCore::Color ComputedStyle::usedScrollbarThumbColor() const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -199,6 +199,11 @@ inline void ComputedStyleBase::setUsedAppearance(StyleAppearance a)
     SET_NESTED(m_nonInheritedData, miscData, usedAppearance, static_cast<unsigned>(a));
 }
 
+inline void ComputedStyleBase::setUsedUserSelect(UserSelect userSelect)
+{
+    SET(m_inheritedRareData, usedUserSelect, static_cast<unsigned>(userSelect));
+}
+
 inline void ComputedStyleBase::setUsedContentVisibility(ContentVisibility usedContentVisibility)
 {
     SET(m_inheritedRareData, usedContentVisibility, static_cast<unsigned>(usedContentVisibility));

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -558,6 +558,8 @@ public:
     inline StyleAppearance usedAppearance() const;
     inline void setUsedAppearance(StyleAppearance);
 
+    inline void setUsedUserSelect(UserSelect);
+
     // usedContentVisibility will return ContentVisibility::Hidden in a content-visibility: hidden subtree (overriding
     // content-visibility: auto at all times), ContentVisibility::Auto in a content-visibility: auto subtree (when the
     // content is not user relevant and thus skipped), and ContentVisibility::Visible otherwise.

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
@@ -92,6 +92,7 @@ InheritedRareData::InheritedRareData()
     , nbspMode(static_cast<unsigned>(NBSPMode::Normal))
     , lineBreak(static_cast<unsigned>(LineBreak::Auto))
     , webkitUserSelect(static_cast<unsigned>(ComputedStyle::initialWebkitUserSelect()))
+    , usedUserSelect(static_cast<unsigned>(UserSelect::Text))
     , speakAs(ComputedStyle::initialSpeakAs().toRaw())
     , hyphens(static_cast<unsigned>(Hyphens::Manual))
     , textCombine(static_cast<unsigned>(ComputedStyle::initialTextCombine()))
@@ -199,6 +200,7 @@ inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     , nbspMode(o.nbspMode)
     , lineBreak(o.lineBreak)
     , webkitUserSelect(o.webkitUserSelect)
+    , usedUserSelect(o.usedUserSelect)
     , speakAs(o.speakAs)
     , hyphens(o.hyphens)
     , textCombine(o.textCombine)
@@ -296,6 +298,7 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
         && textSizeAdjust == o.textSizeAdjust
 #endif
         && webkitUserSelect == o.webkitUserSelect
+        && usedUserSelect == o.usedUserSelect
         && speakAs == o.speakAs
         && hyphens == o.hyphens
         && hyphenateLimitBefore == o.hyphenateLimitBefore
@@ -413,6 +416,7 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
     LOG_IF_DIFFERENT_WITH_CAST(NBSPMode, nbspMode);
     LOG_IF_DIFFERENT_WITH_CAST(LineBreak, lineBreak);
     LOG_IF_DIFFERENT_WITH_CAST(UserSelect, webkitUserSelect);
+    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, usedUserSelect);
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(SpeakAs, speakAs);
 

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -184,6 +184,7 @@ public:
     PREFERRED_TYPE(NBSPMode) unsigned nbspMode : 1;
     PREFERRED_TYPE(LineBreak) unsigned lineBreak : 3;
     PREFERRED_TYPE(UserSelect) unsigned webkitUserSelect : 2;
+    PREFERRED_TYPE(UserSelect) unsigned usedUserSelect : 2;
     PREFERRED_TYPE(SpeakAs) unsigned speakAs : 4;
     PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
     PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;


### PR DESCRIPTION
#### 5c7f87f8da391622fe1cd4d26e99baa86c14c514
<pre>
[CSS] Add Style::InheritedRareData::usedUserSelect
<a href="https://bugs.webkit.org/show_bug.cgi?id=321737">https://bugs.webkit.org/show_bug.cgi?id=321737</a>
<a href="https://rdar.apple.com/184867143">rdar://184867143</a>

Reviewed by Megan Gardner and Tim Nguyen.

This patch adds `Style::InheritedRareData::usedUserSelect` as the source
of truth for `usedUserSelect()``, which used to read
`Style::InheritedRareData::webkitUserSelect` instead. This is only
plumbing for a future `-webkit-user-select` unprefixing effort:
`usedUserSelect` and `webkitUserSelect` here should always remain in
sync, so no changes is behavior are expected.

usedUserSelect is updated by `Adjuster::adjustUsedUserSelect()`, called by
`Adjuster::adjust()`. For cases in which `resolveCustomStyle()` might
cause `adjust()` to be skipped, `adjustUsedUserSelect()` is called
manually (on TextControlInnerElement and HTMLTextFormControlElement).
Test coverage was added specifically for this.

Tests: editing/selection/user-select-in-text-control.html

* LayoutTests/editing/selection/user-select-in-text-control-expected.txt: Added.
* LayoutTests/editing/selection/user-select-in-text-control.html: Added.
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::adjustInnerTextStyle const):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::TextControlInnerElement::resolveCustomStyle):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::Adjuster::adjustUsedUserSelect const):
* Source/WebCore/style/StyleAdjuster.h:
* Source/WebCore/style/StyleDifference.cpp:
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
(WebCore::Style::ComputedStyle::usedUserSelect const):
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
(WebCore::Style::ComputedStyleBase::setUsedUserSelect):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/data/StyleInheritedRareData.cpp:
(WebCore::Style::InheritedRareData::InheritedRareData):
(WebCore::Style::InheritedRareData::operator== const):
(WebCore::Style::InheritedRareData::dumpDifferences const):
* Source/WebCore/style/computed/data/StyleInheritedRareData.h:

temp

Canonical link: <a href="https://commits.webkit.org/319199@main">https://commits.webkit.org/319199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94987b11464fa25636509d42a63d787def3911bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190990 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145100 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f372c87-9a7b-4407-85c0-0a664ee38096) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141028 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fd05536-2a26-4a1b-a95c-b18ac2de9b53) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183732 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/44688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121480 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8f63f5d-27bb-4aad-a207-ec4716a75741) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41299 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2151 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47334 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192925 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150398 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40248 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55076 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150126 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44711 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122628 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53593 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16292 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52975 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53212 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53040 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->