### PR TITLE
Avoid re-walking LCP tracking data on every repaint of an already-tracked image

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9241,12 +9241,12 @@ void Document::didLoadImage(Element& element, CachedImage* image) const
     largestContentfulPaintData().didLoadImage(element, image);
 }
 
-void Document::didPaintImage(Element& element, CachedImage* image, FloatRect localRect) const
+bool Document::didPaintImage(Element& element, CachedImage* image, FloatRect localRect) const
 {
     if (!supportsLargestContentfulPaint())
-        return;
+        return false;
 
-    largestContentfulPaintData().didPaintImage(element, image, localRect);
+    return largestContentfulPaintData().didPaintImage(element, image, localRect);
 }
 
 void Document::didPaintText(const RenderBlockFlow& formattingContextRoot, FloatRect localRect, bool isOnlyTextBoxForElement) const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1523,7 +1523,7 @@ public:
 
     LargestContentfulPaintData& largestContentfulPaintData() const;
     void didLoadImage(Element&, CachedImage*) const;
-    void didPaintImage(Element&, CachedImage*, FloatRect localRect) const;
+    bool didPaintImage(Element&, CachedImage*, FloatRect localRect) const;
     void didPaintText(const RenderBlockFlow&, FloatRect localRect, bool isOnlyTextBoxForElement) const;
 
     int requestAnimationFrame(Ref<RequestAnimationFrameCallback>&&);

--- a/Source/WebCore/page/LargestContentfulPaintData.cpp
+++ b/Source/WebCore/page/LargestContentfulPaintData.cpp
@@ -371,12 +371,12 @@ void LargestContentfulPaintData::didLoadImage(Element& element, CachedImage* ima
         lcpData.imageData[findIndex].loadTime = now;
 }
 
-void LargestContentfulPaintData::didPaintImage(Element& element, CachedImage* image, FloatRect localRect)
+bool LargestContentfulPaintData::didPaintImage(Element& element, CachedImage* image, FloatRect localRect)
 {
     LOG_WITH_STREAM(LargestContentfulPaint, stream << "LargestContentfulPaintData " << this << " didPaintImage() " << element << " image " << (image ? image->url().string() : emptyString()) << " localRect " << localRect);
 
     if (!image)
-        return;
+        return false;
 
     auto& lcpData = element.ensureLargestContentfulPaintData();
     auto findIndex = lcpData.imageData.findIf([&](auto& value) {
@@ -391,18 +391,18 @@ void LargestContentfulPaintData::didPaintImage(Element& element, CachedImage* im
 
     auto& imageData = lcpData.imageData[findIndex];
     if (imageData.inContentSet)
-        return;
+        return true;
 
     imageData.inContentSet = true;
 
     if (localRect.isEmpty())
-        return;
+        return true;
 
     if (canCompareWithLargestPaintArea(element) && localRect.area() <= m_largestPaintArea)
-        return;
+        return true;
 
     if (!isExposedForPaintTiming(element))
-        return;
+        return true;
 
     if (!imageData.loadTime)
         imageData.loadTime = MonotonicTime::now();
@@ -415,6 +415,7 @@ void LargestContentfulPaintData::didPaintImage(Element& element, CachedImage* im
     }).iterator->value.append(*image);
 
     scheduleRenderingUpdateIfNecessary(element);
+    return true;
 }
 
 void LargestContentfulPaintData::didPaintText(const RenderBlockFlow& formattingContextRoot, FloatRect localRect, bool isOnlyTextBoxForElement)

--- a/Source/WebCore/page/LargestContentfulPaintData.h
+++ b/Source/WebCore/page/LargestContentfulPaintData.h
@@ -65,7 +65,7 @@ public:
     ~LargestContentfulPaintData();
 
     void didLoadImage(Element&, CachedImage*);
-    void didPaintImage(Element&, CachedImage*, FloatRect localRect);
+    bool didPaintImage(Element&, CachedImage*, FloatRect localRect);
     void didPaintText(const RenderBlockFlow& formattingContextRoot, FloatRect localRect, bool isOnlyTextBoxForElement);
 
     RefPtr<LargestContentfulPaint> generateLargestContentfulPaintEntry(DOMHighResTimeStamp);

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -718,11 +718,12 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
         else
             protect(page())->addRelevantRepaintedObject(*this, visibleRect);
 
-        if (protect(cachedImage())->currentFrameIsComplete(this)) {
+        if (!imageResource().largestContentfulPaintTrackingConfirmed() && protect(cachedImage())->currentFrameIsComplete(this)) {
             if (auto styleable = Styleable::fromRenderer(*this)) {
                 auto localVisibleRect = visibleRect;
                 localVisibleRect.moveBy(-paintOffset);
-                protect(document())->didPaintImage(protect(styleable->element), protect(cachedImage()), localVisibleRect);
+                if (protect(document())->didPaintImage(protect(styleable->element), protect(cachedImage()), localVisibleRect))
+                    imageResource().setLargestContentfulPaintTrackingConfirmed(true);
             }
         }
     }

--- a/Source/WebCore/rendering/RenderImageResource.cpp
+++ b/Source/WebCore/rendering/RenderImageResource.cpp
@@ -86,6 +86,8 @@ void RenderImageResource::setCachedImage(CachedImage* newImage)
     if (existingCachedImage == newImage)
         return;
 
+    m_largestContentfulPaintTrackingConfirmed = false;
+
     if (m_styleImage && m_renderer) {
         RefPtr styleImage = m_styleImage;
         styleImage->removeClient(*m_renderer);

--- a/Source/WebCore/rendering/RenderImageResource.h
+++ b/Source/WebCore/rendering/RenderImageResource.h
@@ -69,11 +69,15 @@ public:
 
     WrappedImagePtr imagePtr() const { return m_styleImage ? m_styleImage->data() : nullptr; }
 
+    bool largestContentfulPaintTrackingConfirmed() const { return m_largestContentfulPaintTrackingConfirmed; }
+    void setLargestContentfulPaintTrackingConfirmed(bool confirmed) { m_largestContentfulPaintTrackingConfirmed = confirmed; }
+
 private:
     LayoutSize imageSize(float multiplier, CachedImage::SizeType) const;
 
     SingleThreadWeakPtr<RenderElement> m_renderer;
     RefPtr<Style::Image> m_styleImage;
+    bool m_largestContentfulPaintTrackingConfirmed { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -209,9 +209,12 @@ void RenderSVGImage::paintForeground(PaintInfo& paintInfo, const LayoutPoint& pa
         else
             protect(page())->addRelevantRepaintedObject(*this, enclosingLayoutRect(visibleRect));
 
-        auto localVisibleRect = visibleRect;
-        localVisibleRect.moveBy(-paintOffset);
-        protect(document())->didPaintImage(protect(imageElement()).get(), protect(cachedImage()), localVisibleRect);
+        if (!imageResource().largestContentfulPaintTrackingConfirmed()) {
+            auto localVisibleRect = visibleRect;
+            localVisibleRect.moveBy(-paintOffset);
+            if (protect(document())->didPaintImage(protect(imageElement()).get(), protect(cachedImage()), localVisibleRect))
+                imageResource().setLargestContentfulPaintTrackingConfirmed(true);
+        }
     }
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -216,8 +216,10 @@ void LegacyRenderSVGImage::paintForeground(PaintInfo& paintInfo)
     context.drawImage(*image, destRect, srcRect, options);
 
     RefPtr cachedImage = imageResource().cachedImage();
-    if (cachedImage && !context.paintingDisabled())
-        protect(document())->didPaintImage(imageElement(), cachedImage, destRect);
+    if (cachedImage && !context.paintingDisabled() && !imageResource().largestContentfulPaintTrackingConfirmed()) {
+        if (protect(document())->didPaintImage(imageElement(), cachedImage, destRect))
+            imageResource().setLargestContentfulPaintTrackingConfirmed(true);
+    }
 }
 
 void LegacyRenderSVGImage::invalidateBufferedForeground()


### PR DESCRIPTION
#### 6439e320118fdc54165be63d65d6dfad5acd6b26
<pre>
Avoid re-walking LCP tracking data on every repaint of an already-tracked image
<a href="https://bugs.webkit.org/show_bug.cgi?id=321766">https://bugs.webkit.org/show_bug.cgi?id=321766</a>
<a href="https://rdar.apple.com/184887037">rdar://184887037</a>

Reviewed by NOBODY (OOPS!).

LargestContentfulPaintData::didPaintImage() runs on every paint of every tracked
image, for the life of the page, but once an image&apos;s LCP status is known, every
subsequent call is answering a question we already know the answer to. Getting
to that answer requires walking a cold pointer chain (Element -&gt; RareData -&gt;
ElementLargestContentfulPaintData -&gt; Vector&lt;PerElementImageData&gt;&apos;s heap buffer)
that has no other reason to be cache-resident during paint.

Added a self-invalidating fast-path bit,
m_largestContentfulPaintTrackingConfirmed, to
RenderImageResource. Document::didPaintImage() and
LargestContentfulPaintData::didPaintImage() now return a bool reporting whether
the (element, image) pair is fully tracked; callers latch that onto the
renderer&apos;s bit and skip the call entirely on subsequent paints. The bit is
cleared in RenderImageResource::setCachedImage() exactly where image identity is
already detected to change, so it can&apos;t go stale without a separate invalidation
path to get wrong.

Deliberately not applied to RenderVideo or BackgroundPainter.

No behavior change.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::didPaintImage const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/LargestContentfulPaintData.cpp:
(WebCore::LargestContentfulPaintData::didPaintImage):
* Source/WebCore/page/LargestContentfulPaintData.h:
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintReplaced):
* Source/WebCore/rendering/RenderImageResource.cpp:
(WebCore::RenderImageResource::setCachedImage):
* Source/WebCore/rendering/RenderImageResource.h:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::paintForeground):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::paintForeground):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6439e320118fdc54165be63d65d6dfad5acd6b26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145027 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54366 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140951 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; 8 flakes; Uploaded test results; Passed layout tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97664 "5 flakes 9 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121403 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43299 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41582 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3370 "Build is in progress. Recent messages:") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41260 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2077 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192853 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54316 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150332 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55004 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150049 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44668 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127269 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122505 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53521 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16253 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52903 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53140 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52968 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->