### PR TITLE
Don't share StringImpl for worker names

### DIFF
--- a/JSTests/wasm/stress/wasm-imported-string-constants-utf8.js
+++ b/JSTests/wasm/stress/wasm-imported-string-constants-utf8.js
@@ -1,0 +1,76 @@
+//@ skip if $addressBits <= 32
+//@ requireOptions("--useWasmJSStringBuiltins=true")
+
+import * as assert from '../assert.js';
+
+// Import names are raw UTF-8 in the module while importedStringConstants arrives as a JS string, so
+// the two match only when the JS string is compared in its UTF-8 encoding.
+
+function uleb(bytes, value) {
+    do {
+        const byte = value & 0x7f;
+        value >>>= 7;
+        bytes.push(value ? byte | 0x80 : byte);
+    } while (value);
+}
+
+function name(bytes, utf8) {
+    uleb(bytes, utf8.length);
+    bytes.push(...utf8);
+}
+
+// (module (import <moduleName> "hello" (global externref)) (export "g" (global 0)))
+// An immutable externref global is the only import shape eligible to be a string constant.
+function moduleWithGlobalImport(moduleName) {
+    const imports = [1];
+    name(imports, moduleName);
+    name(imports, [0x68, 0x65, 0x6c, 0x6c, 0x6f]); // "hello"
+    imports.push(0x03, 0x6f, 0x00);
+
+    const exports = [1];
+    name(exports, [0x67]); // "g"
+    exports.push(0x03, 0x00);
+
+    const bytes = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+    bytes.push(0x02);
+    uleb(bytes, imports.length);
+    bytes.push(...imports);
+    bytes.push(0x07);
+    uleb(bytes, exports.length);
+    bytes.push(...exports);
+    return new Uint8Array(bytes);
+}
+
+const cafeUTF8 = [0x63, 0x61, 0x66, 0xc3, 0xa9]; // "caf\u00e9"
+const replacementUTF8 = [0xef, 0xbf, 0xbd]; // "\ufffd"
+
+function testMatch(moduleName, importedStringConstants) {
+    const module = new WebAssembly.Module(moduleWithGlobalImport(moduleName), { importedStringConstants });
+    // The engine supplies a string constant itself, so it is hidden from imports() and needs no import object.
+    assert.eq(WebAssembly.Module.imports(module).length, 0);
+    assert.eq(new WebAssembly.Instance(module, {}).exports.g.value, "hello");
+}
+
+function testNoMatch(moduleName, importedStringConstants) {
+    const module = new WebAssembly.Module(moduleWithGlobalImport(moduleName), { importedStringConstants });
+    assert.eq(WebAssembly.Module.imports(module).length, 1);
+    assert.throws(() => new WebAssembly.Instance(module, {}), TypeError, "must be an object");
+}
+
+testMatch(cafeUTF8, "caf\u00e9");
+testMatch(replacementUTF8, "\ufffd");
+testMatch([], "");
+
+// A lone surrogate has no UTF-8 encoding, and import names are required to be well-formed UTF-8, so
+// it can never name an import.
+testNoMatch(replacementUTF8, "\ud800");
+testNoMatch(cafeUTF8, "caf\ud800");
+
+testNoMatch(cafeUTF8, "cafe");
+testNoMatch(cafeUTF8, "caf\u00e9x");
+
+// Builtin set names take the same encoding path, and none of these name a registered set.
+for (const builtin of ["caf\u00e9", "\ud800", "\ufffd"]) {
+    const module = new WebAssembly.Module(moduleWithGlobalImport(cafeUTF8), { builtins: [builtin] });
+    assert.eq(WebAssembly.Module.imports(module).length, 1);
+}

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.cpp
@@ -65,23 +65,25 @@ void ModuleInformation::setNameSection(Ref<NameSection>&& section)
     m_nameSectionPtr.store(m_nameSection.ptr(), std::memory_order_release);
 }
 
+static std::optional<Name> encodeAsImportName(const String& string)
+{
+    auto utf8 = string.tryGetUTF8(StrictConversion);
+    if (!utf8)
+        return std::nullopt;
+    return Name(byteCast<char8_t>(utf8->span()));
+}
+
 // This is called during module creation, so at this point we have fully isolated access
 // to this ModuleInformation object.
 void ModuleInformation::applyCompileOptions(const WebAssemblyCompileOptions& options)
 {
     const auto& constants = options.importedStringConstants();
-    if (constants.has_value()) {
-        m_importedStringConstants = constants->isolatedCopy();
-        // We are making an isolated copy so we are not holding onto a unique string specific to some random thread.
-        // The assert below ensures that. Empty strings are special because their isolated copies are all the same canonical atomic empty string.
-        ASSERT(!(m_importedStringConstants->impl()->isAtom() || m_importedStringConstants->impl()->isSymbol()) || m_importedStringConstants->impl() == StringImpl::empty());
-    }
+    if (constants.has_value())
+        m_importedStringConstants = encodeAsImportName(*constants);
     const auto& builtinSetNames = options.qualifiedBuiltinSetNames();
     for (const auto& name : builtinSetNames) {
-        auto copy = name.isolatedCopy();
-        // See the assert notes above.
-        ASSERT(!(copy.impl()->isAtom() || copy.impl()->isSymbol()) || copy.impl() == StringImpl::empty());
-        m_qualifiedBuiltinSetNames.append(copy);
+        if (auto encoded = encodeAsImportName(name))
+            m_qualifiedBuiltinSetNames.append(WTF::move(*encoded));
     }
     populateImportShouldBeHidden();
 }
@@ -98,11 +100,10 @@ void ModuleInformation::populateImportShouldBeHidden()
     for (size_t i = 0; i < imports.size(); ++i) {
         const Import& import = imports[i];
 
-        String moduleName = makeString(import.module);
-        if (importedStringConstantsEquals(moduleName))
+        if (importedStringConstantsEquals(import.module))
             importShouldBeHidden.testAndSet(i);
-        else if (builtinSetsInclude(moduleName)) {
-            auto* builtinSet = WebAssemblyBuiltinRegistry::singleton().findByQualifiedName(moduleName);
+        else if (builtinSetsInclude(import.module)) {
+            auto* builtinSet = WebAssemblyBuiltinRegistry::singleton().findByQualifiedName(makeString(import.module));
             if (builtinSet) {
                 String fieldName = makeString(import.field);
                 if (builtinSet->findBuiltin(fieldName))

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -194,8 +194,8 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     size_t totalFunctionSize() const { return m_totalFunctionSize; }
 
     void applyCompileOptions(const WebAssemblyCompileOptions&);
-    bool importedStringConstantsEquals(const String& expected) const { return m_importedStringConstants && m_importedStringConstants.value() == expected; }
-    bool builtinSetsInclude(const String& qualifiedName) const { return m_qualifiedBuiltinSetNames.contains(qualifiedName); }
+    bool importedStringConstantsEquals(const Name& moduleName) const { return m_importedStringConstants && m_importedStringConstants.value() == moduleName; }
+    bool builtinSetsInclude(const Name& moduleName) const { return m_qualifiedBuiltinSetNames.contains(moduleName); }
 
     // nameSection is read from compiler threads (lock-free via atomic pointer)
     // and written from the main thread when the custom "name" section is parsed.
@@ -249,8 +249,8 @@ private:
 
     Vector<Ref<const RTT>> m_rtts;
 
-    std::optional<String> m_importedStringConstants;
-    Vector<String> m_qualifiedBuiltinSetNames;
+    std::optional<Name> m_importedStringConstants;
+    Vector<Name> m_qualifiedBuiltinSetNames;
     Ref<NameSection> m_nameSection;
     RefPtr<NameSection> m_retiredNameSection;
     std::atomic<NameSection*> m_nameSectionPtr { nullptr };

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -122,11 +122,11 @@ Synchronousness WebAssemblyModuleRecord::link(JSGlobalObject* globalObject, RefP
     return Synchronousness::Sync;
 }
 
-static const WebAssemblyBuiltinSet* findEnabledBuiltinSet(const String& qualifiedName, const Wasm::ModuleInformation& moduleInformation)
+static const WebAssemblyBuiltinSet* findEnabledBuiltinSet(const Wasm::Import& import, const Wasm::ModuleInformation& moduleInformation)
 {
-    if (!moduleInformation.builtinSetsInclude(qualifiedName))
+    if (!moduleInformation.builtinSetsInclude(import.module))
         return nullptr;
-    return WebAssemblyBuiltinRegistry::singleton().findByQualifiedName(qualifiedName);
+    return WebAssemblyBuiltinRegistry::singleton().findByQualifiedName(makeString(import.module));
 }
 
 static void defineImportedStringConstant(VM& vm, WriteBarrier<JSWebAssemblyInstance>& instance, const Wasm::Import& import)
@@ -178,11 +178,11 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
 
         // Imports related to builtins or importedStringConstants are special and bypass
         // the normal procedure of looking up a value in importObject.
-        if (moduleInformation.importedStringConstantsEquals(moduleNameString)) {
+        if (moduleInformation.importedStringConstantsEquals(import.module)) {
             defineImportedStringConstant(vm, m_instance, import);
             continue;
         }
-        const WebAssemblyBuiltinSet* builtinSet = findEnabledBuiltinSet(moduleNameString, moduleInformation);
+        const WebAssemblyBuiltinSet* builtinSet = findEnabledBuiltinSet(import, moduleInformation);
         if (builtinSet) {
             String fieldName = makeString(import.field);
             auto* builtin = builtinSet->findBuiltin(fieldName);


### PR DESCRIPTION
#### 3400ff6aa7b63e840b7cecd229e38e2c19e538ae
<pre>
Don&apos;t share StringImpl for worker names
<a href="https://bugs.webkit.org/show_bug.cgi?id=321818">https://bugs.webkit.org/show_bug.cgi?id=321818</a>

Reviewed by Yusuke Suzuki.

Since not all fields of StringImpl are atomic yet, it is
better form to just not share them, even if this site is
benign

* JSTests/wasm/stress/wasm-imported-string-constants-utf8.js: Added.
(uleb):
(name):
(moduleWithGlobalImport):
(testMatch):
(testNoMatch):
(string_appeared_here.const.module.new.WebAssembly.Module.moduleWithGlobalImport):
* Source/JavaScriptCore/wasm/WasmModuleInformation.cpp:
(JSC::Wasm::encodeAsImportName):
(JSC::Wasm::ModuleInformation::applyCompileOptions):
(JSC::Wasm::ModuleInformation::populateImportShouldBeHidden):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::findEnabledBuiltinSet):
(JSC::WebAssemblyModuleRecord::initializeImports):

Canonical link: <a href="https://commits.webkit.org/319371@main">https://commits.webkit.org/319371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fc47b8ae9d2ffa54af23164c231b458c017bab3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145441 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141331 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98026 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121782 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43671 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41949 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3747 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10565 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41610 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2492 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42392 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193267 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54729 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150719 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40412 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55417 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150435 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45027 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127683 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123232 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53934 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16606 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53553 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->