### PR TITLE
Implement CanvasRenderingContext2DBase::drawImage() for a WebGPU source

### DIFF
--- a/LayoutTests/fast/webgpu/float16-2dcanvas-drawimage-webgpu-expected.txt
+++ b/LayoutTests/fast/webgpu/float16-2dcanvas-drawimage-webgpu-expected.txt
@@ -1,0 +1,11 @@
+Tests that drawImage() of an HDR WebGPU canvas into a float16 2D canvas preserves extended-range values.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS HDR WebGPU -> float16: kept an extended-range value (max 3.0000)
+PASS HDR WebGPU -> unorm8: clamped to the SDR range (max 1.0000)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/webgpu/float16-2dcanvas-drawimage-webgpu.html
+++ b/LayoutTests/fast/webgpu/float16-2dcanvas-drawimage-webgpu.html
@@ -1,0 +1,138 @@
+<!-- webkit-test-runner [ CanvasColorTypeEnabled=true WebGPUEnabled=true WebGPUHDREnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests that drawImage() of an HDR WebGPU canvas into a float16 2D canvas preserves extended-range values.");
+
+window.jsTestIsAsync = true;
+
+const canvasSize = 4;
+const componentsPerPixel = 4;
+// The value the shader writes to the green channel. Well outside [0,1].
+const hdrGreen = 3;
+// The maximum a unorm8 destination can hold, plus an allowance for color conversion.
+const sdrMaximum = 1 + 1.5 / 255;
+
+function create2DContext(colorType)
+{
+    const element = document.createElement("canvas");
+    element.width = canvasSize;
+    element.height = canvasSize;
+    const context = element.getContext("2d", { colorSpace: "srgb", colorType });
+    if (!context)
+        testFailed(`Could not create a "${colorType}" 2D context`);
+    return context;
+}
+
+// Renders a solid `hdrGreen` into a WebGPU canvas configured for extended tone mapping.
+async function createHDRWebGPUCanvas(device)
+{
+    const element = document.createElement("canvas");
+    element.width = canvasSize;
+    element.height = canvasSize;
+
+    const gpuContext = element.getContext("webgpu");
+    if (!gpuContext) {
+        testFailed("Could not get a webgpu context");
+        return null;
+    }
+
+    gpuContext.configure({
+        device,
+        format: "rgba16float",
+        toneMapping: { mode: "extended" },
+        alphaMode: "premultiplied",
+    });
+
+    const commandEncoder = device.createCommandEncoder();
+    const renderPassEncoder = commandEncoder.beginRenderPass({
+        colorAttachments: [{
+            view: gpuContext.getCurrentTexture().createView(),
+            loadOp: "clear",
+            storeOp: "store",
+            clearValue: { r: 0, g: hdrGreen, b: 0, a: 1 },
+        }],
+    });
+    renderPassEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+
+    return element;
+}
+
+function maxComponent(context)
+{
+    const data = context.getImageData(0, 0, canvasSize, canvasSize, { pixelFormat: "rgba-float16" }).data;
+    let maximum = -Infinity;
+    for (let pixel = 0; pixel < canvasSize * canvasSize; ++pixel) {
+        for (let component = 0; component < componentsPerPixel - 1; ++component)
+            maximum = Math.max(maximum, data[pixel * componentsPerPixel + component]);
+    }
+    return maximum;
+}
+
+function drawAndVerify(label, sourceCanvas, destinationColorType, expectHDR)
+{
+    const destination = create2DContext(destinationColorType);
+    if (!destination)
+        return;
+
+    destination.drawImage(sourceCanvas, 0, 0);
+    const maximum = maxComponent(destination);
+
+    if (!(maximum > 0)) {
+        testFailed(`${label}: nothing appears to have been drawn (maximum is ${maximum}).`);
+        return;
+    }
+
+    if (expectHDR) {
+        if (maximum > sdrMaximum)
+            testPassed(`${label}: kept an extended-range value (max ${maximum.toFixed(4)})`);
+        else
+            testFailed(`${label}: expected a value > ${sdrMaximum.toFixed(4)}, but the maximum was ${maximum.toFixed(4)}`);
+        return;
+    }
+    if (maximum <= sdrMaximum)
+        testPassed(`${label}: clamped to the SDR range (max ${maximum.toFixed(4)})`);
+    else
+        testFailed(`${label}: expected all values <= ${sdrMaximum.toFixed(4)}, but the maximum was ${maximum.toFixed(4)}`);
+}
+
+async function runTests()
+{
+    if (!navigator.gpu) {
+        testFailed("WebGPU is not available");
+        finishJSTest();
+        return;
+    }
+
+    const adapter = await navigator.gpu.requestAdapter();
+    const device = await adapter?.requestDevice();
+    if (!device) {
+        testFailed("Could not get a GPUDevice");
+        finishJSTest();
+        return;
+    }
+
+    const hdrCanvas = await createHDRWebGPUCanvas(device);
+    if (!hdrCanvas) {
+        finishJSTest();
+        return;
+    }
+
+    // The extended-range value must survive into a float16 canvas...
+    drawAndVerify("HDR WebGPU -> float16", hdrCanvas, "float16", true);
+    // ...and must be clamped by a unorm8 one.
+    drawAndVerify("HDR WebGPU -> unorm8", hdrCanvas, "unorm8", false);
+
+    finishJSTest();
+}
+
+runTests();
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -367,6 +367,18 @@ void GPUCanvasContextCocoa::didUpdateCanvasSizeProperties(bool)
     }
 }
 
+static PixelFormat readbackPixelFormat(PixelFormat format)
+{
+    // ImageBufferCGBitmapBackend only supports BGRA8 and RGBA16F.
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (format == PixelFormat::RGBA16F)
+        return format;
+#else
+    UNUSED_PARAM(format);
+#endif
+    return PixelFormat::BGRA8;
+}
+
 RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuffer sourceBuffer)
 {
     RefPtr scriptExecutionContext = protect(canvasBase())->scriptExecutionContext();
@@ -376,7 +388,7 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
     if (size.isEmpty())
         return nullptr;
     if (!m_readDisplayBuffer) {
-        m_readDisplayBuffer = ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, scriptExecutionContext->graphicsClient());
+        m_readDisplayBuffer = ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, colorSpace(), readbackPixelFormat(pixelFormat()), scriptExecutionContext->graphicsClient());
         updateMemoryCost();
     }
     RefPtr<ImageBuffer> buffer = m_readDisplayBuffer;
@@ -389,7 +401,7 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
     updateScreenHeadroomFromScreenPropertiesIfNeeded();
 #endif
 
-    if (sourceBuffer == SurfaceBuffer::DisplayBufferForInspector && m_configuration->lastPresentedFrameIndex) {
+    if (m_configuration->lastPresentedFrameIndex && (sourceBuffer == SurfaceBuffer::DisplayBufferForInspector || !m_compositingResultsNeedsUpdating)) {
         if (buffer) {
             buffer->flushDrawingContext();
             m_compositorIntegration->paintCompositedResultsToCanvas(*buffer, *m_configuration->lastPresentedFrameIndex);
@@ -421,7 +433,7 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::transferToImageBuffer()
     const auto size = canvasBase().size();
     if (size.isEmpty())
         return nullptr;
-    RefPtr buffer = ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, scriptExecutionContext->graphicsClient());
+    RefPtr buffer = ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, colorSpace(), readbackPixelFormat(pixelFormat()), scriptExecutionContext->graphicsClient());
     if (!buffer)
         return nullptr;
     Ref<ImageBuffer> bufferRef = buffer.releaseNonNull();


### PR DESCRIPTION
#### 073ef61115aaf34ff86f43c902237c474255fe10
<pre>
Implement CanvasRenderingContext2DBase::drawImage() for a WebGPU source
<a href="https://bugs.webkit.org/show_bug.cgi?id=321778">https://bugs.webkit.org/show_bug.cgi?id=321778</a>
<a href="https://rdar.apple.com/problem/184900228">rdar://problem/184900228</a>

Reviewed by Mike Wyrzykowski.

Most of the plumbing was already in place.
GPUCanvasContextCocoa::surfaceBufferToImageBuffer() and
transferToImageBuffer() just needed to return an ImageBuffer with the
WebGPU canvas color space, and PixelFormat::RGBA16F if it was configured
to show an extended color range.

The new test also revealed a small latent issue, where an obsolete
compositing result was output in the image buffer despite
m_compositingResultsNeedsUpdating being true.

* LayoutTests/fast/webgpu/float16-2dcanvas-drawimage-webgpu-expected.txt: Added.
* LayoutTests/fast/webgpu/float16-2dcanvas-drawimage-webgpu.html: Added.
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::readbackPixelFormat):
(WebCore::GPUCanvasContextCocoa::surfaceBufferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::transferToImageBuffer):

Canonical link: <a href="https://commits.webkit.org/319231@main">https://commits.webkit.org/319231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4f07f0bf469857b9faa24c640c206beed42bcd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191066 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145175 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/22c9c21b-60e2-4a93-a32a-86fc820a4bae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141085 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/687bb379-6141-4a77-b672-1ce005788d9e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161827 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121536 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08e8fea7-13de-4c7d-b853-97d2466f86a2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43419 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41698 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41355 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2226 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193001 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40272 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55151 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150184 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44777 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127417 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122717 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53668 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16348 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53050 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53287 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53115 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->