### PR TITLE
[xml] Add deprecation console warning upon usage of XML external entities

### DIFF
--- a/LayoutTests/dom/xhtml/level3/core/entitygetinputencoding03-expected.txt
+++ b/LayoutTests/dom/xhtml/level3/core/entitygetinputencoding03-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 Test	http://www.w3.org/2001/DOM-Test-Suite/level3/core/entitygetinputencoding03
 Status	skip
 Message	HTML loader does not support validating=true

--- a/LayoutTests/dom/xhtml/level3/core/entitygetinputencoding04-expected.txt
+++ b/LayoutTests/dom/xhtml/level3/core/entitygetinputencoding04-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 Test	http://www.w3.org/2001/DOM-Test-Suite/level3/core/entitygetinputencoding04
 Status	skip
 Message	HTML loader does not support validating=true

--- a/LayoutTests/dom/xhtml/level3/core/entitygetxmlencoding02-expected.txt
+++ b/LayoutTests/dom/xhtml/level3/core/entitygetxmlencoding02-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 Test	http://www.w3.org/2001/DOM-Test-Suite/level3/core/entitygetxmlencoding02
 Status	error
 Message	Line 103: TypeError

--- a/LayoutTests/dom/xhtml/level3/core/entitygetxmlencoding03-expected.txt
+++ b/LayoutTests/dom/xhtml/level3/core/entitygetxmlencoding03-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 Test	http://www.w3.org/2001/DOM-Test-Suite/level3/core/entitygetxmlencoding03
 Status	skip
 Message	HTML loader does not support validating=true

--- a/LayoutTests/dom/xhtml/level3/core/entitygetxmlencoding04-expected.txt
+++ b/LayoutTests/dom/xhtml/level3/core/entitygetxmlencoding04-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 Test	http://www.w3.org/2001/DOM-Test-Suite/level3/core/entitygetxmlencoding04
 Status	skip
 Message	HTML loader does not support validating=true

--- a/LayoutTests/dom/xhtml/level3/core/entitygetxmlversion03-expected.txt
+++ b/LayoutTests/dom/xhtml/level3/core/entitygetxmlversion03-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 Test	http://www.w3.org/2001/DOM-Test-Suite/level3/core/entitygetxmlversion03
 Status	skip
 Message	HTML loader does not support validating=true

--- a/LayoutTests/dom/xhtml/level3/core/entitygetxmlversion04-expected.txt
+++ b/LayoutTests/dom/xhtml/level3/core/entitygetxmlversion04-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 Test	http://www.w3.org/2001/DOM-Test-Suite/level3/core/entitygetxmlversion04
 Status	skip
 Message	HTML loader does not support validating=true

--- a/LayoutTests/dom/xhtml/level3/core/nodegetbaseuri16-expected.txt
+++ b/LayoutTests/dom/xhtml/level3/core/nodegetbaseuri16-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 Test	http://www.w3.org/2001/DOM-Test-Suite/level3/core/nodegetbaseuri16
 Status	skip
 Message	HTML loader does not support expandEntityReferences=false

--- a/LayoutTests/dom/xhtml/level3/core/nodegetbaseuri19-expected.txt
+++ b/LayoutTests/dom/xhtml/level3/core/nodegetbaseuri19-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 Test	http://www.w3.org/2001/DOM-Test-Suite/level3/core/nodegetbaseuri19
 Status	skip
 Message	HTML loader does not support validating=true

--- a/LayoutTests/dom/xhtml/level3/core/nodegetbaseuri20-expected.txt
+++ b/LayoutTests/dom/xhtml/level3/core/nodegetbaseuri20-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 Test	http://www.w3.org/2001/DOM-Test-Suite/level3/core/nodegetbaseuri20
 Status	skip
 Message	HTML loader does not support validating=true

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/external-entity.xml
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/external-entity.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html [
+<!ENTITY message SYSTEM "message.xml">
+]>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<body>
+<p id="result">&message;</p>
+</body>
+</html>

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/external-subset.dtd.xml
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/external-subset.dtd.xml
@@ -1,0 +1,3 @@
+<!-- WebKit never fetches an external DTD subset, so the external entity declared here must
+     not produce a deprecation warning. -->
+<!ENTITY unusedExternalEntity SYSTEM "message.xml">

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/message.xml
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/message.xml
@@ -1,0 +1,1 @@
+SUCCESS

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/multiple-external-entities.xml
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/multiple-external-entities.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html [
+<!ENTITY first SYSTEM "message.xml">
+<!ENTITY second SYSTEM "message.xml">
+<!ENTITY third SYSTEM "message.xml">
+]>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<body>
+<p id="first">&first;</p>
+<p id="second">&second;</p>
+<p id="third">&third;</p>
+</body>
+</html>

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/no-warning-external-subset.xml
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/no-warning-external-subset.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html SYSTEM "external-subset.dtd.xml">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<body>
+<p id="result">PASS</p>
+</body>
+</html>

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/no-warning-internal-entities.xhtml
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/no-warning-internal-entities.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
+[
+<!ENTITY internalEntity "PASS">
+<!ENTITY nestedEntity "&internalEntity;">
+]>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<body>
+<p id="internal">&internalEntity;</p>
+<p id="nested">&nestedEntity;</p>
+<p id="predefined">&amp;&lt;&gt;</p>
+<p id="named">&nbsp;</p>
+</body>
+</html>

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-expected.txt
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
+This test ensures a deprecation warning is logged to the console when an XML document uses an external entity.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS externalEntityText is "SUCCESS"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-not-fired-expected.txt
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-not-fired-expected.txt
@@ -1,0 +1,14 @@
+This test ensures no XML external entity deprecation warning is logged for internal entities, predefined entities, XHTML named entities, or an external DTD subset, which WebKit never fetches.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internalEntityText is "PASS"
+PASS nestedEntityText is "PASS"
+PASS predefinedEntityText is "&<>"
+PASS namedEntityCharCode is 160
+PASS externalSubsetText is "PASS"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-not-fired.html
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-not-fired.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("This test ensures no XML external entity deprecation warning is logged for internal entities, predefined entities, XHTML named entities, or an external DTD subset, which WebKit never fetches.");
+
+jsTestIsAsync = true;
+
+var internalEntityText;
+var nestedEntityText;
+var predefinedEntityText;
+var namedEntityCharCode;
+var externalSubsetText;
+
+var framesLoaded = 0;
+
+function frameLoaded() {
+    if (++framesLoaded < 2)
+        return;
+
+    var internalDocument = document.getElementById("internal-entities-iframe").contentDocument;
+
+    internalEntityText = internalDocument.getElementById("internal").textContent.trim();
+    shouldBeEqualToString("internalEntityText", "PASS");
+
+    nestedEntityText = internalDocument.getElementById("nested").textContent.trim();
+    shouldBeEqualToString("nestedEntityText", "PASS");
+
+    predefinedEntityText = internalDocument.getElementById("predefined").textContent.trim();
+    shouldBeEqualToString("predefinedEntityText", "&<>");
+
+    namedEntityCharCode = internalDocument.getElementById("named").textContent.charCodeAt(0);
+    shouldBe("namedEntityCharCode", "160");
+
+    externalSubsetText = document.getElementById("external-subset-iframe").contentDocument.getElementById("result").textContent.trim();
+    shouldBeEqualToString("externalSubsetText", "PASS");
+
+    finishJSTest();
+}
+</script>
+<iframe id="internal-entities-iframe" src="resources/no-warning-internal-entities.xhtml" onload="frameLoaded()"></iframe>
+<iframe id="external-subset-iframe" src="resources/no-warning-external-subset.xml" onload="frameLoaded()"></iframe>
+</body>
+</html>

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-once-per-page-expected.txt
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-once-per-page-expected.txt
@@ -1,0 +1,13 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
+This test ensures the XML external entity deprecation warning is logged only once per page, even when a document declares and references several external entities.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS firstEntityText is "SUCCESS"
+PASS secondEntityText is "SUCCESS"
+PASS thirdEntityText is "SUCCESS"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-once-per-page.html
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-once-per-page.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("This test ensures the XML external entity deprecation warning is logged only once per page, even when a document declares and references several external entities.");
+
+jsTestIsAsync = true;
+
+var firstEntityText;
+var secondEntityText;
+var thirdEntityText;
+
+function runTest() {
+    var xmlDocument = document.getElementById("xml-iframe").contentDocument;
+
+    firstEntityText = xmlDocument.getElementById("first").textContent.trim();
+    shouldBeEqualToString("firstEntityText", "SUCCESS");
+
+    secondEntityText = xmlDocument.getElementById("second").textContent.trim();
+    shouldBeEqualToString("secondEntityText", "SUCCESS");
+
+    thirdEntityText = xmlDocument.getElementById("third").textContent.trim();
+    shouldBeEqualToString("thirdEntityText", "SUCCESS");
+
+    finishJSTest();
+}
+</script>
+<iframe id="xml-iframe" src="resources/multiple-external-entities.xml" onload="runTest()"></iframe>
+</body>
+</html>

--- a/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning.html
+++ b/LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("This test ensures a deprecation warning is logged to the console when an XML document uses an external entity.");
+
+jsTestIsAsync = true;
+
+var externalEntityText;
+
+function runTest() {
+    var xmlDocument = document.getElementById("xml-iframe").contentDocument;
+    externalEntityText = xmlDocument.getElementById("result").textContent.trim();
+    shouldBeEqualToString("externalEntityText", "SUCCESS");
+    finishJSTest();
+}
+</script>
+<iframe id="xml-iframe" src="resources/external-entity.xml" onload="runTest()"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentTypeOptions/nosniff-xml-external-entity-expected.txt
+++ b/LayoutTests/http/tests/security/contentTypeOptions/nosniff-xml-external-entity-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 CONSOLE MESSAGE: Did not parse external entity resource at 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=application/pdf' because only XML MIME types are allowed.
 CONSOLE MESSAGE: Did not parse external entity resource at 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=text/html' because only XML MIME types are allowed.
 CONSOLE MESSAGE: Did not parse external entity resource at 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=text/javascript' because only XML MIME types are allowed.

--- a/LayoutTests/http/tests/security/xss-DENIED-xml-external-entity-expected.txt
+++ b/LayoutTests/http/tests/security/xss-DENIED-xml-external-entity-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/resources/target.xml from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
 
 This test includes a cross-origin external entity. It passes if the load fails and thus there is no text below this line.

--- a/LayoutTests/platform/glib/dom/xhtml/level3/core/entitygetinputencoding03-expected.txt
+++ b/LayoutTests/platform/glib/dom/xhtml/level3/core/entitygetinputencoding03-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 This page contains the following errors:
 
 error on line 29 at column 13: Document is empty

--- a/LayoutTests/platform/glib/http/tests/security/contentTypeOptions/nosniff-xml-external-entity-expected.txt
+++ b/LayoutTests/platform/glib/http/tests/security/contentTypeOptions/nosniff-xml-external-entity-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: XML external entities are deprecated and will be removed in a future version of WebKit.
 CONSOLE MESSAGE: Did not parse external entity resource at 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=application/pdf' because only XML MIME types are allowed.
 CONSOLE MESSAGE: Did not parse external entity resource at 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=text/html' because only XML MIME types are allowed.
 CONSOLE MESSAGE: Did not parse external entity resource at 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=text/javascript' because only XML MIME types are allowed.

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8031,6 +8031,18 @@ void Document::setTransformSource(std::unique_ptr<TransformSource> source)
 
 #endif
 
+void Document::logXMLExternalEntityDeprecationWarningIfNeeded()
+{
+    // Documents created by DOMParser and XMLHttpRequest have no frame, and addConsoleMessage
+    // silently drops messages in that case, so report on the context document instead. Throttling
+    // on the target document also keeps repeated DOMParser parses from logging more than once.
+    Ref document = frame() ? protect(*this) : protect(contextDocument());
+    if (document->m_hasLoggedXMLExternalEntityDeprecationWarning)
+        return;
+    document->m_hasLoggedXMLExternalEntityDeprecationWarning = true;
+    document->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "XML external entities are deprecated and will be removed in a future version of WebKit."_s);
+}
+
 String Document::designMode() const
 {
     return inDesignMode() ? onAtom() : offAtom();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1323,6 +1323,8 @@ public:
     TransformSource* transformSource() const LIFETIME_BOUND { return m_transformSource.get(); }
 #endif
 
+    void logXMLExternalEntityDeprecationWarningIfNeeded();
+
     void incDOMTreeVersion() { m_domTreeVersion = ++s_globalTreeVersion; }
     uint64_t domTreeVersion() const { return m_domTreeVersion; }
 
@@ -2837,6 +2839,8 @@ private:
     bool m_hasPendingXSLTransforms { false };
     bool m_hasLoggedXSLTDeprecationWarning { false };
 #endif
+
+    bool m_hasLoggedXMLExternalEntityDeprecationWarning { false };
 
 #if ENABLE(MEDIA_STREAM)
     bool m_hasHadCaptureMediaStreamTrack { false };

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1349,6 +1349,15 @@ xmlEntityPtr XMLDocumentParser::getEntity(const xmlChar* name)
 
 void XMLDocumentParser::entityDecl(const xmlChar* name, int type, const xmlChar* publicId, const xmlChar* systemId, xmlChar* content)
 {
+    // External general parsed entities are the only external DTD construct WebKit still loads:
+    // external DTD subsets are never fetched because XML_PARSE_DTDLOAD is not set and
+    // externalSubsetHandler does not call xmlSAX2ExternalSubset, and parameter entities never
+    // resolve because sax.getParameterEntity is null.
+    if (type == XML_EXTERNAL_GENERAL_PARSED_ENTITY) {
+        if (RefPtr document = this->document())
+            document->logXMLExternalEntityDeprecationWarningIfNeeded();
+    }
+
     auto contentString = toString(content);
     if (type == XML_INTERNAL_GENERAL_ENTITY && contentString.contains('&')) {
         m_deferredEntityDeclarations.append({


### PR DESCRIPTION
#### 2015944bd6f82e31c15a6f1294f577447c166d04
<pre>
[xml] Add deprecation console warning upon usage of XML external entities
<a href="https://bugs.webkit.org/show_bug.cgi?id=321742">https://bugs.webkit.org/show_bug.cgi?id=321742</a>
<a href="https://rdar.apple.com/184870654">rdar://184870654</a>

Reviewed by NOBODY (OOPS!).

Add a console warning whenever a page uses an XML external entity, so that web developers
see it in the Web Inspector console. Chromium deprecated the same feature in M144 and
removed it in M145.

The warning is emitted from XMLDocumentParser::entityDecl() for declarations of type
XML_EXTERNAL_GENERAL_PARSED_ENTITY, the only external DTD construct WebKit still loads.
External DTD subsets are never fetched and parameter entities never resolve, so neither
needs a warning, and predefined entities, XHTML named entities, and internal entities are
unaffected. The XSLT paths use libxml2&apos;s default SAX handlers and are therefore excluded;
those documents already log the XSLT deprecation warning.
The warning is logged once per document. Documents created by DOMParser and
XMLHttpRequest.responseXML have no frame, which makes addConsoleMessage() drop the message,
so for those it is reported on the context document instead.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::logXMLExternalEntityDeprecationWarningIfNeeded):
* Source/WebCore/dom/Document.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::entityDecl):
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/external-entity.xml: Added.
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/external-subset.dtd.xml: Added.
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/message.xml: Added.
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/multiple-external-entities.xml: Added.
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/no-warning-external-subset.xml: Added.
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/resources/no-warning-internal-entities.xhtml: Added.
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-expected.txt: Added.
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-not-fired-expected.txt: Added.
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-not-fired.html: Added.
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-once-per-page-expected.txt: Added.
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning-once-per-page.html: Added.
* LayoutTests/fast/parser/xml-external-entity-deprecation-warning/xml-external-entity-deprecation-warning.html: Added.
* LayoutTests/dom/xhtml/level3/core/entitygetinputencoding03-expected.txt:
* LayoutTests/dom/xhtml/level3/core/entitygetinputencoding04-expected.txt:
* LayoutTests/dom/xhtml/level3/core/entitygetxmlencoding02-expected.txt:
* LayoutTests/dom/xhtml/level3/core/entitygetxmlencoding03-expected.txt:
* LayoutTests/dom/xhtml/level3/core/entitygetxmlencoding04-expected.txt:
* LayoutTests/dom/xhtml/level3/core/entitygetxmlversion03-expected.txt:
* LayoutTests/dom/xhtml/level3/core/entitygetxmlversion04-expected.txt:
* LayoutTests/dom/xhtml/level3/core/nodegetbaseuri16-expected.txt:
* LayoutTests/dom/xhtml/level3/core/nodegetbaseuri19-expected.txt:
* LayoutTests/dom/xhtml/level3/core/nodegetbaseuri20-expected.txt:
* LayoutTests/http/tests/security/contentTypeOptions/nosniff-xml-external-entity-expected.txt:
* LayoutTests/http/tests/security/xss-DENIED-xml-external-entity-expected.txt:
* LayoutTests/platform/glib/dom/xhtml/level3/core/entitygetinputencoding03-expected.txt:
* LayoutTests/platform/glib/http/tests/security/contentTypeOptions/nosniff-xml-external-entity-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2015944bd6f82e31c15a6f1294f577447c166d04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145735 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b77aa85c-195c-42b2-9d60-1b98743390c5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141599 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98249 "12 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f7178c9-62b7-4fb1-a49b-079443470c5c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122039 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43941 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42212 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41857 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2789 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47982 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46468 "Found 1 new test failure: http/tests/websocket/tests/hybi/inspector/handshake-error.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193560 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150979 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55712 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150685 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45274 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127993 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123594 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54228 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16856 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53610 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53848 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53675 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->