### PR TITLE
CSP source-expression *. is not treated as invalid

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/invalid-host-part-wildcard-dot-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/invalid-host-part-wildcard-dot-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: The source list for Content Security Policy directive 'connect-src' contains an invalid source: '*?'. It will be ignored.
+CONSOLE MESSAGE: The source list for Content Security Policy directive 'connect-src' contains an invalid source: '*.'. It will be ignored.
+CONSOLE MESSAGE: The source list for Content Security Policy directive 'connect-src' contains an invalid source: '*.?'. It will be ignored.
+CONSOLE MESSAGE: The source list for Content Security Policy directive 'connect-src' contains an invalid source: '*.A1?'. It will be ignored.
+CONSOLE MESSAGE: The source list for Content Security Policy directive 'connect-src' contains an invalid source: '*.A1.?'. It will be ignored.
+CONSOLE MESSAGE: The source list for Content Security Policy directive 'connect-src' contains an invalid source: '*.A1.B2.?'. It will be ignored.
+PASS if you see console 6 messages about CSP directive 'connect-src' containing invalid source: "*?" ,"*." ,"*.?" ,"*.A1?" ,"*.A1.?" ,"*.A1.B2.?"

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/invalid-host-part-wildcard-dot.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/invalid-host-part-wildcard-dot.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<!-- host-part   = "*" / [ "*." ] 1*host-char *( "." 1*host-char ) [ "." ] -->
+<meta http-equiv="Content-Security-Policy" content="connect-src *">
+<meta http-equiv="Content-Security-Policy" content="connect-src *?" class="invalid">
+<meta http-equiv="Content-Security-Policy" content="connect-src *."  class="invalid">
+<meta http-equiv="Content-Security-Policy" content="connect-src *.?"  class="invalid">
+<meta http-equiv="Content-Security-Policy" content="connect-src *.A1">
+<meta http-equiv="Content-Security-Policy" content="connect-src *.A1?" class="invalid">
+<meta http-equiv="Content-Security-Policy" content="connect-src *.A1.">
+<meta http-equiv="Content-Security-Policy" content="connect-src *.A1.?" class="invalid">
+<meta http-equiv="Content-Security-Policy" content="connect-src *.A1.B2">
+<meta http-equiv="Content-Security-Policy" content="connect-src *.A1.B2.">
+<meta http-equiv="Content-Security-Policy" content="connect-src *.A1.B2.?" class="invalid">
+<meta http-equiv="Content-Security-Policy" content="connect-src *.A1.B2.C3">
+<div id="log"></div>
+<script>
+  window.testRunner?.dumpAsText();
+  let invalidMetas = Array.from(document.getElementsByClassName("invalid")).
+      map(meta => meta.content.replace('connect-src ', '')).
+      map(value => `"${value}" `);
+  log.textContent = `PASS if you see console ${invalidMetas.length} messages about CSP directive 'connect-src' containing invalid source: ${invalidMetas}`;
+</script>

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -482,9 +482,9 @@ template<typename CharacterType> StringView ContentSecurityPolicySourceList::par
     return begin.first(buffer.position() - begin.data());
 }
 
-// host              = [ "*." ] 1*host-char *( "." 1*host-char )
-//                   / "*"
-// host-char         = ALPHA / DIGIT / "-"
+// https://w3c.github.io/webappsec-csp/#grammardef-host-char
+// host-part = "*" / [ "*." ] 1*host-char *( "." 1*host-char ) [ "." ]
+// host-char = ALPHA / DIGIT / "-"
 //
 template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::Host> ContentSecurityPolicySourceList::parseHost(std::span<const CharacterType> span)
 {
@@ -503,6 +503,9 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
             return host;
 
         if (!skipExactly(buffer, '.'))
+            return std::nullopt;
+
+        if (buffer.atEnd())
             return std::nullopt;
     }
 


### PR DESCRIPTION
#### 6627b0ce039fd9655a6754e98c1effa67241086e
<pre>
CSP source-expression *. is not treated as invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=321780">https://bugs.webkit.org/show_bug.cgi?id=321780</a>

Reviewed by Patrick Griffis.

ContentSecurityPolicySourceList::parseHost successfuly parses &quot;*.&quot; as a
Host with hasWildcard set to true and value set to an empty string,
instead of treating it as invalid. This is visible in the error console,
because no warning is triggered for that case.

* LayoutTests/http/tests/security/contentSecurityPolicy/invalid-host-part-wildcard-dot-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/invalid-host-part-wildcard-dot.html: Added.
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::ContentSecurityPolicySourceList::parseHost): return std::nullopt for &quot;*.&quot;.

Canonical link: <a href="https://commits.webkit.org/319232@main">https://commits.webkit.org/319232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef2063228079a248663ae6c24931ea03c1071c5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191092 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145201 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141108 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43444 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41722 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41382 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2252 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193027 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150490 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40273 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55177 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150209 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44801 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127443 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122770 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53694 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16375 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53076 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53313 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->