### PR TITLE
Port more of WebExtensionController to C++

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -36,31 +36,18 @@
 #import "CocoaHelpers.h"
 #import "ContextMenuContextData.h"
 #import "Logging.h"
-#import "SandboxUtilities.h"
 #import "WKFeature.h"
 #import "WKPreferences.h"
 #import "WKPreferencesPrivate.h"
 #import "WKWebViewConfigurationPrivate.h"
-#import "WKWebsiteDataStoreInternal.h"
 #import "WebExtensionContext.h"
-#import "WebExtensionContextMessages.h"
-#import "WebExtensionContextParameters.h"
-#import "WebExtensionContextProxyMessages.h"
-#import "WebExtensionControllerMessages.h"
-#import "WebExtensionControllerProxyMessages.h"
 #import "WebExtensionDataRecord.h"
-#import "WebExtensionEventListenerType.h"
-#import "WebExtensionStorageSQLiteStore.h"
 #import "WebPageProxy.h"
-#import "WebProcessPool.h"
 #import "_WKFeatureInternal.h"
 #import <WebCore/ContentRuleListResults.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CallbackAggregator.h>
 #import <wtf/FileSystem.h>
-#import <wtf/HashMap.h>
-#import <wtf/HashSet.h>
-#import <wtf/NeverDestroyed.h>
 #import <wtf/text/WTFString.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -124,13 +111,6 @@ void WebExtensionController::initializePlatform()
     m_webExtensionControllerHelper = [[_WKWebExtensionControllerHelper alloc] initWithWebExtensionController:*this];
 }
 
-String WebExtensionController::storageDirectory(WebExtensionContext& extensionContext) const
-{
-    if (m_configuration->storageIsPersistent() && extensionContext.hasCustomUniqueIdentifier())
-        return FileSystem::pathByAppendingComponent(m_configuration->storageDirectory(), extensionContext.uniqueIdentifier());
-    return nullString();
-}
-
 void WebExtensionController::getDataRecords(OptionSet<WebExtensionDataType> dataTypes, CompletionHandler<void(Vector<Ref<WebExtensionDataRecord>>)>&& completionHandler)
 {
     if (!m_configuration->storageIsPersistent() || dataTypes.isEmpty()) {
@@ -167,7 +147,7 @@ void WebExtensionController::getDataRecords(OptionSet<WebExtensionDataType> data
                 continue;
             }
 
-            calculateStorageSize(storage, dataType, makeBlockPtr([recordHolder, aggregator, uniqueIdentifier, displayName, dataType, record = Ref { record }](Expected<size_t, WebExtensionError>&& result) mutable {
+            calculateStorageSize(*storage, dataType, makeBlockPtr([recordHolder, aggregator, uniqueIdentifier, displayName, dataType, record = Ref { record }](Expected<size_t, WebExtensionError>&& result) mutable {
                 if (!result)
                     record->addError(result.error().createNSString().get(), dataType);
                 else
@@ -217,7 +197,7 @@ void WebExtensionController::getDataRecord(OptionSet<WebExtensionDataType> dataT
             continue;
         }
 
-        calculateStorageSize(storage, dataType, makeBlockPtr([recordHolder, aggregator, matchingUniqueIdentifier, displayName, dataType, record = Ref { record }](Expected<size_t, WebExtensionError>&& result) mutable {
+        calculateStorageSize(*storage, dataType, makeBlockPtr([recordHolder, aggregator, matchingUniqueIdentifier, displayName, dataType, record = Ref { record }](Expected<size_t, WebExtensionError>&& result) mutable {
             if (!result)
                 record->addError(result.error().createNSString().get(), dataType);
             else
@@ -248,7 +228,7 @@ void WebExtensionController::removeData(OptionSet<WebExtensionDataType> dataType
                 continue;
             }
 
-            removeStorage(storage, dataType, makeBlockPtr([aggregator, uniqueIdentifier, dataType, record = Ref { record }](Expected<void, WebExtensionError>&& result) mutable {
+            removeStorage(*storage, dataType, makeBlockPtr([aggregator, uniqueIdentifier, dataType, record = Ref { record }](Expected<void, WebExtensionError>&& result) mutable {
                 if (!result)
                     record->addError(result.error().createNSString().get(), dataType);
                 else
@@ -256,278 +236,6 @@ void WebExtensionController::removeData(OptionSet<WebExtensionDataType> dataType
             }));
         }
     }
-}
-
-void WebExtensionController::calculateStorageSize(RefPtr<WebExtensionStorageSQLiteStore> storage, WebExtensionDataType type, CompletionHandler<void(Expected<size_t, WebExtensionError>&&)>&& completionHandler)
-{
-    if (!storage)
-        return;
-
-    storage->getStorageSizeForKeys({ }, [completionHandler = WTF::move(completionHandler)](size_t storageSize, const String& errorMessage) mutable {
-        // FIXME: <https://webkit.org/b/269100> Add storage size of window.localStorage, window.sessionStorage and indexedDB.
-        if (!errorMessage.isEmpty())
-            completionHandler(makeUnexpected(errorMessage));
-        else
-            completionHandler(storageSize);
-    });
-}
-
-void WebExtensionController::removeStorage(RefPtr<WebExtensionStorageSQLiteStore> storage, WebExtensionDataType type, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
-{
-    storage->deleteDatabase([completionHandler = WTF::move(completionHandler)](const String& errorMessage) mutable {
-        // FIXME: <https://webkit.org/b/269100> Remove window.localStorage, window.sessionStorage, indexedDB.
-        if (!errorMessage.isEmpty())
-            completionHandler(makeUnexpected(errorMessage));
-        else
-            completionHandler({ });
-    });
-}
-
-Expected<bool, RefPtr<API::Error>> WebExtensionController::load(WebExtensionContext& extensionContext)
-{
-    if (!m_extensionContexts.add(extensionContext)) {
-        RELEASE_LOG_ERROR(Extensions, "Extension context already loaded");
-        return makeUnexpected(extensionContext.createError(WebExtensionContext::Error::AlreadyLoaded));
-    }
-
-    if (!m_extensionContextBaseURLMap.add(extensionContext.baseURL().protocolHostAndPort(), extensionContext)) {
-        RELEASE_LOG_ERROR(Extensions, "Extension context already loaded with same base URL: %{private}@", extensionContext.baseURL().createNSURL().get());
-        m_extensionContexts.remove(extensionContext);
-        return makeUnexpected(extensionContext.createError(WebExtensionContext::Error::BaseURLAlreadyInUse));
-    }
-
-    for (Ref processPool : m_processPools) {
-        processPool->addMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), extensionContext.identifier(), extensionContext);
-        processPool->addMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), extensionContext.privilegedIdentifier(), extensionContext);
-    }
-
-    auto scheme = extensionContext.baseURL().protocol().toString();
-    m_registeredSchemeHandlers.ensure(scheme, [&]() {
-        Ref handler = WebExtensionURLSchemeHandler::create(*this);
-
-        for (Ref page : m_pages)
-            page->setURLSchemeHandlerForScheme(handler.copyRef(), scheme);
-
-        return handler;
-    });
-
-    auto extensionDirectory = storageDirectory(extensionContext);
-    if (!!extensionDirectory && !FileSystem::makeAllDirectories(extensionDirectory))
-        RELEASE_LOG_ERROR(Extensions, "Failed to create directory: %{private}@", extensionDirectory.createNSString().get());
-
-    auto loadResult = extensionContext.load(*this, extensionDirectory);
-    if (!loadResult) {
-        m_extensionContexts.remove(extensionContext);
-        m_extensionContextBaseURLMap.remove(extensionContext.baseURL().protocolHostAndPort());
-
-        for (Ref processPool : m_processPools) {
-            processPool->removeMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), extensionContext.identifier());
-            processPool->removeMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), extensionContext.privilegedIdentifier());
-        }
-
-        return makeUnexpected(loadResult.error());
-    }
-
-    return true;
-}
-
-Expected<bool, RefPtr<API::Error>> WebExtensionController::unload(WebExtensionContext& extensionContext)
-{
-    Ref protectedExtensionContext = extensionContext;
-
-    if (!m_extensionContexts.remove(extensionContext)) {
-        RELEASE_LOG_ERROR(Extensions, "Extension context not loaded");
-        return makeUnexpected(extensionContext.createError(WebExtensionContext::Error::NotLoaded));
-    }
-
-    bool result = m_extensionContextBaseURLMap.remove(extensionContext.baseURL().protocolHostAndPort());
-    UNUSED_VARIABLE(result);
-    ASSERT(result);
-
-    sendToAllProcesses(Messages::WebExtensionControllerProxy::Unload(extensionContext.identifier()), identifier());
-
-    for (Ref processPool : m_processPools) {
-        processPool->removeMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), extensionContext.identifier());
-        processPool->removeMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), extensionContext.privilegedIdentifier());
-    }
-
-    auto unloadResult = extensionContext.unload();
-    if (!unloadResult)
-        return makeUnexpected(unloadResult.error());
-
-    return true;
-}
-
-void WebExtensionController::unloadAll()
-{
-    auto contextsCopy = m_extensionContexts;
-    for (Ref context : contextsCopy)
-        std::ignore = unload(context);
-}
-
-void WebExtensionController::dispatchDidLoad(WebExtensionContext& context)
-{
-    sendToAllProcesses(Messages::WebExtensionControllerProxy::Load(context.parameters(WebExtensionContext::IncludePrivilegedIdentifier::No)), identifier());
-}
-
-void WebExtensionController::addPage(WebPageProxy& page)
-{
-    ASSERT(!m_pages.contains(page));
-    m_pages.add(page);
-
-    for (auto& entry : m_registeredSchemeHandlers)
-        page.setURLSchemeHandlerForScheme(entry.value.copyRef(), entry.key);
-
-    Ref pool = page.configuration().processPool();
-    addProcessPool(pool);
-
-    Ref dataStore = page.websiteDataStore();
-    addWebsiteDataStore(dataStore);
-
-    Ref controller = page.userContentController();
-    bool isOwnStore = !dataStore->isPersistent() && (&dataStore.get() == &m_configuration->defaultWebsiteDataStore());
-    addUserContentController(controller, (dataStore->isPersistent() || isOwnStore) ? ForPrivateBrowsing::No : ForPrivateBrowsing::Yes);
-}
-
-void WebExtensionController::removePage(WebPageProxy& page)
-{
-    ASSERT(m_pages.contains(page));
-    m_pages.remove(page);
-
-    Ref pool = page.configuration().processPool();
-    removeProcessPool(pool);
-
-    Ref dataStore = page.websiteDataStore();
-    removeWebsiteDataStore(dataStore);
-
-    Ref controller = page.userContentController();
-    removeUserContentController(controller);
-
-    for (Ref context : m_extensionContexts)
-        context->removePage(page);
-}
-
-void WebExtensionController::addProcessPool(WebProcessPool& processPool)
-{
-    if (!m_processPools.add(processPool))
-        return;
-
-    for (auto& urlScheme : WebExtensionMatchPattern::extensionSchemes()) {
-        processPool.registerURLSchemeAsSecure(urlScheme);
-        processPool.registerURLSchemeAsBypassingContentSecurityPolicy(urlScheme);
-        processPool.setDomainRelaxationForbiddenForURLScheme(urlScheme);
-    }
-
-    processPool.addMessageReceiver(Messages::WebExtensionController::messageReceiverName(), identifier(), *this);
-
-    for (Ref context : m_extensionContexts) {
-        processPool.addMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), context->identifier(), context);
-        processPool.addMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), context->privilegedIdentifier(), context);
-    }
-}
-
-void WebExtensionController::removeProcessPool(WebProcessPool& processPool)
-{
-    // Only remove the message receiver and process pool if no other pages use the same process pool.
-    for (Ref knownPage : m_pages) {
-        if (knownPage->configuration().processPool() == processPool)
-            return;
-    }
-
-    processPool.removeMessageReceiver(Messages::WebExtensionController::messageReceiverName(), identifier());
-
-    for (Ref context : m_extensionContexts) {
-        processPool.removeMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), context->identifier());
-        processPool.removeMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), context->privilegedIdentifier());
-    }
-
-    m_processPools.remove(processPool);
-}
-
-void WebExtensionController::addUserContentController(WebUserContentControllerProxy& userContentController, ForPrivateBrowsing forPrivateBrowsing)
-{
-    if (forPrivateBrowsing == ForPrivateBrowsing::No)
-        m_allNonPrivateUserContentControllers.add(userContentController);
-    else
-        m_allPrivateUserContentControllers.add(userContentController);
-
-    if (!m_allUserContentControllers.add(userContentController))
-        return;
-
-    for (Ref context : m_extensionContexts) {
-        if (!context->hasAccessToPrivateData() && forPrivateBrowsing == ForPrivateBrowsing::Yes)
-            continue;
-
-        context->addInjectedContent(userContentController);
-        context->addDeclarativeNetRequestRules(userContentController);
-    }
-}
-
-void WebExtensionController::removeUserContentController(WebUserContentControllerProxy& userContentController)
-{
-    // Only remove the user content controller if no other pages use the same one.
-    for (auto& knownPage : m_pages) {
-        if (knownPage.userContentController() == userContentController)
-            return;
-    }
-
-    for (Ref context : m_extensionContexts) {
-        context->removeInjectedContent(userContentController);
-        userContentController.removeContentRuleList(context->uniqueIdentifier());
-    }
-
-    m_allNonPrivateUserContentControllers.remove(userContentController);
-    m_allPrivateUserContentControllers.remove(userContentController);
-    m_allUserContentControllers.remove(userContentController);
-}
-
-RefPtr<WebsiteDataStore> WebExtensionController::websiteDataStore(std::optional<PAL::SessionID> sessionID) const
-{
-    Ref configuration = m_configuration;
-    if (!sessionID || configuration->defaultWebsiteDataStore().sessionID() == sessionID.value())
-        return configuration->defaultWebsiteDataStore();
-
-    for (auto& dataStore : allWebsiteDataStores()) {
-        if (dataStore.sessionID() == sessionID.value())
-            return &dataStore;
-    }
-
-    return nullptr;
-}
-
-void WebExtensionController::addWebsiteDataStore(WebsiteDataStore& dataStore)
-{
-    m_websiteDataStores.add(dataStore);
-
-    if (!m_cookieStoreObserver)
-        m_cookieStoreObserver = HTTPCookieStoreObserver::create(*this);
-
-    protect(dataStore.cookieStore())->registerObserver(*protect(m_cookieStoreObserver));
-}
-
-void WebExtensionController::removeWebsiteDataStore(WebsiteDataStore& dataStore)
-{
-    // Only remove the data store if no other pages use the same one.
-    for (auto& knownPage : m_pages) {
-        if (knownPage.websiteDataStore() == dataStore)
-            return;
-    }
-
-    m_websiteDataStores.remove(dataStore);
-
-    if (RefPtr observer = m_cookieStoreObserver)
-        protect(dataStore.cookieStore())->unregisterObserver(*observer);
-
-    if (m_websiteDataStores.isEmptyIgnoringNullReferences())
-        m_cookieStoreObserver = nullptr;
-}
-
-void WebExtensionController::cookiesDidChange(API::HTTPCookieStore& cookieStore)
-{
-    // FIXME: <https://webkit.org/b/267514> Add support for changeInfo.
-
-    for (Ref context : m_extensionContexts)
-        context->cookiesDidChange(cookieStore);
 }
 
 bool WebExtensionController::isFeatureEnabled(const String& featureName) const
@@ -543,82 +251,6 @@ bool WebExtensionController::isFeatureEnabled(const String& featureName) const
     return false;
 }
 
-RefPtr<WebExtensionContext> WebExtensionController::extensionContext(const WebExtension& extension) const
-{
-    for (auto& context : m_extensionContexts) {
-        if (context->extension() == extension)
-            return context.ptr();
-    }
-
-    return nullptr;
-}
-
-RefPtr<WebExtensionContext> WebExtensionController::extensionContext(const UniqueIdentifier& uniqueIdentifier) const
-{
-    for (auto& context : m_extensionContexts) {
-        if (context->uniqueIdentifier() == uniqueIdentifier)
-            return context.ptr();
-    }
-
-    return nullptr;
-}
-
-RefPtr<WebExtensionContext> WebExtensionController::extensionContext(const URL& url) const
-{
-    return m_extensionContextBaseURLMap.get(url.protocolHostAndPort());
-}
-
-WebExtensionController::WebExtensionSet WebExtensionController::extensions() const
-{
-    WebExtensionSet extensions;
-    extensions.reserveInitialCapacity(m_extensionContexts.size());
-    for (Ref context : m_extensionContexts)
-        extensions.addVoid(context->extension());
-    return extensions;
-}
-
-String WebExtensionController::stateFilePath(const String& uniqueIdentifier) const
-{
-    return FileSystem::pathByAppendingComponent(storageDirectory(uniqueIdentifier), WebExtensionContext::plistFileName());
-}
-
-String WebExtensionController::storageDirectory(const String& uniqueIdentifier) const
-{
-    return FileSystem::pathByAppendingComponent(m_configuration->storageDirectory(), uniqueIdentifier);
-}
-
-HashSet<String> WebExtensionController::activeExtensionURLs() const
-{
-    HashSet<String> origins;
-
-    for (auto& context : m_extensionContexts)
-        origins.add(context->baseURL().protocolHostAndPort().convertToASCIILowercase());
-
-    if (m_configuration->storageIsPersistent()) {
-        for (auto& uniqueIdentifier : FileSystem::listDirectory(m_configuration->storageDirectory())) {
-            if (uniqueIdentifier == "StaleExtensionOriginsCleared"_s)
-                continue;
-            URL lastSeenBaseURL;
-            if (WebExtensionContext::readLastBaseURLFromState(stateFilePath(uniqueIdentifier), lastSeenBaseURL))
-                origins.add(lastSeenBaseURL.protocolHostAndPort().convertToASCIILowercase());
-        }
-    }
-
-    return origins;
-}
-
-RefPtr<WebExtensionStorageSQLiteStore> WebExtensionController::sqliteStore(const String& storageDirectory, WebExtensionDataType type, RefPtr<WebExtensionContext> extensionContext)
-{
-    if (type == WebExtensionDataType::Session) {
-        if (extensionContext)
-            return extensionContext->storageForType(WebExtensionDataType::Session);
-        return nullptr;
-    }
-
-    auto uniqueIdentifier = FileSystem::lastComponentOfPathIgnoringTrailingSlash(storageDirectory);
-    return WebExtensionStorageSQLiteStore::create(uniqueIdentifier, type, storageDirectory, WebExtensionStorageSQLiteStore::UsesInMemoryDatabase::No);
-}
-
 #if PLATFORM(MAC)
 void WebExtensionController::addItemsToContextMenu(WebPageProxy& page, const ContextMenuContextData& contextData, NSMenu *menu)
 {
@@ -628,32 +260,6 @@ void WebExtensionController::addItemsToContextMenu(WebPageProxy& page, const Con
         context->addItemsToContextMenu(page, contextData, menu);
 }
 #endif
-
-// MARK: webNavigation
-
-void WebExtensionController::didStartProvisionalLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
-{
-    for (Ref context : m_extensionContexts)
-        context->didStartProvisionalLoadForFrame(pageID, frameParameters, timestamp);
-}
-
-void WebExtensionController::didCommitLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
-{
-    for (Ref context : m_extensionContexts)
-        context->didCommitLoadForFrame(pageID, frameParameters, timestamp);
-}
-
-void WebExtensionController::didFinishLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
-{
-    for (Ref context : m_extensionContexts)
-        context->didFinishLoadForFrame(pageID, frameParameters, timestamp);
-}
-
-void WebExtensionController::didFailLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
-{
-    for (Ref context : m_extensionContexts)
-        context->didFailLoadForFrame(pageID, frameParameters, timestamp);
-}
 
 // MARK: declarativeNetRequest
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -28,11 +28,17 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "APIError.h"
+#include "Logging.h"
+#include "WebExtensionContextMessages.h"
 #include "WebExtensionControllerMessages.h"
 #include "WebExtensionControllerParameters.h"
 #include "WebExtensionControllerProxyMessages.h"
+#include "WebExtensionMatchPattern.h"
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
+#include "WebsiteDataStore.h"
+#include <wtf/FileSystem.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -46,6 +52,28 @@ namespace WebKit {
 #if PLATFORM(COCOA)
 constexpr auto freshlyCreatedTimeout = 5_s;
 #endif
+
+static void addContextMessageReceivers(WebProcessPool& processPool, WebExtensionContext& context)
+{
+#if PLATFORM(COCOA)
+    processPool.addMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), context.identifier(), context);
+    processPool.addMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), context.privilegedIdentifier(), context);
+#else
+    UNUSED_PARAM(processPool);
+    UNUSED_PARAM(context);
+#endif
+}
+
+static void removeContextMessageReceivers(WebProcessPool& processPool, WebExtensionContext& context)
+{
+#if PLATFORM(COCOA)
+    processPool.removeMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), context.identifier());
+    processPool.removeMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), context.privilegedIdentifier());
+#else
+    UNUSED_PARAM(processPool);
+    UNUSED_PARAM(context);
+#endif
+}
 
 static HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionController>>& NODELETE webExtensionControllers()
 {
@@ -114,6 +142,374 @@ WebExtensionController::WebProcessProxySet WebExtensionController::allProcesses(
     }
 
     return result;
+}
+
+Expected<bool, RefPtr<API::Error>> WebExtensionController::load(WebExtensionContext& extensionContext)
+{
+    if (!m_extensionContexts.add(extensionContext)) {
+        RELEASE_LOG_ERROR(Extensions, "Extension context already loaded");
+        return makeUnexpected(extensionContext.createError(WebExtensionContext::Error::AlreadyLoaded));
+    }
+
+    if (!m_extensionContextBaseURLMap.add(extensionContext.baseURL().protocolHostAndPort(), extensionContext)) {
+        RELEASE_LOG_ERROR(Extensions, "Extension context already loaded with same base URL: %" PRIVATE_LOG_STRING, extensionContext.baseURL().string().utf8().data());
+        m_extensionContexts.remove(extensionContext);
+        return makeUnexpected(extensionContext.createError(WebExtensionContext::Error::BaseURLAlreadyInUse));
+    }
+
+    for (Ref processPool : m_processPools)
+        addContextMessageReceivers(processPool, extensionContext);
+
+    auto scheme = extensionContext.baseURL().protocol().toString();
+    m_registeredSchemeHandlers.ensure(scheme, [&]() {
+        Ref handler = WebExtensionURLSchemeHandler::create(*this);
+
+        for (Ref page : m_pages)
+            page->setURLSchemeHandlerForScheme(handler.copyRef(), scheme);
+
+        return handler;
+    });
+
+    auto extensionDirectory = storageDirectory(extensionContext);
+    if (!!extensionDirectory && !FileSystem::makeAllDirectories(extensionDirectory))
+        RELEASE_LOG_ERROR(Extensions, "Failed to create directory: %" PRIVATE_LOG_STRING, extensionDirectory.utf8().data());
+
+    auto loadResult = extensionContext.load(*this, extensionDirectory);
+    if (!loadResult) {
+        m_extensionContexts.remove(extensionContext);
+        m_extensionContextBaseURLMap.remove(extensionContext.baseURL().protocolHostAndPort());
+
+        for (Ref processPool : m_processPools)
+            removeContextMessageReceivers(processPool, extensionContext);
+
+        return makeUnexpected(loadResult.error());
+    }
+
+    return true;
+}
+
+Expected<bool, RefPtr<API::Error>> WebExtensionController::unload(WebExtensionContext& extensionContext)
+{
+    Ref protectedExtensionContext = extensionContext;
+
+    if (!m_extensionContexts.remove(extensionContext)) {
+        RELEASE_LOG_ERROR(Extensions, "Extension context not loaded");
+        return makeUnexpected(extensionContext.createError(WebExtensionContext::Error::NotLoaded));
+    }
+
+    bool result = m_extensionContextBaseURLMap.remove(extensionContext.baseURL().protocolHostAndPort());
+    UNUSED_VARIABLE(result);
+    ASSERT(result);
+
+    sendToAllProcesses(Messages::WebExtensionControllerProxy::Unload(extensionContext.identifier()), identifier());
+
+    for (Ref processPool : m_processPools)
+        removeContextMessageReceivers(processPool, extensionContext);
+
+    auto unloadResult = extensionContext.unload();
+    if (!unloadResult)
+        return makeUnexpected(unloadResult.error());
+
+    return true;
+}
+
+void WebExtensionController::unloadAll()
+{
+    auto contextsCopy = m_extensionContexts;
+    for (Ref context : contextsCopy)
+        std::ignore = unload(context);
+}
+
+void WebExtensionController::dispatchDidLoad(WebExtensionContext& context)
+{
+    sendToAllProcesses(Messages::WebExtensionControllerProxy::Load(context.parameters(WebExtensionContext::IncludePrivilegedIdentifier::No)), identifier());
+}
+
+void WebExtensionController::addPage(WebPageProxy& page)
+{
+    ASSERT(!m_pages.contains(page));
+    m_pages.add(page);
+
+    for (auto& entry : m_registeredSchemeHandlers)
+        page.setURLSchemeHandlerForScheme(entry.value.copyRef(), entry.key);
+
+    Ref pool = page.configuration().processPool();
+    addProcessPool(pool);
+
+    Ref dataStore = page.websiteDataStore();
+    addWebsiteDataStore(dataStore);
+
+    Ref controller = page.userContentController();
+    bool isOwnStore = !dataStore->isPersistent() && (&dataStore.get() == &m_configuration->defaultWebsiteDataStore());
+    addUserContentController(controller, (dataStore->isPersistent() || isOwnStore) ? ForPrivateBrowsing::No : ForPrivateBrowsing::Yes);
+}
+
+void WebExtensionController::removePage(WebPageProxy& page)
+{
+    ASSERT(m_pages.contains(page));
+    m_pages.remove(page);
+
+    Ref pool = page.configuration().processPool();
+    removeProcessPool(pool);
+
+    Ref dataStore = page.websiteDataStore();
+    removeWebsiteDataStore(dataStore);
+
+    Ref controller = page.userContentController();
+    removeUserContentController(controller);
+
+    for (Ref context : m_extensionContexts)
+        context->removePage(page);
+}
+
+void WebExtensionController::addProcessPool(WebProcessPool& processPool)
+{
+    if (!m_processPools.add(processPool))
+        return;
+
+    for (auto& urlScheme : WebExtensionMatchPattern::extensionSchemes()) {
+        processPool.registerURLSchemeAsSecure(urlScheme);
+        processPool.registerURLSchemeAsBypassingContentSecurityPolicy(urlScheme);
+        processPool.setDomainRelaxationForbiddenForURLScheme(urlScheme);
+    }
+
+    processPool.addMessageReceiver(Messages::WebExtensionController::messageReceiverName(), identifier(), *this);
+
+    for (Ref context : m_extensionContexts)
+        addContextMessageReceivers(processPool, context);
+}
+
+void WebExtensionController::removeProcessPool(WebProcessPool& processPool)
+{
+    // Only remove the message receiver and process pool if no other pages use the same process pool.
+    for (Ref knownPage : m_pages) {
+        if (knownPage->configuration().processPool() == processPool)
+            return;
+    }
+
+    processPool.removeMessageReceiver(Messages::WebExtensionController::messageReceiverName(), identifier());
+
+    for (Ref context : m_extensionContexts)
+        removeContextMessageReceivers(processPool, context);
+
+    m_processPools.remove(processPool);
+}
+
+void WebExtensionController::addUserContentController(WebUserContentControllerProxy& userContentController, ForPrivateBrowsing forPrivateBrowsing)
+{
+    if (forPrivateBrowsing == ForPrivateBrowsing::No)
+        m_allNonPrivateUserContentControllers.add(userContentController);
+    else
+        m_allPrivateUserContentControllers.add(userContentController);
+
+    if (!m_allUserContentControllers.add(userContentController))
+        return;
+
+    for (Ref context : m_extensionContexts) {
+        if (!context->hasAccessToPrivateData() && forPrivateBrowsing == ForPrivateBrowsing::Yes)
+            continue;
+
+        context->addInjectedContent(userContentController);
+        context->addDeclarativeNetRequestRules(userContentController);
+    }
+}
+
+void WebExtensionController::removeUserContentController(WebUserContentControllerProxy& userContentController)
+{
+    // Only remove the user content controller if no other pages use the same one.
+    for (auto& knownPage : m_pages) {
+        if (knownPage.userContentController() == userContentController)
+            return;
+    }
+
+    for (Ref context : m_extensionContexts) {
+        context->removeInjectedContent(userContentController);
+        userContentController.removeContentRuleList(context->uniqueIdentifier());
+    }
+
+    m_allNonPrivateUserContentControllers.remove(userContentController);
+    m_allPrivateUserContentControllers.remove(userContentController);
+    m_allUserContentControllers.remove(userContentController);
+}
+
+RefPtr<WebsiteDataStore> WebExtensionController::websiteDataStore(std::optional<PAL::SessionID> sessionID) const
+{
+    Ref configuration = m_configuration;
+    if (!sessionID || configuration->defaultWebsiteDataStore().sessionID() == sessionID.value())
+        return configuration->defaultWebsiteDataStore();
+
+    for (auto& dataStore : allWebsiteDataStores()) {
+        if (dataStore.sessionID() == sessionID.value())
+            return &dataStore;
+    }
+
+    return nullptr;
+}
+
+void WebExtensionController::addWebsiteDataStore(WebsiteDataStore& dataStore)
+{
+    m_websiteDataStores.add(dataStore);
+
+    if (!m_cookieStoreObserver)
+        m_cookieStoreObserver = HTTPCookieStoreObserver::create(*this);
+
+    protect(dataStore.cookieStore())->registerObserver(*protect(m_cookieStoreObserver));
+}
+
+void WebExtensionController::removeWebsiteDataStore(WebsiteDataStore& dataStore)
+{
+    // Only remove the data store if no other pages use the same one.
+    for (auto& knownPage : m_pages) {
+        if (knownPage.websiteDataStore() == dataStore)
+            return;
+    }
+
+    m_websiteDataStores.remove(dataStore);
+
+    if (RefPtr observer = m_cookieStoreObserver)
+        protect(dataStore.cookieStore())->unregisterObserver(*observer);
+
+    if (m_websiteDataStores.isEmptyIgnoringNullReferences())
+        m_cookieStoreObserver = nullptr;
+}
+
+// MARK: webNavigation
+
+void WebExtensionController::didStartProvisionalLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
+{
+    for (Ref context : m_extensionContexts)
+        context->didStartProvisionalLoadForFrame(pageID, frameParameters, timestamp);
+}
+
+void WebExtensionController::didCommitLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
+{
+    for (Ref context : m_extensionContexts)
+        context->didCommitLoadForFrame(pageID, frameParameters, timestamp);
+}
+
+void WebExtensionController::didFinishLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
+{
+    for (Ref context : m_extensionContexts)
+        context->didFinishLoadForFrame(pageID, frameParameters, timestamp);
+}
+
+void WebExtensionController::didFailLoadForFrame(WebPageProxyIdentifier pageID, const WebExtensionFrameParameters& frameParameters, WallTime timestamp)
+{
+    for (Ref context : m_extensionContexts)
+        context->didFailLoadForFrame(pageID, frameParameters, timestamp);
+}
+
+void WebExtensionController::cookiesDidChange(API::HTTPCookieStore& cookieStore)
+{
+    // FIXME: <https://webkit.org/b/267514> Add support for changeInfo.
+
+    for (Ref context : m_extensionContexts)
+        context->cookiesDidChange(cookieStore);
+}
+
+RefPtr<WebExtensionContext> WebExtensionController::extensionContext(const WebExtension& extension) const
+{
+    for (auto& context : m_extensionContexts) {
+        if (context->extension() == extension)
+            return context.ptr();
+    }
+
+    return nullptr;
+}
+
+RefPtr<WebExtensionContext> WebExtensionController::extensionContext(const UniqueIdentifier& uniqueIdentifier) const
+{
+    for (auto& context : m_extensionContexts) {
+        if (context->uniqueIdentifier() == uniqueIdentifier)
+            return context.ptr();
+    }
+
+    return nullptr;
+}
+
+RefPtr<WebExtensionContext> WebExtensionController::extensionContext(const URL& url) const
+{
+    return m_extensionContextBaseURLMap.get(url.protocolHostAndPort());
+}
+
+WebExtensionController::WebExtensionSet WebExtensionController::extensions() const
+{
+    WebExtensionSet extensions;
+    extensions.reserveInitialCapacity(m_extensionContexts.size());
+    for (Ref context : m_extensionContexts)
+        extensions.addVoid(context->extension());
+    return extensions;
+}
+
+String WebExtensionController::storageDirectory(WebExtensionContext& extensionContext) const
+{
+    if (m_configuration->storageIsPersistent() && extensionContext.hasCustomUniqueIdentifier())
+        return FileSystem::pathByAppendingComponent(m_configuration->storageDirectory(), extensionContext.uniqueIdentifier());
+    return nullString();
+}
+
+String WebExtensionController::storageDirectory(const String& uniqueIdentifier) const
+{
+    return FileSystem::pathByAppendingComponent(m_configuration->storageDirectory(), uniqueIdentifier);
+}
+
+String WebExtensionController::stateFilePath(const String& uniqueIdentifier) const
+{
+    return FileSystem::pathByAppendingComponent(storageDirectory(uniqueIdentifier), WebExtensionContext::plistFileName());
+}
+
+HashSet<String> WebExtensionController::activeExtensionURLs() const
+{
+    HashSet<String> origins;
+
+    for (auto& context : m_extensionContexts)
+        origins.add(context->baseURL().protocolHostAndPort().convertToASCIILowercase());
+
+    if (m_configuration->storageIsPersistent()) {
+        for (auto& uniqueIdentifier : FileSystem::listDirectory(m_configuration->storageDirectory())) {
+            if (uniqueIdentifier == "StaleExtensionOriginsCleared"_s)
+                continue;
+            URL lastSeenBaseURL;
+            if (WebExtensionContext::readLastBaseURLFromState(stateFilePath(uniqueIdentifier), lastSeenBaseURL))
+                origins.add(lastSeenBaseURL.protocolHostAndPort().convertToASCIILowercase());
+        }
+    }
+
+    return origins;
+}
+
+RefPtr<WebExtensionStorageSQLiteStore> WebExtensionController::sqliteStore(const String& storageDirectory, WebExtensionDataType type, RefPtr<WebExtensionContext> extensionContext)
+{
+    if (type == WebExtensionDataType::Session) {
+        if (extensionContext)
+            return extensionContext->storageForType(WebExtensionDataType::Session);
+        return nullptr;
+    }
+
+    auto uniqueIdentifier = FileSystem::lastComponentOfPathIgnoringTrailingSlash(storageDirectory);
+    return WebExtensionStorageSQLiteStore::create(uniqueIdentifier, type, storageDirectory, WebExtensionStorageSQLiteStore::UsesInMemoryDatabase::No);
+}
+
+void WebExtensionController::calculateStorageSize(WebExtensionStorageSQLiteStore& storage, WebExtensionDataType type, CompletionHandler<void(Expected<size_t, WebExtensionError>&&)>&& completionHandler)
+{
+    storage.getStorageSizeForKeys({ }, [completionHandler = WTF::move(completionHandler)](size_t storageSize, const String& errorMessage) mutable {
+        // FIXME: <https://webkit.org/b/269100> Add storage size of window.localStorage, window.sessionStorage and indexedDB.
+        if (!errorMessage.isEmpty())
+            completionHandler(makeUnexpected(errorMessage));
+        else
+            completionHandler(storageSize);
+    });
+}
+
+void WebExtensionController::removeStorage(WebExtensionStorageSQLiteStore& storage, WebExtensionDataType type, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
+{
+    storage.deleteDatabase([completionHandler = WTF::move(completionHandler)](const String& errorMessage) mutable {
+        // FIXME: <https://webkit.org/b/269100> Remove window.localStorage, window.sessionStorage, indexedDB.
+        if (!errorMessage.isEmpty())
+            completionHandler(makeUnexpected(errorMessage));
+        else
+            completionHandler({ });
+    });
 }
 
 bool WebExtensionController::markDidRemoveStaleExtensionWebsiteData()

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -125,8 +125,8 @@ public:
     void getDataRecord(OptionSet<WebExtensionDataType>, WebExtensionContext&, CompletionHandler<void(RefPtr<WebExtensionDataRecord>)>&&);
     void removeData(OptionSet<WebExtensionDataType>, const Vector<Ref<WebExtensionDataRecord>>&, CompletionHandler<void()>&&);
 
-    void calculateStorageSize(RefPtr<WebExtensionStorageSQLiteStore>, WebExtensionDataType, CompletionHandler<void(Expected<size_t, WebExtensionError>&&)>&&);
-    void removeStorage(RefPtr<WebExtensionStorageSQLiteStore>, WebExtensionDataType, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void calculateStorageSize(WebExtensionStorageSQLiteStore&, WebExtensionDataType, CompletionHandler<void(Expected<size_t, WebExtensionError>&&)>&&);
+    void removeStorage(WebExtensionStorageSQLiteStore&, WebExtensionDataType, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     bool hasLoadedContexts() const { return !m_extensionContexts.isEmpty(); }
     bool isFreshlyCreated() const { return m_freshlyCreated; }


### PR DESCRIPTION
#### 2f7f667d287f31d24f0e7c2179f6ce0ad3ed754e
<pre>
Port more of WebExtensionController to C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=321809">https://bugs.webkit.org/show_bug.cgi?id=321809</a>

Reviewed by Timothy Hatcher.

This moves a big chunk of the port-neutral code to C++.
There should be no change in behavior.

Minor tweak to where WebExtensionStorageSQLiteStore was
used to be a reference since all call sites verify it is
non-null before usage.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::getDataRecords):
(WebKit::WebExtensionController::getDataRecord):
(WebKit::WebExtensionController::removeData):
(WebKit::WebExtensionController::storageDirectory const): Deleted.
(WebKit::WebExtensionController::calculateStorageSize): Deleted.
(WebKit::WebExtensionController::removeStorage): Deleted.
(WebKit::WebExtensionController::load): Deleted.
(WebKit::WebExtensionController::unload): Deleted.
(WebKit::WebExtensionController::unloadAll): Deleted.
(WebKit::WebExtensionController::dispatchDidLoad): Deleted.
(WebKit::WebExtensionController::addPage): Deleted.
(WebKit::WebExtensionController::removePage): Deleted.
(WebKit::WebExtensionController::addProcessPool): Deleted.
(WebKit::WebExtensionController::removeProcessPool): Deleted.
(WebKit::WebExtensionController::addUserContentController): Deleted.
(WebKit::WebExtensionController::removeUserContentController): Deleted.
(WebKit::WebExtensionController::websiteDataStore const): Deleted.
(WebKit::WebExtensionController::addWebsiteDataStore): Deleted.
(WebKit::WebExtensionController::removeWebsiteDataStore): Deleted.
(WebKit::WebExtensionController::cookiesDidChange): Deleted.
(WebKit::WebExtensionController::extensionContext const): Deleted.
(WebKit::WebExtensionController::extensions const): Deleted.
(WebKit::WebExtensionController::stateFilePath const): Deleted.
(WebKit::WebExtensionController::activeExtensionURLs const): Deleted.
(WebKit::WebExtensionController::sqliteStore): Deleted.
(WebKit::WebExtensionController::didStartProvisionalLoadForFrame): Deleted.
(WebKit::WebExtensionController::didCommitLoadForFrame): Deleted.
(WebKit::WebExtensionController::didFinishLoadForFrame): Deleted.
(WebKit::WebExtensionController::didFailLoadForFrame): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::addContextMessageReceivers):
(WebKit::removeContextMessageReceivers):
(WebKit::WebExtensionController::load):
(WebKit::WebExtensionController::unload):
(WebKit::WebExtensionController::unloadAll):
(WebKit::WebExtensionController::dispatchDidLoad):
(WebKit::WebExtensionController::addPage):
(WebKit::WebExtensionController::removePage):
(WebKit::WebExtensionController::addProcessPool):
(WebKit::WebExtensionController::removeProcessPool):
(WebKit::WebExtensionController::addUserContentController):
(WebKit::WebExtensionController::removeUserContentController):
(WebKit::WebExtensionController::websiteDataStore const):
(WebKit::WebExtensionController::addWebsiteDataStore):
(WebKit::WebExtensionController::removeWebsiteDataStore):
(WebKit::WebExtensionController::didStartProvisionalLoadForFrame):
(WebKit::WebExtensionController::didCommitLoadForFrame):
(WebKit::WebExtensionController::didFinishLoadForFrame):
(WebKit::WebExtensionController::didFailLoadForFrame):
(WebKit::WebExtensionController::cookiesDidChange):
(WebKit::WebExtensionController::extensionContext const):
(WebKit::WebExtensionController::extensions const):
(WebKit::WebExtensionController::storageDirectory const):
(WebKit::WebExtensionController::stateFilePath const):
(WebKit::WebExtensionController::activeExtensionURLs const):
(WebKit::WebExtensionController::sqliteStore):
(WebKit::WebExtensionController::calculateStorageSize):
(WebKit::WebExtensionController::removeStorage):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:

Canonical link: <a href="https://commits.webkit.org/319234@main">https://commits.webkit.org/319234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9aed54e3188349a07d8ffcc2be73e415bb3663b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191008 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145117 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141032 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121483 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43369 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41650 "Passed tests") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153773 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.LAMakeCredentialAllowLocalAuthenticator (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41314 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2168 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192942 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54405 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150414 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55093 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150132 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27456 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44725 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127359 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122656 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53610 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16307 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52992 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->