### PR TITLE
[css-values-5 random-item()] auto random() and random-item() in the same property value get the same random value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt
@@ -33,5 +33,6 @@ PASS A shared dashed-ident key selects the same item across properties
 PASS random() and random-item() using auto in one declaration both resolve
 PASS A bare element-scoped key selects the same item across random-item() instances
 PASS random() and random-item() share the base value for a bare element-scoped key
+PASS auto random() and auto random-item() in one value do not share a base value
 PASS Property color value 'random-item(--, rgb(1, 0, 0), rgb(0, 1, 0))'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html
@@ -204,6 +204,31 @@ test(() => {
     assert_equals(m, Math.min(400, Math.floor(w / 100) * 100), 'random() and random-item() share the element-scoped base value');
 }, 'random() and random-item() share the base value for a bare element-scoped key');
 
+// One source-order index sequence spans both functions, so an auto random() and an auto random-item()
+// in the same value get different indexes and draw independently. With random() scaled to 0-400px and
+// two items 0/1000px, a shared draw would make the item choice track whether random() landed above
+// half; over 40 samples that agreeing every time is about 1 in 10^12.
+test(() => {
+    let consistentWithSharing = 0;
+    const holder = document.createElement('div');
+    document.body.appendChild(holder);
+    try {
+        for (let i = 0; i < 40; ++i) {
+            const element = document.createElement('div');
+            element.style.cssText = 'width: calc(random(auto, 0px, 400px) + random-item(auto, 0px, 1000px))';
+            holder.appendChild(element);
+            const width = parseFloat(getComputedStyle(element).width);
+            const selectedSecondItem = width >= 1000;
+            const randomFraction = (width - (selectedSecondItem ? 1000 : 0)) / 400;
+            if ((randomFraction >= 0.5) === selectedSecondItem)
+                ++consistentWithSharing;
+        }
+    } finally {
+        document.body.removeChild(holder);
+    }
+    assert_less_than(consistentWithSharing, 40, 'random() and random-item() drew the same base value');
+}, 'auto random() and auto random-item() in one value do not share a base value');
+
 // A <dashed-ident> as short as "--" is a valid key (parity with random()); the value resolves rather
 // than becoming guaranteed-invalid.
 test_computed_value('color', 'random-item(--, rgb(1, 0, 0), rgb(0, 1, 0))', ['rgb(1, 0, 0)', 'rgb(0, 1, 0)']);

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -678,9 +678,19 @@ static std::optional<TypedChild> consumeRandom(CSSParserTokenRange& tokens, int 
         .autoElementScoped = CSS::Keyword::ElementScoped { }
     };
 
+    // Substitution assigns indexes when a value mixes random() with random-item(), since random-item()
+    // is resolved and gone before this parse. Replay them rather than counting from zero.
+    auto& parserState = state.propertyParserState;
+    auto indexForThisFunction = [&] {
+        auto reserved = parserState.cssRandomFunctionIndexes;
+        if (parserState.cssRandomFunctionCount < reserved.size())
+            return reserved[parserState.cssRandomFunctionCount];
+        return parserState.cssRandomFunctionCount;
+    };
+
     std::optional<Random::Sharing> sharing;
     if (auto optionalSharing = CSSPropertyParserHelpers::consumeUnresolvedRandomKey(tokens, state.propertyParserState, keySource, [&] {
-        return state.propertyParserState.cssRandomFunctionCount;
+        return indexForThisFunction();
     })) {
         if (!CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(tokens)) {
             LOG_WITH_STREAM(Calc, stream << "Failed '" << nameLiteralForSerialization(Op::id) << "' function - missing comma after <random-key>");
@@ -689,7 +699,7 @@ static std::optional<TypedChild> consumeRandom(CSSParserTokenRange& tokens, int 
 
         sharing = WTF::move(optionalSharing);
     } else
-        sharing = CSSPropertyParserHelpers::randomSharingAuto(keySource, state.propertyParserState.cssRandomFunctionCount);
+        sharing = CSSPropertyParserHelpers::randomSharingAuto(keySource, indexForThisFunction());
 
     // Increment the random function count early, but after processing the the sharing production to
     // ensure that any nested random() functions in the <calc-sum> productions have an incremented value.

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -94,7 +94,7 @@ static std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> 
 // MARK: - Root consumers
 
 // Style properties.
-static bool consumeStyleProperty(CSSParserTokenRange&, const CSSParserContext&, CSSPropertyID, IsImportant, StyleRuleType, CSS::PropertyParserResult&, const CSSNamespacePrefixMap& = { });
+static bool consumeStyleProperty(CSSParserTokenRange&, const CSSParserContext&, CSSPropertyID, IsImportant, StyleRuleType, CSS::PropertyParserResult&, const CSSNamespacePrefixMap& = { }, std::span<const unsigned> randomFunctionIndexes = { });
 
 // @font-face descriptors.
 static bool consumeFontFaceDescriptor(CSSParserTokenRange&, const CSSParserContext&, CSSPropertyID, CSS::PropertyParserResult&);
@@ -221,7 +221,7 @@ static RefPtr<CSSValue> consumeCSSWideKeywordValue(CSSParserTokenRange& range)
 
 using namespace CSSPropertyParserHelpers;
 
-bool CSSPropertyParser::parseValue(CSSPropertyID property, IsImportant important, CSSParserTokenRange range, const CSSParserContext& context, ParsedPropertyVector& parsedProperties, StyleRuleType ruleType, const CSSNamespacePrefixMap& namespaceMap)
+bool CSSPropertyParser::parseValue(CSSPropertyID property, IsImportant important, CSSParserTokenRange range, const CSSParserContext& context, ParsedPropertyVector& parsedProperties, StyleRuleType ruleType, const CSSNamespacePrefixMap& namespaceMap, std::span<const unsigned> randomFunctionIndexes)
 {
     int initialParsedPropertiesSize = parsedProperties.size();
 
@@ -259,7 +259,7 @@ bool CSSPropertyParser::parseValue(CSSPropertyID property, IsImportant important
         parseSuccess = consumeFunctionDescriptor(range, context, property, result);
         break;
     default:
-        parseSuccess = consumeStyleProperty(range, context, property, important, ruleType, result, namespaceMap);
+        parseSuccess = consumeStyleProperty(range, context, property, important, ruleType, result, namespaceMap, randomFunctionIndexes);
         break;
     }
 
@@ -300,7 +300,7 @@ RefPtr<CSSValue> CSSPropertyParser::parseStylePropertyLonghand(CSSPropertyID pro
     return value;
 }
 
-RefPtr<CSSValue> CSSPropertyParser::parseStylePropertyLonghand(CSSPropertyID property, CSSParserTokenRange range, const CSSParserContext& context)
+RefPtr<CSSValue> CSSPropertyParser::parseStylePropertyLonghand(CSSPropertyID property, CSSParserTokenRange range, const CSSParserContext& context, std::span<const unsigned> randomFunctionIndexes)
 {
     ASSERT(!WebCore::isShorthand(property));
 
@@ -314,6 +314,7 @@ RefPtr<CSSValue> CSSPropertyParser::parseStylePropertyLonghand(CSSPropertyID pro
         .currentRule = StyleRuleType::Style,
         .currentProperty = property,
         .important = IsImportant::No,
+        .cssRandomFunctionIndexes = randomFunctionIndexes,
     };
 
     RefPtr value = CSSPropertyParsing::parseStylePropertyLonghand(range, property, state);
@@ -353,7 +354,7 @@ RefPtr<CSSValue> CSSPropertyParser::parseCounterStyleDescriptor(CSSPropertyID pr
 
 // MARK: - Custom properties
 
-std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> CSSPropertyParser::parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax& syntax, CSSParserTokenRange range, Style::BuilderState& builderState, const CSSParserContext& context, Style::IsAttrTainted isAttrTainted)
+std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> CSSPropertyParser::parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax& syntax, CSSParserTokenRange range, Style::BuilderState& builderState, const CSSParserContext& context, Style::IsAttrTainted isAttrTainted, std::span<const unsigned> randomFunctionIndexes)
 {
     auto state = CSS::PropertyParserState {
         .context = context,
@@ -361,6 +362,7 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> CSSProp
         .currentProperty = CSSPropertyCustom,
         .currentCustomPropertyName = name,
         .important = IsImportant::No,
+        .cssRandomFunctionIndexes = randomFunctionIndexes,
         .randomFunctionsDisallowed = builderState.isResolvingContainerQueries(),
     };
 
@@ -608,7 +610,7 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> consume
 
 // MARK: - Root consumers
 
-bool consumeStyleProperty(CSSParserTokenRange& range, const CSSParserContext& context, CSSPropertyID property, IsImportant important, StyleRuleType ruleType, CSS::PropertyParserResult& result, const CSSNamespacePrefixMap& namespaceMap)
+bool consumeStyleProperty(CSSParserTokenRange& range, const CSSParserContext& context, CSSPropertyID property, IsImportant important, StyleRuleType ruleType, CSS::PropertyParserResult& result, const CSSNamespacePrefixMap& namespaceMap, std::span<const unsigned> randomFunctionIndexes)
 {
     if (CSSProperty::isDescriptorOnly(property))
         return false;
@@ -618,6 +620,7 @@ bool consumeStyleProperty(CSSParserTokenRange& range, const CSSParserContext& co
         .currentRule = ruleType,
         .currentProperty = property,
         .important = important,
+        .cssRandomFunctionIndexes = randomFunctionIndexes,
     };
 
     if (WebCore::isShorthand(property)) {

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -54,17 +54,17 @@ enum class IsAttrTainted : bool;
 class CSSPropertyParser {
 public:
     // Parses any CSS property or descriptor. If successful, the result will be appended to the `result` Vector and the function will return true, otherwise, the function will return false and the `result` Vector will be unmodified.
-    static bool parseValue(CSSPropertyID, IsImportant, CSSParserTokenRange, const CSSParserContext&, Vector<CSSProperty, 256>& result, StyleRuleType, const CSSNamespacePrefixMap& = { });
+    static bool parseValue(CSSPropertyID, IsImportant, CSSParserTokenRange, const CSSParserContext&, Vector<CSSProperty, 256>& result, StyleRuleType, const CSSNamespacePrefixMap& = { }, std::span<const unsigned> randomFunctionIndexes = { });
 
     // Parses a longhand style property.
     static RefPtr<CSSValue> parseStylePropertyLonghand(CSSPropertyID, const String&, const CSSParserContext&);
-    static RefPtr<CSSValue> parseStylePropertyLonghand(CSSPropertyID, CSSParserTokenRange, const CSSParserContext&);
+    static RefPtr<CSSValue> parseStylePropertyLonghand(CSSPropertyID, CSSParserTokenRange, const CSSParserContext&, std::span<const unsigned> randomFunctionIndexes = { });
 
     // Parses a @counter-style descriptor.
     static RefPtr<CSSValue> parseCounterStyleDescriptor(CSSPropertyID, const String&, const CSSParserContext&);
 
     static RefPtr<const Style::CustomProperty> parseTypedCustomPropertyInitialValue(const AtomString&, const CSSCustomPropertySyntax&, CSSParserTokenRange, Style::BuilderState&, const CSSParserContext&);
-    static std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax&, CSSParserTokenRange, Style::BuilderState&, const CSSParserContext&, Style::IsAttrTainted);
+    static std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax&, CSSParserTokenRange, Style::BuilderState&, const CSSParserContext&, Style::IsAttrTainted, std::span<const unsigned> randomFunctionIndexes = { });
 
     static ComputedStyleDependencies collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
     static bool isValidCustomPropertyValueForSyntax(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);

--- a/Source/WebCore/css/parser/CSSPropertyParserState.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserState.h
@@ -28,6 +28,7 @@
 #include "CSSPropertyNames.h"
 #include "CSSValuePool.h"
 #include "StyleRuleType.h"
+#include <span>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -48,6 +49,11 @@ struct PropertyParserState {
 
     // Count of CSS random() functions seen so far for the current property.
     unsigned cssRandomFunctionCount { 0 };
+
+    // <random-key> indexes reserved for the random() functions in this value, in source order, when
+    // substitution has already assigned them alongside random-item(). Empty when there was no
+    // substitution, in which case cssRandomFunctionCount is the index.
+    std::span<const unsigned> cssRandomFunctionIndexes { };
 
     // Set where there is no element to key a random draw to: a @container style() query value or an @property initial value.
     // FIXME: Should cover every function needing an element context, like the tree counting ones, not just random(). https://github.com/w3c/csswg-drafts/issues/10982

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -814,7 +814,7 @@ std::optional<Builder::CustomPropertyOrKeyword> Builder::resolveCustomPropertyVa
         }
     }
 
-    return CSSPropertyParser::parseTypedCustomPropertyValue(name, registered->syntax, resolvedData->tokens(), m_state, resolvedData->context(), isAttrTainted);
+    return CSSPropertyParser::parseTypedCustomPropertyValue(name, registered->syntax, resolvedData->tokens(), m_state, resolvedData->context(), isAttrTainted, m_state->m_randomFunctionIndexes.span());
 }
 
 void Builder::applyPageSizeDescriptor(CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -305,6 +305,10 @@ private:
     bool m_fontDirty { false };
     Vector<RegisteredSubstitutionAttribute> m_registeredSubstitutionAttributes;
 
+    // <random-key> indexes for the random() functions in the value being resolved, in source order.
+    // Substitution assigns them alongside random-item(), which is gone by the time the value is parsed.
+    Vector<unsigned> m_randomFunctionIndexes;
+
     bool m_isBuildingKeyframeStyle { false };
     bool m_hasRevertRuleOrLayerInKeyframeStyle { false };
     bool m_isResolvingContainerQueries { false };

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -1083,7 +1083,7 @@ std::optional<double> SubstitutionResolver::randomItemBaseValue(Vector<CSSParser
         .autoElementScoped = CSS::Keyword::ElementScoped { }
     };
     auto sharing = CSSPropertyParserHelpers::consumeUnresolvedRandomKey(randomKeyRange, parserState, keySource, [&] {
-        return m_randomItemAutoIndex++;
+        return m_randomFunctionIndex++;
     });
     if (!sharing || !randomKeyRange.atEnd())
         return { };
@@ -1258,6 +1258,9 @@ std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange
 
         updateURLContext(token);
 
+        if (token.type() == FunctionToken && token.functionId() == CSSValueRandom)
+            m_styleBuilder.state().m_randomFunctionIndexes.append(m_randomFunctionIndex++);
+
         tokens.append(range.consume());
     }
     if (!success)
@@ -1312,7 +1315,8 @@ RefPtr<CSSVariableData> SubstitutionResolver::substitute(const CSSSubstitutionVa
 {
     m_isAttrTainted = false;
     m_hasTaintedURL = false;
-    m_randomItemAutoIndex = 0;
+    m_randomFunctionIndex = 0;
+    m_styleBuilder.state().m_randomFunctionIndexes.clear();
     m_substitutionValue = &value;
 
     if (auto data = trySimpleSubstitution(value)) {
@@ -1346,7 +1350,7 @@ RefPtr<CSSValue> SubstitutionResolver::substituteAndParse(const CSSSubstitutionV
         return nullptr;
 
     if (!arePointingToEqualData(substitutionValue.m_cache.dependencyData, data) || substitutionValue.m_cache.propertyID != propertyID) {
-        substitutionValue.m_cache.value = CSSPropertyParser::parseStylePropertyLonghand(propertyID, data->tokens(), substitutionValue.context());
+        substitutionValue.m_cache.value = CSSPropertyParser::parseStylePropertyLonghand(propertyID, data->tokens(), substitutionValue.context(), m_styleBuilder.state().m_randomFunctionIndexes.span());
         substitutionValue.m_cache.propertyID = propertyID;
     }
     substitutionValue.m_cache.dependencyData = WTF::move(data);
@@ -1372,7 +1376,7 @@ RefPtr<CSSValue> SubstitutionResolver::substituteAndParseShorthand(const CSSShor
 
     if (!arePointingToEqualData(substitutionValue.m_cache.dependencyData, data)) {
         ParsedPropertyVector parsedProperties;
-        if (!CSSPropertyParser::parseValue(substitution.m_shorthandPropertyId, IsImportant::No, data->tokens(), data->context(), parsedProperties, StyleRuleType::Style))
+        if (!CSSPropertyParser::parseValue(substitution.m_shorthandPropertyId, IsImportant::No, data->tokens(), data->context(), parsedProperties, StyleRuleType::Style, { }, m_styleBuilder.state().m_randomFunctionIndexes.span()))
             substitution.m_cachedPropertyValues = { };
         else
             substitution.m_cachedPropertyValues = parsedProperties;

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -119,7 +119,9 @@ private:
     Vector<WTF::String> m_intermediateTokenStrings;
     Vector<RefPtr<const CustomProperty>> m_intermediateCustomProperties;
     unsigned m_urlContextDepth { 0 };
-    unsigned m_randomItemAutoIndex { 0 };
+    // Indexes run in one source-order sequence across random() and random-item(). The list of those
+    // assigned to random() lives on BuilderState, which outlives this resolver in the custom property path.
+    unsigned m_randomFunctionIndex { 0 };
     bool m_isAttrTainted { false };
     bool m_hasTaintedURL { false };
 };


### PR DESCRIPTION
#### 83b7a17f8140efd9ab1b5b840318dd040ce14a32
<pre>
[css-values-5 random-item()] auto random() and random-item() should share a common &lt;random-key&gt; index
<a href="https://bugs.webkit.org/show_bug.cgi?id=319919">https://bugs.webkit.org/show_bug.cgi?id=319919</a>
<a href="https://rdar.apple.com/182846761">rdar://182846761</a>

Reviewed by NOBODY (OOPS!).

A property-index-scoped &lt;random-key&gt; is scoped to &quot;the index of the random
function among all the random functions used in the same property value&quot;, one
sequence spanning random() and random-item(). Each counted from zero in its own
space instead, so an auto random() and an auto random-item() in one value both
claimed index 0 and, being on the same property and element, resolved to the same
base value. <a href="https://commits.webkit.org/319153@main">319153@main</a> made this reachable by giving random-item()&apos;s `auto` the
element scoping it was missing.

The two are counted in different phases: random() at parse time, random-item()
during substitution, which resolves it and splices in the selected item before
the value is ever parsed. So the parser cannot see a random-item() to count, and
substitution cannot know what index the parser would reach.

Count both in SubstitutionResolver, which already walks the value in source
order. random-item() takes an index when it resolves, and each random() function
token takes one as it is appended to the output. Counting at the append rather
than on sight keeps an unused var() fallback from consuming an index. The indexes
handed to random() are recorded on BuilderState, which outlives the resolver in
the custom property path, and consumeRandom() replays them instead of counting
from zero. Values that were never substituted carry an empty list and keep
counting as before.

Threaded through all three paths that parse a substituted value: longhand,
shorthand, and registered custom property.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::consumeRandom):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeStyleProperty):
(WebCore::CSSPropertyParser::parseValue):
(WebCore::CSSPropertyParser::parseStylePropertyLonghand):
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/css/parser/CSSPropertyParserState.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveCustomPropertyValue):
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::randomItemBaseValue):
(WebCore::Style::SubstitutionResolver::substituteTokenRange):
(WebCore::Style::SubstitutionResolver::substitute):
(WebCore::Style::SubstitutionResolver::substituteAndParse):
(WebCore::Style::SubstitutionResolver::substituteAndParseShorthand):
* Source/WebCore/style/StyleSubstitutionResolver.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83b7a17f8140efd9ab1b5b840318dd040ce14a32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190871 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144982 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3260bed-4ace-426e-989e-fafb0cf47b7b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140912 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b43feecb-fb3f-4068-a6af-ab08641e52c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121364 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/20955367-0bb1-4ec7-ae56-9c86337b8401) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43260 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41543 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41219 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2032 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192808 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150294 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54959 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37837 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150011 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44626 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127224 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122440 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53476 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16212 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52858 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53095 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52923 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->