### PR TITLE
import-w3c-tests drops webkit-test-runner options when cleaning the destination directory

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -182,6 +182,7 @@ class TestImporter(object):
 
         self.import_list = []
         self.upstream_revision = None
+        self._saved_webkit_test_runner_options = {}
 
         self._resource_files_json_path = self.filesystem.join(self.layout_tests_w3c_path, 'resources', 'resource-files.json')
         self._resource_files = json.loads(self.filesystem.read_text_file(self._resource_files_json_path)) if self.filesystem.exists(self._resource_files_json_path) else None
@@ -243,6 +244,7 @@ class TestImporter(object):
 
         if self.options.clean_destination_directory:
             for test_path in test_paths:
+                self.save_webkit_test_runner_options(test_path)
                 self.clean_destination_directory(test_path)
             if self._resource_files:
                 test_paths_tuple = tuple(test_paths)
@@ -373,6 +375,18 @@ class TestImporter(object):
         for relative_path in self.filesystem.files_under(directory, file_filter=self._should_remove_before_importing):
             self.filesystem.remove(self.filesystem.join(directory, relative_path))
 
+    def save_webkit_test_runner_options(self, filename):
+        # Cleaning the destination directory deletes the test files that carry
+        # <!-- webkit-test-runner --> options, so record them beforehand. Without this the options
+        # are silently dropped on every import, since _webkit_test_runner_options() reads them back
+        # from a file that no longer exists.
+        directory = self.filesystem.join(self.destination_directory, filename)
+        for relative_path in self.filesystem.files_under(directory, file_filter=self._should_remove_before_importing):
+            path = self.filesystem.join(directory, relative_path)
+            options = self._read_webkit_test_runner_options(path)
+            if options:
+                self._saved_webkit_test_runner_options[self.filesystem.normpath(path)] = options
+
     def remove_dangling_expectations(self, filename):
         #FIXME: Clean also the expected files stored in all platform specific folders.
         directory = self.filesystem.join(self.destination_directory, filename)
@@ -489,6 +503,13 @@ class TestImporter(object):
                     'reftests': reftests, 'jstests': jstests, 'crashtests': crashtests, 'total_tests': total_tests})
 
     def _webkit_test_runner_options(self, path):
+        saved_options = self._saved_webkit_test_runner_options.get(self.filesystem.normpath(path))
+        if saved_options:
+            return saved_options
+
+        return self._read_webkit_test_runner_options(path)
+
+    def _read_webkit_test_runner_options(self, path):
         if not(self.filesystem.isfile(path)):
             return ''
 

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -594,6 +594,24 @@ class TestImporterTest(unittest.TestCase):
         self.assertTrue('<!-- webkit-test-runner [ dummy ] -->' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.any.html').split('\n')[0])
         self.assertFalse('<!-- webkit-test-runner [ dummy ] -->' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.any.worker.html').split('\n')[0])
 
+    def test_webkit_test_runner_options_are_preserved_when_cleaning_destination_directory(self):
+        # Cleaning the destination directory is the default, and it deletes the very files the
+        # options are read back from, so the options must be saved before the cleaning happens.
+        FAKE_FILES = {
+            f'{FAKE_WPT_DIR}/css/test.html': '<!doctype html>\n<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script>',
+            '/mock-checkout/LayoutTests/w3c/web-platform-tests/css/test.html': '<!-- webkit-test-runner [ dummy ] -->\n<!doctype html>',
+            f'{FAKE_WPT_DIR}/t/test.html': '<!doctype html><script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script>',
+            '/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.html': '<!-- doctype html --><!-- webkit-test-runner [ dummy ] -->',
+            '/mock-checkout/Source/WebCore/css/CSSProperties.json': '',
+        }
+        FAKE_FILES.update(FAKE_RESOURCES)
+
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
+
+        # The header sits on its own line above the doctype here, the way it is written by hand.
+        self.assertTrue('<!-- webkit-test-runner [ dummy ] -->' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/css/test.html').split('\n')[0])
+        self.assertTrue('<!-- webkit-test-runner [ dummy ] -->' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.html').split('\n')[0])
+
     def test_webkit_test_runner_import_reftests_with_absolute_paths_download(self):
         FAKE_FILES = {
             f'{FAKE_WPT_DIR}/css/css-images/test3.html': '<html><head><link rel=match href=/css/css-images/test3-ref.html></head></html>',


### PR DESCRIPTION
#### a810429647227ee93738e4b1da3e5fd4d8231518
<pre>
import-w3c-tests drops webkit-test-runner options when cleaning the destination directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=321811">https://bugs.webkit.org/show_bug.cgi?id=321811</a>
<a href="https://rdar.apple.com/184947474">rdar://184947474</a>

Reviewed by NOBODY (OOPS!).

_webkit_test_runner_options() reads a test&apos;s &lt;!-- webkit-test-runner --&gt; options back from
the existing file in the destination directory, but clean_destination_directory() has
already deleted that file by then. Since cleaning is the default, the options were silently
dropped on every re-import, making the existing preservation logic unreachable outside
--no-clean-dest-dir.

This patch saves these options before cleaning to avoid losing these settings when
synching with upstream WPT.

* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.__init__):
(TestImporter.do_import):
(TestImporter.save_webkit_test_runner_options):
(TestImporter._webkit_test_runner_options):
(TestImporter):
(TestImporter._read_webkit_test_runner_options):
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a810429647227ee93738e4b1da3e5fd4d8231518

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191014 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145123 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc13405d-8f93-439a-8692-4725f31b0770) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141037 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97745 "1 flakes 8 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5fc45a3-d9f1-4b30-8bdf-21cbb1429c34) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121488 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92dafba0-8beb-457b-9e61-24af94246cbf) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180124 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43376 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41655 "Passed tests") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153780 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.LAMakeCredentialAllowLocalAuthenticator (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41319 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2174 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192948 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54411 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150426 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55099 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150143 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44733 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122664 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53616 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16312 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52998 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53235 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53063 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->