### PR TITLE
this._isNewPageOrReload assertion fails in ConsoleManager.js on the first navigation

### DIFF
--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -885,8 +885,6 @@ void InspectorInstrumentation::didCommitLoadImpl(InstrumentingAgents& instrument
         if (CheckedPtr networkAgent = instrumentingAgents.enabledNetworkAgent())
             networkAgent->mainFrameNavigated(*loader);
 
-        // The Web Inspector frontend relies on `networkAgent->mainFrameNavigated` being called first to establish the
-        // type of navigation that has occured.
         if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
             consoleAgent->mainFrameNavigated();
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -36,7 +36,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
         this._lastMessageLevel = null;
         this._clearMessagesRequested = false;
-        this._isNewPageOrReload = false;
+        this._legacyPendingMainFrameNavigationClear = false;
         this._remoteObjectsToRelease = null;
 
         this._customLoggingChannels = [];
@@ -211,7 +211,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         WI.ConsoleCommandResultMessage.clearMaximumSavedResultIndex();
         WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
 
-        // COMPATIBILITY (iOS 16.4, macOS 13.3): `Console.ClearReason` did not exist.
+        // COMPATIBILITY (iOS 16.4, macOS 13.3): `Console.messagesCleared` did not have a `reason` parameter yet.
         if (!reason) {
             if (this._clearMessagesRequested) {
                 // Frontend requested "clear console" and Backend successfully completed the request.
@@ -243,9 +243,6 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
             return;
 
         case WI.ConsoleManager.ClearReason.MainFrameNavigation:
-            console.assert(this._isNewPageOrReload);
-            this._isNewPageOrReload = false;
-
             if (WI.settings.clearLogOnNavigate.value)
                 this._clearMessages();
 
@@ -338,8 +335,8 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
     _delayedMessagesCleared()
     {
-        if (this._isNewPageOrReload) {
-            this._isNewPageOrReload = false;
+        if (this._legacyPendingMainFrameNavigationClear) {
+            this._legacyPendingMainFrameNavigationClear = false;
 
             if (!WI.settings.clearLogOnNavigate.value)
                 return;
@@ -370,7 +367,9 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         if (!event.target.isMainFrame())
             return;
 
-        this._isNewPageOrReload = true;
+        // COMPATIBILITY (iOS 16.4, macOS 13.3): `Console.messagesCleared` did not have a `reason` parameter yet.
+        if (!InspectorBackend.hasEvent("Console.messagesCleared", "reason"))
+            this._legacyPendingMainFrameNavigationClear = true;
 
         let timestamp = Date.now();
         let wasReloaded = event.data.oldMainResource && event.data.oldMainResource.url === event.target.mainResource.url;


### PR DESCRIPTION
#### 1d867f31b1819721c9efb1ccb4576133c5588020
<pre>
this._isNewPageOrReload assertion fails in ConsoleManager.js on the first navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=321815">https://bugs.webkit.org/show_bug.cgi?id=321815</a>
<a href="https://rdar.apple.com/184955117">rdar://184955117</a>

Reviewed by BJ Burg.

`Console.messagesCleared` arrives before the `Page.frameNavigated` that sets the flag, so the
assertion fired on the first navigation and afterwards only ever tested the previous one. In fact,
the two events cannot be reliably correlated at all: under Site Isolation they arrive on
different targets, and on a cross-process navigation the frontend synthesizes the main resource
change only after an asynchronous `Page.getResourceTree` round-trip.

`reason` is authoritative, so drop the cross-check and keep the flag solely for backends that don&apos;t
send one, renaming it to say so.

* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didCommitLoadImpl): Remove an incorrect comment.
`InspectorNetworkAgent::mainFrameNavigated` dispatches no event, so its position is not observable
by the frontend.
* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager): Rename `_isNewPageOrReload` to `_legacyPendingMainFrameNavigationClear`.
(WI.ConsoleManager.prototype.messagesCleared): Drop the assertion.
(WI.ConsoleManager.prototype._delayedMessagesCleared): Rename.
(WI.ConsoleManager.prototype._mainResourceDidChange): Only track the pending clear when the backend
doesn&apos;t send a `reason`.

Canonical link: <a href="https://commits.webkit.org/319338@main">https://commits.webkit.org/319338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/597b32aa10806377b37de63187439146bd7f60c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [⏳ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | ⏳ 🛠 vision-apple 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40378 "Built successfully and passed tests") | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->