### PR TITLE
[CMake] Fix macOS build broken with redefinition of 'alertCount' in TestWebKitAPI

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentExtensionStore.mm
@@ -548,7 +548,7 @@ TEST_F(WKContentRuleListStoreTest, NonASCIISource)
     TestWebKitAPI::Util::run(&done);
 }
 
-static size_t alertCount { 0 };
+static size_t contentExtensionAlertCount { 0 };
 static bool contentExtensionReceivedAlert { false };
 
 @interface ContentRuleListDelegate : NSObject <WKUIDelegate>
@@ -558,7 +558,7 @@ static bool contentExtensionReceivedAlert { false };
 
 - (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
 {
-    switch (alertCount++) {
+    switch (contentExtensionAlertCount++) {
     case 0:
         // Default behavior.
         EXPECT_STREQ("content blockers enabled", message.UTF8String);
@@ -600,7 +600,7 @@ TEST_F(WKContentRuleListStoreTest, AddRemove)
     [webView setUIDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"contentBlockerCheck" withExtension:@"html"]];
-    alertCount = 0;
+    contentExtensionAlertCount = 0;
     contentExtensionReceivedAlert = false;
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&contentExtensionReceivedAlert);


### PR DESCRIPTION
#### 11c7bc44b1119e68b5ea42ef21dc71b5278b5eec
<pre>
[CMake] Fix macOS build broken with redefinition of &apos;alertCount&apos; in TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=321830">https://bugs.webkit.org/show_bug.cgi?id=321830</a>
<a href="https://rdar.apple.com/184972366">rdar://184972366</a>

Reviewed by Simon Fraser.

WKContentExtensionStore.mm and WebsitePolicies.mm both declare a
file-scope `static size_t alertCount`. This has been latent since 2017
and only breaks when the two files share a unified source bundle.

319204@main added HTTP3Server.mm to SourcesCocoa.txt, which shifted the
bundle boundary and placed both files in
UnifiedSource-Tests-3-nonARC.mm. Xcode still builds because it uses the
default bundle size of 8, which keeps the files 11 bundles apart; the
CMake Cocoa build uses 128.

Rename the variable in WKContentExtensionStore.mm to match the
`contentExtensionReceivedAlert` flag next to it. No behavior change.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentExtensionStore.mm:
(-[ContentRuleListDelegate webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:]):
(TEST_F(WKContentRuleListStoreTest, AddRemove)):

Canonical link: <a href="https://commits.webkit.org/319214@main">https://commits.webkit.org/319214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1588592bf240072570925e3459be7c643ff2b29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145182 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/347329de-4363-4b0e-a656-057b9739ec7f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54520 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141092 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a18ec2ad-f821-4d06-ae3e-5dea89481c00) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183814 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/44753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121543 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03d58536-6902-4d4f-915a-eda688917ad9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41365 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2233 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193008 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54470 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55158 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150191 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27448 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44783 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122724 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53675 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16358 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53057 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53294 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53122 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->