### PR TITLE
[Site Isolation][iOS] A file open panel request from a second frame orphans the panel that is already open

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11380,14 +11380,32 @@ void WebPageProxy::setHasModelElement(bool hasModelElement)
 
 void WebPageProxy::runOpenPanel(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, const FileChooserSettings& settings)
 {
-    if (RefPtr openPanelResultListener = std::exchange(m_openPanelResultListener, nullptr))
-        openPanelResultListener->invalidate();
+    // A process that hears nothing back keeps its listener and can never open another panel.
+    auto cancelRequest = [&] {
+        Ref process = WebProcessProxy::fromConnection(connection);
+        process->send(Messages::WebPage::DidCancelForOpenPanel(), webPageIDInProcess(process));
+    };
 
     RefPtr frame = WebFrameProxy::webFrame(frameID);
-    if (!frame)
+    if (!frame) {
+        cancelRequest();
         return;
+    }
     MESSAGE_CHECK_BASE(frame->page() == this, connection);
     MESSAGE_CHECK_BASE(!frameInfo.webPageProxyID || *frameInfo.webPageProxyID == m_identifier, connection);
+
+    if (RefPtr pendingListener = m_openPanelResultListener) {
+        // Refuse rather than replace the open panel.
+        RefPtr pendingProcess = pendingListener->process();
+        if (pendingProcess && pendingProcess->hasConnection()) {
+            cancelRequest();
+            return;
+        }
+
+        // That process is gone, so its panel can never complete.
+        m_openPanelResultListener = nullptr;
+        pendingListener->invalidate();
+    }
 
     Ref parameters = API::OpenPanelParameters::create(settings);
     Ref openPanelResultListener = WebOpenPanelResultListenerProxy::create(this, protect(frame->process()));
@@ -11396,6 +11414,8 @@ void WebPageProxy::runOpenPanel(IPC::Connection& connection, FrameIdentifier fra
     if (m_controlledByAutomation) {
         if (RefPtr automationSession = configuration().processPool().automationSession())
             automationSession->handleRunOpenPanel(*this, *frame, parameters.get(), openPanelResultListener);
+        else
+            didCancelForOpenPanel();
 
         // Don't show a file chooser, since automation will be unable to interact with it.
         return;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -847,8 +847,7 @@ bool PageClientImpl::handleRunOpenPanel(const WebPageProxy& page, const WebFrame
     }
 #endif
 
-    [contentView() _showRunOpenPanel:&parameters frameInfo:frameInfo resultListener:&listener];
-    return true;
+    return [contentView() _showRunOpenPanel:&parameters frameInfo:frameInfo resultListener:&listener];
 }
 
 bool PageClientImpl::showShareSheet(ShareDataWithParsedURL&& shareData, WTF::CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -855,7 +855,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_scrollingNodeScrollingWillBegin:(std::optional<WebCore::ScrollingNodeID>)nodeID;
 - (void)_scrollingNodeScrollingDidEnd:(std::optional<WebCore::ScrollingNodeID>)nodeID;
 - (void)_showPlaybackTargetPicker:(BOOL)hasVideo fromRect:(const WebCore::IntRect&)elementRect routeSharingPolicy:(WebCore::RouteSharingPolicy)policy routingContextUID:(NSString *)contextUID;
-- (void)_showRunOpenPanel:(API::OpenPanelParameters*)parameters frameInfo:(const WebKit::FrameInfoData&)frameInfo resultListener:(WebKit::WebOpenPanelResultListenerProxy*)listener;
+- (BOOL)_showRunOpenPanel:(API::OpenPanelParameters*)parameters frameInfo:(const WebKit::FrameInfoData&)frameInfo resultListener:(WebKit::WebOpenPanelResultListenerProxy*)listener;
 - (void)_showShareSheet:(const WebCore::ShareDataWithParsedURL&)shareData inRect:(std::optional<WebCore::FloatRect>)rect completionHandler:(WTF::CompletionHandler<void(bool)>&&)completionHandler;
 - (void)_showContactPicker:(const WebCore::ContactsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&&)completionHandler;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -9858,16 +9858,17 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 #endif
 }
 
-- (void)_showRunOpenPanel:(API::OpenPanelParameters*)parameters frameInfo:(const WebKit::FrameInfoData&)frameInfo resultListener:(WebKit::WebOpenPanelResultListenerProxy*)listener
+- (BOOL)_showRunOpenPanel:(API::OpenPanelParameters*)parameters frameInfo:(const WebKit::FrameInfoData&)frameInfo resultListener:(WebKit::WebOpenPanelResultListenerProxy*)listener
 {
     ASSERT(!_fileUploadPanel);
     if (_fileUploadPanel)
-        return;
+        return NO;
 
     _frameInfoForFileUploadPanel = frameInfo;
     _fileUploadPanel = adoptNS([[WKFileUploadPanel alloc] initWithView:self]);
     [_fileUploadPanel setDelegate:self];
     [_fileUploadPanel presentWithParameters:parameters resultListener:listener];
+    return YES;
 }
 
 - (void)fileUploadPanelDidDismiss:(WKFileUploadPanel *)fileUploadPanel

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9622,6 +9622,80 @@ TEST(SiteIsolation, SelectElementPopupAfterFocusChangesDuringTracking)
 
 #endif
 
+TEST(SiteIsolation, FileOpenPanelRequestWhileAnotherFramesPanelIsOpen)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<iframe src='https://domain2.com/subframe'></iframe><iframe src='https://domain3.com/subframe'></iframe>"_s } },
+        { "/subframe"_s, { "<input type='file'><script>window.cancelCount = 0; document.querySelector('input').addEventListener('cancel', () => { window.cancelCount++; });</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    __block unsigned openPanelCount = 0;
+    __block RetainPtr<WKFrameInfo> openPanelFrame;
+    __block BlockPtr<void(NSArray<NSURL *> *)> completeOpenPanel;
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    [uiDelegate setRunOpenPanelWithParameters:^(WKWebView *, WKOpenPanelParameters *, WKFrameInfo *frame, void (^completionHandler)(NSArray<NSURL *> *)) {
+        openPanelCount++;
+        openPanelFrame = frame;
+        completeOpenPanel = makeBlockPtr(completionHandler);
+    }];
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    while ([webView mainFrame].childFrames.count < 2)
+        Util::spinRunLoop();
+
+    RetainPtr firstFrame = [webView mainFrame].childFrames[0].info;
+    RetainPtr secondFrame = [webView mainFrame].childFrames[1].info;
+    EXPECT_NE([firstFrame _processIdentifier], [secondFrame _processIdentifier]);
+
+    auto showPicker = [&](WKFrameInfo *frame) {
+        [webView objectByEvaluatingJavaScriptWithUserGesture:@"document.querySelector('input').showPicker()" inFrame:frame];
+    };
+    auto waitForOpenPanelCount = [&](unsigned count) {
+        EXPECT_TRUE(Util::waitFor([&] {
+            return openPanelCount >= count;
+        }));
+    };
+    // A cancel event means that frame's process is no longer waiting on a panel.
+    auto waitForCancelCount = [&](WKFrameInfo *frame, int count) {
+        EXPECT_TRUE(Util::waitFor([&] {
+            return [[webView objectByEvaluatingJavaScript:@"window.cancelCount" inFrame:frame] intValue] >= count;
+        }));
+    };
+
+    showPicker(firstFrame.get());
+    waitForOpenPanelCount(1);
+    EXPECT_WK_STREQ([openPanelFrame securityOrigin].host, "domain2.com");
+
+    // The second frame's request is refused, and the open panel is left alone.
+    showPicker(secondFrame.get());
+    waitForCancelCount(secondFrame.get(), 1);
+    EXPECT_EQ(openPanelCount, 1u);
+
+    // The open panel still delivers its files to the frame that opened it.
+    RetainPtr file = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"SiteIsolationOpenPanel.txt"]];
+    [@"upload" writeToURL:file.get() atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    completeOpenPanel(@[ file.get() ]);
+    EXPECT_TRUE(Util::waitFor([&] {
+        return [[webView objectByEvaluatingJavaScript:@"document.querySelector('input').files.length" inFrame:firstFrame.get()] intValue] == 1;
+    }));
+
+    // Both processes can still open a panel.
+    showPicker(secondFrame.get());
+    waitForOpenPanelCount(2);
+    EXPECT_WK_STREQ([openPanelFrame securityOrigin].host, "domain3.com");
+    completeOpenPanel(nil);
+
+    showPicker(firstFrame.get());
+    waitForOpenPanelCount(3);
+    EXPECT_WK_STREQ([openPanelFrame securityOrigin].host, "domain2.com");
+    completeOpenPanel(nil);
+}
+
 #if PLATFORM(IOS_FAMILY)
 
 TEST(SiteIsolation, SelectMultiplePickerLocationInCrossOriginIframe)


### PR DESCRIPTION
#### a8251e547c1754f468452222a5841527892245a9
<pre>
[Site Isolation][iOS] A file open panel request from a second frame orphans the panel that is already open
<a href="https://bugs.webkit.org/show_bug.cgi?id=321744">https://bugs.webkit.org/show_bug.cgi?id=321744</a>
<a href="https://rdar.apple.com/184871864">rdar://184871864</a>

Reviewed by NOBODY (OOPS!).

A web process refuses a file chooser request while it already has one pending, because
WebChromeClient::runOpenPanel returns early while WebPage::activeOpenPanelResultListener() is set.
With site isolation a second frame runs in another process, which cannot know a panel is already
open, so it can ask for one. WebPageProxy::runOpenPanel replaced the pending listener and called
invalidate() on it, which only nulls the proxy&apos;s page and process pointers. It never sent
DidCancelForOpenPanel, so the first process kept its listener forever and every file input in its
frames stayed dead for the life of the page.

Refuse the new request instead, which is what each web process already does for itself, and send
DidCancelForOpenPanel to the process that asked. The open panel and its listener are left alone, so
the user&apos;s interaction is not thrown away, and the requesting element gets a cancel event instead of
waiting for a reply that never comes. There is no way to withdraw a request the client already holds,
so replacing the open panel cannot be done correctly: -[WKUIDelegate
webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:] has no cancellation channel,
and on iOS -[WKContentView _showRunOpenPanel:...] refuses to present a second panel.

Since a pending listener now blocks later requests, the paths that leave one behind are closed:

- A request naming a frame that is already gone is cancelled rather than dropped.
- A request under automation with no session attached is cancelled, since nothing can complete it.
- If the process that opened the panel is gone, its panel can never complete, so a new request
  replaces it instead of being refused. Otherwise a site-isolated frame&apos;s process being killed while
  its panel was open would block file inputs across the whole page.
- -[WKContentView _showRunOpenPanel:...] now reports whether it presented a panel, so
  PageClientImpl::handleRunOpenPanel no longer claims success when it presented nothing, and the page
  cancels the request instead.

Two behaviors worth noting. A second request within one process is still dropped silently by
WebChromeClient rather than cancelled, so the cancel event is only sent across processes. And a client
that never calls its completion handler now blocks later requests for that page, where before the
next request would take over; WebOpenPanelResultListenerProxy holds a strong reference to the page, so
it cannot cancel itself when the client drops it.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::runOpenPanel):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::handleRunOpenPanel):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _showRunOpenPanel:frameInfo:resultListener:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, FileOpenPanelRequestWhileAnotherFramesPanelIsOpen)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8251e547c1754f468452222a5841527892245a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180664 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54609 "Hash a8251e54 for PR 71596 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48407 "Hash a8251e54 for PR 71596 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144986 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41f6619e-c264-4a05-9111-0be3080c9ff4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182526 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55907 "Hash a8251e54 for PR 71596 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54325 "Hash a8251e54 for PR 71596 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140914 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97631 "3 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e93c5c5-930e-4b81-8f95-7731dc95f641) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183619 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/55907 "Hash a8251e54 for PR 71596 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/48407 "Hash a8251e54 for PR 71596 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121366 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0aa1d78d-b6f4-46b2-bba0-78ec09773b54) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/55907 "Hash a8251e54 for PR 71596 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/54325 "Hash a8251e54 for PR 71596 does not build (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3333 "Build is in progress. Recent messages:") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/48407 "Hash a8251e54 for PR 71596 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/55907 "Hash a8251e54 for PR 71596 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/48407 "Hash a8251e54 for PR 71596 does not build (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2036 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47218 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/54325 "Hash a8251e54 for PR 71596 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192812 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54275 "Hash a8251e54 for PR 71596 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/48407 "Hash a8251e54 for PR 71596 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150295 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54963 "Hash a8251e54 for PR 71596 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/48407 "Hash a8251e54 for PR 71596 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150012 "Passed tests") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/54963 "Hash a8251e54 for PR 71596 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127228 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122447 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53480 "Hash a8251e54 for PR 71596 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/48407 "Hash a8251e54 for PR 71596 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52862 "Hash a8251e54 for PR 71596 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53099 "Hash a8251e54 for PR 71596 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52927 "Hash a8251e54 for PR 71596 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->