### PR TITLE
Web Inspector: Canvas: add syntax highlighting to recording actions

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.css
@@ -55,12 +55,13 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .
 }
 
 .item.recording-action > .titles :is(.object-handle, .receiver, .subtitle) {
-    color: var(--text-color-gray-medium);
+    color: var(--syntax-highlight-symbol-color);
     font-style: italic;
 }
 
 .item.recording-action > .titles .parameter.swizzled {
     color: var(--text-color-gray-medium);
+    font-style: italic;
 }
 
 .item.recording-action > .titles .parameter.constant {
@@ -72,6 +73,11 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .
 body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.recording-action.selected > .titles :is(.object-handle, .parameter.swizzled, .receiver, .subtitle),
 body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.recording-action.selected::before {
     color: var(--selected-secondary-text-color);
+}
+
+body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.recording-action.selected > .titles :is(.formatted-bigint, .formatted-boolean, .formatted-null, .formatted-number, .formatted-string, .formatted-symbol, .formatted-undefined),
+body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.recording-action.selected > .titles .object-preview .name {
+    color: var(--selected-foreground-color);
 }
 
 .tree-outline[data-indent="1"] .item.recording-action::before,
@@ -113,6 +119,10 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .
 
 .item.recording-action > .titles .parameters > .inline-swatch {
     vertical-align: -1px;
+}
+
+.item.recording-action > .titles .parameter > .formatted-string {
+    white-space: nowrap;
 }
 
 .item.recording-action.composite > .icon {

--- a/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js
@@ -84,7 +84,13 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
                 for (let [name, item] of Object.entries(value)) {
                     let comma = added ? "," : "";
                     let propertyName = WI.ScriptSyntaxTree.isIdentifierName(name) ? name : JSON.stringify(name);
-                    parent.appendChild(document.createTextNode(`${comma}\n${valueIndent}${propertyName}: `));
+                    parent.appendChild(document.createTextNode(`${comma}\n${valueIndent}`));
+
+                    let propertyNameElement = parent.appendChild(document.createElement("span"));
+                    propertyNameElement.classList.add("name");
+                    propertyNameElement.textContent = propertyName;
+
+                    parent.appendChild(document.createTextNode(": "));
                     appendJSON(parent, item, objectReferences, index, [...path, name], indent + 1);
                     added = true;
                 }
@@ -102,7 +108,9 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
                 }
             }
 
-            parent.appendChild(document.createTextNode(JSON.stringify(value)));
+            let type = value === null ? "object" : typeof value;
+            let subtype = value === null ? "null" : null;
+            parent.appendChild(WI.FormattedValue.createElementForTypesAndValue(type, subtype, String(value)));
         }
 
         function createParameterElement(parameter, swizzleType, index) {
@@ -122,6 +130,7 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
 
             if (WI.Recording.isReferenceSwizzleType(swizzleType)) {
                 let objectReferences = WI.RecordingAction.objectReferencesForParameter(recordingType, recordingAction.name, parameter, index);
+                parameterElement.classList.add("object-preview", "lossless");
                 appendJSON(parameterElement, parameter, objectReferences, index);
                 return parameterElement;
             }
@@ -130,22 +139,23 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
             case WI.Recording.Swizzle.Number:
                 var constantNameForParameter = WI.RecordingAction.constantNameForParameter(recordingType, recordingAction.name, parameter, index, parameterCount);
                 var bitfieldNamesForParameter = WI.RecordingAction.bitfieldNamesForParameter(recordingType, recordingAction.name, parameter, index, parameterCount);
+                var displayString = parameter.maxDecimals(2);
                 if (constantNameForParameter) {
                     parameterElement.classList.add("constant");
-                    parameterElement.textContent = "context." + constantNameForParameter;
+                    displayString = "context." + constantNameForParameter;
                 } else if (bitfieldNamesForParameter) {
                     parameterElement.classList.add("constant");
-                    parameterElement.textContent = bitfieldNamesForParameter.join(" | ");
-                } else
-                    parameterElement.textContent = parameter.maxDecimals(2);
+                    displayString = bitfieldNamesForParameter.join(" | ");
+                }
+                parameterElement.appendChild(WI.FormattedValue.createElementForTypesAndValue("number", null, displayString));
                 break;
 
             case WI.Recording.Swizzle.Boolean:
-                parameterElement.textContent = parameter;
+                parameterElement.appendChild(WI.FormattedValue.createElementForTypesAndValue("boolean", null, String(parameter)));
                 break;
 
             case WI.Recording.Swizzle.String:
-                parameterElement.textContent = JSON.stringify(parameter);
+                parameterElement.appendChild(WI.FormattedValue.createElementForTypesAndValue("string", null, parameter));
                 break;
 
             case WI.Recording.Swizzle.TypedArray:


### PR DESCRIPTION
#### bf8c27cd3d2a8fe001a1fc907f0b315dba4e9fb3
<pre>
Web Inspector: Canvas: add syntax highlighting to recording actions
<a href="https://bugs.webkit.org/show_bug.cgi?id=321759">https://bugs.webkit.org/show_bug.cgi?id=321759</a>

Reviewed by Mike Wyrzykowski.

* Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js:
(WI.RecordingActionTreeElement._generateDOM):
(WI.RecordingActionTreeElement._generateDOM.appendJSON):
(WI.RecordingActionTreeElement._generateDOM.createParameterElement):
Format primitive action parameters and values inside structured parameters with `WI.FormattedValue` to get standard syntax highlighting.
Reuse the existing `WI.ObjectPreviewView` styles for object keys.

* Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.css:
(.item.recording-action &gt; .titles :is(.object-handle, .receiver, .subtitle)):
(.item.recording-action &gt; .titles .parameter.swizzled):
(.item.recording-action &gt; .titles .parameter &gt; .formatted-string): Added.
(body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.recording-action.selected &gt; .titles :is(.formatted-bigint, .formatted-boolean, .formatted-null, .formatted-number, .formatted-string, .formatted-symbol, .formatted-undefined), body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.recording-action.selected &gt; .titles .object-preview .name): Added.
Use the existing syntax highlighting color for recorded object references and italics for unavailable swizzled placeholders.
Keep highlighted values readable when an action is selected.

Canonical link: <a href="https://commits.webkit.org/319189@main">https://commits.webkit.org/319189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bb912ce83e6227e76a417cd091b472041e222ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54701 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145079 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54417 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/140996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183711 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/44665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/48499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121448 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/48499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2130 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47313 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192904 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54367 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/48499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40240 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/55055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150095 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/55055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122605 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53572 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/48499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/52954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->