### PR TITLE
[Site Isolation] Evict isolated sites once the store reaches its size cap

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1272,6 +1272,11 @@ struct WKWebsiteData {
     protect(*_websiteDataStore)->setHighValueFraudTargetDomainsForTesting(makeVector<String>(domains));
 }
 
+- (void)_setMaximumIsolatedSiteCountForTesting:(NSUInteger)count
+{
+    protect(*_websiteDataStore)->setMaximumIsolatedSiteCountForTesting(count);
+}
+
 - (void)_getPendingPushMessage:(void(^)(NSDictionary *))completionHandler
 {
     RELEASE_LOG(Push, "Getting pending push message");

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -130,6 +130,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 -(bool)_hasServiceWorkerBackgroundActivityForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(NSNumber *)_isolatedSiteSignalsForTesting:(NSURL *)url WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0)); // IsolatedSiteStore::Signal bits, or nil if the site is not isolated.
 -(void)_setHighValueFraudTargetDomainsForTesting:(NSArray<NSString *> *)domains WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
+-(void)_setMaximumIsolatedSiteCountForTesting:(NSUInteger)count WK_API_AVAILABLE(macos(27.0), ios(27.0), visionos(27.0));
 -(void)_getPendingPushMessage:(void(^)(NSDictionary *))completionHandler WK_API_AVAILABLE(macos(15.2), ios(18.2));
 -(void)_getPendingPushMessages:(void(^)(NSArray<NSDictionary *> *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_processPushMessage:(NSDictionary *)pushMessage completionHandler:(void(^)(bool))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp
@@ -27,13 +27,18 @@
 #include "IsolatedSiteStore.h"
 
 #include "IsolatedSitePersistence.h"
+#include "Logging.h"
+#include <algorithm>
 #include <cmath>
+#include <ranges>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/SetForScope.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRandomNumber.h>
 
 #if PLATFORM(COCOA)
 #include "WebPrivacyHelpers.h"
@@ -99,7 +104,7 @@ IsolatedSiteStore::IsolatedSiteStore(const String& databaseDirectoryPath, UserIn
             if (signals.isEmpty())
                 continue;
 
-            sites.set(domain, Entry { signals, record.lastUpdated });
+            sites.set(domain, Entry { .lastUpdated = record.lastUpdated, .signals = signals });
         }
         bool didImportUserInteractions = protectedThis->m_persistence->didImportUserInteractions();
 
@@ -139,6 +144,9 @@ void IsolatedSiteStore::didLoadSites(HashMap<WebCore::RegistrableDomain, Entry>&
     }
 
     m_isLoaded = true;
+
+    evictSitesIfNeeded();
+
     for (auto& completionHandler : std::exchange(m_loadCompletionHandlers, { }))
         completionHandler();
 
@@ -197,14 +205,18 @@ void IsolatedSiteStore::importUserInteractions()
             return protectedThis->becomeReady();
 
         auto now = today();
-        for (auto& [domain, interactionTime] : *domains) {
-            if (domain.isEmpty())
-                continue;
-            auto lastUpdated = roundDownToDay(interactionTime);
-            if (!lastUpdated || lastUpdated > now)
-                lastUpdated = now;
-            protectedThis->recordSignals(domain, { Signal::FirstPartyVisit, Signal::FirstPartyUserGesture }, lastUpdated);
+        {
+            SetForScope isImporting(protectedThis->m_isImportingUserInteractions, true);
+            for (auto& [domain, interactionTime] : *domains) {
+                if (domain.isEmpty())
+                    continue;
+                auto lastUpdated = roundDownToDay(interactionTime);
+                if (!lastUpdated || lastUpdated > now)
+                    lastUpdated = now;
+                protectedThis->recordSignals(domain, { Signal::FirstPartyVisit, Signal::FirstPartyUserGesture }, lastUpdated);
+            }
         }
+        protectedThis->evictSitesIfNeeded();
 
         sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { protectedThis.get() }] {
             assertIsCurrent(sharedWorkQueueSingleton());
@@ -274,6 +286,82 @@ void IsolatedSiteStore::recordSignals(const WebCore::RegistrableDomain& domain, 
     entry.signals.add(signals);
     entry.lastUpdated = std::max(entry.lastUpdated, lastUpdated);
     saveSite(domain, entry);
+
+    evictSitesIfNeeded();
+}
+
+auto IsolatedSiteStore::evictionTier(OptionSet<Signal> signals) -> EvictionTier
+{
+    if (!firstPartySignals.containsAll(signals))
+        return EvictionTier::CredentialEvidence;
+
+    if (signals.contains(Signal::FirstPartyUserGesture))
+        return EvictionTier::Gestured;
+
+    return EvictionTier::VisitOnly;
+}
+
+void IsolatedSiteStore::evictSitesIfNeeded()
+{
+    ASSERT(isMainRunLoop());
+
+    if (!m_isLoaded || m_isImportingUserInteractions)
+        return;
+
+    if (m_sites.size() <= m_maximumSiteCount)
+        return;
+
+    // When tier and day (lastUpdated has day granularity) both tie, pick the victim at random
+    // to avoid eviction pathology.
+    struct Candidate {
+        EvictionTier tier;
+        WallTime lastUpdated;
+        uint32_t randomKey;
+        const WebCore::RegistrableDomain* domain;
+    };
+    auto candidates = WTF::map(m_sites, [](auto& site) {
+        return Candidate { evictionTier(site.value.signals), site.value.lastUpdated, weakRandomNumber<uint32_t>(), &site.key };
+    });
+
+    auto evictionCount = m_sites.size() - m_maximumSiteCount;
+    std::ranges::nth_element(candidates, std::next(candidates.begin(), evictionCount), [](auto& a, auto& b) {
+        return std::tie(a.tier, a.lastUpdated, a.randomKey) < std::tie(b.tier, b.lastUpdated, b.randomKey);
+    });
+    candidates.shrink(evictionCount);
+
+    auto evictedDomains = WTF::map(candidates, [](auto& candidate) {
+        return *candidate.domain;
+    });
+
+#if !RELEASE_LOG_DISABLED
+    auto evictedInTier = [&candidates](EvictionTier tier) {
+        return std::ranges::count_if(candidates, [tier](auto& candidate) {
+            return candidate.tier == tier;
+        });
+    };
+    RELEASE_LOG(Storage, "IsolatedSiteStore::evictSitesIfNeeded evicted %u of %u sites to reach a cap of %u (visit-only %td, gestured %td, credential evidence %td)", evictionCount, m_sites.size(), m_maximumSiteCount, evictedInTier(EvictionTier::VisitOnly), evictedInTier(EvictionTier::Gestured), evictedInTier(EvictionTier::CredentialEvidence));
+#endif
+
+    for (auto& domain : evictedDomains)
+        m_sites.remove(domain);
+
+    if (!m_isPersistent)
+        return;
+
+    sharedWorkQueueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, domains = crossThreadCopy(WTF::move(evictedDomains))] {
+        assertIsCurrent(sharedWorkQueueSingleton());
+
+        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_persistence)
+            protectedThis->m_persistence->deleteSites(domains);
+    });
+}
+
+void IsolatedSiteStore::setMaximumSiteCountForTesting(uint32_t maximumSiteCount)
+{
+    ASSERT(isMainRunLoop());
+
+    m_maximumSiteCount = maximumSiteCount;
+    evictSitesIfNeeded();
 }
 
 void IsolatedSiteStore::addSite(const WebCore::Site& site, Signal signal)

--- a/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h
@@ -50,9 +50,9 @@ public:
         FirstPartyUserGesture = 1 << 2,
         HighValueFraudTarget = 1 << 3,
     };
-    // HighValueFraudTarget is derived from WebPrivacy's list on every lookup, so it is deliberately
-    // absent here: it must never be written to or read back from IsolatedSitePersistence.
     static constexpr OptionSet<Signal> persistedSignals { Signal::Autofill, Signal::FirstPartyVisit, Signal::FirstPartyUserGesture };
+    static constexpr OptionSet<Signal> firstPartySignals { Signal::FirstPartyVisit, Signal::FirstPartyUserGesture };
+    static constexpr uint32_t defaultMaximumSiteCount = 5000;
 
     using UserInteractionDomainFetcher = Function<void(CompletionHandler<void(std::optional<HashMap<WebCore::RegistrableDomain, WallTime>>&&)>&&)>;
     static Ref<IsolatedSiteStore> create(const String& databaseDirectoryPath, UserInteractionDomainFetcher&&, bool highValueFraudTargetDomainsEnabled, HashSet<WebCore::RegistrableDomain>&& additionalSitesForTesting);
@@ -74,14 +74,23 @@ public:
     bool isReady() const { return m_isReady; }
     void whenReady(CompletionHandler<void()>&&);
 
+    void setMaximumSiteCountForTesting(uint32_t);
+
 private:
     IsolatedSiteStore(const String& databaseDirectoryPath, UserInteractionDomainFetcher&&, bool highValueFraudTargetDomainsEnabled, HashSet<WebCore::RegistrableDomain>&&);
 
     static WorkQueue& sharedWorkQueueSingleton();
 
+    // Ordered by alignment to keep the entry at 16 bytes.
     struct Entry {
-        OptionSet<Signal> signals;
         WallTime lastUpdated;
+        OptionSet<Signal> signals;
+    };
+
+    enum class EvictionTier : uint8_t {
+        VisitOnly,
+        Gestured,
+        CredentialEvidence,
     };
 
     bool isHighValueFraudTargetDomain(const WebCore::RegistrableDomain&) const;
@@ -94,17 +103,21 @@ private:
     void skipImport();
     void recordSignals(const WebCore::RegistrableDomain&, OptionSet<Signal>, WallTime lastUpdated);
     void saveSite(const WebCore::RegistrableDomain&, const Entry&);
+    static EvictionTier evictionTier(OptionSet<Signal>);
+    void evictSitesIfNeeded();
 
     HashMap<WebCore::RegistrableDomain, Entry> m_sites;
     Vector<CompletionHandler<void()>> m_loadCompletionHandlers;
     Vector<CompletionHandler<void()>> m_readyCompletionHandlers;
     UserInteractionDomainFetcher m_userInteractionDomainFetcher;
     HashSet<WebCore::RegistrableDomain> m_additionalSitesForTesting;
+    uint32_t m_maximumSiteCount { defaultMaximumSiteCount };
     const bool m_isPersistent { false };
     bool m_highValueFraudTargetDomainsEnabled { false };
     bool m_isLoaded { false };
     bool m_isReady { false };
     bool m_importSuppressed { false };
+    bool m_isImportingUserInteractions { false };
     std::unique_ptr<IsolatedSitePersistence> m_persistence WTF_GUARDED_BY_CAPABILITY(sharedWorkQueueSingleton());
 };
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1613,6 +1613,11 @@ void WebsiteDataStore::setHighValueFraudTargetDomainsForTesting(Vector<String>&&
 #endif
 }
 
+void WebsiteDataStore::setMaximumIsolatedSiteCountForTesting(size_t maximumSiteCount)
+{
+    protect(isolatedSiteStore())->setMaximumSiteCountForTesting(maximumSiteCount);
+}
+
 void WebsiteDataStore::logUserInteraction(const URL& url, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -234,6 +234,7 @@ public:
     IsolatedSiteStore& isolatedSiteStore();
     std::optional<OptionSet<IsolatedSiteStore::Signal>> isolatedSiteSignalsForTesting(const URL&);
     void setHighValueFraudTargetDomainsForTesting(Vector<String>&&);
+    void setMaximumIsolatedSiteCountForTesting(size_t);
     void logUserInteraction(const URL&, CompletionHandler<void()>&&);
     void getAllStorageAccessEntries(WebPageProxyIdentifier, CompletionHandler<void(Vector<String>&& domains)>&&);
     void hasHadUserInteraction(const URL&, CompletionHandler<void(bool)>&&);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
@@ -2436,7 +2436,7 @@ TEST(IsolatedSiteStore, PersistsAcrossSessions)
     }
 }
 
-static RetainPtr<WKWebsiteDataRecord> isolatedSiteRecordForDisplayName(WKWebsiteDataStore *dataStore, NSString *displayName)
+static RetainPtr<NSArray<WKWebsiteDataRecord *>> isolatedSiteRecords(WKWebsiteDataStore *dataStore)
 {
     __block RetainPtr<NSArray<WKWebsiteDataRecord *>> records;
     __block bool done = false;
@@ -2445,7 +2445,12 @@ static RetainPtr<WKWebsiteDataRecord> isolatedSiteRecordForDisplayName(WKWebsite
         done = true;
     }];
     Util::run(&done);
+    return records;
+}
 
+static RetainPtr<WKWebsiteDataRecord> isolatedSiteRecordForDisplayName(WKWebsiteDataStore *dataStore, NSString *displayName)
+{
+    RetainPtr records = isolatedSiteRecords(dataStore);
     for (WKWebsiteDataRecord *record in records.get()) {
         if ([record.displayName isEqualToString:displayName])
             return record;
@@ -2616,6 +2621,131 @@ TEST(IsolatedSiteStore, ImportsWhenTrackingPreventionIsTurnedOnLater)
         // the entry carries that time rather than the time it was imported.
         removeIsolatedSiteDataSince(dataStore.get(), [NSDate dateWithTimeIntervalSinceNow:-3600]);
         EXPECT_TRUE(isolatedSiteSignals(dataStore.get(), @"https://webkit.org/") & firstPartyVisitSignal);
+    }
+}
+
+TEST(IsolatedSiteStore, EvictsOneOfTwoTiedSitesWithinTier)
+{
+    HTTPServer server({
+        { "/example"_s, { "example as a top-level page"_s } },
+        { "/webkit"_s, { "webkit as a top-level page"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = webViewForIsolatedSiteStoreTest(server);
+    WKWebsiteDataStore *dataStore = [webView configuration].websiteDataStore;
+    [dataStore _setMaximumIsolatedSiteCountForTesting:1];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Both entries carry the same signal and the timestamp is rounded down to a day, so which one
+    // is evicted is randomized; only their count is deterministic.
+    bool exampleSurvived = !!(isolatedSiteSignals(dataStore, @"https://example.com/") & firstPartyVisitSignal);
+    bool webkitSurvived = !!(isolatedSiteSignals(dataStore, @"https://webkit.org/") & firstPartyVisitSignal);
+    EXPECT_TRUE(exampleSurvived != webkitSurvived);
+}
+
+#if PLATFORM(MAC)
+
+TEST(IsolatedSiteStore, EvictsVisitOnlySiteBeforeGesturedSite)
+{
+    HTTPServer server({
+        { "/example"_s, { "<body style='margin:0'><div style='width:300px;height:300px'></div></body>"_s } },
+        { "/webkit"_s, { "webkit as a top-level page"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = webViewForIsolatedSiteStoreTest(server);
+    WKWebsiteDataStore *dataStore = [webView configuration].websiteDataStore;
+    [dataStore _setMaximumIsolatedSiteCountForTesting:1];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView sendClickAtPoint:NSMakePoint(100, 100)];
+    [webView waitForPendingMouseEvents];
+    EXPECT_TRUE(Util::waitFor([&] {
+        return !!(isolatedSiteSignals(dataStore, @"https://example.com/") & firstPartyUserGestureSignal);
+    }));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // webkit.org is the site visited more recently, but the gesture puts example.com in a tier that is
+    // only evicted once the visit-only entries are gone.
+    EXPECT_TRUE(isolatedSiteSignals(dataStore, @"https://example.com/") & firstPartyUserGestureSignal);
+    EXPECT_NULL([dataStore _isolatedSiteSignalsForTesting:[NSURL URLWithString:@"https://webkit.org/"]]);
+}
+
+#endif // PLATFORM(MAC)
+
+TEST(IsolatedSiteStore, EvictionIsPersisted)
+{
+    HTTPServer server({
+        { "/example"_s, { "example as a top-level page"_s } },
+        { "/webkit"_s, { "webkit as a top-level page"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    NSURL *directory = temporaryDirectoryForIsolatedSiteStoreTest(@"IsolatedSiteStoreEvictionIsPersisted");
+    RetainPtr<NSString> survivingDomain;
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory);
+        [dataStore _setMaximumIsolatedSiteCountForTesting:1];
+        auto [webView, navigationDelegate] = webViewForDataStore(dataStore.get());
+
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit"]]];
+        [navigationDelegate waitForDidFinishNavigation];
+
+        EXPECT_EQ(1u, [isolatedSiteRecords(dataStore.get()) count]);
+
+        // Both entries are in the same tier and were updated on the same day, so which one survives
+        // eviction is randomized; record it so the second session can check that eviction was persisted.
+        bool exampleSurvived = !!(isolatedSiteSignals(dataStore.get(), @"https://example.com/") & firstPartyVisitSignal);
+        survivingDomain = exampleSurvived ? @"https://example.com/" : @"https://webkit.org/";
+    }
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory);
+        EXPECT_EQ(1u, [isolatedSiteRecords(dataStore.get()) count]);
+        EXPECT_TRUE(isolatedSiteSignals(dataStore.get(), survivingDomain.get()) & firstPartyVisitSignal);
+    }
+}
+
+TEST(IsolatedSiteStore, EvictsLoadedSitesOverTheCap)
+{
+    HTTPServer server({
+        { "/example"_s, { "example as a top-level page"_s } },
+        { "/webkit"_s, { "webkit as a top-level page"_s } },
+        { "/apple"_s, { "apple as a top-level page"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    NSURL *directory = temporaryDirectoryForIsolatedSiteStoreTest(@"IsolatedSiteStoreEvictionOnLoad");
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory);
+        auto [webView, navigationDelegate] = webViewForDataStore(dataStore.get());
+
+        for (NSString *url in @[@"https://example.com/example", @"https://webkit.org/webkit", @"https://apple.com/apple"]) {
+            [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+            [navigationDelegate waitForDidFinishNavigation];
+        }
+
+        EXPECT_EQ(3u, [isolatedSiteRecords(dataStore.get()) count]);
+    }
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory);
+        [dataStore _setMaximumIsolatedSiteCountForTesting:1];
+        EXPECT_EQ(1u, [isolatedSiteRecords(dataStore.get()) count]);
+    }
+
+    @autoreleasepool {
+        RetainPtr dataStore = persistentDataStore(server, directory);
+        EXPECT_EQ(1u, [isolatedSiteRecords(dataStore.get()) count]);
     }
 }
 


### PR DESCRIPTION
#### 9c27c4ccf517794644bc3e08facc1e95a14f4e75
<pre>
[Site Isolation] Evict isolated sites once the store reaches its size cap
<a href="https://bugs.webkit.org/show_bug.cgi?id=321824">https://bugs.webkit.org/show_bug.cgi?id=321824</a>
<a href="https://rdar.apple.com/184964977">rdar://184964977</a>

Reviewed by Ryosuke Niwa.

Every top-level visit records FirstPartyVisit, so IsolatedSiteStore could grow without bound. Cap it at 5000 entries,
which take roughly 600 KB in UIProcess and cover on the order of a year of first-party browsing. The number is a
judgment rather than a measurement, and may be adjusted once there is more data.

Eviction priority is decided by signal first and then by last updated time:
1. VisitOnly - FirstPartyVisit and nothing else
2. Gestured - the user also did something deliberate there
3. CredentialEvidence - anything outside firstPartySignals, evicted last

lastUpdated is rounded down to a day, so entries recorded on the same day cannot be ordered by it. Breaking that tie
by insertion order would make eviction depend on an implementation artifact rather than a meaningful signal - e.g. a
bulk import would always evict whichever half of the batch happened to be processed first, every time it ran. Ties
are broken at random instead, the same as WebProcessCache&apos;s and NetworkCache&apos;s eviction.

Since the steady state evicts a single entry per navigation, eviction targets are picked with nth_element rather than a
full sort. Candidates hold pointers to the keys in the table to avoid copying every domain, which is only safe because
nothing mutates m_sites between building the candidates and reading them back.

Eviction runs on the write path, and again after the load merges the rows from the database. The tracking prevention
import defers it until its batch finishes, so the imported set is capped in one pass rather than evicting entries as
each domain is added.

Split isolatedSiteRecordForDisplayName into isolatedSiteRecords so the new tests can count records directly, and hold
the returned array in a local rather than enumerating the temporary: Objective-C fast enumeration destroys temporaries
in the collection expression before the loop body runs, which would leave the enumeration walking a released array.

Tests: IsolatedSiteStore.EvictsOneOfTwoTiedSitesWithinTier
       IsolatedSiteStore.EvictsVisitOnlySiteBeforeGesturedSite
       IsolatedSiteStore.EvictionIsPersisted
       IsolatedSiteStore.EvictsLoadedSitesOverTheCap

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _setMaximumIsolatedSiteCountForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.cpp:
(WebKit::IsolatedSiteStore::IsolatedSiteStore):
(WebKit::IsolatedSiteStore::didLoadSites):
(WebKit::IsolatedSiteStore::importUserInteractions):
(WebKit::IsolatedSiteStore::recordSignals):
(WebKit::IsolatedSiteStore::evictionTier):
(WebKit::IsolatedSiteStore::evictSitesIfNeeded):
(WebKit::IsolatedSiteStore::setMaximumSiteCountForTesting):
* Source/WebKit/UIProcess/WebsiteData/IsolatedSiteStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::setMaximumIsolatedSiteCountForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm:
(TestWebKitAPI::(IsolatedSiteStore, EvictsOneOfTwoTiedSitesWithinTier)):
(TestWebKitAPI::(IsolatedSiteStore, EvictsVisitOnlySiteBeforeGesturedSite)):
(TestWebKitAPI::(IsolatedSiteStore, EvictionIsPersisted)):
(TestWebKitAPI::(IsolatedSiteStore, EvictsLoadedSitesOverTheCap)):

Canonical link: <a href="https://commits.webkit.org/319435@main">https://commits.webkit.org/319435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89c694ab54fac4edce69e6bb716a39973f8034f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191650 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145753 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66258c5f-4d41-475b-ae48-640dd537d5d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141597 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/230a2b37-72f3-4957-af4f-7ffaeb6b46b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122037 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c9987c9-2bc4-4412-898e-0a0e7f6e6bf1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43951 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42226 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41865 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2810 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193578 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55043 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150998 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40448 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55730 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38488 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150703 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45281 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128011 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123612 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54246 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16864 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53628 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53866 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53693 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->