### PR TITLE
[Site Isolation] Keep high-value fraud target domains out of the shared process

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8392,6 +8392,20 @@ SiteIsolationEnabled:
       default: false
   sharedPreferenceForWebProcess: true
 
+SiteIsolationHighValueFraudTargetDomainsEnabled:
+  type: bool
+  status: unstable
+  category: security
+  humanReadableName: "High-value fraud target domains for Site Isolation"
+  humanReadableDescription: "Exclude sites on the high-value fraud target domains list from the shared web process"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 SiteIsolationSharedProcessEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
@@ -164,6 +164,20 @@ typedef void (^WPRestrictedOpenerDomainsCompletionHandler)(NSArray<WPRestrictedO
 @end
 #endif
 
+#if !defined(HAS_WEB_PRIVACY_HIGH_VALUE_FRAUD_TARGET_DOMAIN_CLASS)
+constexpr NSInteger WPResourceTypeHighValueFraudTargetDomains = 11;
+
+@interface WPHighValueFraudTargetDomain : NSObject
+@property (nonatomic, readonly) NSString *domain;
+@end
+
+typedef void (^WPHighValueFraudTargetDomainsCompletionHandler)(NSArray<WPHighValueFraudTargetDomain *> *, NSError *);
+
+@interface WPResources (Staging_183971390)
+- (void)requestHighValueFraudTargetDomains:(WPResourceRequestOptions *)options completionHandler:(WPHighValueFraudTargetDomainsCompletionHandler)completion;
+@end
+#endif
+
 #if !defined(HAS_WEB_PRIVACY_STORAGE_ACCESS_PROMPT_TRIGGER) && HAVE(WEB_PRIVACY_FRAMEWORK)
 @interface WPStorageAccessPromptQuirk (Staging_124689085)
 @property (nonatomic, readonly) NSDictionary<NSString *, NSArray<NSString *> *> *quirkDomains;

--- a/Source/WebKit/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebKit/Configurations/AllowedSPI-legacy.toml
@@ -491,6 +491,7 @@ selectors = [
     { name = "replacement", class = "?" },
     { name = "reportAnErrorBaseURLString", class = "?" },
     { name = "requestAllowedLinkFilteringData:completionHandler:", class = "?" },
+    { name = "requestHighValueFraudTargetDomains:completionHandler:", class = "?" },
     { name = "requestLinkFilteringData:completionHandler:", class = "?" },
     { name = "requestPoliciesForWebsites:completionHandler:", class = "?" },
     { name = "requestRestrictedOpenerDomains:completionHandler:", class = "?" },

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -30,6 +30,7 @@
 #import <wtf/CompletionHandler.h>
 #import <wtf/ContinuousApproximateTime.h>
 #import <wtf/Function.h>
+#import <wtf/HashSet.h>
 #import <wtf/Ref.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/Vector.h>
@@ -185,6 +186,26 @@ private:
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
     HashMap<WebCore::RegistrableDomain, RestrictedOpenerType> m_restrictedOpenerTypes;
     ContinuousApproximateTime m_nextScheduledUpdateTime;
+};
+
+class HighValueFraudTargetDomainsController {
+public:
+    static HighValueFraudTargetDomainsController& singleton();
+
+    bool contains(const WebCore::RegistrableDomain&) const;
+    void setDomainsForTesting(HashSet<WebCore::RegistrableDomain>&&);
+
+private:
+    friend class NeverDestroyed<HighValueFraudTargetDomainsController, MainRunLoopAccessTraits>;
+    HighValueFraudTargetDomainsController();
+    void scheduleNextUpdate(ContinuousApproximateTime);
+    void update();
+
+    RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
+    HashSet<WebCore::RegistrableDomain> m_domains;
+    ContinuousApproximateTime m_nextScheduledUpdateTime;
+    bool m_didReceiveInitialData { false };
+    bool m_hasInjectedDomainsForTesting { false };
 };
 
 class ResourceMonitorURLsController {

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -41,6 +41,7 @@
 #import <pal/spi/cocoa/NetworkSPI.h>
 #import <time.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/MonotonicTime.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RobinHoodHashMap.h>
 #import <wtf/RunLoop.h>
@@ -416,6 +417,92 @@ RestrictedOpenerType RestrictedOpenerDomainsController::lookup(const WebCore::Re
 
     auto it = m_restrictedOpenerTypes.find(domain);
     return it == m_restrictedOpenerTypes.end() ? RestrictedOpenerType::Unrestricted : it->value;
+}
+
+HighValueFraudTargetDomainsController& HighValueFraudTargetDomainsController::singleton()
+{
+    static MainRunLoopNeverDestroyed<HighValueFraudTargetDomainsController> sharedInstance;
+    return sharedInstance.get();
+}
+
+HighValueFraudTargetDomainsController::HighValueFraudTargetDomainsController()
+{
+    scheduleNextUpdate(ContinuousApproximateTime::now());
+    update();
+
+    m_notificationListener = adoptNS([[WKWebPrivacyNotificationListener alloc] initWithType:static_cast<WPResourceType>(WPResourceTypeHighValueFraudTargetDomains) callback:^{
+        update();
+    }]);
+}
+
+void HighValueFraudTargetDomainsController::scheduleNextUpdate(ContinuousApproximateTime now)
+{
+    // Allow the list to be re-requested from the server sometime between [24, 26) hours from now.
+    static WeakRandom random;
+    m_nextScheduledUpdateTime = now + 24_h + random.get() * 2_h;
+}
+
+void HighValueFraudTargetDomainsController::update()
+{
+    ASSERT(RunLoop::isMain());
+    if (m_hasInjectedDomainsForTesting)
+        return;
+
+    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClassSingleton() instancesRespondToSelector:@selector(requestHighValueFraudTargetDomains:completionHandler:)])
+        return;
+
+    RetainPtr options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
+    [options setAfterUpdates:NO];
+
+    auto requestStartTime = MonotonicTime::now();
+    [[PAL::getWPResourcesClassSingleton() sharedInstance] requestHighValueFraudTargetDomains:options.get() completionHandler:^(NSArray<WPHighValueFraudTargetDomain *> *domains, NSError *error) {
+        if (m_hasInjectedDomainsForTesting)
+            return;
+
+        auto elapsed = MonotonicTime::now() - requestStartTime;
+        if (error) {
+            RELEASE_LOG_ERROR(ResourceLoadStatistics, "Failed to request high-value fraud target domains from WebPrivacy after %.1f ms: %@", elapsed.milliseconds(), error);
+            return;
+        }
+
+        HashSet<WebCore::RegistrableDomain> highValueDomains;
+        highValueDomains.reserveInitialCapacity(domains.count);
+
+        for (WPHighValueFraudTargetDomain *domainInfo in domains) {
+            auto registrableDomain = WebCore::RegistrableDomain::fromRawString(domainInfo.domain);
+            if (registrableDomain.isEmpty())
+                continue;
+            highValueDomains.add(WTF::move(registrableDomain));
+        }
+
+        m_domains = WTF::move(highValueDomains);
+
+        if (std::exchange(m_didReceiveInitialData, true))
+            RELEASE_LOG(ResourceLoadStatistics, "HighValueFraudTargetDomainsController::update: Reloaded %u high-value fraud target domain(s) from WebPrivacy in %.1f ms.", m_domains.size(), elapsed.milliseconds());
+        else
+            RELEASE_LOG(ResourceLoadStatistics, "HighValueFraudTargetDomainsController::update: Loaded initial %u high-value fraud target domain(s) from WebPrivacy in %.1f ms.", m_domains.size(), elapsed.milliseconds());
+    }];
+}
+
+bool HighValueFraudTargetDomainsController::contains(const WebCore::RegistrableDomain& domain) const
+{
+    auto now = ContinuousApproximateTime::now();
+    if (now > m_nextScheduledUpdateTime) {
+        auto mutableThis = const_cast<HighValueFraudTargetDomainsController*>(this);
+        mutableThis->scheduleNextUpdate(now);
+        mutableThis->update();
+    }
+
+    return m_domains.contains(domain);
+}
+
+void HighValueFraudTargetDomainsController::setDomainsForTesting(HashSet<WebCore::RegistrableDomain>&& domains)
+{
+    ASSERT(RunLoop::isMain());
+    m_domains = WTF::move(domains);
+    m_didReceiveInitialData = true;
+    // Keep update() from replacing the injected list with real data from WebPrivacy.
+    m_hasInjectedDomainsForTesting = true;
 }
 
 ResourceMonitorURLsController& ResourceMonitorURLsController::singleton()

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1267,6 +1267,11 @@ struct WKWebsiteData {
     return @(signals->toRaw());
 }
 
+- (void)_setHighValueFraudTargetDomainsForTesting:(NSArray<NSString *> *)domains
+{
+    protect(*_websiteDataStore)->setHighValueFraudTargetDomainsForTesting(makeVector<String>(domains));
+}
+
 - (void)_getPendingPushMessage:(void(^)(NSDictionary *))completionHandler
 {
     RELEASE_LOG(Push, "Getting pending push message");

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -129,6 +129,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 
 -(bool)_hasServiceWorkerBackgroundActivityForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(NSNumber *)_isolatedSiteSignalsForTesting:(NSURL *)url WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0)); // IsolatedSiteStore::Signal bits, or nil if the site is not isolated.
+-(void)_setHighValueFraudTargetDomainsForTesting:(NSArray<NSString *> *)domains WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 -(void)_getPendingPushMessage:(void(^)(NSDictionary *))completionHandler WK_API_AVAILABLE(macos(15.2), ios(18.2));
 -(void)_getPendingPushMessages:(void(^)(NSArray<NSDictionary *> *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_processPushMessage:(NSDictionary *)pushMessage completionHandler:(void(^)(bool))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp
@@ -35,6 +35,10 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
+#if PLATFORM(COCOA)
+#include "WebPrivacyHelpers.h"
+#endif
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IsolatedSiteStore);
@@ -60,15 +64,16 @@ WorkQueue& IsolatedSiteStore::sharedWorkQueueSingleton()
     return workQueue.get();
 }
 
-Ref<IsolatedSiteStore> IsolatedSiteStore::create(const String& databaseDirectoryPath, UserInteractionDomainFetcher&& userInteractionDomainFetcher, HashSet<WebCore::RegistrableDomain>&& additionalSitesForTesting)
+Ref<IsolatedSiteStore> IsolatedSiteStore::create(const String& databaseDirectoryPath, UserInteractionDomainFetcher&& userInteractionDomainFetcher, bool highValueFraudTargetDomainsEnabled, HashSet<WebCore::RegistrableDomain>&& additionalSitesForTesting)
 {
-    return adoptRef(*new IsolatedSiteStore(databaseDirectoryPath, WTF::move(userInteractionDomainFetcher), WTF::move(additionalSitesForTesting)));
+    return adoptRef(*new IsolatedSiteStore(databaseDirectoryPath, WTF::move(userInteractionDomainFetcher), highValueFraudTargetDomainsEnabled, WTF::move(additionalSitesForTesting)));
 }
 
-IsolatedSiteStore::IsolatedSiteStore(const String& databaseDirectoryPath, UserInteractionDomainFetcher&& userInteractionDomainFetcher, HashSet<WebCore::RegistrableDomain>&& additionalSitesForTesting)
+IsolatedSiteStore::IsolatedSiteStore(const String& databaseDirectoryPath, UserInteractionDomainFetcher&& userInteractionDomainFetcher, bool highValueFraudTargetDomainsEnabled, HashSet<WebCore::RegistrableDomain>&& additionalSitesForTesting)
     : m_userInteractionDomainFetcher(WTF::move(userInteractionDomainFetcher))
     , m_additionalSitesForTesting(WTF::move(additionalSitesForTesting))
     , m_isPersistent(!databaseDirectoryPath.isEmpty())
+    , m_highValueFraudTargetDomainsEnabled(highValueFraudTargetDomainsEnabled)
 {
     ASSERT(isMainRunLoop());
 
@@ -90,7 +95,7 @@ IsolatedSiteStore::IsolatedSiteStore(const String& databaseDirectoryPath, UserIn
         HashMap<WebCore::RegistrableDomain, Entry> sites;
         for (auto& [domain, record] : protectedThis->m_persistence->allSites()) {
             // A bit written by a newer WebKit has no meaning here.
-            auto signals = OptionSet<Signal>::fromRaw(record.signals & allSignals.toRaw());
+            auto signals = OptionSet<Signal>::fromRaw(record.signals & persistedSignals.toRaw());
             if (signals.isEmpty())
                 continue;
 
@@ -363,11 +368,14 @@ OptionSet<IsolatedSiteStore::Signal> IsolatedSiteStore::reasonsFor(const WebCore
 {
     ASSERT(isMainRunLoop());
 
-    auto it = m_sites.find(site.domain());
-    if (it == m_sites.end())
-        return { };
+    OptionSet<Signal> signals;
+    if (auto it = m_sites.find(site.domain()); it != m_sites.end())
+        signals = it->value.signals;
 
-    return it->value.signals;
+    if (isHighValueFraudTargetDomain(site.domain()))
+        signals.add(Signal::HighValueFraudTarget);
+
+    return signals;
 }
 
 bool IsolatedSiteStore::contains(const WebCore::Site& site) const
@@ -379,7 +387,29 @@ bool IsolatedSiteStore::containsDomain(const WebCore::RegistrableDomain& domain)
 {
     ASSERT(isMainRunLoop());
 
-    return m_sites.contains(domain);
+    return m_sites.contains(domain) || isHighValueFraudTargetDomain(domain);
+}
+
+bool IsolatedSiteStore::isHighValueFraudTargetDomain(const WebCore::RegistrableDomain& domain) const
+{
+    ASSERT(isMainRunLoop());
+
+    if (!m_highValueFraudTargetDomainsEnabled)
+        return false;
+
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+    return HighValueFraudTargetDomainsController::singleton().contains(domain);
+#else
+    UNUSED_PARAM(domain);
+    return false;
+#endif
+}
+
+void IsolatedSiteStore::setHighValueFraudTargetDomainsEnabled(bool enabled)
+{
+    ASSERT(isMainRunLoop());
+
+    m_highValueFraudTargetDomainsEnabled = enabled;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h
@@ -48,11 +48,14 @@ public:
         Autofill = 1 << 0,
         FirstPartyVisit = 1 << 1,
         FirstPartyUserGesture = 1 << 2,
+        HighValueFraudTarget = 1 << 3,
     };
-    static constexpr OptionSet<Signal> allSignals { Signal::Autofill, Signal::FirstPartyVisit, Signal::FirstPartyUserGesture };
+    // HighValueFraudTarget is derived from WebPrivacy's list on every lookup, so it is deliberately
+    // absent here: it must never be written to or read back from IsolatedSitePersistence.
+    static constexpr OptionSet<Signal> persistedSignals { Signal::Autofill, Signal::FirstPartyVisit, Signal::FirstPartyUserGesture };
 
     using UserInteractionDomainFetcher = Function<void(CompletionHandler<void(std::optional<HashMap<WebCore::RegistrableDomain, WallTime>>&&)>&&)>;
-    static Ref<IsolatedSiteStore> create(const String& databaseDirectoryPath, UserInteractionDomainFetcher&&, HashSet<WebCore::RegistrableDomain>&& additionalSitesForTesting);
+    static Ref<IsolatedSiteStore> create(const String& databaseDirectoryPath, UserInteractionDomainFetcher&&, bool highValueFraudTargetDomainsEnabled, HashSet<WebCore::RegistrableDomain>&& additionalSitesForTesting);
     ~IsolatedSiteStore();
 
     void addSite(const WebCore::Site&, Signal);
@@ -64,11 +67,15 @@ public:
     void removeSitesUpdatedSince(WallTime, CompletionHandler<void()>&&);
     void removeSites(Vector<WebCore::RegistrableDomain>&&, CompletionHandler<void()>&&);
 
+    // Aggregated across every page using the owning WebsiteDataStore; see
+    // WebsiteDataStore::updateIsolatedSiteStoreSettings().
+    void setHighValueFraudTargetDomainsEnabled(bool);
+
     bool isReady() const { return m_isReady; }
     void whenReady(CompletionHandler<void()>&&);
 
 private:
-    IsolatedSiteStore(const String& databaseDirectoryPath, UserInteractionDomainFetcher&&, HashSet<WebCore::RegistrableDomain>&&);
+    IsolatedSiteStore(const String& databaseDirectoryPath, UserInteractionDomainFetcher&&, bool highValueFraudTargetDomainsEnabled, HashSet<WebCore::RegistrableDomain>&&);
 
     static WorkQueue& sharedWorkQueueSingleton();
 
@@ -76,6 +83,8 @@ private:
         OptionSet<Signal> signals;
         WallTime lastUpdated;
     };
+
+    bool isHighValueFraudTargetDomain(const WebCore::RegistrableDomain&) const;
 
     void didLoadSites(HashMap<WebCore::RegistrableDomain, Entry>&&, bool didImportUserInteractions);
     void whenLoaded(CompletionHandler<void()>&&);
@@ -92,6 +101,7 @@ private:
     UserInteractionDomainFetcher m_userInteractionDomainFetcher;
     HashSet<WebCore::RegistrableDomain> m_additionalSitesForTesting;
     const bool m_isPersistent { false };
+    bool m_highValueFraudTargetDomainsEnabled { false };
     bool m_isLoaded { false };
     bool m_isReady { false };
     bool m_importSuppressed { false };

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1556,10 +1556,37 @@ IsolatedSiteStore& WebsiteDataStore::isolatedSiteStore()
             protectedThis->fetchDomainsWithUserInteraction(WTF::move(completionHandler));
         };
 
-        lazyInitialize(m_isolatedSiteStore, IsolatedSiteStore::create(isPersistent() ? resolvedDirectories().isolatedSitesDirectory : String { }, WTF::move(fetcher), platformAdditionalDomainsWithUserInteraction()));
+        lazyInitialize(m_isolatedSiteStore, IsolatedSiteStore::create(isPersistent() ? resolvedDirectories().isolatedSitesDirectory : String { }, WTF::move(fetcher), computeSiteIsolationHighValueFraudTargetDomainsEnabled(), platformAdditionalDomainsWithUserInteraction()));
     }
 
     return *m_isolatedSiteStore;
+}
+
+bool WebsiteDataStore::computeSiteIsolationHighValueFraudTargetDomainsEnabled() const
+{
+    for (Ref page : m_pages) {
+        if (protect(page->preferences())->siteIsolationHighValueFraudTargetDomainsEnabled())
+            return true;
+    }
+
+    return false;
+}
+
+void WebsiteDataStore::updateIsolatedSiteStoreSettings()
+{
+    bool highValueFraudTargetDomainsEnabled = computeSiteIsolationHighValueFraudTargetDomainsEnabled();
+
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+    // Constructing the controller starts fetching the list, so that it is more likely to be ready
+    // for the first lookup.
+    if (highValueFraudTargetDomainsEnabled)
+        HighValueFraudTargetDomainsController::singleton();
+#endif
+
+    if (!m_isolatedSiteStore)
+        return;
+
+    m_isolatedSiteStore->setHighValueFraudTargetDomainsEnabled(highValueFraudTargetDomainsEnabled);
 }
 
 std::optional<OptionSet<IsolatedSiteStore::Signal>> WebsiteDataStore::isolatedSiteSignalsForTesting(const URL& url)
@@ -1570,6 +1597,20 @@ std::optional<OptionSet<IsolatedSiteStore::Signal>> WebsiteDataStore::isolatedSi
         return std::nullopt;
 
     return siteStore->reasonsFor(site);
+}
+
+void WebsiteDataStore::setHighValueFraudTargetDomainsForTesting(Vector<String>&& domains)
+{
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+    HashSet<WebCore::RegistrableDomain> registrableDomains;
+    registrableDomains.reserveInitialCapacity(domains.size());
+    for (auto& domain : domains)
+        registrableDomains.add(WebCore::RegistrableDomain::fromRawString(WTF::move(domain)));
+
+    HighValueFraudTargetDomainsController::singleton().setDomainsForTesting(WTF::move(registrableDomains));
+#else
+    UNUSED_PARAM(domains);
+#endif
 }
 
 void WebsiteDataStore::logUserInteraction(const URL& url, CompletionHandler<void()>&& completionHandler)
@@ -2115,6 +2156,10 @@ bool WebsiteDataStore::computeIsOptInCookiePartitioningEnabled() const
 
 void WebsiteDataStore::propagateSettingUpdates()
 {
+    // Intentionally above the guards below: this setting has nothing to do with the network process,
+    // and is needed even on ports without OPT_IN_PARTITIONED_COOKIES.
+    updateIsolatedSiteStoreSettings();
+
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
     RefPtr networkProcess = networkProcessIfExists();
     if (!networkProcess)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -233,6 +233,7 @@ public:
     void logTestingEvent(const String&);
     IsolatedSiteStore& isolatedSiteStore();
     std::optional<OptionSet<IsolatedSiteStore::Signal>> isolatedSiteSignalsForTesting(const URL&);
+    void setHighValueFraudTargetDomainsForTesting(Vector<String>&&);
     void logUserInteraction(const URL&, CompletionHandler<void()>&&);
     void getAllStorageAccessEntries(WebPageProxyIdentifier, CompletionHandler<void(Vector<String>&& domains)>&&);
     void hasHadUserInteraction(const URL&, CompletionHandler<void(bool)>&&);
@@ -541,6 +542,9 @@ private:
     void addTestDomains() const;
 #endif
     void initializeManagedDomains(ForceReinitialization = ForceReinitialization::No);
+
+    bool computeSiteIsolationHighValueFraudTargetDomainsEnabled() const;
+    void updateIsolatedSiteStoreSettings();
 
     void fetchDataAndApply(OptionSet<WebsiteDataType>, OptionSet<WebsiteDataFetchOption>, Ref<WorkQueue>&&, Function<void(Vector<WebsiteDataRecord>)>&& apply);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -12847,4 +12847,70 @@ TEST(SiteIsolation, RestoredPageWithIframeIsRenderedAfterCrossSiteBFCacheRoundTr
     checkFrameTreesInProcesses(webView.get(), { { "https://b.com"_s } });
 }
 
+enum class SiteIsolationHighValueFraudTargetDomainsEnabled : bool { No, Yes };
+
+static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> siteIsolatedViewWithHighValueFraudTargetDomains(const HTTPServer& server, NSArray<NSString *> *domains, SiteIsolationHighValueFraudTargetDomainsEnabled enabled)
+{
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+
+    // Stand in for the list WebPrivacy would have delivered, which is unavailable in tests.
+    [dataStore _setHighValueFraudTargetDomainsForTesting:domains];
+
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [viewConfiguration setWebsiteDataStore:dataStore.get()];
+    enableSiteIsolation(viewConfiguration.get());
+    enableFeature(viewConfiguration.get(), @"SiteIsolationSharedProcessEnabled");
+    if (enabled == SiteIsolationHighValueFraudTargetDomainsEnabled::Yes)
+        enableFeature(viewConfiguration.get(), @"SiteIsolationHighValueFraudTargetDomainsEnabled");
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:viewConfiguration.get()]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+    return { WTF::move(webView), WTF::move(navigationDelegate) };
+}
+
+static HTTPServer serverWithTwoCrossSiteFrames()
+{
+    return HTTPServer({
+        { "/example"_s, { "<!DOCTYPE html><iframe src='https://b.com/frame'></iframe><iframe src='https://c.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "hi"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+}
+
+TEST(SiteIsolation, SharedProcessExcludesHighValueFraudTargetDomains)
+{
+    auto server = serverWithTwoCrossSiteFrames();
+    auto [webView, navigationDelegate] = siteIsolatedViewWithHighValueFraudTargetDomains(server, @[@"b.com"], SiteIsolationHighValueFraudTargetDomainsEnabled::Yes);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // b.com is on the high-value fraud target domains list, so it gets its own process rather than
+    // joining c.com in the shared process.
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://example.com"_s, { { RemoteFrame }, { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s }, { RemoteFrame } } },
+        { RemoteFrame, { { RemoteFrame }, { "https://c.com"_s } } },
+    });
+}
+
+TEST(SiteIsolation, SharedProcessIgnoresHighValueFraudTargetDomainsWhenDisabled)
+{
+    auto server = serverWithTwoCrossSiteFrames();
+    auto [webView, navigationDelegate] = siteIsolatedViewWithHighValueFraudTargetDomains(server, @[@"b.com"], SiteIsolationHighValueFraudTargetDomainsEnabled::No);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // The list is populated but the preference is off, so b.com is still allowed to share a process.
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://example.com"_s, { { RemoteFrame }, { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s }, { "https://c.com"_s } } },
+    });
+}
+
 }


### PR DESCRIPTION
#### 8bd2ba0d3e5c4e753b5238a0180a5900df05e5db
<pre>
[Site Isolation] Keep high-value fraud target domains out of the shared process
<a href="https://bugs.webkit.org/show_bug.cgi?id=321804">https://bugs.webkit.org/show_bug.cgi?id=321804</a>
<a href="https://rdar.apple.com/184938204">rdar://184938204</a>

Reviewed by Basuke Suzuki.

IsolatedSiteStore currently only knows what this device has observed -- Autofill, FirstPartyVisit, FirstPartyUserGesture
-- so a site is kept out of the shared Web process only after the user has already interacted with it here, leaving the
first visit unprotected. Adopt WebPrivacy&apos;s high-value fraud target domains list as an additional signal so that a site
likely to hold sensitive user data is isolated on first contact.

HighValueFraudTargetDomainsController follows RestrictedOpenerDomainsController: it fetches the list on construction,
has it refreshed by a WKWebPrivacyNotificationListener, and re-requests it every [24, 26) hours. It is constructed from
WebsiteDataStore::updateIsolatedSiteStoreSettings() when a page that enables this is added to the data store -- earlier
than prewarming or the start of a load, and skipped for pages that do not enable this.

Note that placement does not wait for the list. The fetch has no bounded completion time, and a timeout-based bailout
would not help: every cross-site subframe in that window would wait out the full timeout first. A site looked up before
the list arrives is therefore treated as not being on it and may enter the shared process. The opposite default --
assuming an unknown site is on the list -- would instead launch a process per cross-site subframe. Given that sites
already recorded in IsolatedSiteStore are still isolated, this is the tradeoff we chose.

The new signal is behind SiteIsolationHighValueFraudTargetDomainsEnabled, which is unstable and off by default. It has
no effect unless SiteIsolationSharedProcessEnabled is also on. Although that is a WebPreferences flag, the placement it
influences is per-data-store state: a shared process&apos;s domain set is shared by every page in the store, and
WebProcessCache keys cached shared processes on the store. Aggregate it across every page using the WebsiteDataStore and
keep the result as a single flag on IsolatedSiteStore, updated from propagateSettingUpdates() -- which already runs on
addPage, removePage and WebPageProxy::preferencesDidChange -- and seeded when the store is created.

Tests: SiteIsolation.SharedProcessExcludesHighValueFraudTargetDomains
       SiteIsolation.SharedProcessIgnoresHighValueFraudTargetDomainsWhenDisabled

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h:
* Source/WebKit/Configurations/AllowedSPI-legacy.toml:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::HighValueFraudTargetDomainsController::singleton):
(WebKit::HighValueFraudTargetDomainsController::HighValueFraudTargetDomainsController):
(WebKit::HighValueFraudTargetDomainsController::scheduleNextUpdate):
(WebKit::HighValueFraudTargetDomainsController::update):
(WebKit::HighValueFraudTargetDomainsController::contains const):
(WebKit::HighValueFraudTargetDomainsController::setDomainsForTesting):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _setHighValueFraudTargetDomainsForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp:
(WebKit::IsolatedSiteStore::create):
(WebKit::IsolatedSiteStore::IsolatedSiteStore):
(WebKit::IsolatedSiteStore::reasonsFor const):
(WebKit::IsolatedSiteStore::containsDomain const):
(WebKit::IsolatedSiteStore::isHighValueFraudTargetDomain const):
(WebKit::IsolatedSiteStore::setHighValueFraudTargetDomainsEnabled):
* Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::isolatedSiteStore):
(WebKit::WebsiteDataStore::computeSiteIsolationHighValueFraudTargetDomainsEnabled const):
(WebKit::WebsiteDataStore::updateIsolatedSiteStoreSettings):
(WebKit::WebsiteDataStore::setHighValueFraudTargetDomainsForTesting):
(WebKit::WebsiteDataStore::propagateSettingUpdates):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, SharedProcessExcludesHighValueFraudTargetDomains)):
(TestWebKitAPI::(SiteIsolation, SharedProcessIgnoresHighValueFraudTargetDomainsWhenDisabled)):

Canonical link: <a href="https://commits.webkit.org/319324@main">https://commits.webkit.org/319324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2abdde3399a7fe2db426e226be3b05635e78d5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191391 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145497 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10139066-ecbc-45f9-a4d6-59a221a30567) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54835 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141390 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eaf582e2-4b99-4348-9959-aeb24d666b5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45061 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121841 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d98f8223-81cc-4f5e-94ee-5bba1b0e1264) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43734 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3806 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10623 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154138 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/41668 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2550 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42448 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47731 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193323 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54785 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150773 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55473 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150489 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45086 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127741 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123299 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53990 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16664 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53372 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53609 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->