### PR TITLE
[Site Isolation] Validate the target frame of cross-process postMessage and focus

### DIFF
--- a/LayoutTests/http/tests/site-isolation/post-message-forged-source-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/post-message-forged-source-frame-expected.txt
@@ -1,0 +1,2 @@
+Tests that a WebContent process cannot postMessage as a frame it does not host.
+PASS

--- a/LayoutTests/http/tests/site-isolation/post-message-forged-source-frame.html
+++ b/LayoutTests/http/tests/site-isolation/post-message-forged-source-frame.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+<!-- Cross-site, so the iframe runs in another process and can replay a message this process sent. -->
+<iframe id="frame" src="http://localhost:8000/site-isolation/resources/post-message-forged-source-iframe.html"></iframe>
+<script>
+// The IPC testing API is compiled into debug and ASan builds only, so this test reports the same
+// result whether or not it can forge a message.
+const summary = "Tests that a WebContent process cannot postMessage as a frame it does not host.";
+
+let captured = false;
+let replayed = false;
+let finished = false;
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function finish(result) {
+    if (finished)
+        return;
+    finished = true;
+    document.body.innerText = summary + "\n" + result;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+addEventListener("message", (event) => {
+    if (event.data == "loaded") {
+        if (!window.IPC) {
+            finish("PASS");
+            return;
+        }
+
+        IPC.addOutgoingMessageListener("UI", (description) => {
+            if (captured || !description || !description.buffer)
+                return;
+            if (description.name !== IPC.messages.WebPageProxy_PostMessageToRemote.name)
+                return;
+            captured = true;
+
+            // slice(16) drops the message header, which IPC.sendMessage writes itself.
+            frame.contentWindow.postMessage({
+                replay: true,
+                name: description.name,
+                bytes: new Uint8Array(description.buffer).slice(16),
+            }, "*");
+        });
+
+        // This message names this frame as its source, and the iframe's process does not host it.
+        frame.contentWindow.postMessage("probe", "*");
+        return;
+    }
+
+    if (event.data == "ipc unavailable") {
+        finish("PASS");
+        return;
+    }
+
+    if (event.data == "replayed") {
+        replayed = true;
+        frame.contentWindow.postMessage("count", "*");
+        return;
+    }
+
+    if (typeof event.data != "string" || !event.data.startsWith("probe count "))
+        return;
+
+    if (!replayed)
+        finish("FAIL: the iframe did not replay the message.");
+    else if (event.data != "probe count 1")
+        finish("FAIL: the iframe reported \"" + event.data + "\", expected \"probe count 1\".");
+    else
+        finish("PASS");
+});
+
+setTimeout(() => finish("FAIL: timed out."), 20000);
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/post-message-forged-source-origin-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/post-message-forged-source-origin-expected.txt
@@ -1,0 +1,2 @@
+Tests that an opaque-origin frame cannot be named as the source of a message claiming a real origin.
+PASS

--- a/LayoutTests/http/tests/site-isolation/post-message-forged-source-origin.html
+++ b/LayoutTests/http/tests/site-isolation/post-message-forged-source-origin.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+<!-- Sandboxed and same-site, so this frame has an opaque origin and stays in this process. -->
+<iframe id="sandboxed" sandbox="allow-scripts" src="resources/post-message-forged-source-origin-sandboxed.html"></iframe>
+<!-- Cross-site, so it runs in another process and reports the origin it observes. -->
+<iframe id="victim" src="http://localhost:8000/site-isolation/resources/post-message-forged-source-origin-victim.html"></iframe>
+<script>
+// The IPC testing API is compiled into debug and ASan builds only, so this test reports the same
+// result whether or not it can forge a message.
+const summary = "Tests that an opaque-origin frame cannot be named as the source of a message claiming a real origin.";
+
+// A PostMessageToRemote body starts with the source FrameIdentifier, an ObjectIdentifier, followed
+// by sourceOrigin, whose leading variant index is 0 for a real origin and 1 for an opaque one.
+const sourceSize = 8;
+const originVariantIsOpaque = 1;
+
+let loaded = 0;
+let bodyClaimingThisOrigin;
+let opaqueSource;
+let replayed = false;
+let probesSeenByVictim = 0;
+let finished = false;
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function finish(result) {
+    if (finished)
+        return;
+    finished = true;
+    document.body.innerText = summary + "\n" + result;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+addEventListener("message", (event) => {
+    if (event.data == "sandboxed loaded" || event.data == "victim loaded") {
+        if (++loaded == 2)
+            runTest();
+        return;
+    }
+
+    if (event.data == "victim got probe from http://127.0.0.1:8000") {
+        ++probesSeenByVictim;
+        return;
+    }
+
+    if (!event.data.startsWith("victim got done "))
+        return;
+
+    if (!replayed)
+        finish("FAIL: captured no pair of messages to splice.");
+    else if (probesSeenByVictim != 1)
+        finish("FAIL: the victim saw " + probesSeenByVictim + " probes, expected 1.");
+    else
+        finish("PASS");
+});
+
+function runTest() {
+    if (!window.IPC) {
+        finish("PASS");
+        return;
+    }
+
+    IPC.addOutgoingMessageListener("UI", (description) => {
+        if (replayed || !description || !description.buffer)
+            return;
+        if (description.name !== IPC.messages.WebPageProxy_PostMessageToRemote.name)
+            return;
+
+        // slice(16) drops the message header, which IPC.sendMessage writes itself.
+        const body = new Uint8Array(description.buffer).slice(16);
+        if (body[sourceSize] == originVariantIsOpaque)
+            opaqueSource = body.slice(0, sourceSize);
+        else
+            bodyClaimingThisOrigin = body;
+
+        if (!opaqueSource || !bodyClaimingThisOrigin)
+            return;
+
+        // Name the opaque-origin frame as the source of a message that claims this page's real
+        // origin. The victim would otherwise read that origin as event.origin.
+        bodyClaimingThisOrigin.set(opaqueSource, 0);
+        replayed = true;
+        IPC.sendMessage("UI", description.destinationID, description.name, bodyClaimingThisOrigin);
+        victim.contentWindow.postMessage("done", "*");
+    });
+
+    sandboxed.contentWindow.postMessage("post to victim", "*");
+    victim.contentWindow.postMessage("probe", "*");
+}
+
+victim.addEventListener("load", () => window.postMessage("victim loaded", "*"));
+setTimeout(() => finish("FAIL: timed out."), 20000);
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/post-message-forged-target-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/post-message-forged-target-frame-expected.txt
@@ -1,0 +1,2 @@
+Tests that a WebContent process cannot postMessage into a frame belonging to another page.
+PASS

--- a/LayoutTests/http/tests/site-isolation/post-message-forged-target-frame.html
+++ b/LayoutTests/http/tests/site-isolation/post-message-forged-target-frame.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+<!-- Cross-site, so this page is also represented in the opened window's process. -->
+<iframe id="frame" src="http://localhost:8000/site-isolation/resources/post-message-to-parent.html" onload="runTest()"></iframe>
+<script>
+// The IPC testing API is compiled into debug and ASan builds only, so this test reports the same
+// result whether or not it can forge a message.
+const summary = "Tests that a WebContent process cannot postMessage into a frame belonging to another page.";
+
+let openedWindow;
+let ownPageDestination;
+let replayed = false;
+let probesReceivedByOpenedWindow = 0;
+let finished = false;
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function finish(result) {
+    if (finished)
+        return;
+    finished = true;
+    document.body.innerText = summary + "\n" + result;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+addEventListener("message", (event) => {
+    if (event.data == "opened window loaded") {
+        frame.contentWindow.postMessage("probe", "*");
+        return;
+    }
+
+    if (event.data == "iframe received probe") {
+        openedWindow.postMessage("probe", "*");
+        return;
+    }
+
+    if (event.data == "opened window received probe") {
+        ++probesReceivedByOpenedWindow;
+        return;
+    }
+
+    if (event.data != "opened window received done")
+        return;
+
+    if (!replayed)
+        finish("FAIL: captured no PostMessageToRemote naming the opened window's page.");
+    else if (probesReceivedByOpenedWindow != 1)
+        finish("FAIL: the opened window received " + probesReceivedByOpenedWindow + " probes, expected 1.");
+    else
+        finish("PASS");
+});
+
+function runTest() {
+    if (!window.IPC) {
+        finish("PASS");
+        return;
+    }
+
+    IPC.addOutgoingMessageListener("UI", (description) => {
+        if (replayed || !description || !description.buffer)
+            return;
+        if (description.name !== IPC.messages.WebPageProxy_PostMessageToRemote.name)
+            return;
+
+        // The first message is posted on this page, the second on the opened window's page. Send the
+        // second one to this page instead, naming a frame this page has no reference to.
+        if (ownPageDestination === undefined) {
+            ownPageDestination = description.destinationID;
+            return;
+        }
+        if (description.destinationID === ownPageDestination)
+            return;
+        replayed = true;
+        // slice(16) drops the message header, which IPC.sendMessage writes itself.
+        IPC.sendMessage("UI", ownPageDestination, description.name, new Uint8Array(description.buffer).slice(16));
+        openedWindow.postMessage("done", "*");
+    });
+
+    openedWindow = window.open("http://localhost:8000/site-isolation/resources/post-message-forged-target-popup.html");
+}
+
+setTimeout(() => finish("FAIL: timed out."), 20000);
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-iframe.html
@@ -1,0 +1,31 @@
+<script>
+let probeCount = 0;
+
+addEventListener("message", (event) => {
+    if (event.data == "probe") {
+        ++probeCount;
+        return;
+    }
+
+    if (event.data == "count") {
+        parent.postMessage("probe count " + probeCount, "*");
+        return;
+    }
+
+    if (!event.data || !event.data.replay)
+        return;
+
+    if (!window.IPC) {
+        parent.postMessage("ipc unavailable", "*");
+        return;
+    }
+
+    // Address the page by this process's own PageIdentifier; each process has its own for one page.
+    IPC.sendMessage("UI", IPC.pageID, event.data.name, event.data.bytes);
+    parent.postMessage("replayed", "*");
+});
+
+onload = () => {
+    parent.postMessage("loaded", "*");
+};
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-origin-sandboxed.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-origin-sandboxed.html
@@ -1,0 +1,13 @@
+<script>
+onload = () => {
+    parent.postMessage("sandboxed loaded", "*");
+};
+
+addEventListener("message", (event) => {
+    if (event.data != "post to victim")
+        return;
+    // frames[1] is the cross-site iframe, so this produces a PostMessageToRemote whose source is
+    // this opaque-origin frame.
+    parent.frames[1].postMessage("from sandbox", "*");
+});
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-origin-victim.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-origin-victim.html
@@ -1,0 +1,5 @@
+<script>
+addEventListener("message", (event) => {
+    parent.postMessage("victim got " + event.data + " from " + event.origin, "*");
+});
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/post-message-forged-target-popup.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-message-forged-target-popup.html
@@ -1,0 +1,9 @@
+<script>
+addEventListener("message", (event) => {
+    opener.postMessage("opened window received " + event.data, "*");
+});
+
+onload = () => {
+    opener.postMessage("opened window loaded", "*");
+};
+</script>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -19077,10 +19077,9 @@ INSTANTIATE_SEND_SYNC_TO_PROCESS_CONTAINING_FRAME(WebPage::SyncApplyAutocorrecti
 void WebPageProxy::focusRemoteFrame(IPC::Connection& connection, WebCore::FrameIdentifier frameID, std::optional<WebCore::UserGestureTokenIdentifier> userGestureTokenIdentifier)
 {
     RefPtr destinationFrame = WebFrameProxy::webFrame(frameID);
-    if (!destinationFrame || !destinationFrame->isMainFrame())
+    if (!destinationFrame || !destinationFrame->isMainFrame() || !destinationFrame->page())
         return;
-
-    ASSERT(destinationFrame->page() == this);
+    MESSAGE_CHECK_BASE(destinationFrame->page() == this, connection);
 
     if (userGestureTokenIdentifier) {
         if (RefPtr userInitiatedAction = WebProcessProxy::fromConnection(connection)->userInitiatedActivity(userGestureTokenIdentifier)) {
@@ -19094,8 +19093,30 @@ void WebPageProxy::focusRemoteFrame(IPC::Connection& connection, WebCore::FrameI
     setFocus(true);
 }
 
-void WebPageProxy::postMessageToRemote(WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts& message, std::optional<WebCore::UserGestureTokenData>&& userGestureToken)
+void WebPageProxy::postMessageToRemote(IPC::Connection& connection, WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts& message, std::optional<WebCore::UserGestureTokenData>&& userGestureToken)
 {
+    // This message is posted on the page owning the target frame, so another page's frame is forged.
+    // The source frame belongs to any page referencing the target, such as an opener.
+    RefPtr sourceFrame = WebFrameProxy::webFrame(source);
+    RefPtr targetFrame = WebFrameProxy::webFrame(target);
+    if (!sourceFrame || !targetFrame || !targetFrame->page())
+        return;
+    MESSAGE_CHECK_BASE(targetFrame->page() == this, connection);
+
+    // event.source and event.origin come from source and sourceOrigin, so the sending process must
+    // host the source frame. A frame that just committed elsewhere still runs pageswap and unload
+    // handlers here, which is a race, so drop the message instead of terminating the sender.
+    if (&sourceFrame->process() != WebProcessProxy::fromConnection(connection).ptr()) {
+        WEBPAGEPROXY_RELEASE_LOG_ERROR(Process, "postMessageToRemote: the sending process does not host the source frame");
+        return;
+    }
+
+    // A frame may only claim the origin the UI process derives for it, or an opaque one. Claiming
+    // opaque is a downgrade to "null" and is the one case the UI process cannot derive: a
+    // Content-Security-Policy sandbox header makes a document opaque without a sandbox flag here.
+    auto expectedSourceOrigin = sourceFrame->documentSecurityOriginData();
+    MESSAGE_CHECK_BASE(sourceOrigin.isOpaque() || sourceOrigin == expectedSourceOrigin, connection);
+
     if (message.transferredPorts.isEmpty()) {
         sendToProcessContainingFrame(target, Messages::WebPage::RemotePostMessage(source, sourceOrigin, target, targetOrigin, message, userGestureToken));
         return;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3666,7 +3666,7 @@ private:
     void broadcastFocusedFrameToOtherProcesses(IPC::Connection&, std::optional<WebCore::FrameIdentifier>&&);
 
     void focusRemoteFrame(IPC::Connection&, WebCore::FrameIdentifier, std::optional<WebCore::UserGestureTokenIdentifier>);
-    void postMessageToRemote(WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts&, std::optional<WebCore::UserGestureTokenData>&&);
+    void postMessageToRemote(IPC::Connection&, WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts&, std::optional<WebCore::UserGestureTokenData>&&);
     void renderTreeAsTextForTesting(WebCore::FrameIdentifier, uint64_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);
     void layerTreeAsTextForTesting(WebCore::FrameIdentifier, uint64_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>, CompletionHandler<void(String&&)>&&);
     void dispatchCrossOriginBeforeUnloadCheckForFrame(WebCore::FrameIdentifier, WebCore::SecurityOriginData&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10499,7 +10499,7 @@ void WebPage::frameWasFocusedInAnotherProcess(std::optional<WebCore::FrameIdenti
 void WebPage::remotePostMessage(WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData>&& targetOrigin, const WebCore::MessageWithMessagePorts& message, std::optional<WebCore::UserGestureTokenData>&& userGestureToken)
 {
     RefPtr targetFrame = WebProcess::singleton().webFrame(target);
-    if (!targetFrame)
+    if (!targetFrame || targetFrame->page() != this)
         return;
 
     if (!targetFrame->coreLocalFrame())


### PR DESCRIPTION
#### e53c3dd52bd76c766a8c3ecceaac4f9ebb0dc1b7
<pre>
[Site Isolation] Validate the target frame of cross-process postMessage and focus
<a href="https://bugs.webkit.org/show_bug.cgi?id=321743">https://bugs.webkit.org/show_bug.cgi?id=321743</a>
<a href="https://rdar.apple.com/184871551">rdar://184871551</a>

Reviewed by NOBODY (OOPS!).

Under Site Isolation, WebPageProxy::postMessageToRemote and
WebPageProxy::focusRemoteFrame resolved a frame identifier supplied by the
sending WebContent process through a global frame map, so a compromised
process could name a frame belonging to another page and have a message
delivered into a window it holds no reference to, or focus another page&apos;s
main frame.

Both messages are posted on the page owning the frame they name, so that
frame always belongs to the page receiving the message. focusRemoteFrame
already ASSERTed this; make it a message check, do the same in
postMessageToRemote, and check it again in the WebContent process, which
resolves the identifier through a process-global map of its own.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::focusRemoteFrame):
(WebKit::WebPageProxy::postMessageToRemote):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::remotePostMessage):
* LayoutTests/http/tests/site-isolation/post-message-forged-target-frame-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/post-message-forged-target-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/post-message-forged-target-popup.html: Added.
* LayoutTests/http/tests/site-isolation/post-message-forged-source-frame-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/post-message-forged-source-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/post-message-forged-source-origin-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/post-message-forged-source-origin.html: Added.
* LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-origin-sandboxed.html: Added.
* LayoutTests/http/tests/site-isolation/resources/post-message-forged-source-origin-victim.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e53c3dd52bd76c766a8c3ecceaac4f9ebb0dc1b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145244 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8f0788dc-0bba-4924-be09-9056adfd25c2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141150 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97846 "3 flakes 6 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fff62edb-2874-4cdf-aa0e-9d0515038ef2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121601 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90a30ecf-6374-4851-beae-a142551d7b12) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43486 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41764 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41425 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2295 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193070 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150533 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55220 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150251 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44844 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127486 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122874 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53737 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16418 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53119 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53356 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53184 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->