### PR TITLE
[JSC] Add small-sized fast copy before memcpy in operationMemoryCopy

### DIFF
--- a/Source/JavaScriptCore/b3/B3Operations.cpp
+++ b/Source/JavaScriptCore/b3/B3Operations.cpp
@@ -26,15 +26,73 @@
 #include "config.h"
 #include "B3Operations.h"
 
+#include <wtf/Int128.h>
+#include <wtf/UnalignedAccess.h>
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #if ENABLE(B3_JIT)
 
 namespace JSC::B3 {
 
+namespace {
+
+#if HAVE(INT128_T)
+using WidestCopyUnit = UInt128;
+#else
+using WidestCopyUnit = uint64_t;
+#endif
+
+constexpr size_t maxFastCopyCount = 4 * sizeof(WidestCopyUnit);
+
+// Copies count bytes as two overlapping sizeof(T) accesses, so it needs
+// sizeof(T) <= count <= 2 * sizeof(T). Both source reads happen before either destination write,
+// which is what makes this safe for overlapping ranges without comparing the two pointers.
+template<typename T>
+ALWAYS_INLINE void copyOverlappingEnds(uint8_t* dst, const uint8_t* src, size_t count)
+{
+    T low = WTF::unalignedLoad<T>(src);
+    T high = WTF::unalignedLoad<T>(src + count - sizeof(T));
+    WTF::unalignedStore<T>(dst, low);
+    WTF::unalignedStore<T>(dst + count - sizeof(T), high);
+}
+
+// The same idea one step wider: two overlapping pairs, for
+// 2 * sizeof(T) <= count <= 4 * sizeof(T).
+template<typename T>
+ALWAYS_INLINE void copyOverlappingEndPairs(uint8_t* dst, const uint8_t* src, size_t count)
+{
+    T low0 = WTF::unalignedLoad<T>(src);
+    T low1 = WTF::unalignedLoad<T>(src + sizeof(T));
+    T high0 = WTF::unalignedLoad<T>(src + count - 2 * sizeof(T));
+    T high1 = WTF::unalignedLoad<T>(src + count - sizeof(T));
+    WTF::unalignedStore<T>(dst, low0);
+    WTF::unalignedStore<T>(dst + sizeof(T), low1);
+    WTF::unalignedStore<T>(dst + count - 2 * sizeof(T), high0);
+    WTF::unalignedStore<T>(dst + count - sizeof(T), high1);
+}
+
+} // namespace
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryCopy, void, (void* dst, const void* src, size_t count))
 {
+    // Short copies dominate this operation, because memory.copy is what a compiler targeting wasm
+    // emits for memcpy. libc's memmove spends more on dispatching by size than a short copy costs,
+    // so handle the short counts here. One unsigned compare rejects both the too-short and the
+    // too-long counts.
+    if (count - sizeof(uint32_t) <= maxFastCopyCount - sizeof(uint32_t)) {
+        auto* to = static_cast<uint8_t*>(dst);
+        const auto* from = static_cast<const uint8_t*>(src);
+        if (count < sizeof(uint64_t))
+            copyOverlappingEnds<uint32_t>(to, from, count);
+        else if (count < 2 * sizeof(uint64_t))
+            copyOverlappingEnds<uint64_t>(to, from, count);
+        else if (count < 2 * sizeof(WidestCopyUnit))
+            copyOverlappingEnds<WidestCopyUnit>(to, from, count);
+        else
+            copyOverlappingEndPairs<WidestCopyUnit>(to, from, count);
+        return;
+    }
     memmove(dst, src, count);
 }
 


### PR DESCRIPTION
#### 53517eb3a2b824d9cad0e95b1263ee68c8cd9762
<pre>
[JSC] Add small-sized fast copy before memcpy in operationMemoryCopy
<a href="https://bugs.webkit.org/show_bug.cgi?id=321793">https://bugs.webkit.org/show_bug.cgi?id=321793</a>
<a href="https://rdar.apple.com/184928316">rdar://184928316</a>

Reviewed by Vassili Bykov and Dan Hecht.

memcpy does not inline itself when count is unknown. And wasm
memory.copy is concentrated into operationMemoryCopy instruction even if
the size can be small enough. This patch adds super fast copying before
operationMemoryCopy&apos;s `memcpy` to accelerate memory.copy performance.

* Source/JavaScriptCore/b3/B3Operations.cpp:
(JSC::B3::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/319202@main">https://commits.webkit.org/319202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48fe0ead317c47ae70dcad34690312edd7547756

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190966 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145076 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e3b9e1a-d744-4dd1-af94-f99d23d3905b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140990 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6537a40-e1ab-4b9b-b371-95d24f3ab58f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44657 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121442 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9f6f902-2b58-409a-a019-79fbce544f8a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3409 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10250 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153734 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41294 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2127 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42027 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47310 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192901 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54364 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150373 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55052 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150090 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27442 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44693 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127318 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122602 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53569 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16287 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52951 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53188 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53016 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->