### PR TITLE
[GStreamer] Fix issues with pipewire device capture

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.cpp
@@ -88,6 +88,15 @@ DesktopPortal::DesktopPortal(ASCIILiteral interfaceName, GRefPtr<GDBusProxy>&& p
 {
 }
 
+DesktopPortal::~DesktopPortal()
+{
+    if (m_responseSignalId)
+        g_dbus_connection_signal_unsubscribe(g_dbus_proxy_get_connection(m_proxy.get()), m_responseSignalId);
+
+    if (m_currentResponseCallback)
+        m_currentResponseCallback(nullptr);
+}
+
 GRefPtr<GVariant> DesktopPortal::getProperty(ASCIILiteral name)
 {
     GRefPtr propertiesResult = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "org.freedesktop.DBus.Properties.Get",
@@ -116,6 +125,16 @@ void DesktopPortal::waitResponseSignal(CStringView objectPath, ResponseCallback&
         g_main_context_iteration(nullptr, false);
 
     g_dbus_connection_signal_unsubscribe(connection, signalId);
+}
+
+void DesktopPortal::notifyResponse(GVariant* parameters)
+{
+    auto signalId = std::exchange(m_responseSignalId, 0);
+
+    m_currentResponseCallback(parameters);
+
+    if (signalId)
+        g_dbus_connection_signal_unsubscribe(g_dbus_proxy_get_connection(m_proxy.get()), signalId);
 }
 
 bool DesktopPortalCamera::isCameraPresent()
@@ -155,7 +174,7 @@ void DesktopPortalCamera::accessCamera(Function<void(std::optional<int>)>&& call
         callback(std::nullopt);
     };
 
-    auto signalId = g_dbus_connection_signal_subscribe(connection, "org.freedesktop.portal.Desktop", "org.freedesktop.portal.Request",
+    m_responseSignalId = g_dbus_connection_signal_subscribe(connection, "org.freedesktop.portal.Desktop", "org.freedesktop.portal.Request",
         "Response", objectPath.utf8().data(), nullptr, G_DBUS_SIGNAL_FLAGS_NO_MATCH_RULE, reinterpret_cast<GDBusSignalCallback>(+[](GDBusConnection*, const char* /* senderName */, const char* /* objectPath */, const char* /* interfaceName */, const char* /* signalName */, GVariant* parameters, gpointer userData) {
             auto& self = *reinterpret_cast<DesktopPortal*>(userData);
             self.notifyResponse(parameters);
@@ -164,10 +183,6 @@ void DesktopPortalCamera::accessCamera(Function<void(std::optional<int>)>&& call
     g_dbus_proxy_call(m_proxy.get(), "AccessCamera", g_variant_new("(a{sv})", &options), G_DBUS_CALL_FLAGS_NONE, -1, nullptr, reinterpret_cast<GAsyncReadyCallback>(+[](GDBusProxy* proxy, GAsyncResult* result, gpointer) {
         GRefPtr finalResult = adoptGRef(g_dbus_proxy_call_finish(proxy, result, nullptr));
     }), nullptr);
-
-    while (m_currentResponseCallback)
-        g_main_context_iteration(nullptr, false);
-    g_dbus_connection_signal_unsubscribe(connection, signalId);
 }
 
 std::optional<int> DesktopPortalCamera::openCameraPipewireRemote()

--- a/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
@@ -38,19 +38,20 @@ class DesktopPortal : public RefCounted<DesktopPortal> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DesktopPortal);
 public:
     DesktopPortal(ASCIILiteral, GRefPtr<GDBusProxy>&&);
-    virtual ~DesktopPortal() = default;
+    virtual ~DesktopPortal();
 
     GRefPtr<GVariant> getProperty(ASCIILiteral name);
 
     using ResponseCallback = CompletionHandler<void(GVariant*)>;
     void waitResponseSignal(CStringView objectPath, ResponseCallback&& = [](auto*) { });
 
-    void notifyResponse(GVariant* parameters) { m_currentResponseCallback(parameters); }
+    void notifyResponse(GVariant* parameters);
 
 protected:
     ASCIILiteral m_interfaceName;
     GRefPtr<GDBusProxy> m_proxy;
     ResponseCallback m_currentResponseCallback;
+    unsigned m_responseSignalId { 0 };
 };
 
 class DesktopPortalCamera : public DesktopPortal {

--- a/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.cpp
@@ -25,6 +25,8 @@
 #include "GStreamerCaptureDeviceManager.h"
 #include "GStreamerVideoCaptureSource.h"
 #include "MockRealtimeMediaSourceCenter.h"
+#include <errno.h>
+#include <unistd.h>
 #include <wtf/Scope.h>
 
 namespace WebCore {
@@ -47,6 +49,43 @@ PipeWireCaptureDeviceManager::PipeWireCaptureDeviceManager(OptionSet<CaptureDevi
     });
 }
 
+PipeWireCaptureDeviceManager::~PipeWireCaptureDeviceManager()
+{
+    notifyDevicesComputed();
+    m_portal = nullptr;
+}
+
+void PipeWireCaptureDeviceManager::notifyDevicesComputed()
+{
+    auto callbacks = std::exchange(m_pendingDeviceCallbacks, { });
+    for (auto& callback : callbacks)
+        callback();
+}
+
+void PipeWireCaptureDeviceManager::provisionDevices(int fd)
+{
+    // pw_context_connect_fd() closes the socket it is given when it disconnects, so the provider
+    // gets a copy each time and the one the portal handed over stays good for the next enumeration.
+    int providerFd = dup(fd);
+    if (providerFd == -1) {
+        GST_WARNING("Unable to duplicate the PipeWire remote fd: %s", g_strerror(errno));
+        return;
+    }
+
+    g_object_set(m_pipewireDeviceProvider.get(), "fd", providerFd, nullptr);
+    gst_device_provider_start(m_pipewireDeviceProvider.get());
+
+    GList* devices = gst_device_provider_get_devices(m_pipewireDeviceProvider.get());
+    GST_DEBUG("Provisioning VideoCaptureDeviceManager with %u device(s).", g_list_length(devices));
+    auto& manager = GStreamerVideoCaptureDeviceManager::singleton();
+    while (devices) {
+        manager.addDevice(adoptGRef(GST_DEVICE_CAST(devices->data)));
+        devices = g_list_delete_link(devices, devices);
+    }
+
+    gst_device_provider_stop(m_pipewireDeviceProvider.get());
+}
+
 void PipeWireCaptureDeviceManager::computeCaptureDevices(CompletionHandler<void()>&& callback)
 {
     if (MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled()) {
@@ -54,47 +93,46 @@ void PipeWireCaptureDeviceManager::computeCaptureDevices(CompletionHandler<void(
         return;
     }
 
-#if PLATFORM(WPE)
-    callback();
-    return;
-#endif
     if (!m_pipewireDeviceProvider || !gstObjectHasProperty(GST_OBJECT_CAST(m_pipewireDeviceProvider.get()), "fd"_s)) {
         GST_WARNING("PipeWire Device Provider is missing or too old. Please install PipeWire >= 0.3.64.");
         callback();
         return;
     }
 
-    auto portal = DesktopPortalCamera::create();
-
-    GST_DEBUG("Checking with Camera portal");
-    if (!portal || !portal->isCameraPresent()) {
-        GST_DEBUG("Portal not present or has no camera");
+    // Every getUserMedia() and enumerateDevices() call ends up here, and the portal raises a dialog
+    // for each request it is sent, so the remote is opened once and kept.
+    if (m_pipewireFd) {
+        provisionDevices(*m_pipewireFd);
         callback();
         return;
     }
 
+    m_pendingDeviceCallbacks.append(WTF::move(callback));
+    if (m_pendingDeviceCallbacks.size() > 1) {
+        GST_DEBUG("Camera portal request already in flight");
+        return;
+    }
+
+    m_portal = DesktopPortalCamera::create();
+
+    GST_DEBUG("Checking with Camera portal");
+    if (!m_portal || !m_portal->isCameraPresent()) {
+        GST_DEBUG("Portal not present or has no camera");
+        notifyDevicesComputed();
+        return;
+    }
+
     GST_DEBUG("Attempting to access the camera");
-    portal->accessCamera([this, callback = WTF::move(callback)](auto fd) mutable {
-        if (!fd) {
+    m_portal->accessCamera([this](auto fd) mutable {
+        if (!fd)
             GST_DEBUG("Camera access unavailable");
-            callback();
-            return;
+        else {
+            GST_DEBUG("FD from portal: %d", *fd);
+            m_pipewireFd = *fd;
+            provisionDevices(*fd);
         }
 
-        GST_DEBUG("FD from portal: %d", *fd);
-        g_object_set(m_pipewireDeviceProvider.get(), "fd", *fd, nullptr);
-        gst_device_provider_start(m_pipewireDeviceProvider.get());
-
-        GList* devices = gst_device_provider_get_devices(m_pipewireDeviceProvider.get());
-        GST_DEBUG("Provisioning VideoCaptureDeviceManager with %u device(s).", g_list_length(devices));
-        auto& manager = GStreamerVideoCaptureDeviceManager::singleton();
-        while (devices) {
-            manager.addDevice(adoptGRef(GST_DEVICE_CAST(devices->data)));
-            devices = g_list_delete_link(devices, devices);
-        }
-
-        gst_device_provider_stop(m_pipewireDeviceProvider.get());
-        callback();
+        notifyDevicesComputed();
     });
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.h
@@ -38,15 +38,22 @@ class PipeWireCaptureDeviceManager : public RefCounted<PipeWireCaptureDeviceMana
 public:
     static RefPtr<PipeWireCaptureDeviceManager> create(OptionSet<CaptureDevice::DeviceType>);
     PipeWireCaptureDeviceManager(OptionSet<CaptureDevice::DeviceType>);
+    ~PipeWireCaptureDeviceManager();
 
     void computeCaptureDevices(CompletionHandler<void()>&&);
     const Vector<CaptureDevice>& captureDevices() const LIFETIME_BOUND { return m_devices; }
     CaptureSourceOrError createCaptureSource(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*);
 
 private:
+    void provisionDevices(int pipewireFd);
+    void notifyDevicesComputed();
+
     OptionSet<CaptureDevice::DeviceType> m_deviceTypes;
     GRefPtr<GstDeviceProvider> m_pipewireDeviceProvider;
     Vector<CaptureDevice> m_devices;
+    std::optional<int> m_pipewireFd;
+    RefPtr<DesktopPortalCamera> m_portal;
+    Vector<CompletionHandler<void()>> m_pendingDeviceCallbacks;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 32aac5dacfa53cb1d89423f91f2e49e1210a3952
<pre>
[GStreamer] Fix issues with pipewire device capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=321834">https://bugs.webkit.org/show_bug.cgi?id=321834</a>

Reviewed by Philippe Normand.

- Every call to getUserMedia() or enumerateDevices() made a new connection
and sent a request to the portal. So it was very easy for 5 dialogs to
pop up opening one site. This keeps a single connection and reuses it.

- accessCamera() used to wait for responses by using a nested mainloop,
this causes reentrancy issues that are impossible to reason about,
just remove the mainloop as everything is async anyway.

This re-enables this feature on WPE which incorrectly asserted nobody
uses WPE with portals.

* Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.cpp:
(WebCore::DesktopPortal::~DesktopPortal):
(WebCore::DesktopPortal::notifyResponse):
(WebCore::DesktopPortalCamera::accessCamera):
* Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h:
(WebCore::DesktopPortal::notifyResponse): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.cpp:
(WebCore::PipeWireCaptureDeviceManager::~PipeWireCaptureDeviceManager):
(WebCore::PipeWireCaptureDeviceManager::notifyDevicesComputed):
(WebCore::PipeWireCaptureDeviceManager::provisionDevices):
(WebCore::PipeWireCaptureDeviceManager::computeCaptureDevices):
* Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.h:

Canonical link: <a href="https://commits.webkit.org/319608@main">https://commits.webkit.org/319608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d461d1a72555f2a1a84b5450498c56a67ab1b5e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141095 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97788 "3 flakes 7 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161841 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121546 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43429 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41708 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41368 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2236 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193011 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54473 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150475 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40566 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55161 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150194 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44786 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127427 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122742 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53678 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16361 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53125 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->