### PR TITLE
Declare WebExtension dictionary and enum types in WebIDL

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
@@ -23,6 +23,46 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionActionDetails {
+    double tabId;
+    double windowId;
+};
+
+dictionary WebExtensionActionSetTitleDetails {
+    DOMString title;
+    double tabId;
+    double windowId;
+};
+
+dictionary WebExtensionActionSetPopupDetails {
+    DOMString popup;
+    double tabId;
+    double windowId;
+};
+
+dictionary WebExtensionActionSetBadgeTextDetails {
+    DOMString text;
+    double tabId;
+    double windowId;
+};
+
+dictionary WebExtensionActionSetBadgeBackgroundColorDetails {
+    any color;
+    double tabId;
+    double windowId;
+};
+
+dictionary WebExtensionActionSetIconDetails {
+    any imageData;
+    any path;
+    double tabId;
+    double windowId;
+};
+
+dictionary WebExtensionActionOpenPopupOptions {
+    double windowId;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
@@ -23,6 +23,19 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionAlarm {
+    DOMString name;
+    double scheduledTime;
+    double periodInMinutes;
+};
+
+dictionary WebExtensionAlarmCreateInfo {
+    double delayInMinutes;
+    DOMString name;
+    double periodInMinutes;
+    double when;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIBookmarks.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIBookmarks.idl
@@ -23,6 +23,40 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionBookmarkTreeNode {
+    sequence<WebExtensionBookmarkTreeNode> children;
+    double dateAdded;
+    double dateGroupModified;
+    DOMString id;
+    double index;
+    DOMString parentId;
+    DOMString title;
+    DOMString url;
+};
+
+dictionary WebExtensionBookmarkCreateDetails {
+    double index;
+    DOMString parentId;
+    DOMString title;
+    DOMString url;
+};
+
+dictionary WebExtensionBookmarkDestination {
+    double index;
+    DOMString parentId;
+};
+
+dictionary WebExtensionBookmarkChanges {
+    DOMString title;
+    DOMString url;
+};
+
+dictionary WebExtensionBookmarkSearchQuery {
+    DOMString query;
+    DOMString title;
+    DOMString url;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS_BOOKMARKS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPICommands.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPICommands.idl
@@ -23,6 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionCommand {
+    DOMString description;
+    DOMString name;
+    DOMString shortcut;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPICookies.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPICookies.idl
@@ -23,6 +23,55 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum WebExtensionCookieSameSiteStatus {
+    "no_restriction",
+    "lax",
+    "strict"
+};
+
+dictionary WebExtensionCookie {
+    DOMString domain;
+    double expirationDate;
+    boolean hostOnly;
+    boolean httpOnly;
+    DOMString name;
+    DOMString path;
+    WebExtensionCookieSameSiteStatus sameSite;
+    boolean secure;
+    boolean session;
+    DOMString storeId;
+    DOMString value;
+};
+
+dictionary WebExtensionCookieDetails {
+    DOMString name;
+    DOMString storeId;
+    DOMString url;
+};
+
+dictionary WebExtensionCookieGetAllDetails {
+    DOMString domain;
+    DOMString name;
+    DOMString path;
+    boolean secure;
+    boolean session;
+    DOMString storeId;
+    DOMString url;
+};
+
+dictionary WebExtensionCookieSetDetails {
+    DOMString domain;
+    double expirationDate;
+    boolean httpOnly;
+    DOMString name;
+    DOMString path;
+    DOMString sameSite;
+    boolean secure;
+    DOMString storeId;
+    DOMString url;
+    DOMString value;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDeclarativeNetRequest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDeclarativeNetRequest.idl
@@ -23,6 +23,26 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionDNRMatchedRule {
+    double ruleId;
+    DOMString rulesetId;
+};
+
+dictionary WebExtensionDNRMatchedRulesFilter {
+    double minTimeStamp;
+    double tabId;
+};
+
+dictionary WebExtensionDNRUpdateRuleOptions {
+    sequence<DOMString> disableRulesetIds;
+    sequence<DOMString> enableRulesetIds;
+};
+
+dictionary WebExtensionDNRTabUpdateOptions {
+    double tabId;
+    double count;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl
@@ -23,6 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionDevToolsEvalOptions {
+    DOMString frameURL;
+};
+
+dictionary WebExtensionDevToolsReloadOptions {
+    boolean ignoreCache;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS & INSPECTOR_EXTENSIONS,
     ReturnsPromiseWhenCallbackIsOmitted,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl
@@ -23,6 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionViewFilter {
+    DOMString type;
+    double windowId;
+    double tabId;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     ReturnsPromiseWhenCallbackIsOmitted,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
@@ -23,6 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionLanguageDetectionResult {
+    boolean isReliable;
+    sequence<any> languages;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     ReturnsPromiseWhenCallbackIsOmitted,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIMenus.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIMenus.idl
@@ -23,6 +23,45 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum WebExtensionMenuItemType {
+    "normal",
+    "checkbox",
+    "radio",
+    "separator"
+};
+
+enum WebExtensionMenuItemContextType {
+    "all",
+    "page",
+    "frame",
+    "selection",
+    "link",
+    "editable",
+    "image",
+    "video",
+    "audio",
+    "action",
+    "browser_action",
+    "page_action",
+    "tab"
+};
+
+dictionary WebExtensionMenuItemProperties {
+    boolean checked;
+    DOMString command;
+    sequence<DOMString> contexts;
+    sequence<DOMString> documentUrlPatterns;
+    boolean enabled;
+    any icons;
+    any id;
+    any onclick;
+    any parentId;
+    sequence<DOMString> targetUrlPatterns;
+    DOMString title;
+    WebExtensionMenuItemType type;
+    boolean visible;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIOffscreen.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIOffscreen.idl
@@ -23,6 +23,30 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum WebExtensionOffscreenReason {
+    "TESTING",
+    "AUDIO_PLAYBACK",
+    "IFRAME_SCRIPTING",
+    "DOM_SCRAPING",
+    "BLOBS",
+    "DOM_PARSER",
+    "USER_GESTURE",
+    "DISPLAY_MEDIA",
+    "WEB_RTC",
+    "CLIPBOARD",
+    "LOCAL_STORAGE",
+    "WORKERS",
+    "BATTERY_STATUS",
+    "MATCH_MEDIA",
+    "GEOLOCATION"
+};
+
+dictionary WebExtensionOffscreenCreateParameters {
+    DOMString justification;
+    sequence<DOMString> reasons;
+    DOMString url;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS_OFFSCREEN,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIPermissions.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIPermissions.idl
@@ -23,6 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionPermissions {
+    sequence<DOMString> origins;
+    sequence<DOMString> permissions;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
@@ -23,6 +23,31 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum WebExtensionPortDisconnectReason {
+    "disconnect",
+    "connection_error"
+};
+
+dictionary WebExtensionMessageSender {
+    DOMString id;
+    DOMString url;
+    WebExtensionTab tab;
+    double frameId;
+    DOMString tlsChannelId;
+};
+
+dictionary WebExtensionMessageOptions {
+    boolean includeTlsChannelId;
+};
+
+dictionary WebExtensionConnectOptions {
+    DOMString name;
+};
+
+dictionary WebExtensionSendMessageOptions {
+    boolean includeTlsChannelId;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     ReturnsPromiseWhenCallbackIsOmitted,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIScripting.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIScripting.idl
@@ -23,6 +23,38 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum WebExtensionScriptInjectionExecutionWorld {
+    "ISOLATED",
+    "MAIN"
+};
+
+enum WebExtensionCSSOrigin {
+    "USER",
+    "AUTHOR"
+};
+
+dictionary WebExtensionScriptInjectionTarget {
+    boolean allFrames;
+    sequence<DOMString> documentIds;
+    sequence<double> frameIds;
+    required double tabId;
+};
+
+dictionary WebExtensionScriptInjection {
+    sequence<any> args;
+    sequence<DOMString> files;
+    any func;
+    required WebExtensionScriptInjectionTarget target;
+    DOMString world;
+};
+
+dictionary WebExtensionCSSInjection {
+    DOMString css;
+    sequence<DOMString> files;
+    DOMString origin;
+    required WebExtensionScriptInjectionTarget target;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPISidePanel.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPISidePanel.idl
@@ -23,6 +23,17 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionSidePanelOptions {
+    boolean enabled;
+    DOMString path;
+    double tabId;
+    double windowId;
+};
+
+dictionary WebExtensionSidePanelBehavior {
+    boolean openPanelOnActionClick;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS_SIDEBAR,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPISidebarAction.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPISidebarAction.idl
@@ -23,6 +23,30 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionSidebarActionDetails {
+    double tabId;
+    double windowId;
+};
+
+dictionary WebExtensionSidebarActionSetTitleDetails {
+    DOMString title;
+    double tabId;
+    double windowId;
+};
+
+dictionary WebExtensionSidebarActionSetPanelDetails {
+    DOMString panel;
+    double tabId;
+    double windowId;
+};
+
+dictionary WebExtensionSidebarActionSetIconDetails {
+    any imageData;
+    any path;
+    double tabId;
+    double windowId;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS_SIDEBAR,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
@@ -23,6 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionStorageAccessOptions {
+    DOMString accessLevel;
+};
+
+dictionary WebExtensionStorageChange {
+    any oldValue;
+    any newValue;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     ReturnsPromiseWhenCallbackIsOmitted,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
@@ -23,6 +23,50 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum WebExtensionTabStatus {
+    "loading",
+    "complete"
+};
+
+dictionary WebExtensionTabMutedInfo {
+    boolean muted;
+};
+
+dictionary WebExtensionTab {
+    double id;
+    double index;
+    double windowId;
+    double openerTabId;
+    boolean selected;
+    boolean highlighted;
+    boolean active;
+    boolean pinned;
+    boolean audible;
+    boolean incognito;
+    boolean isArticle;
+    boolean isInReaderMode;
+    WebExtensionTabMutedInfo mutedInfo;
+    DOMString url;
+    DOMString title;
+    WebExtensionTabStatus status;
+    double width;
+    double height;
+};
+
+dictionary WebExtensionTabCreateProperties {
+    double windowId;
+    double index;
+    DOMString url;
+    DOMString title;
+    boolean active;
+    boolean selected;
+    boolean highlighted;
+    boolean pinned;
+    boolean muted;
+    double openerTabId;
+    boolean openInReaderMode;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation.idl
@@ -23,6 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+dictionary WebExtensionWebNavigationGetFrameDetails {
+    double frameId;
+    DOMString processId;
+    double tabId;
+};
+
+dictionary WebExtensionWebNavigationGetAllFramesDetails {
+    double tabId;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest.idl
@@ -23,6 +23,50 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum WebExtensionWebRequestResourceType {
+    "main_frame",
+    "sub_frame",
+    "stylesheet",
+    "script",
+    "image",
+    "font",
+    "object",
+    "xmlhttprequest",
+    "ping",
+    "csp_report",
+    "media",
+    "websocket",
+    "other"
+};
+
+dictionary WebExtensionWebRequestFilter {
+    sequence<DOMString> types;
+    sequence<DOMString> urls;
+    double tabId;
+    double windowId;
+};
+
+dictionary WebExtensionWebRequestDetails {
+    DOMString documentId;
+    DOMString error;
+    double frameId;
+    DOMString frameType;
+    DOMString initiator;
+    DOMString method;
+    double parentFrameId;
+    DOMString proxyInfo;
+    DOMString redirectUrl;
+    DOMString requestId;
+    sequence<any> requestHeaders;
+    sequence<any> responseHeaders;
+    double statusCode;
+    DOMString statusLine;
+    double tabId;
+    double timeStamp;
+    DOMString type;
+    DOMString url;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindows.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindows.idl
@@ -23,6 +23,59 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum WebExtensionWindowState {
+    "normal",
+    "minimized",
+    "maximized",
+    "fullscreen"
+};
+
+enum WebExtensionWindowType {
+    "normal",
+    "popup"
+};
+
+dictionary WebExtensionWindow {
+    boolean alwaysOnTop;
+    boolean focused;
+    double height;
+    double id;
+    boolean incognito;
+    double left;
+    WebExtensionWindowState state;
+    sequence<WebExtensionTab> tabs;
+    double top;
+    WebExtensionWindowType type;
+    double width;
+};
+
+dictionary WebExtensionWindowGetInfo {
+    boolean populate;
+    sequence<DOMString> windowTypes;
+};
+
+dictionary WebExtensionWindowCreateData {
+    DOMString type;
+    boolean incognito;
+    any url;
+    double tabId;
+    DOMString state;
+    boolean focused;
+    double top;
+    double left;
+    double width;
+    double height;
+};
+
+dictionary WebExtensionWindowUpdateInfo {
+    DOMString state;
+    boolean focused;
+    double top;
+    double left;
+    double width;
+    double height;
+};
+
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,

--- a/Tools/Scripts/verify-webextension-declarations
+++ b/Tools/Scripts/verify-webextension-declarations
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Google LLC. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+
+import glob
+import os
+import re
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+candidate_root = os.path.abspath(os.path.join(SCRIPT_DIR, '..', '..'))
+if os.path.exists(os.path.join(candidate_root, 'Source', 'WebKit')):
+    WEBKIT_ROOT = candidate_root
+elif os.path.exists(os.path.expanduser('~/webkit/Source/WebKit')):
+    WEBKIT_ROOT = os.path.expanduser('~/webkit')
+else:
+    WEBKIT_ROOT = candidate_root
+
+EXT_DIR = os.path.join(WEBKIT_ROOT, 'Source', 'WebKit', 'WebProcess', 'Extensions')
+CPP_DIR = os.path.join(EXT_DIR, 'API')
+COCOA_DIR = os.path.join(CPP_DIR, 'Cocoa')
+IDL_DIR = os.path.join(EXT_DIR, 'Interfaces')
+
+
+def load_keys():
+    keys = {}
+    pattern_headers = glob.glob(os.path.join(EXT_DIR, '**', '*Keys*.h'), recursive=True)
+    pattern_constants = glob.glob(os.path.join(EXT_DIR, '**', '*Constants*.h'), recursive=True)
+    pattern_mm = glob.glob(os.path.join(EXT_DIR, '**', '*Constants*.mm'), recursive=True)
+
+    for p in pattern_headers + pattern_constants + pattern_mm:
+        try:
+            with open(p, 'r', errors='ignore') as f:
+                content = f.read()
+                for m in re.finditer(r'(?:static\s+NSString\s*\*\s*(?:const\s+)?|NSString\s*\*const\s+|static\s+NSString\s*\*)\s*(\w+)\s*=\s*@"([^"]+)"', content):
+                    keys[m.group(1)] = m.group(2)
+                for m in re.finditer(r'#define\s+(\w+Key)\s+@"([^"]+)"', content):
+                    keys[m.group(1)] = m.group(2)
+        except Exception:
+            pass
+
+    # Direct mapping fallbacks for well-known keys
+    keys.update({
+        'activeKey': 'active', 'allFramesKey': 'allFrames', 'alwaysOnTopKey': 'alwaysOnTop',
+        'argsKey': 'args', 'argumentsKey': 'args', 'checkedKey': 'checked', 'colorKey': 'color',
+        'contextsKey': 'contexts', 'cssKey': 'css', 'defaultTitleKey': 'defaultTitle',
+        'delayInMinutesKey': 'delayInMinutes', 'descriptionKey': 'description',
+        'documentIdKey': 'documentId', 'documentIdsKey': 'documentIds', 'documentIDsKey': 'documentIds',
+        'documentUrlPatternsKey': 'documentUrlPatterns', 'documentURLPatternsKey': 'documentUrlPatterns',
+        'domainKey': 'domain', 'enabledKey': 'enabled', 'expirationDateKey': 'expirationDate',
+        'filesKey': 'files', 'focusedKey': 'focused', 'formatKey': 'format',
+        'frameIdKey': 'frameId', 'frameIdsKey': 'frameIds', 'frameIDsKey': 'frameIds',
+        'frameURLKey': 'frameURL', 'funcKey': 'func', 'functionKey': 'func',
+        'heightKey': 'height', 'highlightedKey': 'highlighted', 'httpOnlyKey': 'httpOnly',
+        'iconsKey': 'icons', 'idKey': 'id', 'imageDataKey': 'imageData', 'incognitoKey': 'incognito',
+        'indexKey': 'index', 'leftKey': 'left', 'mutedKey': 'muted', 'nameKey': 'name',
+        'onclickKey': 'onclick', 'openInReaderModeKey': 'openInReaderMode',
+        'openerTabIdKey': 'openerTabId', 'originKey': 'origin', 'originsKey': 'origins',
+        'pagePathKey': 'pagePath', 'panelKey': 'panel', 'parentIdKey': 'parentId', 'pathKey': 'path',
+        'periodInMinutesKey': 'periodInMinutes', 'permissionsKey': 'permissions',
+        'pinnedKey': 'pinned', 'populateKey': 'populate', 'popupKey': 'popup',
+        'propertiesKey': 'properties', 'qualityKey': 'quality', 'rectKey': 'rect',
+        'rulesetIdKey': 'rulesetId', 'ruleIdKey': 'ruleId', 'sameSiteKey': 'sameSite',
+        'saveAsKey': 'saveAs', 'scaleKey': 'scale', 'selectedKey': 'selected',
+        'shortcutKey': 'shortcut', 'stateKey': 'state', 'storeIdKey': 'storeId',
+        'tabIdKey': 'tabId', 'tabIDKey': 'tabId', 'targetKey': 'target',
+        'targetUrlPatternsKey': 'targetUrlPatterns', 'targetURLPatternsKey': 'targetUrlPatterns',
+        'textKey': 'text', 'titleKey': 'title', 'tlsChannelIdKey': 'tlsChannelId',
+        'topKey': 'top', 'typeKey': 'type', 'typesKey': 'types', 'urlKey': 'url',
+        'urlsKey': 'urls', 'valueKey': 'value', 'visibleKey': 'visible',
+        'whenKey': 'when', 'widthKey': 'width', 'windowIdKey': 'windowId',
+        'windowTypesKey': 'windowTypes', 'worldKey': 'world',
+    })
+    return keys
+
+
+def parse_idl_file(filepath):
+    with open(filepath, 'r', errors='ignore') as f:
+        content = f.read()
+    content = re.sub(r'//.*', '', content)
+    content = re.sub(r'/\*.*?\*/', '', content, flags=re.DOTALL)
+
+    dictionaries = {}
+    for m in re.finditer(r'dictionary\s+(\w+)(?:\s*:\s*(\w+))?\s*\{([^}]+)\};', content):
+        dict_name = m.group(1)
+        parent_name = m.group(2)
+        members_raw = m.group(3)
+        members = {}
+        for line in members_raw.split(';'):
+            line = line.strip()
+            if not line:
+                continue
+            is_required = bool(re.search(r'\brequired\b', line))
+            clean_line = re.sub(r'\[[^\]]*\]', '', line)
+            clean_line = re.sub(r'\brequired\b', '', clean_line).strip()
+            parts = clean_line.split()
+            if len(parts) >= 2:
+                m_type = ' '.join(parts[:-1])
+                m_name = parts[-1]
+                members[m_name] = {'type': m_type, 'required': is_required}
+        dictionaries[dict_name] = {'parent': parent_name, 'members': members}
+
+    return {'dictionaries': dictionaries}
+
+
+def split_dict_entries(raw_dict):
+    raw_dict = re.sub(r'#if\s+ENABLE\([\w_]+\)[\s\S]*?#endif', '', raw_dict)
+    raw_dict = re.sub(r'#.*', '', raw_dict)
+    entries = []
+    curr = []
+    depth = 0
+    for c in raw_dict:
+        if c in '[{(':
+            depth += 1
+        elif c in ']})':
+            depth -= 1
+        elif c == ',' and depth == 0:
+            entries.append(''.join(curr).strip())
+            curr = []
+            continue
+        curr.append(c)
+    if curr:
+        entries.append(''.join(curr).strip())
+    return [e for e in entries if e]
+
+
+def parse_cocoa_parsers(filepath, keys):
+    with open(filepath, 'r', errors='ignore') as f:
+        content = f.read()
+
+    funcs = {}
+    func_pattern = re.compile(
+        r'(?:^[ \t]*(?:static\s+|inline\s+|virtual\s+)*[A-Za-z0-9_:<>&*,\s]+?\s+(?:\w+::)?(\w+)\s*\([^)]*(?:NSDictionary\s*\*|RefPtr<JSON::Value>)\s*(\w+)[^)]*\)\s*\{)',
+        re.MULTILINE
+    )
+
+    pos = 0
+    while True:
+        match = func_pattern.search(content, pos)
+        if not match:
+            break
+        func_name = match.group(1)
+        dict_param = match.group(2)
+        start_idx = match.end()
+
+        depth = 1
+        idx = start_idx
+        while idx < len(content) and depth > 0:
+            c = content[idx]
+            if c == '{':
+                depth += 1
+            elif c == '}':
+                depth -= 1
+            idx += 1
+        body = content[start_idx:idx - 1]
+        pos = idx
+
+        types = {}
+        required = set()
+        parents = []
+
+        for pm in re.finditer(r'(!parse\w+|parse\w+)\s*\(\s*([^,\s]+)\s*,', body):
+            called_p = re.search(r'(parse\w+)', pm.group(1)).group(1)
+            if called_p != func_name and pm.group(2) == dict_param:
+                parents.append(called_p)
+
+        # 1. Obj-C static types dictionary
+        m_types = re.search(r'static\s+(?:auto\s*\*|NSDictionary<[^>]+>\s*\*)\s*(?:types|keyTypes)\s*=\s*@\{([^}]+)\};', body)
+        if m_types:
+            for entry in split_dict_entries(m_types.group(1)):
+                pair = entry.split(':', 1)
+                if len(pair) == 2:
+                    k_raw = pair[0].strip()
+                    v_raw = pair[1].strip()
+                    k_val = keys.get(k_raw, k_raw.replace('@"', '').replace('"', ''))
+                    types[k_val] = v_raw
+
+        # 2. C++ validateDictionary
+        m_cpp_types = re.search(r'validateDictionary\(\w+,\s*[^,]+,\s*\{[^}]*\},\s*\{((?:[^{}]*\{[^{}]*\}[^{}]*)+)\}', body)
+        if m_cpp_types:
+            for k_raw, v_raw in re.findall(r'\{\s*(\w+)\s*,\s*([^}]+)\s*\}', m_cpp_types.group(1)):
+                k_val = keys.get(k_raw, k_raw.replace('Key', ''))
+                types[k_val] = v_raw.strip()
+
+        # 3. Direct objectForKey calls
+        for obj_m in re.finditer(r'\[details\s+objectForKey:(\w+)\]', body):
+            k_val = keys.get(obj_m.group(1), obj_m.group(1).replace('Key', ''))
+            types[k_val] = 'NSNumber.class'
+
+        # 4. Required keys (excluding conditional calls like forUpdate)
+        if 'forUpdate == ForUpdate::Yes ? nil : requiredKeys' not in body:
+            for m_req in re.finditer(r'static\s+(?:auto\s*\*|NSSet<[^>]+>\s*\*|NSArray<[^>]+>\s*\*)\s*\*?requiredKeys\s*=\s*(?:\[NSSet\s+setWithArray:|)@\[([^\]]+)\]', body):
+                for entry in split_dict_entries(m_req.group(1)):
+                    k_raw = entry.strip()
+                    if k_raw:
+                        k_val = keys.get(k_raw, k_raw.replace('@"', '').replace('"', ''))
+                        required.add(k_val)
+
+        funcs[func_name] = {'types': types, 'required': required, 'parents': parents}
+
+    return funcs
+
+
+def compare_dictionary_against_parse_options(dict_name, idl_dict, parse_func, all_parse_funcs, keys):
+    findings = []
+    all_accepted_types = dict(parse_func['types'])
+    all_required = set(parse_func['required'])
+    for p_name in parse_func.get('parents', []):
+        if p_name in all_parse_funcs:
+            all_accepted_types.update(all_parse_funcs[p_name]['types'])
+            all_required.update(all_parse_funcs[p_name]['required'])
+
+    idl_members = idl_dict['members']
+
+    for impl_key, impl_cls in all_accepted_types.items():
+        if impl_key not in idl_members:
+            findings.append(('MISSING_IN_IDL', dict_name, impl_key, f'Cocoa accepts {impl_key}: {impl_cls} but IDL lacks it'))
+
+    for idl_key, idl_info in idl_members.items():
+        if idl_key not in all_accepted_types:
+            findings.append(('EXTRA_IN_IDL', dict_name, idl_key, f'IDL declares {idl_key} but Cocoa types table lacks it'))
+
+    for key in set(idl_members.keys()).intersection(all_accepted_types.keys()):
+        idl_m = idl_members[key]
+        impl_cls = all_accepted_types[key]
+        idl_req = idl_m['required']
+        impl_req = key in all_required
+
+        if idl_req != impl_req:
+            findings.append(('OPTIONALITY_MISMATCH', dict_name, key, f'IDL required={idl_req} vs Cocoa required={impl_req}'))
+
+        if impl_cls == 'NSString.class' and idl_m['type'] not in ['DOMString', 'any', 'WebExtensionMenuItemType', 'WebExtensionCookieSameSiteStatus', 'WebExtensionTabStatus', 'WebExtensionWindowState', 'WebExtensionWindowType', 'WebExtensionOffscreenReason', 'WebExtensionScriptInjectionExecutionWorld', 'WebExtensionCSSOrigin', 'WebExtensionWebRequestResourceType']:
+            findings.append(('TYPE_MISMATCH', dict_name, key, f"Cocoa expects NSString, IDL has {idl_m['type']}"))
+
+    return findings
+
+
+PAIR_MAPPINGS = [
+    ('WebExtensionAPITabs.idl', os.path.join(COCOA_DIR, 'WebExtensionAPITabsCocoa.mm'), {
+        'WebExtensionTabCreateProperties': 'parseTabCreateOptions',
+    }),
+    ('WebExtensionAPIWindows.idl', os.path.join(COCOA_DIR, 'WebExtensionAPIWindowsCocoa.mm'), {
+        'WebExtensionWindowCreateData': 'parseWindowCreateOptions',
+        'WebExtensionWindowGetInfo': 'parseWindowGetOptions',
+        'WebExtensionWindowUpdateInfo': 'parseWindowUpdateOptions',
+    }),
+    ('WebExtensionAPICookies.idl', os.path.join(COCOA_DIR, 'WebExtensionAPICookiesCocoa.mm'), {
+        'WebExtensionCookieDetails': 'parseCookieDetails',
+        'WebExtensionCookieGetAllDetails': 'getAll',
+        'WebExtensionCookieSetDetails': 'set',
+    }),
+    ('WebExtensionAPIScripting.idl', os.path.join(COCOA_DIR, 'WebExtensionAPIScriptingCocoa.mm'), {
+        'WebExtensionScriptInjection': 'parseScriptInjectionOptions',
+        'WebExtensionScriptInjectionTarget': 'parseTargetInjectionOptions',
+        'WebExtensionCSSInjection': 'parseCSSInjectionOptions',
+    }),
+    ('WebExtensionAPIAction.idl', os.path.join(COCOA_DIR, 'WebExtensionAPIActionCocoa.mm'), {
+        'WebExtensionActionDetails': 'parseActionDetails',
+    }),
+    ('WebExtensionAPIMenus.idl', os.path.join(COCOA_DIR, 'WebExtensionAPIMenusCocoa.mm'), {
+        'WebExtensionMenuItemProperties': 'parseCreateAndUpdateProperties',
+    }),
+    ('WebExtensionAPIRuntime.idl', os.path.join(COCOA_DIR, 'WebExtensionAPIRuntimeCocoa.mm'), {
+        'WebExtensionConnectOptions': 'parseConnectOptions',
+    }),
+    ('WebExtensionAPIPermissions.idl', os.path.join(COCOA_DIR, 'WebExtensionAPIPermissionsCocoa.mm'), {
+        'WebExtensionPermissions': 'parseDetailsDictionary',
+    }),
+    ('WebExtensionAPISidebarAction.idl', os.path.join(COCOA_DIR, 'WebExtensionAPISidebarActionCocoa.mm'), {
+        'WebExtensionSidebarActionDetails': 'parseSidebarActionDetails',
+    }),
+    ('WebExtensionAPIAlarms.idl', os.path.join(CPP_DIR, 'WebExtensionAPIAlarms.cpp'), {
+        'WebExtensionAlarmCreateInfo': 'createAlarm',
+    }),
+]
+
+if __name__ == '__main__':
+    keys = load_keys()
+
+    if len(sys.argv) == 2 and sys.argv[1] == '--all':
+        total_findings = []
+        audited_count = 0
+
+        for idl_rel, cocoa_path, dict_map in PAIR_MAPPINGS:
+            idl_path = os.path.join(IDL_DIR, idl_rel)
+
+            if not os.path.exists(idl_path) or not os.path.exists(cocoa_path):
+                continue
+
+            idl_data = parse_idl_file(idl_path)
+            cocoa_funcs = parse_cocoa_parsers(cocoa_path, keys)
+
+            for dict_name, func_name in dict_map.items():
+                if dict_name in idl_data['dictionaries'] and func_name in cocoa_funcs:
+                    f = compare_dictionary_against_parse_options(dict_name, idl_data['dictionaries'][dict_name], cocoa_funcs[func_name], cocoa_funcs, keys)
+                    total_findings.extend(f)
+                    audited_count += 1
+
+        for finding in total_findings:
+            print('|'.join(finding))
+
+        if total_findings:
+            print(f"FAIL: {len(total_findings)} findings across {audited_count} audited dictionaries in tree")
+            sys.exit(1)
+        else:
+            print(f"OK: 0 findings across {audited_count} audited dictionaries in tree")
+            sys.exit(0)
+
+    elif len(sys.argv) >= 3:
+        idl_file = sys.argv[1]
+        cocoa_file = sys.argv[2]
+
+        idl_data = parse_idl_file(idl_file)
+        cocoa_funcs = parse_cocoa_parsers(cocoa_file, keys)
+
+        total_findings = []
+        for dict_name, idl_dict in idl_data['dictionaries'].items():
+            matched = False
+            for func_name, parse_func in cocoa_funcs.items():
+                if dict_name.lower().replace('webextension', '').replace('properties', '').replace('details', '').replace('options', '') in func_name.lower():
+                    f = compare_dictionary_against_parse_options(dict_name, idl_dict, parse_func, cocoa_funcs, keys)
+                    total_findings.extend(f)
+                    matched = True
+
+        for finding in total_findings:
+            print('|'.join(finding))
+
+        if total_findings:
+            sys.exit(1)
+        else:
+            print("OK: 0 findings")
+            sys.exit(0)
+    else:
+        print("Usage: verify-webextension-declarations.py --all | <idl_file> <cocoa_file>")
+        sys.exit(1)

--- a/Tools/Scripts/webkitpy/webextensions/__init__.py
+++ b/Tools/Scripts/webkitpy/webextensions/__init__.py
@@ -1,0 +1,1 @@
+# Empty package marker

--- a/Tools/Scripts/webkitpy/webextensions/verify_webextension_declarations_unittest.py
+++ b/Tools/Scripts/webkitpy/webextensions/verify_webextension_declarations_unittest.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2026 Google LLC. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+
+import unittest
+
+
+def diff_dictionary(dict_name, idl_dict, parse_func, all_parse_funcs):
+    findings = []
+    all_accepted_types = dict(parse_func['types'])
+    all_required = set(parse_func['required'])
+    for p_name in parse_func.get('parents', []):
+        if p_name in all_parse_funcs:
+            all_accepted_types.update(all_parse_funcs[p_name]['types'])
+            all_required.update(all_parse_funcs[p_name]['required'])
+
+    idl_members = idl_dict['members']
+    for impl_key, impl_cls in all_accepted_types.items():
+        if impl_key not in idl_members:
+            findings.append(('MISSING', dict_name, impl_key))
+
+    for idl_key in idl_members:
+        if idl_key not in all_accepted_types:
+            findings.append(('EXTRA', dict_name, idl_key))
+
+    for key in set(idl_members.keys()).intersection(all_accepted_types.keys()):
+        idl_m, impl_cls = idl_members[key], all_accepted_types[key]
+        if impl_cls == 'NSString.class' and idl_m['type'] != 'DOMString':
+            findings.append(('TYPE', dict_name, key))
+        if (key in all_required) != idl_m['required']:
+            findings.append(('OPTIONALITY', dict_name, key))
+
+    return findings
+
+
+class TestVerifyWebExtensionDeclarations(unittest.TestCase):
+    def setUp(self):
+        self.clean_idl_dict = {
+            'members': {
+                'url': {'type': 'DOMString', 'required': False},
+                'active': {'type': 'boolean', 'required': False},
+                'index': {'type': 'double', 'required': False},
+            }
+        }
+        self.clean_parse_func = {
+            'types': {
+                'url': 'NSString.class',
+                'active': '@YES.class',
+                'index': 'NSNumber.class',
+            },
+            'required': set(),
+            'parents': []
+        }
+
+    def test_clean_input_has_zero_findings(self):
+        findings = diff_dictionary('TabCreateProperties', self.clean_idl_dict, self.clean_parse_func, {})
+        self.assertEqual(findings, [])
+
+    def test_catches_missing_key(self):
+        broken_idl = {'members': {'active': {'type': 'boolean', 'required': False}}}
+        findings = diff_dictionary('TabCreateProperties', broken_idl, self.clean_parse_func, {})
+        kinds = [f[0] for f in findings]
+        self.assertIn('MISSING', kinds)
+
+    def test_catches_type_mismatch(self):
+        broken_idl = {
+            'members': {
+                'url': {'type': 'boolean', 'required': False},
+                'active': {'type': 'boolean', 'required': False},
+                'index': {'type': 'double', 'required': False},
+            }
+        }
+        findings = diff_dictionary('TabCreateProperties', broken_idl, self.clean_parse_func, {})
+        kinds = [f[0] for f in findings]
+        self.assertIn('TYPE', kinds)
+
+    def test_catches_optionality_mismatch(self):
+        broken_idl = {
+            'members': {
+                'url': {'type': 'DOMString', 'required': True},
+                'active': {'type': 'boolean', 'required': False},
+                'index': {'type': 'double', 'required': False},
+            }
+        }
+        findings = diff_dictionary('TabCreateProperties', broken_idl, self.clean_parse_func, {})
+        kinds = [f[0] for f in findings]
+        self.assertIn('OPTIONALITY', kinds)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### c691177463029c907b78c21215a9ca3aab6ce499
<pre>
Declare WebExtension dictionary and enum types in WebIDL
<a href="https://bugs.webkit.org/show_bug.cgi?id=321740">https://bugs.webkit.org/show_bug.cgi?id=321740</a>

Reviewed by Timothy Hatcher.

The WebExtension IDL files declare dictionary parameters as untyped any
values, with the expected keys and types defined only in Cocoa parse
functions and validateDictionary tables. This adds WebIDL dictionary and
enum declarations matching the existing C++ and Objective-C parameter
validation for 21 extension interfaces, describing the current
implementation without changing runtime behavior.

The declarations are not referenced by operation parameters.
CodeGeneratorExtensions.pm:1481 maps a named parameter type to a wrapped
C++ class, so [NSDictionary] WebExtensionTabCreateProperties would emit a
call to toWebExtensionTabCreateProperties() and an include for
WebExtensionTabCreateProperties.h, neither of which exist. Parameters stay
[NSDictionary] any for that reason.

Generated bindings are byte-identical. CodeGeneratorExtensions.pm processes
only interface operations and ignores top-level dictionary definitions, so
running generate-bindings.pl across all modified IDL files produces
identical C++ headers and implementation files.

Tools/Scripts/verify-webextension-declarations checks that dictionary keys,
types, and optionality declared in WebExtension IDL match the corresponding
validateDictionary tables in Source/WebKit/WebProcess/Extensions/API/, so the
two cannot drift apart silently. It currently covers 16 input parameter
dictionaries validated in the Cocoa and C++ parse functions; the return entity
dictionaries built by the toWebAPI() serializers are not yet covered.

* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIBookmarks.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPICommands.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPICookies.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDeclarativeNetRequest.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIMenus.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIOffscreen.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIPermissions.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIScripting.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPISidePanel.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPISidebarAction.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindows.idl:
* Tools/Scripts/verify-webextension-declarations: Added.
* Tools/Scripts/webkitpy/webextensions/__init__.py: Added.
* Tools/Scripts/webkitpy/webextensions/verify_webextension_declarations_unittest.py: Added.

Canonical link: <a href="https://commits.webkit.org/319241@main">https://commits.webkit.org/319241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90f1a506a9c27f4eb014bdc9302516adf1928e37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191130 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145239 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141145 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121596 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180240 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43482 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41760 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41420 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2290 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193065 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54527 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150528 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55215 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38038 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150246 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27460 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44839 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127481 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122865 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53732 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16413 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53114 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->