### PR TITLE
[css-conditional] Support CSSConditionRule.supports

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-matches-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-matches-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Matching @supports rule assert_true: expected true got undefined
-FAIL Non matching @supports rule assert_false: expected false got undefined
+PASS Matching @supports rule
+PASS Non matching @supports rule
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/idlharness-expected.txt
@@ -32,10 +32,10 @@ PASS CSSSupportsRule interface object name
 PASS CSSSupportsRule interface: existence and properties of interface prototype object
 PASS CSSSupportsRule interface: existence and properties of interface prototype object's "constructor" property
 PASS CSSSupportsRule interface: existence and properties of interface prototype object's @@unscopables property
-FAIL CSSSupportsRule interface: attribute matches assert_true: The prototype object must have a property "matches" expected true got false
+PASS CSSSupportsRule interface: attribute matches
 PASS CSSSupportsRule must be primary interface of cssSupportsRule
 PASS Stringification of cssSupportsRule
-FAIL CSSSupportsRule interface: cssSupportsRule must inherit property "matches" with the proper type assert_inherits: property "matches" not found in prototype chain
+PASS CSSSupportsRule interface: cssSupportsRule must inherit property "matches" with the proper type
 PASS CSSConditionRule interface: cssSupportsRule must inherit property "conditionText" with the proper type
 PASS CSSRule interface: cssSupportsRule must inherit property "SUPPORTS_RULE" with the proper type
 PASS CSSRule interface: constant SUPPORTS_RULE on interface object

--- a/Source/WebCore/css/CSSSupportsRule.cpp
+++ b/Source/WebCore/css/CSSSupportsRule.cpp
@@ -69,4 +69,9 @@ String CSSSupportsRule::conditionText() const
     return downcast<StyleRuleSupports>(groupRule()).conditionText();
 }
 
+bool CSSSupportsRule::matches() const
+{
+    return downcast<StyleRuleSupports>(groupRule()).conditionIsSupported();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSupportsRule.h
+++ b/Source/WebCore/css/CSSSupportsRule.h
@@ -43,6 +43,7 @@ public:
     String cssText() const final;
     String cssText(const CSS::SerializationContext&) const final;
     String NODELETE conditionText() const final;
+    bool NODELETE matches() const;
 
 private:
     CSSSupportsRule(StyleRuleSupports&, CSSStyleSheet*);

--- a/Source/WebCore/css/CSSSupportsRule.idl
+++ b/Source/WebCore/css/CSSSupportsRule.idl
@@ -33,6 +33,5 @@
 [
     Exposed=Window
 ] interface CSSSupportsRule : CSSConditionRule {
-    // FIXME: Add support for `matches`.
-    // readonly attribute boolean matches;
+    readonly attribute boolean matches;
 };


### PR DESCRIPTION
#### 97ac901a7a5597d332b3a91365ab360f23dcc069
<pre>
[css-conditional] Support CSSConditionRule.supports
<a href="https://rdar.apple.com/184943650">rdar://184943650</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321808">https://bugs.webkit.org/show_bug.cgi?id=321808</a>

Reviewed by NOBODY (OOPS!).

CSSWG resolves in 2022 [1] to add CSSConditionRule.supports, which returns
whether the supports query in @supports is supported or not. In WebKit,
CSSConditionRule wraps StyleRuleSupports, and it exposes the supported status
via conditionIsSupported(), so it&apos;s straightforward to expose it to CSSOM.

[1]: <a href="https://github.com/w3c/csswg-drafts/issues/4240#issuecomment-1196983719">https://github.com/w3c/csswg-drafts/issues/4240#issuecomment-1196983719</a>

Tests: imported/w3c/web-platform-tests/css/css-conditional/at-supports-matches.html
       imported/w3c/web-platform-tests/css/css-conditional/idlharness.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-matches-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/idlharness-expected.txt:
* Source/WebCore/css/CSSSupportsRule.cpp:
(WebCore::CSSSupportsRule::matches const):
* Source/WebCore/css/CSSSupportsRule.h:
* Source/WebCore/css/CSSSupportsRule.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97ac901a7a5597d332b3a91365ab360f23dcc069

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191006 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145115 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8998e685-8df8-451f-8102-426243b874d9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54453 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141033 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97740 "1 flakes 6 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb2391d5-886f-40e3-a269-725dd018e5c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121484 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb817bc2-1018-4ed3-9f9d-04f924595233) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43368 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41647 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41307 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2166 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192940 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54403 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150413 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40331 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55091 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150131 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44724 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127357 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122649 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53608 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16300 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52990 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53227 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53055 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->