### PR TITLE
Extend Style::CurrentColor to support future color keywords that take an existing color from a property

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3281,6 +3281,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/color/StyleDynamicRangeLimitMix.h
     style/values/color/StyleOpacity.h
     style/values/color/StyleResolvedColor.h
+    style/values/color/StyleResolvedColors.h
 
     style/values/contain/StyleContain.h
     style/values/contain/StyleContainerName.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3415,6 +3415,7 @@ style/values/color/StyleLightDarkColor.cpp
 style/values/color/StyleOpacity.cpp
 style/values/color/StyleRelativeAlphaColor.cpp
 style/values/color/StyleResolvedColor.cpp
+style/values/color/StyleResolvedColors.cpp
 style/values/contain/StyleContain.cpp
 style/values/contain/StyleContainerType.cpp
 style/values/content/StyleContent.cpp @header:RenderStyleGetters @cost:6

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -7158,6 +7158,7 @@
 		EDEC98030AED7E170059137F /* WebCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEC98020AED7E170059137F /* WebCorePrefix.h */; };
 		EE042903F1A0DE0100A1B2C3 /* JSDOMBindingFacade.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EE042901F1A0DE0100A1B2C3 /* JSDOMBindingFacade.cpp */; };
 		EE042904F1A0DE0100A1B2C3 /* JSDOMBindingFacade.h in Headers */ = {isa = PBXBuildFile; fileRef = EE042902F1A0DE0100A1B2C3 /* JSDOMBindingFacade.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EE0730583035331700B23328 /* StyleResolvedColors.h in Headers */ = {isa = PBXBuildFile; fileRef = EE073056303532EF00B23328 /* StyleResolvedColors.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EE0C7E042CE845CB0043DAF8 /* CSSPositionTryRule.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0C7E002CE845CB0043DAF8 /* CSSPositionTryRule.h */; };
 		EE0D3C492D2F4B4C00072978 /* StageModeOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0D3C482D2F4AE600072978 /* StageModeOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EE1A93AA2F2AE00A0054FAE4 /* NavigationActivation.h in Headers */ = {isa = PBXBuildFile; fileRef = DFD9B92D2C29D16200E10B53 /* NavigationActivation.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -23293,6 +23294,8 @@
 		EDEC98020AED7E170059137F /* WebCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCorePrefix.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
 		EE042901F1A0DE0100A1B2C3 /* JSDOMBindingFacade.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSDOMBindingFacade.cpp; sourceTree = "<group>"; };
 		EE042902F1A0DE0100A1B2C3 /* JSDOMBindingFacade.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSDOMBindingFacade.h; sourceTree = "<group>"; };
+		EE073056303532EF00B23328 /* StyleResolvedColors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleResolvedColors.h; sourceTree = "<group>"; };
+		EE073057303532EF00B23328 /* StyleResolvedColors.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleResolvedColors.cpp; sourceTree = "<group>"; };
 		EE0C7E002CE845CB0043DAF8 /* CSSPositionTryRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSPositionTryRule.h; sourceTree = "<group>"; };
 		EE0C7E012CE845CB0043DAF8 /* CSSPositionTryRule.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSPositionTryRule.cpp; sourceTree = "<group>"; };
 		EE0C7E022CE845CB0043DAF8 /* CSSPositionTryRule.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CSSPositionTryRule.idl; sourceTree = "<group>"; };
@@ -38118,6 +38121,8 @@
 				BC2CFBBC2BEFC6F6008CA222 /* StyleRelativeColor.h */,
 				BC4AF4062CF62F0E0037C65C /* StyleResolvedColor.cpp */,
 				BC4AF4052CF62F0E0037C65C /* StyleResolvedColor.h */,
+				EE073057303532EF00B23328 /* StyleResolvedColors.cpp */,
+				EE073056303532EF00B23328 /* StyleResolvedColors.h */,
 			);
 			path = color;
 			sourceTree = "<group>";
@@ -49225,6 +49230,7 @@
 				BC2E5C992E47BF5F0083FFF5 /* StyleRepeatStyle.h in Headers */,
 				BC452A902ED24DE500FD066C /* StyleResize.h in Headers */,
 				BC4AF41A2CF96E070037C65C /* StyleResolvedColor.h in Headers */,
+				EE0730583035331700B23328 /* StyleResolvedColors.h in Headers */,
 				E4D58EB517B4DBDC00CBDCA8 /* StyleResolveForDocument.h in Headers */,
 				E4D68EB517B4DBDC00CBDCA8 /* StyleResolveForFont.h in Headers */,
 				E139866415478474001E3F65 /* StyleResolver.h in Headers */,

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -58,6 +58,7 @@
 #include "StylePrimitiveNumericOrKeyword+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StyleResolveForFont.h"
+#include "StyleResolvedColors.h"
 #include "StyleResolver.h"
 #include "StyleTextEdge+CSSValueConversion.h"
 #include "StyleValueTypes+CSSValueConversion.h"
@@ -679,11 +680,11 @@ inline void BuilderCustom::applyInitialColor(BuilderState& builderState)
 
     if (builderState.applyPropertyToRegularStyle()) {
         auto styleColor = toStyle(initialColor, builderState, ForVisitedLink::No);
-        builderState.style().setColor(styleColor.resolveColor(builderState.parentStyle().color()));
+        builderState.style().setColor(styleColor.resolveColor(ResolvedColors::fromStyle(builderState.parentStyle())));
     }
     if (builderState.applyPropertyToVisitedLinkStyle()) {
         auto styleColor = toStyle(initialColor, builderState, ForVisitedLink::Yes);
-        builderState.style().setVisitedLinkColor(styleColor.resolveColor(builderState.parentStyle().visitedLinkColor()));
+        builderState.style().setVisitedLinkColor(styleColor.resolveColor(ResolvedColors::fromVisitedLinkStyle(builderState.parentStyle())));
     }
 
     builderState.style().setDisallowsFastPathInheritance();
@@ -695,11 +696,11 @@ inline void BuilderCustom::applyValueColor(BuilderState& builderState, CSSValue&
 {
     if (builderState.applyPropertyToRegularStyle()) {
         auto color = toStyleFromCSSValue<Color>(builderState, value, ForVisitedLink::No);
-        builderState.style().setColor(color.resolveColor(builderState.parentStyle().color()));
+        builderState.style().setColor(color.resolveColor(ResolvedColors::fromStyle(builderState.parentStyle())));
     }
     if (builderState.applyPropertyToVisitedLinkStyle()) {
         auto color = toStyleFromCSSValue<Color>(builderState, value, ForVisitedLink::Yes);
-        builderState.style().setVisitedLinkColor(color.resolveColor(builderState.parentStyle().visitedLinkColor()));
+        builderState.style().setVisitedLinkColor(color.resolveColor(ResolvedColors::fromVisitedLinkStyle(builderState.parentStyle())));
     }
 
     builderState.style().setDisallowsFastPathInheritance();

--- a/Source/WebCore/style/StyleColorResolver.cpp
+++ b/Source/WebCore/style/StyleColorResolver.cpp
@@ -40,7 +40,7 @@ WebCore::Color ColorResolver::colorApplyingColorFilter(const WebCore::Color& col
 
 WebCore::Color ColorResolver::colorResolvingCurrentColor(const Style::Color& color) const
 {
-    return color.resolveColor(m_style->color());
+    return color.resolveColor(ResolvedColors::fromStyle(m_style));
 }
 
 WebCore::Color ColorResolver::colorResolvingCurrentColorApplyingColorFilter(const Style::Color& color) const
@@ -50,7 +50,7 @@ WebCore::Color ColorResolver::colorResolvingCurrentColorApplyingColorFilter(cons
 
 WebCore::Color ColorResolver::visitedLinkColorResolvingCurrentColor(const Style::Color& color) const
 {
-    return color.resolveColor(m_style->visitedLinkColor());
+    return color.resolveColor(ResolvedColors::fromVisitedLinkStyle(m_style));
 }
 
 WebCore::Color ColorResolver::visitedLinkColorResolvingCurrentColorApplyingColorFilter(const Style::Color& color) const

--- a/Source/WebCore/style/StyleColorResolver.h
+++ b/Source/WebCore/style/StyleColorResolver.h
@@ -28,6 +28,7 @@
 #include <WebCore/Color.h>
 #include <WebCore/StyleAppleColorFilter.h>
 #include <WebCore/StyleComputedStyle.h>
+#include <WebCore/StyleResolvedColors.h>
 
 namespace WebCore {
 namespace Style {
@@ -110,7 +111,7 @@ WebCore::Color ColorPropertyResolver<ColorTraits>::colorResolvingCurrentColor() 
     else if constexpr (ImplementsColorResolvingCurrentColor<ColorTraits>)
         return ColorTraits::colorResolvingCurrentColor(m_style);
     else
-        return ColorTraits::color(m_style).resolveColor(m_style->color());
+        return ColorTraits::color(m_style).resolveColor(ResolvedColors::fromStyle(m_style));
 }
 
 template<typename ColorTraits>
@@ -130,7 +131,7 @@ WebCore::Color ColorPropertyResolver<ColorTraits>::visitedLinkColorResolvingCurr
     else if constexpr (ImplementsVisitedLinkColorResolvingCurrentColor<ColorTraits>)
         return ColorTraits::visitedLinkColorResolvingCurrentColor(m_style);
     else
-        return ColorTraits::visitedLinkColor(m_style).resolveColor(m_style->visitedLinkColor());
+        return ColorTraits::visitedLinkColor(m_style).resolveColor(ResolvedColors::fromVisitedLinkStyle(m_style));
 }
 
 template<typename ColorTraits>

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
@@ -69,6 +69,7 @@
 #include <WebCore/StyleNonInheritedData.h>
 #include <WebCore/StyleNonInheritedMiscData.h>
 #include <WebCore/StyleNonInheritedRareData.h>
+#include <WebCore/StyleResolvedColors.h>
 #include <WebCore/StyleSVGData.h>
 #include <WebCore/StyleSVGFillData.h>
 #include <WebCore/StyleSVGLayoutData.h>
@@ -325,18 +326,18 @@ inline WebCore::Color ColorPropertyTraits<PropertyNameConstant<CSSPropertyTextDe
         if ((style.hasExplicitlySetStrokeWidth() && style.strokeWidth().isPossiblyPositive()) || style.textStrokeWidth().isPositive()) {
             // Prefer stroke color if possible but not if it's fully transparent.
             if (style.hasExplicitlySetStrokeColor()) {
-                auto strokeColor = style.strokeColor().resolveColor(style.color());
+                auto strokeColor = style.strokeColor().resolveColor(ResolvedColors::fromStyle(style));
                 if (strokeColor.isVisible())
                     return strokeColor;
             } else {
-                auto strokeColor = style.textStrokeColor().resolveColor(style.color());
+                auto strokeColor = style.textStrokeColor().resolveColor(ResolvedColors::fromStyle(style));
                 if (strokeColor.isVisible())
                     return strokeColor;
             }
         }
         return style.color();
     }
-    return result.resolveColor(style.color());
+    return result.resolveColor(ResolvedColors::fromStyle(style));
 }
 
 inline WebCore::Color ColorPropertyTraits<PropertyNameConstant<CSSPropertyTextDecorationColor>>::visitedLinkColorResolvingCurrentColor(const ComputedStyleProperties& style)
@@ -346,18 +347,18 @@ inline WebCore::Color ColorPropertyTraits<PropertyNameConstant<CSSPropertyTextDe
         if ((style.hasExplicitlySetStrokeWidth() && style.strokeWidth().isPossiblyPositive()) || style.textStrokeWidth().isPositive()) {
             // Prefer stroke color if possible but not if it's fully transparent.
             if (style.hasExplicitlySetStrokeColor()) {
-                auto strokeColor = style.visitedLinkStrokeColor().resolveColor(style.visitedLinkColor());
+                auto strokeColor = style.visitedLinkStrokeColor().resolveColor(ResolvedColors::fromVisitedLinkStyle(style));
                 if (strokeColor.isVisible())
                     return strokeColor;
             } else {
-                auto strokeColor = style.visitedLinkTextStrokeColor().resolveColor(style.visitedLinkColor());
+                auto strokeColor = style.visitedLinkTextStrokeColor().resolveColor(ResolvedColors::fromVisitedLinkStyle(style));
                 if (strokeColor.isVisible())
                     return strokeColor;
             }
         }
         return style.visitedLinkColor();
     }
-    return result.resolveColor(style.visitedLinkColor());
+    return result.resolveColor(ResolvedColors::fromVisitedLinkStyle(style));
 }
 
 inline bool ColorPropertyTraits<PropertyNameConstant<CSSPropertyBackgroundColor>>::excludesVisitedLinkColor(const WebCore::Color& visitedLinkColor)

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -70,12 +70,12 @@ Color::Color(EmptyToken token)
 }
 
 Color::Color()
-    : value { CurrentColor { } }
+    : value { CurrentColor { CurrentColor::Property::Color } }
 {
 }
 
 Color::Color(CSS::Keyword::Currentcolor)
-    : value { CurrentColor { } }
+    : value { CurrentColor { CurrentColor::Property::Color } }
 {
 }
 
@@ -234,7 +234,7 @@ bool Color::operator==(const Color& other) const = default;
 
 const Color& Color::currentColor()
 {
-    static NeverDestroyed<Style::Color> color { CurrentColor { } };
+    static NeverDestroyed<Style::Color> color { CurrentColor { CurrentColor::Property::Color } };
     return color.get();
 }
 
@@ -257,9 +257,9 @@ WTF::String Color::debugDescription() const
     return ts.release();
 }
 
-WebCore::Color Color::resolveColor(const WebCore::Color& currentColor) const
+WebCore::Color Color::resolveColor(const ResolvedColors& resolvedColors) const
 {
-    return switchOn([&](const auto& kind) { return WebCore::Style::resolveColor(kind, currentColor); });
+    return switchOn([&](const auto& kind) { return WebCore::Style::resolveColor(kind, resolvedColors); });
 }
 
 bool Color::containsCurrentColor() const
@@ -328,9 +328,9 @@ template<typename T> Color::ColorKind Color::makeIndirectColor(T&& colorType)
     return { makeUniqueRef<T>(WTF::move(colorType)) };
 }
 
-WebCore::Color resolveColor(const Color& value, const WebCore::Color& currentColor)
+WebCore::Color resolveColor(const Color& value, const ResolvedColors& resolvedColors)
 {
-    return value.resolveColor(currentColor);
+    return value.resolveColor(resolvedColors);
 }
 
 bool containsCurrentColor(const Color& value)

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -53,6 +53,7 @@ namespace Style {
 enum class ForVisitedLink : bool;
 
 class ComputedStyle;
+class ResolvedColors;
 
 // The following style color kinds are forward declared and stored in
 // UniqueRefs to avoid unnecessarily growing the size of Color for the
@@ -156,7 +157,7 @@ public:
     bool NODELETE isResolvedColor() const;
     const WebCore::Color& resolvedColor() const;
 
-    WEBCORE_EXPORT WebCore::Color resolveColor(const WebCore::Color& currentColor) const;
+    WEBCORE_EXPORT WebCore::Color resolveColor(const ResolvedColors&) const;
 
     bool isKnownTransparent() const;
 
@@ -174,7 +175,7 @@ private:
     ColorKind value;
 };
 
-WebCore::Color resolveColor(const Color&, const WebCore::Color& currentColor);
+WebCore::Color resolveColor(const Color&, const ResolvedColors&);
 bool containsCurrentColor(const Color&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const Color&);

--- a/Source/WebCore/style/values/color/StyleColorLayers.cpp
+++ b/Source/WebCore/style/values/color/StyleColorLayers.cpp
@@ -71,13 +71,13 @@ Color toStyleColor(const CSS::ColorLayers& unresolved, ColorResolutionState& sta
 
 // MARK: Resolve
 
-WebCore::Color resolveColor(const ColorLayers& colorLayers, const WebCore::Color& currentColor)
+WebCore::Color resolveColor(const ColorLayers& colorLayers, const ResolvedColors& resolvedColors)
 {
     return blendSourceOver(
         CSS::ColorLayersResolver {
             .blendMode = colorLayers.blendMode,
             .colors = colorLayers.colors.map([&](auto& color) {
-                return color.resolveColor(currentColor);
+                return color.resolveColor(resolvedColors);
             })
         }
     );

--- a/Source/WebCore/style/values/color/StyleColorLayers.h
+++ b/Source/WebCore/style/values/color/StyleColorLayers.h
@@ -54,7 +54,7 @@ inline bool operator==(const UniqueRef<ColorLayers>& a, const UniqueRef<ColorLay
 }
 
 Color toStyleColor(const CSS::ColorLayers&, ColorResolutionState&);
-WebCore::Color resolveColor(const ColorLayers&, const WebCore::Color& currentColor);
+WebCore::Color resolveColor(const ColorLayers&, const ResolvedColors&);
 bool containsCurrentColor(const ColorLayers&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ColorLayers&);

--- a/Source/WebCore/style/values/color/StyleColorMix.cpp
+++ b/Source/WebCore/style/values/color/StyleColorMix.cpp
@@ -81,14 +81,14 @@ Color toStyleColor(const CSS::ColorMix& unresolved, ColorResolutionState& state)
 
 // MARK: - Resolve
 
-WebCore::Color resolveColor(const ColorMix& colorMix, const WebCore::Color& currentColor)
+WebCore::Color resolveColor(const ColorMix& colorMix, const ResolvedColors& resolvedColors)
 {
     return mix(
         CSS::ColorMixResolver {
             colorMix.colorInterpolationMethod,
             colorMix.components.map([&](auto& component) {
                 return CSS::ColorMixResolver::Component {
-                    component.color.resolveColor(currentColor),
+                    component.color.resolveColor(resolvedColors),
                     component.percentage,
                 };
             })

--- a/Source/WebCore/style/values/color/StyleContrastColor.cpp
+++ b/Source/WebCore/style/values/color/StyleContrastColor.cpp
@@ -60,11 +60,11 @@ Color toStyleColor(const CSS::ContrastColor& unresolved, ColorResolutionState& s
 
 // MARK: - Resolve
 
-WebCore::Color resolveColor(const ContrastColor& contrastColor, const WebCore::Color& currentColor)
+WebCore::Color resolveColor(const ContrastColor& contrastColor, const ResolvedColors& resolvedColors)
 {
     return resolve(
         CSS::ContrastColorResolver {
-            contrastColor.color.resolveColor(currentColor),
+            contrastColor.color.resolveColor(resolvedColors),
         }
     );
 }

--- a/Source/WebCore/style/values/color/StyleContrastColor.h
+++ b/Source/WebCore/style/values/color/StyleContrastColor.h
@@ -50,7 +50,7 @@ inline bool operator==(const UniqueRef<ContrastColor>& a, const UniqueRef<Contra
 }
 
 Color toStyleColor(const CSS::ContrastColor&, ColorResolutionState&);
-WebCore::Color resolveColor(const ContrastColor&, const WebCore::Color& currentColor);
+WebCore::Color resolveColor(const ContrastColor&, const ResolvedColors&);
 bool containsCurrentColor(const ContrastColor&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ContrastColor&);

--- a/Source/WebCore/style/values/color/StyleCurrentColor.cpp
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.cpp
@@ -32,23 +32,52 @@
 namespace WebCore {
 namespace Style {
 
-// MARK: - Serialization
-
-void serializationForCSSTokenization(StringBuilder& builder, const CSS::SerializationContext&, const CurrentColor&)
+CurrentColor::CurrentColor(Property property)
+    : m_property(property)
 {
-    builder.append("currentcolor"_s);
 }
 
-WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const CurrentColor&)
+// MARK: - Serialization
+
+void serializationForCSSTokenization(StringBuilder& builder, const CSS::SerializationContext&, const CurrentColor& currentColor)
 {
-    return "currentcolor"_s;
+    switch (currentColor.property()) {
+    case CurrentColor::Property::Color:
+        builder.append("currentcolor"_s);
+        return;
+    default:
+        ASSERT_NOT_REACHED();
+        builder.append("<invalid color>"_s);
+        break;
+    }
+}
+
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const CurrentColor& currentColor)
+{
+    switch (currentColor.property()) {
+    case CurrentColor::Property::Color:
+        return "currentcolor"_s;
+    default:
+        break;
+    }
+
+    ASSERT_NOT_REACHED();
+    return "<invalid color>"_s;
 }
 
 // MARK: - TextStream
 
-WTF::TextStream& operator<<(WTF::TextStream& ts, const CurrentColor&)
+WTF::TextStream& operator<<(WTF::TextStream& ts, const CurrentColor& currentColor)
 {
-    return ts << "currentColor"_s;
+    switch (currentColor.property()) {
+    case CurrentColor::Property::Color:
+        return ts << "currentcolor"_s;
+    default:
+        break;
+    }
+
+    ASSERT_NOT_REACHED();
+    return ts << "<invalid color>"_s;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleCurrentColor.h
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/Color.h>
+#include <WebCore/StyleResolvedColors.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -37,13 +38,41 @@ struct SerializationContext;
 
 namespace Style {
 
-struct CurrentColor {
+class ComputedStyleProperties;
+
+// CurrentColor refers to a color that is defined in the elemene's style.
+// Note that this is a bit different from CSS 'currentColor' keyword:
+// 'currentColor' keyword refers to the current value of the 'color' property
+// of the element, while this CurrentColor refers to any color that is defined
+// in the style, including 'currentColor'.
+class CurrentColor {
+public:
+    // Represents the CSS property in which to obtain the color from.
+    enum class Property {
+        // 'color' property.
+        Color
+    };
+
+    WEBCORE_EXPORT CurrentColor(Property);
+
+    Property property() const { return m_property; }
+
     constexpr bool operator==(const CurrentColor&) const = default;
+
+private:
+    Property m_property;
 };
 
-inline WebCore::Color resolveColor(const CurrentColor&, const WebCore::Color& currentColor)
+inline WebCore::Color resolveColor(const CurrentColor& currentColor, const ResolvedColors& resolvedColors)
 {
-    return currentColor;
+    switch (currentColor.property()) {
+    case CurrentColor::Property::Color:
+        return resolvedColors.currentColor();
+
+    default:
+        ASSERT_NOT_REACHED();
+        return { };
+    }
 }
 
 constexpr bool containsCurrentColor(const CurrentColor&)

--- a/Source/WebCore/style/values/color/StyleKeywordColor.cpp
+++ b/Source/WebCore/style/values/color/StyleKeywordColor.cpp
@@ -51,7 +51,7 @@ Color toStyleColor(const CSS::KeywordColor& unresolved, ColorResolutionState& st
     case CSSValueWebkitFocusRingColor:
         return { RenderTheme::singleton().focusRingColor(state.document->styleColorOptions(state.style.ptr())) };
     case CSSValueCurrentcolor:
-        return { CurrentColor() };
+        return { CurrentColor { CurrentColor::Property::Color } };
     default:
         return { CSS::colorFromKeyword(unresolved.valueID, state.document->styleColorOptions(state.style.ptr())) };
     }

--- a/Source/WebCore/style/values/color/StyleRelativeAlphaColor.cpp
+++ b/Source/WebCore/style/values/color/StyleRelativeAlphaColor.cpp
@@ -73,11 +73,11 @@ Color toStyleColor(const CSS::RelativeAlphaColor& unresolved, ColorResolutionSta
 
 // MARK: - Resolve
 
-WebCore::Color resolveColor(const RelativeAlphaColor& value, const WebCore::Color& currentColor)
+WebCore::Color resolveColor(const RelativeAlphaColor& value, const ResolvedColors& resolvedColors)
 {
     return resolveNoConversionDataRequired(
         CSS::RelativeAlphaColorResolver {
-            .origin = value.origin.resolveColor(currentColor),
+            .origin = value.origin.resolveColor(resolvedColors),
             .alpha = value.alpha
         }
     );

--- a/Source/WebCore/style/values/color/StyleRelativeAlphaColor.h
+++ b/Source/WebCore/style/values/color/StyleRelativeAlphaColor.h
@@ -57,7 +57,7 @@ inline bool operator==(const UniqueRef<RelativeAlphaColor>& a, const UniqueRef<R
 }
 
 Color toStyleColor(const CSS::RelativeAlphaColor&, ColorResolutionState&);
-WebCore::Color resolveColor(const RelativeAlphaColor&, const WebCore::Color& currentColor);
+WebCore::Color resolveColor(const RelativeAlphaColor&, const ResolvedColors&);
 bool containsCurrentColor(const RelativeAlphaColor&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const RelativeAlphaColor&);

--- a/Source/WebCore/style/values/color/StyleRelativeColor.h
+++ b/Source/WebCore/style/values/color/StyleRelativeColor.h
@@ -88,11 +88,11 @@ template<typename D> Style::Color toStyleColor(const CSS::RelativeColor<D>& unre
     return { ResolvedColor { WTF::move(color) } };
 }
 
-template<typename D> WebCore::Color resolveColor(const RelativeColor<D>& relative, const WebCore::Color& currentColor)
+template<typename D> WebCore::Color resolveColor(const RelativeColor<D>& relative, const ResolvedColors& resolvedColors)
 {
     return resolveNoConversionDataRequired(
         CSS::RelativeColorResolver<D> {
-            .origin = relative.origin.resolveColor(currentColor),
+            .origin = relative.origin.resolveColor(resolvedColors),
             .components = relative.components
         }
     );

--- a/Source/WebCore/style/values/color/StyleResolvedColor.h
+++ b/Source/WebCore/style/values/color/StyleResolvedColor.h
@@ -46,7 +46,7 @@ struct ResolvedColor {
 
 Color toStyleColor(const CSS::ResolvedColor&, ColorResolutionState&);
 
-inline WebCore::Color resolveColor(const ResolvedColor& absoluteColor, const WebCore::Color&)
+inline WebCore::Color resolveColor(const ResolvedColor& absoluteColor, const ResolvedColors&)
 {
     return absoluteColor.color;
 }

--- a/Source/WebCore/style/values/color/StyleResolvedColors.cpp
+++ b/Source/WebCore/style/values/color/StyleResolvedColors.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
- * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,57 +23,26 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "ColorInterpolationMethod.h"
-#include "StyleColor.h"
-#include "StylePrimitiveNumericTypes.h"
-#include <optional>
-#include <wtf/UniqueRef.h>
+#include "config.h"
+#include "StyleResolvedColors.h"
 
 namespace WebCore {
-
-class Color;
-
-namespace CSS {
-struct ColorMix;
-}
-
 namespace Style {
 
-struct ColorResolutionState;
-
-struct ColorMix {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(ColorMix);
-
-    struct Component {
-        using Percentage = Style::Percentage<CSS::Range{0, 100}>;
-
-        Color color;
-        std::optional<Percentage> percentage;
-
-        bool operator==(const Component&) const = default;
-    };
-
-    ColorInterpolationMethod colorInterpolationMethod;
-    CommaSeparatedVector<Component> components;
-
-    bool operator==(const ColorMix&) const = default;
-};
-
-inline bool operator==(const UniqueRef<ColorMix>& a, const UniqueRef<ColorMix>& b)
+ResolvedColors::ResolvedColors(WebCore::Color currentColor)
+    : m_currentColor(currentColor)
 {
-    return a.get() == b.get();
 }
 
-Color toStyleColor(const CSS::ColorMix&, ColorResolutionState&);
-WebCore::Color resolveColor(const ColorMix&, const ResolvedColors&);
-bool containsCurrentColor(const ColorMix&);
+ResolvedColors ResolvedColors::fromStyle(const ComputedStyleProperties& style)
+{
+    return ResolvedColors(style.color());
+}
 
-void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ColorMix&);
-WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const ColorMix&);
-
-WTF::TextStream& operator<<(WTF::TextStream&, const ColorMix&);
+ResolvedColors ResolvedColors::fromVisitedLinkStyle(const ComputedStyleProperties& style)
+{
+    return ResolvedColors(style.visitedLinkColorResolvingCurrentColor());
+}
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/color/StyleResolvedColors.h
+++ b/Source/WebCore/style/values/color/StyleResolvedColors.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
- * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,55 +25,30 @@
 
 #pragma once
 
-#include "ColorInterpolationMethod.h"
-#include "StyleColor.h"
-#include "StylePrimitiveNumericTypes.h"
-#include <optional>
-#include <wtf/UniqueRef.h>
+#include <WebCore/Color.h>
 
 namespace WebCore {
-
-class Color;
-
-namespace CSS {
-struct ColorMix;
-}
-
 namespace Style {
 
-struct ColorResolutionState;
+class ComputedStyleProperties;
 
-struct ColorMix {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(ColorMix);
+// Stores colors from a computed style that a CurrentColor will need to resolve.
+class ResolvedColors {
+    WTF_MAKE_TZONE_ALLOCATED(ResolvedColors);
 
-    struct Component {
-        using Percentage = Style::Percentage<CSS::Range{0, 100}>;
+public:
+    explicit ResolvedColors(WebCore::Color);
 
-        Color color;
-        std::optional<Percentage> percentage;
+    static ResolvedColors fromStyle(const ComputedStyleProperties&);
 
-        bool operator==(const Component&) const = default;
-    };
+    // This grabs the visited link color from the style, instead of the 'normal' color.
+    static ResolvedColors fromVisitedLinkStyle(const ComputedStyleProperties&);
 
-    ColorInterpolationMethod colorInterpolationMethod;
-    CommaSeparatedVector<Component> components;
+    WebCore::Color currentColor() const { return m_currentColor; }
 
-    bool operator==(const ColorMix&) const = default;
+private:
+    WebCore::Color m_currentColor;
 };
-
-inline bool operator==(const UniqueRef<ColorMix>& a, const UniqueRef<ColorMix>& b)
-{
-    return a.get() == b.get();
-}
-
-Color toStyleColor(const CSS::ColorMix&, ColorResolutionState&);
-WebCore::Color resolveColor(const ColorMix&, const ResolvedColors&);
-bool containsCurrentColor(const ColorMix&);
-
-void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ColorMix&);
-WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const ColorMix&);
-
-WTF::TextStream& operator<<(WTF::TextStream&, const ColorMix&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
@@ -34,6 +34,7 @@
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "StyleResolvedColors.h"
 
 namespace WebCore {
 namespace Style {
@@ -95,7 +96,7 @@ auto Evaluation<DropShadow, Ref<FilterEffect>>::operator()(const DropShadow& val
     auto y = Style::roundForImpreciseConversion<int>(evaluate<float>(value.location.y(), zoom));
     auto stdDeviation = Style::roundForImpreciseConversion<int>(evaluate<float>(value.stdDeviation, zoom));
 
-    return FEDropShadow::create(stdDeviation, stdDeviation, x, y, value.color.resolveColor(style.color()), 1);
+    return FEDropShadow::create(stdDeviation, stdDeviation, x, y, value.color.resolveColor(ResolvedColors::fromStyle(style)), 1);
 }
 
 // MARK: - Platform
@@ -105,7 +106,7 @@ auto ToPlatform<DropShadow>::operator()(const DropShadow& value, const Style::Co
     auto zoom = style.usedZoomForLength();
 
     return DropShadowFilterOperation::create(
-        value.color.resolveColor(style.color()),
+        value.color.resolveColor(ResolvedColors::fromStyle(style)),
         IntPoint {
             Style::roundForImpreciseConversion<int>(evaluate<float>(value.location.x(), zoom)),
             Style::roundForImpreciseConversion<int>(evaluate<float>(value.location.y(), zoom)),

--- a/Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp
@@ -51,7 +51,7 @@ static WebCore::Style::GradientLinearColorStopList someUncacheableStops()
 {
     return {
         {
-            WebCore::Style::Color { WebCore::Style::CurrentColor { } },
+            WebCore::Style::Color { WebCore::Style::CurrentColor { WebCore::Style::CurrentColor::Property::Color } },
             50_css_percentage
         },
         {
@@ -65,11 +65,11 @@ static WebCore::Style::GradientLinearColorStopList allUncacheableStops()
 {
     return {
         {
-            WebCore::Style::Color { WebCore::Style::CurrentColor { } },
+            WebCore::Style::Color { WebCore::Style::CurrentColor { WebCore::Style::CurrentColor::Property::Color } },
             50_css_percentage
         },
         {
-            WebCore::Style::Color { WebCore::Style::CurrentColor { } },
+            WebCore::Style::Color { WebCore::Style::CurrentColor { WebCore::Style::CurrentColor::Property::Color } },
             100_css_percentage
         }
     };


### PR DESCRIPTION
#### 4e058c7fd10dbd4248d634b76e7909b24907fab2
<pre>
Extend Style::CurrentColor to support future color keywords that take an existing color from a property
<a href="https://rdar.apple.com/184897363">rdar://184897363</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321775">https://bugs.webkit.org/show_bug.cgi?id=321775</a>

Reviewed by NOBODY (OOPS!).

Style::CurrentColor currently refers to the CSS `currentColor` keyword, which resolves
to the value of the &apos;color&apos; CSS property of the element. CSSWG is receptive to adding
more colors that refer to the value of a property than just `currentColor`. An example
is `AccentColor`, which is the value of `accent-color` if an accent color is set [1].
There&apos;s also a proposal [2] to add `currentBackgroundColor`, which reflects the value
of `background-color`.

To prepare for these new colors, this patch extends Style::CurrentColor to encompass
any color that refers to a property&apos;s value. Style::CurrentColor now includes a
Style::CurrentColor::Property enum, which indicates which CSS property to take the
color value from For now, the only available Property is Color, which corresponds to
CSS `color` property, so it can represent `currentColor`.

Additionally, we add a new class named Style::ResolvedColors. This class stores the
colors necessary to resolve a CurrentColor, and it can be initialized from a computed
style. Style::resolveColor is modified to take a ResolvedColors, instead of just a
Color indicating the current color.

Refactoring - no differences in behavior, tested by existing test suite.

[1]: <a href="https://drafts.csswg.org/css-color-4/#">https://drafts.csswg.org/css-color-4/#</a>:~:text=AccentColor%20takes%20its%20value%20from%20accent%2Dcolor
[2]: <a href="https://github.com/w3c/csswg-drafts/issues/5292">https://github.com/w3c/csswg-drafts/issues/5292</a>

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInitialColor):
(WebCore::Style::BuilderCustom::applyValueColor):
* Source/WebCore/style/StyleColorResolver.cpp:
(WebCore::Style::ColorResolver::colorResolvingCurrentColor const):
(WebCore::Style::ColorResolver::visitedLinkColorResolvingCurrentColor const):
* Source/WebCore/style/StyleColorResolver.h:
(WebCore::Style::ColorPropertyResolver&lt;ColorTraits&gt;::colorResolvingCurrentColor const):
(WebCore::Style::requires):
* Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h:
(WebCore::Style::ColorPropertyTraits&lt;PropertyNameConstant&lt;CSSPropertyTextDecorationColor&gt;&gt;::colorResolvingCurrentColor):
(WebCore::Style::ColorPropertyTraits&lt;PropertyNameConstant&lt;CSSPropertyTextDecorationColor&gt;&gt;::visitedLinkColorResolvingCurrentColor):
* Source/WebCore/style/values/color/StyleColor.cpp:
(WebCore::Style::Color::Color):
(WebCore::Style::Color::currentColor):
(WebCore::Style::Color::resolveColor const):
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/color/StyleColorLayers.cpp:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleColorLayers.h:
* Source/WebCore/style/values/color/StyleColorMix.cpp:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleColorMix.h:
* Source/WebCore/style/values/color/StyleContrastColor.cpp:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleContrastColor.h:
* Source/WebCore/style/values/color/StyleCurrentColor.cpp:
(WebCore::Style::CurrentColor::CurrentColor):
(WebCore::Style::serializationForCSSTokenization):
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/style/values/color/StyleCurrentColor.h:
(WebCore::Style::CurrentColor::property const):
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleKeywordColor.cpp:
(WebCore::Style::toStyleColor):
* Source/WebCore/style/values/color/StyleRelativeAlphaColor.cpp:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleRelativeAlphaColor.h:
* Source/WebCore/style/values/color/StyleRelativeColor.h:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleResolvedColor.h:
(WebCore::Style::resolveColor):
* Source/WebCore/style/values/color/StyleResolvedColors.cpp: Copied from Source/WebCore/style/values/color/StyleCurrentColor.cpp.
(WebCore::Style::ResolvedColors::ResolvedColors):
(WebCore::Style::ResolvedColors::fromStyle):
(WebCore::Style::ResolvedColors::fromVisitedLinkStyle):
* Source/WebCore/style/values/color/StyleResolvedColors.h: Copied from Source/WebCore/style/values/color/StyleCurrentColor.cpp.
(WebCore::Style::ResolvedColors::currentColor const):
* Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp:
(WebCore::Style::Ref&lt;FilterEffect&gt;&gt;::operator):
(WebCore::Style::ToPlatform&lt;DropShadow&gt;::operator):
* Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp:
(TestWebKitAPI::someUncacheableStops):
(TestWebKitAPI::allUncacheableStops):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e058c7fd10dbd4248d634b76e7909b24907fab2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181479 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49228 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191702 "Hash 4e058c7f for PR 71626 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145805 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55147 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/191702 "Hash 4e058c7f for PR 71626 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98291 "2 flakes 12 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162386 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/191702 "Hash 4e058c7f for PR 71626 does not build (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43998 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42272 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/191702 "Hash 4e058c7f for PR 71626 does not build (failure)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154400 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41912 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2863 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193630 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55095 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151043 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55782 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38535 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150750 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45328 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128064 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123683 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54298 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16911 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53680 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53918 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53745 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->