### PR TITLE
Stop chooseInterpolationQuality()'s settle-detection timer from restarting on every unrelated repaint

### DIFF
--- a/Source/WebCore/rendering/ImageQualityController.cpp
+++ b/Source/WebCore/rendering/ImageQualityController.cpp
@@ -187,23 +187,27 @@ InterpolationQuality ImageQualityController::chooseInterpolationQuality(Graphics
     }
 
     auto saveEntryIfNewOrSizeChanged = [&]() {
-        if (!oldSize || oldSize.value() != size)
+        bool isNewOrChanged = !oldSize || oldSize.value() != size;
+        if (isNewOrChanged)
             set(object, innerMap, layer, size);
+        return isNewOrChanged;
     };
 
-    // If an animated resize is active, paint in low quality and kick the timer ahead.
+    // If an animated resize is active, paint in low quality. Only push the
+    // "resize settled" timer back out when this object's size actually changed,
+    // otherwise every repaint will perpetually restart the timer and
+    // m_animatedResizeIsActive would never get a chance to clear.
     if (m_animatedResizeIsActive) {
-        saveEntryIfNewOrSizeChanged();
-        restartTimer();
+        if (saveEntryIfNewOrSizeChanged())
+            restartTimer();
         return InterpolationQuality::Low;
     }
 
     // If this is the first time resizing this image, or its size is the
-    // same as the last resize, draw at high res, but record the paint
-    // size and set the timer.
+    // same as the last resize, draw at high res.
     if (!oldSize || oldSize.value() == size) {
-        saveEntryIfNewOrSizeChanged();
-        restartTimer();
+        if (saveEntryIfNewOrSizeChanged())
+            restartTimer();
         return InterpolationQuality::Default;
     }
 


### PR DESCRIPTION
#### 56280693841f28c6c99342ba21b99c82ccefde5d
<pre>
Stop chooseInterpolationQuality()&apos;s settle-detection timer from restarting on every unrelated repaint
<a href="https://bugs.webkit.org/show_bug.cgi?id=321768">https://bugs.webkit.org/show_bug.cgi?id=321768</a>
<a href="https://rdar.apple.com/184888867">rdar://184888867</a>

Reviewed by NOBODY (OOPS!).

ImageQualityController uses a DeferrableOneShotTimer to detect when an
animated/live resize has settled: once m_animatedResizeIsActive is set, images
paint at InterpolationQuality::Low until the timer gets a clean 500ms window to
fire, at which point highQualityRepaintTimerFired() clears the flag and repaints
everything at high quality.

DeferrableOneShotTimer::restart() on an already-active timer does not push its
deadline out -- it just sets shouldRestartWhenTimerFires. When the
timer&apos;s *original* deadline arrives, fired() checks that flag: if set, it
restarts itself instead of invoking the real callback. So the callback only ever
runs if nothing called restart() since the last time the timer popped.

chooseInterpolationQuality() called restartTimer() unconditionally inside the
m_animatedResizeIsActive branch for every tracked image, on every paint,
regardless of whether that image&apos;s own size had changed. Once any single object
anywhere on the page triggered animated-resize mode, every other image being
repainted for any reason kept the shared timer perpetually re-armed, so it could
never get a clean window to fire. In practice this meant one resizing image
could permanently freeze *every other image on the page* at low interpolation
quality, for as long as anything else kept repainting.

Only call restartTimer() when the object&apos;s tracked size is new or actually
changed, not just because a paint happened. No change to what gets returned for
the case that&apos;s actually resizing -- only to how eagerly the shared timer gets
kept alive by paints that aren&apos;t.

* Source/WebCore/rendering/ImageQualityController.cpp:
(WebCore::ImageQualityController::chooseInterpolationQuality):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56280693841f28c6c99342ba21b99c82ccefde5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145029 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54368 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140950 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97663 "3 flakes 6 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121402 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180031 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43293 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41578 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3369 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed JSC tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10203 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41247 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2079 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41981 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192855 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/180108 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161236 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150333 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55006 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150050 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44660 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127271 "Built successfully") | [⏳ 🛠 playstation](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53523 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16240 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52905 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52970 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->