### PR TITLE
AutoInstall drops path prefix from pip index-url

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='1.0.3',
+    version='1.0.4',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     long_description_content_type='text/markdown',

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -52,7 +52,7 @@ from webkitcorepy.null_context import NullContext
 from webkitcorepy.filtered_call import filtered_call
 from webkitcorepy.partial_proxy import PartialProxy
 
-version = Version(1, 0, 3)
+version = Version(1, 0, 4)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -475,7 +475,13 @@ def _pypi_indices_from_file(file):
                     if url:
                         parsed = urlparse(url)
                         if parsed.hostname:
-                            result.append(parsed.hostname)
+                            # AutoInstall appends 'simple/<package>/' to the index, but
+                            # index-url values conventionally end with '/simple/' and may
+                            # contain a path prefix (e.g. a proxy at https://host/pypi/simple/).
+                            # Keep the prefix, dropping the trailing '/simple' component.
+                            host = parsed.netloc.rpartition('@')[2]
+                            path = parsed.path.rstrip('/').removesuffix('/simple')
+                            result.append(host + path)
     return result
 
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
@@ -57,6 +57,26 @@ class DefaultPyPIIndexTest(unittest.TestCase):
         result = _pypi_indices_from_file(config)
         self.assertEqual(result, ['primary.example.com', 'extra1.example.com', 'extra2.example.com'])
 
+    def test_index_with_simple_suffix(self):
+        config = io.StringIO('[global]\nindex-url = https://internal.example.com/simple/\n')
+        self.assertEqual(_pypi_indices_from_file(config), ['internal.example.com'])
+
+    def test_index_with_path_prefix(self):
+        config = io.StringIO('[global]\nindex-url = https://internal.example.com/pypi/simple/\n')
+        self.assertEqual(_pypi_indices_from_file(config), ['internal.example.com/pypi'])
+
+    def test_index_with_path_prefix_without_simple_suffix(self):
+        config = io.StringIO('[global]\nindex-url = https://internal.example.com/pypi\n')
+        self.assertEqual(_pypi_indices_from_file(config), ['internal.example.com/pypi'])
+
+    def test_index_with_port(self):
+        config = io.StringIO('[global]\nindex-url = http://localhost:8080/pypi/simple/\n')
+        self.assertEqual(_pypi_indices_from_file(config), ['localhost:8080/pypi'])
+
+    def test_index_with_credentials(self):
+        config = io.StringIO('[global]\nindex-url = https://user:pass@internal.example.com/pypi/simple/\n')
+        self.assertEqual(_pypi_indices_from_file(config), ['internal.example.com/pypi'])
+
 
 class ArchiveTest(unittest.TestCase):
     @patch.object(AutoInstall, "_verify_index", autospec=True, return_value=None)


### PR DESCRIPTION
#### 37e50b0dd84f7e560f08cee7f3f4349e6e16bd3e
<pre>
AutoInstall drops path prefix from pip index-url
<a href="https://bugs.webkit.org/show_bug.cgi?id=321747">https://bugs.webkit.org/show_bug.cgi?id=321747</a>

Reviewed by Devin Rousso.

Preserve the port and path prefix when extracting the PyPI index from
pip.conf, stripping only the trailing /simple component that AutoInstall
appends itself. Bare-host index URLs are unaffected. Credentials in the
index URL are still dropped, as they were before.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(_pypi_indices_from_file):
* Tools/Scripts/libraries/webkitcorepy/setup.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py:
(DefaultPyPIIndexTest.test_index_with_simple_suffix):
(DefaultPyPIIndexTest):
(DefaultPyPIIndexTest.test_index_with_path_prefix):
(DefaultPyPIIndexTest.test_index_with_path_prefix_without_simple_suffix):
(DefaultPyPIIndexTest.test_index_with_port):
(DefaultPyPIIndexTest.test_index_with_credentials):

Canonical link: <a href="https://commits.webkit.org/319293@main">https://commits.webkit.org/319293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bbf322f298da059016a0230e20a9b63a57e4912

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145090 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141005 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97723 "1 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161757 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121457 "") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180091 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43341 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41624 "Passed tests") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153745 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.LAMakeCredentialAllowLocalAuthenticator (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41286 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2141 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192915 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/180168 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54378 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150387 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40316 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55066 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37904 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150104 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44710 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122618 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53583 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16279 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52965 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53202 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->