### PR TITLE
[CSS] Set CSSUserSelectEnabled to stable

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1846,17 +1846,17 @@ CSSUnprefixedBackdropFilterEnabled:
 
 CSSUserSelectEnabled:
   type: bool
-  status: testable
+  status: stable
   category: css
   humanReadableName: "CSS Unprefixed User Select"
   humanReadableDescription: "Enable the unprefixed user-select CSS property"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 CSSWhiteSpaceTrimEnabled:
   type: bool

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm
@@ -62,15 +62,15 @@ static NSData *readRTFDataFromPasteboard()
 }
 #endif
 
-static RetainPtr<NSAttributedString> copyAttributedStringFromHTML(NSString *htmlString, bool forceDarkMode, bool enableUnprefixedUserSelect = false)
+static RetainPtr<NSAttributedString> copyAttributedStringFromHTML(NSString *htmlString, bool forceDarkMode, bool disableUnprefixedUserSelect = false)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
 
     auto preferences = (__bridge WKPreferencesRef)[[webView configuration] preferences];
     WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging(preferences, true);
 
-    if (enableUnprefixedUserSelect)
-        WKPreferencesSetBoolValueForKeyForTesting(preferences, true, WKStringCreateWithUTF8CString("CSSUserSelectEnabled"));
+    if (disableUnprefixedUserSelect)
+        WKPreferencesSetBoolValueForKeyForTesting(preferences, false, WKStringCreateWithUTF8CString("CSSUserSelectEnabled"));
 
     if (forceDarkMode)
         [webView forceDarkMode];
@@ -178,19 +178,18 @@ TEST(CopyRTF, StripsUserSelectNone)
         "<span style='-webkit-user-select: initial; user-select: initial;'>WebKit </span></span>"
         "<div style='-webkit-user-select: none; user-select: none;'>some<br>user-select-none<br>content</div><span inert>foo </span>bar", false);
 
-    EXPECT_WK_STREQ([attributedString string].UTF8String, "hello WebKit bar");
+    EXPECT_WK_STREQ([attributedString string].UTF8String, "hello bar");
 }
 
-TEST(CopyRTF, StripsUserSelectNoneWithUnprefixedUserSelectEnabled)
+TEST(CopyRTF, StripsUserSelectNonewithLegacyUserSelectBehavior)
 {
-    // Same content as StripsUserSelectNone. With the unprefixed property enabled, 'initial' no
-    // longer counts as explicitly set for either spelling, so the inner span falls back to
-    // 'user-select: auto', resolves to the surrounding 'none', and is stripped too.
+    // Same content as StripsUserSelectNone. On legacy behavior,
+    // 'initial' is resolved to 'text':
     auto attributedString = copyAttributedStringFromHTML(@"hello <span style='-webkit-user-select: none; user-select: none;'>world "
         "<span style='-webkit-user-select: initial; user-select: initial;'>WebKit </span></span>"
         "<div style='-webkit-user-select: none; user-select: none;'>some<br>user-select-none<br>content</div><span inert>foo </span>bar", false, true);
 
-    EXPECT_WK_STREQ([attributedString string].UTF8String, "hello bar");
+    EXPECT_WK_STREQ([attributedString string].UTF8String, "hello WebKit bar");
 }
 
 TEST(CopyRTF, StripsUserSelectNoneQuirks)


### PR DESCRIPTION
#### 2f072fbfecffc76a8567e87be967fbb8653e9472
<pre>
[CSS] Set CSSUserSelectEnabled to stable
<a href="https://bugs.webkit.org/show_bug.cgi?id=321825">https://bugs.webkit.org/show_bug.cgi?id=321825</a>
<a href="https://rdar.apple.com/184964807">rdar://184964807</a>

Reviewed by Tim Nguyen and Megan Gardner.

Set CSSUserSelectEnabled to stable.

This also adapts a pair of API test that specifically exercises both
values of this flag, with no change of behavior.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm:
(copyAttributedStringFromHTML):
(TEST(CopyRTF, StripsUserSelectNone)): now assumes the flag is true
(TEST(CopyRTF, StripsUserSelectNonewithLegacyUserSelectBehavior)): flag off behavior
(TEST(CopyRTF, StripsUserSelectNoneWithUnprefixedUserSelectEnabled)): Deleted.

Canonical link: <a href="https://commits.webkit.org/319562@main">https://commits.webkit.org/319562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f2654bd9cd71d2c45e19c4b1f51faa26c584437

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146176 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c56fcd6-839f-458c-bc63-9baa9d10260e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141959 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8cbcbf3b-69fa-4739-b423-c2831b081b57) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122395 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44326 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42596 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4362 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11167 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42225 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3234 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43126 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193999 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55464 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40535 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56153 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151082 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45649 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128436 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124195 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54666 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17221 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54048 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54287 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54113 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->