### PR TITLE
[Navigation API] dispose events for entries truncated by another frame's navigation see stale entries(), and detaching a frame during dispose crashes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-entries-updated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-entries-updated-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Entries truncated by a child frame's push must be removed from entries() before their dispose events fire
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-entries-updated.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-entries-updated.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Navigation API: entries() and currentEntry must already be updated when dispose fires for entries truncated by a navigation in another frame</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<iframe id="iframe" src="/common/blank.html"></iframe>
+<!--
+  Companion to navigation-api/per-entry-events/dispose-for-navigation-in-child.html,
+  which only checks that the top frame's forward entries are disposed when a child
+  frame pushes. This test checks the state that those dispose handlers observe:
+  per spec the entry list and current entry index are updated *before* the dispose
+  events fire, so a handler must never see the entry it is being notified about
+  still in navigation.entries().
+-->
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigations don't get converted
+  // into replace navigations.
+  await new Promise(r => window.onload = () => t.step_timeout(r, 0));
+
+  const startLength = navigation.entries().length;
+  const startIndex = navigation.currentEntry.index;
+  const childNav = iframe.contentWindow.navigation;
+
+  await childNav.navigate("#a").finished;
+  await navigation.navigate("#1").finished;
+  await navigation.navigate("#2").finished;
+  await navigation.navigate("#3").finished;
+  await childNav.back().finished;
+
+  assert_equals(navigation.entries().length, startLength + 3, "top frame keeps its forward entries after the child traverses back");
+  assert_equals(navigation.currentEntry.index, startIndex, "top frame moved back with the child");
+
+  // Snapshot what each dispose handler sees, rather than asserting inside the
+  // handler, so that a failure reports every handler's view.
+  const observed = [];
+  const disposed = [];
+  for (let i = startIndex + 1; i < navigation.entries().length; i++) {
+    const entry = navigation.entries()[i];
+    disposed.push(new Promise(resolve => {
+      entry.ondispose = e => {
+        observed.push({
+          entriesLength: navigation.entries().length,
+          currentIndex: navigation.currentEntry.index,
+          targetIndex: e.target.index,
+          stillInEntries: navigation.entries().indexOf(entry) !== -1,
+        });
+        resolve();
+      };
+    }));
+  }
+
+  // A push navigation in the child truncates the joint session history, which
+  // removes the top frame's forward entries even though the top frame is not
+  // the frame that navigated.
+  await childNav.navigate("#b").finished;
+  await Promise.all(disposed);
+
+  assert_equals(observed.length, 3, "all three forward entries fired dispose");
+  observed.forEach((state, i) => {
+    assert_equals(state.entriesLength, startLength, `dispose ${i}: entries() must already be truncated`);
+    assert_equals(state.currentIndex, startIndex, `dispose ${i}: currentEntry.index must already be updated`);
+    assert_false(state.stillInEntries, `dispose ${i}: the disposed entry must already be removed from entries()`);
+    assert_equals(state.targetIndex, -1, `dispose ${i}: the disposed entry's index must be -1`);
+  });
+}, "Entries truncated by a child frame's push must be removed from entries() before their dispose events fire");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-sibling-detach-frame-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-sibling-detach-frame-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Detaching a frame from its own dispose handler during another frame's truncating push must not crash
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-sibling-detach-frame.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-sibling-detach-frame.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Navigation API: removing a frame from its own dispose handler while another frame's push truncates the joint session history must not crash</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<!--
+  A push navigation in one frame truncates the joint session history, which
+  disposes forward entries in *every other* frame in the tree. Those dispose
+  events run author script, which is free to detach a frame the truncation walk
+  has not finished with yet -- including the very frame whose entry is being
+  disposed. The walk must survive that.
+
+  Frame layout: two same-origin sibling iframes under the main frame.
+    frameA: performs the truncating push navigation.
+    frameB: holds a forward entry that the push truncates, and is removed from
+            that entry's dispose handler.
+  The main frame cannot play frameB's part: it cannot be detached.
+-->
+<iframe id="frameA" src="/common/blank.html"></iframe>
+<iframe id="frameB" src="/common/blank.html"></iframe>
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigations below are pushes
+  // rather than being converted into replaces.
+  await new Promise(r => window.onload = () => t.step_timeout(r, 0));
+
+  // Hold the elements in variables: named access via id stops resolving once
+  // frameB is removed from the document.
+  const frameA = document.getElementById("frameA");
+  const frameB = document.getElementById("frameB");
+  const navA = frameA.contentWindow.navigation;
+  const navB = frameB.contentWindow.navigation;
+
+  // frameB pushes an entry and then traverses back to where it started, so that
+  // the pushed entry becomes a forward entry of the joint session history.
+  // Counts are start-relative and the traversal targets a recorded key, because
+  // how many entries an iframe starts with is not interoperable.
+  const startEntryB = navB.currentEntry;
+  const startIndexB = startEntryB.index;
+  await navB.navigate("#b1").finished;
+  assert_equals(navB.currentEntry.index, startIndexB + 1, "frameB pushed an entry");
+  const forwardEntry = navB.currentEntry;
+  await navB.traverseTo(startEntryB.key).finished;
+  assert_equals(navB.currentEntry, startEntryB, "frameB traversed back to where it started");
+  assert_equals(navB.entries()[startIndexB + 1], forwardEntry, "frameB keeps its forward entry");
+
+  const disposed = new Promise(resolve => {
+    forwardEntry.ondispose = () => {
+      // Detach the frame this entry belongs to, from inside its own dispose
+      // dispatch, while the truncation walk is still in progress.
+      frameB.remove();
+      resolve();
+    };
+  });
+
+  // A push in frameA truncates the joint session history, which must dispose
+  // frameB's forward entry even though frameB is not the frame that navigated.
+  const startIndexA = navA.currentEntry.index;
+  navA.navigate("#a1");
+  await disposed;
+  await new Promise(r => t.step_timeout(r, 0));
+
+  assert_equals(frameB.contentWindow, null, "frameB is detached");
+  // Reaching here at all is the point: the truncation walk must not have crashed.
+  assert_equals(frameA.contentWindow.location.hash, "#a1", "frameA's push completed");
+  assert_equals(navA.currentEntry.index, startIndexA + 1, "frameA pushed an entry");
+}, "Detaching a frame from its own dispose handler during another frame's truncating push must not crash");
+</script>

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -758,11 +758,19 @@ void Navigation::recursivelyDisposeOfForwardEntriesInParents(BackForwardItemIden
     if (!index)
         return;
 
-    for (size_t i = *index + 1; i < m_entries.size(); i++)
-        Ref { m_entries[i] }->dispatchDisposeEvent();
+    auto disposedEntries = m_entries.subvector(*index + 1);
 
     m_currentEntryIndex = index;
     m_entries.resize(*m_currentEntryIndex + 1);
+
+    // The entry list and current entry index must be updated before dispatching, so that
+    // dispose handlers do not observe the entries they are being notified about.
+    for (auto& disposedEntry : disposedEntries)
+        disposedEntry->dispatchDisposeEvent();
+
+    // Dispatching above ran author script, which may have detached this frame.
+    if (!frame())
+        return;
 
     for (RefPtr child = frame()->tree().firstChild(); child; child = child->tree().nextSibling()) {
         RefPtr localChild = dynamicDowncast<LocalFrame>(child.get());


### PR DESCRIPTION
#### bb54c41d7665fb62bc202d6477411947764528cf
<pre>
[Navigation API] dispose events for entries truncated by another frame&apos;s navigation see stale entries(), and detaching a frame during dispose crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=321821">https://bugs.webkit.org/show_bug.cgi?id=321821</a>
<a href="https://rdar.apple.com/184961466">rdar://184961466</a>

Reviewed by NOBODY (OOPS!).

When a frame performs a push navigation, the joint session history is truncated,
which must dispose the forward entries of every other frame in the tree.
Navigation::recursivelyDisposeOfForwardEntriesInParents did that in the wrong
order: it dispatched the dispose events before assigning m_currentEntryIndex and
resizing m_entries, so a dispose handler observed the entry it was being notified
about still present in navigation.entries(), with the old currentEntry index and
a still-valid entry.index. Per spec the entry list and current entry index are
updated first and the dispose events fire afterwards, which is also what the two
sibling paths in this file already do (updateForNavigation for push/replace, and
updateForReactivation). Snapshot the doomed entries with Vector::subvector(),
truncate, then dispatch.

Dispatching those events also runs author script, which is free to detach this
frame -- for instance from the dispose handler of one of its own entries. The
child walk that follows then dereferenced a null frame() and crashed with a
segmentation fault in the WebContent process. Bail out if the frame is gone, the
same way updateNavigationEntry() already does before its identical walk.

Both new tests pass in Gecko and Chromium and failed in WebKit before this
change: the first with entries().length reporting 4 instead of 1 inside the
dispose handler, the second with a null-deref crash.

Tests: imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-entries-updated.html
       imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-sibling-detach-frame.html

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-entries-updated-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-entries-updated.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-sibling-detach-frame-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-sibling-detach-frame.html: Added.
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::recursivelyDisposeOfForwardEntriesInParents):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb54c41d7665fb62bc202d6477411947764528cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150874 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145604 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100926 "2 flakes 15 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125953 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48027 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45977 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45724 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7725 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47602 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198638 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155191 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60625 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154828 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49249 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132931 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130091 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59049 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20703 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58452 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58668 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58518 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->