### PR TITLE
Make WebCore::appleVisualEffectNeedsBackdrop inline.

### DIFF
--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,38 +31,6 @@
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
-
-bool appleVisualEffectNeedsBackdrop(AppleVisualEffect effect)
-{
-    switch (effect) {
-    case AppleVisualEffect::BlurUltraThinMaterial:
-    case AppleVisualEffect::BlurThinMaterial:
-    case AppleVisualEffect::BlurMaterial:
-    case AppleVisualEffect::BlurThickMaterial:
-    case AppleVisualEffect::BlurChromeMaterial:
-        return true;
-    case AppleVisualEffect::None:
-#if HAVE(MATERIAL_HOSTING)
-    case AppleVisualEffect::GlassMaterial:
-    case AppleVisualEffect::GlassClearMaterial:
-    case AppleVisualEffect::GlassSubduedMaterial:
-    case AppleVisualEffect::GlassMediaControlsMaterial:
-    case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
-#endif
-    case AppleVisualEffect::VibrancyLabel:
-    case AppleVisualEffect::VibrancySecondaryLabel:
-    case AppleVisualEffect::VibrancyTertiaryLabel:
-    case AppleVisualEffect::VibrancyQuaternaryLabel:
-    case AppleVisualEffect::VibrancyFill:
-    case AppleVisualEffect::VibrancySecondaryFill:
-    case AppleVisualEffect::VibrancyTertiaryFill:
-    case AppleVisualEffect::VibrancySeparator:
-        return false;
-    }
-
-    ASSERT_NOT_REACHED();
-    return false;
-}
 
 bool appleVisualEffectAppliesFilter(AppleVisualEffect effect)
 {

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.h
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.h
@@ -28,6 +28,7 @@
 #if HAVE(CORE_MATERIAL)
 
 #include <WebCore/FloatRoundedRect.h>
+#include <wtf/Assertions.h>
 
 namespace WTF {
 class TextStream;
@@ -59,7 +60,38 @@ enum class AppleVisualEffect : uint8_t {
     VibrancySeparator,
 };
 
-WEBCORE_EXPORT bool NODELETE appleVisualEffectNeedsBackdrop(AppleVisualEffect);
+inline bool NODELETE appleVisualEffectNeedsBackdrop(AppleVisualEffect effect)
+{
+    switch (effect) {
+    case AppleVisualEffect::BlurUltraThinMaterial:
+    case AppleVisualEffect::BlurThinMaterial:
+    case AppleVisualEffect::BlurMaterial:
+    case AppleVisualEffect::BlurThickMaterial:
+    case AppleVisualEffect::BlurChromeMaterial:
+        return true;
+    case AppleVisualEffect::None:
+#if HAVE(MATERIAL_HOSTING)
+    case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassClearMaterial:
+    case AppleVisualEffect::GlassSubduedMaterial:
+    case AppleVisualEffect::GlassMediaControlsMaterial:
+    case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
+#endif
+    case AppleVisualEffect::VibrancyLabel:
+    case AppleVisualEffect::VibrancySecondaryLabel:
+    case AppleVisualEffect::VibrancyTertiaryLabel:
+    case AppleVisualEffect::VibrancyQuaternaryLabel:
+    case AppleVisualEffect::VibrancyFill:
+    case AppleVisualEffect::VibrancySecondaryFill:
+    case AppleVisualEffect::VibrancyTertiaryFill:
+    case AppleVisualEffect::VibrancySeparator:
+        return false;
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 WEBCORE_EXPORT bool NODELETE appleVisualEffectAppliesFilter(AppleVisualEffect);
 #if HAVE(MATERIAL_HOSTING)
 WEBCORE_EXPORT bool NODELETE appleVisualEffectIsHostedMaterial(AppleVisualEffect);


### PR DESCRIPTION
#### 1aaf950edb3116d37d4b1787f27332212340cec3
<pre>
Make WebCore::appleVisualEffectNeedsBackdrop inline.
<a href="https://bugs.webkit.org/show_bug.cgi?id=321763">https://bugs.webkit.org/show_bug.cgi?id=321763</a>
<a href="https://rdar.apple.com/184884068">rdar://184884068</a>

Reviewed by Simon Fraser.

No change to functionality.

* Source/WebCore/platform/cocoa/AppleVisualEffect.cpp:
(WebCore::appleVisualEffectNeedsBackdrop): Deleted.
* Source/WebCore/platform/cocoa/AppleVisualEffect.h:
(WebCore::appleVisualEffectNeedsBackdrop):

Canonical link: <a href="https://commits.webkit.org/319342@main">https://commits.webkit.org/319342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e648d27c054231c25a2478f2453555a570ec6bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145018 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140942 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97656 "1 flakes 7 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121394 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43289 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41571 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41239 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2068 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192844 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54307 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150324 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40388 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54995 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150041 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44655 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127260 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122496 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53512 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16232 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52894 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53131 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52959 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->