### PR TITLE
Make process count limiter work better with Site Isolation

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -109,6 +109,7 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 + (NSURL *)_websiteDataURLForContainerWithURL:(NSURL *)containerURL;
 + (NSURL *)_websiteDataURLForContainerWithURL:(NSURL *)containerURL bundleIdentifierIfNotInContainer:(NSString *)bundleIdentifier;
 
+// A limit of 0 implies resetting back to the default process count limit.
 + (void)_setWebProcessCountLimit:(unsigned)limit WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 - (void)_warmInitialProcess WK_API_AVAILABLE(macos(10.12), ios(10.0));

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -318,6 +318,15 @@ bool BrowsingContextGroup::hasMultiplePages() const
     return m_pages.computeSize() > 1;
 }
 
+bool BrowsingContextGroup::hasVisiblePage() const
+{
+    for (Ref page : m_pages) {
+        if (page->isViewVisible())
+            return true;
+    }
+    return false;
+}
+
 void BrowsingContextGroup::forEachRemotePage(const WebPageProxy& page, Function<void(RemotePageProxy&)>&& function)
 {
     auto it = m_remotePages.find(page);

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -81,6 +81,7 @@ public:
     void removePage(WebPageProxy&);
     void closeRemotePagesForPage(WebPageProxy&);
     bool hasMultiplePages() const;
+    bool hasVisiblePage() const;
     void forEachRemotePage(const WebPageProxy&, Function<void(RemotePageProxy&)>&&);
 
     RefPtr<RemotePageProxy> remotePageInProcess(const WebPageProxy&, const WebProcessProxy&);

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -47,7 +47,6 @@ ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProc
     , m_navigationID(navigationID)
 {
     Ref process = this->process();
-    process->markProcessAsRecentlyUsed();
     auto parameters = frame.provisionalFrameCreationParameters(std::nullopt, frame.layerHostingContextIdentifier(), commitTiming);
     process->send(Messages::WebFrame::CreateProvisionalFrame(parameters), frame.frameID());
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -322,6 +322,7 @@
 #include <wtf/URL.h>
 #include <wtf/URLHash.h>
 #include <wtf/URLParser.h>
+#include <wtf/WeakListHashSet.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringView.h>
@@ -513,6 +514,20 @@ using namespace WebCore;
 static constexpr Seconds resetRecentCrashCountDelay = 30_s;
 static constexpr unsigned maximumWebProcessRelaunchAttempts = 1;
 static constexpr Seconds tryCloseTimeoutDelay = 50_ms;
+
+static WeakListHashSet<WebPageProxy>& NODELETE leastRecentlyVisiblePages()
+{
+    ASSERT(RunLoop::isMain());
+    static NeverDestroyed<WeakListHashSet<WebPageProxy>> pages;
+    return pages;
+}
+
+static WeakListHashSet<WebPageProxy>& NODELETE leastRecentlyHiddenPages()
+{
+    ASSERT(RunLoop::isMain());
+    static NeverDestroyed<WeakListHashSet<WebPageProxy>> pages;
+    return pages;
+}
 
 static bool shouldUseEnhancedSecurityHeuristics(const Ref<WebPreferences>& preferences)
 {
@@ -1068,6 +1083,8 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 
     if (shouldUseEnhancedSecurityHeuristics(protect(preferences())))
         internals().enhancedSecurityTracker.initializeWithWebsiteDataStore(protect(websiteDataStore()));
+
+    leastRecentlyHiddenPages().add(*this);
 }
 
 WebPageProxy::~WebPageProxy()
@@ -1902,6 +1919,9 @@ void WebPageProxy::close()
 
     m_isClosed = true;
 
+    leastRecentlyVisiblePages().remove(*this);
+    leastRecentlyHiddenPages().remove(*this);
+
 #if ENABLE(WEB_AUTHN) && ENABLE(WEBDRIVER_BIDI)
     abortPendingDigitalCredentialWaitHandlers("Page closed."_s);
 #endif
@@ -2344,7 +2364,6 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
             protectedThis->preconnectTo(ResourceRequest { loadParameters.request });
 
         navigation->setIsLoadedWithNavigationShared(true);
-        protectedProcess->markProcessAsRecentlyUsed();
         if (!protectedProcess->isLaunching() || !url.protocolIsFile())
             protectedProcess->send(Messages::WebPage::LoadRequest(WTF::move(loadParameters)), webPageID);
         else
@@ -2430,7 +2449,6 @@ RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, cons
 
         protectedThis->prepareToLoadWebPage(*protectedProcess, loadParameters);
 
-        protectedProcess->markProcessAsRecentlyUsed();
         if (protectedProcess->isLaunching())
             protectedThis->send(Messages::WebPage::LoadRequestWaitingForProcessLaunch(WTF::move(loadParameters), resourceDirectoryURL, protectedThis->identifier(), checkAssumedReadAccessToResourceURL));
         else
@@ -2504,7 +2522,6 @@ void WebPageProxy::loadDataWithNavigationShared(Ref<WebProcessProxy>&& process, 
     loadParameters.isServiceWorkerLoad = isServiceWorkerPage();
     prepareToLoadWebPage(process, loadParameters);
 
-    process->markProcessAsRecentlyUsed();
     process->assumeReadAccessToBaseURL(*this, baseURL, [weakProcess = WeakPtr { process }, webPageID, loadParameters = WTF::move(loadParameters)] () mutable {
         RefPtr protectedProcess = weakProcess.get();
         if (!protectedProcess)
@@ -2574,7 +2591,6 @@ RefPtr<API::Navigation> WebPageProxy::loadSimulatedRequest(WebCore::ResourceRequ
     Ref process = m_legacyMainFrameProcess;
     prepareToLoadWebPage(process, loadParameters);
 
-    process->markProcessAsRecentlyUsed();
     process->assumeReadAccessToBaseURL(*this, baseURL, [weakProcess = WeakPtr { process }, loadParameters = WTF::move(loadParameters), simulatedResponse = WTF::move(simulatedResponse), webPageID = m_webPageID] () mutable {
         RefPtr protectedProcess = weakProcess.get();
         if (!protectedProcess)
@@ -2644,7 +2660,6 @@ void WebPageProxy::loadAlternateHTML(Ref<WebCore::DataSegment>&& htmlData, const
         unreachableURL,
         preventProcessShutdownScope = process->shutdownPreventingScope()
     ] () mutable {
-        process->markProcessAsRecentlyUsed();
         process->assumeReadAccessToBaseURLs(*this, { baseURL.string(), unreachableURL.string() }, [weakThis = WeakPtr { *this }, weakProcess = WeakPtr { process }, baseURL, unreachableURL, loadParameters = WTF::move(loadParameters)] () mutable {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
@@ -2723,7 +2738,6 @@ RefPtr<API::Navigation> WebPageProxy::reload(OptionSet<WebCore::ReloadOption> op
         navigation->setUserContentExtensionsEnabled(false);
 
     Ref process = m_legacyMainFrameProcess;
-    process->markProcessAsRecentlyUsed();
     if (!url.isEmpty()) {
         // We may not have an extension yet if back/forward list was reinstated after a WebProcess crash or a browser relaunch
         maybeInitializeSandboxExtensionHandle(protect(legacyMainFrameProcess()), URL { url }, currentResourceDirectoryURL(), true, [weakThis = WeakPtr { *this }, process = WTF::move(process), options = WTF::move(options), sandboxExtensionHandle = WTF::move(sandboxExtensionHandle), navigation](std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
@@ -2898,7 +2912,6 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
             WEBPAGEPROXY_RELEASE_LOG_ERROR(ProcessSwapping, "goToBackForwardItem: walk dispatched no GoToBackForwardItem messages — back/forward action will be silently dropped");
         navigation->setBackForwardTraversalWasDispatched(anySent);
     } else {
-        process->markProcessAsRecentlyUsed();
         process->send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), copyFrameStateForBackForwardNavigation(frameItem), frameLoadType, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, shouldRestoreFromBackForwardCache, std::nullopt, WTF::move(publicSuffix), { }, WebCore::ProcessSwapDisposition::None }), webPageIDInProcess(process));
         process->startResponsivenessTimer();
         navigation->setBackForwardTraversalWasDispatched(true);
@@ -2975,7 +2988,6 @@ bool WebPageProxy::sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& 
 
     Ref process = processForTheFrameItem(targetFrame);
     auto suffixCopy = publicSuffix;
-    process->markProcessAsRecentlyUsed();
     process->send(Messages::WebPage::GoToBackForwardItem({
         navigationID,
         targetFrame.copyFrameState(),
@@ -3705,6 +3717,9 @@ void WebPageProxy::dispatchActivityStateChange()
             protect(legacyMainFrameProcess())->stopResponsivenessTimer();
         }
     }
+
+    if ((changed & ActivityState::IsFocused) && isViewFocused())
+        leastRecentlyVisiblePages().moveToLastIfPresent(*this);
 
     if (changed & ActivityState::IsInWindow) {
         if (isInWindow())
@@ -9501,10 +9516,41 @@ void WebPageProxy::didChangeMainDocument(IPC::Connection& connection, FrameIdent
 #endif
 }
 
+RefPtr<WebPageProxy> WebPageProxy::leastRecentlyVisiblePageToUnload()
+{
+    enum class AvoidDisruptingVisiblePages : bool { No, Yes };
+    auto findVictim = [](WeakListHashSet<WebPageProxy>& pages, AvoidDisruptingVisiblePages avoidDisruptingVisiblePages) -> RefPtr<WebPageProxy> {
+        for (Ref page : pages) {
+            if (page->isClosed())
+                continue;
+            if (page->siteIsolatedProcess().state() == WebProcessProxy::State::Terminated)
+                continue;
+            if (page->internals().activityState.containsAny({ ActivityState::IsAudible, ActivityState::IsCapturingMedia }))
+                continue;
+            if (avoidDisruptingVisiblePages == AvoidDisruptingVisiblePages::Yes
+                && (protect(page->browsingContextGroup())->hasVisiblePage() || protect(page->siteIsolatedProcess())->hasVisiblePage()))
+                continue;
+            return page.ptr();
+        }
+        return nullptr;
+    };
+
+    // Try to avoid killing a non-visible page whose process a visible page depends on. A visible
+    // page might be synchronously scripting the non-visible page in the same browsing context
+    // group, or the process we would kill might also be serving a frame of a visible page (e.g.
+    // when Site Isolation is off, or when the process was reused across browsing context groups).
+    if (RefPtr page = findVictim(leastRecentlyHiddenPages(), AvoidDisruptingVisiblePages::Yes))
+        return page;
+    if (RefPtr page = findVictim(leastRecentlyHiddenPages(), AvoidDisruptingVisiblePages::No))
+        return page;
+    return findVictim(leastRecentlyVisiblePages(), AvoidDisruptingVisiblePages::No);
+}
+
 void WebPageProxy::viewIsBecomingVisible()
 {
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "viewIsBecomingVisible:");
-    protect(legacyMainFrameProcess())->markProcessAsRecentlyUsed();
+    leastRecentlyHiddenPages().remove(*this);
+    leastRecentlyVisiblePages().add(*this);
     if (RefPtr drawingAreaProxy = drawingArea())
         drawingAreaProxy->viewIsBecomingVisible();
 #if ENABLE(MEDIA_STREAM)
@@ -9519,6 +9565,8 @@ void WebPageProxy::viewIsBecomingVisible()
 void WebPageProxy::viewIsBecomingInvisible()
 {
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "viewIsBecomingInvisible:");
+    leastRecentlyVisiblePages().remove(*this);
+    leastRecentlyHiddenPages().add(*this);
     protect(legacyMainFrameProcess())->pageIsBecomingInvisible(m_webPageID);
     if (RefPtr drawingAreaProxy = drawingArea())
         drawingAreaProxy->viewIsBecomingInvisible();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1870,6 +1870,9 @@ public:
 
     WebProcessProxy& ensureRunningProcess();
     WebProcessProxy& siteIsolatedProcess() const { return m_legacyMainFrameProcess; }
+
+    static RefPtr<WebPageProxy> leastRecentlyVisiblePageToUnload();
+
     // rdar://168057355
     WebProcessProxy* WTF_NONNULL legacyMainFrameProcessPtrForSwift() const SWIFT_NAME(legacyMainFrameProcess()) { return &legacyMainFrameProcess(); }
     WebProcessProxy& legacyMainFrameProcess() const SWIFT_NAME(__legacyMainFrameProcessUnsafe()) { return m_legacyMainFrameProcess; }

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -120,6 +120,11 @@ bool WebProcessCache::canCacheProcess(WebProcessProxy& process) const
         return false;
     }
 
+    if (WebProcessProxy::isNearingProcessCountLimit()) {
+        WEBPROCESSCACHE_RELEASE_LOG("canCacheProcess: Not caching process because we are nearing the process count limit (running WebProcesses: %u)", process.processID(), WebProcessProxy::runningProcessCount());
+        return false;
+    }
+
     if (!process.websiteDataStore()) {
         WEBPROCESSCACHE_RELEASE_LOG("canCacheProcess: Not caching process because this session has been destroyed", process.processID());
         return false;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -191,6 +191,8 @@ constexpr Seconds resetModelProcessCrashCountDelay { 30_s };
 constexpr unsigned maximumModelProcessRelaunchAttemptsBeforeKillingWebProcesses { 2 };
 #endif
 
+static bool s_hasAnyProcessPoolUsedSiteIsolation;
+
 Ref<WebProcessPool> WebProcessPool::create(API::ProcessPoolConfiguration& configuration)
 {
     InitializeWebKit2();
@@ -1119,8 +1121,8 @@ void WebProcessPool::prewarmProcess()
     if (m_prewarmedProcesses.computeSize() >= prewarmedProcessCountLimit())
         return;
 
-    if (WebProcessProxy::hasReachedProcessCountLimit()) {
-        WEBPROCESSPOOL_RELEASE_LOG(PerformanceLogging, "prewarmProcess: Not prewarming a WebProcess due to reaching process count limit");
+    if (WebProcessProxy::isNearingProcessCountLimit()) {
+        WEBPROCESSPOOL_RELEASE_LOG(PerformanceLogging, "prewarmProcess: Not prewarming a WebProcess due to nearing process count limit (running WebProcesses: %u)", WebProcessProxy::runningProcessCount());
         return;
     }
 
@@ -1512,7 +1514,7 @@ void WebProcessPool::didReachGoodTimeToPrewarm()
         return;
 
     if (MemoryPressureHandler::singleton().isUnderMemoryPressure()) {
-        WEBPROCESSPOOL_RELEASE_LOG(PerformanceLogging, "prewarmProcess: Not prewarming a WebProcess due to memory pressure");
+        WEBPROCESSPOOL_RELEASE_LOG(PerformanceLogging, "didReachGoodTimeToPrewarm: Not prewarming a WebProcess due to memory pressure");
         return;
     }
 
@@ -1531,10 +1533,8 @@ WebProcessPool::Statistics& WebProcessPool::statistics()
     return statistics;
 }
 
-void WebProcessPool::handleMemoryPressureWarning(Critical)
+void WebProcessPool::reclaimIdleProcesses()
 {
-    WEBPROCESSPOOL_RELEASE_LOG(PerformanceLogging, "handleMemoryPressureWarning:");
-
     // Clear back/forward cache first as processes removed from the back/forward cache will likely
     // be added to the WebProcess cache.
     m_backForwardCache->clear();
@@ -1546,6 +1546,13 @@ void WebProcessPool::handleMemoryPressureWarning(Critical)
     }
 
     ASSERT(m_prewarmedProcesses.isEmptyIgnoringNullReferences());
+}
+
+void WebProcessPool::handleMemoryPressureWarning(Critical)
+{
+    WEBPROCESSPOOL_RELEASE_LOG(PerformanceLogging, "handleMemoryPressureWarning:");
+
+    reclaimIdleProcesses();
 
     for (Ref process : m_processes)
         process->clearSandboxExtensions();
@@ -2153,6 +2160,11 @@ void WebProcessPool::removeProcessFromOriginCacheSet(WebProcessProxy& process)
     });
 }
 
+bool WebProcessPool::hasAnyProcessPoolUsedSiteIsolation()
+{
+    return s_hasAnyProcessPoolUsedSiteIsolation;
+}
+
 unsigned WebProcessPool::prewarmedProcessCountLimit() const
 {
 #if PLATFORM(COCOA)
@@ -2177,6 +2189,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
     bool siteIsolationEnabled = protect(page.preferences())->siteIsolationEnabled();
     if (siteIsolationEnabled && !m_hasUsedSiteIsolation) {
         m_hasUsedSiteIsolation = true;
+        s_hasAnyProcessPoolUsedSiteIsolation = true;
         m_webProcessCache->updateCapacity(*this);
     }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -253,6 +253,7 @@ public:
     void setProcessesShouldSuspend(bool);
 #endif
 
+    void reclaimIdleProcesses();
     void handleMemoryPressureWarning(Critical);
 
 #if PLATFORM(COCOA)
@@ -626,6 +627,7 @@ public:
     Seconds pltResourceDelayInterval() const { return m_pltResourceDelayInterval; }
 
     bool hasUsedSiteIsolation() const { return m_hasUsedSiteIsolation; }
+    static bool hasAnyProcessPoolUsedSiteIsolation();
 
     unsigned prewarmedProcessCountLimit() const;
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -115,6 +115,7 @@
 #include <wtf/ProcessPrivilege.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Scope.h>
+#include <wtf/SetForScope.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
@@ -174,25 +175,64 @@
 namespace WebKit {
 using namespace WebCore;
 
-static unsigned s_maxProcessCount { 400 };
+static constexpr unsigned defaultMaxProcessCount { 400 };
+static constexpr unsigned defaultMaxProcessCountWithSiteIsolation { 512 };
 
-static WeakListHashSet<WebProcessProxy>& NODELETE liveProcessesLRU()
+// Stop prewarming processes if we're near the process limit.
+static constexpr unsigned processCountLimitHeadroom { 8 };
+
+static unsigned s_maxProcessCountOverride;
+static unsigned s_runningProcessCount;
+
+static unsigned maxProcessCount()
 {
-    ASSERT(RunLoop::isMain());
-    static NeverDestroyed<WeakListHashSet<WebProcessProxy>> processes;
-    return processes;
+    if (s_maxProcessCountOverride)
+        return s_maxProcessCountOverride;
+
+    if (WebProcessPool::hasAnyProcessPoolUsedSiteIsolation())
+        return defaultMaxProcessCountWithSiteIsolation;
+
+    return defaultMaxProcessCount;
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebProcessProxy);
 
 void WebProcessProxy::setProcessCountLimit(unsigned limit)
 {
-    s_maxProcessCount = limit;
+    s_maxProcessCountOverride = limit;
+}
+
+unsigned WebProcessProxy::runningProcessCount()
+{
+    return s_runningProcessCount;
+}
+
+bool WebProcessProxy::isNearingProcessCountLimit()
+{
+    return s_runningProcessCount + processCountLimitHeadroom >= maxProcessCount();
 }
 
 bool WebProcessProxy::hasReachedProcessCountLimit()
 {
-    return liveProcessesLRU().computeSize() >= s_maxProcessCount;
+    return s_runningProcessCount >= maxProcessCount();
+}
+
+void WebProcessProxy::didStartRunningProcess()
+{
+    ASSERT(RunLoop::isMain());
+    ASSERT(!m_isRunningProcess);
+    m_isRunningProcess = true;
+    ++s_runningProcessCount;
+}
+
+void WebProcessProxy::didStopRunningProcess()
+{
+    ASSERT(RunLoop::isMain());
+    if (!m_isRunningProcess)
+        return;
+    m_isRunningProcess = false;
+    ASSERT(s_runningProcessCount > 0);
+    --s_runningProcessCount;
 }
 
 static bool isMainThreadOrCheckDisabled()
@@ -272,6 +312,22 @@ unsigned WebProcessProxy::provisionalPageCount() const
     return m_provisionalPages.computeSize();
 }
 
+bool WebProcessProxy::hasVisiblePage() const
+{
+    for (Ref page : pages()) {
+        if (page->isViewVisible())
+            return true;
+    }
+
+    for (Ref provisionalPage : m_provisionalPages) {
+        RefPtr page = provisionalPage->page();
+        if (page && page->isViewVisible())
+            return true;
+    }
+
+    return false;
+}
+
 Vector<WeakPtr<RemotePageProxy>> WebProcessProxy::remotePages() const
 {
     return WTF::copyToVector(m_remotePages);
@@ -302,17 +358,52 @@ Ref<WebProcessProxy> WebProcessProxy::create(WebProcessPool& processPool, Websit
 {
     Ref proxy = adoptRef(*new WebProcessProxy(processPool, websiteDataStore, isPrewarmed, crossOriginMode, lockdownMode, enhancedSecurity));
     if (shouldLaunchProcess == ShouldLaunchProcess::Yes) {
-        if (liveProcessesLRU().computeSize() >= s_maxProcessCount) {
-            for (auto& processPool : WebProcessPool::allProcessPools())
-                processPool->webProcessCache().clear();
-            if (liveProcessesLRU().computeSize() >= s_maxProcessCount)
-                protect(liveProcessesLRU().first())->requestTermination(ProcessTerminationReason::ExceededProcessCountLimit);
-        }
-        ASSERT(liveProcessesLRU().computeSize() < s_maxProcessCount);
-        liveProcessesLRU().add(proxy.get());
+        proxy->didStartRunningProcess();
         proxy->connect();
+        scheduleReclaimProcessesIfNeeded();
     }
     return proxy;
+}
+
+void WebProcessProxy::scheduleReclaimProcessesIfNeeded()
+{
+    if (!hasReachedProcessCountLimit())
+        return;
+
+    // Reclaiming unloads a page, which calls out to the client and can start another load.
+    // Reclaim on the next run loop to avoid reentrancy issues.
+    RunLoop::mainSingleton().dispatch([] {
+        reclaimProcessesIfNeeded();
+    });
+}
+
+void WebProcessProxy::reclaimProcessesIfNeeded()
+{
+    static bool isReclaiming = false;
+    if (isReclaiming)
+        return;
+    SetForScope reclaiming(isReclaiming, true);
+
+    if (!hasReachedProcessCountLimit())
+        return;
+
+    for (auto& processPool : WebProcessPool::allProcessPools())
+        processPool->reclaimIdleProcesses();
+
+    if (!hasReachedProcessCountLimit()) {
+        RELEASE_LOG(Process, "WebProcessProxy::reclaimProcessesIfNeeded: reaped idle processes due to exceeding the process count limit of %u (new count: %u)", maxProcessCount(), s_runningProcessCount);
+        return;
+    }
+
+    RefPtr page = WebPageProxy::leastRecentlyVisiblePageToUnload();
+    if (!page) {
+        RELEASE_LOG_ERROR(Process, "WebProcessProxy::reclaimProcessesIfNeeded: exceeding the process count limit of %u because no page could be unloaded (running WebProcesses: %u)", maxProcessCount(), s_runningProcessCount);
+        return;
+    }
+
+    Ref process = page->siteIsolatedProcess();
+    RELEASE_LOG(Process, "WebProcessProxy::reclaimProcessesIfNeeded: unloading page %" PRIu64 " (PID=%i) to stay under the process count limit of %u", page->identifier().toUInt64(), process->processID(), maxProcessCount());
+    process->requestTermination(ProcessTerminationReason::ExceededProcessCountLimit);
 }
 
 Ref<WebProcessProxy> WebProcessProxy::createForRemoteWorkers(RemoteWorkerType workerType, WebProcessPool& processPool, Site&& site, WebsiteDataStore& websiteDataStore, CrossOriginMode crossOriginMode, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity)
@@ -321,7 +412,9 @@ Ref<WebProcessProxy> WebProcessProxy::createForRemoteWorkers(RemoteWorkerType wo
     proxy->m_committedSites.add(site);
     proxy->m_site = WTF::move(site);
     proxy->enableRemoteWorkers(workerType, processPool.userContentControllerForRemoteWorkers());
+    proxy->didStartRunningProcess();
     proxy->connect();
+    scheduleReclaimProcessesIfNeeded();
     return proxy;
 }
 
@@ -379,7 +472,7 @@ WebProcessProxy::~WebProcessProxy()
     // (e.g. m_pagesPendingClose). Cancel them now, while our state is intact.
     replyToPendingMessages();
 
-    liveProcessesLRU().remove(*this);
+    didStopRunningProcess();
 
     for (auto identifier : m_speechRecognitionServerMap.keys())
         removeMessageReceiver(Messages::SpeechRecognitionServer::messageReceiverName(), identifier);
@@ -551,7 +644,6 @@ void WebProcessProxy::addProvisionalPageProxy(ProvisionalPageProxy& provisionalP
 
     ASSERT(!m_isInProcessCache);
     ASSERT(!m_provisionalPages.contains(provisionalPage));
-    markProcessAsRecentlyUsed();
     m_provisionalPages.add(provisionalPage);
     initializePreferencesForGPUAndNetworkProcesses(*protect(provisionalPage.page()));
     updateRegistrationWithDataStore();
@@ -579,7 +671,6 @@ void WebProcessProxy::addRemotePageProxy(RemotePageProxy& remotePage)
     ASSERT(!m_remotePages.contains(remotePage));
     m_remotePages.add(remotePage);
     updateRegistrationWithDataStore();
-    markProcessAsRecentlyUsed();
     initializePreferencesForGPUAndNetworkProcesses(*protect(remotePage.page()));
 }
 
@@ -759,6 +850,8 @@ void WebProcessProxy::shutDown()
 
     m_isShuttingDown = true;
 
+    didStopRunningProcess();
+
     if (m_isInProcessCache) {
         processPool().webProcessCache().removeProcess(*this, WebProcessCache::ShouldShutDownProcess::No);
         ASSERT(!m_isInProcessCache);
@@ -916,7 +1009,6 @@ void WebProcessProxy::addExistingWebPage(WebPageProxy& webPage, BeginsUsingDataS
     if (webPage.preferences().backgroundWebContentRunningBoardThrottlingEnabled())
         setRunningBoardThrottlingEnabled();
 #endif
-    markProcessAsRecentlyUsed();
     m_pageMap.set(webPage.identifier(), webPage);
     globalPageMap().set(webPage.identifier(), webPage);
 
@@ -1478,8 +1570,6 @@ void WebProcessProxy::processDidTerminateOrFailedToLaunch(ProcessTerminationReas
     // to be deleted before we can finish our work.
     Ref protectedThis { *this };
 
-    liveProcessesLRU().remove(*this);
-
     auto pages = mainPages();
 
     Vector<Ref<ProvisionalPageProxy>> provisionalPages;
@@ -1611,6 +1701,7 @@ bool WebProcessProxy::isAllowedAttachmentFilePath(const String& filePath) const
 void WebProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier&& connectionIdentifier)
 {
     WEBPROCESSPROXY_RELEASE_LOG(Process, "didFinishLaunching:");
+    ASSERT(m_isRunningProcess);
     RELEASE_ASSERT(isMainThreadOrCheckDisabled());
 
     Ref protectedThis { *this };
@@ -2880,7 +2971,6 @@ void WebProcessProxy::establishRemoteWorkerContext(RemoteWorkerType workerType, 
 {
     updateSharedPreferences(store);
     WEBPROCESSPROXY_RELEASE_LOG(Loading, "establishRemoteWorkerContext: Started (workerType=%" PUBLIC_LOG_STRING ")", workerType == RemoteWorkerType::ServiceWorker ? "service" : "shared");
-    markProcessAsRecentlyUsed();
     auto& remoteWorkerInformation = workerType == RemoteWorkerType::ServiceWorker ? m_serviceWorkerInformation : m_sharedWorkerInformation;
     sendWithAsyncReply(Messages::WebProcess::EstablishRemoteWorkerContextConnectionToNetworkProcess { workerType, processPool().defaultPageGroup().pageGroupID(), remoteWorkerInformation->remoteWorkerPageProxyID, remoteWorkerInformation->remoteWorkerPageID, store, site, serviceWorkerPageIdentifier, remoteWorkerInformation->initializationData, workerCrossOriginEmbedderPolicy }, [weakThis = WeakPtr { *this }, workerType, completionHandler = WTF::move(completionHandler)]() mutable {
 #if RELEASE_LOG_DISABLED
@@ -3057,11 +3147,6 @@ void WebProcessProxy::enableRemoteWorkers(RemoteWorkerType workerType, const Web
     updateBackgroundResponsivenessTimer();
 
     updateRemoteWorkerProcessAssertion(workerType);
-}
-
-void WebProcessProxy::markProcessAsRecentlyUsed()
-{
-    liveProcessesLRU().moveToLastIfPresent(*this);
 }
 
 #if !USE(GLIB)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -258,8 +258,13 @@ public:
     
     PAL::SessionID NODELETE sessionID() const;
 
+    static unsigned runningProcessCount();
+    static bool isNearingProcessCountLimit();
     static bool hasReachedProcessCountLimit();
     static void NODELETE setProcessCountLimit(unsigned);
+
+    static void reclaimProcessesIfNeeded();
+    static void scheduleReclaimProcessesIfNeeded();
 
     static RefPtr<WebProcessProxy> processForIdentifier(WebCore::ProcessIdentifier);
     static Ref<WebProcessProxy> fromConnection(const IPC::Connection&);
@@ -291,6 +296,10 @@ public:
     unsigned pageCount() const { return m_pageMap.size(); }
     unsigned provisionalPageCount() const;
     unsigned visiblePageCount() const { return m_visiblePageCounter.value(); }
+
+    // Unlike visiblePageCount(), this also accounts for pages this process only serves a subframe
+    // or a provisional load for.
+    bool hasVisiblePage() const;
 
     Vector<WeakPtr<RemotePageProxy>> remotePages() const;
     unsigned remotePageCount() const;
@@ -541,8 +550,6 @@ public:
     static bool shouldEnableRemoteInspector();
 #endif
 
-    void markProcessAsRecentlyUsed();
-
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     void platformSuspendProcess();
     void platformResumeProcess();
@@ -731,6 +738,9 @@ private:
 
     void processDidTerminateOrFailedToLaunch(ProcessTerminationReason);
 
+    void didStartRunningProcess();
+    void didStopRunningProcess();
+
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
@@ -862,6 +872,7 @@ private:
     std::pair<LoadedWebArchive, HashSet<WebCore::RegistrableDomain>> m_allowedFirstPartiesForCookies { LoadedWebArchive::No, { } };
     bool m_isInProcessCache { false };
     bool m_isShuttingDown { false };
+    bool m_isRunningProcess { false };
 
     IsolatedProcessType m_isolatedProcessType { IsolatedProcessType::Unspecified };
     std::optional<WebCore::Site> m_mainFrameSite;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -12817,6 +12817,105 @@ TEST(SiteIsolation, ColorSchemePreferenceInheritedByCrossSiteIframe)
     EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:check inFrame:childFrame.get()], "true");
 }
 
+static bool hasProcessExited(pid_t pid)
+{
+    return kill(pid, 0) == -1 && errno == ESRCH;
+}
+
+TEST(SiteIsolation, ProcessLimitUnloadsAllProcessesOfLeastRecentlyVisiblePage)
+{
+    // Each view loads a page in to two processes.
+    constexpr unsigned maxProcessCount = 10;
+    unsigned maxViewsToCreate = maxProcessCount / 2;
+
+    [WKProcessPool _setWebProcessCountLimit:maxProcessCount];
+
+    HTTPServer::ResponseMap responses;
+    responses.add("/subframe"_s, HTTPResponse("<body>subframe</body>"_s));
+    for (unsigned i = 0; i < maxViewsToCreate; ++i)
+        responses.add(makeString("/mainframe"_s, i), HTTPResponse(makeString("<iframe src='https://frame"_s, i, ".com/subframe'></iframe>"_s)));
+    HTTPServer server(WTF::move(responses), HTTPServer::Protocol::HttpsProxy);
+
+    auto loadCrossSitePage = [&](TestWKWebView *webView, TestNavigationDelegate *navigationDelegate, unsigned index) {
+        [webView loadRequest:[NSURLRequest requestWithURL:adoptNS([[NSURL alloc] initWithString:[NSString stringWithFormat:@"https://main%u.com/mainframe%u", index, index]]).get()]];
+        [navigationDelegate waitForDidFinishNavigation];
+        RetainPtr childFrameHost = [NSString stringWithFormat:@"frame%u.com", index];
+        EXPECT_TRUE(Util::waitFor([&] {
+            return [[webView firstChildFrame].securityOrigin.host isEqualToString:childFrameHost.get()];
+        }));
+    };
+
+    struct PageProcesses {
+        pid_t mainFrame { 0 };
+        pid_t remoteFrame { 0 };
+    };
+    auto processesForPage = [](TestWKWebView *webView) {
+        PageProcesses processes { [webView _webProcessIdentifier], [webView firstChildFrame]._processIdentifier };
+        EXPECT_NE(processes.mainFrame, 0);
+        EXPECT_NE(processes.remoteFrame, 0);
+        EXPECT_NE(processes.mainFrame, processes.remoteFrame);
+        return processes;
+    };
+
+    // mainFrameOnlyPolicyViewAndDelegate() puts the view in a window, so this is visible.
+    auto [visibleWebView, visibleNavigationDelegate] = mainFrameOnlyPolicyViewAndDelegate(server, ^(WKWebpagePreferences *) { });
+    loadCrossSitePage(visibleWebView.get(), visibleNavigationDelegate.get(), 0);
+    auto visibleProcesses = processesForPage(visibleWebView.get());
+
+    __block RetainPtr<WKWebView> unloadedView;
+    auto recordUnloadedView = ^(WKWebView *view, _WKProcessTerminationReason) {
+        unloadedView = view;
+    };
+    [visibleNavigationDelegate setWebContentProcessDidTerminate:recordUnloadedView];
+
+    RetainPtr nonVisibleNavigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [nonVisibleNavigationDelegate allowAnyTLSCertificate];
+    [nonVisibleNavigationDelegate setWebContentProcessDidTerminate:recordUnloadedView];
+    nonVisibleNavigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        completionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+
+    RetainPtr nonVisibleConfiguration = server.httpsProxyConfiguration();
+    enableSiteIsolation(nonVisibleConfiguration.get());
+
+    Vector<RetainPtr<TestWKWebView>> nonVisibleViews;
+    Vector<PageProcesses> nonVisibleProcesses;
+    while (!unloadedView && nonVisibleViews.size() + 1 < maxViewsToCreate) {
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:nonVisibleConfiguration.get() addToWindow:NO]);
+        webView.get().navigationDelegate = nonVisibleNavigationDelegate.get();
+        loadCrossSitePage(webView.get(), nonVisibleNavigationDelegate.get(), nonVisibleViews.size() + 1);
+        nonVisibleProcesses.append(processesForPage(webView.get()));
+        nonVisibleViews.append(WTF::move(webView));
+    }
+
+    // The least recently visible page was the one unloaded, not the visible one. All of its
+    // processes should be dead.
+    EXPECT_NOT_NULL(unloadedView.get());
+    EXPECT_EQ(unloadedView.get(), nonVisibleViews[0].get());
+    EXPECT_EQ([nonVisibleViews[0] _webProcessIdentifier], 0);
+    EXPECT_TRUE(Util::waitFor([&] {
+        return hasProcessExited(nonVisibleProcesses[0].mainFrame);
+    }));
+    EXPECT_TRUE(Util::waitFor([&] {
+        return hasProcessExited(nonVisibleProcesses[0].remoteFrame);
+    }));
+
+    // The visible page should still be running.
+    EXPECT_EQ([visibleWebView _webProcessIdentifier], visibleProcesses.mainFrame);
+    EXPECT_EQ([visibleWebView firstChildFrame]._processIdentifier, visibleProcesses.remoteFrame);
+    EXPECT_FALSE(hasProcessExited(visibleProcesses.mainFrame));
+    EXPECT_FALSE(hasProcessExited(visibleProcesses.remoteFrame));
+
+    // Every page newer than the victim kept both of its processes too.
+    for (size_t i = 1; i < nonVisibleViews.size(); ++i) {
+        EXPECT_EQ([nonVisibleViews[i] _webProcessIdentifier], nonVisibleProcesses[i].mainFrame);
+        EXPECT_FALSE(hasProcessExited(nonVisibleProcesses[i].mainFrame));
+        EXPECT_FALSE(hasProcessExited(nonVisibleProcesses[i].remoteFrame));
+    }
+
+    [WKProcessPool _setWebProcessCountLimit:0];
+}
+
 TEST(SiteIsolation, RestoredPageIsRenderedAfterCrossSiteBFCacheRoundTrip)
 {
     HTTPServer server({

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebContentProcessDidTerminate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebContentProcessDidTerminate.mm
@@ -418,15 +418,22 @@ TEST(WKNavigation, WebViewURLInProcessDidTerminate)
     TestWebKitAPI::Util::run(&done);
 }
 
+static constexpr unsigned maxProcessCount = 5;
+
 TEST(WKNavigation, WebProcessLimit)
 {
-    constexpr unsigned maxProcessCount = 10;
     [WKProcessPool _setWebProcessCountLimit:maxProcessCount];
 
+    __block RetainPtr<WKWebView> unloadedView;
     RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         finishedLoad = true;
     }];
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *view, _WKProcessTerminationReason) {
+        unloadedView = view;
+    }];
+
+    // All of these pages are non-visible, so they are unloaded in creation order.
     auto createWebView = [&] {
         RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
@@ -437,49 +444,69 @@ TEST(WKNavigation, WebProcessLimit)
         return webView;
     };
 
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
-        didCrash = true;
-    }];
-
     Vector<RetainPtr<WKWebView>> views;
-    for (unsigned i = 0; i < maxProcessCount; ++i)
+    while (!unloadedView && views.size() < maxProcessCount)
         views.append(createWebView());
-    EXPECT_FALSE(didCrash);
-    for (auto& view : views)
-        EXPECT_NE([view _webProcessIdentifier], 0);
 
-    // We have now reached the WebProcess cap, let's try and launch a new one.
-    __block unsigned crashCount = 0;
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView * view, _WKProcessTerminationReason) {
-        EXPECT_EQ(views[0], view);
-        ++crashCount;
-    }];
+    EXPECT_NOT_NULL(unloadedView.get());
+    EXPECT_EQ(unloadedView.get(), views[0].get());
+    EXPECT_EQ([views[0] _webProcessIdentifier], 0);
+    for (size_t i = 1; i < views.size(); ++i)
+        EXPECT_NE([views[i] _webProcessIdentifier], 0);
+
+    unloadedView = nil;
     views.append(createWebView());
 
-    EXPECT_EQ(crashCount, 1U);
-    for (unsigned i = 0; i < views.size(); ++i) {
-        if (!i)
-            EXPECT_EQ([views[i] _webProcessIdentifier], 0);
-        else
-            EXPECT_NE([views[i] _webProcessIdentifier], 0);
-    }
+    EXPECT_NOT_NULL(unloadedView.get());
+    EXPECT_EQ(unloadedView.get(), views[1].get());
+    EXPECT_EQ([views[1] _webProcessIdentifier], 0);
+    for (size_t i = 2; i < views.size(); ++i)
+        EXPECT_NE([views[i] _webProcessIdentifier], 0);
 
-    crashCount = 0;
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView * view, _WKProcessTerminationReason) {
-        EXPECT_EQ(views[1], view);
-        ++crashCount;
+    [WKProcessPool _setWebProcessCountLimit:0];
+}
+
+TEST(WKNavigation, WebProcessLimitPrefersUnloadingNonVisiblePages)
+{
+    [WKProcessPool _setWebProcessCountLimit:maxProcessCount];
+
+    __block RetainPtr<WKWebView> unloadedView;
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
+        finishedLoad = true;
     }];
-    views.append(createWebView());
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *view, _WKProcessTerminationReason) {
+        unloadedView = view;
+    }];
 
-    EXPECT_EQ(crashCount, 1U);
-    for (unsigned i = 0; i < views.size(); ++i) {
-        if (i < 2)
-            EXPECT_EQ([views[i] _webProcessIdentifier], 0);
-        else
-            EXPECT_NE([views[i] _webProcessIdentifier], 0);
-    }
+    auto loadInView = [&](WKWebView *webView) {
+        [webView setNavigationDelegate:navigationDelegate.get()];
+        finishedLoad = false;
+        [webView loadTestPageNamed:@"simple"];
+        TestWebKitAPI::Util::run(&finishedLoad);
+    };
 
-    [WKProcessPool _setWebProcessCountLimit:400];
+    RetainPtr visibleView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get() addToWindow:YES]);
+    loadInView(visibleView.get());
+    auto visibleViewProcessIdentifier = [visibleView _webProcessIdentifier];
+    EXPECT_NE(visibleViewProcessIdentifier, 0);
+
+    Vector<RetainPtr<WKWebView>> nonVisibleViews;
+    auto createNonVisibleWebView = [&] {
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get()]);
+        loadInView(webView.get());
+        return webView;
+    };
+
+    while (!unloadedView && nonVisibleViews.size() < maxProcessCount)
+        nonVisibleViews.append(createNonVisibleWebView());
+
+    EXPECT_NOT_NULL(unloadedView.get());
+    EXPECT_EQ(unloadedView.get(), nonVisibleViews[0].get());
+    EXPECT_NE(unloadedView.get(), visibleView.get());
+    EXPECT_EQ([visibleView _webProcessIdentifier], visibleViewProcessIdentifier);
+
+    [WKProcessPool _setWebProcessCountLimit:0];
 }
 
 TEST(WKNavigation, MultipleProcessCrashesRelatedWebViews)


### PR DESCRIPTION
#### 7d93638aae8d51aacdd521d4311aff523dcdc1b6
<pre>
Make process count limiter work better with Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=321769">https://bugs.webkit.org/show_bug.cgi?id=321769</a>
<a href="https://rdar.apple.com/172301423">rdar://172301423</a>

Reviewed by Sihui Liu.

The existing process count limiter depends on various codepaths maintaining an LRU list of all
WebProcesses at navigation time. With Site Isolation enabled, this strategy doesn&apos;t work, since the
LRU list maintenance didn&apos;t fan out to remote frame processes, so processes that should logically be
clustered together in the LRU list ended up spread apart.

This patch replaces the LRU list of WebProcess with an LRU list of WebPageProxy. LRU in this case
means:

1. Non-visible pages, in order of creation time
2. Visible pages, in order of last visible or focused time

So we upon reaching the process count limit, we first try to kill the page that was visible the
longest time ago.

This also contains a couple of other drive-by fixes:

1. We arbitrarily raise the process count limit from 400 to 512 when Site Isolation is enabled.
2. We stop prewarming processes if we&apos;re close to the process count limit.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebContentProcessDidTerminate.mm

* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::hasVisiblePage const):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::leastRecentlyVisiblePages):
(WebKit::leastRecentlyHiddenPages):
(WebKit::m_pageForTesting):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::loadDataWithNavigationShared):
(WebKit::WebPageProxy::loadSimulatedRequest):
(WebKit::WebPageProxy::loadAlternateHTML):
(WebKit::WebPageProxy::reload):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::sendGoToBackForwardItemForFrame):
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::WebPageProxy::leastRecentlyVisiblePageToUnload):
(WebKit::WebPageProxy::viewIsBecomingVisible):
(WebKit::WebPageProxy::viewIsBecomingInvisible):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::canCacheProcess const):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::prewarmProcess):
(WebKit::WebProcessPool::didReachGoodTimeToPrewarm):
(WebKit::WebProcessPool::reclaimIdleProcesses):
(WebKit::WebProcessPool::handleMemoryPressureWarning):
(WebKit::WebProcessPool::hasAnyProcessPoolUsedSiteIsolation):
(WebKit::WebProcessPool::processForNavigation):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::maxProcessCount):
(WebKit::WebProcessProxy::setProcessCountLimit):
(WebKit::WebProcessProxy::runningProcessCount):
(WebKit::WebProcessProxy::isNearingProcessCountLimit):
(WebKit::WebProcessProxy::hasReachedProcessCountLimit):
(WebKit::WebProcessProxy::didStartRunningProcess):
(WebKit::WebProcessProxy::didStopRunningProcess):
(WebKit::WebProcessProxy::create):
(WebKit::WebProcessProxy::reclaimProcessesIfNeeded):
(WebKit::WebProcessProxy::createForRemoteWorkers):
(WebKit::WebProcessProxy::~WebProcessProxy):
(WebKit::WebProcessProxy::addProvisionalPageProxy):
(WebKit::WebProcessProxy::addRemotePageProxy):
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::addExistingWebPage):
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
(WebKit::WebProcessProxy::didFinishLaunching):
(WebKit::WebProcessProxy::establishRemoteWorkerContext):
(WebKit::liveProcessesLRU): Deleted.
(WebKit::WebProcessProxy::markProcessAsRecentlyUsed): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, ProcessLimitUnloadsAllProcessesOfLeastRecentlyVisiblePage)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebContentProcessDidTerminate.mm:
(TEST(WKNavigation, WebProcessLimit)):
(TEST(WKNavigation, WebProcessLimitPrefersUnloadingNonVisiblePages)):

Canonical link: <a href="https://commits.webkit.org/319408@main">https://commits.webkit.org/319408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dddce68a9ce922c6a2ccb28cf59d40ca5a07c81e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191575 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145678 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141539 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121979 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43893 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42163 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41819 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2731 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193503 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54968 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150933 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40434 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55655 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150639 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45225 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127936 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123537 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54171 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16818 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53553 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53791 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53618 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->