### PR TITLE
[GFC] Clamp a track's growth limit to its base size when sizing non-spanning items

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -106,6 +106,14 @@ struct UnsizedTrack {
         // Growth limits: an infinitely-growable track has no ceiling; otherwise its growth limit.
         return infinitelyGrowable ? LayoutUnit::max() : growthLimit;
     }
+
+    // https://drafts.csswg.org/css-grid-1/#algo-single-span-items
+    // "In all cases, if a track's growth limit is now less than its base size,
+    // increase the growth limit to match the base size."
+    void ensureGrowthLimitIsBiggerThanBaseSize()
+    {
+        growthLimit = std::max(growthLimit, baseSize);
+    }
 };
 
 using GridItemIndexes = Vector<size_t>;
@@ -445,6 +453,10 @@ static void sizeTracksToFitNonSpanningItems(const ResolveIntrinsicTrackSizesCont
                 return { };
             }
         );
+
+        // In all cases, if a track’s growth limit is now less than its base size, increase the
+        // growth limit to match the base size.
+        track.ensureGrowthLimitIsBiggerThanBaseSize();
     }
 }
 


### PR DESCRIPTION
#### 0c9c8bd55498d1a6a5b893aeeb7d291f706b2e08
<pre>
[GFC] Clamp a track&apos;s growth limit to its base size when sizing non-spanning items
<a href="https://bugs.webkit.org/show_bug.cgi?id=321760">https://bugs.webkit.org/show_bug.cgi?id=321760</a>
&lt;<a href="https://rdar.apple.com/184881194">rdar://184881194</a>&gt;

Reviewed by Sammy Gill.

Per spec:

<a href="https://drafts.csswg.org/css-grid-1/#algo-single-span-items">https://drafts.csswg.org/css-grid-1/#algo-single-span-items</a>

11.5.2: Size tracks to fit non-spanning items

&quot;if a track&apos;s growth limit is now less than its base size,
increase the growth limit to match the base size.&quot;

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::UnsizedTrack::ensureGrowthLimitIsBiggerThanBaseSize):
(WebCore::Layout::sizeTracksToFitNonSpanningItems):

Canonical link: <a href="https://commits.webkit.org/319184@main">https://commits.webkit.org/319184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc96c065c539c423312b7551b6de6d2901c1b759

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145009 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67de8c48-818e-4d56-b01f-04b2335626e2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140936 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac88324b-a203-4629-87ac-08cc27f59850) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121388 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c423b776-cdbb-4f00-8db4-985468ec4168) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41235 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2059 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192835 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54298 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150316 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54986 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150033 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27436 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44647 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127251 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122476 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53503 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16228 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52885 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53122 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52950 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->