### PR TITLE
Adding a missing null check in WebCore::attributedStringByReplacingRemoteFrameMarkers

### DIFF
--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -203,7 +203,11 @@ void populateRichTextDataIfNeeded(PasteboardContent& content, const Document& do
     if (!document.settings().writeRichTextDataWhenCopyingOrDragging())
         return;
 
-    auto string = attributedStringByReplacingRemoteFrameMarkers(selectionAsAttributedString(document), remoteFrameContent);
+    RetainPtr stringWithRemoteFrameMarkers = selectionAsAttributedString(document);
+    if (!stringWithRemoteFrameMarkers)
+        return;
+
+    auto string = attributedStringByReplacingRemoteFrameMarkers(WTF::move(stringWithRemoteFrameMarkers), remoteFrameContent);
     content.dataInRTFDFormat = [string containsAttachments] ? Editor::dataInRTFDFormat(string.get()) : nullptr;
     content.dataInRTFFormat = Editor::dataInRTFFormat(string.get());
     content.dataInAttributedStringFormat = AttributedString::fromNSAttributedString(string.get());

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
@@ -56,6 +56,7 @@
 
 @interface WKWebView (AdditionalDeclarations)
 #if PLATFORM(MAC)
+- (void)copy:(id)sender;
 - (void)paste:(id)sender;
 - (void)changeAttributes:(id)sender;
 - (void)changeColor:(id)sender;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyHTML.mm
@@ -46,7 +46,6 @@
 #endif
 
 @interface WKWebView ()
-- (void)copy:(id)sender;
 - (void)paste:(id)sender;
 @end
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyURL.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyURL.mm
@@ -40,7 +40,6 @@
 #endif
 
 @interface WKWebView ()
-- (void)copy:(id)sender;
 - (void)paste:(id)sender;
 @end
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ImageAnalysisTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ImageAnalysisTests.mm
@@ -32,11 +32,13 @@
 #import "InstanceMethodSwizzler.h"
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
+#import "Helpers/cocoa/PasteboardUtilities.h"
 #import "TestInputDelegate.h"
 #import "Helpers/ios/TestUIMenuBuilder.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "UIKitSPIForTesting.h"
 #import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebCore/LocalizedStrings.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
@@ -483,6 +485,58 @@ TEST(ImageAnalysisTests, AllowRemoveBackgroundOnce)
 }
 
 #endif // PLATFORM(IOS_FAMILY)
+
+#if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
+
+static bool generalPasteboardContainsRichTextData()
+{
+#if PLATFORM(MAC)
+    RetainPtr pasteboard = [NSPasteboard generalPasteboard];
+    return !![pasteboard dataForType:NSPasteboardTypeRTF] || !![pasteboard dataForType:NSPasteboardTypeRTFD];
+#else
+    for (NSItemProvider *itemProvider in UIPasteboard.generalPasteboard.itemProviders) {
+        for (NSString *identifier in itemProvider.registeredTypeIdentifiers) {
+            RetainPtr type = [UTType typeWithIdentifier:identifier];
+            if ([type conformsToType:UTTypeRTF] || [type conformsToType:UTTypeFlatRTFD])
+                return true;
+        }
+    }
+    return false;
+#endif
+}
+
+static NSString *stringFromGeneralPasteboard()
+{
+#if PLATFORM(MAC)
+    return [NSPasteboard.generalPasteboard stringForType:NSPasteboardTypeString];
+#else
+    return UIPasteboard.generalPasteboard.string;
+#endif
+}
+
+TEST(ImageAnalysisTests, CopyImageOverlayTextWithoutAttributedString)
+{
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    for (_WKFeature *feature in WKPreferences._features) {
+        if ([feature.key isEqualToString:@"WriteRichTextDataWhenCopyingOrDragging"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300) configuration:configuration]);
+    [webView synchronouslyLoadTestPageNamed:@"simple-image-overlay"];
+    [webView stringByEvaluatingJavaScript:@"selectImageOverlay()"];
+    [webView waitForNextPresentationUpdate];
+
+    clearPasteboard();
+    [webView copy:nil];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_FALSE(generalPasteboardContainsRichTextData());
+    EXPECT_TRUE([stringFromGeneralPasteboard() containsString:@"foobar"]);
+    EXPECT_WK_STREQ("IMG", [webView stringByEvaluatingJavaScript:@"document.querySelector('img').tagName"]);
+}
+
+#endif // !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
 
 #if ENABLE(SERVICE_CONTROLS)
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -96,7 +96,6 @@
 #endif
 
 @interface WKWebView ()
-- (void)copy:(id)sender;
 - (void)paste:(id)sender;
 - (WKPageRef)_pageForTesting;
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -63,10 +63,6 @@
 #import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 
-@interface WKWebView ()
-- (void)copy:(id)sender;
-@end
-
 #if PLATFORM(IOS_FAMILY)
 @interface UIPrintInteractionController ()
 - (BOOL)_setupPrintPanel:(void (^)(UIPrintInteractionController *printInteractionController, BOOL completed, NSError *error))completion;


### PR DESCRIPTION
#### 41d0d5bc00e7a614ba4a23052ae65d3935ad646e
<pre>
Adding a missing null check in WebCore::attributedStringByReplacingRemoteFrameMarkers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321810">https://bugs.webkit.org/show_bug.cgi?id=321810</a>
<a href="https://rdar.apple.com/184945791">rdar://184945791</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Add a missing null check in the case where `selectionAsAttributedString` returns `nil`.

* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::attributedStringByReplacingRemoteFrameMarkers):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ImageAnalysisTests.mm:
(TestWebKitAPI::generalPasteboardContainsRichTextData):
(TestWebKitAPI::stringFromGeneralPasteboard):
(TestWebKitAPI::TEST(ImageAnalysisTests, CopyImageOverlayTextWithoutAttributedString)):

Canonical link: <a href="https://commits.webkit.org/319215@main">https://commits.webkit.org/319215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12e9b404d40928211d2a26d58bbb7f9e659ed520

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145134 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/40f4b97e-8a6a-4438-8bb6-7ed98b7816b9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141047 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11582311-e416-4641-9aeb-325e6e99f349) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121499 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4535a971-591e-41ca-82f8-7cadb1b07984) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41328 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2185 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47368 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45918 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192959 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54422 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150428 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40261 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55110 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150146 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44740 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127376 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122676 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53627 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16321 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53009 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53246 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53074 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->