### PR TITLE
Cherry-pick 318089@main (33e302a9ccbc). https://bugs.webkit.org/show_bug.cgi?id=320371

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -61,6 +61,11 @@
 #include <wtf/OSObjectPtr.h>
 #endif
 
+#if ENABLE(JOURNALD_LOG)
+#include <stdlib.h>
+#include <unistd.h>
+#endif
+
 #if !RELEASE_LOG_DISABLED && !USE(OS_LOG)
 #include <wtf/StringPrintStream.h>
 #endif
@@ -490,6 +495,28 @@ bool WTFWillLogWithLevel(WTFLogChannel* channel, WTFLogLevel level)
 {
     return channel->level >= level && channel->state != WTFLogChannelState::Off;
 }
+
+#if ENABLE(JOURNALD_LOG)
+bool WTFShouldLogToJournal()
+{
+    static const bool shouldLogToJournal = [] {
+        if (const char* output = getenv("WEBKIT_DEBUG_OUTPUT")) {
+            auto outputSpan = unsafeSpan(output);
+            if (equalSpans(outputSpan, "stderr"_span))
+                return false;
+            if (equalSpans(outputSpan, "journal"_span))
+                return true;
+            WTFLogAlways("Unknown WEBKIT_DEBUG_OUTPUT value '%s', expected 'journal' or 'stderr'.", output);
+        }
+
+        // sd_journal_send() returns success even when journald is not running:
+        // https://man.archlinux.org/man/sd_journal_send_with_location.3.en#RETURN_VALUE
+        return !access("/run/systemd/journal/socket", F_OK);
+    }();
+
+    return shouldLogToJournal;
+}
+#endif // ENABLE(JOURNALD_LOG)
 
 void WTFLogWithLevel(WTFLogChannel* channel, WTFLogLevel level, const char* format, ...)
 {

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -237,6 +237,10 @@ WTF_EXPORT_PRIVATE void WTFLogWithLevel(WTFLogChannel*, WTFLogLevel, const char*
 WTF_EXPORT_PRIVATE void NODELETE WTFSetLogChannelLevel(WTFLogChannel*, WTFLogLevel);
 WTF_EXPORT_PRIVATE bool NODELETE WTFWillLogWithLevel(WTFLogChannel*, WTFLogLevel);
 
+#if ENABLE(JOURNALD_LOG)
+WTF_EXPORT_PRIVATE bool WTFShouldLogToJournal(void);
+#endif
+
 WTF_EXPORT_PRIVATE NEVER_INLINE void WTFGetBacktrace(void** stack, int* size);
 WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefix(const char*);
 WTF_EXPORT_PRIVATE void WTFReportBacktraceWithStackDepth(int);
@@ -788,11 +792,42 @@ inline void wtfCompileTimeCheckPrintfSpecifier(const char* format, ...)
     UNUSED_PARAM(format); // Function intentionally empty.
 }
 
-#define SD_JOURNAL_SEND(channel, priority, file, line, function, ...) do { \
+inline const char* wtfLogPriorityName(int priority)
+{
+    switch (priority) {
+    case LOG_CRIT:
+        return "crit";
+    case LOG_ERR:
+        return "err";
+    case LOG_WARNING:
+        return "warning";
+    case LOG_NOTICE:
+        return "notice";
+    case LOG_INFO:
+        return "info";
+    case LOG_DEBUG:
+        return "debug";
+    default:
+        return "log";
+    }
+}
+
+#define JOURNAL_FALLBACK_LOGF(logChannel, priority, file, line, function, fmt, ...) do { \
+    IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call") \
+    fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:%s] " fmt " [" file ":" line " %s]\n", logChannel.name, wtfLogPriorityName(priority), ##__VA_ARGS__, function); \
+    IGNORE_WARNINGS_END \
+} while (0)
+
+#define SD_JOURNAL_SEND(channel, priority, file, line, function, fmt, ...) do { \
     IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-format-attr-call") \
-    wtfCompileTimeCheckPrintfSpecifier(__VA_ARGS__); \
-    if (LOG_CHANNEL(channel).state != WTFLogChannelState::Off) \
-        sd_journal_send_with_location("CODE_FILE=" file, "CODE_LINE=" line, function, "WEBKIT_SUBSYSTEM=" LOG_CHANNEL_WEBKIT_SUBSYSTEM, "WEBKIT_CHANNEL=%s", LOG_CHANNEL(channel).name, "PRIORITY=%u", static_cast<unsigned>(priority), "MESSAGE=" __VA_ARGS__, nullptr); \
+    wtfCompileTimeCheckPrintfSpecifier(fmt, ##__VA_ARGS__); \
+    auto& logChannel = LOG_CHANNEL(channel); \
+    if (logChannel.state != WTFLogChannelState::Off) { \
+        if (WTFShouldLogToJournal()) \
+            sd_journal_send_with_location("CODE_FILE=" file, "CODE_LINE=" line, function, "WEBKIT_SUBSYSTEM=" LOG_CHANNEL_WEBKIT_SUBSYSTEM, "WEBKIT_CHANNEL=%s", logChannel.name, "PRIORITY=%u", static_cast<unsigned>(priority), "MESSAGE=" fmt, ##__VA_ARGS__, nullptr); \
+        else \
+            JOURNAL_FALLBACK_LOGF(logChannel, priority, file, line, function, fmt, ##__VA_ARGS__); \
+    } \
     IGNORE_WARNINGS_END \
 } while (0)
 

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -381,7 +381,13 @@ private:
 #elif OS(ANDROID)
         __android_log_print(ANDROID_LOG_VERBOSE, LOG_CHANNEL_WEBKIT_SUBSYSTEM, "[%s] %s", channel.name, logMessage.utf8().data());
 #elif ENABLE(JOURNALD_LOG)
-        sd_journal_send("WEBKIT_SUBSYSTEM=" LOG_CHANNEL_WEBKIT_SUBSYSTEM, "WEBKIT_CHANNEL=%s", channel.name, "MESSAGE=%s", logMessage.utf8().data(), nullptr);
+        if (WTFShouldLogToJournal())
+            sd_journal_send("WEBKIT_SUBSYSTEM=" LOG_CHANNEL_WEBKIT_SUBSYSTEM, "WEBKIT_CHANNEL=%s", channel.name, "MESSAGE=%s", logMessage.utf8().data(), nullptr);
+        else {
+            IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
+            fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:-] %s\n", channel.name, logMessage.utf8().data());
+            IGNORE_WARNINGS_END
+        }
 #else
         IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
         fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:-] %s\n", channel.name, logMessage.utf8().data());
@@ -420,9 +426,15 @@ private:
 #elif OS(ANDROID)
         __android_log_print(ANDROID_LOG_VERBOSE, LOG_CHANNEL_WEBKIT_SUBSYSTEM, "[%s] %s FILE=%s:%d: %s", channel.name, logMessage.utf8().data(), file, line, function);
 #elif ENABLE(JOURNALD_LOG)
-        auto fileString = makeString("CODE_FILE="_s, unsafeSpan(file));
-        auto lineString = makeString("CODE_LINE="_s, line);
-        sd_journal_send_with_location(fileString.utf8().data(), lineString.utf8().data(), function, "WEBKIT_SUBSYSTEM=" LOG_CHANNEL_WEBKIT_SUBSYSTEM, "WEBKIT_CHANNEL=%s", channel.name, "MESSAGE=%s", logMessage.utf8().data(), nullptr);
+        if (WTFShouldLogToJournal()) {
+            auto fileString = makeString("CODE_FILE="_s, unsafeSpan(file));
+            auto lineString = makeString("CODE_LINE="_s, line);
+            sd_journal_send_with_location(fileString.utf8().data(), lineString.utf8().data(), function, "WEBKIT_SUBSYSTEM=" LOG_CHANNEL_WEBKIT_SUBSYSTEM, "WEBKIT_CHANNEL=%s", channel.name, "MESSAGE=%s", logMessage.utf8().data(), nullptr);
+        } else {
+            IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
+            fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:-] %s [%s:%d %s]\n", channel.name, logMessage.utf8().data(), file, line, function);
+            IGNORE_WARNINGS_END
+        }
 #else
         fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:-] %s FILE=%s:%d %s\n", channel.name, logMessage.utf8().data(), file, line, function);
 #endif

--- a/Source/WebKit/glib/environment-variables.md.in
+++ b/Source/WebKit/glib/environment-variables.md.in
@@ -23,6 +23,21 @@ Defines a comma-separated list of logging channels and their levels for WebKit's
       e.g. with `WEBKIT_DEBUG='GLContext=debug'`, backtraces leading to errors are added to the
       error messages.
 
+- `WEBKIT_DEBUG_OUTPUT`
+Selects where the log messages that would be sent the journal should actually go. Only available when
+WebKit is built with journald support (`ENABLE_JOURNALD_LOG`, the default for the GTK and WPE ports).
+It does not alter channel filtering or which messages are enabled.
+    - **Default** (unset): messages go to the systemd journal, if its socket is present, and can be
+      read back filtering by the `WEBKIT_SUBSYSTEM` and `WEBKIT_CHANNEL` fields, e.g.
+      `journalctl WEBKIT_SUBSYSTEM=WPEWebKit WEBKIT_CHANNEL=WebDriverBiDi`. Use `WebKitGTK` as the
+      subsystem for the GTK port. When the journal is not reachable, for instance in a container or
+      a CI image that has no journald running, messages are written to standard error instead.
+    - `journal` - Always write to the systemd journal, even if it's inaccessible.
+    - `stderr` - Always write to standard error, one line per message, prefixed with the subsystem,
+      the channel and the priority, and followed by the source location, if available. Useful to
+      capture the output of a single process into a file, and to force the fallback on a machine
+      that does run journald.
+
 ## Graphics-related variables
 
 #if WPE


### PR DESCRIPTION
#### 28aeac3b935d9575b86b4fab77bed29af6d093b9
<pre>
Cherry-pick 318089@main (33e302a9ccbc). <a href="https://bugs.webkit.org/show_bug.cgi?id=320371">https://bugs.webkit.org/show_bug.cgi?id=320371</a>

    [GLIB] Add log fallback when journald is not reachable
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320371">https://bugs.webkit.org/show_bug.cgi?id=320371</a>

    Reviewed by Adrian Perez de Castro.

    Currently, when JOURNALD_LOG is enabled, RELEASE_LOG messages are sent
    to sd_journal_send_with_location without any fallback. But, according to
    this function&apos;s documentation:

    &quot;If systemd-journald(8) is not running (the socket is not present),
    those functions do nothing, and also return 0.&quot;

    This behavior can lead to lost RELEASE_LOG messages. For example, small CI
    runners might not run systemd at all during the tests.

    This commit adds a stderr fallback, enabled when the journald&apos;s socket
    is not found at startup. The new WEBKIT_DEBUG_OUTPUT environment
    variable can be set to &apos;stderr&apos; to replace the journal output, or to
    &apos;journal&apos; to disable the fallback completely.

    Note that the actual filtering of what would be printed is still
    controlled by the WEBKIT_DEBUG variable as usual. That is, &quot;off&quot;
    channels are still filtered out.

    * Source/WTF/wtf/Assertions.cpp:
    * Source/WTF/wtf/Assertions.h:
    (wtfLogPriorityName):
    * Source/WTF/wtf/Logger.h:
    (WTF::Logger::log):
    (WTF::Logger::logVerbose):
    * Source/WebKit/glib/environment-variables.md.in:

    Canonical link: <a href="https://commits.webkit.org/318089@main">https://commits.webkit.org/318089@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.106@webkitglib/2.54">https://commits.webkit.org/317695.106@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfb9355e067a12db0fe8ddeeb451ae981edb17d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180809 "5 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/54754 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48552 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191023 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145132 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/56052 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54470 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141070 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145132 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183764 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/56052 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/48552 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121522 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/56052 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54470 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3488 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/48552 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/56052 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48552 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2183 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/42083 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/47366 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/54470 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192957 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/54420 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/48552 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150430 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/55108 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48552 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150148 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27480 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/55108 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127374 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122674 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/53625 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/48552 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/53007 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53244 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53072 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->