### PR TITLE
[Site Isolation] Fix page identifier confusion in _WKUserStyleSheet code

### DIFF
--- a/Source/WebKit/UIProcess/API/APIUserStyleSheet.cpp
+++ b/Source/WebKit/UIProcess/API/APIUserStyleSheet.cpp
@@ -26,12 +26,23 @@
 #include "config.h"
 #include "APIUserStyleSheet.h"
 
+#include "WebPageProxy.h"
+
 namespace API {
 
-UserStyleSheet::UserStyleSheet(WebCore::UserStyleSheet userStyleSheet, API::ContentWorld& world)
+UserStyleSheet::UserStyleSheet(WebCore::UserStyleSheet userStyleSheet, API::ContentWorld& world, WebKit::WebPageProxy* page)
     : m_userStyleSheet(userStyleSheet)
     , m_world(world)
+    , m_page(page)
+    , m_isPageScoped(!!page)
 {
+}
+
+UserStyleSheet::~UserStyleSheet() = default;
+
+WebKit::WebPageProxy* UserStyleSheet::page() const
+{
+    return m_page.get();
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIUserStyleSheet.h
+++ b/Source/WebKit/UIProcess/API/APIUserStyleSheet.h
@@ -30,19 +30,34 @@
 #include "UserStyleSheetIdentifier.h"
 #include <WebCore/UserStyleSheet.h>
 #include <wtf/Identified.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+class WebPageProxy;
+}
 
 namespace API {
 
 class UserStyleSheet final : public ObjectImpl<Object::Type::UserStyleSheet>, public Identified<WebKit::UserStyleSheetIdentifier> {
 public:
-    static Ref<UserStyleSheet> create(WebCore::UserStyleSheet userStyleSheet, API::ContentWorld& world)
+    static Ref<UserStyleSheet> create(WebCore::UserStyleSheet userStyleSheet, API::ContentWorld& world, WebKit::WebPageProxy* page = nullptr)
     {
-        return adoptRef(*new UserStyleSheet(WTF::move(userStyleSheet), world));
+        return adoptRef(*new UserStyleSheet(WTF::move(userStyleSheet), world, page));
     }
 
-    UserStyleSheet(WebCore::UserStyleSheet, API::ContentWorld&);
+    UserStyleSheet(WebCore::UserStyleSheet, API::ContentWorld&, WebKit::WebPageProxy* = nullptr);
+    ~UserStyleSheet();
 
     const WebCore::UserStyleSheet& userStyleSheet() const LIFETIME_BOUND { return m_userStyleSheet; }
+
+    WebKit::WebPageProxy* page() const;
+
+    // Sheets that are not page scoped apply to every page.
+    bool isPageScoped() const { return m_isPageScoped; }
+
+    // Sheets that are page scoped but whose page has gone away are orphaned,
+    // and should not message anywhere.
+    bool isOrphaned() const { return m_isPageScoped && !page(); }
 
     ContentWorld& contentWorld() { return m_world; }
     const ContentWorld& contentWorld() const { return m_world; }
@@ -50,6 +65,8 @@ public:
 private:
     WebCore::UserStyleSheet m_userStyleSheet;
     Ref<ContentWorld> m_world;
+    WeakPtr<WebKit::WebPageProxy> m_page;
+    bool m_isPageScoped { false };
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
@@ -56,7 +56,7 @@
 
     WebKit::InitializeWebKit2();
 
-    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, baseURL, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, WebCore::UserContentMatchParentFrame::Never, API::toWebCoreUserStyleLevel(level), webView ? std::optional<WebCore::PageIdentifier>([webView _page]->webPageIDInMainFrameProcess()) : std::nullopt }, Ref { contentWorld ? *contentWorld->_contentWorld : API::ContentWorld::pageContentWorldSingleton() });
+    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, baseURL, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, WebCore::UserContentMatchParentFrame::Never, API::toWebCoreUserStyleLevel(level), std::nullopt }, Ref { contentWorld ? *contentWorld->_contentWorld : API::ContentWorld::pageContentWorldSingleton() }, webView ? [webView _page].get() : nullptr);
 
     return self;
 }

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -169,14 +169,16 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
             return HashSet<Ref<RemotePageProxy>> { };
         }).iterator->value;
         Ref newRemotePage = RemotePageProxy::create(page, processProxy, site);
-        newRemotePage->injectPageIntoNewProcess();
 #if ASSERT_ENABLED
         for (auto& existingPage : set) {
             ASSERT(existingPage->process().coreProcessIdentifier() != newRemotePage->process().coreProcessIdentifier() || existingPage->site() != newRemotePage->site());
             ASSERT(existingPage->page() == newRemotePage->page());
         }
 #endif
-        set.add(WTF::move(newRemotePage));
+        // Register before injecting, so creation parameters can resolve this page's identifier in the
+        // new process via webPageIDInProcess().
+        set.add(newRemotePage.copyRef());
+        newRemotePage->injectPageIntoNewProcess();
     };
 
     if (process.isSharedProcess()) {
@@ -280,14 +282,14 @@ void BrowsingContextGroup::addPage(WebPageProxy& page)
             return false;
         Ref processProxy = process->process();
         Ref newRemotePage = RemotePageProxy::create(page, processProxy, site);
-        newRemotePage->injectPageIntoNewProcess();
 #if ASSERT_ENABLED
         for (auto& existingPage : set) {
             ASSERT(existingPage->process().coreProcessIdentifier() != newRemotePage->process().coreProcessIdentifier() || existingPage->site() != newRemotePage->site());
             ASSERT(existingPage->page() == newRemotePage->page());
         }
 #endif
-        set.add(WTF::move(newRemotePage));
+        set.add(newRemotePage.copyRef());
+        newRemotePage->injectPageIntoNewProcess();
         return false;
     });
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1645,8 +1645,7 @@ void WebExtensionContext::didCommitLoadForFrame(WebPageProxyIdentifier pageID, c
         // FIXME: <https://webkit.org/b/262491> There is currently no way to inject CSS in specific frames based on ID's.
         Ref userContentController = page.get()->userContentController();
         m_dynamicallyInjectedUserStyleSheets.removeAllMatching([&](auto& styleSheet) {
-            auto styleSheetPageID = styleSheet->userStyleSheet().pageID();
-            if (!styleSheetPageID || styleSheetPageID.value() != page->webPageIDInMainFrameProcess())
+            if (styleSheet->page() != page.get())
                 return false;
 
             userContentController->removeUserStyleSheet(styleSheet);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -177,13 +177,12 @@ void executeScript(const SourcePairs& scriptPairs, WKWebView *webView, API::Cont
 
 void injectStyleSheets(const SourcePairs& styleSheetPairs, WKWebView *webView, API::ContentWorld& executionWorld, WebCore::UserStyleLevel styleLevel, WebCore::UserContentInjectedFrames injectedFrames, WebExtensionContext& context)
 {
-    auto page = webView._page;
-    auto pageID = page->webPageIDInMainFrameProcess();
+    Ref page = *webView._page;
 
     for (auto& styleSheet : styleSheetPairs) {
-        auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.first, styleSheet.second, { }, { }, injectedFrames, WebCore::UserContentMatchParentFrame::Never, styleLevel, pageID }, executionWorld);
+        auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.first, styleSheet.second, { }, { }, injectedFrames, WebCore::UserContentMatchParentFrame::Never, styleLevel, std::nullopt }, executionWorld, page.ptr());
 
-        Ref controller = page.get()->userContentController();
+        Ref controller = page->userContentController();
         controller->addUserStyleSheet(userStyleSheet);
 
         context.dynamicallyInjectedUserStyleSheets().append(userStyleSheet);

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -134,9 +134,15 @@ WebCoreUserScriptData WebUserContentControllerProxy::dataFromUserScript(const We
     return { cachedTransferString(script.source()), script.url(), script.allowlist(), script.blocklist(), script.injectionTime(), script.injectedFrames(), script.matchParentFrame() };
 }
 
-WebCoreUserStyleSheetData WebUserContentControllerProxy::dataFromUserStyleSheet(const WebCore::UserStyleSheet& sheet) const
+WebCoreUserStyleSheetData WebUserContentControllerProxy::dataFromUserStyleSheet(const API::UserStyleSheet& userStyleSheet, WebProcessProxy& process) const
 {
-    return { cachedTransferString(sheet.source()), sheet.url(), sheet.allowlist(), sheet.blocklist(), sheet.injectedFrames(), sheet.matchParentFrame(), sheet.level(), sheet.pageID() };
+    auto& sheet = userStyleSheet.userStyleSheet();
+
+    std::optional<WebCore::PageIdentifier> pageID;
+    if (RefPtr page = userStyleSheet.page())
+        pageID = page->webPageIDInProcess(process);
+
+    return { cachedTransferString(sheet.source()), sheet.url(), sheet.allowlist(), sheet.blocklist(), sheet.injectedFrames(), sheet.matchParentFrame(), sheet.level(), pageID };
 }
 
 UserContentControllerParameters WebUserContentControllerProxy::parametersForProcess(WebProcessProxy& process) const
@@ -148,8 +154,11 @@ UserContentControllerParameters WebUserContentControllerProxy::parametersForProc
         userScripts.append({ userScript->identifier(), Ref { userScript->contentWorld() }->worldDataForProcess(process), dataFromUserScript(userScript->userScript()) });
 
     Vector<WebUserStyleSheetData> userStyleSheets;
-    for (RefPtr userStyleSheet : m_userStyleSheets->elementsOfType<API::UserStyleSheet>())
-        userStyleSheets.append({ userStyleSheet->identifier(), Ref { userStyleSheet->contentWorld() }->worldDataForProcess(process), dataFromUserStyleSheet(userStyleSheet->userStyleSheet()) });
+    for (RefPtr userStyleSheet : m_userStyleSheets->elementsOfType<API::UserStyleSheet>()) {
+        if (userStyleSheet->isOrphaned())
+            continue;
+        userStyleSheets.append({ userStyleSheet->identifier(), Ref { userStyleSheet->contentWorld() }->worldDataForProcess(process), dataFromUserStyleSheet(*userStyleSheet, process) });
+    }
 
     Vector<WebJSBufferData> buffers;
     for (auto& [pair, buffer] : m_buffers) {
@@ -262,8 +271,11 @@ void WebUserContentControllerProxy::addUserStyleSheet(API::UserStyleSheet& userS
 
     m_userStyleSheets->elements().append(&userStyleSheet);
 
+    if (userStyleSheet.isOrphaned())
+        return;
+
     for (Ref process : m_processes)
-        process->send(Messages::WebUserContentController::AddUserStyleSheets({ { userStyleSheet.identifier(), world->worldDataForProcess(process), dataFromUserStyleSheet(userStyleSheet.userStyleSheet()) } }), identifier());
+        process->send(Messages::WebUserContentController::AddUserStyleSheets({ { userStyleSheet.identifier(), world->worldDataForProcess(process), dataFromUserStyleSheet(userStyleSheet, process) } }), identifier());
 }
 
 void WebUserContentControllerProxy::removeUserStyleSheet(API::UserStyleSheet& userStyleSheet)

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -115,7 +115,7 @@ public:
 #else
     void removeAllUserStyleSheets();
 #endif
-    WebCoreUserStyleSheetData dataFromUserStyleSheet(const WebCore::UserStyleSheet&) const;
+    WebCoreUserStyleSheetData dataFromUserStyleSheet(const API::UserStyleSheet&, WebProcessProxy&) const;
 
     void addJSBuffer(Ref<WebCore::SharedMemory>&&, API::ContentWorld&, const String&);
     void removeJSBuffer(API::ContentWorld&, const String&);

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
@@ -169,6 +169,8 @@ void performWithAppearance(Appearance, void (^block)(void));
 
 #endif
 
+extern bool shouldEnableSiteIsolationForWebExtensionsTest;
+
 RetainPtr<TestWebExtensionManager> parseExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil, BOOL usesEnhancedSecurity = NO);
 RetainPtr<TestWebExtensionManager> loadExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil, BOOL usesEnhancedSecurity = NO);
 void loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil);

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
@@ -43,9 +43,6 @@
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
 
-// Enable this to test all web extension tests with site isolation.
-static constexpr BOOL shouldEnableSiteIsolation = NO;
-
 @interface TestWebExtensionManager () <WKWebExtensionControllerDelegatePrivate>
 @end
 
@@ -75,7 +72,7 @@ static constexpr BOOL shouldEnableSiteIsolation = NO;
     if (!configuration)
         configuration = WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
 
-    configuration.webViewConfiguration.preferences._siteIsolationEnabled = shouldEnableSiteIsolation;
+    configuration.webViewConfiguration.preferences._siteIsolationEnabled = TestWebKitAPI::Util::shouldEnableSiteIsolationForWebExtensionsTest;
 
     _extension = extension;
     _context = [[WKWebExtensionContext alloc] initForExtension:extension];
@@ -462,7 +459,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         configuration.userContentController = userContentController(usingPrivateBrowsing);
 
         auto *preferences = configuration.preferences;
-        preferences._siteIsolationEnabled = shouldEnableSiteIsolation;
+        preferences._siteIsolationEnabled = TestWebKitAPI::Util::shouldEnableSiteIsolationForWebExtensionsTest;
         preferences._developerExtrasEnabled = YES;
 
         if (_window.usingEnhancedSecurity) {
@@ -524,7 +521,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     configuration.userContentController = userContentController(usingPrivateBrowsing);
 
     auto *preferences = configuration.preferences;
-    preferences._siteIsolationEnabled = shouldEnableSiteIsolation;
+    preferences._siteIsolationEnabled = TestWebKitAPI::Util::shouldEnableSiteIsolationForWebExtensionsTest;
     preferences._developerExtrasEnabled = YES;
 
     _webView = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration];
@@ -1015,6 +1012,8 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 namespace TestWebKitAPI {
 namespace Util {
+
+bool shouldEnableSiteIsolationForWebExtensionsTest = false;
 
 RetainPtr<TestWebExtensionManager> parseExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration *configuration, BOOL usesEnhancedSecurity)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
@@ -31,6 +31,7 @@
 #import "Helpers/cocoa/WebExtensionUtilities.h"
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKUserContentControllerPrivate.h>
+#import <wtf/SetForScope.h>
 
 namespace TestWebKitAPI {
 
@@ -602,6 +603,92 @@ TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSS)
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+// The main frame is served from 127.0.0.1 and the subframe from localhost, so with site isolation the
+// subframe gets its own web content process.
+TEST(WKWebExtensionAPIScripting, InsertCSSInAllFramesWithCrossSiteFrame)
+{
+    SetForScope siteIsolation { Util::shouldEnableSiteIsolationForWebExtensionsTest, true };
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Scripting Test",
+        @"description": @"Scripting Test",
+        @"version": @"1",
+
+        @"permissions": @[ @"scripting" ],
+        @"host_permissions": @[ @"*://localhost/*", @"*://127.0.0.1/*" ],
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<script>onload = () => { const frame = document.createElement('iframe'); frame.src = 'http://localhost:' + window.location.port + '/frame.html'; document.body.appendChild(frame); }</script>"_s } },
+        { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"const pinkValue = 'rgb(255, 192, 203)'",
+        @"const blueValue = 'rgb(0, 0, 255)'",
+
+        @"function getBackgroundColor() { return window.getComputedStyle(document.body).getPropertyValue('background-color') }",
+
+        @"function readAllFrames(tabId) {",
+        @"  return browser.scripting.executeScript({ target: { tabId, allFrames: true }, func: getBackgroundColor })",
+        @"}",
+
+        // The cross-site subframe is not loaded yet when the main frame reaches 'complete'.
+        @"async function readBothFrames(tabId) {",
+        @"  for (let attempt = 0; attempt < 200; ++attempt) {",
+        @"    const results = await readAllFrames(tabId)",
+        @"    if (results.length === 2)",
+        @"      return results",
+        @"    await new Promise((resolve) => setTimeout(resolve, 50))",
+        @"  }",
+        @"  browser.test.notifyFail('Timed out waiting for the cross-site subframe to appear')",
+        @"}",
+
+        @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
+        @"  if (tab.status !== 'complete')",
+        @"    return",
+
+        @"  let results = await readBothFrames(tabId)",
+        @"  browser.test.assertTrue(results.some((result) => result.result === blueValue), 'The cross-site subframe should start out blue')",
+
+        @"  await browser.scripting.insertCSS({ target: { tabId, allFrames: true }, css: 'body { background-color: pink !important }' })",
+
+        @"  results = await readAllFrames(tabId)",
+        @"  browser.test.assertEq(results.length, 2, 'Both frames should be reachable')",
+
+        @"  for (const result of results)",
+        @"    browser.test.assertEq(result.result, pinkValue, `Frame ${result.frameId} should be styled by insertCSS with allFrames`)",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')",
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    auto *urlRequest = server.request();
+
+    for (NSURL *url in @[ urlRequest.URL, server.requestWithLocalhost().URL ]) {
+        auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
+        [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+    }
 
     [manager runUntilTestMessage:@"Load Tab"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
@@ -31,6 +31,7 @@
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "Helpers/cocoa/WebExtensionUtilities.h"
 #import <JavaScriptCore/MathCommon.h>
+#import <wtf/SetForScope.h>
 #import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
@@ -3911,6 +3912,90 @@ TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInAllFrames)
     [manager runUntilTestMessage:@"Load Tab"];
 
     [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
+
+    [manager run];
+}
+
+// tabs.insertCSS shares injectStyleSheets() with scripting.insertCSS. The main frame is served from
+// 127.0.0.1 and the subframe from localhost, so with site isolation the subframe gets its own process.
+TEST(WKWebExtensionAPITabs, InsertCSSInAllFramesWithCrossSiteFrame)
+{
+    SetForScope siteIsolation { Util::shouldEnableSiteIsolationForWebExtensionsTest, true };
+
+    auto *manifest = @{
+        @"manifest_version": @2,
+
+        @"name": @"Tabs Test",
+        @"description": @"Tabs Test",
+        @"version": @"1",
+
+        @"permissions": @[ @"*://localhost/*", @"*://127.0.0.1/*" ],
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<script>onload = () => { const frame = document.createElement('iframe'); frame.src = 'http://localhost:' + window.location.port + '/frame.html'; document.body.appendChild(frame); }</script>"_s } },
+        { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"const pinkValue = 'rgb(255, 192, 203)'",
+        @"const blueValue = 'rgb(0, 0, 255)'",
+        @"const readBackgroundColor = \"window.getComputedStyle(document.body).getPropertyValue('background-color')\"",
+
+        @"function readAllFrames(tabId) {",
+        @"  return browser.tabs.executeScript(tabId, { allFrames: true, code: readBackgroundColor })",
+        @"}",
+
+        // The cross-site subframe is not loaded yet when the main frame reaches 'complete'.
+        @"async function readBothFrames(tabId) {",
+        @"  for (let attempt = 0; attempt < 200; ++attempt) {",
+        @"    const result = await readAllFrames(tabId)",
+        @"    if (result.length === 2)",
+        @"      return result",
+        @"    await new Promise((resolve) => setTimeout(resolve, 50))",
+        @"  }",
+        @"  browser.test.notifyFail('Timed out waiting for the cross-site subframe to appear')",
+        @"}",
+
+        @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
+        @"  if (tab.status !== 'complete')",
+        @"    return",
+
+        @"  let result = await readBothFrames(tabId)",
+        @"  browser.test.assertTrue(result.includes(blueValue), 'The cross-site subframe should start out blue')",
+
+        @"  await browser.tabs.insertCSS(tabId, { allFrames: true, code: 'body { background-color: pink !important }' })",
+
+        @"  result = await readAllFrames(tabId)",
+        @"  browser.test.assertEq(result.length, 2, 'Both frames should be reachable')",
+
+        @"  for (const value of result)",
+        @"    browser.test.assertEq(value, pinkValue, 'Every frame should be styled by insertCSS with allFrames')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')",
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    RetainPtr crossSiteURLRequest = server.request();
+
+    for (NSURL *url in @[ crossSiteURLRequest.get().URL, server.requestWithLocalhost().URL ]) {
+        auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
+        [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+    }
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:crossSiteURLRequest.get()];
 
     [manager run];
 }


### PR DESCRIPTION
#### 35b639797fbbd7db560b0d54791e7c01f73e02ac
<pre>
[Site Isolation] Fix page identifier confusion in _WKUserStyleSheet code
<a href="https://rdar.apple.com/184973318">rdar://184973318</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321831">https://bugs.webkit.org/show_bug.cgi?id=321831</a>

Reviewed by Timothy Hatcher.

A page-scoped WKUserStyleSheet was incompatible with how ExtensionStyleSheets work with
site isolation enabled due to page identifier confusion and not messaging enough processes.

API::UserStyleSheet now holds the WebPageProxy, and dataFromUserStyleSheet() derives the
identifier for each destination process. Orphaned page-scoped sheets are no longer sent.

We now also register a new RemotePageProxy with its BrowsingContextGroup before
injectPageIntoNewProcess() so process creation parameters can now resolve correctly.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm

* Source/WebKit/UIProcess/API/APIUserStyleSheet.cpp:
(API::UserStyleSheet::UserStyleSheet):
(API::UserStyleSheet::page const):
* Source/WebKit/UIProcess/API/APIUserStyleSheet.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm:
(-[_WKUserStyleSheet initWithSource:forWKWebView:forMainFrameOnly:includeMatchPatternStrings:excludeMatchPatternStrings:baseURL:level:contentWorld:]):
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::addFrameProcessAndInjectPageContextIf):
(WebKit::BrowsingContextGroup::addPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::didCommitLoadForFrame):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::injectStyleSheets):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::dataFromUserStyleSheet const):
(WebKit::WebUserContentControllerProxy::parametersForProcess const):
(WebKit::WebUserContentControllerProxy::addUserStyleSheet):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:usesEnhancedSecurity:]):
(-[TestWebExtensionTab initWithWindow:extensionController:]):
(-[TestWebExtensionTab changeWebViewIfNeededForURL:forExtensionContext:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSS)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, InsertCSSInAllFramesWithCrossSiteFrame)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, InsertCSSInAllFramesWithCrossSiteFrame)):

Canonical link: <a href="https://commits.webkit.org/319246@main">https://commits.webkit.org/319246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90bf7236fc8d621001597e68ac1ee74adb772af1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145192 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02a61943-b66a-4146-9ac1-177b62e5d97f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141101 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46a7b9ed-ff8b-4a42-9703-707dde44f723) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161846 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121552 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/599a9b1c-54f4-479c-8905-93116a037256) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43435 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41713 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41373 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2243 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193018 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54480 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150481 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40279 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55168 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150200 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44792 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127434 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122758 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53685 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16366 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53067 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53304 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53132 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->