### PR TITLE
[JSC] Move the fields only global code uses out of `UnlinkedCodeBlock`

### DIFF
--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -49,7 +49,6 @@ UnlinkedCodeBlock::UnlinkedCodeBlock(VM& vm, Structure* structure, CodeType code
     , m_numCalleeLocals(0)
     , m_isConstructor(info.isConstructor())
     , m_numParameters(0)
-    , m_hasCapturedVariables(false)
     , m_isBuiltinFunction(info.isBuiltinFunction())
     , m_isBuiltinDefaultClassConstructor(info.isBuiltinDefaultClassConstructor())
     , m_superBinding(static_cast<unsigned>(info.superBinding()))

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -167,8 +167,6 @@ public:
     bool isClassContext() const { return m_isClassContext; }
     bool hasTailCalls() const { return m_hasTailCalls; }
     void setHasTailCalls() { m_hasTailCalls = true; }
-    bool allowDirectEvalCache() const { return !(m_features & NoEvalCacheFeature); }
-    bool usesImportMeta() const { return m_features & ImportMetaFeature; }
     bool isBuiltinDefaultClassConstructor() const { return m_isBuiltinDefaultClassConstructor; }
 
     bool hasExpressionInfo() { return !m_expressionInfo->isEmpty(); }
@@ -278,28 +276,6 @@ public:
     LineColumn lineColumnForBytecodeIndex(BytecodeIndex);
 
     bool typeProfilerExpressionInfoForBytecodeOffset(unsigned bytecodeOffset, unsigned& startDivot, unsigned& endDivot);
-
-    void recordParse(CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, bool hasCapturedVariables, unsigned lineCount, unsigned endColumn)
-    {
-        m_features = features;
-        m_lexicallyScopedFeatures = lexicallyScopedFeatures;
-        m_hasCapturedVariables = hasCapturedVariables;
-        m_lineCount = lineCount;
-        // For the UnlinkedCodeBlock, startColumn is always 0.
-        m_endColumn = endColumn;
-    }
-
-    StringImpl* sourceURLDirective() const { return m_sourceURLDirective.get(); }
-    StringImpl* sourceMappingURLDirective() const { return m_sourceMappingURLDirective.get(); }
-    void setSourceURLDirective(const String& sourceURL) { m_sourceURLDirective = sourceURL.impl(); }
-    void setSourceMappingURLDirective(const String& sourceMappingURL) { m_sourceMappingURLDirective = sourceMappingURL.impl(); }
-
-    CodeFeatures codeFeatures() const { return m_features; }
-    LexicallyScopedFeatures lexicallyScopedFeatures() const { return m_lexicallyScopedFeatures; }
-    bool hasCapturedVariables() const { return m_hasCapturedVariables; }
-    unsigned lineCount() const { return m_lineCount; }
-    ALWAYS_INLINE unsigned startColumn() const { return 0; }
-    unsigned endColumn() const { return m_endColumn; }
 
     const FixedVector<JSInstructionStream::Offset>& opProfileControlFlowBytecodeOffsets() const
     {
@@ -422,7 +398,6 @@ private:
     unsigned m_numCalleeLocals : 31;
     unsigned m_isConstructor : 1;
     unsigned m_numParameters : 31;
-    unsigned m_hasCapturedVariables : 1;
 
     unsigned m_isBuiltinFunction : 1;
     unsigned m_isBuiltinDefaultClassConstructor : 1;
@@ -438,7 +413,6 @@ private:
     unsigned m_age : 3;
     static_assert(((1U << 3) - 1) >= maxAge);
     bool m_hasCheckpoints : 1;
-    LexicallyScopedFeatures m_lexicallyScopedFeatures : bitWidthOfLexicallyScopedFeatures { 0 };
     TriState m_quickDFGTierUp : 2 { TriState::Indeterminate };
     bool m_quickFTLTierUp : 1 { false };
 
@@ -448,15 +422,9 @@ public:
     RefPtr<BaselineJITCode> m_unlinkedBaselineCode;
 #endif
 private:
-    CodeFeatures m_features { 0 };
     SourceParseMode m_parseMode;
     OptionSet<CodeGenerationMode> m_codeGenerationMode;
-
-    unsigned m_lineCount { 0 };
-    unsigned m_endColumn { UINT_MAX };
-
-    PackedRefPtr<StringImpl> m_sourceURLDirective;
-    PackedRefPtr<StringImpl> m_sourceMappingURLDirective;
+    BaselineExecutionCounter m_llintExecuteCounter;
 
     FixedVector<JSInstructionStream::Offset> m_jumpTargets;
     const Ref<UnlinkedMetadataTable> m_metadata;
@@ -522,7 +490,6 @@ private:
     OutOfLineJumpTargets m_outOfLineJumpTargets;
     std::unique_ptr<RareData> m_rareData;
     std::unique_ptr<ExpressionInfo> m_expressionInfo;
-    BaselineExecutionCounter m_llintExecuteCounter;
     FixedVector<UnlinkedValueProfile> m_valueProfiles;
     FixedVector<UnlinkedArrayProfile> m_arrayProfiles;
     FixedVector<BinaryArithProfile> m_binaryArithProfiles;

--- a/Source/JavaScriptCore/bytecode/UnlinkedGlobalCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedGlobalCodeBlock.h
@@ -29,9 +29,35 @@
 
 namespace JSC {
 
+template<typename CodeBlockType>
+class CachedGlobalCodeBlock;
+
 class UnlinkedGlobalCodeBlock : public UnlinkedCodeBlock {
 public:
     typedef UnlinkedCodeBlock Base;
+
+    void recordParse(CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, bool hasCapturedVariables, unsigned lineCount, unsigned endColumn)
+    {
+        m_features = features;
+        m_lexicallyScopedFeatures = lexicallyScopedFeatures;
+        m_hasCapturedVariables = hasCapturedVariables;
+        m_lineCount = lineCount;
+        // For the UnlinkedCodeBlock, startColumn is always 0.
+        m_endColumn = endColumn;
+    }
+
+    StringImpl* sourceURLDirective() const { return m_sourceURLDirective.get(); }
+    StringImpl* sourceMappingURLDirective() const { return m_sourceMappingURLDirective.get(); }
+    void setSourceURLDirective(const String& sourceURL) { m_sourceURLDirective = sourceURL.impl(); }
+    void setSourceMappingURLDirective(const String& sourceMappingURL) { m_sourceMappingURLDirective = sourceMappingURL.impl(); }
+
+    CodeFeatures codeFeatures() const { return m_features; }
+    bool allowDirectEvalCache() const { return !(m_features & NoEvalCacheFeature); }
+    LexicallyScopedFeatures lexicallyScopedFeatures() const { return m_lexicallyScopedFeatures; }
+    bool hasCapturedVariables() const { return m_hasCapturedVariables; }
+    unsigned lineCount() const { return m_lineCount; }
+    ALWAYS_INLINE unsigned startColumn() const { return 0; }
+    unsigned endColumn() const { return m_endColumn; }
 
 protected:
     UnlinkedGlobalCodeBlock(VM& vm, Structure* structure, CodeType codeType, const ExecutableInfo& info, OptionSet<CodeGenerationMode> codeGenerationMode)
@@ -44,6 +70,19 @@ protected:
         : Base(decoder, structure, cachedCodeBlock)
     {
     }
+
+private:
+    template<typename CodeBlockType>
+    friend class CachedGlobalCodeBlock;
+
+    CodeFeatures m_features { NoFeatures };
+    LexicallyScopedFeatures m_lexicallyScopedFeatures { NoLexicallyScopedFeatures };
+    bool m_hasCapturedVariables { false };
+    unsigned m_lineCount { 0 };
+    unsigned m_endColumn { UINT_MAX };
+
+    PackedRefPtr<StringImpl> m_sourceURLDirective;
+    PackedRefPtr<StringImpl> m_sourceMappingURLDirective;
 };
 
 }

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -2005,14 +2005,10 @@ public:
     VirtualRegister NODELETE thisRegister() const { return m_thisRegister; }
     VirtualRegister NODELETE scopeRegister() const { return m_scopeRegister; }
 
-    RefPtr<StringImpl> sourceURLDirective(Decoder& decoder) const { return m_sourceURLDirective.decode(decoder); }
-    RefPtr<StringImpl> sourceMappingURLDirective(Decoder& decoder) const { return m_sourceMappingURLDirective.decode(decoder); }
-
     Ref<UnlinkedMetadataTable> metadata(Decoder& decoder) const { return m_metadata.decode(decoder); }
 
     unsigned NODELETE isConstructor() const { return m_isConstructor; }
     unsigned NODELETE isBuiltinDefaultClassConstructor() const { return m_isBuiltinDefaultClassConstructor; }
-    unsigned NODELETE hasCapturedVariables() const { return m_hasCapturedVariables; }
     unsigned NODELETE isBuiltinFunction() const { return m_isBuiltinFunction; }
     unsigned NODELETE superBinding() const { return m_superBinding; }
     unsigned NODELETE scriptMode() const { return m_scriptMode; }
@@ -2023,15 +2019,11 @@ public:
     unsigned NODELETE evalContextType() const { return m_evalContextType; }
     unsigned NODELETE hasTailCalls() const { return m_hasTailCalls; }
     unsigned NODELETE hasCheckpoints() const { return m_hasCheckpoints; }
-    unsigned NODELETE lineCount() const { return m_lineCount; }
-    unsigned NODELETE endColumn() const { return m_endColumn; }
 
     int NODELETE numVars() const { return m_numVars; }
     int NODELETE numCalleeLocals() const { return m_numCalleeLocals; }
     int NODELETE numParameters() const { return m_numParameters; }
 
-    CodeFeatures NODELETE features() const { return m_features; }
-    LexicallyScopedFeatures NODELETE lexicallyScopedFeatures() const { return m_lexicallyScopedFeatures; }
     SourceParseMode NODELETE parseMode() const { return m_parseMode; }
     OptionSet<CodeGenerationMode> NODELETE codeGenerationMode() const { return m_codeGenerationMode; }
     unsigned NODELETE codeType() const { return m_codeType; }
@@ -2049,7 +2041,6 @@ private:
 
     unsigned m_isConstructor : 1;
     unsigned m_isBuiltinDefaultClassConstructor : 1;
-    unsigned m_hasCapturedVariables : 1;
     unsigned m_isBuiltinFunction : 1;
     unsigned m_superBinding : 1;
     unsigned m_scriptMode: 1;
@@ -2062,13 +2053,8 @@ private:
     unsigned m_codeType : 2;
     unsigned m_hasCheckpoints : 1;
 
-    CodeFeatures m_features : bitWidthOfCodeFeatures;
-    LexicallyScopedFeatures m_lexicallyScopedFeatures : bitWidthOfLexicallyScopedFeatures;
     SourceParseMode m_parseMode;
     OptionSet<CodeGenerationMode> m_codeGenerationMode;
-
-    unsigned m_lineCount;
-    unsigned m_endColumn;
 
     int m_numVars;
     int m_numCalleeLocals;
@@ -2083,9 +2069,6 @@ private:
 
     CachedPtr<CachedCodeBlockRareData> m_rareData;
 
-    CachedRefPtr<CachedStringImpl> m_sourceURLDirective;
-    CachedRefPtr<CachedStringImpl> m_sourceMappingURLDirective;
-
     CachedPtr<CachedInstructionStream> m_instructions;
     CachedVector<JSInstructionStream::Offset> m_jumpTargets;
     CachedVector<CachedJSValue> m_constantRegisters;
@@ -2098,8 +2081,47 @@ private:
     CachedVector<CachedWriteBarrier<CachedFunctionExecutable>> m_functionExprs;
 };
 
-class CachedProgramCodeBlock : public CachedCodeBlock<UnlinkedProgramCodeBlock> {
-    using Base = CachedCodeBlock<UnlinkedProgramCodeBlock>;
+template<typename CodeBlockType>
+class CachedGlobalCodeBlock : public CachedCodeBlock<CodeBlockType> {
+    using Base = CachedCodeBlock<CodeBlockType>;
+
+public:
+    void encode(Encoder& encoder, const UnlinkedGlobalCodeBlock& codeBlock)
+    {
+        Base::encode(encoder, codeBlock);
+        m_features = codeBlock.m_features;
+        m_lexicallyScopedFeatures = codeBlock.m_lexicallyScopedFeatures;
+        m_hasCapturedVariables = codeBlock.m_hasCapturedVariables;
+        m_lineCount = codeBlock.m_lineCount;
+        m_endColumn = codeBlock.m_endColumn;
+        m_sourceURLDirective.encode(encoder, codeBlock.m_sourceURLDirective.get());
+        m_sourceMappingURLDirective.encode(encoder, codeBlock.m_sourceMappingURLDirective.get());
+    }
+
+    void decode(Decoder& decoder, UnlinkedGlobalCodeBlock& codeBlock) const
+    {
+        Base::decode(decoder, codeBlock);
+        codeBlock.m_features = m_features;
+        codeBlock.m_lexicallyScopedFeatures = m_lexicallyScopedFeatures;
+        codeBlock.m_hasCapturedVariables = m_hasCapturedVariables;
+        codeBlock.m_lineCount = m_lineCount;
+        codeBlock.m_endColumn = m_endColumn;
+        codeBlock.m_sourceURLDirective = m_sourceURLDirective.decode(decoder);
+        codeBlock.m_sourceMappingURLDirective = m_sourceMappingURLDirective.decode(decoder);
+    }
+
+private:
+    CodeFeatures m_features;
+    LexicallyScopedFeatures m_lexicallyScopedFeatures;
+    bool m_hasCapturedVariables;
+    unsigned m_lineCount;
+    unsigned m_endColumn;
+    CachedRefPtr<CachedStringImpl> m_sourceURLDirective;
+    CachedRefPtr<CachedStringImpl> m_sourceMappingURLDirective;
+};
+
+class CachedProgramCodeBlock : public CachedGlobalCodeBlock<UnlinkedProgramCodeBlock> {
+    using Base = CachedGlobalCodeBlock<UnlinkedProgramCodeBlock>;
 
 public:
     void encode(Encoder& encoder, const UnlinkedProgramCodeBlock& codeBlock)
@@ -2124,8 +2146,8 @@ private:
     CachedVariableEnvironment m_lexicalDeclarations;
 };
 
-class CachedModuleCodeBlock : public CachedCodeBlock<UnlinkedModuleProgramCodeBlock> {
-    using Base = CachedCodeBlock<UnlinkedModuleProgramCodeBlock>;
+class CachedModuleCodeBlock : public CachedGlobalCodeBlock<UnlinkedModuleProgramCodeBlock> {
+    using Base = CachedGlobalCodeBlock<UnlinkedModuleProgramCodeBlock>;
 
 public:
     void encode(Encoder& encoder, const UnlinkedModuleProgramCodeBlock& codeBlock)
@@ -2150,8 +2172,8 @@ private:
     int m_moduleEnvironmentSymbolTableConstantRegisterOffset;
 };
 
-class CachedEvalCodeBlock : public CachedCodeBlock<UnlinkedEvalCodeBlock> {
-    using Base = CachedCodeBlock<UnlinkedEvalCodeBlock>;
+class CachedEvalCodeBlock : public CachedGlobalCodeBlock<UnlinkedEvalCodeBlock> {
+    using Base = CachedGlobalCodeBlock<UnlinkedEvalCodeBlock>;
 
 public:
     void encode(Encoder& encoder, const UnlinkedEvalCodeBlock& codeBlock)
@@ -2255,7 +2277,6 @@ ALWAYS_INLINE UnlinkedCodeBlock::UnlinkedCodeBlock(Decoder& decoder, Structure* 
     , m_numCalleeLocals(cachedCodeBlock.numCalleeLocals())
     , m_isConstructor(cachedCodeBlock.isConstructor())
     , m_numParameters(cachedCodeBlock.numParameters())
-    , m_hasCapturedVariables(cachedCodeBlock.hasCapturedVariables())
 
     , m_isBuiltinFunction(cachedCodeBlock.isBuiltinFunction())
     , m_isBuiltinDefaultClassConstructor(cachedCodeBlock.isBuiltinDefaultClassConstructor())
@@ -2272,16 +2293,8 @@ ALWAYS_INLINE UnlinkedCodeBlock::UnlinkedCodeBlock(Decoder& decoder, Structure* 
     , m_age(0)
     , m_hasCheckpoints(cachedCodeBlock.hasCheckpoints())
 
-    , m_lexicallyScopedFeatures(cachedCodeBlock.lexicallyScopedFeatures())
-    , m_features(cachedCodeBlock.features())
     , m_parseMode(cachedCodeBlock.parseMode())
     , m_codeGenerationMode(cachedCodeBlock.codeGenerationMode())
-
-    , m_lineCount(cachedCodeBlock.lineCount())
-    , m_endColumn(cachedCodeBlock.endColumn())
-
-    , m_sourceURLDirective(cachedCodeBlock.sourceURLDirective(decoder))
-    , m_sourceMappingURLDirective(cachedCodeBlock.sourceMappingURLDirective(decoder))
 
     , m_metadata(cachedCodeBlock.metadata(decoder))
     , m_instructions(cachedCodeBlock.instructions(decoder))
@@ -2451,7 +2464,6 @@ ALWAYS_INLINE void CachedCodeBlock<CodeBlockType>::encode(Encoder& encoder, cons
     m_thisRegister = codeBlock.m_thisRegister;
     m_scopeRegister = codeBlock.m_scopeRegister;
     m_isConstructor = codeBlock.m_isConstructor;
-    m_hasCapturedVariables = codeBlock.m_hasCapturedVariables;
     m_isBuiltinFunction = codeBlock.m_isBuiltinFunction;
     m_isBuiltinDefaultClassConstructor = codeBlock.m_isBuiltinDefaultClassConstructor;
     m_superBinding = codeBlock.m_superBinding;
@@ -2462,13 +2474,9 @@ ALWAYS_INLINE void CachedCodeBlock<CodeBlockType>::encode(Encoder& encoder, cons
     m_constructorKind = codeBlock.m_constructorKind;
     m_derivedContextType = codeBlock.m_derivedContextType;
     m_evalContextType = codeBlock.m_evalContextType;
-    m_lineCount = codeBlock.m_lineCount;
-    m_endColumn = codeBlock.m_endColumn;
     m_numVars = codeBlock.m_numVars;
     m_numCalleeLocals = codeBlock.m_numCalleeLocals;
     m_numParameters = codeBlock.m_numParameters;
-    m_features = codeBlock.m_features;
-    m_lexicallyScopedFeatures = codeBlock.m_lexicallyScopedFeatures;
     m_parseMode = codeBlock.m_parseMode;
     m_codeGenerationMode = codeBlock.m_codeGenerationMode;
     m_codeType = codeBlock.m_codeType;
@@ -2480,9 +2488,6 @@ ALWAYS_INLINE void CachedCodeBlock<CodeBlockType>::encode(Encoder& encoder, cons
 
     m_metadata.encode(encoder, codeBlock.m_metadata.get());
     m_rareData.encode(encoder, codeBlock.m_rareData.get());
-
-    m_sourceURLDirective.encode(encoder, codeBlock.m_sourceURLDirective.get());
-    m_sourceMappingURLDirective.encode(encoder, codeBlock.m_sourceMappingURLDirective.get());
 
     m_instructions.encode(encoder, codeBlock.m_instructions.get());
     m_constantRegisters.encode(encoder, codeBlock.m_constantRegisters);


### PR DESCRIPTION
#### 3d0e6c14b12c2641c27faaf2f213483432d13b7a
<pre>
[JSC] Move the fields only global code uses out of `UnlinkedCodeBlock`
<a href="https://bugs.webkit.org/show_bug.cgi?id=321764">https://bugs.webkit.org/show_bug.cgi?id=321764</a>

Reviewed by Yusuke Suzuki.

UnlinkedCodeBlock has m_features, m_lineCount, m_endColumn and the two source URL directives.
Only Program / Eval / Module code writes them, so that CodeCache can copy them into the new
executable on a cache hit. Function code never touches them because UnlinkedFunctionExecutable
has its own copies. Still, every UnlinkedFunctionCodeBlock pays 22 bytes for them.

This patch moves them to UnlinkedGlobalCodeBlock, as GlobalExecutable already does on the linked
side, and moves m_llintExecuteCounter next to the remaining small fields so that the freed bytes
are not lost to padding. CachedCodeBlock is split in the same way.

sizeof(UnlinkedFunctionCodeBlock) goes from 216 to 192 bytes, so its cell goes from 224 to 192
bytes. That is 32 bytes per function that has been compiled to bytecode (1,665 of them, 53 KB,
after loading typescript.js and compiling one file). The global code blocks do not change in size.

* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp:
(JSC::UnlinkedCodeBlock::UnlinkedCodeBlock):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
(JSC::UnlinkedCodeBlock::setHasTailCalls):
(JSC::UnlinkedCodeBlock::allowDirectEvalCache const): Deleted.
(JSC::UnlinkedCodeBlock::usesImportMeta const): Deleted.
(JSC::UnlinkedCodeBlock::recordParse): Deleted.
(JSC::UnlinkedCodeBlock::sourceURLDirective const): Deleted.
(JSC::UnlinkedCodeBlock::sourceMappingURLDirective const): Deleted.
(JSC::UnlinkedCodeBlock::setSourceURLDirective): Deleted.
(JSC::UnlinkedCodeBlock::setSourceMappingURLDirective): Deleted.
(JSC::UnlinkedCodeBlock::codeFeatures const): Deleted.
(JSC::UnlinkedCodeBlock::lexicallyScopedFeatures const): Deleted.
(JSC::UnlinkedCodeBlock::hasCapturedVariables const): Deleted.
(JSC::UnlinkedCodeBlock::lineCount const): Deleted.
(JSC::UnlinkedCodeBlock::startColumn const): Deleted.
(JSC::UnlinkedCodeBlock::endColumn const): Deleted.
* Source/JavaScriptCore/bytecode/UnlinkedGlobalCodeBlock.h:
(JSC::UnlinkedGlobalCodeBlock::recordParse):
(JSC::UnlinkedGlobalCodeBlock::sourceURLDirective const):
(JSC::UnlinkedGlobalCodeBlock::sourceMappingURLDirective const):
(JSC::UnlinkedGlobalCodeBlock::setSourceURLDirective):
(JSC::UnlinkedGlobalCodeBlock::setSourceMappingURLDirective):
(JSC::UnlinkedGlobalCodeBlock::codeFeatures const):
(JSC::UnlinkedGlobalCodeBlock::allowDirectEvalCache const):
(JSC::UnlinkedGlobalCodeBlock::lexicallyScopedFeatures const):
(JSC::UnlinkedGlobalCodeBlock::hasCapturedVariables const):
(JSC::UnlinkedGlobalCodeBlock::lineCount const):
(JSC::UnlinkedGlobalCodeBlock::startColumn const):
(JSC::UnlinkedGlobalCodeBlock::endColumn const):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedCodeBlock::isBuiltinDefaultClassConstructor const):
(JSC::CachedCodeBlock::hasCheckpoints const):
(JSC::CachedGlobalCodeBlock::encode):
(JSC::CachedGlobalCodeBlock::features const):
(JSC::CachedGlobalCodeBlock::lexicallyScopedFeatures const):
(JSC::CachedGlobalCodeBlock::hasCapturedVariables const):
(JSC::CachedGlobalCodeBlock::lineCount const):
(JSC::CachedGlobalCodeBlock::endColumn const):
(JSC::CachedGlobalCodeBlock::sourceURLDirective const):
(JSC::CachedGlobalCodeBlock::sourceMappingURLDirective const):
(JSC::UnlinkedCodeBlock::UnlinkedCodeBlock):
(JSC::UnlinkedGlobalCodeBlock::UnlinkedGlobalCodeBlock):
(JSC::CachedCodeBlock&lt;CodeBlockType&gt;::encode):
(JSC::CachedCodeBlock::sourceURLDirective const): Deleted.
(JSC::CachedCodeBlock::sourceMappingURLDirective const): Deleted.
(JSC::CachedCodeBlock::hasCapturedVariables const): Deleted.
(JSC::CachedCodeBlock::lineCount const): Deleted.
(JSC::CachedCodeBlock::endColumn const): Deleted.
(JSC::CachedCodeBlock::features const): Deleted.
(JSC::CachedCodeBlock::lexicallyScopedFeatures const): Deleted.

Canonical link: <a href="https://commits.webkit.org/319346@main">https://commits.webkit.org/319346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ca2bf59d2d5b5170f75a965f523529ff091e474

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145016 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54355 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140941 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Running run-layout-tests-in-stress-mode; 7 flakes 2 failures; Uploaded test results; layout-tests; Passed layout tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97655 "2 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121393 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43287 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41569 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3360 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed JSC tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10196 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41240 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2066 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41968 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192842 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54305 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150322 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40394 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54993 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150039 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44653 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127258 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122494 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53510 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16233 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52957 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->