### PR TITLE
Web Inspector: Canvas: show names for recorded WebGPU bitfields

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/RecordingAction.js
+++ b/Source/WebInspectorUI/UserInterface/Models/RecordingAction.js
@@ -140,17 +140,30 @@ WI.RecordingAction = class RecordingAction extends WI.Object
         return typeof propertyDescriptor.value === "function";
     }
 
-    static bitfieldNamesForParameter(type, name, value, index, count)
+    static bitfieldNamesForParameter(type, name, value, index, count, path = [])
     {
         if (!value)
             return null;
 
-        let prototype = WI.RecordingAction._prototypeForType(type);
-        if (!prototype)
+        let bitfield = WI.RecordingAction._bitfields[type]?.[name]?.[index];
+        for (let propertyName of path)
+            bitfield = bitfield?.[propertyName];
+        if (!bitfield)
             return null;
 
-        function testAndClearBit(name) {
-            let bit = prototype[name];
+        let namespaceName = typeof bitfield === "string" ? bitfield : "context";
+        let namespace = namespaceName === "context" ? WI.RecordingAction._prototypeForType(type) : window[namespaceName];
+        if (!namespace)
+            return null;
+
+        let constantNames = Array.isArray(bitfield) ? bitfield : Object.getOwnPropertyNames(namespace);
+        for (let name of constantNames) {
+            let bit = namespace[name];
+            if (typeof bit === "number" && bit === value)
+                return [`${namespaceName}.${name}`];
+        }
+
+        function testAndClearBit(bit, name) {
             if (!bit)
                 return;
 
@@ -166,27 +179,15 @@ WI.RecordingAction = class RecordingAction extends WI.Object
 
         let names = [];
 
-        let isWebGL = type === WI.Recording.Type.CanvasWebGL || type === WI.Recording.Type.OffscreenCanvasWebGL;
-        let isWebGL2 = type === WI.Recording.Type.CanvasWebGL2 || type === WI.Recording.Type.OffscreenCanvasWebGL2;
-
-        if ((name === "clear" && index === 0 && (isWebGL || isWebGL2)) || (name === "blitFramebuffer" && index === 8 && isWebGL2)) {
-            testAndClearBit("COLOR_BUFFER_BIT");
-            testAndClearBit("DEPTH_BUFFER_BIT");
-            testAndClearBit("STENCIL_BUFFER_BIT");
-            if (value)
-                names.push(hexString(value));
+        for (let name of constantNames) {
+            let bit = namespace[name];
+            if (typeof bit === "number" && !(bit & (bit - 1)))
+                testAndClearBit(bit, `${namespaceName}.${name}`);
         }
+        if (value)
+            names.push(hexString(value));
 
-        if (name === "clientWaitSync" && index === 1 && isWebGL2) {
-            testAndClearBit("SYNC_FLUSH_COMMANDS_BIT");
-            if (value)
-                names.push(hexString(value));
-        }
-
-        if (!names.length)
-            return null;
-
-        return names;
+        return names.length ? names : null;
     }
 
     static constantNameForParameter(type, name, value, index, count)
@@ -608,6 +609,72 @@ WI.RecordingAction = class RecordingAction extends WI.Object
 WI.RecordingAction.Event = {
     ValidityChanged: "recording-action-marked-invalid",
 };
+
+WI.RecordingAction._bitfields = {
+    [WI.Recording.Type.CanvasWebGL]: {
+        "clear": {
+            0: ["COLOR_BUFFER_BIT", "DEPTH_BUFFER_BIT", "STENCIL_BUFFER_BIT"],
+        },
+    },
+    [WI.Recording.Type.CanvasWebGL2]: {
+        "blitFramebuffer": {
+            8: ["COLOR_BUFFER_BIT", "DEPTH_BUFFER_BIT", "STENCIL_BUFFER_BIT"],
+        },
+        "clear": {
+            0: ["COLOR_BUFFER_BIT", "DEPTH_BUFFER_BIT", "STENCIL_BUFFER_BIT"],
+        },
+        "clientWaitSync": {
+            1: ["SYNC_FLUSH_COMMANDS_BIT"],
+        },
+    },
+    [WI.Recording.Type.CanvasWebGPU]: {
+        "createBindGroupLayout": {
+            0: {
+                "entries": {
+                    "visibility": "GPUShaderStage",
+                },
+            },
+        },
+        "createBuffer": {
+            0: {
+                "usage": "GPUBufferUsage",
+            },
+        },
+        "createRenderPipeline": {
+            0: {
+                "fragment": {
+                    "targets": {
+                        "writeMask": "GPUColorWrite",
+                    },
+                },
+            },
+        },
+        "createRenderPipelineAsync": {
+            0: {
+                "fragment": {
+                    "targets": {
+                        "writeMask": "GPUColorWrite",
+                    },
+                },
+            },
+        },
+        "createTexture": {
+            0: {
+                "usage": "GPUTextureUsage",
+            },
+        },
+        "createView": {
+            0: {
+                "usage": "GPUTextureUsage",
+            },
+        },
+        "mapAsync": {
+            0: "GPUMapMode",
+        },
+    },
+};
+WI.RecordingAction._bitfields[WI.Recording.Type.OffscreenCanvasWebGL] = WI.RecordingAction._bitfields[WI.Recording.Type.CanvasWebGL];
+WI.RecordingAction._bitfields[WI.Recording.Type.OffscreenCanvasWebGL2] = WI.RecordingAction._bitfields[WI.Recording.Type.CanvasWebGL2];
 
 WI.RecordingAction._constantIndexes = {
     [WI.Recording.Type.CanvasWebGL]: {

--- a/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js
@@ -48,7 +48,7 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
         let recordingType = recording.type;
         let parameterCount = recordingAction.parameters.length;
 
-        function appendJSON(parent, value, objectReferences, indent = 0) {
+        function appendJSON(parent, value, objectReferences, index, path = [], indent = 0) {
             if (objectReferences.has(value)) {
                 let objectReferenceElement = parent.appendChild(document.createElement("span"));
                 objectReferenceElement.classList.add("object-handle");
@@ -71,7 +71,7 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
                 for (let item of value) {
                     let comma = added ? "," : "";
                     parent.appendChild(document.createTextNode(`${comma}\n${valueIndent}`));
-                    appendJSON(parent, item, objectReferences, indent + 1);
+                    appendJSON(parent, item, objectReferences, index, path, indent + 1);
                     added = true;
                 }
                 parent.appendChild(document.createTextNode(added ? `\n${braceIndent}]` : " ]"));
@@ -85,11 +85,21 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
                     let comma = added ? "," : "";
                     let propertyName = WI.ScriptSyntaxTree.isIdentifierName(name) ? name : JSON.stringify(name);
                     parent.appendChild(document.createTextNode(`${comma}\n${valueIndent}${propertyName}: `));
-                    appendJSON(parent, item, objectReferences, indent + 1);
+                    appendJSON(parent, item, objectReferences, index, [...path, name], indent + 1);
                     added = true;
                 }
                 parent.appendChild(document.createTextNode(added ? `\n${braceIndent}}` : " }"));
                 return;
+            }
+
+            if (typeof value === "number") {
+                let bitfieldNames = WI.RecordingAction.bitfieldNamesForParameter(recordingType, recordingAction.name, value, index, parameterCount, path);
+                if (bitfieldNames) {
+                    let constantElement = parent.appendChild(document.createElement("span"));
+                    constantElement.classList.add("parameter", "constant");
+                    constantElement.textContent = bitfieldNames.join(" | ");
+                    return;
+                }
             }
 
             parent.appendChild(document.createTextNode(JSON.stringify(value)));
@@ -112,7 +122,7 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
 
             if (WI.Recording.isReferenceSwizzleType(swizzleType)) {
                 let objectReferences = WI.RecordingAction.objectReferencesForParameter(recordingType, recordingAction.name, parameter, index);
-                appendJSON(parameterElement, parameter, objectReferences);
+                appendJSON(parameterElement, parameter, objectReferences, index);
                 return parameterElement;
             }
 
@@ -125,7 +135,7 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
                     parameterElement.textContent = "context." + constantNameForParameter;
                 } else if (bitfieldNamesForParameter) {
                     parameterElement.classList.add("constant");
-                    parameterElement.textContent = bitfieldNamesForParameter.map((p) => p.startsWith("0x") ? p : "context." + p).join(" | ");
+                    parameterElement.textContent = bitfieldNamesForParameter.join(" | ");
                 } else
                     parameterElement.textContent = parameter.maxDecimals(2);
                 break;


### PR DESCRIPTION
#### 075c50dcf56d75fd771eef3587a2ae170e67bcbd
<pre>
Web Inspector: Canvas: show names for recorded WebGPU bitfields
<a href="https://bugs.webkit.org/show_bug.cgi?id=321758">https://bugs.webkit.org/show_bug.cgi?id=321758</a>

Reviewed by Mike Wyrzykowski.

* Source/WebInspectorUI/UserInterface/Models/RecordingAction.js:
(WI.RecordingAction.bitfieldNamesForParameter):
(WI.RecordingAction._bitfields): Added.
Describe WebGL and WebGPU bitfield argument locations in one table that mirrors nested WebGPU descriptors.
Use existing WebGPU namespace constants to decompose each bitfield and return fully qualified names so callers do not have to assume a `context` prefix.

* Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js:
(WI.RecordingActionTreeElement._generateDOM):
(WI.RecordingActionTreeElement._generateDOM.appendJSON):
(WI.RecordingActionTreeElement._generateDOM.createParameterElement):
Track property paths while rendering structured arguments so nested WebGPU bitfields use namespace-qualified names.

Canonical link: <a href="https://commits.webkit.org/319174@main">https://commits.webkit.org/319174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2483bf5cad00a8f8b1e9ae31548314984b85d98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145003 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44604 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161701 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121383 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41230 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2053 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47235 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192829 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54292 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150311 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40232 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54980 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150028 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44640 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122467 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53497 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16223 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52879 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->