### PR TITLE
[Navigation API] Call dispatchNavigateEvent() directly from continueLoadAfterNavigationPolicy()

### DIFF
--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -68,6 +68,12 @@ public:
     Element* sourceElement() const { return m_sourceElement.get(); }
     void setSourceElement(Element* sourceElement) { m_sourceElement = sourceElement; }
 
+    NavigationHistoryBehavior navigationHistoryBehavior() const { return m_navigationHistoryBehavior; }
+    void setNavigationHistoryBehavior(NavigationHistoryBehavior historyHandling) { m_navigationHistoryBehavior = historyHandling; }
+
+    bool skipNavigateEvent() const { return m_skipNavigateEvent; }
+    void setSkipNavigateEvent(bool value) { m_skipNavigateEvent = value; }
+
     InitiatedByMainFrame initiatedByMainFrame() const { return m_initiatedByMainFrame; }
 
     bool isRequestFromClientOrUserInput() const { return m_isRequestFromClientOrUserInput; }
@@ -106,10 +112,12 @@ private:
     RefPtr<Element> m_sourceElement;
     InitiatedByMainFrame m_initiatedByMainFrame { InitiatedByMainFrame::Unknown };
     std::optional<BackForwardItemIdentifier> m_targetBackForwardItemIdentifier;
+    NavigationHistoryBehavior m_navigationHistoryBehavior { NavigationHistoryBehavior::Auto };
     bool m_isRequestFromClientOrUserInput { false };
     bool m_isInitialFrameSrcLoad { false };
     bool m_isContentRuleListRedirect { false };
     bool m_isFromNavigationAPI { false };
+    bool m_skipNavigateEvent { false };
 };
 
 class FrameLoadRequest : public FrameLoadRequestBase {
@@ -170,15 +178,8 @@ public:
     void setAdvancedPrivacyProtections(OptionSet<AdvancedPrivacyProtections> policy) { m_advancedPrivacyProtections = policy; }
     std::optional<OptionSet<AdvancedPrivacyProtections>> advancedPrivacyProtections() const { return m_advancedPrivacyProtections; }
 
-    NavigationHistoryBehavior navigationHistoryBehavior() const { return m_navigationHistoryBehavior; }
-    void setNavigationHistoryBehavior(NavigationHistoryBehavior historyHandling) { m_navigationHistoryBehavior = historyHandling; }
-
-
     bool isHandledByAboutSchemeHandler() const { return m_isHandledByAboutSchemeHandler; }
     void setIsHandledByAboutSchemeHandler(bool isHandledByAboutSchemeHandler) { m_isHandledByAboutSchemeHandler = isHandledByAboutSchemeHandler; }
-
-    bool skipNavigateEvent() const { return m_skipNavigateEvent; }
-    void setSkipNavigateEvent(bool value) { m_skipNavigateEvent = value; }
 
     MonotonicTime originalNavigationStartTime() const { return m_originalNavigationStartTime; }
     void setOriginalNavigationStartTime(MonotonicTime time) { m_originalNavigationStartTime = time; }
@@ -197,10 +198,8 @@ private:
     ReferrerPolicy m_referrerPolicy { ReferrerPolicy::EmptyString };
     AllowNavigationToInvalidURL m_allowNavigationToInvalidURL { AllowNavigationToInvalidURL::Yes };
     std::optional<OptionSet<AdvancedPrivacyProtections>> m_advancedPrivacyProtections;
-    NavigationHistoryBehavior m_navigationHistoryBehavior { NavigationHistoryBehavior::Auto };
     MonotonicTime m_originalNavigationStartTime;
     bool m_isHandledByAboutSchemeHandler { false };
-    bool m_skipNavigateEvent { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1568,7 +1568,7 @@ void FrameLoader::loadFrameRequest(FrameLoadRequest&& request, Event* event, Ref
                 RefPtr<SerializedScriptValue> stateObject;
                 if (RefPtr currentItem = history().currentItem())
                     stateObject = currentItem->navigationAPIStateObject();
-                if (!dispatchNavigateEvent(loadType, request, false, formState.get(), event, stateObject.get()))
+                if (!dispatchNavigateEvent(loadType, request, request.resourceRequest().url(), false, formState.get(), event, stateObject.get()))
                     return;
                 if (!frame->page())
                     return;
@@ -1676,6 +1676,8 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
     action.setIsInitialFrameSrcLoad(frameLoadRequest.isInitialFrameSrcLoad());
     action.setIsFromNavigationAPI(frameLoadRequest.isFromNavigationAPI());
     action.setNewFrameOpenerPolicy(frameLoadRequest.newFrameOpenerPolicy());
+    if (!action.sourceElement() && event)
+        action.setSourceElement(dynamicDowncast<Element>(event->target()));
     auto historyHandling = frameLoadRequest.navigationHistoryBehavior();
     RefPtr document = m_frame->document();
     bool isSameOrigin = protect(frameLoadRequest.requesterSecurityOrigin())->isSameOriginDomain(protect(document->securityOrigin()).get());
@@ -1693,6 +1695,7 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
             historyHandling = NavigationHistoryBehavior::Replace;
     }
     frameLoadRequest.setNavigationHistoryBehavior(historyHandling);
+    action.setNavigationHistoryBehavior(historyHandling);
     action.setNavigationAPIType(determineNavigationType(newLoadType, historyHandling));
     if (privateClickMeasurement && frame->isMainFrame())
         action.setPrivateClickMeasurement(WTF::move(*privateClickMeasurement));
@@ -1731,7 +1734,7 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
     // exactly the same so pages with '#' links and DHTML side effects
     // work properly.
     if (shouldPerformFragmentNavigation(isFormSubmission, httpMethod, newLoadType, newURL)) {
-        if (!dispatchNavigateEvent(newLoadType, frameLoadRequest, true, formState.get(), event))
+        if (!dispatchNavigateEvent(newLoadType, frameLoadRequest, frameLoadRequest.resourceRequest().url(), true, formState.get(), event))
             return;
 
         oldDocumentLoader->setTriggeringAction(WTF::move(action));
@@ -1745,14 +1748,10 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
         return;
     }
 
-    if (isSameOrigin && newLoadType != FrameLoadType::Reload && !frameLoadRequest.isInitialFrameSrcLoad()) {
-        // FIXME: Ideally, we'd call dispatchNavigateEvent() directly from continueLoadAfterNavigationPolicy()
-        // instead of storing a lambda on the NavigationAction.
-        action.setPendingDispatchNavigateEvent([weakThis = WeakPtr { *this }, newLoadType, frameLoadRequest, formState, event = RefPtr { event }] {
-            RefPtr protectedThis = weakThis.get();
-            return protectedThis && protectedThis->dispatchNavigateEvent(newLoadType, frameLoadRequest, false, formState.get(), event.get());
-        });
-    }
+    action.setSkipNavigateEvent(frameLoadRequest.skipNavigateEvent()
+        || !isSameOrigin
+        || newLoadType == FrameLoadType::Reload
+        || frameLoadRequest.isInitialFrameSrcLoad());
 
     // Must grab this now, since this load may stop the previous load and clear this flag.
     bool isRedirect = m_quickRedirectComing;
@@ -3752,7 +3751,7 @@ void FrameLoader::loadPostRequest(FrameLoadRequest&& request, const String& refe
 
     if (protect(request.requesterSecurityOrigin())->isSameOriginDomain(protect(protect(frame->document())->securityOrigin()).get())) {
         RefPtr formState = formSubmission ? protect(formSubmission->state()): nullptr;
-        if (!dispatchNavigateEvent(loadType, request, false, formState.get()))
+        if (!dispatchNavigateEvent(loadType, request, request.resourceRequest().url(), false, formState.get()))
             return completionHandler();
     }
 
@@ -4275,8 +4274,11 @@ void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& reque
         return;
     }
 
-    if (auto pendingDispatchNavigateEvent = m_policyDocumentLoader ? m_policyDocumentLoader->triggeringAction().takePendingDispatchNavigateEvent() : std::function<bool()> { }) {
-        if (!pendingDispatchNavigateEvent())
+    if (RefPtr policyDocumentLoader = m_policyDocumentLoader) {
+        auto& action = policyDocumentLoader->triggeringAction();
+        bool proceed = dispatchNavigateEvent(policyChecker().loadType(), action, action.url(), false, formSubmission ? formSubmission->state() : nullptr);
+        action.setSkipNavigateEvent(true); // Dispatch at most once.
+        if (!proceed)
             return;
     }
 
@@ -4552,7 +4554,7 @@ RefPtr<Frame> FrameLoader::findFrameForNavigation(const AtomString& name, Docume
     return frame;
 }
 
-bool FrameLoader::dispatchNavigateEvent(FrameLoadType loadType, const FrameLoadRequest& request, bool isSameDocument, FormState* formState, Event* event, SerializedScriptValue* classicHistoryAPIState)
+bool FrameLoader::dispatchNavigateEvent(FrameLoadType loadType, const FrameLoadRequestBase& request, const URL& destinationURL, bool isSameDocument, FormState* formState, Event* event, SerializedScriptValue* classicHistoryAPIState)
 {
     RefPtr document = m_frame->document();
     if (!document || !document->settings().navigationAPIEnabled())
@@ -4566,8 +4568,7 @@ bool FrameLoader::dispatchNavigateEvent(FrameLoadType loadType, const FrameLoadR
     if (!request.downloadAttribute().isNull())
         return true;
 
-    const URL& newURL = request.resourceRequest().url();
-    if (!isSameDocument && !newURL.hasFetchScheme())
+    if (!isSameDocument && !destinationURL.hasFetchScheme())
         return true;
 
     auto navigationType = determineNavigationType(loadType, request.navigationHistoryBehavior());
@@ -4588,7 +4589,7 @@ bool FrameLoader::dispatchNavigateEvent(FrameLoadType loadType, const FrameLoadR
     if (!sourceElement && event)
         sourceElement = dynamicDowncast<Element>(event->target());
 
-    return protect(window->navigation())->dispatchPushReplaceReloadNavigateEvent(newURL, navigationType, isSameDocument, formState, classicHistoryAPIState, sourceElement.get());
+    return protect(window->navigation())->dispatchPushReplaceReloadNavigateEvent(destinationURL, navigationType, isSameDocument, formState, classicHistoryAPIState, sourceElement.get());
 }
 
 void FrameLoader::loadSameDocumentItem(HistoryItem& item)

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -76,6 +76,7 @@ class Frame;
 class FormState;
 class FormSubmission;
 class FrameLoadRequest;
+class FrameLoadRequestBase;
 class FrameNetworkingContext;
 class HistoryController;
 class HistoryItem;
@@ -493,7 +494,7 @@ private:
 
     void updateRequestAndAddExtraFields(Frame&, ResourceRequest&, IsMainResource, FrameLoadType, ShouldUpdateAppInitiatedValue, IsServiceWorkerNavigationLoad, WillOpenInNewWindow, Document*);
 
-    bool dispatchNavigateEvent(FrameLoadType, const FrameLoadRequest&, bool isSameDocument, FormState* = nullptr, Event* = nullptr, SerializedScriptValue* classicHistoryAPIState = nullptr);
+    bool dispatchNavigateEvent(FrameLoadType, const FrameLoadRequestBase&, const URL& destinationURL, bool isSameDocument, FormState* = nullptr, Event* = nullptr, SerializedScriptValue* classicHistoryAPIState = nullptr);
     bool shouldDispatchNavigateEventForHistoryTraversal(const HistoryItem&, const HistoryItem* fromItem);
 
     WeakRef<LocalFrame> m_frame;
@@ -583,8 +584,6 @@ private:
     uint64_t m_requiredCookiesVersion { 0 };
 
     const Ref<DocumentPrefetcher> m_documentPrefetcher;
-
-    Function<bool()> m_pendingDispatchNavigateEvent;
 
     bool m_needsCancellationForContentRuleListCrossOriginRedirect { false };
 };

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -125,9 +125,6 @@ public:
     std::optional<NavigationNavigationType> navigationAPIType() const { return m_navigationAPIType; }
     void setNavigationAPIType(NavigationNavigationType navigationAPIType) { m_navigationAPIType = navigationAPIType; }
 
-    void setPendingDispatchNavigateEvent(std::function<bool()>&& function) { m_pendingDispatchNavigateEvent = WTF::move(function); }
-    std::function<bool()> takePendingDispatchNavigateEvent() { return std::exchange(m_pendingDispatchNavigateEvent, nullptr); }
-
     // Whether UIProcess has already made the policy decision for this navigation.
     PolicyAlreadyDecided policyAlreadyDecided() const { return m_policyAlreadyDecided; }
     void setPolicyAlreadyDecided(PolicyAlreadyDecided value) { m_policyAlreadyDecided = value; }
@@ -142,7 +139,6 @@ private:
     RefPtr<UserGestureToken> m_userGestureToken { UserGestureIndicator::currentUserGesture() };
     std::optional<BackForwardItemIdentifier> m_sourceBackForwardItemIdentifier;
     std::optional<PrivateClickMeasurement> m_privateClickMeasurement;
-    std::function<bool()> m_pendingDispatchNavigateEvent;
 
     NavigationType m_type;
     std::optional<NavigationNavigationType> m_navigationAPIType;


### PR DESCRIPTION
#### 8aa5ce1f675d37aa02822f94ec23134c67195869
<pre>
[Navigation API] Call dispatchNavigateEvent() directly from continueLoadAfterNavigationPolicy()
<a href="https://bugs.webkit.org/show_bug.cgi?id=321776">https://bugs.webkit.org/show_bug.cgi?id=321776</a>
<a href="https://rdar.apple.com/184898697">rdar://184898697</a>

Reviewed by NOBODY (OOPS!).

Addresses the FIXME in FrameLoader::loadURL(). The dispatch was stored as a
lambda on the NavigationAction, capturing the FrameLoadRequest and Event.
NavigationAction and FrameLoadRequest are both FrameLoadRequestBase subclasses,
so everything dispatchNavigateEvent() reads can be set on the action instead.

- Move navigationHistoryBehavior and skipNavigateEvent into FrameLoadRequestBase,
  and have loadURL() set both on the action. Previously, we decided if the event
  should fire based on if the lambda existed, now we just set the skipNavigateEvent
  flag on the action, which dispatchNavigateEvent() already checks.

- dispatchNavigateEvent() now takes in the destination URL. It previously got it
  from the ResourceRequest, but that exists only on FrameLoadRequest.

- The source element is set on the action in loadURL(), while the triggering event
  is still available, because continueLoadAfterNavigationPolicy() no longer has the
  event. It is computed in the same way that dispatchNavigateEvent() computes it
  for other callers that do pass in an event (like this code path used to).

There is no change in behavior.

* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequestBase::navigationHistoryBehavior const):
(WebCore::FrameLoadRequestBase::setNavigationHistoryBehavior):
(WebCore::FrameLoadRequestBase::skipNavigateEvent const):
(WebCore::FrameLoadRequestBase::setSkipNavigateEvent):
(WebCore::FrameLoadRequest::navigationHistoryBehavior const): Deleted.
(WebCore::FrameLoadRequest::setNavigationHistoryBehavior): Deleted.
(WebCore::FrameLoadRequest::skipNavigateEvent const): Deleted.
(WebCore::FrameLoadRequest::setSkipNavigateEvent): Deleted.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadFrameRequest):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::dispatchNavigateEvent):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/NavigationAction.h:
(WebCore::NavigationAction::setPendingDispatchNavigateEvent): Deleted.
(WebCore::NavigationAction::std::function&lt;bool): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8aa5ce1f675d37aa02822f94ec23134c67195869

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145044 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54383 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140963 "Found 1 new test failure: fast/editing/document-leak-altered-text-field.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97678 "3 flakes 7 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183677 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44635 "Found 1 new test failure: fast/editing/document-leak-altered-text-field.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121415 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43308 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41589 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153712 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41263 "Found 1 new test failure: fast/editing/document-leak-altered-text-field.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2094 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47276 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45844 "Found 1 new test failure: fast/editing/document-leak-altered-text-field.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192870 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54333 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150347 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55021 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37881 "Found 1 new test failure: fast/editing/document-leak-altered-text-field.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150064 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44676 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127286 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122533 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53538 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16256 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52920 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53157 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52985 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->