### PR TITLE
Put the extension created offscreen web view into a window so it's able to play audio

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm
@@ -86,6 +86,15 @@ void WebExtensionContext::offscreenCreateDocument(const WebExtensionOffscreenDoc
     else
         m_offscreenWebViewActivity = protect(offscreenProcess->throttler())->foregroundActivity(activityName);
 
+    // Put the offscreen web view into a window so that it can be used to play audio (a common use case for the API).
+#if PLATFORM(MAC)
+    m_offscreenWebViewWindow = adoptNS([[NSWindow alloc] initWithContentRect:NSZeroRect styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:NO]);
+    [m_offscreenWebViewWindow.get().contentView addSubview:m_offscreenWebView.get()];
+#elif PLATFORM(IOS_FAMILY)
+    m_offscreenWebViewWindow = adoptNS([[UIWindow alloc] initWithFrame:CGRectZero]);
+    [m_offscreenWebViewWindow.get() addSubview:m_offscreenWebView.get()];
+#endif
+
     [m_offscreenWebView loadRequest:[NSURLRequest requestWithURL:documentURL.createNSURL().get()]];
 
     m_offscreenDocumentLoadCompletionHandlers.append(WTF::move(completionHandler));
@@ -117,6 +126,11 @@ void WebExtensionContext::unloadOffscreenWebView()
         completionHandler(toWebExtensionError(completionHandlerAPIName, nullString(), @"offscreen document was closed"));
 
     m_offscreenWebViewActivity = { };
+
+#if PLATFORM(MAC) || PLATFORM(IOS_FAMILY)
+    [m_offscreenWebView removeFromSuperview];
+    m_offscreenWebViewWindow = nil;
+#endif
 
     [m_offscreenWebView _close];
     m_offscreenWebView = nil;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2538,7 +2538,11 @@ WKWebViewConfiguration *WebExtensionContext::webViewConfiguration(WebViewPurpose
     auto *preferences = configuration.preferences;
     preferences._javaScriptCanAccessClipboard = hasPermission(WebExtensionPermission::clipboardWrite());
 
-    if (purpose == WebViewPurpose::Background || purpose == WebViewPurpose::Inspector) {
+    bool shouldDisableThrottling = purpose == WebViewPurpose::Background || purpose == WebViewPurpose::Inspector;
+#if ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
+    shouldDisableThrottling = shouldDisableThrottling || purpose == WebViewPurpose::Offscreen;
+#endif
+    if (shouldDisableThrottling) {
         // FIXME: <https://webkit.org/b/263286> Consider allowing the background page to throttle or be suspended.
         preferences._hiddenPageDOMTimerThrottlingEnabled = NO;
         preferences._pageVisibilityBasedProcessSuppressionEnabled = NO;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -129,7 +129,12 @@ OBJC_PROTOCOL(WKWebExtensionWindow);
 #if PLATFORM(MAC)
 OBJC_CLASS NSEvent;
 OBJC_CLASS NSMenu;
+OBJC_CLASS NSWindow;
 OBJC_CLASS WKOpenPanelParameters;
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+OBJC_CLASS UIWindow;
 #endif
 
 namespace PAL {
@@ -1140,6 +1145,11 @@ private:
     RetainPtr<WKWebView> m_offscreenWebView;
     Variant<std::monostate, Ref<ProcessThrottlerActivity>, Ref<ProcessActivityGroup>> m_offscreenWebViewActivity;
     Vector<CompletionHandler<void(Expected<void, WebExtensionError>&&)>> m_offscreenDocumentLoadCompletionHandlers;
+#if PLATFORM(MAC)
+    RetainPtr<NSWindow> m_offscreenWebViewWindow;
+#elif PLATFORM(IOS_FAMILY)
+    RetainPtr<UIWindow> m_offscreenWebViewWindow;
+#endif
 #endif
 
     RetainPtr<_WKWebExtensionContextDelegate> m_delegate;


### PR DESCRIPTION
#### 84aa5da69757a9379b0754da91aeee8cf4fabb47
<pre>
Put the extension created offscreen web view into a window so it&apos;s able to play audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=321797">https://bugs.webkit.org/show_bug.cgi?id=321797</a>
<a href="https://rdar.apple.com/184269255">rdar://184269255</a>

Reviewed by Timothy Hatcher.

This PR will also have the offscreen page opt out of being throttled or suspended due to it not being visible.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm:
(WebKit::WebExtensionContext::offscreenCreateDocument):
(WebKit::WebExtensionContext::unloadOffscreenWebView):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::webViewConfiguration):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/319193@main">https://commits.webkit.org/319193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b1cf242936d67ef46d9c3742e547b9eb03a29a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190982 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145092 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e86562fb-d7cb-44ff-a803-0bb3fba266fd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54430 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141006 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183724 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/44669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121458 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5075c053-74a1-4f33-a2a1-aa0e0458aafe) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10245 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41289 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2143 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47326 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192917 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54380 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150390 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40245 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55068 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150107 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44699 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122620 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53585 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16282 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52967 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53032 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->