### PR TITLE
Web Inspector: Canvas: snapshot WebGPU element image copies

### DIFF
--- a/LayoutTests/inspector/canvas/recording-webgpu-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgpu-full-expected.txt
@@ -767,6 +767,7 @@ frames:
         2: ignoreException
         3: (anonymous function)
         4: executeFrameFunction
+      snapshot: <filtered>
   95: (duration)
     0: queue.submit(["<commandBuffer>"])
       swizzleTypes: [ArrayOf]

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -424,7 +424,8 @@ static bool shouldSnapshotWebGPUAction(RecordingSwizzleType receiverSwizzleType,
     if (receiverSwizzleType == RecordingSwizzleType::GPUQueue) {
         return name == "submit"_s
             || name == "writeTexture"_s
-            || name == "copyExternalImageToTexture"_s;
+            || name == "copyExternalImageToTexture"_s
+            || name == "copyElementImageToTexture"_s;
     }
     return false;
 }

--- a/Source/WebInspectorUI/UserInterface/Models/RecordingAction.js
+++ b/Source/WebInspectorUI/UserInterface/Models/RecordingAction.js
@@ -1059,6 +1059,7 @@ WI.RecordingAction._visualNames = {
         "multiDrawElementsWEBGL",
     ]),
     [WI.Recording.Type.CanvasWebGPU]: new Set([
+        "copyElementImageToTexture",
         "copyExternalImageToTexture",
         "submit",
         "writeTexture",


### PR DESCRIPTION
#### 6139ca35df650d04c073f6fb6b41914030685681
<pre>
Web Inspector: Canvas: snapshot WebGPU element image copies
<a href="https://bugs.webkit.org/show_bug.cgi?id=321757">https://bugs.webkit.org/show_bug.cgi?id=321757</a>

Reviewed by Mike Wyrzykowski.

* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::shouldSnapshotWebGPUAction):
Capture a snapshot after `GPUQueue.copyElementImageToTexture`.

* Source/WebInspectorUI/UserInterface/Models/RecordingAction.js:
(WI.RecordingAction._visualNames):
Classify `copyElementImageToTexture` as a visual WebGPU action.

* LayoutTests/inspector/canvas/recording-webgpu-full-expected.txt:

Canonical link: <a href="https://commits.webkit.org/319176@main">https://commits.webkit.org/319176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/812f4723b666518d465dbe3d8a424be6da883111

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190891 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145002 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140929 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121381 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41229 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2052 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47234 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192828 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54291 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150310 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40234 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54979 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150027 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44641 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122465 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53496 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16222 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52878 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53115 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->