### PR TITLE
Location::ancestorOrigins() should build its cached list through a local Ref

### DIFF
--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -140,10 +140,11 @@ Ref<DOMStringList> Location::ancestorOrigins() const
         return *m_ancestorOrigins;
     }
     if (!m_ancestorOrigins) {
-        m_ancestorOrigins = DOMStringList::create();
+        Ref ancestorOrigins = DOMStringList::create();
+        m_ancestorOrigins = ancestorOrigins.copyRef();
         for (RefPtr ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
             if (RefPtr origin = ancestor->frameDocumentSecurityOrigin())
-                protect(m_ancestorOrigins)->append(origin->toString());
+                ancestorOrigins->append(origin->toString());
         }
     }
     return *m_ancestorOrigins;


### PR DESCRIPTION
#### becdb864c9ddd9e05c4ecfd9c2b304e0856dc015
<pre>
Location::ancestorOrigins() should build its cached list through a local Ref
<a href="https://bugs.webkit.org/show_bug.cgi?id=321827">https://bugs.webkit.org/show_bug.cgi?id=321827</a>
<a href="https://rdar.apple.com/184966612">rdar://184966612</a>

Reviewed by Chris Dumez.

Location::ancestorOrigins() built its cached list by calling
protect(m_ancestorOrigins)-&gt;append(...) inside the ancestor walk, taking a
fresh RefPtr copy of the member on every iteration just to reach
DOMStringList::append(). Append through a Ref local instead.

This is a readability cleanup rather than a measurable win: the list is built
once per Location and then cached, ancestor chains are short, and
DOMStringList is non-atomically ref-counted, so the churn removed is a few
increments on a cold path. The copyRef() that publishes the member even adds
one ref/deref back in the common no-ancestor case.

The member is still assigned before the loop is entered, so the list is
published in the same order as before and a re-entrant read during the walk
observes the same partially-built list it does today.

No behavior change, so no new test.

* Source/WebCore/page/Location.cpp:
(WebCore::Location::ancestorOrigins const):

Canonical link: <a href="https://commits.webkit.org/319446@main">https://commits.webkit.org/319446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c15362b87a7da5181f851a6ebb318d063e1000f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145791 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1eac203a-d8f1-4a48-9175-78fc14b27555) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141628 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b286fb2-1564-4635-a8d5-9cae9871e621) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122068 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ecb6bade-d85c-4c1d-a249-008de1027277) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43987 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42260 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41900 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2849 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48038 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193616 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55081 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151030 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40456 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55768 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150736 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45315 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128049 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123663 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54284 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16899 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53666 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53904 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53731 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->