### PR TITLE
Add a --reset-author argument to `git-webkit apply`

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py
@@ -22,6 +22,7 @@
 
 import argparse
 import os
+import shlex
 import sys
 import tempfile
 
@@ -51,6 +52,10 @@ class Apply(Command):
         parser.add_argument(
             '--no-commit', default=True, action='store_false', dest='commit',
             help='Apply the patch to the working tree only, instead of committing it with `git am`',
+        )
+        parser.add_argument(
+            '--reset-author', default=False, action='store_true', dest='reset_author',
+            help='Attribute the commit to you instead of the patch\'s author, refreshing the author date',
         )
 
     @classmethod
@@ -111,9 +116,60 @@ class Apply(Command):
     @classmethod
     def edit_commit_message(cls, repository):
         '''Amend the just-applied commit without a message flag, so git opens its message in the editor.
-        No --date, so `git am`'s preserved author date survives.'''
+        No --date, so the author date `git am` preserved (or --reset-author refreshed) survives.'''
         if run([repository.executable(), 'commit', '--amend'], cwd=repository.root_path).returncode:
             sys.stderr.write("Applied the patch, but couldn't open the commit message for editing; it keeps the patch's message.\n")
+
+    @classmethod
+    def head(cls, repository):
+        '''Hash of the current HEAD, or None on an unborn branch.'''
+        result = run(
+            [repository.executable(), 'rev-parse', 'HEAD'],
+            cwd=repository.root_path, capture_output=True, encoding='utf-8',
+        )
+        return None if result.returncode else result.stdout.strip()
+
+    @classmethod
+    def commit_count(cls, repository, since):
+        '''Number of commits `since` is behind HEAD, or None when git won't say.'''
+        result = run(
+            [repository.executable(), 'rev-list', '--count', '{}..HEAD'.format(since)],
+            cwd=repository.root_path, capture_output=True, encoding='utf-8',
+        )
+        if result.returncode:
+            return None
+        try:
+            return int(result.stdout.strip())
+        except ValueError:
+            return None
+
+    @classmethod
+    def reset_author(cls, repository, since=None):
+        '''Re-attribute the commits `git am` just created to the local git identity, which `git am` has
+        no way to do while applying them. One commit is amended in place; an mbox that produced several
+        is replayed with that amend after each one, since amending only reaches the last. --reset-author
+        also refreshes the author date. `since` is HEAD from before the patch was applied.'''
+        applied = cls.commit_count(repository, since) if since else None
+        if applied and applied > 1:
+            # --no-autosquash so a patch whose message starts with fixup!/squash! is replayed as its
+            # own commit, whatever the checkout's rebase.autoSquash says.
+            result = run(
+                [
+                    repository.executable(), 'rebase', '--no-autosquash',
+                    '--exec', '{} commit --amend --reset-author --no-edit'.format(shlex.quote(repository.executable())),
+                    since,
+                ],
+                cwd=repository.root_path,
+            )
+            if result.returncode:
+                run([repository.executable(), 'rebase', '--abort'], cwd=repository.root_path, capture_output=True)
+                sys.stderr.write("Applied the patch, but couldn't reset its commits' authors; they keep the patch's authors.\n")
+            return
+        if run(
+            [repository.executable(), 'commit', '--amend', '--reset-author', '--no-edit'],
+            cwd=repository.root_path,
+        ).returncode:
+            sys.stderr.write("Applied the patch, but couldn't reset the commit's author; it keeps the patch's author.\n")
 
     @classmethod
     def offer_pull_request(cls, repository, **kwargs):
@@ -134,6 +190,9 @@ class Apply(Command):
             return 1
         if repository.modified():
             sys.stderr.write('Please commit or stash your changes before applying a patch\n')
+            return 1
+        if args.reset_author and not args.commit:
+            sys.stderr.write('--reset-author requires a commit to re-attribute, so it cannot be combined with --no-commit\n')
             return 1
 
         issue = cls.resolve_issue(args.issue)
@@ -170,6 +229,10 @@ class Apply(Command):
             sys.stderr.write("'{}' on {} is empty\n".format(patch.name, issue.link))
             return 1
 
+        # Remember where the branch stood, so resetting the author can tell how many commits `git am`
+        # went on to create.
+        head = cls.head(repository) if args.commit and args.reset_author else None
+
         handle, patch_path = tempfile.mkstemp(suffix='.patch')
         try:
             with os.fdopen(handle, 'wb') as patch_file:
@@ -190,6 +253,9 @@ class Apply(Command):
                 return 1
         finally:
             os.remove(patch_path)
+
+        if args.commit and args.reset_author:
+            cls.reset_author(repository, since=head)
 
         if args.commit and interactive:
             cls.edit_commit_message(repository)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py
@@ -22,7 +22,7 @@
 
 import os
 import unittest
-from argparse import Namespace
+from argparse import ArgumentParser, Namespace
 from unittest.mock import MagicMock, patch
 
 from webkitbugspy import Issue, radar
@@ -33,6 +33,37 @@ from webkitscmpy.program.apply import Apply
 
 
 class TestApply(unittest.TestCase):
+    AMEND_RESET = ['git', 'commit', '--amend', '--reset-author', '--no-edit']
+    REPLAY_RESET = [
+        'git', 'rebase', '--no-autosquash',
+        '--exec', 'git commit --amend --reset-author --no-edit',
+        'HEAD-BEFORE-AM',
+    ]
+
+    @staticmethod
+    def _args(issue='rdar://5', name=None, commit=True, reset_author=False):
+        return Namespace(issue=issue, name=name, commit=commit, reset_author=reset_author)
+
+    @staticmethod
+    def _run(head='HEAD-BEFORE-AM', count='1', failures=()):
+        '''Stub for `run` answering the queries that resetting the author makes, and failing the git
+        sub-commands named in `failures`. A None `head` or `count` makes that query fail.'''
+        def invoke(command, **kwargs):
+            if command[1] == 'rev-parse':
+                return MagicMock(returncode=1) if head is None else MagicMock(returncode=0, stdout='{}\n'.format(head))
+            if command[1] == 'rev-list':
+                return MagicMock(returncode=1) if count is None else MagicMock(returncode=0, stdout='{}\n'.format(count))
+            return MagicMock(returncode=1 if command[1] in failures else 0)
+        return invoke
+
+    @staticmethod
+    def _commands(mock_run, queries=False):
+        '''Git commands run, without the read-only queries unless they are asked for.'''
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        if queries:
+            return commands
+        return [command for command in commands if command[1] not in ('rev-parse', 'rev-list')]
+
     @staticmethod
     def _patch(name, contents=b'PATCH'):
         return Issue.Attachment(name=name, contents=contents)
@@ -183,7 +214,7 @@ class TestApply(unittest.TestCase):
     @patch('webkitscmpy.program.apply.run')
     def test_main_rejects_non_git_repository(self, mock_run):
         with OutputCapture() as captured:
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), MagicMock(spec=local.Svn))
+            result = Apply.main(self._args(), MagicMock(spec=local.Svn))
         self.assertEqual(result, 1)
         self.assertEqual(captured.stderr.getvalue(), "Can only 'apply' on a native Git repository\n")
         mock_run.assert_not_called()
@@ -191,14 +222,14 @@ class TestApply(unittest.TestCase):
     @patch('webkitscmpy.program.apply.run')
     def test_main_rejects_dirty_tree(self, mock_run):
         with OutputCapture():
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo(modified={'f': 1}))
+            result = Apply.main(self._args(), self._repo(modified={'f': 1}))
         self.assertEqual(result, 1)
         mock_run.assert_not_called()
 
     @patch('webkitscmpy.program.apply.run')
     def test_main_errors_when_issue_unresolvable(self, mock_run):
         with patch.object(Apply, 'resolve_issue', return_value=None), OutputCapture() as captured:
-            result = Apply.main(Namespace(issue='bogus', name=None, commit=True), self._repo())
+            result = Apply.main(self._args(issue='bogus'), self._repo())
         self.assertEqual(result, 1)
         self.assertEqual(captured.stderr.getvalue(), "Could not resolve 'bogus' to an issue\n")
         mock_run.assert_not_called()
@@ -207,7 +238,7 @@ class TestApply(unittest.TestCase):
     def test_main_errors_when_attachments_unsupported(self, mock_run):
         issue = self._issue(patches=None, tracker_name='GitHub Issue')
         with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
-            result = Apply.main(Namespace(issue='https://github.example.com/x/1', name=None, commit=True), self._repo())
+            result = Apply.main(self._args(issue='https://github.example.com/x/1'), self._repo())
         self.assertEqual(result, 1)
         self.assertEqual(captured.stderr.getvalue(), 'GitHub Issue does not support patch attachments\n')
         mock_run.assert_not_called()
@@ -216,7 +247,7 @@ class TestApply(unittest.TestCase):
     def test_main_errors_when_no_patches(self, mock_run):
         issue = self._issue(patches=[])
         with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+            result = Apply.main(self._args(), self._repo())
         self.assertEqual(result, 1)
         self.assertIn('No patches are attached', captured.stderr.getvalue())
         mock_run.assert_not_called()
@@ -225,7 +256,7 @@ class TestApply(unittest.TestCase):
     def test_main_errors_when_named_patch_missing(self, mock_run):
         issue = self._issue(patches=[self._patch('triage-fix.patch')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
-            result = Apply.main(Namespace(issue='rdar://5', name='absent.patch', commit=True), self._repo())
+            result = Apply.main(self._args(name='absent.patch'), self._repo())
         self.assertEqual(result, 1)
         self.assertIn("No 'absent.patch' patch is attached", captured.stderr.getvalue())
         mock_run.assert_not_called()
@@ -237,7 +268,7 @@ class TestApply(unittest.TestCase):
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), \
              patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), OutputCapture() as captured:
-            result = Apply.main(Namespace(issue='rdar://5', name='triage-fix.patch', commit=True), self._repo())
+            result = Apply.main(self._args(name='triage-fix.patch'), self._repo())
         self.assertEqual(result, 1)
         self.assertIn('No patch applied', captured.stderr.getvalue())
         self.assertNotIn('is attached', captured.stderr.getvalue())
@@ -247,7 +278,7 @@ class TestApply(unittest.TestCase):
     def test_main_errors_on_download_failure(self, mock_run):
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=None)])
         with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+            result = Apply.main(self._args(), self._repo())
         self.assertEqual(result, 1)
         self.assertIn('Could not download', captured.stderr.getvalue())
         mock_run.assert_not_called()
@@ -256,7 +287,7 @@ class TestApply(unittest.TestCase):
     def test_main_errors_on_empty_content(self, mock_run):
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'   \n')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=False), self._repo())
+            result = Apply.main(self._args(commit=False), self._repo())
         self.assertEqual(result, 1)
         self.assertIn('is empty', captured.stderr.getvalue())
         mock_run.assert_not_called()
@@ -266,7 +297,7 @@ class TestApply(unittest.TestCase):
         mock_run.return_value = MagicMock(returncode=0)
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+            result = Apply.main(self._args(), self._repo())
         self.assertEqual(result, 0)
         self.assertEqual(mock_run.call_args.args[0][:2], ['git', 'am'])
         self.assertEqual(mock_run.call_args.kwargs.get('cwd'), '/repo')
@@ -276,16 +307,146 @@ class TestApply(unittest.TestCase):
         mock_run.return_value = MagicMock(returncode=0)
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=False), self._repo())
+            result = Apply.main(self._args(commit=False), self._repo())
         self.assertEqual(result, 0)
         self.assertEqual(mock_run.call_args.args[0][:3], ['git', 'apply', '--3way'])
+
+    def test_parser_reset_author_defaults_to_off(self):
+        parser = ArgumentParser()
+        Apply.parser(parser)
+        self.assertFalse(parser.parse_args(['rdar://5']).reset_author)
+        self.assertTrue(parser.parse_args(['rdar://5', '--reset-author']).reset_author)
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_rejects_reset_author_without_a_commit(self, mock_run):
+        with OutputCapture() as captured:
+            result = Apply.main(self._args(commit=False, reset_author=True), self._repo())
+        self.assertEqual(result, 1)
+        self.assertIn('--reset-author requires a commit', captured.stderr.getvalue())
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_resets_author_after_am(self, mock_run):
+        mock_run.side_effect = self._run(count='1')
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            result = Apply.main(self._args(reset_author=True), self._repo())
+        self.assertEqual(result, 0)
+        commands = self._commands(mock_run)
+        self.assertEqual(commands[0][:2], ['git', 'am'])
+        self.assertEqual(commands[1], self.AMEND_RESET)
+        self.assertEqual(mock_run.call_args.kwargs.get('cwd'), '/repo')
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_replays_a_multi_commit_patch_to_reset_every_author(self, mock_run):
+        # Amending only reaches the last commit `git am` created, so several are replayed instead.
+        mock_run.side_effect = self._run(count='3')
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            result = Apply.main(self._args(reset_author=True), self._repo())
+        self.assertEqual(result, 0)
+        commands = self._commands(mock_run)
+        self.assertEqual(commands[0][:2], ['git', 'am'])
+        self.assertEqual(commands[1], self.REPLAY_RESET)
+        self.assertNotIn(self.AMEND_RESET, commands)
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_counts_commits_from_head_before_the_patch(self, mock_run):
+        mock_run.side_effect = self._run(head='ffffff', count='2')
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            Apply.main(self._args(reset_author=True), self._repo())
+        commands = self._commands(mock_run, queries=True)
+        self.assertEqual(commands[0], ['git', 'rev-parse', 'HEAD'])
+        self.assertIn(['git', 'rev-list', '--count', 'ffffff..HEAD'], commands)
+        self.assertEqual(commands[-1][-1], 'ffffff')
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_aborts_the_replay_when_it_fails(self, mock_run):
+        mock_run.side_effect = self._run(count='2', failures=('rebase',))
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
+            result = Apply.main(self._args(reset_author=True), self._repo())
+        self.assertEqual(result, 0)
+        self.assertIn("couldn't reset its commits' authors", captured.stderr.getvalue())
+        self.assertIn(['git', 'rebase', '--abort'], self._commands(mock_run))
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_amends_when_the_commit_count_is_unavailable(self, mock_run):
+        mock_run.side_effect = self._run(count=None)
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            result = Apply.main(self._args(reset_author=True), self._repo())
+        self.assertEqual(result, 0)
+        commands = self._commands(mock_run)
+        self.assertEqual(commands[1], self.AMEND_RESET)
+        self.assertEqual(len(commands), 2)
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_amends_when_head_does_not_resolve(self, mock_run):
+        # An unborn branch has no HEAD to count from, so the applied commit is amended in place.
+        mock_run.side_effect = self._run(head=None)
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            result = Apply.main(self._args(reset_author=True), self._repo())
+        self.assertEqual(result, 0)
+        commands = self._commands(mock_run, queries=True)
+        self.assertEqual(commands[-1], self.AMEND_RESET)
+        self.assertNotIn(['git', 'rev-list', '--count', 'None..HEAD'], commands)
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_keeps_patch_author_by_default(self, mock_run):
+        mock_run.side_effect = self._run()
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            result = Apply.main(self._args(), self._repo())
+        self.assertEqual(result, 0)
+        commands = self._commands(mock_run, queries=True)
+        self.assertNotIn(self.AMEND_RESET, commands)
+        self.assertEqual(len(commands), 1)
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_does_not_reset_author_when_am_fails(self, mock_run):
+        mock_run.side_effect = self._run(failures=('am',))
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            result = Apply.main(self._args(reset_author=True), self._repo())
+        self.assertEqual(result, 1)
+        commands = self._commands(mock_run)
+        self.assertNotIn(self.AMEND_RESET, commands)
+        self.assertNotIn(self.REPLAY_RESET, commands)
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_warns_when_author_reset_fails(self, mock_run):
+        mock_run.side_effect = self._run(failures=('commit',))
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
+            result = Apply.main(self._args(reset_author=True), self._repo())
+        self.assertEqual(result, 0)
+        self.assertIn("couldn't reset the commit's author", captured.stderr.getvalue())
+
+    @patch('webkitscmpy.program.apply.HTMLDiff')
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_resets_author_before_editing_the_message(self, mock_run, mock_htmldiff):
+        mock_run.side_effect = self._run(count='1')
+        mock_htmldiff.return_value.__enter__.return_value.accepted = True
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), \
+             patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), \
+             patch('webkitscmpy.program.apply.Terminal.choose', return_value='No'), OutputCapture():
+            result = Apply.main(self._args(reset_author=True), self._repo())
+        self.assertEqual(result, 0)
+        commands = self._commands(mock_run)
+        self.assertEqual(commands[0][:2], ['git', 'am'])
+        self.assertEqual(commands[1], self.AMEND_RESET)
+        self.assertEqual(commands[2], ['git', 'commit', '--amend'])
 
     @patch('webkitscmpy.program.apply.run')
     def test_main_aborts_am_on_conflict(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1)
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+            result = Apply.main(self._args(), self._repo())
         self.assertEqual(result, 1)
         commands = [call.args[0] for call in mock_run.call_args_list]
         self.assertEqual(commands[0][:2], ['git', 'am'])
@@ -296,7 +457,7 @@ class TestApply(unittest.TestCase):
         mock_run.return_value = MagicMock(returncode=1)
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=False), self._repo())
+            result = Apply.main(self._args(commit=False), self._repo())
         self.assertEqual(result, 1)
         commands = [call.args[0] for call in mock_run.call_args_list]
         self.assertNotIn(['git', 'am', '--abort'], commands)
@@ -307,7 +468,7 @@ class TestApply(unittest.TestCase):
         mock_run.return_value = MagicMock(returncode=1)
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
-            Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+            Apply.main(self._args(), self._repo())
         patch_path = mock_run.call_args_list[0].args[0][2]
         self.assertFalse(os.path.exists(patch_path))
 
@@ -316,7 +477,7 @@ class TestApply(unittest.TestCase):
         mock_run.return_value = MagicMock(returncode=0)
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents='PATCH-AS-STR')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=False), self._repo())
+            result = Apply.main(self._args(commit=False), self._repo())
         self.assertEqual(result, 0)
 
     def test_main_downloads_named_patch_from_radar(self):
@@ -347,7 +508,7 @@ class TestApply(unittest.TestCase):
         with bmocks.Radar(issues=issues), \
              patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]), \
              patch('webkitscmpy.program.apply.run', side_effect=fake_run), OutputCapture():
-            result = Apply.main(Namespace(issue='rdar://1', name='triage-fix.patch', commit=True), self._repo())
+            result = Apply.main(self._args(issue='rdar://1', name='triage-fix.patch'), self._repo())
         self.assertEqual(result, 0)
         self.assertEqual(written.get('content'), b'FIX BYTES')
 
@@ -360,7 +521,7 @@ class TestApply(unittest.TestCase):
         with patch.object(Apply, 'resolve_issue', return_value=issue), \
              patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), \
              patch('webkitscmpy.program.apply.Terminal.choose', return_value='No'), OutputCapture():
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+            result = Apply.main(self._args(), self._repo())
         self.assertEqual(result, 0)
         self.assertEqual(mock_htmldiff.call_args.kwargs.get('block'), True)
         commands = [call.args[0] for call in mock_run.call_args_list]
@@ -377,7 +538,7 @@ class TestApply(unittest.TestCase):
         with patch.object(Apply, 'resolve_issue', return_value=issue), \
              patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), \
              patch('webkitscmpy.program.apply.Terminal.choose', return_value='Yes'), OutputCapture():
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+            result = Apply.main(self._args(), self._repo())
         self.assertEqual(result, 0)
         pr_main.assert_called_once()
 
@@ -391,7 +552,7 @@ class TestApply(unittest.TestCase):
         with patch.object(Apply, 'resolve_issue', return_value=issue), \
              patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), \
              patch('webkitscmpy.program.apply.Terminal.choose', return_value='No'), OutputCapture():
-            Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+            Apply.main(self._args(), self._repo())
         pr_main.assert_not_called()
 
     @patch('webkitscmpy.program.apply.HTMLDiff')
@@ -402,7 +563,7 @@ class TestApply(unittest.TestCase):
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), \
              patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), OutputCapture():
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=False), self._repo())
+            result = Apply.main(self._args(commit=False), self._repo())
         self.assertEqual(result, 0)
         commands = [call.args[0] for call in mock_run.call_args_list]
         self.assertEqual(commands[0][:3], ['git', 'apply', '--3way'])
@@ -415,7 +576,7 @@ class TestApply(unittest.TestCase):
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), \
              patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), OutputCapture() as captured:
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+            result = Apply.main(self._args(), self._repo())
         self.assertEqual(result, 1)
         self.assertIn('No patch applied', captured.stderr.getvalue())
         mock_run.assert_not_called()
@@ -427,7 +588,7 @@ class TestApply(unittest.TestCase):
         issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
         with patch.object(Apply, 'resolve_issue', return_value=issue), \
              patch('webkitscmpy.program.apply.Terminal.isatty', return_value=False), OutputCapture():
-            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+            result = Apply.main(self._args(), self._repo())
         self.assertEqual(result, 0)
         mock_htmldiff.assert_not_called()
         commands = [call.args[0] for call in mock_run.call_args_list]


### PR DESCRIPTION
#### f8225fcd9756b6c2e4e3054cb0539d861638e0e1
<pre>
Add a --reset-author argument to `git-webkit apply`
<a href="https://bugs.webkit.org/show_bug.cgi?id=321745">https://bugs.webkit.org/show_bug.cgi?id=321745</a>
<a href="https://rdar.apple.com/problem/184872095">rdar://problem/184872095</a>

Reviewed by Ryosuke Niwa.

Since `git am` doesn&apos;t have a --reset-author like `git apply` does, we
let `git am` commit the changes first, then amend them to change the
author.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py:
(Apply.parser):
(Apply.edit_commit_message):
(Apply):
(Apply.head):
(Apply.commit_count):
(Apply.reset_author):
(Apply.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py:
(TestApply):
(TestApply._args):
(TestApply._run):
(TestApply._run.invoke):
(TestApply._commands):
(TestApply.test_main_rejects_non_git_repository):
(TestApply.test_main_rejects_dirty_tree):
(TestApply.test_main_errors_when_issue_unresolvable):
(TestApply.test_main_errors_when_attachments_unsupported):
(TestApply.test_main_errors_when_no_patches):
(TestApply.test_main_errors_when_named_patch_missing):
(TestApply.test_main_named_patch_rejected_reports_not_applied):
(TestApply.test_main_errors_on_download_failure):
(TestApply.test_main_errors_on_empty_content):
(TestApply.test_main_commits_with_git_am):
(TestApply.test_main_no_commit_uses_git_apply_3way):
(TestApply.test_parser_reset_author_defaults_to_off):
(TestApply.test_main_rejects_reset_author_without_a_commit):
(TestApply.test_main_resets_author_after_am):
(TestApply.test_main_replays_a_multi_commit_patch_to_reset_every_author):
(TestApply.test_main_counts_commits_from_head_before_the_patch):
(TestApply.test_main_aborts_the_replay_when_it_fails):
(TestApply.test_main_amends_when_the_commit_count_is_unavailable):
(TestApply.test_main_amends_when_head_does_not_resolve):
(TestApply.test_main_keeps_patch_author_by_default):
(TestApply.test_main_does_not_reset_author_when_am_fails):
(TestApply.test_main_warns_when_author_reset_fails):
(TestApply.test_main_resets_author_before_editing_the_message):
(TestApply.test_main_aborts_am_on_conflict):
(TestApply.test_main_no_commit_failure_does_not_abort):
(TestApply.test_main_removes_tempfile_even_on_failure):
(TestApply.test_main_encodes_str_content):
(TestApply.test_main_downloads_named_patch_from_radar):
(TestApply.test_main_reviews_and_opens_editor_when_interactive):
(TestApply.test_main_creates_pull_request_when_accepted):
(TestApply.test_main_skips_pull_request_when_declined):
(TestApply.test_main_no_editor_when_not_committing):
(TestApply.test_main_declined_review_is_not_applied):
(TestApply.test_main_skips_review_and_editor_when_not_interactive):

Canonical link: <a href="https://commits.webkit.org/319159@main">https://commits.webkit.org/319159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8f15aa08c704cd7b71ad0db662c9df2397e5cfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/180666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/54611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190877 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/144988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/735da482-7f95-4c86-9e86-73817f51510a) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/182528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/55909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140916 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/144988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/183621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/55909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/48409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121368 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7ef5289-5589-482b-aed9-123efdb8f06a) 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/179990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/55909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/48409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/55909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2038 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47220 "Build is in progress. Recent messages:") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/54327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192814 "Built successfully") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/180067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/54277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/48409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150296 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40223 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/54965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150013 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/54965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122449 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/53482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/48409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/52929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->