### PR TITLE
[AppKit Gestures] Refactor gesture event handling to support gesture recognizers

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -273,6 +273,10 @@ NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 NS_HEADER_AUDIT_END(nullability, sendability)
 
+@interface NSGestureRecognizer (IPI)
+@property (setter=_setIsScrollGestureRecognizer:) BOOL _isScrollGestureRecognizer;
+@end
+
 #endif // HAVE(APPKIT_GESTURES_SUPPORT)
 
 #if HAVE(NSREFRESHCONTROLLER)

--- a/Source/WebKit/Shared/NativeWebGestureEvent.h
+++ b/Source/WebKit/Shared/NativeWebGestureEvent.h
@@ -46,11 +46,13 @@ public:
         float gestureScale { 0 };
         float gestureRotation { 0 };
         MonotonicTime timestamp;
+        bool allowsNativeZoom { true };
     };
 
     static std::optional<NativeWebGestureEvent> create(NSEvent *, NSView *);
     static std::optional<NativeWebGestureEvent> create(const Init&, NSView *);
 
+    bool allowsNativeZoom() const { return m_allowsNativeZoom; }
     Kind kind() const { return m_kind; }
     NSEvent *nativeEvent() const { return m_nativeEvent.get(); }
 
@@ -58,6 +60,7 @@ private:
     static std::optional<NativeWebGestureEvent> create(const Init&, NSView *, NSEvent *);
     explicit NativeWebGestureEvent(WebEventType, const Init&, NSView *, NSEvent *);
 
+    bool m_allowsNativeZoom { true };
     Kind m_kind;
     RetainPtr<NSEvent> m_nativeEvent;
 };

--- a/Source/WebKit/Shared/mac/NativeWebGestureEventMac.mm
+++ b/Source/WebKit/Shared/mac/NativeWebGestureEventMac.mm
@@ -98,6 +98,7 @@ NativeWebGestureEvent::NativeWebGestureEvent(WebEventType type, const Init& init
         init.gestureScale,
         init.gestureRotation,
         init.phase }
+    , m_allowsNativeZoom(init.allowsNativeZoom)
     , m_kind(init.kind)
     , m_nativeEvent(event)
 {

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -33,6 +33,7 @@
 #import "ImageAnalysisUtilities.h"
 #import "InteractionInformationAtPosition.h"
 #import "InteractionInformationRequest.h"
+#import "NativeWebGestureEvent.h"
 #import "NativeWebWheelEvent.h"
 #import "PositionInformationManager.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
@@ -86,9 +87,9 @@ static WebCore::FloatSize translationInView(NSPanGestureRecognizer *gesture, WKW
     return translation;
 }
 
-static WebKit::WebWheelEvent::Phase toWheelEventPhase(NSGestureRecognizerState state)
+static WebKit::WebEventPhase toWebEventPhase(NSGestureRecognizerState state)
 {
-    using enum WebKit::WebWheelEvent::Phase;
+    using enum WebKit::WebEventPhase;
     switch (state) {
     case NSGestureRecognizerStatePossible:
         return MayBegin;
@@ -232,6 +233,17 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     std::unique_ptr<WebKit::PositionInformationManager> _positionInformationManager;
     std::unique_ptr<WebKit::WKFastScrollTracker> _fastScrollTracker;
     std::unique_ptr<WebKit::WKDirectionalScrollLockTracker> _directionalScrollLockTracker;
+
+    RetainPtr<NSMagnificationGestureRecognizer> _magnificationGestureRecognizer;
+#if ENABLE(MAC_GESTURE_EVENTS)
+    RetainPtr<NSRotationGestureRecognizer> _rotationGestureRecognizer;
+#endif
+
+    // FIXME: <webkit.org/b/321828> Avoid further bloating this class and instead manage state through a separate/independent entity.
+    // Magnification and rotation GRs report their values cumulatively over a gesture.
+    // These variables track the last reported value so that we can forward deltas.
+    double _lastCumulativeMagnification;
+    double _lastCumulativeRotation;
 }
 
 #if __has_include(<WebKitAdditions/WKAppKitGestureControllerAdditionsImpl.mm>)
@@ -305,6 +317,11 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
 
     [self setUpImageAnalysisGestureRecognizer];
     [self setUpImageAnalysisDeferringGestureRecognizers];
+
+    [self setUpMagnificationGestureRecognizer];
+#if ENABLE(MAC_GESTURE_EVENTS)
+    [self setUpRotationGestureRecognizer];
+#endif
 }
 
 - (void)setUpMouseTrackingGestureRecognizer
@@ -381,6 +398,26 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     _imageAnalysisDragAndContextMenuDeferringGestureRecognizer = [self makeImageAnalysisDeferringGestureRecognizerWithName:@"WKImageAnalysisDragAndContextMenuDeferringGesture"];
 }
 
+- (void)setUpMagnificationGestureRecognizer
+{
+    _magnificationGestureRecognizer = adoptNS([[NSMagnificationGestureRecognizer alloc] initWithTarget:self action:@selector(magnificationGestureRecognized:)]);
+    [self configureForMagnification:_magnificationGestureRecognizer];
+    [_magnificationGestureRecognizer setDelegate:self];
+    [_magnificationGestureRecognizer setName:@"WKMagnificationGesture"];
+}
+
+#if ENABLE(MAC_GESTURE_EVENTS)
+
+- (void)setUpRotationGestureRecognizer
+{
+    _rotationGestureRecognizer = adoptNS([[NSRotationGestureRecognizer alloc] initWithTarget:self action:@selector(rotationGestureRecognized:)]);
+    [self configureForRotation:_rotationGestureRecognizer];
+    [_rotationGestureRecognizer setDelegate:self];
+    [_rotationGestureRecognizer setName:@"WKRotationGesture"];
+}
+
+#endif
+
 - (void)addGesturesToWebView
 {
     RetainPtr webView = _view.get();
@@ -402,6 +439,11 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     [webView addGestureRecognizer:_imageAnalysisGestureRecognizer.get()];
     [webView addGestureRecognizer:_imageAnalysisTextSelectionDeferringGestureRecognizer.get()];
     [webView addGestureRecognizer:_imageAnalysisDragAndContextMenuDeferringGestureRecognizer.get()];
+
+    [webView addGestureRecognizer:_magnificationGestureRecognizer];
+#if ENABLE(MAC_GESTURE_EVENTS)
+    [webView addGestureRecognizer:_rotationGestureRecognizer];
+#endif
 }
 
 - (void)enableGesturesIfNeeded
@@ -414,6 +456,10 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     [self enableGestureIfNeeded:_secondaryClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_dragPressGestureRecognizer.get()];
     [self enableGestureIfNeeded:_imageAnalysisGestureRecognizer.get()];
+    [self enableGestureIfNeeded:_magnificationGestureRecognizer];
+#if ENABLE(MAC_GESTURE_EVENTS)
+    [self enableGestureIfNeeded:_rotationGestureRecognizer];
+#endif
 
     // The deferring gesture recognizers are intentionally not enabled.
 }
@@ -439,6 +485,11 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     [_imageAnalysisGestureRecognizer setShouldBeArchived:NO];
     [_imageAnalysisTextSelectionDeferringGestureRecognizer setShouldBeArchived:NO];
     [_imageAnalysisDragAndContextMenuDeferringGestureRecognizer setShouldBeArchived:NO];
+
+    [_magnificationGestureRecognizer setShouldBeArchived:NO];
+#if ENABLE(MAC_GESTURE_EVENTS)
+    [_rotationGestureRecognizer setShouldBeArchived:NO];
+#endif
 }
 
 - (void)enableGestureIfNeeded:(NSGestureRecognizer *)gesture
@@ -451,6 +502,14 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
 
     if (gesture == _imageAnalysisGestureRecognizer)
         gestureEnabled = gestureEnabled && WebKit::isLiveTextAvailableAndEnabled();
+
+    bool gestureEventRecognizersEnabled = gestureEnabled && protect([webView _protectedPage]->preferences())->useAppKitGesturesForGestureEvents();
+    if (gesture == _magnificationGestureRecognizer)
+        gestureEnabled = gestureEventRecognizersEnabled;
+#if ENABLE(MAC_GESTURE_EVENTS)
+    if (gesture == _rotationGestureRecognizer)
+        gestureEnabled = gestureEventRecognizersEnabled;
+#endif
 
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG([webView _protectedPage]->logIdentifier(), "%@ setEnabled:%d", gestureLogDescription(gesture), static_cast<int>(gestureEnabled));
     [gesture setEnabled:gestureEnabled];
@@ -1375,7 +1434,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     auto wheelTicks { gestureDelta.scaled(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep())) };
     auto granularity = WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
     bool directionInvertedFromDevice = false;
-    auto phase = toWheelEventPhase(gesture.state);
+    auto phase = toWebEventPhase(gesture.state);
     auto momentumPhase = WebKit::WebWheelEvent::Phase::None;
     bool hasPreciseScrollingDeltas = true;
     uint32_t scrollCount = 1;
@@ -1530,6 +1589,102 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     _suppressNextPanScrollDelta = false;
 }
 
+#pragma mark - Magnification and Rotation
+
+- (double)currentMagnification:(double)magnification atPhase:(WebKit::WebEventPhase)phase
+{
+    using enum WebKit::WebEventPhase;
+    if (phase == Began)
+        _lastCumulativeMagnification = 0;
+    auto currentMagnification = magnification - _lastCumulativeMagnification;
+    _lastCumulativeMagnification = magnification;
+    return currentMagnification;
+}
+
+#if ENABLE(MAC_GESTURE_EVENTS)
+- (double)currentRotation:(double)rotation atPhase:(WebKit::WebEventPhase)phase
+{
+    using enum WebKit::WebEventPhase;
+    if (phase == Began)
+        _lastCumulativeRotation = 0;
+    auto currentRotation = rotation - _lastCumulativeRotation;
+    _lastCumulativeRotation = rotation;
+    return currentRotation;
+}
+#endif
+
+- (void)magnificationGestureRecognized:(NSMagnificationGestureRecognizer *)gesture
+{
+    RetainPtr webView = _view.get();
+    if (!webView)
+        return;
+
+    auto phase = toWebEventPhase(gesture.state);
+    auto magnification = [self currentMagnification:gesture.magnification atPhase:phase];
+
+    WebKit::NativeWebGestureEvent::Init init {
+        .kind = WebKit::NativeWebGestureEvent::Kind::Magnification,
+        .phase = phase,
+        .locationInWindow = WebCore::FloatPoint { [gesture locationInView:nil] },
+        .gestureScale = static_cast<float>(magnification),
+        .gestureRotation = 0,
+        .timestamp = MonotonicTime::fromRawSeconds(GetCurrentEventTime()),
+        .allowsNativeZoom = [self magnificationGestureRecognizerCanZoom]
+    };
+    auto webEvent = WebKit::NativeWebGestureEvent::create(init, webView.getAutoreleased());
+
+    CheckedPtr viewImpl = [webView _impl];
+    RefPtr page = [webView _protectedPage];
+    if (!viewImpl->allowsMagnification()) {
+#if ENABLE(MAC_GESTURE_EVENTS)
+        if (webEvent)
+            page->handleGestureEvent(*webEvent);
+#endif
+        return;
+    }
+
+    if (phase == WebKit::WebEventPhase::Began)
+        viewImpl->dismissContentRelativeChildWindowsWithAnimation(false);
+
+    Ref gestureController = viewImpl->ensureGestureController();
+
+#if ENABLE(MAC_GESTURE_EVENTS)
+    if (gestureController->hasActiveMagnificationGesture()) {
+        gestureController->handleMagnificationGesture(magnification, phase, webEvent ? webEvent->position() : WebCore::FloatPoint { });
+        return;
+    }
+
+    if (webEvent)
+        page->handleGestureEvent(*webEvent);
+#else
+    gestureController->handleMagnificationGesture(magnification, phase, webEvent ? webEvent->position() : WebCore::FloatPoint { });
+#endif
+}
+
+#if ENABLE(MAC_GESTURE_EVENTS)
+
+- (void)rotationGestureRecognized:(NSRotationGestureRecognizer *)gesture
+{
+    RetainPtr webView = _view.get();
+    if (!webView)
+        return;
+
+    auto phase = toWebEventPhase(gesture.state);
+
+    WebKit::NativeWebGestureEvent::Init init {
+        .kind = WebKit::NativeWebGestureEvent::Kind::Rotation,
+        .phase = phase,
+        .locationInWindow = WebCore::FloatPoint { [gesture locationInView:nil] },
+        .gestureScale = 0,
+        .gestureRotation = static_cast<float>([self currentRotation:gesture.rotationInDegrees atPhase:phase]),
+        .timestamp = MonotonicTime::fromRawSeconds(GetCurrentEventTime())
+    };
+    if (auto webEvent = WebKit::NativeWebGestureEvent::create(init, webView.getAutoreleased()))
+        [webView _protectedPage]->handleGestureEvent(*webEvent);
+}
+
+#endif
+
 #pragma mark - Drag Gesture State
 
 - (NSGestureRecognizer *)activeDragGestureRecognizer
@@ -1601,6 +1756,11 @@ static BOOL isBuiltInScrollViewPanGestureRecognizer(NSGestureRecognizer *recogni
     return [recognizer isKindOfClass:scrollViewPanGestureClass];
 }
 
+static inline bool isBuiltInScrollViewMagnificationGestureRecognizer(NSGestureRecognizer *gesture)
+{
+    return [gesture isKindOfClass:NSMagnificationGestureRecognizer.class] && gesture._isScrollGestureRecognizer;
+}
+
 static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NSGestureRecognizer *x, NSGestureRecognizer *y)
 {
     return (a == x && b == y) || (b == x && a == y);
@@ -1616,6 +1776,17 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
 
     if (isSamePair(gestureRecognizer, otherGestureRecognizer, _singleClickGestureRecognizer.get(), _panGestureRecognizer.get()))
         return YES;
+
+    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _magnificationGestureRecognizer.get(), _panGestureRecognizer.get()))
+        return YES;
+
+#if ENABLE(MAC_GESTURE_EVENTS)
+    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _rotationGestureRecognizer.get(), _panGestureRecognizer.get()))
+        return YES;
+
+    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _magnificationGestureRecognizer.get(), _rotationGestureRecognizer.get()))
+        return YES;
+#endif
 
     if ([gestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class] || [otherGestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class])
         return YES;
@@ -1759,9 +1930,13 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     return YES;
 }
 
-- (BOOL)_isScrollOrZoomGestureRecognizer:(NSGestureRecognizer *)gesture
+- (BOOL)_isSomeManipulationGestureRecognizer:(NSGestureRecognizer *)gesture
 {
-    return gesture == _panGestureRecognizer || isBuiltInScrollViewPanGestureRecognizer(gesture) || [gesture isKindOfClass:[NSMagnificationGestureRecognizer class]];
+    return gesture == _panGestureRecognizer
+        || isBuiltInScrollViewPanGestureRecognizer(gesture)
+        || gesture == _magnificationGestureRecognizer
+        || isBuiltInScrollViewMagnificationGestureRecognizer(gesture)
+        || gesture == _rotationGestureRecognizer;
 }
 
 - (BOOL)_gestureRecognizer:(NSGestureRecognizer *)preventingGestureRecognizer canPreventGestureRecognizer:(NSGestureRecognizer *)preventedGestureRecognizer
@@ -1775,7 +1950,7 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     // None of our gesture recognizers may prevent an enclosing scroll view's pan (or any other
     // scroll/zoom) gesture, so that a scroll can always be handed off to the enclosing scroll view
     // e.g. a scroll over a draggable <img> in a non-scrollable web view.
-    if ([self _isScrollOrZoomGestureRecognizer:preventedGestureRecognizer])
+    if ([self _isSomeManipulationGestureRecognizer:preventedGestureRecognizer])
         return NO;
 
     // Live Text (see the Image Analysis design note): the preflight is a passive observer, so it prevents

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5826,7 +5826,7 @@ void WebViewImpl::gestureEventWasNotHandledByWebCore(const NativeWebGestureEvent
         return;
     }
 
-    if (event.kind() != NativeWebGestureEvent::Kind::Magnification)
+    if (event.kind() != NativeWebGestureEvent::Kind::Magnification || !event.allowsNativeZoom())
         return;
 
     magnificationGestureWasNotHandledByWebCoreFromViewOnly(event.gestureScale(), event.phase(), event.position());

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -1427,6 +1427,8 @@ extension AppKitGesturesTests.Basic {
         .bug("https://webkit.org/b/321650", "Certain diagonal scrolls should be able to bypass directional locking")
     )
     func diagonallySwipingBetweenSpacesScrollsBothAxes() async throws {
+        page.setWebFeature("UseAppKitGesturesForGestureEvents", enabled: true)
+
         try await loadScrollableGrid()
         await page.waitForNextPresentationUpdate()
 


### PR DESCRIPTION
#### 59d076ef61e6fe776685d06bc408976bae040e8e
<pre>
[AppKit Gestures] Refactor gesture event handling to support gesture recognizers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321784">https://bugs.webkit.org/show_bug.cgi?id=321784</a>
<a href="https://rdar.apple.com/184904955">rdar://184904955</a>

Reviewed by Richard Robinson.

This patch adds infrastructure to support DOM gesture events using
gesture recognizers, complementing the existing NSResponder machinery.

To facilitate this change, we build on existing changes to WebKit&apos;s
representation of native gesture events (318771@main, 318693@main). We
gate this behavior change behind the UseAppKitGesturesForGestureEvents
preference, added in 319130@main. The actual event dispatch plumbing is
more or less the same shape as seen in the WebViewImpl namesakes.

Test coverage will be added in a forthcoming patch.

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/Shared/NativeWebGestureEvent.h:
* Source/WebKit/Shared/mac/NativeWebGestureEventMac.mm:
* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm:
(toWebEventPhase):
(-[WKAppKitGestureController setUpGestureRecognizers]):
(-[WKAppKitGestureController setUpMagnificationGestureRecognizer]):
(-[WKAppKitGestureController setUpRotationGestureRecognizer]):
(-[WKAppKitGestureController addGesturesToWebView]):
(-[WKAppKitGestureController enableGesturesIfNeeded]):
(-[WKAppKitGestureController ensureGesturesAreNotArchived]):
(-[WKAppKitGestureController enableGestureIfNeeded:]):
(-[WKAppKitGestureController sendWheelEventForGesture:]):
(-[WKAppKitGestureController _resetCaughtDeceleratingScroll]):
(-[WKAppKitGestureController currentMagnification:atPhase:]):
(-[WKAppKitGestureController currentRotation:atPhase:]):
(-[WKAppKitGestureController magnificationGestureRecognized:]):
(-[WKAppKitGestureController rotationGestureRecognized:]):
(isBuiltInScrollViewPanGestureRecognizer):
(-[WKAppKitGestureController gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
(-[WKAppKitGestureController gestureRecognizerShouldBegin:]):
(-[WKAppKitGestureController _isSomeManipulationGestureRecognizer:]):
(-[WKAppKitGestureController _gestureRecognizer:canPreventGestureRecognizer:]):
(toWheelEventPhase): Deleted.
(-[WKAppKitGestureController _isScrollOrZoomGestureRecognizer:]): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::gestureEventWasNotHandledByWebCore):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/319224@main">https://commits.webkit.org/319224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c6e80e3e4f9d4cad21710db132a9ff0470bbf4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180856 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191070 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145179 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12ba659d-2879-4154-9c5b-f73918da1b5d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141090 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7f1370e-4c2a-4cd1-a19b-aa2182b979a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121541 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c0ce2da-dd7f-4741-a155-6308a51d11fd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41363 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2230 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193005 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54467 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150469 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55155 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150188 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27452 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44780 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122721 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53672 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16356 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53054 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53291 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53119 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->