### PR TITLE
[site-isolation] The content process should decide whether playback may begin and activate the audio session itself

### DIFF
--- a/Source/WebCore/platform/audio/MediaSessionManagerClient.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerClient.h
@@ -40,10 +40,6 @@ class MediaSessionManagerClient {
 public:
     virtual ~MediaSessionManagerClient() = default;
 
-    // Activate/deactivate the audio session on behalf of a session (may be null). The returned
-    // promise resolves on success, rejects on failure to activate.
-    virtual Ref<GenericPromise> tryToSetAudioSessionActive(bool active, PlatformMediaSessionInterface*) = 0;
-
     // Notify the environment (the owning page) that the active NowPlaying session changed.
     virtual void hasActiveNowPlayingSessionChanged(PlatformMediaSessionInterface*) = 0;
 };

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -54,16 +54,6 @@ public:
         : m_pageIdentifier(pageIdentifier) { }
 
 private:
-    Ref<GenericPromise> tryToSetAudioSessionActive(bool active, PlatformMediaSessionInterface*) final
-    {
-#if USE(AUDIO_SESSION)
-        return AudioSession::singleton().tryToSetActive(active);
-#else
-        UNUSED_PARAM(active);
-        return GenericPromise::createAndResolve();
-#endif
-    }
-
     void hasActiveNowPlayingSessionChanged(PlatformMediaSessionInterface*) final
     {
         if (RefPtr page = m_pageIdentifier ? Page::fromPageIdentifier(*m_pageIdentifier) : nullptr)

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -608,21 +608,6 @@ RemoteAudioSessionProxyManager& GPUProcess::audioSessionManager() const
 }
 #endif
 
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-void GPUProcess::tryToSetAudioSessionActiveForProcess(WebCore::ProcessIdentifier identifier, bool active, CompletionHandler<void(GenericPromise::Result&&)>&& completionHandler)
-{
-#if USE(AUDIO_SESSION)
-    protect(audioSessionManager())->tryToSetActiveForProcess(identifier, active)->whenSettled(RunLoop::mainSingleton(), [completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
-        completionHandler(WTF::move(result));
-    });
-#else
-    UNUSED_PARAM(identifier);
-    UNUSED_PARAM(active);
-    completionHandler(makeUnexpected(GenericPromise::RejectValueType { }));
-#endif
-}
-#endif
-
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
 WorkQueue& GPUProcess::videoMediaStreamTrackRendererQueue()
 {

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -231,9 +231,6 @@ private:
     void promptForGetDisplayMedia(WebCore::DisplayCapturePromptType, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&&);
     void cancelGetDisplayMediaPrompt();
 #endif
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    void tryToSetAudioSessionActiveForProcess(WebCore::ProcessIdentifier, bool, CompletionHandler<void(GenericPromise::Result&&)>&&);
-#endif
 #if PLATFORM(MAC)
     void NODELETE setScreenProperties(const WebCore::ScreenProperties&);
     void updateProcessName();

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -74,10 +74,6 @@ messages -> GPUProcess : AuxiliaryProcess {
     CancelGetDisplayMediaPrompt()
 #endif
 
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    TryToSetAudioSessionActiveForProcess(WebCore::ProcessIdentifier processID, bool active) -> (GenericPromise::Result result)
-#endif
-
 #if PLATFORM(MAC)
     OpenDirectoryCacheInvalidated(WebKit::SandboxExtensionHandle handle)
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -30,7 +30,6 @@
 
 #include "GPUConnectionToWebProcess.h"
 #include "GPUProcess.h"
-#include "GPUProcessProxyMessages.h"
 #include "Logging.h"
 #include "RemoteAudioSessionMessages.h"
 #include "RemoteAudioSessionProxyManager.h"
@@ -125,16 +124,8 @@ void RemoteAudioSessionProxy::tryToSetActive(bool active, SetActiveCompletion&& 
 #endif
             }
             completion(success);
-            if (hasActiveChanged && m_gpuConnection.get()) {
+            if (hasActiveChanged && m_gpuConnection.get())
                 configurationChanged();
-                // Also tell the UI-process RemoteMediaSessionManagerProxy singleton (the audio-session
-                // authority under site isolation) this process's active state, so its activation gate uses
-                // the value the GPU process owns rather than one relayed by the untrusted WebContent
-                // process. Guarded by the connection being live: processIdentifier() dereferences it, and
-                // when the process is gone the UI process cleans up via webProcessWillShutDown anyway.
-                if (RefPtr parentConnection = GPUProcess::singleton().parentProcessConnection())
-                    parentConnection->send(Messages::GPUProcessProxy::AudioSessionActiveStateChangedForProcess(processIdentifier(), m_active), 0);
-            }
             manager->updatePresentingProcesses();
             manager->updateSpatialExperience();
         });

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -205,32 +205,6 @@ static void providePresentingApplicationPID(RemoteAudioSessionProxy& proxy)
 }
 #endif
 
-Ref<AudioSession::SetActivePromise> RemoteAudioSessionProxyManager::tryToSetActiveForProcess(WebCore::ProcessIdentifier identifier, bool active)
-{
-    for (Ref proxy : m_proxies) {
-        if (proxy->processIdentifier() != identifier)
-            continue;
-
-        // Route through RemoteAudioSessionProxy::tryToSetActive (rather than the per-proxy overload
-        // below directly) so the proxy's active state, interruption flag, and the ConfigurationChanged
-        // push back to the WebContent process all happen — exactly as for a WebContent-initiated
-        // activation. Otherwise the proxy's isActive() stays stale, corrupting cross-process
-        // aggregation, and the original WebContent process never learns when the session's active
-        // state changes.
-        AudioSession::SetActivePromise::Producer producer;
-        Ref promise = producer.promise();
-        proxy->tryToSetActive(active, [producer = WTF::move(producer)](bool succeeded) mutable {
-            if (succeeded)
-                producer.resolve();
-            else
-                producer.reject();
-        });
-        return promise;
-    }
-
-    return AudioSession::SetActivePromise::createAndReject();
-}
-
 Ref<AudioSession::SetActivePromise> RemoteAudioSessionProxyManager::tryToSetActiveForProcess(RemoteAudioSessionProxy& proxy, bool active)
 {
     ASSERT(m_proxies.contains(proxy));

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -63,7 +63,6 @@ public:
     void updateSpatialExperience();
 
     Ref<WebCore::AudioSession::SetActivePromise> tryToSetActiveForProcess(RemoteAudioSessionProxy&, bool);
-    Ref<WebCore::AudioSession::SetActivePromise> tryToSetActiveForProcess(WebCore::ProcessIdentifier, bool);
 
     void beginInterruptionRemote();
     void endInterruptionRemote(WebCore::AudioSession::MayResume);

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -506,13 +506,6 @@ void GPUProcessProxy::cancelGetDisplayMediaPrompt()
 }
 #endif
 
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-Ref<GenericPromise> GPUProcessProxy::tryToSetAudioSessionActiveForProcess(WebCore::ProcessIdentifier identifier, bool active)
-{
-    return protect(connection())->sendWithPromisedReply<WTF::GenericPromiseConverter>(Messages::GPUProcess::TryToSetAudioSessionActiveForProcess(identifier, active));
-}
-#endif
-
 void GPUProcessProxy::getLaunchOptions(ProcessLauncher::LaunchOptions& launchOptions)
 {
     launchOptions.processType = ProcessLauncher::ProcessType::GPU;
@@ -895,22 +888,6 @@ void GPUProcessProxy::statusBarWasTapped(CompletionHandler<void()>&& completionH
 }
 #endif
 #endif // ENABLE(MEDIA_STREAM)
-
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-void GPUProcessProxy::audioSessionActiveStateChangedForProcess(WebCore::ProcessIdentifier webProcessIdentifier, bool active)
-{
-    // The GPU process owns each web process's real audio-session active state; forward it to the
-    // UI-process RemoteMediaSessionManagerProxy singleton, which uses it at its activation gate instead
-    // of a value relayed by the (untrusted) WebContent process.
-#if USE(AUDIO_SESSION)
-    if (RefPtr manager = RemoteMediaSessionManagerProxy::singletonIfCreated())
-        manager->setAudioSessionActiveForProcess(webProcessIdentifier, active);
-#else
-    UNUSED_PARAM(webProcessIdentifier);
-    UNUSED_PARAM(active);
-#endif
-}
-#endif
 
 #if HAVE(AUDIT_TOKEN)
 void GPUProcessProxy::setPresentingApplicationAuditToken(WebCore::ProcessIdentifier processIdentifier, WebCore::PageIdentifier pageIdentifier, std::optional<CoreIPCAuditToken> auditToken)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -124,10 +124,6 @@ public:
     void cancelGetDisplayMediaPrompt();
 #endif
 
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    Ref<GenericPromise> tryToSetAudioSessionActiveForProcess(WebCore::ProcessIdentifier, bool);
-#endif
-
     void removeSession(PAL::SessionID);
 
 #if PLATFORM(MAC)
@@ -234,10 +230,6 @@ private:
     void statusBarWasTapped(CompletionHandler<void()>&&);
 #endif
 #endif // ENABLE(MEDIA_STREAM)
-
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    void audioSessionActiveStateChangedForProcess(WebCore::ProcessIdentifier, bool active);
-#endif
 
     GPUProcessCreationParameters processCreationParameters();
     void platformInitializeGPUProcessParameters(GPUProcessCreationParameters&);

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
@@ -45,10 +45,6 @@ messages -> GPUProcessProxy {
 #endif
 #endif
 
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    AudioSessionActiveStateChangedForProcess(WebCore::ProcessIdentifier webProcessIdentifier, bool active)
-#endif
-
     ProcessIsReadyToExit()
     TerminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier, enum:uint16_t IPC::MessageName invalidMessageName)
 }

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -28,7 +28,6 @@
 
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
 
-#include "GPUProcessProxy.h"
 #include "MessageSenderInlines.h"
 #include "RemoteMediaSessionManagerMessages.h"
 #include "RemoteMediaSessionManagerProxyMessages.h"
@@ -37,10 +36,8 @@
 #include "SharedPreferencesForWebProcess.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
-#include <WebCore/MediaSessionManagerClient.h>
 #include <WebCore/PlatformMediaSessionInterface.h>
 #include <WebCore/PlatformMediaSessionManager.h>
-#include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -89,51 +86,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionManagerAudioHardwareListener);
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionManagerProxy);
 
-#if USE(AUDIO_SESSION)
-// Routes the UI-process singleton's audio-session activation to the GPU process, on behalf of the
-// web process that owns the triggering session. NowPlaying routing will be added in a follow-up.
-class RemoteMediaSessionManagerProxyClient final : public WebCore::MediaSessionManagerClient {
-    WTF_MAKE_TZONE_ALLOCATED(RemoteMediaSessionManagerProxyClient);
-public:
-    explicit RemoteMediaSessionManagerProxyClient(RemoteMediaSessionManagerProxy& manager)
-        : m_manager(manager) { }
-
-private:
-    Ref<GenericPromise> tryToSetAudioSessionActive(bool active, WebCore::PlatformMediaSessionInterface* session) final
-    {
-        RefPtr manager = m_manager.get();
-        if (!manager)
-            return GenericPromise::createAndReject();
-
-        if (!active) {
-            // The base class only asks to deactivate once no session needs the audio session anymore
-            // (hasNoSession), so drop activation for every web process we activated.
-            manager->deactivateAllAudioSessions();
-            return GenericPromise::createAndResolve();
-        }
-
-        // Activate the audio session for the web process that owns the triggering session.
-        if (!session)
-            return GenericPromise::createAndReject();
-
-        auto target = manager->processForSession(*session);
-        if (!target)
-            return GenericPromise::createAndReject();
-
-        return manager->enqueueAudioSessionActivation(*target, true);
-    }
-
-    void hasActiveNowPlayingSessionChanged(WebCore::PlatformMediaSessionInterface*) final
-    {
-        // FIXME: route to the top-level WebPageProxy for the session's page (follow-up).
-    }
-
-    WeakPtr<RemoteMediaSessionManagerProxy> m_manager;
-};
-
-WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionManagerProxyClient);
-#endif // USE(AUDIO_SESSION)
-
 static WeakPtr<RemoteMediaSessionManagerProxy>& NODELETE singletonWeakPtr()
 {
     static NeverDestroyed<WeakPtr<RemoteMediaSessionManagerProxy>> singleton;
@@ -156,12 +108,10 @@ RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy()
     : REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS(std::nullopt) // No need to access a WebCore::Page in the UI process
 {
 #if USE(AUDIO_SESSION)
-    // The UI-process singleton is the audio-session authority under site isolation, so it must
-    // deactivate the shared session once no web process needs it. Page::ensureMediaSessionManager
-    // sets this on a page's manager, but the singleton has no Page, so set it here.
-    setShouldDeactivateAudioSession(true);
+    // This manager has no audio session of its own to drive: each content process activates its own with
+    // the GPU process. Being the UI process's shared session keeps the configuration this process reports
+    // in sync with the content processes and stops a real one being created here.
     AudioSession::setSharedSession(*this);
-    setClient(makeUnique<RemoteMediaSessionManagerProxyClient>(*this));
 #endif
 
 #if PLATFORM(COCOA)
@@ -196,26 +146,6 @@ void RemoteMediaSessionManagerProxy::removeMediaSession(IPC::Connection& connect
     if (RefPtr session = findAndUpdateSession(connection, state))
         removeSession(*session);
     m_sessionProxies.remove({ state.sessionIdentifier, processIdentifier });
-
-#if USE(AUDIO_SESSION)
-    // If that was the process's last session and it is not still capturing audio, drive its audio session
-    // inactive and clear the per-process activation state now -- decoupled from the global
-    // maybeDeactivateAudioSession() path (gated on m_becameActive, which can't track per-process state).
-    // Otherwise a reused process (same-origin navigation) keeps a stale "active" flag and the next document's
-    // sessionWillBeginPlayback skips activation even though the process's audio session was reset.
-    bool processStillHasSession = false;
-    for (auto& key : m_sessionProxies.keys()) {
-        if (key.processIdentifier() == processIdentifier) {
-            processStillHasSession = true;
-            break;
-        }
-    }
-    if (!processStillHasSession && !processRequiresAudioSession(processIdentifier)) {
-        auto it = m_activationByProcess.find(processIdentifier);
-        if (it != m_activationByProcess.end() && it->value.active)
-            enqueueAudioSessionActivation(processIdentifier, false)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
-    }
-#endif
 }
 
 void RemoteMediaSessionManagerProxy::webProcessWillShutDown(WebCore::ProcessIdentifier processIdentifier)
@@ -239,14 +169,6 @@ void RemoteMediaSessionManagerProxy::webProcessWillShutDown(WebCore::ProcessIden
         return entry.key.processIdentifier() == processIdentifier;
     }))
         updateSessionState();
-
-#if USE(AUDIO_SESSION)
-    // The process is gone; drop the activation state we tracked for it (keyed by ProcessIdentifier, so a
-    // reused process starts clean). The pending activations' waiters are AutoRejectProducers, so removing the
-    // entry rejects any still-pending promises as it is destroyed. setAudioSessionActiveForProcess() relies on
-    // this removal (it uses find(), not ensure(), so it never resurrects a departed process's entry).
-    m_activationByProcess.remove(processIdentifier);
-#endif
 }
 
 void RemoteMediaSessionManagerProxy::setCurrentMediaSession(IPC::Connection& connection, RemoteMediaSessionState&& state)
@@ -270,23 +192,10 @@ void RemoteMediaSessionManagerProxy::updateMediaSessionStates(IPC::Connection& c
 
     auto process = WebProcessProxy::fromConnection(connection)->coreProcessIdentifier();
     WebCore::ProcessQualified<WebCore::PageIdentifier> key { WTF::move(pageIdentifier), process };
-#if USE(AUDIO_SESSION)
-    uint64_t previousPageCaptureCount = m_audioCaptureSourceCountsByPage.get(key);
-#endif
     if (!audioCaptureSourceCount)
         m_audioCaptureSourceCountsByPage.remove(key);
     else
         m_audioCaptureSourceCountsByPage.set(key, audioCaptureSourceCount);
-
-#if USE(AUDIO_SESSION)
-    // Drive audio-session activation for this process's audio capture: activeAudioSessionRequired() can't see
-    // capture from the UI process (only the count is forwarded, not the AudioCaptureSource objects), so key off
-    // the capture-count transition -- activate when it starts, deactivate when it stops and nothing else needs it.
-    if (audioCaptureSourceCount && !previousPageCaptureCount)
-        enqueueAudioSessionActivation(process, true)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
-    else if (!audioCaptureSourceCount && previousPageCaptureCount && !processRequiresAudioSession(process))
-        enqueueAudioSessionActivation(process, false)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
-#endif
 }
 
 int RemoteMediaSessionManagerProxy::countActiveAudioCaptureSources()
@@ -316,28 +225,12 @@ void RemoteMediaSessionManagerProxy::setCurrentSession(WebCore::PlatformMediaSes
     REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::setCurrentSession(session);
 }
 
-void RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback(IPC::Connection& connection, RemoteMediaSessionState&& state, CompletionHandler<void(bool)>&& completionHandler)
+void RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback(IPC::Connection& connection, RemoteMediaSessionState&& state)
 {
-    RefPtr session = findAndUpdateSession(connection, state);
-    if (!session) {
-        completionHandler(false);
-        return;
-    }
-
-#if USE(AUDIO_SESSION)
-    // Mirror this process's real audio-session active state onto the shared session's active flag (which
-    // the base sessionWillBeginPlayback reads via AudioSession::singleton().isActive() on its fast-activation
-    // path) before the base activation gate, so the gate decides on this process's reality. The value is the
-    // authoritative per-process state the GPU process reports (via setAudioSessionActiveForProcess()) plus the
-    // activation chain (NOT a WebContent-supplied bool); the per-process entry the base reads via hasActiveAudioSession()
-    // is already up to date. Key by the connection's process (trusted), not by any value the web process
-    // sent. setActive() only sets the flag; it fires no observers.
-    auto processIdentifier = WebProcessProxy::fromConnection(connection)->coreProcessIdentifier();
-    auto it = m_activationByProcess.find(processIdentifier);
-    AudioSession::setActive(it != m_activationByProcess.end() && it->value.active);
-#endif
-
-    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionWillBeginPlayback(*session, WTF::move(completionHandler));
+    // The content process decided whether playback may begin; this runs the part that needs every
+    // process's sessions: making this one current, and the concurrent playback restriction.
+    if (RefPtr session = findAndUpdateSession(connection, state))
+        REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionWillBeginPlayback(*session, [](bool) { });
 }
 
 void RemoteMediaSessionManagerProxy::addMediaSessionRestriction(WebCore::PlatformMediaSessionMediaType type, WebCore::MediaSessionRestrictions restrictions)
@@ -358,205 +251,16 @@ void RemoteMediaSessionManagerProxy::resetMediaSessionRestrictions()
 #if USE(AUDIO_SESSION)
 void RemoteMediaSessionManagerProxy::remoteAudioConfigurationChanged(RemoteAudioSessionConfiguration&& configuration)
 {
-    // configuration.isActive is NOT trusted for the activation gate: it is relayed by the (untrusted)
-    // WebContent process. Each process's active state is derived from the GPU process via
-    // setAudioSessionActiveForProcess(); this message carries only the descriptive configuration
-    // (category, sample rate, buffer size, routing, ...).
+    // configuration.isActive is NOT trusted: it is relayed by the (untrusted) WebContent process. This
+    // message carries only the descriptive configuration (category, sample rate, buffer size, routing, ...).
     m_audioConfiguration = WTF::move(configuration);
 }
 
-void RemoteMediaSessionManagerProxy::setAudioSessionActiveForProcess(WebCore::ProcessIdentifier process, bool active)
+Ref<WebCore::AudioSession::SetActivePromise> RemoteMediaSessionManagerProxy::tryToSetActiveInternal(bool)
 {
-    // Correct the cached active state of a process the UI process is already tracking, pushed by the GPU
-    // process (see GPUProcessProxy::audioSessionActiveStateChangedForProcess). Use find(), NOT ensure():
-    // creating an entry here could resurrect one that webProcessWillShutDown() removed while an activation
-    // IPC was still in flight, and the stale reply would then crash sendNextActivationIPC()'s completion on
-    // an empty chain. A process we aren't tracking has no cache to correct -- its next gate just activates.
-    auto it = m_activationByProcess.find(process);
-    if (it == m_activationByProcess.end())
-        return;
-    // Don't clobber an in-flight UI-driven activation/deactivation: while its chain is pending the
-    // optimistic state governs (that is what lets stop->replay re-activate), and the chain reverts on
-    // failure / otherwise converges to what the GPU process reports. Adopt the GPU process's value only
-    // when the process's chain is quiescent.
-    auto& state = it->value;
-    if (state.ipcInFlight || !state.pendingChain.isEmpty())
-        return;
-    state.active = active;
-}
-
-Ref<WebCore::AudioSession::SetActivePromise> RemoteMediaSessionManagerProxy::tryToSetActiveInternal(bool active)
-{
-    if (active && m_isInterruptedForTesting)
-        return SetActivePromise::createAndReject();
-
-    return client().tryToSetAudioSessionActive(active, currentSession().get());
-}
-
-void RemoteMediaSessionManagerProxy::reevaluateAudioSessionActivation(WebCore::PlatformMediaSessionInterface& session)
-{
-    scheduleUpdateSessionState();
-
-    auto process = processForSession(session);
-    if (!process)
-        return;
-
-    // Gate on the session's own process, not the manager-wide activeAudioSessionRequired(): otherwise an
-    // unrelated process holding an audible session would let this process -- driven by its own untrusted
-    // state update -- activate the shared session and cache active=true for itself, short-circuiting its
-    // later playback-activation gate. Mirrors remoteProcessDidResume().
-    if (!processRequiresAudioSession(*process))
-        return;
-
-    enqueueAudioSessionActivation(*process, true);
-}
-
-void RemoteMediaSessionManagerProxy::remoteProcessWillSuspend(IPC::Connection& connection)
-{
-    // The content process is suspending and no longer drives the shared audio session, so release it here;
-    // otherwise a suspended process would keep the system session active (matching the pre-site-isolation
-    // behavior where the web process released it on suspend).
-    auto process = WebProcessProxy::fromConnection(connection)->coreProcessIdentifier();
-    enqueueAudioSessionActivation(process, false);
-}
-
-void RemoteMediaSessionManagerProxy::remoteProcessDidResume(IPC::Connection& connection)
-{
-    auto process = WebProcessProxy::fromConnection(connection)->coreProcessIdentifier();
-    if (processRequiresAudioSession(process))
-        enqueueAudioSessionActivation(process, true);
-}
-
-bool RemoteMediaSessionManagerProxy::hasActiveAudioSession(WebCore::PlatformMediaSessionInterface& session) const
-{
-    // Track activation per web process instead of with the base class's single flag: under site
-    // isolation one manager serves every process, so a session in one process must not make
-    // sessionWillBeginPlayback treat a session in another process as already active (which would skip
-    // activating the latter). Emulates the non-site-isolation model where each process has its own manager.
-    auto process = processForSession(session);
-    if (!process)
-        return false;
-    auto it = m_activationByProcess.find(*process);
-    return it != m_activationByProcess.end() && it->value.active;
-}
-
-std::optional<WebCore::ProcessIdentifier> RemoteMediaSessionManagerProxy::processForSession(const WebCore::PlatformMediaSessionInterface& session) const
-{
-    for (auto& entry : m_sessionProxies) {
-        if (entry.value.ptr() == &session)
-            return entry.key.processIdentifier();
-    }
-    return std::nullopt;
-}
-
-bool RemoteMediaSessionManagerProxy::processRequiresAudioSession(WebCore::ProcessIdentifier process) const
-{
-    for (auto& entry : m_audioCaptureSourceCountsByPage) {
-        if (entry.key.processIdentifier() == process && entry.value)
-            return true;
-    }
-    for (auto& entry : m_sessionProxies) {
-        if (entry.key.processIdentifier() != process)
-            continue;
-        Ref session = entry.value;
-        if (session->activeAudioSessionRequired())
-            return true;
-    }
-    return false;
-}
-
-Ref<WebCore::AudioSession::SetActivePromise> RemoteMediaSessionManagerProxy::enqueueAudioSessionActivation(WebCore::ProcessIdentifier process, bool active)
-{
-    auto& state = m_activationByProcess.ensure(process, [] {
-        return ProcessActivationState { };
-    }).iterator->value;
-
-    SetActivePromise::AutoRejectProducer producer;
-    Ref promise = producer.promise();
-
-    // Optimistically reflect the requested state so hasActiveAudioSession() sees it without waiting
-    // for the GPU process round-trip. This is what lets a stop->replay re-activate: the replay's gate sees the
-    // process as inactive (set when the deactivation was enqueued) even while that deactivation IPC is
-    // still in flight. Mirrors RemoteAudioSession's optimistic setActive.
-    state.active = active;
-
-    // Keep at most one activation IPC per process in flight, coalescing consecutive same-state requests
-    // against the tail; a different-state request appends a new entry dispatched when the previous reply
-    // arrives. This serializes an in-flight deactivation and a following activation so the last state wins.
-    if (!state.pendingChain.isEmpty() && state.pendingChain.last().active == active) {
-        state.pendingChain.last().waiters.append(WTF::move(producer));
-        return promise;
-    }
-
-    PendingActivation entry { active, { } };
-    entry.waiters.append(WTF::move(producer));
-    state.pendingChain.append(WTF::move(entry));
-
-    sendNextActivationIPC(process);
-    return promise;
-}
-
-void RemoteMediaSessionManagerProxy::deactivateAllAudioSessions()
-{
-    Vector<WebCore::ProcessIdentifier> processes;
-    for (auto& entry : m_activationByProcess) {
-        if (entry.value.active)
-            processes.append(entry.key);
-    }
-    for (auto process : processes)
-        enqueueAudioSessionActivation(process, false);
-}
-
-void RemoteMediaSessionManagerProxy::sendNextActivationIPC(WebCore::ProcessIdentifier process)
-{
-    auto it = m_activationByProcess.find(process);
-    if (it == m_activationByProcess.end() || it->value.ipcInFlight || it->value.pendingChain.isEmpty())
-        return;
-
-    bool active = it->value.pendingChain.first().active;
-    it->value.ipcInFlight = true;
-
-    auto processResult = [protectedThis = Ref { *this }, process, active](bool succeeded) mutable {
-        auto it = protectedThis->m_activationByProcess.find(process);
-        if (it == protectedThis->m_activationByProcess.end())
-            return;
-
-        // The chain should be non-empty while an IPC we sent is outstanding. An empty chain here means a
-        // stale reply for an entry that was reset (e.g. removed at process shutdown then re-created) --
-        // unexpected, so ASSERT to catch it in debug (this assert is what surfaced the ensure()-resurrection
-        // bug on the bots), but tolerate it in release rather than take from an empty chain.
-        ASSERT(!it->value.pendingChain.isEmpty());
-        if (it->value.pendingChain.isEmpty())
-            return;
-
-        ASSERT(it->value.pendingChain.first().active == active);
-        auto pending = it->value.pendingChain.takeFirst();
-        it->value.ipcInFlight = false;
-
-        // If the request failed and nothing newer superseded it, revert the optimistic state.
-        if (!succeeded && it->value.pendingChain.isEmpty())
-            it->value.active = !active;
-
-        protectedThis->sendNextActivationIPC(process);
-
-        for (auto& waiter : pending.waiters) {
-            if (succeeded)
-                waiter.resolve();
-            else
-                waiter.reject();
-        }
-    };
-
-    RefPtr gpuProcess = GPUProcessProxy::singletonIfCreated();
-    if (!gpuProcess) {
-        processResult(false);
-        return;
-    }
-
-    gpuProcess->tryToSetAudioSessionActiveForProcess(process, active)->whenSettled(RunLoop::mainSingleton(),
-        [processResult = WTF::move(processResult)](auto&& result) mutable {
-            processResult(result.has_value());
-        });
+    // Each content process activates its own audio session with the GPU process, so the UI process has
+    // no session of its own to activate.
+    return SetActivePromise::createAndResolve();
 }
 
 void RemoteMediaSessionManagerProxy::setPreferredBufferSize(size_t size)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -34,7 +34,6 @@
 #include <WebCore/MediaSessionIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessQualified.h>
-#include <wtf/Deque.h>
 #include <wtf/HashMap.h>
 #include <wtf/NativePromise.h>
 #include <wtf/Ref.h>
@@ -61,7 +60,6 @@ class PlatformMediaSessionInterface;
 namespace WebKit {
 
 class RemoteMediaSessionManagerAudioHardwareListener;
-class RemoteMediaSessionManagerProxyClient;
 class RemoteMediaSessionProxy;
 class WebPageProxy;
 class WebProcessProxy;
@@ -75,7 +73,6 @@ class RemoteMediaSessionManagerProxy
 #endif
     , public IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(RemoteMediaSessionManagerProxy);
-    friend class RemoteMediaSessionManagerProxyClient;
 public:
     USING_CAN_MAKE_WEAKPTR(MessageReceiver);
 
@@ -85,19 +82,6 @@ public:
     virtual ~RemoteMediaSessionManagerProxy();
 
     void webProcessWillShutDown(WebCore::ProcessIdentifier);
-
-#if USE(AUDIO_SESSION)
-    // Called by a RemoteMediaSessionProxy when its session's state changes. Under site isolation the content
-    // process keeps only an optimistic local audio-session state and does not drive the GPU (see
-    // RemoteAudioSession::sendNextActivationIPC); the UI process is the sole activation driver, so it activates
-    // the given session's process here when the session requires an active audio session (e.g. WebAudio, which
-    // becomes audible only after begin).
-    void reevaluateAudioSessionActivation(WebCore::PlatformMediaSessionInterface&);
-
-    // Called by GPUProcessProxy with the GPU-authoritative per-process audio-session active state (the
-    // trusted source), so the activation gate never depends on a value sent by the WebContent process.
-    void setAudioSessionActiveForProcess(WebCore::ProcessIdentifier, bool active);
-#endif
 
     // IPC::MessageReceiver, WebCore::AudioSession.
     void ref() const final { WebCore::REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::ref(); }
@@ -120,7 +104,7 @@ private:
     void setCurrentMediaSession(IPC::Connection&, RemoteMediaSessionState&&);
     void updateMediaSessionStates(IPC::Connection&, WebCore::PageIdentifier, Vector<RemoteMediaSessionState>&&, uint64_t audioCaptureSourceCount);
     void mediaSessionStateChanged(IPC::Connection&, WebKit::RemoteMediaSessionState&&);
-    void mediaSessionWillBeginPlayback(IPC::Connection&, RemoteMediaSessionState&&, CompletionHandler<void(bool)>&&);
+    void mediaSessionWillBeginPlayback(IPC::Connection&, RemoteMediaSessionState&&);
 
     // The audio session category is computed by each content process for its own sessions; the GPU
     // process reconciles them. Nothing is computed here.
@@ -142,8 +126,6 @@ private:
 
 #if USE(AUDIO_SESSION)
     void remoteAudioConfigurationChanged(RemoteAudioSessionConfiguration&&);
-    void remoteProcessWillSuspend(IPC::Connection&);
-    void remoteProcessDidResume(IPC::Connection&);
 
     // AudioSession
     String routingContextUID() const final { return m_audioConfiguration.routingContextUID; }
@@ -155,12 +137,6 @@ private:
     size_t outputLatency() const final { return m_audioConfiguration.outputLatency; }
 
     Ref<SetActivePromise> tryToSetActiveInternal(bool) final;
-    bool hasActiveAudioSession(WebCore::PlatformMediaSessionInterface&) const final;
-    std::optional<WebCore::ProcessIdentifier> processForSession(const WebCore::PlatformMediaSessionInterface&) const;
-    bool processRequiresAudioSession(WebCore::ProcessIdentifier) const;
-    Ref<SetActivePromise> enqueueAudioSessionActivation(WebCore::ProcessIdentifier, bool active);
-    void deactivateAllAudioSessions();
-    void sendNextActivationIPC(WebCore::ProcessIdentifier);
 
     size_t preferredBufferSize() const final { return m_audioConfiguration.preferredBufferSize; }
     void setPreferredBufferSize(size_t) final;
@@ -187,19 +163,8 @@ private:
 #if USE(AUDIO_SESSION)
     mutable RemoteAudioSessionConfiguration m_audioConfiguration;
 
-    struct PendingActivation {
-        bool active;
-        Vector<WebCore::AudioSession::SetActivePromise::AutoRejectProducer> waiters;
-    };
-    struct ProcessActivationState {
-        bool active { false };
-        Deque<PendingActivation> pendingChain;
-        bool ipcInFlight { false };
-    };
-    HashMap<WebCore::ProcessIdentifier, ProcessActivationState> m_activationByProcess;
 #endif
 
-    bool m_isInterruptedForTesting { false };
     bool m_isInSetCurrentSession { false };
 };
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in
@@ -39,7 +39,7 @@ messages -> RemoteMediaSessionManagerProxy {
     void RemoveMediaSessionRestriction(enum:uint8_t WebCore::PlatformMediaSessionMediaType type, WebCore::MediaSessionRestrictions restrictions);
     void ResetMediaSessionRestrictions();
 
-    MediaSessionWillBeginPlayback(struct WebKit::RemoteMediaSessionState session) -> (bool granted)
+    void MediaSessionWillBeginPlayback(struct WebKit::RemoteMediaSessionState session)
 
 #if PLATFORM(COCOA)
     void RemoteAudioHardwareDidBecomeActive();
@@ -49,8 +49,6 @@ messages -> RemoteMediaSessionManagerProxy {
 
 #if USE(AUDIO_SESSION)
     void RemoteAudioConfigurationChanged(struct WebKit::RemoteAudioSessionConfiguration configuration);
-    void RemoteProcessWillSuspend();
-    void RemoteProcessDidResume();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
@@ -68,13 +68,6 @@ void RemoteMediaSessionProxy::updateState(const RemoteMediaSessionState& remoteS
 {
     m_sessionState = remoteState;
     downcast<RemoteMediaSessionClientProxy>(protect(client())).updateState(remoteState);
-
-#if USE(AUDIO_SESSION)
-    // Re-evaluate activation for this session when its state changes: WebAudio becomes audible (canProduceAudio)
-    // only after sessionWillBeginPlayback, so the begin-time activation gate can't catch it.
-    if (RefPtr manager = RemoteMediaSessionManagerProxy::singletonIfCreated())
-        manager->reevaluateAudioSessionActivation(*this);
-#endif
 }
 
 void RemoteMediaSessionProxy::setState(WebCore::PlatformMediaSessionState state)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -161,19 +161,6 @@ void RemoteAudioSession::sendNextActivationIPC()
     if (m_activationIPCInFlight || m_pendingActivationChain.isEmpty())
         return;
 
-    // Under site isolation the UI process is the sole driver of the shared audio session; the content
-    // process keeps only an optimistic local view (set in tryToSetActiveInternal) and must not send
-    // TryToSetActive to the GPU, or it would race the UI process. Resolve the pending waiters and let the
-    // GPU push the authoritative state back via configurationChanged.
-    if (WebProcess::singleton().sharedPreferencesForWebProcessValue().remoteMediaSessionManagerEnabled) {
-        while (!m_pendingActivationChain.isEmpty()) {
-            auto pending = m_pendingActivationChain.takeFirst();
-            for (auto& waiter : pending.waiters)
-                waiter.resolve();
-        }
-        return;
-    }
-
     bool active = m_pendingActivationChain.first().active;
     m_activationIPCInFlight = true;
 
@@ -245,10 +232,9 @@ void RemoteAudioSession::configurationChanged(RemoteAudioSessionConfiguration&& 
 
     m_configuration = WTF::move(configuration);
 
-    // The GPU process is the source of truth for whether the audio session is active. Mirror it
-    // here so AudioSession::isActive() and its observers behave the same with and without site
-    // isolation, even with the site isolation activation is decided in the UI process which
-    // talks to the RemoteAudioSessionProxy in the GPU directly.
+    // The GPU process is the source of truth for whether the audio session is active. Mirror it here so
+    // AudioSession::isActive() and its observers see an active-state change the GPU process decided on its
+    // own, such as this process losing the session to another one.
     if (activeChanged) {
         setActive(m_configuration->isActive);
         activeStateChanged();
@@ -268,13 +254,7 @@ void RemoteAudioSession::configurationChanged(RemoteAudioSessionConfiguration&& 
             observer.routingContextUIDDidChange(*this);
     });
 
-    // Forward the configuration to the UI process on an active-state change too (not only on
-    // muted/buffer/sampleRate/routing changes) so the RemoteMediaSessionManagerProxy singleton's
-    // per-process activation state mirrors this web process's real audio session state. Under site
-    // isolation the UI process has no other signal for a GPU-driven active-state change (e.g. after a
-    // same-origin navigation reuses the process), so without this its cached state drifts and it can
-    // wrongly skip activating the reused process.
-    if (!mutedStateChanged && !bufferSizeChanged && !sampleRateChanged && !routingContextUIDChanged && !activeChanged)
+    if (!mutedStateChanged && !bufferSizeChanged && !sampleRateChanged && !routingContextUIDChanged)
         return;
 
     RefPtr protectedProcess = m_webProcess.get();

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
@@ -112,23 +112,14 @@ void RemoteMediaSessionManager::setCurrentSession(WebCore::PlatformMediaSessionI
 
 void RemoteMediaSessionManager::sessionWillBeginPlayback(WebCore::PlatformMediaSessionInterface& session, CompletionHandler<void(bool)>&& completionHandler)
 {
-    // MediaSession never calls PlatformMediaSession::setActive(), so setCurrentSession() is the only
-    // thing that registers it here, and beginInterruption() only reaches registered sessions.
-    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::setCurrentSession(session);
-
-    // The UI process runs the rest of the admission on this session's RemoteMediaSessionProxy. Ending
-    // the interruption the session was under has to happen here, where the interrupted sessions are.
-    bool sessionWasAlreadyInterrupted = session.state() == WebCore::PlatformMediaSessionState::Interrupted;
-
-    // The UI-process proxy decides activation using each process's audio-session active state as reported
-    // by the GPU process (the source of truth); this process does not send its own view, which the proxy
-    // could not trust.
-    sendWithAsyncReply(Messages::RemoteMediaSessionManagerProxy::MediaSessionWillBeginPlayback(currentSessionState(session)),
-        [protectedThis = Ref { *this }, sessionWasAlreadyInterrupted, completionHandler = WTF::move(completionHandler)](bool granted) mutable {
-            if (granted && sessionWasAlreadyInterrupted && protectedThis->isInterrupted())
-                protectedThis->endInterruption(WebCore::PlatformMediaSessionEndInterruptionFlags::NoFlags);
-            completionHandler(granted);
-        });
+    // Whether playback may begin is decided here: the session, its state and the restrictions are all
+    // in this process. The UI process is told so that it can make this session current and enforce the
+    // concurrent playback restriction across every process's sessions.
+    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionWillBeginPlayback(session, [protectedThis = Ref { *this }, state = currentSessionState(session), completionHandler = WTF::move(completionHandler)](bool granted) mutable {
+        if (granted)
+            protectedThis->send(Messages::RemoteMediaSessionManagerProxy::MediaSessionWillBeginPlayback(state));
+        completionHandler(granted);
+    });
 }
 
 void RemoteMediaSessionManager::addRestriction(WebCore::PlatformMediaSessionMediaType type, WebCore::MediaSessionRestrictions restrictions)
@@ -170,24 +161,6 @@ void RemoteMediaSessionManager::sessionStateChanged(WebCore::PlatformMediaSessio
 {
     send(Messages::RemoteMediaSessionManagerProxy::MediaSessionStateChanged(currentSessionState(session)));
     REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionStateChanged(session);
-}
-
-void RemoteMediaSessionManager::processWillSuspend()
-{
-    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::processWillSuspend();
-#if USE(AUDIO_SESSION)
-    // The base class only updated this process's optimistic local state; under site isolation the UI process
-    // owns the shared audio session, so ask it to release this process's session on suspend.
-    send(Messages::RemoteMediaSessionManagerProxy::RemoteProcessWillSuspend());
-#endif
-}
-
-void RemoteMediaSessionManager::processDidResume()
-{
-    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::processDidResume();
-#if USE(AUDIO_SESSION)
-    send(Messages::RemoteMediaSessionManagerProxy::RemoteProcessDidResume());
-#endif
 }
 
 RefPtr<WebCore::PlatformMediaSessionInterface> RemoteMediaSessionManager::sessionWithIdentifier(WebCore::MediaSessionIdentifier identifier)

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h
@@ -98,8 +98,6 @@ private:
     void sessionWillBeginPlayback(WebCore::PlatformMediaSessionInterface&, CompletionHandler<void(bool)>&&) final;
     void updateSessionState() final;
     void sessionStateChanged(WebCore::PlatformMediaSessionInterface&) final;
-    void processWillSuspend() final;
-    void processDidResume() final;
 
     void addRestriction(WebCore::PlatformMediaSessionMediaType, WebCore::MediaSessionRestrictions) final;
     void removeRestriction(WebCore::PlatformMediaSessionMediaType, WebCore::MediaSessionRestrictions) final;


### PR DESCRIPTION
#### a2aebcb3a8edd1d1eff788e4fe509dbdb758e026
<pre>
[site-isolation] The content process should decide whether playback may begin and activate the audio session itself
<a href="https://bugs.webkit.org/show_bug.cgi?id=321774">https://bugs.webkit.org/show_bug.cgi?id=321774</a>
<a href="https://rdar.apple.com/184896873">rdar://184896873</a>

Reviewed by Eric Carlson.

Under site isolation, three things ran in the UI process when then didn&apos;t have to:

1) The playback admission ran in the UI process on a mirrored session:
    RemoteMediaSessionManager::sessionWillBeginPlayback sent MediaSessionWillBeginPlayback and waited
    for granted, which RemoteMediaSessionManagerProxy computed by running the base
    sessionWillBeginPlayback on a RemoteMediaSessionProxy. Both inputs to that decision were in the
    content process already: the session state, since interruptions reached it
    from the GPU process through RemoteAudioSession::beginInterruptionRemote,
    and the restrictions, which RemoteMediaSessionManager::addRestriction kept
    there as well as forwarding.

2) The UI process activated the audio session on behalf of each content process, per process since
    319006@main: an activation queue and per-process state, TryToSetAudioSessionActiveForProcess to
    the GPU process, and AudioSessionActiveStateChangedForProcess back from it. That hop decided
    nothing. It carried a ProcessIdentifier and a bool to
    RemoteAudioSessionProxyManager::tryToSetActiveForProcess, which a content process could reach
    directly through its own RemoteAudioSessionProxy, and where the arbitration across processes had
    always been.

3) The check meant to stop the content process driving the GPU process at the same time read
    sharedPreferencesForWebProcessValue().remoteMediaSessionManagerEnabled, which was false by
    default and was not set by --site-isolation, while WebPage installed the RemoteMediaSessionManager
    when either that preference or SiteIsolationEnabled was set. So both processes drove the same
    process&apos;s audio session, each through its own activation chain and neither aware of the other&apos;s,
    and resetToConsistentStateForTesting() reached the GPU process between test iterations for the
    same reason.

RemoteMediaSessionManager::sessionWillBeginPlayback now calls the base implementation, so the whole
admission runs where the sessions, their state and the restrictions are, and
MediaSessionWillBeginPlayback becomes a void message, sent so that the UI process can still make
the session current and enforce the concurrent playback restriction across every process&apos;s
sessions. RemoteAudioSession sends TryToSetActive to the GPU process again, so the activation
failure arrives on the activation reply, resolving or rejecting the waiters that
MediaSessionManagerInterface::sessionWillBeginPlayback already reads;
clientWillBeginPlayback&apos;s CompletionHandler is unchanged.

Activation runs as it did before 318337@main: the content process&apos;s AudioSession::singleton()
is a RemoteAudioSession, whose tryToSetActive sends TryToSetActive to that
process&apos;s RemoteAudioSessionProxy in the GPU process. The proxy hands it to
RemoteAudioSessionProxyManager, which arbitrates against the other processes&apos;
proxies and activates the audio session the GPU process owns.
The reply resolves or rejects the promise the content process is waiting on, and
RemoteAudioSessionProxy::configurationChanged pushes the resulting state back to
it.

The UI process no longer activates an audio session on behalf of another process, because it does
not need to: nothing there reads a per-process active state now, the concurrent playback
restriction and the current session work from PlatformMediaSession state, and the GPU process has
the real state first-hand. RemoteMediaSessionManagerProxy stays the UI process&apos;s shared audio
session, as 303417@main made it, so this process reports the configuration the content processes
see, and its tryToSetActiveInternal resolves without doing anything.

RemoteMediaSessionManager::processWillSuspend and processDidResume are removed with the messages
they sent: the base versions deactivate and re-activate this process&apos;s own session, which reaches
the GPU process now that the check in 3) is gone.

Commits 318337@main and 319006@main are reverted apart from their tests.

* Source/WebCore/platform/audio/MediaSessionManagerClient.h:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::PageMediaSessionManagerClient::tryToSetAudioSessionActive): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::tryToSetAudioSessionActiveForProcess): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebCore/platform/audio/MediaSessionManagerClient.h:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::PageMediaSessionManagerClient::tryToSetAudioSessionActive): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::tryToSetAudioSessionActiveForProcess): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::tryToSetActive): Stop telling the UI process about this process&apos;s
active state.
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::tryToSetActiveForProcess): Deleted the ProcessIdentifier
overload, which existed for a caller with no proxy of its own. The RemoteAudioSessionProxy overload,
which every activation goes through and which holds the arbitration, is unchanged.
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::tryToSetAudioSessionActiveForProcess): Deleted.
(WebKit::GPUProcessProxy::audioSessionActiveStateChangedForProcess): Deleted.
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxyClient): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy): Keep this manager as the
shared audio session, and stop making it the deactivation authority.
(WebKit::RemoteMediaSessionManagerProxy::removeMediaSession): No per-process activation to drop.
(WebKit::RemoteMediaSessionManagerProxy::webProcessWillShutDown): Ditto.
(WebKit::RemoteMediaSessionManagerProxy::updateMediaSessionStates): Stop activating a process while
it has audio capture sources; the content process does that from its own capture count.
(WebKit::RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback): Run only the part that
needs every process&apos;s sessions.
(WebKit::RemoteMediaSessionManagerProxy::tryToSetActiveInternal): Resolve without doing anything.
(WebKit::RemoteMediaSessionManagerProxy::remoteAudioConfigurationChanged): Take the descriptive
configuration only.
(WebKit::RemoteMediaSessionManagerProxy::setAudioSessionActiveForProcess): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::reevaluateAudioSessionActivation): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::enqueueAudioSessionActivation): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::sendNextActivationIPC): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::deactivateAllAudioSessions): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::hasActiveAudioSession const): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::processForSession const): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::processRequiresAudioSession const): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::remoteProcessWillSuspend): Deleted.
(WebKit::RemoteMediaSessionManagerProxy::remoteProcessDidResume): Deleted.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.messages.in:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp:
(WebKit::RemoteMediaSessionProxy::updateState): Stop re-evaluating activation from the UI process.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::sendNextActivationIPC): Always send the activation to the GPU process.
(WebKit::RemoteAudioSession::configurationChanged): Forward the configuration to the UI process on a
muted, buffer size, sample rate or routing change only.
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp:
(WebKit::RemoteMediaSessionManager::sessionWillBeginPlayback): Decide here, and tell the UI process
when playback may begin.
(WebKit::RemoteMediaSessionManager::processWillSuspend): Deleted.
(WebKit::RemoteMediaSessionManager::processDidResume): Deleted.
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h:

Canonical link: <a href="https://commits.webkit.org/319249@main">https://commits.webkit.org/319249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/376d4f690396c02ca1b28e27723eb6d05fe6a2ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145210 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c995753-3361-4ef4-8bbc-5f9682d852fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141118 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f0b2b58-eef9-4227-a688-2868fe5a856b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121569 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2377280-b336-4fac-b48e-407dc9991355) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43453 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41731 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41391 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2261 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193036 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54498 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150499 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40281 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55186 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150218 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44810 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127452 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122789 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53703 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16384 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53085 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53322 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53150 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->