### PR TITLE
blog.rekhta.org: Text underline does not work properly for Urdu Text

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/resources/Litherum-arabic.svg
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/resources/Litherum-arabic.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg">
+<metadata></metadata>
+<defs>
+<font id="LitherumArabic" horiz-adv-x="1024">
+<font-face units-per-em="56" ascent="56" descent="-28"/>
+<glyph unicode="ب" horiz-adv-x="56" d="M20 -28v84h16v-84z"/>
+<glyph unicode="ݐ" horiz-adv-x="56" d="M20 -28v84h16v-84z"/>
+<glyph unicode="ࢠ" horiz-adv-x="56" d="M20 -28v84h16v-84z"/>
+<glyph unicode="ࡰ" horiz-adv-x="56" d="M20 -28v84h16v-84z"/>
+<glyph unicode="𐻀" horiz-adv-x="56" d="M20 -28v84h16v-84z"/>
+<glyph unicode="ﭐ" horiz-adv-x="56" d="M20 -28v84h16v-84z"/>
+<glyph unicode="ﹰ" horiz-adv-x="56" d="M20 -28v84h16v-84z"/>
+</font>
+</defs>
+</svg>

--- a/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-arabic-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-arabic-expected.html
@@ -1,0 +1,18 @@
+<style>
+@font-face {
+    font-family: 'LitherumArabic';
+    src: url("./resources/Litherum-arabic.svg") format(svg)
+}
+</style>
+<meta charset="utf-8">
+This test makes sure that underlines under Arabic-family script text (e.g. Urdu Nastaliq) do not skip
+over low-hanging curves in the glyphs, the same way CJK text is already handled.
+<div style="text-decoration: underline; -webkit-text-decoration-skip: none; font-family: LitherumArabic">
+<p>ب</p>
+<p>ݐ</p>
+<p>ࢠ</p>
+<p>ࡰ</p>
+<p>𐻀</p>
+<p>ﭐ</p>
+<p>ﹰ</p>
+</div>

--- a/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-arabic.html
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-arabic.html
@@ -1,0 +1,19 @@
+<style>
+@font-face {
+    font-family: 'LitherumArabic';
+    src: url("./resources/Litherum-arabic.svg") format(svg)
+}
+</style>
+<meta charset="utf-8">
+<meta name="fuzzy" content="maxDifference=0-30; totalPixels=0-15" />
+This test makes sure that underlines under Arabic-family script text (e.g. Urdu Nastaliq) do not skip
+over low-hanging curves in the glyphs, the same way CJK text is already handled.
+<div style="text-decoration: underline; font-family: LitherumArabic">
+<p>ب</p>
+<p>ݐ</p>
+<p>ࢠ</p>
+<p>ࡰ</p>
+<p>𐻀</p>
+<p>ﭐ</p>
+<p>ﹰ</p>
+</div>

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1403,6 +1403,13 @@ static GlyphUnderlineType computeUnderlineType(const TextRun& textRun, const Gly
     case UBLOCK_HANGUL_SYLLABLES:
     case UBLOCK_HANGUL_JAMO_EXTENDED_A:
     case UBLOCK_HANGUL_JAMO_EXTENDED_B:
+    case UBLOCK_ARABIC:
+    case UBLOCK_ARABIC_SUPPLEMENT:
+    case UBLOCK_ARABIC_EXTENDED_A:
+    case UBLOCK_ARABIC_EXTENDED_B:
+    case UBLOCK_ARABIC_EXTENDED_C:
+    case UBLOCK_ARABIC_PRESENTATION_FORMS_A:
+    case UBLOCK_ARABIC_PRESENTATION_FORMS_B:
         return GlyphUnderlineType::DrawOverGlyph;
     default:
         return GlyphUnderlineType::SkipDescenders;


### PR DESCRIPTION
#### e6f1dbc88e5cce50f4af716f925d6eaf14bcb617
<pre>
blog.rekhta.org: Text underline does not work properly for Urdu Text
<a href="https://bugs.webkit.org/show_bug.cgi?id=321816">https://bugs.webkit.org/show_bug.cgi?id=321816</a>
<a href="https://rdar.apple.com/161299983">rdar://161299983</a>

Reviewed by Brent Fulgham.

WebKit&apos;s underline ink-skip painting exempts CJK-family scripts from per-glyph ink
detection. Arabic-family connected scripts like Urdu Nastaliq hit the same problem: a
single glyph&apos;s ink envelope can span nearly its full width, so skip-ink treats most of
the underline as intersecting ink and paints only a few disconnected segments. This
extends the CJK exception to the Arabic-family Unicode blocks.

Test: fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-arabic.html

* LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/resources/Litherum-arabic.svg: Added.
* LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-arabic-expected.html: Added.
* LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-arabic.html: Added.
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::computeUnderlineType):

Canonical link: <a href="https://commits.webkit.org/319220@main">https://commits.webkit.org/319220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/797fdde3c5a46dbe82dfa7ae8f4d404e46c92ad8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191060 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145169 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141078 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121530 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41349 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2220 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47403 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192995 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150460 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40264 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55145 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150179 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44768 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122711 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53662 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16342 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53044 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53281 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53109 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->