### PR TITLE
visibility:visible child stays hidden when it has non-visible overflow

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-002-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: A visible descendant of a hidden element renders</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<!-- The test without the overflow clip. Nothing overflows, so it renders the same. -->
+<style>
+#div1
+{
+    border: 1px solid blue;
+}
+#div2
+{
+    color: red;
+    position: relative;
+    visibility: hidden;
+}
+#div3
+{
+    color: green;
+    visibility: visible;
+}
+</style>
+<p>Test passes if the content "Filler Text" is contained within the blue box and there is no red visible on the page.</p>
+<div id="div1">
+    <div id="div2">
+        This test fails if this text is visible on the page.
+        <div id="div3">Filler Text</div>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-002-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: A visible descendant of a hidden element renders</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<!-- The test without the overflow clip. Nothing overflows, so it renders the same. -->
+<style>
+#div1
+{
+    border: 1px solid blue;
+}
+#div2
+{
+    color: red;
+    position: relative;
+    visibility: hidden;
+}
+#div3
+{
+    color: green;
+    visibility: visible;
+}
+</style>
+<p>Test passes if the content "Filler Text" is contained within the blue box and there is no red visible on the page.</p>
+<div id="div1">
+    <div id="div2">
+        This test fails if this text is visible on the page.
+        <div id="div3">Filler Text</div>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-002.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: A visible descendant of a hidden element renders when it has non-visible overflow</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#valdef-visibility-hidden">
+<link rel="match" href="visibility-descendants-002-ref.html">
+<meta name="assert" content="A descendant of a hidden element with 'visibility' set to 'visible' is visible even when it establishes its own overflow clip and the hidden ancestor is positioned.">
+<style>
+#div1
+{
+    border: 1px solid blue;
+}
+#div2
+{
+    color: red;
+    position: relative;
+    visibility: hidden;
+}
+#div3
+{
+    color: green;
+    overflow: hidden;
+    visibility: visible;
+}
+</style>
+<p>Test passes if the content "Filler Text" is contained within the blue box and there is no red visible on the page.</p>
+<div id="div1">
+    <div id="div2">
+        This test fails if this text is visible on the page.
+        <div id="div3">Filler Text</div>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-003-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: A visible descendant of a hidden element renders</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<!-- The test's end state, unscripted and without the overflow clip. Nothing overflows. -->
+<style>
+#div1
+{
+    border: 1px solid blue;
+}
+#div2
+{
+    color: red;
+    position: relative;
+    visibility: hidden;
+}
+#div3
+{
+    color: green;
+    visibility: visible;
+}
+</style>
+<p>Test passes if the content "Filler Text" is contained within the blue box and there is no red visible on the page.</p>
+<div id="div1">
+    <div id="div2">
+        This test fails if this text is visible on the page.
+        <div id="div3">Filler Text</div>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-003-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: A visible descendant of a hidden element renders</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<!-- The test's end state, unscripted and without the overflow clip. Nothing overflows. -->
+<style>
+#div1
+{
+    border: 1px solid blue;
+}
+#div2
+{
+    color: red;
+    position: relative;
+    visibility: hidden;
+}
+#div3
+{
+    color: green;
+    visibility: visible;
+}
+</style>
+<p>Test passes if the content "Filler Text" is contained within the blue box and there is no red visible on the page.</p>
+<div id="div1">
+    <div id="div2">
+        This test fails if this text is visible on the page.
+        <div id="div3">Filler Text</div>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-003.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: A visible descendant of a hidden element still renders after it stops painting itself</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#valdef-visibility-hidden">
+<link rel="match" href="visibility-descendants-003-ref.html">
+<meta name="assert" content="A descendant of a hidden element with 'visibility' set to 'visible' stays visible when it is changed from positioned to statically positioned, which changes whether the descendant or its hidden ancestor is responsible for painting it.">
+<style>
+#div1
+{
+    border: 1px solid blue;
+}
+#div2
+{
+    color: red;
+    position: relative;
+    visibility: hidden;
+}
+#div3
+{
+    color: green;
+    overflow: hidden;
+    visibility: visible;
+    position: relative;
+}
+</style>
+<p>Test passes if the content "Filler Text" is contained within the blue box and there is no red visible on the page.</p>
+<div id="div1">
+    <div id="div2">
+        This test fails if this text is visible on the page.
+        <div id="div3">Filler Text</div>
+    </div>
+</div>
+<script>
+// Start positioned and go static. The reverse order cannot detect a stale cached answer.
+document.body.offsetHeight;
+document.getElementById("div3").style.position = "static";
+</script>

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -960,7 +960,7 @@ void RenderElement::styleWillChange(Style::Difference diff, const Style::Compute
         // Keep layer hierarchy visibility bits up to date if visibility or skipped content state changes.
         if (m_style.usedVisibility() != newStyle.usedVisibility()) {
             if (auto* layer = enclosingLayer())
-                layer->dirtyVisibleContentStatus();
+                layer->dirtyVisibleContentStatusIncludingAncestors();
         }
 
         if (m_style.usedContentVisibility() != newStyle.usedContentVisibility()) {
@@ -1222,7 +1222,7 @@ void RenderElement::insertedIntoTree()
 
     // If |this| is visible but this object was not, tell the layer it has some visible content
     // that needs to be drawn and layer visibility optimization can't be used
-    if (parent()->style().usedVisibility() != Visibility::Visible && style().usedVisibility() == Visibility::Visible && !hasLayer()) {
+    if (parent()->style().usedVisibility() != Visibility::Visible && style().usedVisibility() == Visibility::Visible && !hasSelfPaintingLayer()) {
         if (CheckedPtr parentLayer = layerParent())
             parentLayer->dirtyVisibleContentStatus();
     }
@@ -1243,7 +1243,7 @@ void RenderElement::willBeRemovedFromTree()
     }
 
     // If we remove a visible child from an invisible parent, we don't know the layer visibility any more.
-    if (parent()->style().usedVisibility() != Visibility::Visible && style().usedVisibility() == Visibility::Visible && !hasLayer()) {
+    if (parent()->style().usedVisibility() != Visibility::Visible && style().usedVisibility() == Visibility::Visible && !hasSelfPaintingLayer()) {
         // FIXME: should get parent layer. Necessary?
         if (CheckedPtr enclosingLayer = parent()->enclosingLayer())
             enclosingLayer->dirtyVisibleContentStatus();

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1937,6 +1937,23 @@ void RenderLayer::dirtyVisibleContentStatus()
         parent()->dirtyAncestorChainVisibleDescendantStatus();
 }
 
+void RenderLayer::dirtyVisibleContentStatusIncludingAncestors()
+{
+    dirtyVisibleContentStatus();
+
+    // computeHasVisibleContent() looks past a hidden layer into the children it paints, so those
+    // ancestors are stale too. That walk stops at the first self-painting layer.
+    if (isSelfPaintingLayer())
+        return;
+
+    for (auto* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
+        if (ancestor->renderer().style().usedVisibility() != Visibility::Visible)
+            ancestor->dirtyVisibleContentStatus();
+        if (ancestor->isSelfPaintingLayer())
+            break;
+    }
+}
+
 void RenderLayer::dirtyAncestorChainVisibleDescendantStatus()
 {
     setNeedsPositionUpdate();
@@ -2042,7 +2059,7 @@ bool RenderLayer::computeHasVisibleContent() const
     if (m_svgData && !renderer().style().filter().isNone())
         return true;
 
-    // Layer's renderer has visibility:hidden, but some non-layer child may have visibility:visible.
+    // Layer's renderer has visibility:hidden, but a child we paint ourselves may have visibility:visible.
     auto nextRenderer = [&] (auto& renderer) -> const RenderObject* {
         for (auto* ancestor = &renderer; ancestor && ancestor != &this->renderer(); ancestor = ancestor->parent()) {
             if (auto* sibling = ancestor->nextSibling())
@@ -2052,7 +2069,7 @@ bool RenderLayer::computeHasVisibleContent() const
     };
     const auto* renderer = this->renderer().firstChild();
     while (renderer) {
-        if (CheckedPtr renderElement = dynamicDowncast<RenderElement>(renderer); renderElement && !renderElement->hasLayer()) {
+        if (CheckedPtr renderElement = dynamicDowncast<RenderElement>(renderer); renderElement && !renderElement->hasSelfPaintingLayer()) {
             if (renderElement->style().usedVisibility() == Visibility::Visible)
                 return true;
             if (auto* firstChild = renderElement->firstChild()) {
@@ -5960,6 +5977,9 @@ void RenderLayer::updateSelfPaintingLayer()
 
     if (!parent())
         return;
+
+    // We are part of what a hidden ancestor paints now.
+    parent()->dirtyVisibleContentStatusIncludingAncestors();
 
     if (isSelfPaintingLayer)
         parent()->setAncestorChainHasSelfPaintingLayerDescendant();

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -600,6 +600,7 @@ public:
 
     void setHasVisibleContent();
     void NODELETE dirtyVisibleContentStatus();
+    void NODELETE dirtyVisibleContentStatusIncludingAncestors();
 
     bool hasVisibleBoxDecorationsOrBackground() const;
     bool hasVisibleBoxDecorations() const;


### PR DESCRIPTION
#### a1d6057613b92c9954bc9948da88485062d9c2b5
<pre>
visibility:visible child stays hidden when it has non-visible overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=321588">https://bugs.webkit.org/show_bug.cgi?id=321588</a>
<a href="https://rdar.apple.com/184801325">rdar://184801325</a>

Reviewed by Simon Fraser.

A visibility:visible child of a visibility:hidden element did not render
when the child had overflow:hidden and the hidden parent was positioned.
Firefox and Chrome render it.

overflow:hidden gives the child a layer, but a statically positioned one
does not paint itself, so the hidden parent is what paints it. Before
painting, the parent checks whether anything under it is visible, and
that check skipped any child with a layer, assuming such a child paints
itself.

Fix by skipping only children that really do paint themselves, which is
the test RenderBlock::paintChild already uses.

The check now reads styles it never read before, so it has to hear when
they change. A renderer owning a layer dirtied only that layer, leaving
a hidden ancestor that paints it with a stale answer. Add
dirtyVisibleContentStatusIncludingAncestors(), which dirties hidden
ancestors up to the first self-painting layer, where the check stops
looking.

Tests: imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-002.html
       imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-003.html

* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-003-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/visibility-descendants-003.html: Added.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleWillChange):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::computeHasVisibleContent const):
(WebCore::RenderLayer::dirtyVisibleContentStatusIncludingAncestors):
(WebCore::RenderLayer::updateSelfPaintingLayer):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/319258@main">https://commits.webkit.org/319258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/106ba94fbe5e0205002a29adbadf94bcdc733514

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145310 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b661a51a-eb96-49ec-8511-83e558efe739) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54648 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141213 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ad0521f-cb01-47e7-bdcc-0d086550120b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161956 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121665 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a41c64f9-54cb-4288-bb5c-f602278f66cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43546 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41826 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41483 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2361 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193136 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150598 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40289 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55286 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150315 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44903 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127552 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123046 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53803 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16477 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53185 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53250 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->