### PR TITLE
Context menu is not dismissed when its page is closed

### DIFF
--- a/Source/WebKit/UIProcess/WebContextMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.h
@@ -51,6 +51,7 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     virtual void show();
+    virtual void cancelTracking() { }
 
     WebPageProxy* page() const { return m_page.get(); }
     const FrameInfoData& frameInfo() const LIFETIME_BOUND { return m_frameInfo; }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1940,7 +1940,8 @@ void WebPageProxy::close()
 #endif
 
 #if ENABLE(CONTEXT_MENUS)
-    m_activeContextMenu = nullptr;
+    if (RefPtr activeContextMenu = std::exchange(m_activeContextMenu, nullptr))
+        activeContextMenu->cancelTracking();
 #endif
 
     m_provisionalPage = nullptr;

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
@@ -85,6 +85,7 @@ private:
     WebContextMenuProxyMac(NSView *, WebPageProxy&, FrameInfoData&&, ContextMenuContextData&&, const UserData&);
 
     void show() override;
+    void cancelTracking() override;
     void showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&&) override;
     void useContextMenuItems(Vector<Ref<WebContextMenuItem>>&&) override;
 

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -544,6 +544,11 @@ RetainPtr<NSMenuItem> WebContextMenuProxyMac::createShareMenuItem(ShareMenuItemT
 }
 #endif
 
+void WebContextMenuProxyMac::cancelTracking()
+{
+    [protect(m_menu) cancelTracking];
+}
+
 void WebContextMenuProxyMac::show()
 {
 #if ENABLE(SERVICE_CONTROLS)

--- a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
@@ -99,7 +99,10 @@ void WebContextMenuProxyWin::showContextMenuWithItems(Vector<Ref<WebContextMenuI
     POINT pt = location;
     HWND wnd = reinterpret_cast<HWND>(page()->viewWidget());
     ::ClientToScreen(wnd, &pt);
+
+    m_tracking = true;
     ::TrackPopupMenuEx(m_menu, flags, pt.x, pt.y, wnd, nullptr);
+    m_tracking = false;
 }
 
 WebContextMenuProxyWin::WebContextMenuProxyWin(WebPageProxy& page, FrameInfoData&& frameInfo, ContextMenuContextData&& context, const UserData& userData)
@@ -112,6 +115,12 @@ WebContextMenuProxyWin::~WebContextMenuProxyWin()
 {
     if (m_menu)
         ::DestroyMenu(m_menu);
+}
+
+void WebContextMenuProxyWin::cancelTracking()
+{
+    if (m_tracking)
+        ::EndMenu();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
+++ b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h
@@ -47,8 +47,10 @@ public:
 private:
     WebContextMenuProxyWin(WebPageProxy&, FrameInfoData&&, ContextMenuContextData&&, const UserData&);
     void showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&&) override;
+    void cancelTracking() override;
 
     HMENU m_menu;
+    bool m_tracking { false };
 };
 
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
@@ -40,6 +40,7 @@
 #import <WebKit/WKMenuItemIdentifiersPrivate.h>
 #import <WebKit/WKUIDelegatePrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKContextMenuElementInfo.h>
 #import <WebKit/_WKHitTestResult.h>
@@ -958,6 +959,47 @@ TEST(ContextMenuTests, CopyLinkUsesPathComponentAsTitleForLinkWithPath)
         TestWebKitAPI::Util::runFor(0.1_s);
 
     EXPECT_WK_STREQ(@"something-cool", readTitleFromPasteboard());
+}
+
+TEST(ContextMenuTests, MenuTrackingCancelledWhenPageCloses)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+
+    __block bool didEndTracking = false;
+    RetainPtr observer = [NSNotificationCenter.defaultCenter addObserverForName:NSMenuDidEndTrackingNotification object:nil queue:nil usingBlock:^(NSNotification *) {
+        didEndTracking = true;
+    }];
+
+    bool didClosePage = false;
+    bool menuStayedOpenAfterPageClose = false;
+    RetainPtr closePageTimer = [NSTimer timerWithTimeInterval:0.25 repeats:YES block:[&didClosePage, &menuStayedOpenAfterPageClose, strongWebView = webView](NSTimer *timer) {
+        // This timer only fires while AppKit is tracking the context menu.
+        if (didClosePage) {
+            menuStayedOpenAfterPageClose = true;
+            [timer invalidate];
+            return;
+        }
+
+        if (![strongWebView _activeMenu])
+            return;
+
+        [strongWebView _close];
+        didClosePage = true;
+    }];
+
+    [NSRunLoop.mainRunLoop addTimer:closePageTimer.get() forMode:NSEventTrackingRunLoopMode];
+    [[webView window] orderFrontRegardless];
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    Util::run(&didEndTracking);
+    [closePageTimer invalidate];
+
+    EXPECT_TRUE(didClosePage);
+    EXPECT_FALSE(menuStayedOpenAfterPageClose);
+    EXPECT_NULL([webView _activeMenu]);
+
+    [NSNotificationCenter.defaultCenter removeObserver:observer.get()];
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### ca495b340ba6cccf8f05dc1dc0ac4e892924c53e
<pre>
Context menu is not dismissed when its page is closed
<a href="https://bugs.webkit.org/show_bug.cgi?id=321746">https://bugs.webkit.org/show_bug.cgi?id=321746</a>

Reviewed by Devin Rousso.

WebPageProxy::close() cancels tracking of the active popup menu, but only
drops its reference to the active context menu without dismissing it. On
macOS and Windows the menu runs a nested run loop that keeps the proxy
alive, so the menu stays on screen tracking a closed page.

Cancel tracking of the active context menu in close(), matching popup menus.
Implemented with -[NSMenu cancelTracking] on macOS and ::EndMenu() on
Windows. GTK needs no override since its menus are non-modal and popped down
by the proxy destructor; WPE shows no native menu.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm

* Source/WebKit/UIProcess/WebContextMenuProxy.h:
(WebKit::WebContextMenuProxy::cancelTracking):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::close):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::cancelTracking):
* Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp:
(WebKit::WebContextMenuProxyWin::cancelTracking):
(WebKit::WebContextMenuProxyWin::showContextMenuWithItems):
* Source/WebKit/UIProcess/win/WebContextMenuProxyWin.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST(ContextMenuTests, MenuTrackingCancelledWhenPageCloses)):

Canonical link: <a href="https://commits.webkit.org/319401@main">https://commits.webkit.org/319401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eaa0401e97bdc2b28eaf71d661cfea8e83fd307

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141001 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97715 "2 flakes 7 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161755 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121453 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43343 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41621 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41284 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2138 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192912 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54375 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40432 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55063 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150102 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44698 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127329 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122615 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53580 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16277 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52962 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53027 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->