### PR TITLE
Google Drive on a Debug build, hits assertion: "ASSERT(!descendantDependentFlagsAreDirty());

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -180,6 +180,10 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
+#if ASSERT_ENABLED
+unsigned DescendantDependentFlagsMutationDetector::s_scopeCount = 0;
+#endif
+
 class ClipRects : public RefCounted<ClipRects> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(ClipRects);
 public:
@@ -1017,6 +1021,11 @@ void RenderLayer::setAncestorsHaveCompositingDirtyFlag(Compositing flag)
 void RenderLayer::updateLayerListsIfNeeded()
 {
     updateDescendantDependentFlags();
+
+#if ASSERT_ENABLED
+    DescendantDependentFlagsMutationDetector flagsMutationDetector;
+#endif
+
     updateZOrderLists();
     updateNormalFlowList();
 
@@ -1463,19 +1472,18 @@ void RenderLayer::setAncestorChainHasSelfPaintingLayerDescendant()
     for (RenderLayer* layer = this; layer; layer = layer->parent()) {
         if (layer->renderer().shouldApplyPaintContainment()) {
             layer->m_hasSelfPaintingLayerDescendant = true;
-            layer->m_hasSelfPaintingLayerDescendantDirty = false;
             break;
         }
         if (!layer->m_hasSelfPaintingLayerDescendantDirty && layer->hasSelfPaintingLayerDescendant())
             break;
 
-        layer->m_hasSelfPaintingLayerDescendantDirty = false;
         layer->m_hasSelfPaintingLayerDescendant = true;
     }
 }
 
 void RenderLayer::dirtyAncestorChainHasSelfPaintingLayerDescendantStatus()
 {
+    ASSERT(DescendantDependentFlagsMutationDetector::isMutationAllowed());
     for (RenderLayer* layer = this; layer; layer = layer->parent()) {
         if (layer->m_hasSelfPaintingLayerDescendantDirty)
             break;
@@ -1492,12 +1500,12 @@ void RenderLayer::setAncestorChainHasViewportConstrainedDescendant()
             break;
 
         layer->m_hasViewportConstrainedDescendant = true;
-        layer->m_hasViewportConstrainedDescendantStatusDirty = false;
     }
 }
 
 void RenderLayer::dirtyAncestorChainHasViewportConstrainedDescendantStatus()
 {
+    ASSERT(DescendantDependentFlagsMutationDetector::isMutationAllowed());
     for (auto* layer = this; layer; layer = layer->parent()) {
         if (layer->m_hasViewportConstrainedDescendantStatusDirty)
             break;
@@ -1653,10 +1661,11 @@ void RenderLayer::updateAncestorChainHasBlendingDescendants()
 
 void RenderLayer::dirtyAncestorChainHasBlendingDescendants()
 {
+    ASSERT(DescendantDependentFlagsMutationDetector::isMutationAllowed());
     for (auto* layer = this; layer; layer = layer->parent()) {
         if (layer->hasNotIsolatedBlendingDescendantsStatusDirty())
             break;
-        
+
         layer->m_hasNotIsolatedBlendingDescendantsStatusDirty = true;
         layer->setNeedsPositionUpdate();
     }
@@ -1688,12 +1697,12 @@ void RenderLayer::updateAncestorChainHasAlwaysIncludedInZOrderListsDescendants()
         if (!layer->m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty && layer->m_hasAlwaysIncludedInZOrderListsDescendants)
             break;
         layer->m_hasAlwaysIncludedInZOrderListsDescendants = true;
-        layer->m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty = false;
     }
 }
 
 void RenderLayer::dirtyAncestorChainHasAlwaysIncludedInZOrderListsDescendants()
 {
+    ASSERT(DescendantDependentFlagsMutationDetector::isMutationAllowed());
     for (auto* layer = this; layer; layer = layer->parent()) {
         if (layer->m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty)
             break;
@@ -1929,8 +1938,9 @@ void RenderLayer::setHasVisibleContent()
         parent()->dirtyAncestorChainVisibleDescendantStatus();
 }
 
-void RenderLayer::dirtyVisibleContentStatus() 
-{ 
+void RenderLayer::dirtyVisibleContentStatus()
+{
+    ASSERT(DescendantDependentFlagsMutationDetector::isMutationAllowed());
     m_visibleContentStatusDirty = true;
     setNeedsPositionUpdate();
     if (parent())
@@ -1939,6 +1949,7 @@ void RenderLayer::dirtyVisibleContentStatus()
 
 void RenderLayer::dirtyAncestorChainVisibleDescendantStatus()
 {
+    ASSERT(DescendantDependentFlagsMutationDetector::isMutationAllowed());
     setNeedsPositionUpdate();
     for (auto* layer = this; layer; layer = layer->parent()) {
         if (layer->m_visibleDescendantStatusDirty)
@@ -1970,17 +1981,29 @@ void RenderLayer::updateAncestorDependentState()
 
 void RenderLayer::updateDescendantDependentFlags()
 {
-    if (m_visibleDescendantStatusDirty || m_hasSelfPaintingLayerDescendantDirty || hasNotIsolatedBlendingDescendantsStatusDirty() || m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty || m_hasViewportConstrainedDescendantStatusDirty) {
+    if (!descendantDependentFlagsAreDirty())
+        return;
+
+    // We need the parent to know if we have skipped content or content-visibility root.
+    // Defer visible content computation until parent is available.
+    if (m_visibleContentStatusDirty && renderer().style().isSkippedRootOrSkippedContent() && !renderer().parent()) {
+        if (!m_visibleDescendantStatusDirty && !m_hasSelfPaintingLayerDescendantDirty && !m_hasNotIsolatedBlendingDescendantsStatusDirty && !m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty && !m_hasViewportConstrainedDescendantStatusDirty)
+            return;
+    }
+
+    // Phase 1: Perform computation work, including recursive child updates and side effects
+    // that may re-dirty flags on this layer (e.g. updateSelfPaintingLayer can dirty
+    // m_hasSelfPaintingLayerDescendantDirty on ancestors).
+
+    if (m_visibleDescendantStatusDirty || m_hasSelfPaintingLayerDescendantDirty || m_hasNotIsolatedBlendingDescendantsStatusDirty || m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty || m_hasViewportConstrainedDescendantStatusDirty) {
+        if (m_hasNotIsolatedBlendingDescendantsStatusDirty)
+            updateSelfPaintingLayer();
+
         bool hasVisibleDescendant = false;
         bool hasSelfPaintingLayerDescendant = false;
         bool hasNotIsolatedBlendingDescendants = false;
         bool hasAlwaysIncludedInZOrderListsDescendants = false;
         bool hasViewportConstrainedDescendant = false;
-
-        if (m_hasNotIsolatedBlendingDescendantsStatusDirty) {
-            m_hasNotIsolatedBlendingDescendantsStatusDirty = false;
-            updateSelfPaintingLayer();
-        }
 
         for (RenderLayer* child = firstChild(); child; child = child->nextSibling()) {
             child->updateDescendantDependentFlags();
@@ -1992,26 +2015,19 @@ void RenderLayer::updateDescendantDependentFlags()
             hasViewportConstrainedDescendant |= child->m_hasViewportConstrainedDescendant || child->isViewportConstrained();
         }
 
+        // Apply computed descendant values and trigger side effects (which may dirty ancestors).
         if (hasVisibleDescendant != m_hasVisibleDescendant) {
             m_hasVisibleDescendant = hasVisibleDescendant;
             if (!isNormalFlowOnly())
                 dirtyHiddenStackingContextAncestorZOrderLists();
         }
-        m_visibleDescendantStatusDirty = false;
         m_hasSelfPaintingLayerDescendant = hasSelfPaintingLayerDescendant;
-        m_hasSelfPaintingLayerDescendantDirty = false;
-        m_hasAlwaysIncludedInZOrderListsDescendants = hasAlwaysIncludedInZOrderListsDescendants;
-        m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty = false;
-        m_hasViewportConstrainedDescendant = hasViewportConstrainedDescendant;
-        m_hasViewportConstrainedDescendantStatusDirty = false;
-
         m_hasNotIsolatedBlendingDescendants = hasNotIsolatedBlendingDescendants;
+        m_hasAlwaysIncludedInZOrderListsDescendants = hasAlwaysIncludedInZOrderListsDescendants;
+        m_hasViewportConstrainedDescendant = hasViewportConstrainedDescendant;
     }
 
-    if (m_visibleContentStatusDirty) {
-        //  We need the parent to know if we have skipped content or content-visibility root.
-        if (renderer().style().isSkippedRootOrSkippedContent() && !renderer().parent())
-            return;
+    if (m_visibleContentStatusDirty && !(renderer().style().isSkippedRootOrSkippedContent() && !renderer().parent())) {
         bool hasVisibleContent = computeHasVisibleContent();
         if (hasVisibleContent != m_hasVisibleContent) {
             m_hasVisibleContent = hasVisibleContent;
@@ -2022,10 +2038,19 @@ void RenderLayer::updateDescendantDependentFlags()
                 dirtyHiddenStackingContextAncestorZOrderLists();
             }
         }
-        m_visibleContentStatusDirty = false;
     }
 
-    ASSERT(!descendantDependentFlagsAreDirty());
+    // Phase 2: Clear all dirty bits last. This ensures that any re-dirtying caused by
+    // side effects above (e.g. child processing dirtying ancestor flags) is properly absorbed.
+    m_visibleDescendantStatusDirty = false;
+    m_hasSelfPaintingLayerDescendantDirty = false;
+    m_hasNotIsolatedBlendingDescendantsStatusDirty = false;
+    m_hasAlwaysIncludedInZOrderListsDescendantsStatusDirty = false;
+    m_hasViewportConstrainedDescendantStatusDirty = false;
+    if (!(renderer().style().isSkippedRootOrSkippedContent() && !renderer().parent()))
+        m_visibleContentStatusDirty = false;
+
+    ASSERT(!descendantDependentFlagsAreDirty() || (m_visibleContentStatusDirty && renderer().style().isSkippedRootOrSkippedContent() && !renderer().parent()));
 }
 
 bool RenderLayer::computeHasVisibleContent() const

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1596,7 +1596,7 @@ public:
     {
         m_layer.setLayerListMutationAllowed(false);
     }
-    
+
     ~LayerListMutationDetector()
     {
         m_layer.setLayerListMutationAllowed(m_previousMutationAllowedState);
@@ -1605,6 +1605,18 @@ public:
 private:
     RenderLayer& m_layer;
     bool m_previousMutationAllowedState;
+};
+
+// Detects illegal dirtying of descendant-dependent flags after they've been flushed.
+// Instantiated in updateLayerListsIfNeeded() to cover both the flush and the subsequent
+// z-order list collection, catching mutations at the call site with a full stack trace.
+class DescendantDependentFlagsMutationDetector {
+public:
+    DescendantDependentFlagsMutationDetector() { ++s_scopeCount; }
+    ~DescendantDependentFlagsMutationDetector() { --s_scopeCount; }
+    static bool isMutationAllowed() { return !s_scopeCount; }
+private:
+    WEBCORE_EXPORT static unsigned s_scopeCount;
 };
 #endif // ASSERT_ENABLED
 


### PR DESCRIPTION
#### c3018b8fd46a2439615510a51257416e33d06108
<pre>
Google Drive on a Debug build, hits assertion: &quot;ASSERT(!descendantDependentFlagsAreDirty());
<a href="https://bugs.webkit.org/show_bug.cgi?id=321748">https://bugs.webkit.org/show_bug.cgi?id=321748</a>
&lt;<a href="https://rdar.apple.com/184541999">rdar://184541999</a>&gt;

Reviewed by NOBODY (OOPS!).

Fixes the underlying bug by not clearing m_hasSelfPaintingLayerDescendantDirty (and m_hasViewportConstrainedDescendantStatusDirty), since there might still be dirty state on descendants. The dirty flag causes updateDescendantDependentFlags to recurse, so we need to keep them until we&apos;re sure the whole subtree is valid.

Also fixes a related bug where updateDescendantDependentFlags can re-set dirty bits in the process of clearing them (through calling into updateSelfPaintingLayer). Refactors the function so that all bit clearing happens at the end to prevent this type of bug.

Finally, adds DescendantDependentFlagsMutationDetector (analogue to LayerListMutationDetector) to provide better assertion stack traces if we ever do mutate dirty bits while we expect them to remain clean.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateLayerListsIfNeeded):
(WebCore::RenderLayer::setAncestorChainHasSelfPaintingLayerDescendant):
(WebCore::RenderLayer::dirtyAncestorChainHasSelfPaintingLayerDescendantStatus):
(WebCore::RenderLayer::setAncestorChainHasViewportConstrainedDescendant):
(WebCore::RenderLayer::dirtyAncestorChainHasViewportConstrainedDescendantStatus):
(WebCore::RenderLayer::dirtyAncestorChainHasBlendingDescendants):
(WebCore::RenderLayer::updateAncestorChainHasAlwaysIncludedInZOrderListsDescendants):
(WebCore::RenderLayer::dirtyAncestorChainHasAlwaysIncludedInZOrderListsDescendants):
(WebCore::RenderLayer::dirtyVisibleContentStatus):
(WebCore::RenderLayer::dirtyAncestorChainVisibleDescendantStatus):
(WebCore::RenderLayer::updateDescendantDependentFlags):
* Source/WebCore/rendering/RenderLayer.h:
(WebCore::DescendantDependentFlagsMutationDetector::DescendantDependentFlagsMutationDetector):
(WebCore::DescendantDependentFlagsMutationDetector::~DescendantDependentFlagsMutationDetector):
(WebCore::DescendantDependentFlagsMutationDetector::isMutationAllowed):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3018b8fd46a2439615510a51257416e33d06108

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190886 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144997 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6860dfe-226a-4d7d-8081-4afbf17bd8de) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140927 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97640 "layout-tests (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/473c093a-0ef2-4369-af37-38c7a45fb138) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121379 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4edaef8-cffb-464c-a9b9-179a6f1392ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43273 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41559 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41226 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2047 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192823 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54286 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150306 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54974 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150023 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44638 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127239 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122460 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53491 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16219 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52873 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52938 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->