### PR TITLE
[JSC] Skip WasmGC struct search when nothing else holds the key

### DIFF
--- a/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
@@ -352,8 +352,10 @@ public:
 
                 if (memory)
                     data.memoryValuesAtTail.add(memory);
-                if (wasmStructField)
+                if (wasmStructField) {
                     data.wasmStructValuesAtTail.add(wasmStructField);
+                    noteStructKeyFilter(wasmStructField);
+                }
                 if (wasmArrayElem)
                     data.wasmArrayValuesAtTail.add(wasmArrayElem);
 
@@ -1100,6 +1102,23 @@ private:
         if (replaceWasmStructValue(matches, structGet))
             return;
         m_data.wasmStructValuesAtTail.add(structGet);
+        noteStructKeyFilter(structGet);
+    }
+
+    void noteStructKeyFilter(WasmStructFieldValue* value)
+    {
+        auto& holders = m_structKeyFilters.add(WasmStructFieldKey(value->child(0), value->fieldHeapKey()), StructKeyFilters { }).iterator->value;
+        if (!holders.count)
+            holders.first = value;
+        ++holders.count;
+    }
+
+    bool isOnlyHolderOfStructKey(const WasmStructFieldKey& key) const
+    {
+        auto iter = m_structKeyFilters.find(key);
+        if (iter == m_structKeyFilters.end())
+            return true;
+        return iter->value.count == 1 && iter->value.first == m_value;
     }
 
     template<typename Filter>
@@ -1119,6 +1138,11 @@ private:
         // Check if current block has clobbering writes
         if (readsMutability != Mutability::Immutable && m_data.writes.overlaps(range)) {
             dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Giving up because of writes.");
+            return { };
+        }
+
+        if (isOnlyHolderOfStructKey(WasmStructFieldKey(structPtr, fieldHeapKey))) {
+            dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Giving up because nothing else holds this key.");
             return { };
         }
 
@@ -1287,6 +1311,7 @@ private:
         }
 
         m_data.wasmStructValuesAtTail.add(structSet);
+        noteStructKeyFilter(structSet);
     }
 
     bool findWasmStructSetAfterClobber(Value* structPtr, HeapRange range, uint64_t fieldHeapKey)
@@ -1572,6 +1597,17 @@ private:
     IndexSet<Value*> m_matched;
     // Blocks that own at least one m_sets key, so finalize() can skip whole blocks.
     IndexSet<BasicBlock*> m_blocksWithSets;
+
+    // Every value ever entered into some block's wasmStructValuesAtTail, tallied by field key.
+    // findWasmStructValue can only succeed by matching a value other than the one it is called
+    // for, so a key whose sole holder is that value makes its whole predecessor walk futile.
+    // Entries are never removed, which keeps the test conservative once clobber() prunes a
+    // block's map, and an overcount only means a walk we could have skipped still happens.
+    struct StructKeyFilters {
+        Value* first { nullptr };
+        unsigned count { 0 };
+    };
+    UncheckedKeyHashMap<WasmStructFieldKey, StructKeyFilters> m_structKeyFilters;
 
     InsertionSet m_insertionSet;
 


### PR DESCRIPTION
#### 2ec06de15a0dfa8686509598a5d7e70d62163e66
<pre>
[JSC] Skip WasmGC struct search when nothing else holds the key
<a href="https://bugs.webkit.org/show_bug.cgi?id=321781">https://bugs.webkit.org/show_bug.cgi?id=321781</a>
<a href="https://rdar.apple.com/184903374">rdar://184903374</a>

Reviewed by Justin Michaud.

CSE::findWasmStructValue walks every transitive predecessor block whenever a
WasmStructGet or WasmStructSet has no match in its own block. This is
fine for normal memory access since their range is coarse enough that
data.writes.overlaps(range) removes many possibilities quickly. But
WasmGC struct fields are sparse enough so that we end up running
analysis to almost all blocks up to root.

Let&apos;s just keep tracking how many count of struct field access we
observed so far. This makes looking up the blocks quickly giving up as
we may see count = 1 case in most of cases.

* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:

Canonical link: <a href="https://commits.webkit.org/319237@main">https://commits.webkit.org/319237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a958c872a09733d83a3d0a4e294cf20b8351f974

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191114 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145223 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25c2a4bb-7a5e-4bd7-b26f-37891e3a020b) 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141129 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/284444ed-807c-4045-9bba-b09295302344) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121580 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/866626ac-6c47-471b-b417-5a4f9a455aa8) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180224 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43464 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41744 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3546 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10362 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41406 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2274 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42174 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193049 "Built successfully") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54511 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150511 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55199 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150230 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27457 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44824 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127465 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122825 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53716 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16399 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53098 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53163 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->