### PR TITLE
[JSC] Move repatching-only fields out of `HandlerPropertyInlineCache`

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -233,9 +233,9 @@ RefPtr<AccessCase> AccessCase::createTransition(
         // 1 register for the base.
         ++requiredRegisters;
 
-        if (propertyCache.m_propertyCacheGPR != InvalidGPRReg)
+        if (propertyCache.propertyCacheGPR() != InvalidGPRReg)
             ++requiredRegisters;
-        if (propertyCache.m_arrayProfileGPR != InvalidGPRReg)
+        if (propertyCache.arrayProfileGPR() != InvalidGPRReg)
             ++requiredRegisters;
 
         // One extra register for scratchGPR

--- a/Source/JavaScriptCore/bytecode/InlineAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.cpp
@@ -181,13 +181,13 @@ bool InlineAccess::generateSelfPropertyAccess(PropertyInlineCache& propertyCache
 
     CCallHelpers jit;
 
-    GPRReg base = propertyCache.m_baseGPR;
+    GPRReg base = propertyCache.baseGPR();
     JSValueRegs value = propertyCache.valueRegs();
 
     jit.patchableBranch32(
         MacroAssembler::NotEqual,
         MacroAssembler::Address(base, JSCell::structureIDOffset()),
-        MacroAssembler::TrustedImm32(std::bit_cast<uint32_t>(structure->id()))).linkThunk(propertyCache.slowPathStartLocation, &jit);
+        MacroAssembler::TrustedImm32(std::bit_cast<uint32_t>(structure->id()))).linkThunk(repatchingIC->slowPathStartLocation, &jit);
     GPRReg storage;
     if (isInlineOffset(offset))
         storage = base;
@@ -205,12 +205,13 @@ bool InlineAccess::generateSelfPropertyAccess(PropertyInlineCache& propertyCache
 ALWAYS_INLINE static GPRReg getScratchRegister(PropertyInlineCache& propertyCache)
 {
     ScratchRegisterAllocator allocator(propertyCache.usedRegisters().toRegisterSet());
-    allocator.lock(propertyCache.m_baseGPR);
-    allocator.lock(propertyCache.m_valueGPR);
-    allocator.lock(propertyCache.m_extraGPR);
-    allocator.lock(propertyCache.m_extra2GPR);
-    allocator.lock(propertyCache.m_propertyCacheGPR);
-    allocator.lock(propertyCache.m_arrayProfileGPR);
+    auto registers = propertyCache.registers();
+    allocator.lock(registers.baseGPR);
+    allocator.lock(registers.valueGPR);
+    allocator.lock(registers.extraGPR);
+    allocator.lock(registers.extra2GPR);
+    allocator.lock(registers.propertyCacheGPR);
+    allocator.lock(registers.arrayProfileGPR);
     GPRReg scratch = allocator.allocateScratchGPR();
     if (allocator.didReuseRegisters())
         return InvalidGPRReg;
@@ -249,13 +250,13 @@ bool InlineAccess::generateSelfPropertyReplace(PropertyInlineCache& propertyCach
 
     CCallHelpers jit;
 
-    GPRReg base = propertyCache.m_baseGPR;
+    GPRReg base = propertyCache.baseGPR();
     JSValueRegs value = propertyCache.valueRegs();
 
     jit.patchableBranch32(
         MacroAssembler::NotEqual,
         MacroAssembler::Address(base, JSCell::structureIDOffset()),
-        MacroAssembler::TrustedImm32(std::bit_cast<uint32_t>(structure->id()))).linkThunk(propertyCache.slowPathStartLocation, &jit);
+        MacroAssembler::TrustedImm32(std::bit_cast<uint32_t>(structure->id()))).linkThunk(repatchingIC->slowPathStartLocation, &jit);
 
     GPRReg storage;
     if (isInlineOffset(offset))
@@ -301,14 +302,14 @@ bool InlineAccess::generateArrayLength(PropertyInlineCache& propertyCache, JSArr
 
     CCallHelpers jit;
 
-    GPRReg base = propertyCache.m_baseGPR;
+    GPRReg base = propertyCache.baseGPR();
     JSValueRegs value = propertyCache.valueRegs();
     GPRReg scratch = getScratchRegister(propertyCache);
 
     jit.load8(CCallHelpers::Address(base, JSCell::indexingTypeAndMiscOffset()), scratch);
     jit.and32(CCallHelpers::TrustedImm32(IndexingTypeMask), scratch);
     jit.patchableBranch32(
-        CCallHelpers::NotEqual, scratch, CCallHelpers::TrustedImm32(array->indexingType())).linkThunk(propertyCache.slowPathStartLocation, &jit);
+        CCallHelpers::NotEqual, scratch, CCallHelpers::TrustedImm32(array->indexingType())).linkThunk(repatchingIC->slowPathStartLocation, &jit);
     jit.loadPtr(CCallHelpers::Address(base, JSObject::butterflyOffset()), value.payloadGPR());
     jit.load32(CCallHelpers::Address(value.payloadGPR(), ArrayStorage::lengthOffset()), value.payloadGPR());
     jit.boxInt32(value.payloadGPR(), value);
@@ -340,14 +341,14 @@ bool InlineAccess::generateStringLength(PropertyInlineCache& propertyCache)
 
     CCallHelpers jit;
 
-    GPRReg base = propertyCache.m_baseGPR;
+    GPRReg base = propertyCache.baseGPR();
     JSValueRegs value = propertyCache.valueRegs();
     GPRReg scratch = getScratchRegister(propertyCache);
 
     jit.patchableBranch8(
         CCallHelpers::NotEqual,
         CCallHelpers::Address(base, JSCell::typeInfoTypeOffset()),
-        CCallHelpers::TrustedImm32(StringType)).linkThunk(propertyCache.slowPathStartLocation, &jit);
+        CCallHelpers::TrustedImm32(StringType)).linkThunk(repatchingIC->slowPathStartLocation, &jit);
 
     jit.loadPtr(CCallHelpers::Address(base, JSString::offsetOfValue()), scratch);
     auto isRope = jit.branchIfRopeStringImpl(scratch);
@@ -375,13 +376,13 @@ bool InlineAccess::generateSelfInAccess(PropertyInlineCache& propertyCache, Stru
     if (!repatchingIC)
         return false;
 
-    GPRReg base = propertyCache.m_baseGPR;
+    GPRReg base = propertyCache.baseGPR();
     JSValueRegs value = propertyCache.valueRegs();
 
     jit.patchableBranch32(
         MacroAssembler::NotEqual,
         MacroAssembler::Address(base, JSCell::structureIDOffset()),
-        MacroAssembler::TrustedImm32(std::bit_cast<uint32_t>(structure->id()))).linkThunk(propertyCache.slowPathStartLocation, &jit);
+        MacroAssembler::TrustedImm32(std::bit_cast<uint32_t>(structure->id()))).linkThunk(repatchingIC->slowPathStartLocation, &jit);
     jit.boxBoolean(true, value);
 
     return linkCodeInline("in access", jit, *repatchingIC);

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -1148,7 +1148,7 @@ void InlineCacheCompiler::succeed()
         return;
     }
     if (m_propertyCache.isHandlerIC()) {
-        m_jit->farJump(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfDoneLocation()), JSInternalPtrTag);
+        m_jit->farJump(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfDoneLocation()), JSInternalPtrTag);
         return;
     }
     m_success.append(m_jit->jump());
@@ -1190,7 +1190,7 @@ const ScalarRegisterSet& InlineCacheCompiler::calculateLiveRegistersForCallAndEx
 
         auto liveRegistersForCall = RegisterSet(m_liveRegistersToPreserveAtExceptionHandlingCallSite.toRegisterSet(), m_allocator->usedRegisters());
         if (m_propertyCache.isHandlerIC())
-            liveRegistersForCall.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
+            liveRegistersForCall.add(m_propertyCache.propertyCacheGPR(), IgnoreVectors);
         liveRegistersForCall.exclude(calleeSaveRegisters().includeWholeRegisterWidth());
         m_liveRegistersForCall = liveRegistersForCall.toScalarRegisterSet();
     }
@@ -1221,7 +1221,7 @@ auto InlineCacheCompiler::preserveLiveRegistersToStackForCallWithoutExceptions()
 {
     RegisterSet liveRegisters = m_allocator->usedRegisters();
     if (m_propertyCache.isHandlerIC())
-        liveRegisters.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
+        liveRegisters.add(m_propertyCache.propertyCacheGPR(), IgnoreVectors);
     liveRegisters.exclude(calleeSaveRegisters().includeWholeRegisterWidth());
     liveRegisters.filter(RegisterSet::allScalarRegisters());
 
@@ -1328,12 +1328,13 @@ void InlineCacheCompiler::emitExplicitExceptionHandler()
 ScratchRegisterAllocator InlineCacheCompiler::makeDefaultScratchAllocator(GPRReg extraToLock)
 {
     ScratchRegisterAllocator allocator(m_propertyCache.usedRegisters().toRegisterSet());
-    allocator.lock(m_propertyCache.baseRegs());
-    allocator.lock(m_propertyCache.valueRegs());
-    allocator.lock(m_propertyCache.m_extraGPR);
-    allocator.lock(m_propertyCache.m_extra2GPR);
-    allocator.lock(m_propertyCache.m_propertyCacheGPR);
-    allocator.lock(m_propertyCache.m_arrayProfileGPR);
+    auto registers = m_propertyCache.registers();
+    allocator.lock(registers.baseGPR);
+    allocator.lock(registers.valueGPR);
+    allocator.lock(registers.extraGPR);
+    allocator.lock(registers.extra2GPR);
+    allocator.lock(registers.propertyCacheGPR);
+    allocator.lock(registers.arrayProfileGPR);
     allocator.lock(extraToLock);
 
     if (useHandlerIC())
@@ -1850,7 +1851,7 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
     JIT_COMMENT(jit, "Begin generateWithGuard");
     VM& vm = m_vm;
     JSValueRegs valueRegs = m_propertyCache.valueRegs();
-    GPRReg baseGPR = m_propertyCache.m_baseGPR;
+    GPRReg baseGPR = m_propertyCache.baseGPR();
     GPRReg scratchGPR = m_scratchGPR;
 
     if (accessCase.requiresIdentifierNameMatch() && !hasConstantIdentifier(m_propertyCache.accessType)) {
@@ -1893,7 +1894,7 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
                             jit.move(CCallHelpers::TrustedImmPtr(asObject(prototype)), baseForAccessGPR);
                         } else {
                             ASSERT(useHandlerIC());
-                            jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), baseForAccessGPR);
+                            jit.loadPtr(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfGlobalObject()), baseForAccessGPR);
                             switch (structure->typeInfo().type()) {
                             case StringType:
                                 jit.loadPtr(CCallHelpers::Address(baseForAccessGPR, JSGlobalObject::offsetOfStringPrototype()), baseForAccessGPR);
@@ -2318,8 +2319,8 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         succeed();
 
         isOutOfBounds.link(&jit);
-        if (m_propertyCache.m_arrayProfileGPR != InvalidGPRReg)
-            jit.or32(CCallHelpers::TrustedImm32(static_cast<uint32_t>(ArrayProfileFlag::OutOfBounds)), CCallHelpers::Address(m_propertyCache.m_arrayProfileGPR, ArrayProfile::offsetOfArrayProfileFlags()));
+        if (m_propertyCache.arrayProfileGPR() != InvalidGPRReg)
+            jit.or32(CCallHelpers::TrustedImm32(static_cast<uint32_t>(ArrayProfileFlag::OutOfBounds)), CCallHelpers::Address(m_propertyCache.arrayProfileGPR(), ArrayProfile::offsetOfArrayProfileFlags()));
         if (forInBy(accessCase.m_type))
             jit.moveTrustedValue(jsBoolean(false), valueRegs);
         else
@@ -2628,8 +2629,8 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 
         if (accessCase.m_type == AccessCase::IndexedArrayStorageStore) {
             isOutOfBounds.link(&jit);
-            if (m_propertyCache.m_arrayProfileGPR != InvalidGPRReg)
-                jit.or32(CCallHelpers::TrustedImm32(static_cast<uint32_t>(ArrayProfileFlag::MayStoreHole)), CCallHelpers::Address(m_propertyCache.m_arrayProfileGPR, ArrayProfile::offsetOfArrayProfileFlags()));
+            if (m_propertyCache.arrayProfileGPR() != InvalidGPRReg)
+                jit.or32(CCallHelpers::TrustedImm32(static_cast<uint32_t>(ArrayProfileFlag::MayStoreHole)), CCallHelpers::Address(m_propertyCache.arrayProfileGPR(), ArrayProfile::offsetOfArrayProfileFlags()));
             jit.add32(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(scratchGPR, ArrayStorage::numValuesInVectorOffset()));
             jit.branch32(CCallHelpers::Below, scratch2GPR, CCallHelpers::Address(scratchGPR, ArrayStorage::lengthOffset())).linkTo(storeResult, &jit);
 
@@ -2640,8 +2641,8 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         } else {
             isOutOfBounds.link(&jit);
             failAndIgnore.append(jit.branch32(CCallHelpers::AboveOrEqual, propertyGPR, CCallHelpers::Address(scratchGPR, Butterfly::offsetOfVectorLength())));
-            if (m_propertyCache.m_arrayProfileGPR != InvalidGPRReg)
-                jit.or32(CCallHelpers::TrustedImm32(static_cast<uint32_t>(ArrayProfileFlag::MayStoreHole)), CCallHelpers::Address(m_propertyCache.m_arrayProfileGPR, ArrayProfile::offsetOfArrayProfileFlags()));
+            if (m_propertyCache.arrayProfileGPR() != InvalidGPRReg)
+                jit.or32(CCallHelpers::TrustedImm32(static_cast<uint32_t>(ArrayProfileFlag::MayStoreHole)), CCallHelpers::Address(m_propertyCache.arrayProfileGPR(), ArrayProfile::offsetOfArrayProfileFlags()));
             jit.add32(CCallHelpers::TrustedImm32(1), propertyGPR, scratch2GPR);
             jit.store32(scratch2GPR, CCallHelpers::Address(scratchGPR, Butterfly::offsetOfPublicLength()));
             jit.jump().linkTo(storeResult, &jit);
@@ -2933,7 +2934,7 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 
         isString.link(jit);
         if (useHandlerIC()) {
-            jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratch5GPR);
+            jit.loadPtr(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfGlobalObject()), scratch5GPR);
             jit.loadPtr(CCallHelpers::Address(scratch5GPR, JSGlobalObject::offsetOfStringPrototype()), scratch5GPR);
         } else
             jit.move(CCallHelpers::TrustedImmPtr(m_globalObject->stringPrototype()), scratch5GPR);
@@ -2986,7 +2987,7 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
             InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
             if (m_propertyCache.isHandlerIC()) {
                 callSiteIndexForExceptionHandlingOrOriginal();
-                jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
+                jit.transfer32(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
             } else
                 jit.store32(CCallHelpers::TrustedImm32(callSiteIndexForExceptionHandlingOrOriginal().bits()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
             if (m_propertyCache.isHandlerIC())
@@ -3100,7 +3101,7 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
             InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
             if (m_propertyCache.isHandlerIC()) {
                 callSiteIndexForExceptionHandlingOrOriginal();
-                jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
+                jit.transfer32(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
             } else
                 jit.store32(CCallHelpers::TrustedImm32(callSiteIndexForExceptionHandlingOrOriginal().bits()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
             if (m_propertyCache.isHandlerIC())
@@ -3191,7 +3192,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
     VM& vm = m_vm;
     ECMAMode ecmaMode = m_ecmaMode;
     JSValueRegs valueRegs = m_propertyCache.valueRegs();
-    GPRReg baseGPR = m_propertyCache.m_baseGPR;
+    GPRReg baseGPR = m_propertyCache.baseGPR();
     GPRReg thisGPR = m_propertyCache.thisValueIsInExtraGPR() ? m_propertyCache.thisGPR() : baseGPR;
     GPRReg scratchGPR = m_scratchGPR;
 
@@ -3314,7 +3315,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
 
         if (m_propertyCache.isHandlerIC()) {
             callSiteIndexForExceptionHandlingOrOriginal();
-            jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
+            jit.transfer32(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
         } else
             jit.store32(CCallHelpers::TrustedImm32(callSiteIndexForExceptionHandlingOrOriginal().bits()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
 
@@ -3481,7 +3482,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         if (m_propertyCache.isHandlerIC()) {
             emitDataICPrepareForCall(jit);
             callSiteIndexForExceptionHandlingOrOriginal();
-            jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
+            jit.transfer32(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
         } else
             jit.store32(CCallHelpers::TrustedImm32(callSiteIndexForExceptionHandlingOrOriginal().bits()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
 
@@ -3516,7 +3517,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
                 CCallHelpers::Jump shouldNotThrowError = jit.branchIfNotType(scratchGPR, NullSetterFunctionType);
                 // We replace setter with this AccessCase's JSGlobalObject::nullSetterStrictFunction, which will throw an error with the right JSGlobalObject.
                 if (useHandlerIC()) {
-                    jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
+                    jit.loadPtr(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
                     jit.loadPtr(CCallHelpers::Address(scratchGPR, JSGlobalObject::offsetOfNullSetterStrictFunction()), scratchGPR);
                 } else
                     jit.move(CCallHelpers::TrustedImmPtr(m_globalObject->nullSetterStrictFunction()), scratchGPR);
@@ -3724,7 +3725,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
 
                 if (m_propertyCache.isHandlerIC()) {
                     callSiteIndexForExceptionHandlingOrOriginal();
-                    jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
+                    jit.transfer32(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
                 } else
                     jit.store32(CCallHelpers::TrustedImm32(callSiteIndexForExceptionHandlingOrOriginal().bits()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
 
@@ -3995,12 +3996,12 @@ void InlineCacheCompiler::emitDOMJITGetter(JSGlobalObject* globalObjectForDOMJIT
 {
     CCallHelpers& jit = *m_jit;
     JSValueRegs valueRegs = m_propertyCache.valueRegs();
-    GPRReg baseGPR = m_propertyCache.m_baseGPR;
+    GPRReg baseGPR = m_propertyCache.baseGPR();
     GPRReg scratchGPR = m_scratchGPR;
 
     if (m_propertyCache.isHandlerIC()) {
         callSiteIndexForExceptionHandlingOrOriginal();
-        jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
+        jit.transfer32(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
     } else
         jit.store32(CCallHelpers::TrustedImm32(callSiteIndexForExceptionHandlingOrOriginal().bits()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
 
@@ -4102,7 +4103,7 @@ void InlineCacheCompiler::emitDOMJITGetter(JSGlobalObject* globalObjectForDOMJIT
     for (FPRReg reg : fpScratch)
         usedRegisters.add(reg, IgnoreVectors);
     if (m_propertyCache.isHandlerIC())
-        usedRegisters.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
+        usedRegisters.add(m_propertyCache.propertyCacheGPR(), IgnoreVectors);
     auto registersToSpillForCCall = RegisterSet::registersToSaveForCCall(usedRegisters);
 
     AccessCaseSnippetParams params(m_vm, WTF::move(regs), WTF::move(gpScratch), WTF::move(fpScratch));
@@ -4122,7 +4123,7 @@ void InlineCacheCompiler::emitModuleNamespaceLoad(ModuleNamespaceAccessCase& acc
 {
     CCallHelpers& jit = *m_jit;
     JSValueRegs valueRegs = m_propertyCache.valueRegs();
-    GPRReg baseGPR = m_propertyCache.m_baseGPR;
+    GPRReg baseGPR = m_propertyCache.baseGPR();
     GPRReg scratchGPR = m_scratchGPR;
 
     fallThrough.append(
@@ -4142,7 +4143,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
     CCallHelpers& jit = *m_jit;
     ECMAMode ecmaMode = m_ecmaMode;
     JSValueRegs valueRegs = m_propertyCache.valueRegs();
-    GPRReg baseGPR = m_propertyCache.m_baseGPR;
+    GPRReg baseGPR = m_propertyCache.baseGPR();
     GPRReg scratchGPR = m_scratchGPR;
     GPRReg thisGPR = m_propertyCache.thisValueIsInExtraGPR() ? m_propertyCache.thisGPR() : baseGPR;
 
@@ -4154,7 +4155,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
     if (m_propertyCache.isHandlerIC()) {
         emitDataICPrepareForCall(jit);
         callSiteIndexForExceptionHandlingOrOriginal();
-        jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
+        jit.transfer32(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
     } else
         jit.store32(CCallHelpers::TrustedImm32(callSiteIndexForExceptionHandlingOrOriginal().bits()), CCallHelpers::highWordFor(CallFrameSlot::argumentCountIncludingThis));
 
@@ -4220,7 +4221,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
     switch (accessCase.m_type) {
     case AccessCase::ProxyObjectIn: {
         if (useHandlerIC()) {
-            jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
+            jit.loadPtr(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
             jit.loadPtr(CCallHelpers::Address(scratchGPR, JSGlobalObject::offsetOfPerformProxyObjectHasFunction()), scratchGPR);
         } else
             jit.move(CCallHelpers::TrustedImmPtr(m_globalObject->performProxyObjectHasFunction()), scratchGPR);
@@ -4228,7 +4229,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
     }
     case AccessCase::IndexedProxyObjectIn: {
         if (useHandlerIC()) {
-            jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
+            jit.loadPtr(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
             jit.loadPtr(CCallHelpers::Address(scratchGPR, JSGlobalObject::offsetOfPerformProxyObjectHasByValFunction()), scratchGPR);
         } else
             jit.move(CCallHelpers::TrustedImmPtr(m_globalObject->performProxyObjectHasByValFunction()), scratchGPR);
@@ -4236,7 +4237,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
     }
     case AccessCase::ProxyObjectLoad: {
         if (useHandlerIC()) {
-            jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
+            jit.loadPtr(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
             jit.loadPtr(CCallHelpers::Address(scratchGPR, JSGlobalObject::offsetOfPerformProxyObjectGetFunction()), scratchGPR);
         } else
             jit.move(CCallHelpers::TrustedImmPtr(m_globalObject->performProxyObjectGetFunction()), scratchGPR);
@@ -4244,7 +4245,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
     }
     case AccessCase::IndexedProxyObjectLoad: {
         if (useHandlerIC()) {
-            jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
+            jit.loadPtr(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
             jit.loadPtr(CCallHelpers::Address(scratchGPR, JSGlobalObject::offsetOfPerformProxyObjectGetByValFunction()), scratchGPR);
         } else
             jit.move(CCallHelpers::TrustedImmPtr(m_globalObject->performProxyObjectGetByValFunction()), scratchGPR);
@@ -4252,7 +4253,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
     }
     case AccessCase::ProxyObjectStore: {
         if (useHandlerIC()) {
-            jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
+            jit.loadPtr(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
             if (ecmaMode.isStrict())
                 jit.loadPtr(CCallHelpers::Address(scratchGPR, JSGlobalObject::offsetOfPerformProxyObjectSetStrictFunction()), scratchGPR);
             else
@@ -4263,7 +4264,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
     }
     case AccessCase::IndexedProxyObjectStore: {
         if (useHandlerIC()) {
-            jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
+            jit.loadPtr(CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfGlobalObject()), scratchGPR);
             if (ecmaMode.isStrict())
                 jit.loadPtr(CCallHelpers::Address(scratchGPR, JSGlobalObject::offsetOfPerformProxyObjectSetByValStrictFunction()), scratchGPR);
             else
@@ -4377,7 +4378,7 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
 {
     CCallHelpers& jit = *m_jit;
     JSValueRegs valueRegs = m_propertyCache.valueRegs();
-    GPRReg baseGPR = m_propertyCache.m_baseGPR;
+    GPRReg baseGPR = m_propertyCache.baseGPR();
     GPRReg valueGPR = valueRegs.payloadGPR();
 
     switch (accessCase.intrinsic()) {
@@ -5133,7 +5134,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
     } else {
         JIT_COMMENT(jit, "Cases start (allGuardedByStructureCheck)");
         jit.load32(
-            CCallHelpers::Address(m_propertyCache.m_baseGPR, JSCell::structureIDOffset()),
+            CCallHelpers::Address(m_propertyCache.baseGPR(), JSCell::structureIDOffset()),
             m_scratchGPR);
 
         Vector<int64_t, 16> caseValues(keys.size());
@@ -5155,7 +5156,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
         // patch things if the countdown reaches zero. We increment the slow path count here to ensure
         // that the slow path does not try to patch.
         if (m_propertyCache.isHandlerIC())
-            jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCountdown()));
+            jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfCountdown()));
         else {
             jit.move(CCallHelpers::TrustedImmPtr(&m_propertyCache.countdown), m_scratchGPR);
             jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(m_scratchGPR));
@@ -5214,15 +5215,10 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
         callSiteIndexForExceptionHandling = this->callSiteIndexForExceptionHandling();
     }
 
-    CodeLocationLabel<JSInternalPtrTag> successLabel = m_propertyCache.doneLocation;
-    if (m_propertyCache.isHandlerIC()) {
-        JIT_COMMENT(jit, "failure far jump");
-        failure.link(&jit);
-        jit.farJump(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfSlowPathStartLocation()), JITStubRoutinePtrTag);
-    } else {
-        m_success.linkThunk(successLabel, &jit);
-        failure.linkThunk(m_propertyCache.slowPathStartLocation, &jit);
-    }
+    auto& repatchingIC = downcast<RepatchingPropertyInlineCache>(m_propertyCache);
+    CodeLocationLabel<JSInternalPtrTag> successLabel = repatchingIC.doneLocation;
+    m_success.linkThunk(successLabel, &jit);
+    failure.linkThunk(repatchingIC.slowPathStartLocation, &jit);
 
     LinkBuffer linkBuffer(jit, codeBlock, LinkBuffer::Profile::InlineCache, JITCompilationCanFail);
     if (linkBuffer.didFailToAllocate()) {
@@ -5236,7 +5232,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
 
     dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_propertyCache.codeOrigin), ": Generating polymorphic access stub for ", listDump(keys));
 
-    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_propertyCache.codeOrigin, " with start: ", downcast<RepatchingPropertyInlineCache>(m_propertyCache).startLocation, " with return point ", successLabel, ": ", listDump(keys)).data());
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_propertyCache.codeOrigin, " with start: ", repatchingIC.startLocation, " with return point ", successLabel, ": ", listDump(keys)).data());
 
     CodeBlock* owner = codeBlock;
     FixedVector<StructureID> weakStructures(WTF::move(m_weakStructures));
@@ -8056,7 +8052,7 @@ AccessGenerationResult InlineCacheCompiler::compileOneAccessCaseHandler(const Ve
         // of something that isn't patchable. The slow path will decrement "countdown" and will only
         // patch things if the countdown reaches zero. We increment the slow path count here to ensure
         // that the slow path does not try to patch.
-        jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCountdown()));
+        jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfCountdown()));
     }
 
     m_failAndRepatch.link(&jit);
@@ -8139,7 +8135,7 @@ MacroAssemblerCodeRef<JITStubRoutinePtrTag> InlineCacheCompiler::compileGetByDOM
         // of something that isn't patchable. The slow path will decrement "countdown" and will only
         // patch things if the countdown reaches zero. We increment the slow path count here to ensure
         // that the slow path does not try to patch.
-        jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCountdown()));
+        jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(m_propertyCache.propertyCacheGPR(), PropertyInlineCache::offsetOfCountdown()));
     }
 
     m_failAndRepatch.link(&jit);

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
@@ -655,76 +655,76 @@ static CodePtr<OperationPtrTag> NODELETE slowOperationFromUnlinkedPropertyInline
     return { };
 }
 
-void PropertyInlineCache::initializePredefinedRegisters()
+PropertyInlineCache::Registers PropertyInlineCache::registers() const
 {
+    if (auto* repatching = dynamicDowncast<RepatchingPropertyInlineCache>(*this))
+        return repatching->m_registers;
+
+    Registers registers;
     switch (accessType) {
     case AccessType::DeleteByValStrict:
     case AccessType::DeleteByValSloppy:
-        m_baseGPR = BaselineJITRegisters::DelByVal::baseJSR.payloadGPR();
-        m_extraGPR = BaselineJITRegisters::DelByVal::propertyJSR.payloadGPR();
-        m_valueGPR = BaselineJITRegisters::DelByVal::resultJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::DelByVal::propertyCacheGPR;
+        registers.baseGPR = BaselineJITRegisters::DelByVal::baseJSR.payloadGPR();
+        registers.extraGPR = BaselineJITRegisters::DelByVal::propertyJSR.payloadGPR();
+        registers.valueGPR = BaselineJITRegisters::DelByVal::resultJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::DelByVal::propertyCacheGPR;
         break;
     case AccessType::DeleteByIdStrict:
     case AccessType::DeleteByIdSloppy:
-        m_baseGPR = BaselineJITRegisters::DelById::baseJSR.payloadGPR();
-        m_extraGPR = InvalidGPRReg;
-        m_valueGPR = BaselineJITRegisters::DelById::resultJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::DelById::propertyCacheGPR;
+        registers.baseGPR = BaselineJITRegisters::DelById::baseJSR.payloadGPR();
+        registers.valueGPR = BaselineJITRegisters::DelById::resultJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::DelById::propertyCacheGPR;
         break;
     case AccessType::GetByVal:
     case AccessType::GetPrivateName:
-        m_baseGPR = BaselineJITRegisters::GetByVal::baseJSR.payloadGPR();
-        m_extraGPR = BaselineJITRegisters::GetByVal::propertyJSR.payloadGPR();
-        m_valueGPR = BaselineJITRegisters::GetByVal::resultJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::GetByVal::propertyCacheGPR;
+        registers.baseGPR = BaselineJITRegisters::GetByVal::baseJSR.payloadGPR();
+        registers.extraGPR = BaselineJITRegisters::GetByVal::propertyJSR.payloadGPR();
+        registers.valueGPR = BaselineJITRegisters::GetByVal::resultJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::GetByVal::propertyCacheGPR;
         if (accessType == AccessType::GetByVal)
-            m_arrayProfileGPR = BaselineJITRegisters::GetByVal::profileGPR;
+            registers.arrayProfileGPR = BaselineJITRegisters::GetByVal::profileGPR;
         break;
     case AccessType::InstanceOf:
-        prototypeIsKnownObject = false;
-        m_baseGPR = BaselineJITRegisters::Instanceof::valueJSR.payloadGPR();
-        m_valueGPR = BaselineJITRegisters::Instanceof::resultJSR.payloadGPR();
-        m_extraGPR = BaselineJITRegisters::Instanceof::protoJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::Instanceof::propertyCacheGPR;
+        registers.baseGPR = BaselineJITRegisters::Instanceof::valueJSR.payloadGPR();
+        registers.valueGPR = BaselineJITRegisters::Instanceof::resultJSR.payloadGPR();
+        registers.extraGPR = BaselineJITRegisters::Instanceof::protoJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::Instanceof::propertyCacheGPR;
         break;
     case AccessType::InByVal:
     case AccessType::HasPrivateName:
     case AccessType::HasPrivateBrand:
-        m_baseGPR = BaselineJITRegisters::InByVal::baseJSR.payloadGPR();
-        m_extraGPR = BaselineJITRegisters::InByVal::propertyJSR.payloadGPR();
-        m_valueGPR = BaselineJITRegisters::InByVal::resultJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::InByVal::propertyCacheGPR;
+        registers.baseGPR = BaselineJITRegisters::InByVal::baseJSR.payloadGPR();
+        registers.extraGPR = BaselineJITRegisters::InByVal::propertyJSR.payloadGPR();
+        registers.valueGPR = BaselineJITRegisters::InByVal::resultJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::InByVal::propertyCacheGPR;
         if (accessType == AccessType::InByVal)
-            m_arrayProfileGPR = BaselineJITRegisters::InByVal::profileGPR;
+            registers.arrayProfileGPR = BaselineJITRegisters::InByVal::profileGPR;
         break;
     case AccessType::InById:
-        m_extraGPR = InvalidGPRReg;
-        m_baseGPR = BaselineJITRegisters::InById::baseJSR.payloadGPR();
-        m_valueGPR = BaselineJITRegisters::InById::resultJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::InById::propertyCacheGPR;
+        registers.baseGPR = BaselineJITRegisters::InById::baseJSR.payloadGPR();
+        registers.valueGPR = BaselineJITRegisters::InById::resultJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::InById::propertyCacheGPR;
         break;
     case AccessType::GetByIdDirect:
     case AccessType::GetById:
     case AccessType::GetPrivateNameById:
-        m_extraGPR = InvalidGPRReg;
-        m_baseGPR = BaselineJITRegisters::GetById::baseJSR.payloadGPR();
-        m_valueGPR = BaselineJITRegisters::GetById::resultJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::GetById::propertyCacheGPR;
+        registers.baseGPR = BaselineJITRegisters::GetById::baseJSR.payloadGPR();
+        registers.valueGPR = BaselineJITRegisters::GetById::resultJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::GetById::propertyCacheGPR;
         break;
     case AccessType::GetByIdWithThis:
-        m_baseGPR = BaselineJITRegisters::GetByIdWithThis::baseJSR.payloadGPR();
-        m_valueGPR = BaselineJITRegisters::GetByIdWithThis::resultJSR.payloadGPR();
-        m_extraGPR = BaselineJITRegisters::GetByIdWithThis::thisJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::GetByIdWithThis::propertyCacheGPR;
+        registers.baseGPR = BaselineJITRegisters::GetByIdWithThis::baseJSR.payloadGPR();
+        registers.valueGPR = BaselineJITRegisters::GetByIdWithThis::resultJSR.payloadGPR();
+        registers.extraGPR = BaselineJITRegisters::GetByIdWithThis::thisJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::GetByIdWithThis::propertyCacheGPR;
         break;
     case AccessType::GetByValWithThis:
-        m_baseGPR = BaselineJITRegisters::GetByValWithThis::baseJSR.payloadGPR();
-        m_valueGPR = BaselineJITRegisters::GetByValWithThis::resultJSR.payloadGPR();
-        m_extraGPR = BaselineJITRegisters::GetByValWithThis::thisJSR.payloadGPR();
-        m_extra2GPR = BaselineJITRegisters::GetByValWithThis::propertyJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::GetByValWithThis::propertyCacheGPR;
-        m_arrayProfileGPR = BaselineJITRegisters::GetByValWithThis::profileGPR;
+        registers.baseGPR = BaselineJITRegisters::GetByValWithThis::baseJSR.payloadGPR();
+        registers.valueGPR = BaselineJITRegisters::GetByValWithThis::resultJSR.payloadGPR();
+        registers.extraGPR = BaselineJITRegisters::GetByValWithThis::thisJSR.payloadGPR();
+        registers.extra2GPR = BaselineJITRegisters::GetByValWithThis::propertyJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::GetByValWithThis::propertyCacheGPR;
+        registers.arrayProfileGPR = BaselineJITRegisters::GetByValWithThis::profileGPR;
         break;
     case AccessType::PutByIdStrict:
     case AccessType::PutByIdSloppy:
@@ -732,10 +732,9 @@ void PropertyInlineCache::initializePredefinedRegisters()
     case AccessType::PutByIdDirectSloppy:
     case AccessType::DefinePrivateNameById:
     case AccessType::SetPrivateNameById:
-        m_extraGPR = InvalidGPRReg;
-        m_baseGPR = BaselineJITRegisters::PutById::baseJSR.payloadGPR();
-        m_valueGPR = BaselineJITRegisters::PutById::valueJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::PutById::propertyCacheGPR;
+        registers.baseGPR = BaselineJITRegisters::PutById::baseJSR.payloadGPR();
+        registers.valueGPR = BaselineJITRegisters::PutById::valueJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::PutById::propertyCacheGPR;
         break;
     case AccessType::PutByValStrict:
     case AccessType::PutByValSloppy:
@@ -743,21 +742,21 @@ void PropertyInlineCache::initializePredefinedRegisters()
     case AccessType::PutByValDirectSloppy:
     case AccessType::DefinePrivateNameByVal:
     case AccessType::SetPrivateNameByVal:
-        m_baseGPR = BaselineJITRegisters::PutByVal::baseJSR.payloadGPR();
-        m_extraGPR = BaselineJITRegisters::PutByVal::propertyJSR.payloadGPR();
-        m_valueGPR = BaselineJITRegisters::PutByVal::valueJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::PutByVal::propertyCacheGPR;
+        registers.baseGPR = BaselineJITRegisters::PutByVal::baseJSR.payloadGPR();
+        registers.extraGPR = BaselineJITRegisters::PutByVal::propertyJSR.payloadGPR();
+        registers.valueGPR = BaselineJITRegisters::PutByVal::valueJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::PutByVal::propertyCacheGPR;
         if (accessType != AccessType::DefinePrivateNameByVal && accessType != AccessType::SetPrivateNameByVal)
-            m_arrayProfileGPR = BaselineJITRegisters::PutByVal::profileGPR;
+            registers.arrayProfileGPR = BaselineJITRegisters::PutByVal::profileGPR;
         break;
     case AccessType::SetPrivateBrand:
     case AccessType::CheckPrivateBrand:
-        m_valueGPR = InvalidGPRReg;
-        m_baseGPR = BaselineJITRegisters::PrivateBrand::baseJSR.payloadGPR();
-        m_extraGPR = BaselineJITRegisters::PrivateBrand::propertyJSR.payloadGPR();
-        m_propertyCacheGPR = BaselineJITRegisters::PrivateBrand::propertyCacheGPR;
+        registers.baseGPR = BaselineJITRegisters::PrivateBrand::baseJSR.payloadGPR();
+        registers.extraGPR = BaselineJITRegisters::PrivateBrand::propertyJSR.payloadGPR();
+        registers.propertyCacheGPR = BaselineJITRegisters::PrivateBrand::propertyCacheGPR;
         break;
     }
+    return registers;
 }
 
 void HandlerPropertyInlineCache::initializeFromUnlinkedPropertyInlineCache(VM& vm, CodeBlock* codeBlock, const BaselineUnlinkedPropertyInlineCache& unlinkedPropertyCache)
@@ -785,7 +784,6 @@ void HandlerPropertyInlineCache::initializeFromUnlinkedPropertyInlineCache(VM& v
         bufferingCountdown = 1;
 
     m_slowOperation = slowOperationFromUnlinkedPropertyInlineCache(unlinkedPropertyCache);
-    initializePredefinedRegisters();
 }
 
 #if ENABLE(DFG_JIT)
@@ -821,7 +819,6 @@ void HandlerPropertyInlineCache::initializeFromDFGUnlinkedPropertyInlineCache(Co
         bufferingCountdown = 1;
 
     m_slowOperation = slowOperationFromUnlinkedPropertyInlineCache(unlinkedPropertyCache);
-    initializePredefinedRegisters();
 }
 #endif
 
@@ -926,7 +923,7 @@ void PropertyInlineCache::resetStubAsJumpInAccess(CodeBlock* codeBlock)
         return;
     }
 
-    rewireStubAsJumpInAccess(codeBlock, InlineCacheHandler::createNonHandlerSlowPath(slowPathStartLocation));
+    rewireStubAsJumpInAccess(codeBlock, InlineCacheHandler::createNonHandlerSlowPath(downcast<RepatchingPropertyInlineCache>(*this).slowPathStartLocation));
 }
 
 Vector<AccessCase*, 16> PropertyInlineCache::listedAccessCases(const AbstractLocker&) const

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
@@ -146,8 +146,6 @@ public:
     void deref();
     void aboutToDie();
 
-    void NODELETE initializePredefinedRegisters();
-
     DECLARE_VISIT_AGGREGATE;
 
     // Check if the stub has weak references that are dead. If it does, then it resets itself,
@@ -165,23 +163,9 @@ public:
 
     bool NODELETE containsPC(void* pc) const;
 
-    JSValueRegs valueRegs() const
-    {
-        return JSValueRegs(
-            m_valueGPR);
-    }
-
-    JSValueRegs propertyRegs() const
-    {
-        return JSValueRegs(
-            propertyGPR());
-    }
-
-    JSValueRegs baseRegs() const
-    {
-        return JSValueRegs(
-            m_baseGPR);
-    }
+    JSValueRegs valueRegs() const { return JSValueRegs(valueGPR()); }
+    JSValueRegs propertyRegs() const { return JSValueRegs(propertyGPR()); }
+    JSValueRegs baseRegs() const { return JSValueRegs(baseGPR()); }
 
     bool thisValueIsInExtraGPR() const { return accessType == AccessType::GetByIdWithThis || accessType == AccessType::GetByValWithThis; }
 
@@ -369,7 +353,6 @@ public:
     static constexpr ptrdiff_t offsetOfDoneLocation() { return OBJECT_OFFSETOF(PropertyInlineCache, doneLocation); }
     static constexpr ptrdiff_t offsetOfCountdown() { return OBJECT_OFFSETOF(PropertyInlineCache, countdown); }
     static constexpr ptrdiff_t offsetOfCallSiteIndex() { return OBJECT_OFFSETOF(PropertyInlineCache, callSiteIndex); }
-    static constexpr ptrdiff_t offsetOfSlowPathStartLocation() { return OBJECT_OFFSETOF(PropertyInlineCache, slowPathStartLocation); }
     static constexpr ptrdiff_t offsetOfHandler() { return OBJECT_OFFSETOF(PropertyInlineCache, m_handler); }
     static constexpr ptrdiff_t offsetOfGlobalObject() { return OBJECT_OFFSETOF(PropertyInlineCache, m_globalObject); }
 
@@ -378,21 +361,37 @@ public:
     JSGlobalObject* globalObject() const { return m_globalObject; }
 
     inline ScalarRegisterSet usedRegisters() const;
-    inline void setUsedRegisters(ScalarRegisterSet);
-    inline void removeUsedRegister(GPRReg);
+
+    struct Registers {
+        GPRReg baseGPR { InvalidGPRReg };
+        GPRReg valueGPR { InvalidGPRReg };
+        GPRReg extraGPR { InvalidGPRReg };
+        GPRReg extra2GPR { InvalidGPRReg };
+        GPRReg propertyCacheGPR { InvalidGPRReg };
+        GPRReg arrayProfileGPR { InvalidGPRReg };
+    };
+
+    Registers registers() const;
+
+    GPRReg baseGPR() const { return registers().baseGPR; }
+    GPRReg valueGPR() const { return registers().valueGPR; }
+    GPRReg extraGPR() const { return registers().extraGPR; }
+    GPRReg extra2GPR() const { return registers().extra2GPR; }
+    GPRReg propertyCacheGPR() const { return registers().propertyCacheGPR; }
+    GPRReg arrayProfileGPR() const { return registers().arrayProfileGPR; }
 
     void resetStubAsJumpInAccess(CodeBlock*);
 
-    GPRReg thisGPR() const { return m_extraGPR; }
-    GPRReg prototypeGPR() const { return m_extraGPR; }
-    GPRReg brandGPR() const { return m_extraGPR; }
+    GPRReg thisGPR() const { return extraGPR(); }
+    GPRReg prototypeGPR() const { return extraGPR(); }
+    GPRReg brandGPR() const { return extraGPR(); }
     GPRReg propertyGPR() const
     {
         switch (accessType) {
         case AccessType::GetByValWithThis:
-            return m_extra2GPR;
+            return extra2GPR();
         default:
-            return m_extraGPR;
+            return extraGPR();
         }
     }
 
@@ -402,7 +401,6 @@ public:
     JSCell* m_inlineHolder { nullptr };
     CacheableIdentifier m_identifier;
     CodeLocationLabel<JSInternalPtrTag> doneLocation;
-    CodeLocationLabel<JITStubRoutinePtrTag> slowPathStartLocation;
 
     JSGlobalObject* m_globalObject { nullptr };
 private:
@@ -418,14 +416,6 @@ private:
 public:
 
     CallSiteIndex callSiteIndex;
-
-    // FIXME: These should only be needed by the repatching ICs but it's slightly non-trivial to move them there as different AccessTypes use different pinned registers.
-    GPRReg m_baseGPR { InvalidGPRReg };
-    GPRReg m_valueGPR { InvalidGPRReg };
-    GPRReg m_extraGPR { InvalidGPRReg };
-    GPRReg m_extra2GPR { InvalidGPRReg };
-    GPRReg m_propertyCacheGPR { InvalidGPRReg };
-    GPRReg m_arrayProfileGPR { InvalidGPRReg };
 
     AccessType accessType { AccessType::GetById };
 protected:
@@ -659,10 +649,12 @@ public:
 
     // This is either the start of the inline IC for *byId caches, or the location of patchable jump for 'instanceof' caches.
     CodeLocationLabel<JITStubRoutinePtrTag> startLocation;
+    CodeLocationLabel<JITStubRoutinePtrTag> slowPathStartLocation;
     CodeLocationCall<JSInternalPtrTag> m_slowPathCallLocation;
     std::unique_ptr<PolymorphicAccess> m_stub;
 
     ScalarRegisterSet m_usedRegisters;
+    Registers m_registers;
 
     uint32_t inlineCodeSize() const
     {
@@ -677,18 +669,6 @@ inline ScalarRegisterSet PropertyInlineCache::usedRegisters() const
     if (auto* repatching = dynamicDowncast<RepatchingPropertyInlineCache>(*this))
         return repatching->m_usedRegisters;
     return RegisterSet::stubUnavailableRegisters().toScalarRegisterSet();
-}
-
-inline void PropertyInlineCache::setUsedRegisters(ScalarRegisterSet value)
-{
-    ASSERT(is<RepatchingPropertyInlineCache>(*this));
-    downcast<RepatchingPropertyInlineCache>(*this).m_usedRegisters = value;
-}
-
-inline void PropertyInlineCache::removeUsedRegister(GPRReg reg)
-{
-    ASSERT(is<RepatchingPropertyInlineCache>(*this));
-    downcast<RepatchingPropertyInlineCache>(*this).m_usedRegisters.remove(reg);
 }
 
 inline auto appropriateGetByIdOptimizeFunction(AccessType type) -> decltype(&operationGetByIdOptimize)
@@ -795,7 +775,6 @@ struct UnlinkedPropertyInlineCache {
     bool canBeMegamorphic : 1 { false };
     CacheableIdentifier m_identifier; // This only comes from already marked one. Thus, we do not mark it via GC.
     CodeLocationLabel<JSInternalPtrTag> doneLocation;
-    CodeLocationLabel<JITStubRoutinePtrTag> slowPathStartLocation;
 };
 
 struct BaselineUnlinkedPropertyInlineCache : JSC::UnlinkedPropertyInlineCache {

--- a/Source/JavaScriptCore/dfg/DFGInlineCacheWrapperInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGInlineCacheWrapperInlines.h
@@ -36,10 +36,9 @@ template<typename GeneratorType>
 void InlineCacheWrapper<GeneratorType>::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     m_generator.reportSlowPathCall(m_slowPath->label(), m_slowPath->call());
-    if (m_generator.m_unlinkedPropertyCache) {
+    if (m_generator.m_unlinkedPropertyCache)
         m_generator.m_unlinkedPropertyCache->doneLocation = fastPath.locationOf<JSInternalPtrTag>(m_generator.m_done);
-        static_cast<DFG::UnlinkedPropertyInlineCache*>(m_generator.m_unlinkedPropertyCache)->slowPathStartLocation = fastPath.locationOf<JITStubRoutinePtrTag>(m_generator.m_slowPathBegin);
-    } else
+    else
         m_generator.finalize(fastPath, slowPath);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -53,19 +53,8 @@ class JITCode;
 class JITCompiler;
 
 struct UnlinkedPropertyInlineCache : JSC::UnlinkedPropertyInlineCache {
-    void setUsedRegisters(ScalarRegisterSet value) { m_usedRegisters = value; }
-    void removeUsedRegister(GPRReg reg) { m_usedRegisters.remove(reg); }
-
     CodeOrigin codeOrigin;
     CallSiteIndex callSiteIndex;
-    GPRReg m_baseGPR { InvalidGPRReg };
-    GPRReg m_valueGPR { InvalidGPRReg };
-    GPRReg m_extraGPR { InvalidGPRReg };
-    GPRReg m_extra2GPR { InvalidGPRReg };
-    GPRReg m_propertyCacheGPR { InvalidGPRReg };
-
-private:
-    ScalarRegisterSet m_usedRegisters;
 };
 
 struct UnlinkedCallLinkInfo : JSC::UnlinkedCallLinkInfo {

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -925,10 +925,8 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
 #endif
 
     auto finalizeICs = [&] (auto& generators) {
-        for (auto& gen : generators) {
+        for (auto& gen : generators)
             gen.m_unlinkedPropertyCache->doneLocation = patchBuffer.locationOf<JSInternalPtrTag>(gen.m_done);
-            gen.m_unlinkedPropertyCache->slowPathStartLocation = patchBuffer.locationOf<JITStubRoutinePtrTag>(gen.m_slowPathBegin);
-        }
     };
 
     finalizeICs(m_getByIds);

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -427,7 +427,6 @@ void JIT::emitSlowIteratorOpenGeneric(const JSInstruction*, Vector<SlowCaseEntry
 
     JITGetByIdGenerator& gen = m_getByIds[m_getByIdIndex++];
     gen.generateDataICSlowPath(*this);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
     static_assert(BaselineJITRegisters::GetById::resultJSR == returnValueJSR);
     jump().linkTo(fastPathResumePoint(), this);
@@ -570,7 +569,6 @@ void JIT::emitSlow_op_iterator_next(const JSInstruction*, Vector<SlowCaseEntry>:
     {
         JITGetByIdGenerator& gen = m_getByIds[m_getByIdIndex++];
         gen.generateDataICSlowPath(*this);
-        gen.reportBaselineDataICSlowPathBegin(label());
         nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
         static_assert(BaselineJITRegisters::GetById::resultJSR == returnValueJSR);
         emitJumpSlowToHotForCheckpoint(jump());
@@ -580,7 +578,6 @@ void JIT::emitSlow_op_iterator_next(const JSInstruction*, Vector<SlowCaseEntry>:
         linkAllSlowCases(iter);
         JITGetByIdGenerator& gen = m_getByIds[m_getByIdIndex++];
         gen.generateDataICSlowPath(*this);
-        gen.reportBaselineDataICSlowPathBegin(label());
         nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
         static_assert(BaselineJITRegisters::GetById::resultJSR == returnValueJSR);
     }
@@ -763,7 +760,6 @@ void JIT::emitSlow_op_instanceof(const JSInstruction* instruction, Vector<SlowCa
     {
         JITGetByIdGenerator& gen = m_getByIds[m_getByIdIndex++];
         gen.generateDataICSlowPath(*this);
-        gen.reportBaselineDataICSlowPathBegin(label());
         nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
         static_assert(GetById::resultJSR == returnValueJSR);
         emitJumpSlowToHotForCheckpoint(jump());
@@ -788,7 +784,6 @@ void JIT::emitSlow_op_instanceof(const JSInstruction* instruction, Vector<SlowCa
     {
         JITGetByIdGenerator& gen = m_getByIds[m_getByIdIndex++];
         gen.generateDataICSlowPath(*this);
-        gen.reportBaselineDataICSlowPathBegin(label());
         nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
         static_assert(GetById::resultJSR == returnValueJSR);
         emitJumpSlowToHotForCheckpoint(jump());
@@ -798,7 +793,6 @@ void JIT::emitSlow_op_instanceof(const JSInstruction* instruction, Vector<SlowCa
     linkAllSlowCases(iter);
     {
         JITInstanceOfGenerator& gen = m_instanceOfs[m_instanceOfIndex++];
-        gen.reportBaselineDataICSlowPathBegin(label());
         nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
     }
 

--- a/Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp
@@ -89,7 +89,7 @@ void JITInlineCacheGenerator::finalize(
     repatchingIC.startLocation = start;
     m_propertyCache->doneLocation = fastPath.locationOf<JSInternalPtrTag>(m_done);
     repatchingIC.m_slowPathCallLocation = slowPath.locationOf<JSInternalPtrTag>(m_slowPathCall);
-    m_propertyCache->slowPathStartLocation = slowPath.locationOf<JITStubRoutinePtrTag>(m_slowPathBegin);
+    repatchingIC.slowPathStartLocation = slowPath.locationOf<JITStubRoutinePtrTag>(m_slowPathBegin);
 }
 
 void JITInlineCacheGenerator::generateDataICFastPath(CCallHelpers& jit, GPRReg propertyCacheGPR)

--- a/Source/JavaScriptCore/jit/JITInlineCacheGenerator.h
+++ b/Source/JavaScriptCore/jit/JITInlineCacheGenerator.h
@@ -48,6 +48,7 @@ class CallSiteIndex;
 class CodeBlock;
 class JIT;
 class PropertyInlineCache;
+class RepatchingPropertyInlineCache;
 struct UnlinkedPropertyInlineCache;
 struct BaselineUnlinkedPropertyInlineCache;
 
@@ -73,11 +74,6 @@ public:
 
     CCallHelpers::Label slowPathBegin() const { return m_slowPathBegin; }
 
-    void reportBaselineDataICSlowPathBegin(CCallHelpers::Label slowPathBegin)
-    {
-        m_slowPathBegin = slowPathBegin;
-    }
-
     void NODELETE finalize(
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer,
         CodeLocationLabel<JITStubRoutinePtrTag> start);
@@ -92,18 +88,19 @@ public:
         if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>) {
             propertyCache.bytecodeIndex = codeOrigin.bytecodeIndex();
             UNUSED_PARAM(callSiteIndex);
-            UNUSED_PARAM(usedRegisters);
-            UNUSED_PARAM(codeBlock);
         } else {
             propertyCache.codeOrigin = codeOrigin;
             propertyCache.callSiteIndex = callSiteIndex;
-            propertyCache.setUsedRegisters(usedRegisters.toScalarRegisterSet());
         }
         if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>) {
+            downcast<RepatchingPropertyInlineCache>(propertyCache).m_usedRegisters = usedRegisters.toScalarRegisterSet();
             if (codeOrigin.inlineCallFrame())
                 propertyCache.m_globalObject = baselineCodeBlockForInlineCallFrame(codeOrigin.inlineCallFrame())->globalObject();
             else
                 propertyCache.m_globalObject = codeBlock->globalObject();
+        } else {
+            UNUSED_PARAM(codeBlock);
+            UNUSED_PARAM(usedRegisters);
         }
     }
 
@@ -147,11 +144,11 @@ public:
     {
         JITInlineCacheGenerator::setUpPropertyInlineCacheImpl(propertyCache, codeBlock, accessType, cacheType, codeOrigin, callSiteIndex, usedRegisters);
         propertyCache.m_identifier = propertyName;
-        if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>) {
-            propertyCache.m_baseGPR = baseRegs.payloadGPR();
-            propertyCache.m_valueGPR = valueRegs.payloadGPR();
-            propertyCache.m_extraGPR = InvalidGPRReg;
-            propertyCache.m_propertyCacheGPR = propertyCacheGPR;
+        if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>) {
+            auto& registers = downcast<RepatchingPropertyInlineCache>(propertyCache).m_registers;
+            registers.baseGPR = baseRegs.payloadGPR();
+            registers.valueGPR = valueRegs.payloadGPR();
+            registers.propertyCacheGPR = propertyCacheGPR;
         } else {
             UNUSED_PARAM(baseRegs);
             UNUSED_PARAM(valueRegs);
@@ -216,9 +213,9 @@ public:
         JSValueRegs valueRegs, JSValueRegs baseRegs, JSValueRegs thisRegs, GPRReg propertyCacheGPR)
     {
         JITByIdGenerator::setUpPropertyInlineCacheImpl(propertyCache, codeBlock, accessType, cacheType, codeOrigin, callSiteIndex, usedRegisters, propertyName, baseRegs, valueRegs, propertyCacheGPR);
-        if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>) {
-            propertyCache.m_extraGPR = thisRegs.payloadGPR();
-        } else
+        if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>)
+            downcast<RepatchingPropertyInlineCache>(propertyCache).m_registers.extraGPR = thisRegs.payloadGPR();
+        else
             UNUSED_PARAM(thisRegs);
     }
 };
@@ -241,8 +238,8 @@ public:
         JSValueRegs baseRegs, JSValueRegs valueRegs, GPRReg propertyCacheGPR, GPRReg scratchGPR)
     {
         JITByIdGenerator::setUpPropertyInlineCacheImpl(propertyCache, codeBlock, accessType, cacheType, codeOrigin, callSiteIndex, usedRegisters, propertyName, baseRegs, valueRegs, propertyCacheGPR);
-        if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>)
-            propertyCache.removeUsedRegister(scratchGPR);
+        if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>)
+            downcast<RepatchingPropertyInlineCache>(propertyCache).m_usedRegisters.remove(scratchGPR);
         else
             UNUSED_PARAM(scratchGPR);
     }
@@ -274,15 +271,13 @@ public:
         JSValueRegs baseRegs, JSValueRegs propertyRegs, JSValueRegs valueRegs, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
     {
         JITInlineCacheGenerator::setUpPropertyInlineCacheImpl(propertyCache, codeBlock, accessType, cacheType, codeOrigin, callSiteIndex, usedRegisters);
-        if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>) {
-            propertyCache.m_baseGPR = baseRegs.payloadGPR();
-            propertyCache.m_extraGPR = propertyRegs.payloadGPR();
-            propertyCache.m_valueGPR = valueRegs.payloadGPR();
-            propertyCache.m_propertyCacheGPR = propertyCacheGPR;
-            if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, DFG::UnlinkedPropertyInlineCache>)
-                propertyCache.m_arrayProfileGPR = arrayProfileGPR;
-            else
-                UNUSED_PARAM(arrayProfileGPR);
+        if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>) {
+            auto& registers = downcast<RepatchingPropertyInlineCache>(propertyCache).m_registers;
+            registers.baseGPR = baseRegs.payloadGPR();
+            registers.extraGPR = propertyRegs.payloadGPR();
+            registers.valueGPR = valueRegs.payloadGPR();
+            registers.propertyCacheGPR = propertyCacheGPR;
+            registers.arrayProfileGPR = arrayProfileGPR;
         } else {
             UNUSED_PARAM(baseRegs);
             UNUSED_PARAM(propertyRegs);
@@ -325,11 +320,12 @@ public:
         JSValueRegs baseRegs, JSValueRegs propertyRegs, JSValueRegs resultRegs, GPRReg propertyCacheGPR)
     {
         JITInlineCacheGenerator::setUpPropertyInlineCacheImpl(propertyCache, codeBlock, accessType, cacheType, codeOrigin, callSiteIndex, usedRegisters);
-        if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>) {
-            propertyCache.m_baseGPR = baseRegs.payloadGPR();
-            propertyCache.m_extraGPR = propertyRegs.payloadGPR();
-            propertyCache.m_valueGPR = resultRegs.payloadGPR();
-            propertyCache.m_propertyCacheGPR = propertyCacheGPR;
+        if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>) {
+            auto& registers = downcast<RepatchingPropertyInlineCache>(propertyCache).m_registers;
+            registers.baseGPR = baseRegs.payloadGPR();
+            registers.extraGPR = propertyRegs.payloadGPR();
+            registers.valueGPR = resultRegs.payloadGPR();
+            registers.propertyCacheGPR = propertyCacheGPR;
         } else {
             UNUSED_PARAM(baseRegs);
             UNUSED_PARAM(propertyRegs);
@@ -400,20 +396,19 @@ public:
         JSValueRegs baseRegs, JSValueRegs propertyRegs, JSValueRegs resultRegs, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
     {
         JITInlineCacheGenerator::setUpPropertyInlineCacheImpl(propertyCache, codeBlock, accessType, cacheType, codeOrigin, callSiteIndex, usedRegisters);
-        if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>) {
-            propertyCache.m_baseGPR = baseRegs.payloadGPR();
-            propertyCache.m_extraGPR = propertyRegs.payloadGPR();
-            propertyCache.m_valueGPR = resultRegs.payloadGPR();
-            propertyCache.m_propertyCacheGPR = propertyCacheGPR;
-            if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, DFG::UnlinkedPropertyInlineCache>)
-                propertyCache.m_arrayProfileGPR = arrayProfileGPR;
-            else
-                UNUSED_PARAM(arrayProfileGPR);
+        if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>) {
+            auto& registers = downcast<RepatchingPropertyInlineCache>(propertyCache).m_registers;
+            registers.baseGPR = baseRegs.payloadGPR();
+            registers.extraGPR = propertyRegs.payloadGPR();
+            registers.valueGPR = resultRegs.payloadGPR();
+            registers.propertyCacheGPR = propertyCacheGPR;
+            registers.arrayProfileGPR = arrayProfileGPR;
         } else {
             UNUSED_PARAM(baseRegs);
             UNUSED_PARAM(propertyRegs);
             UNUSED_PARAM(resultRegs);
             UNUSED_PARAM(propertyCacheGPR);
+            UNUSED_PARAM(arrayProfileGPR);
         }
     }
 
@@ -469,11 +464,12 @@ public:
     {
         JITInlineCacheGenerator::setUpPropertyInlineCacheImpl(propertyCache, codeBlock, accessType, cacheType, codeOrigin, callSiteIndex, usedRegisters);
         propertyCache.prototypeIsKnownObject = prototypeIsKnownObject;
-        if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>) {
-            propertyCache.m_baseGPR = valueGPR;
-            propertyCache.m_valueGPR = resultGPR;
-            propertyCache.m_extraGPR = prototypeGPR;
-            propertyCache.m_propertyCacheGPR = propertyCacheGPR;
+        if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>) {
+            auto& registers = downcast<RepatchingPropertyInlineCache>(propertyCache).m_registers;
+            registers.baseGPR = valueGPR;
+            registers.valueGPR = resultGPR;
+            registers.extraGPR = prototypeGPR;
+            registers.propertyCacheGPR = propertyCacheGPR;
         } else {
             UNUSED_PARAM(valueGPR);
             UNUSED_PARAM(resultGPR);
@@ -514,20 +510,19 @@ public:
         JSValueRegs baseRegs, JSValueRegs propertyRegs, JSValueRegs resultRegs, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
     {
         JITInlineCacheGenerator::setUpPropertyInlineCacheImpl(propertyCache, codeBlock, accessType, cacheType, codeOrigin, callSiteIndex, usedRegisters);
-        if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>) {
-            propertyCache.m_baseGPR = baseRegs.payloadGPR();
-            propertyCache.m_extraGPR = propertyRegs.payloadGPR();
-            propertyCache.m_valueGPR = resultRegs.payloadGPR();
-            propertyCache.m_propertyCacheGPR = propertyCacheGPR;
-            if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, DFG::UnlinkedPropertyInlineCache>)
-                propertyCache.m_arrayProfileGPR = arrayProfileGPR;
-            else
-                UNUSED_PARAM(arrayProfileGPR);
+        if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>) {
+            auto& registers = downcast<RepatchingPropertyInlineCache>(propertyCache).m_registers;
+            registers.baseGPR = baseRegs.payloadGPR();
+            registers.extraGPR = propertyRegs.payloadGPR();
+            registers.valueGPR = resultRegs.payloadGPR();
+            registers.propertyCacheGPR = propertyCacheGPR;
+            registers.arrayProfileGPR = arrayProfileGPR;
         } else {
             UNUSED_PARAM(baseRegs);
             UNUSED_PARAM(propertyRegs);
             UNUSED_PARAM(resultRegs);
             UNUSED_PARAM(propertyCacheGPR);
+            UNUSED_PARAM(arrayProfileGPR);
         }
     }
 
@@ -565,22 +560,21 @@ public:
         JSValueRegs baseRegs, JSValueRegs propertyRegs, JSValueRegs thisRegs, JSValueRegs resultRegs, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
     {
         JITInlineCacheGenerator::setUpPropertyInlineCacheImpl(propertyCache, codeBlock, accessType, cacheType, codeOrigin, callSiteIndex, usedRegisters);
-        if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>) {
-            propertyCache.m_baseGPR = baseRegs.payloadGPR();
-            propertyCache.m_extraGPR = thisRegs.payloadGPR();
-            propertyCache.m_valueGPR = resultRegs.payloadGPR();
-            propertyCache.m_extra2GPR = propertyRegs.payloadGPR();
-            propertyCache.m_propertyCacheGPR = propertyCacheGPR;
-            if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, DFG::UnlinkedPropertyInlineCache>)
-                propertyCache.m_arrayProfileGPR = arrayProfileGPR;
-            else
-                UNUSED_PARAM(arrayProfileGPR);
+        if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>) {
+            auto& registers = downcast<RepatchingPropertyInlineCache>(propertyCache).m_registers;
+            registers.baseGPR = baseRegs.payloadGPR();
+            registers.extraGPR = thisRegs.payloadGPR();
+            registers.valueGPR = resultRegs.payloadGPR();
+            registers.extra2GPR = propertyRegs.payloadGPR();
+            registers.propertyCacheGPR = propertyCacheGPR;
+            registers.arrayProfileGPR = arrayProfileGPR;
         } else {
             UNUSED_PARAM(baseRegs);
             UNUSED_PARAM(propertyRegs);
             UNUSED_PARAM(thisRegs);
             UNUSED_PARAM(resultRegs);
             UNUSED_PARAM(propertyCacheGPR);
+            UNUSED_PARAM(arrayProfileGPR);
         }
     }
 
@@ -617,11 +611,11 @@ public:
         JSValueRegs baseRegs, JSValueRegs brandRegs, GPRReg propertyCacheGPR)
     {
         JITInlineCacheGenerator::setUpPropertyInlineCacheImpl(propertyCache, codeBlock, accessType, cacheType, codeOrigin, callSiteIndex, usedRegisters);
-        if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>) {
-            propertyCache.m_baseGPR = baseRegs.payloadGPR();
-            propertyCache.m_extraGPR = brandRegs.payloadGPR();
-            propertyCache.m_valueGPR = InvalidGPRReg;
-            propertyCache.m_propertyCacheGPR = propertyCacheGPR;
+        if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>) {
+            auto& registers = downcast<RepatchingPropertyInlineCache>(propertyCache).m_registers;
+            registers.baseGPR = baseRegs.payloadGPR();
+            registers.extraGPR = brandRegs.payloadGPR();
+            registers.propertyCacheGPR = propertyCacheGPR;
         } else {
             UNUSED_PARAM(baseRegs);
             UNUSED_PARAM(brandRegs);

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -93,7 +93,6 @@ void JIT::generateGetByValSlowCase(const OpcodeType&, Vector<SlowCaseEntry>::ite
     ASSERT(BytecodeIndex(m_bytecodeIndex.offset()) == m_bytecodeIndex);
     JITGetByValGenerator& gen = m_getByVals[m_getByValIndex++];
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -141,7 +140,6 @@ void JIT::emitSlow_op_get_private_name(const JSInstruction*, Vector<SlowCaseEntr
     ASSERT(BytecodeIndex(m_bytecodeIndex.offset()) == m_bytecodeIndex);
     JITGetByValGenerator& gen = m_getByVals[m_getByValIndex++];
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -182,7 +180,6 @@ void JIT::emitSlow_op_set_private_brand(const JSInstruction* currentInstruction,
     ASSERT(BytecodeIndex(m_bytecodeIndex.offset()) == m_bytecodeIndex);
     JITPrivateBrandAccessGenerator& gen = m_privateBrandAccesses[m_privateBrandAccessIndex++];
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -218,7 +215,6 @@ void JIT::emitSlow_op_check_private_brand(const JSInstruction*, Vector<SlowCaseE
     ASSERT(BytecodeIndex(m_bytecodeIndex.offset()) == m_bytecodeIndex);
     JITPrivateBrandAccessGenerator& gen = m_privateBrandAccesses[m_privateBrandAccessIndex++];
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -284,7 +280,6 @@ void JIT::generatePutByValSlowCase(const OpcodeType&, Vector<SlowCaseEntry>::ite
     ASSERT(BytecodeIndex(m_bytecodeIndex.offset()) == m_bytecodeIndex);
     JITPutByValGenerator& gen = m_putByVals[m_putByValIndex++];
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -338,7 +333,6 @@ void JIT::emitSlow_op_put_private_name(const JSInstruction*, Vector<SlowCaseEntr
     ASSERT(BytecodeIndex(m_bytecodeIndex.offset()) == m_bytecodeIndex);
     JITPutByValGenerator& gen = m_putByVals[m_putByValIndex++];
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -457,7 +451,6 @@ void JIT::emitSlow_op_del_by_id(const JSInstruction*, Vector<SlowCaseEntry>::ite
     ASSERT(BytecodeIndex(m_bytecodeIndex.offset()) == m_bytecodeIndex);
     JITDelByIdGenerator& gen = m_delByIds[m_delByIdIndex++];
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -509,7 +502,6 @@ void JIT::emitSlow_op_del_by_val(const JSInstruction*, Vector<SlowCaseEntry>::it
     ASSERT(BytecodeIndex(m_bytecodeIndex.offset()) == m_bytecodeIndex);
     JITDelByValGenerator& gen = m_delByVals[m_delByValIndex++];
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -550,7 +542,6 @@ void JIT::emitSlow_op_get_by_id_direct(const JSInstruction*, Vector<SlowCaseEntr
     JITGetByIdGenerator& gen = m_getByIds[m_getByIdIndex++];
     gen.generateDataICSlowPath(*this);
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -633,7 +624,6 @@ void JIT::emitSlow_op_get_by_id(const JSInstruction*, Vector<SlowCaseEntry>::ite
     JITGetByIdGenerator& gen = m_getByIds[m_getByIdIndex++];
     gen.generateDataICSlowPath(*this);
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -643,7 +633,6 @@ void JIT::emitSlow_op_get_length(const JSInstruction*, Vector<SlowCaseEntry>::it
     JITGetByIdGenerator& gen = m_getByIds[m_getByIdIndex++];
     gen.generateDataICSlowPath(*this);
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -689,7 +678,6 @@ void JIT::emitSlow_op_get_by_id_with_this(const JSInstruction*, Vector<SlowCaseE
     JITGetByIdWithThisGenerator& gen = m_getByIdsWithThis[m_getByIdWithThisIndex++];
     gen.generateDataICSlowPath(*this);
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -741,7 +729,6 @@ void JIT::emitSlow_op_put_by_id(const JSInstruction*, Vector<SlowCaseEntry>::ite
     JITPutByIdGenerator& gen = m_putByIds[m_putByIdIndex++];
     gen.generateDataICSlowPath(*this);
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -782,7 +769,6 @@ void JIT::emitSlow_op_in_by_id(const JSInstruction*, Vector<SlowCaseEntry>::iter
     JITInByIdGenerator& gen = m_inByIds[m_inByIdIndex++];
     gen.generateDataICSlowPath(*this);
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -828,7 +814,6 @@ void JIT::emitSlow_op_in_by_val(const JSInstruction*, Vector<SlowCaseEntry>::ite
     ASSERT(BytecodeIndex(m_bytecodeIndex.offset()) == m_bytecodeIndex);
     JITInByValGenerator& gen = m_inByVals[m_inByValIndex++];
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -866,7 +851,6 @@ void JIT::emitHasPrivateSlow(AccessType type, Vector<SlowCaseEntry>::iterator& i
     ASSERT(BytecodeIndex(m_bytecodeIndex.offset()) == m_bytecodeIndex);
     JITInByValGenerator& gen = m_inByVals[m_inByValIndex++];
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 
@@ -1843,7 +1827,6 @@ void JIT::emitSlow_op_get_by_val_with_this(const JSInstruction*, Vector<SlowCase
     ASSERT(BytecodeIndex(m_bytecodeIndex.offset()) == m_bytecodeIndex);
     JITGetByValWithThisGenerator& gen = m_getByValsWithThis[m_getByValWithThisIndex++];
     linkAllSlowCases(iter);
-    gen.reportBaselineDataICSlowPathBegin(label());
     nearCallThunk(CodeLocationLabel { InlineCacheCompiler::generateSlowPathCode(vm(), gen.accessType()).retaggedCode<NoPtrTag>() });
 }
 


### PR DESCRIPTION
#### b00e0c35f823f59fd5ee06f517c2ce1fdf5c465e
<pre>
[JSC] Move repatching-only fields out of `HandlerPropertyInlineCache`
<a href="https://bugs.webkit.org/show_bug.cgi?id=321765">https://bugs.webkit.org/show_bug.cgi?id=321765</a>

Reviewed by Yusuke Suzuki.

PropertyInlineCache keeps slowPathStartLocation and six GPRReg fields in the base class, so every
HandlerPropertyInlineCache carries them too. Handler ICs never use slowPathStartLocation, and their
registers are fixed per AccessType since 281584@main. Only repatching ICs store per-site values
for them.

This patch moves both to RepatchingPropertyInlineCache and adds registers(), which returns the
stored registers for repatching ICs and computes them from accessType for handler ICs, like
usedRegisters() in 315196@main. The unlinked ICs stored the same fields without anyone reading
them, so they are removed as well.

HandlerPropertyInlineCache shrinks from 128 to 112 bytes, BaselineUnlinkedPropertyInlineCache from
40 to 32 bytes, and DFG::UnlinkedPropertyInlineCache from 64 to 40 bytes. Running Octane typescript,
this saves 465 KB of malloc&apos;ed memory for about 16,500 Baseline and 1,700 DFG IC sites.

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::createTransition):
* Source/JavaScriptCore/bytecode/InlineAccess.cpp:
(JSC::InlineAccess::generateSelfPropertyAccess):
(JSC::getScratchRegister):
(JSC::InlineAccess::generateSelfPropertyReplace):
(JSC::InlineAccess::generateArrayLength):
(JSC::InlineAccess::generateStringLength):
(JSC::InlineAccess::generateSelfInAccess):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::succeed):
(JSC::InlineCacheCompiler::calculateLiveRegistersForCallAndExceptionHandling):
(JSC::InlineCacheCompiler::preserveLiveRegistersToStackForCallWithoutExceptions):
(JSC::InlineCacheCompiler::makeDefaultScratchAllocator):
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generateAccessCase):
(JSC::InlineCacheCompiler::emitDOMJITGetter):
(JSC::InlineCacheCompiler::emitModuleNamespaceLoad):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
(JSC::InlineCacheCompiler::emitIntrinsicGetter):
(JSC::InlineCacheCompiler::compile):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
(JSC::InlineCacheCompiler::compileGetByDOMJITHandler):
* Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp:
(JSC::PropertyInlineCache::registers const):
(JSC::HandlerPropertyInlineCache::initializeFromUnlinkedPropertyInlineCache):
(JSC::HandlerPropertyInlineCache::initializeFromDFGUnlinkedPropertyInlineCache):
(JSC::PropertyInlineCache::resetStubAsJumpInAccess):
(JSC::PropertyInlineCache::initializePredefinedRegisters): Deleted.
* Source/JavaScriptCore/bytecode/PropertyInlineCache.h:
(JSC::PropertyInlineCache::valueRegs const):
(JSC::PropertyInlineCache::propertyRegs const):
(JSC::PropertyInlineCache::baseRegs const):
(JSC::PropertyInlineCache::offsetOfCallSiteIndex):
(JSC::PropertyInlineCache::baseGPR const):
(JSC::PropertyInlineCache::valueGPR const):
(JSC::PropertyInlineCache::extraGPR const):
(JSC::PropertyInlineCache::extra2GPR const):
(JSC::PropertyInlineCache::propertyCacheGPR const):
(JSC::PropertyInlineCache::arrayProfileGPR const):
(JSC::PropertyInlineCache::thisGPR const):
(JSC::PropertyInlineCache::prototypeGPR const):
(JSC::PropertyInlineCache::brandGPR const):
(JSC::PropertyInlineCache::propertyGPR const):
(JSC::PropertyInlineCache::offsetOfSlowPathStartLocation): Deleted.
(JSC::PropertyInlineCache::setUsedRegisters): Deleted.
(JSC::PropertyInlineCache::removeUsedRegister): Deleted.
* Source/JavaScriptCore/dfg/DFGInlineCacheWrapperInlines.h:
(JSC::DFG::InlineCacheWrapper&lt;GeneratorType&gt;::finalize):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
(JSC::DFG::UnlinkedPropertyInlineCache::setUsedRegisters): Deleted.
(JSC::DFG::UnlinkedPropertyInlineCache::removeUsedRegister): Deleted.
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::link):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::emitSlowIteratorOpenGeneric):
(JSC::JIT::emitSlow_op_iterator_next):
(JSC::JIT::emitSlow_op_instanceof):
* Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp:
(JSC::JITInlineCacheGenerator::finalize):
* Source/JavaScriptCore/jit/JITInlineCacheGenerator.h:
(JSC::JITInlineCacheGenerator::setUpPropertyInlineCacheImpl):
(JSC::JITByIdGenerator::setUpPropertyInlineCacheImpl):
(JSC::JITInByValGenerator::setUpPropertyInlineCache):
(JSC::JITInlineCacheGenerator::reportBaselineDataICSlowPathBegin): Deleted.
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::generateGetByValSlowCase):
(JSC::JIT::emitSlow_op_get_private_name):
(JSC::JIT::emitSlow_op_set_private_brand):
(JSC::JIT::emitSlow_op_check_private_brand):
(JSC::JIT::generatePutByValSlowCase):
(JSC::JIT::emitSlow_op_put_private_name):
(JSC::JIT::emitSlow_op_del_by_id):
(JSC::JIT::emitSlow_op_del_by_val):
(JSC::JIT::emitSlow_op_get_by_id_direct):
(JSC::JIT::emitSlow_op_get_by_id):
(JSC::JIT::emitSlow_op_get_length):
(JSC::JIT::emitSlow_op_get_by_id_with_this):
(JSC::JIT::emitSlow_op_put_by_id):
(JSC::JIT::emitSlow_op_in_by_id):
(JSC::JIT::emitSlow_op_in_by_val):
(JSC::JIT::emitHasPrivateSlow):
(JSC::JIT::emitSlow_op_get_by_val_with_this):

Canonical link: <a href="https://commits.webkit.org/319228@main">https://commits.webkit.org/319228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97022908e05fbb851fa7c3c003ecdf64314fee99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145026 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140948 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121400 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43292 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41576 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3367 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10202 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41246 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2076 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41978 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45831 "Passed tests") | [⏳ 🛠 gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54315 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150331 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40271 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55003 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150048 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44658 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127268 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122504 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53520 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16239 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52902 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53139 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52967 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->