### PR TITLE
[css-values-5 random-item()] auto random() and random-item() in the same property value get the same random value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt
@@ -33,5 +33,7 @@ PASS A shared dashed-ident key selects the same item across properties
 PASS random() and random-item() using auto in one declaration both resolve
 PASS A bare element-scoped key selects the same item across random-item() instances
 PASS random() and random-item() share the base value for a bare element-scoped key
+PASS auto random() and auto random-item() in one value do not share a base value
+PASS auto random() substituted through var() does not share a base value with random-item()
 PASS Property color value 'random-item(--, rgb(1, 0, 0), rgb(0, 1, 0))'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html
@@ -204,6 +204,41 @@ test(() => {
     assert_equals(m, Math.min(400, Math.floor(w / 100) * 100), 'random() and random-item() share the element-scoped base value');
 }, 'random() and random-item() share the base value for a bare element-scoped key');
 
+// A derived property scope records which function produced it, so an auto random() and an auto
+// random-item() in one value draw independently. With random() scaled to 0-400px and two items
+// 0/1000px, a shared draw would make the item choice track whether random() landed above half;
+// over 40 samples that agreeing every time is about 1 in 10^12.
+function sharedDrawCount(declaration) {
+    let consistentWithSharing = 0;
+    const holder = document.createElement('div');
+    document.body.appendChild(holder);
+    try {
+        for (let i = 0; i < 40; ++i) {
+            const element = document.createElement('div');
+            element.style.cssText = declaration;
+            holder.appendChild(element);
+            const width = parseFloat(getComputedStyle(element).width);
+            const selectedSecondItem = width >= 1000;
+            const randomFraction = (width - (selectedSecondItem ? 1000 : 0)) / 400;
+            if ((randomFraction >= 0.5) === selectedSecondItem)
+                ++consistentWithSharing;
+        }
+    } finally {
+        document.body.removeChild(holder);
+    }
+    return consistentWithSharing;
+}
+
+test(() => {
+    const shared = sharedDrawCount('width: calc(random(auto, 0px, 400px) + random-item(auto, 0px, 1000px))');
+    assert_less_than(shared, 40, 'random() and random-item() drew the same base value');
+}, 'auto random() and auto random-item() in one value do not share a base value');
+
+test(() => {
+    const shared = sharedDrawCount('--n: random(auto, 0, 1); width: calc(var(--n) * 400px + random-item(auto, 0px, 1000px))');
+    assert_less_than(shared, 40, 'random() reached through var() drew the same base value as random-item()');
+}, 'auto random() substituted through var() does not share a base value with random-item()');
+
 // A <dashed-ident> as short as "--" is a valid key (parity with random()); the value resolves rather
 // than becoming guaranteed-invalid.
 test_computed_value('color', 'random-item(--, rgb(1, 0, 0), rgb(0, 1, 0))', ['rgb(1, 0, 0)', 'rgb(0, 1, 0)']);

--- a/Source/WebCore/css/calc/CSSCalcRandomSharing.h
+++ b/Source/WebCore/css/calc/CSSCalcRandomSharing.h
@@ -38,19 +38,26 @@ enum CSSPropertyID : uint16_t;
 
 namespace CSSCalc {
 
+// Which function a property scope was derived from. random() and random-item() each get their own
+// bucket, so an index derived for one cannot collide with the same index derived for the other. Only
+// derived scopes carry this, so an author's <dashed-ident> still shares across both functions.
+// https://github.com/w3c/csswg-drafts/issues/14330
+enum class RandomFunction : bool { Random, RandomItem };
+
 // The property a random key is scoped to. Every custom property shares CSSPropertyCustom, so the name
 // is what tells them apart and is empty for everything else.
 // FIXME: Same concept as AssociatedProperty and AnimatableCSSProperty.
 struct RandomScopedProperty {
     CSSPropertyID property { CSSPropertyInvalid };
     AtomString customPropertyName { };
+    RandomFunction function { RandomFunction::Random };
 
     bool operator==(const RandomScopedProperty&) const = default;
 };
 
 inline void add(Hasher& hasher, const RandomScopedProperty& scopedProperty)
 {
-    add(hasher, scopedProperty.property, scopedProperty.customPropertyName);
+    add(hasher, scopedProperty.property, scopedProperty.customPropertyName, scopedProperty.function);
 }
 
 // `auto` is a top-level <random-key> alternative; its scoping is chosen per-usage by the caller.

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -674,7 +674,7 @@ static std::optional<TypedChild> consumeRandom(CSSParserTokenRange& tokens, int 
     using Op = Random;
 
     auto keySource = CSSPropertyParserHelpers::RandomKeySource {
-        .property = { state.propertyParserState.currentProperty, state.propertyParserState.currentCustomPropertyName },
+        .property = { state.propertyParserState.currentProperty, state.propertyParserState.currentCustomPropertyName, RandomFunction::Random },
         .autoElementScoped = CSS::Keyword::ElementScoped { }
     };
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -1074,13 +1074,10 @@ std::optional<double> SubstitutionResolver::randomItemBaseValue(Vector<CSSParser
 
     auto parserState = CSS::PropertyParserState { .context = m_substitutionValue->context() };
 
-    // FIXME: This index is counted here, at substitution time, in a separate space from random()'s
-    // parse-time cssRandomFunctionCount. An auto random-item() and an auto random() in the same
-    // property value can therefore land on the same RandomCachingKey and share a base value, and the
-    // index follows the selected branch rather than parse position. Unifying this with random()'s
-    // counter is a follow-up.
+    // This index is counted in its own space, separate from random()'s parse-time
+    // cssRandomFunctionCount, which is why the key records which function it came from.
     auto keySource = CSSPropertyParserHelpers::RandomKeySource {
-        .property = { m_styleBuilder.state().cssPropertyID(), m_styleBuilder.state().customPropertyName() },
+        .property = { m_styleBuilder.state().cssPropertyID(), m_styleBuilder.state().customPropertyName(), CSSCalc::RandomFunction::RandomItem },
         .autoElementScoped = CSS::Keyword::ElementScoped { }
     };
     auto sharing = CSSPropertyParserHelpers::consumeUnresolvedRandomKey(randomKeyRange, parserState, keySource, [&] {


### PR DESCRIPTION
#### b70772b13dd06af968f0de8aef4e81404bede915
<pre>
[css-values-5 random-item()] auto random() and random-item() in the same property value get the same random value
<a href="https://bugs.webkit.org/show_bug.cgi?id=319919">https://bugs.webkit.org/show_bug.cgi?id=319919</a>
<a href="https://rdar.apple.com/182846761">rdar://182846761</a>

Reviewed by Antti Koivisto and Tim Nguyen.

Both functions number their own random draws from zero, so an auto random() and an
auto random-item() in one value each claimed index 0. With the same property and
element they built the same RandomCachingKey and resolved to one base value, so
`width: calc(random(auto, 0px, 400px) + random-item(auto, 0px, 1000px))` rolled
one die instead of two. 319153@main made this reachable by giving random-item()&apos;s
`auto` the element scoping it was missing.

Record which function a derived property scope came from, so the two get separate
buckets. Only derived scopes carry it, leaving an author&apos;s &lt;dashed-ident&gt; and a
bare element-scoped key shared across both functions as before.

Whether the spec wants one index sequence across both functions or one per
function is open as csswg-drafts#14330. This keys on the function rather than
merging the sequences, which fixes the collision under either answer, and does not
depend on counting across the substitution and parse phases. &lt;random-ua-ident&gt;
serialization will need to account for the function once it is implemented
(bug 321552).

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html:
* Source/WebCore/css/calc/CSSCalcRandomSharing.h:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::consumeRandom):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::randomItemBaseValue):

Canonical link: <a href="https://commits.webkit.org/319463@main">https://commits.webkit.org/319463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66cf22fe1f322cc68c00e0329c18831519b9571f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145399 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f206afb-113f-49c9-ab2f-66eea19ee834) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141292 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97989 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ba5936f-0013-49a1-8c4a-c6e0f87fa42a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121743 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35e83c93-28fc-4bac-b704-08b56d8ff41e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43631 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41911 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41572 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2450 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193225 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150680 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40466 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55375 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150396 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44987 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127641 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123181 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53892 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16567 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53274 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53511 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53339 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->