### PR TITLE
[JSC][Wasm] Fast-path i64 BigInt on Wasm-to-JS import returns

### DIFF
--- a/JSTests/wasm/stress/import-return-i64-bigint.js
+++ b/JSTests/wasm/stress/import-return-i64-bigint.js
@@ -1,0 +1,40 @@
+// https://bugs.webkit.org/show_bug.cgi?id=220053
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const values = [
+    0n,
+    1n,
+    -1n,
+    20n,
+    0x7fffffffffffffffn,
+    -0x8000000000000000n,
+    0xffffffffffffffffn,
+    0x10000000000000000n,
+    -0x10000000000000000n,
+    42n,
+];
+
+async function test() {
+    for (const value of values) {
+        const expected = BigInt.asIntN(64, value);
+        const inst = await instantiate(`
+(module
+  (func $imp (import "imp" "func") (result i64))
+  (func (export "run") (result i64)
+    (call $imp))
+)`, { imp: { func: () => value } });
+        for (let i = 0; i < 100; i++)
+            assert.eq(inst.exports.run(), expected);
+    }
+
+    const inst = await instantiate(`
+(module
+  (func $imp (import "imp" "func") (result i64))
+  (func (export "run") (result i64)
+    (call $imp))
+)`, { imp: { func: () => 20 } });
+    assert.throws(() => inst.exports.run(), TypeError, "Invalid argument type in ToBigInt operation");
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -326,15 +326,30 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(const 
         const auto& returnType = signature.returnType(0);
         switch (returnType.kind()) {
         case TypeKind::I64: {
-            // FIXME: Optimize I64 extraction from BigInt.
-            // https://bugs.webkit.org/show_bug.cgi?id=220053
-            JSValueRegs dest = wasmCallInfo.results[0].location.jsr();
+            CCallHelpers::JumpList done;
+            CCallHelpers::JumpList slowPath;
+            JSValueRegs destJSR = wasmCallInfo.results[0].location.jsr();
+            GPRReg destGPR = destJSR.payloadGPR();
+            GPRReg cellGPR = JSRInfo::returnValueJSR.payloadGPR();
+
+            slowPath.append(jit.branchIfNotCell(JSRInfo::returnValueJSR, DoNotHaveTagRegisters));
+            slowPath.append(jit.branchIfNotHeapBigInt(cellGPR));
+            if (cellGPR == destGPR) {
+                GPRReg scratch = GPRInfo::nonPreservedNonReturnGPR;
+                jit.move(cellGPR, scratch);
+                jit.toBigInt64(scratch, destGPR);
+            } else
+                jit.toBigInt64(cellGPR, destGPR);
+            done.append(jit.jump());
+
+            slowPath.link(&jit);
             jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
             jit.setupArguments<decltype(operationConvertToI64)>(GPRInfo::wasmContextInstancePointer, JSRInfo::returnValueJSR);
             jit.callOperation<OperationPtrTag>(operationConvertToI64);
             using ResultType = typename FunctionTraits<decltype(operationConvertToI64)>::ResultType;
             exceptionChecks.append(jit.branchTestPtr(CCallHelpers::NonZero, CCallHelpers::operationExceptionRegister<ResultType>()));
-            jit.moveValueRegs(JSRInfo::returnValueJSR, dest);
+            jit.moveValueRegs(JSRInfo::returnValueJSR, destJSR);
+            done.link(&jit);
             break;
         }
         case TypeKind::I32: {


### PR DESCRIPTION
#### ca730ef8b0fedfc8abb24dfef9f49a55e6bbaa85
<pre>
[JSC][Wasm] Fast-path i64 BigInt on Wasm-to-JS import returns
<a href="https://bugs.webkit.org/show_bug.cgi?id=220053">https://bugs.webkit.org/show_bug.cgi?id=220053</a>

Reviewed by Yusuke Suzuki.

Wasm-to-JS import stubs always called operationConvertToI64 for an i64
result. If the JS value is already a HeapBigInt, convert it in the stub
the same way JS-to-Wasm arguments already do. Numbers still go through
ToBigInt64 and throw TypeError.

* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
* JSTests/wasm/stress/import-return-i64-bigint.js: Added.

Canonical link: <a href="https://commits.webkit.org/319218@main">https://commits.webkit.org/319218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57c10dc604f6a8a103da779fa59f5d4afe975101

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190996 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145106 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141017 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121469 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41635 "Found 1 new API test failure: TestWebKitAPI._WKDownload.DownloadMonitorCancel (failure)") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3436 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10261 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41305 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2157 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42057 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192931 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54394 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150404 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55082 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150121 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27450 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44714 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127348 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122634 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53599 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16298 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52981 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->