### PR TITLE
REGRESSION (319105@main): a policy decision that outlives its navigation is honored for a load it does not belong to

### DIFF
--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -212,7 +212,9 @@ public:
     void didChangeTitle(String&&);
 
     // Only one navigation policy check can be outstanding per frame, so a new one displaces the
-    // previous. A download is not a navigation, so it neither displaces nor is displaced.
+    // previous. A download is not a navigation, so it neither displaces nor is displaced. The check
+    // for a server redirect in a load the client let continue is a navigation check even though its
+    // action still carries the download attribute: it belongs to that load, and dies with it.
     enum class IsDownloadPolicyCheck : bool { No, Yes };
     WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck, IsDownloadPolicyCheck);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10069,7 +10069,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         }
         completionHandlerWrapper(policyAction);
 
-    }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLink, navigationAction->shouldPerformDownload() ? WebFrameProxy::IsDownloadPolicyCheck::Yes : WebFrameProxy::IsDownloadPolicyCheck::No);
+    }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLink, navigationAction->shouldPerformDownload() && !navigationAction->isRedirect() ? WebFrameProxy::IsDownloadPolicyCheck::Yes : WebFrameProxy::IsDownloadPolicyCheck::No);
     if (shouldExpectSafeBrowsingResult == ShouldExpectSafeBrowsingResult::Yes)
         beginSafeBrowsingCheck(request.url(), *navigation, frame.isMainFrame());
     if (shouldWaitForInitialLinkDecorationFilteringData == ShouldWaitForInitialLinkDecorationFilteringData::Yes)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -37,6 +37,7 @@
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
 #include "WebProcess.h"
+#include <WebCore/DocumentLoader.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/HitTestResult.h>
 #include <WebCore/LocalFrameInlines.h>
@@ -199,14 +200,26 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
 
     RefPtr webPage = m_frame->page();
 
+    // Record the document initiating a download attribute check, and the load it is made for.
+    //
+    // Only the check for the activation itself is one: a download attribute link the client answers Use for
+    // is an ordinary navigation, and DocumentLoader::willSendRequest() reuses the same triggering action,
+    // download attribute and all, for the check it makes when the server redirects that load. Unlike the
+    // activation check, that one belongs to a load in progress - its DocumentLoader awaits the answer - so
+    // cancelling the load has to cancel it, and it must not be kept out of the cancellation.
+    //
+    // WebPageProxy::decidePolicyForNavigationAction() draws the same line for its own listener, from the
+    // redirect response in the NavigationActionData, so the two have to stay in agreement.
     Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument;
-    if (!navigationAction.downloadAttribute().isNull()) {
+    SingleThreadWeakPtr<WebCore::DocumentLoader> downloadAttributePolicyDocumentLoader;
+    if (!navigationAction.downloadAttribute().isNull() && redirectResponse.isNull()) {
         if (RefPtr localFrame = m_frame->coreLocalFrame()) {
             if (RefPtr document = localFrame->document())
                 downloadAttributeInitiatingDocument = document->identifier();
+            downloadAttributePolicyDocumentLoader = localFrame->loader().policyDocumentLoader();
         }
     }
-    uint64_t listenerID = m_frame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::Yes, downloadAttributeInitiatingDocument);
+    uint64_t listenerID = m_frame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::Yes, downloadAttributeInitiatingDocument, WTF::move(downloadAttributePolicyDocumentLoader));
 
     // Notify the UIProcess.
     if (policyDecisionMode == PolicyDecisionMode::Synchronous) {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -393,12 +393,13 @@ ScopeExit<Function<void()>> WebFrame::makeInvalidator()
     });
 }
 
-uint64_t WebFrame::setUpPolicyListener(WebCore::FramePolicyFunction&& policyFunction, ForNavigationAction forNavigationAction, Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument)
+uint64_t WebFrame::setUpPolicyListener(WebCore::FramePolicyFunction&& policyFunction, ForNavigationAction forNavigationAction, Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument, SingleThreadWeakPtr<WebCore::DocumentLoader>&& downloadAttributePolicyDocumentLoader)
 {
     auto policyListenerID = generateListenerID();
     m_pendingPolicyChecks.add(policyListenerID, PolicyCheck {
         forNavigationAction,
         downloadAttributeInitiatingDocument,
+        WTF::move(downloadAttributePolicyDocumentLoader),
         WTF::move(policyFunction)
     });
 
@@ -417,6 +418,16 @@ bool WebFrame::shouldHonorDownloadAttributePolicyCheck(const PolicyCheck& policy
         return false;
     RefPtr document = localFrame->document();
     return document && document->identifier() == policyCheck.downloadAttributeInitiatingDocument;
+}
+
+// A download check outliving the navigation that started it also means its decision can arrive once a newer
+// navigation owns the load: FrameLoader::loadWithDocumentLoader() will not continue the load the check was
+// made for then, so all that is left of the decision is the download itself. Everything else in it - the
+// website policies, the navigation identifier - would be applied to the newer navigation instead.
+bool WebFrame::newerNavigationOwnsDownloadAttributePolicyCheckLoad(const PolicyCheck& policyCheck) const
+{
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
+    return !localFrame || localFrame->loader().policyDocumentLoader() != policyCheck.downloadAttributePolicyDocumentLoader.get();
 }
 
 void WebFrame::loadDidCommitInAnotherProcess(WebCore::ProcessIdentifier hostingProcessID, std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier)
@@ -693,7 +704,16 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
     if (policyCheck.downloadAttributeInitiatingDocument && !shouldHonorDownloadAttributePolicyCheck(policyCheck))
         return function(PolicyAction::Ignore);
 
-    if (forNavigationAction && localFrameLoaderClient() && policyDecision.websitePoliciesData) {
+    // Nothing below is the download's to apply once a newer navigation owns the load this check was made for.
+    // The website policies are the clearest of these: they would disable content JavaScript in a document the
+    // client allowed it for. Only a download is still meaningful, so answer anything else Ignore, which
+    // FrameLoader::loadWithDocumentLoader() drops rather than continue with, since it no longer owns the
+    // policy document loader.
+    bool newerNavigationOwnsTheLoad = policyCheck.downloadAttributeInitiatingDocument && newerNavigationOwnsDownloadAttributePolicyCheckLoad(policyCheck);
+    if (newerNavigationOwnsTheLoad && policyDecision.policyAction != PolicyAction::Download)
+        return function(PolicyAction::Ignore);
+
+    if (forNavigationAction && !newerNavigationOwnsTheLoad && localFrameLoaderClient() && policyDecision.websitePoliciesData) {
         ASSERT(page());
         if (page())
             page()->setAllowsContentJavaScriptFromMostRecentNavigation(policyDecision.websitePoliciesData->allowsContentJavaScript);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -59,6 +59,7 @@ class Array;
 
 namespace WebCore {
 class CertificateInfo;
+class DocumentLoader;
 class FloatRect;
 class Frame;
 class FrameTreeSyncData;
@@ -155,8 +156,10 @@ public:
     WebCore::FrameIdentifier frameID() const { return m_frameID; }
 
     enum class ForNavigationAction : bool { No, Yes };
-    // A non-null initiating document marks this as a download attribute check.
-    uint64_t setUpPolicyListener(WebCore::FramePolicyFunction&&, ForNavigationAction, Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument = { });
+    // A non-null initiating document marks this as a download attribute check. Such a check outlives the
+    // navigation that started it, so it also carries the load it was made for: the frame's policy document
+    // loader at the time, which a newer navigation can replace before the decision arrives.
+    uint64_t setUpPolicyListener(WebCore::FramePolicyFunction&&, ForNavigationAction, Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument = { }, SingleThreadWeakPtr<WebCore::DocumentLoader>&& downloadAttributePolicyDocumentLoader = { });
     void invalidatePolicyListeners();
     void didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&&);
 
@@ -337,11 +340,13 @@ private:
     struct PolicyCheck {
         ForNavigationAction forNavigationAction { ForNavigationAction::No };
         Markable<WebCore::ScriptExecutionContextIdentifier> downloadAttributeInitiatingDocument;
+        SingleThreadWeakPtr<WebCore::DocumentLoader> downloadAttributePolicyDocumentLoader;
         WebCore::FramePolicyFunction policyFunction;
     };
     HashMap<uint64_t, PolicyCheck> m_pendingPolicyChecks;
 
     bool shouldHonorDownloadAttributePolicyCheck(const PolicyCheck&) const;
+    bool newerNavigationOwnsDownloadAttributePolicyCheckLoad(const PolicyCheck&) const;
 
     std::optional<DownloadID> m_policyDownloadID;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Download.mm
@@ -1489,6 +1489,45 @@ TEST(_WKDownload, SubframeSecurityOrigin)
 
 @end
 
+@interface DownloadAttributeNewerNavigationSchemeHandler : NSObject <WKURLSchemeHandler>
+// The second load is held so that a decision arriving then finds it provisional, with no document yet.
+@property (nonatomic, strong) id<WKURLSchemeTask> pendingSecondTask;
+- (void)finishPendingSecondTask;
+@end
+
+@implementation DownloadAttributeNewerNavigationSchemeHandler
+
+- (void)respondToTask:(id<WKURLSchemeTask>)task withHTML:(NSString *)html
+{
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:task.request.URL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Content-Type": @"text/html" }]);
+    [task didReceiveResponse:response.get()];
+    [task didReceiveData:[html dataUsingEncoding:NSUTF8StringEncoding]];
+    [task didFinish];
+}
+
+- (void)webView:(WKWebView *)webView startURLSchemeTask:(id<WKURLSchemeTask>)task
+{
+    // One scheme and host throughout, so the download attribute is not dropped as cross origin.
+    if ([task.request.URL.path isEqualToString:@"/main"]) {
+        [self respondToTask:task withHTML:@"<a id='dl' download='downloadFilename' href='download-attribute-identity://host/downloadTarget'>dl</a>"];
+        return;
+    }
+
+    self.pendingSecondTask = task;
+}
+
+- (void)finishPendingSecondTask
+{
+    [self respondToTask:self.pendingSecondTask withHTML:@"<script>document.title = 'scriptRan'</script><body>second</body>"];
+    self.pendingSecondTask = nil;
+}
+
+- (void)webView:(WKWebView *)webView stopURLSchemeTask:(id<WKURLSchemeTask>)task
+{
+}
+
+@end
+
 namespace TestWebKitAPI {
 
 static void checkCallbackRecord(TestDownloadDelegate *delegate, Vector<DownloadCallback> expectedCallbacks)
@@ -2917,6 +2956,135 @@ TEST(WKDownload, DownloadAttributeSurvivesLaterNavigation)
 
     EXPECT_TRUE(answeredDownloadAfterNavigation);
     checkFileContents(expectedDownloadFile.get(), "123"_s);
+}
+
+// A download attribute link the client answers Use for is an ordinary navigation, and the policy check that
+// DocumentLoader::willSendRequest() makes for a server redirect in it reuses the same triggering action,
+// download attribute and all. Unlike the check for the activation itself, that one belongs to a load in
+// progress - its DocumentLoader awaits the answer - so cancelling the load has to cancel it. A check that
+// survived is answered on a stopped, frame-detached DocumentLoader, and answering it Download starts a
+// download of the redirect target for a navigation that is already gone.
+TEST(WKDownload, DownloadAttributeRedirectCheckIsCancelledWithItsNavigation)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/main"_s, { "<a id='dl' download='downloadFilename' href='/redirecting'>download</a>"_s } },
+        { "/redirecting"_s, { 301, { { "Location"_s, "/redirected"_s } } } },
+        { "/redirected"_s, { "redirected"_s } },
+    });
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr downloadDelegate = adoptNS([TestDownloadDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    __block RetainPtr<id> heldRedirectDecision;
+    __block bool sawRedirectCheck = false;
+    delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
+        if ([action.request.URL.path isEqualToString:@"/redirected"]) {
+            EXPECT_TRUE(action.shouldPerformDownload);
+            heldRedirectDecision = adoptNS([completionHandler copy]);
+            sawRedirectCheck = true;
+            return;
+        }
+        completionHandler(WKNavigationActionPolicyAllow);
+    };
+
+    // Reached only by a download the web process really started: the response is the network process having
+    // fetched the redirect target.
+    __block bool startedDownloadOfRedirectTarget = false;
+    delegate.get().navigationActionDidBecomeDownload = ^(WKNavigationAction *, WKDownload *download) {
+        download.delegate = downloadDelegate.get();
+    };
+    downloadDelegate.get().decideDestinationUsingResponse = ^(WKDownload *, NSURLResponse *, NSString *, void (^completionHandler)(NSURL *)) {
+        startedDownloadOfRedirectTarget = true;
+        completionHandler(nil);
+    };
+
+    [webView loadRequest:server.request("/main"_s)];
+    [delegate waitForDidFinishNavigation];
+
+    [webView evaluateJavaScript:@"document.getElementById('dl').click()" completionHandler:nil];
+    Util::run(&sawRedirectCheck);
+
+    // Cancel the navigation the link started while its document stays current, so nothing but the
+    // cancellation can answer the outstanding redirect check. The script round trip that follows is
+    // answered by the web process only once it has handled the cancellation.
+    [webView stopLoading];
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"'cancelled'"], "cancelled");
+
+    auto requestCountBeforeAnsweringRedirectCheck = server.totalRequests();
+    ((void (^)(WKNavigationActionPolicy))heldRedirectDecision.get())(WKNavigationActionPolicyDownload);
+
+    // Give a download that answering the cancelled check may have started the time to fetch the redirect
+    // target, then round trip through the server, which any request it made has reached by the time a later
+    // load finishes.
+    Util::runFor(&startedDownloadOfRedirectTarget, 0.5_s);
+    [webView loadRequest:server.request("/main"_s)];
+    [delegate waitForDidFinishNavigation];
+
+    EXPECT_FALSE(startedDownloadOfRedirectTarget);
+    EXPECT_EQ(server.totalRequests(), requestCountBeforeAnsweringRedirectCheck + 1);
+}
+
+// The website policies in that decision belong to the download too. Applying them to the newer navigation
+// disables content JavaScript in a document the client allowed it for.
+TEST(WKDownload, DownloadAttributeDecisionDoesNotApplyPoliciesToNewerNavigation)
+{
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr schemeHandler = adoptNS([DownloadAttributeNewerNavigationSchemeHandler new]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"download-attribute-identity"];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    __block RetainPtr<id> heldDownloadDecision;
+    __block RetainPtr<id> heldSecondNavigationDecision;
+    __block bool sawDownloadCheck = false;
+    __block bool sawSecondNavigationCheck = false;
+    delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        if (action.shouldPerformDownload) {
+            heldDownloadDecision = adoptNS([completionHandler copy]);
+            sawDownloadCheck = true;
+            return;
+        }
+        if ([action.request.URL.path isEqualToString:@"/second"]) {
+            heldSecondNavigationDecision = adoptNS([completionHandler copy]);
+            sawSecondNavigationCheck = true;
+            return;
+        }
+        completionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"download-attribute-identity://host/main"]]];
+    [delegate waitForDidFinishNavigation];
+
+    [webView evaluateJavaScript:@"document.getElementById('dl').click()" completionHandler:nil];
+    Util::run(&sawDownloadCheck);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"download-attribute-identity://host/second"]]];
+    Util::run(&sawSecondNavigationCheck);
+
+    // Answered first, and with content JavaScript allowed, so that the download's decision below is the
+    // last word on the policies of a load that is still provisional and has not created its document yet.
+    ((void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))heldSecondNavigationDecision.get())(WKNavigationActionPolicyAllow, adoptNS([WKWebpagePreferences new]).get());
+    while (!schemeHandler.get().pendingSecondTask)
+        Util::spinRunLoop();
+
+    RetainPtr downloadPreferences = adoptNS([WKWebpagePreferences new]);
+    [downloadPreferences setAllowsContentJavaScript:NO];
+    ((void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))heldDownloadDecision.get())(WKNavigationActionPolicyAllow, downloadPreferences.get());
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"'answered'"], "answered");
+
+    __block bool done = false;
+    delegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
+        done = true;
+    };
+    [schemeHandler.get() finishPendingSecondTask];
+    Util::run(&done);
+
+    EXPECT_WK_STREQ([webView URL].path, "/second");
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"document.title"], "scriptRan");
 }
 
 TEST(WKDownload, BlobResponseNoFilename)


### PR DESCRIPTION
#### f78e2fb7cfb10417c5a99affaba7fcad58226c52
<pre>
REGRESSION (319105@main): a policy decision that outlives its navigation is honored for a load it does not belong to
<a href="https://bugs.webkit.org/show_bug.cgi?id=321833">https://bugs.webkit.org/show_bug.cgi?id=321833</a>
<a href="https://rdar.apple.com/184974939">rdar://184974939</a>

Reviewed by Alex Christensen.

A download attribute check outlives the navigation that follows it, which 319105@main made deliberate. Two
things followed.

The check DocumentLoader::willSendRequest() makes for a redirect reuses the navigation&apos;s triggering action,
download attribute and all, so it was taken for the download&apos;s own check and left outstanding when the
navigation was cancelled. Answering it then started a download of the redirect target for a navigation that
was already gone. Only the check for the activation is the download&apos;s, and it is the one made with no
redirect response: PolicyChecker makes no other check that carries a download attribute, so the redirect
response tells the two apart, in both processes.

A decision that arrives once a newer navigation owns the load its check was made for was applied to that
navigation. The website policies are the clearest of these, disabling content JavaScript in a document the
client allowed it for; the navigation identifier and origin keying in the same decision belong to the load
that is gone. Record that load with the check, and once it is gone answer anything but a download Ignore.

Tests: TestWebKitAPI.WKDownload.DownloadAttributeRedirectCheckIsCancelledWithItsNavigation
       TestWebKitAPI.WKDownload.DownloadAttributeDecisionDoesNotApplyPoliciesToNewerNavigation

* Source/WebKit/UIProcess/WebFrameProxy.h: Say which checks are download checks.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationAction): Keep a redirect check out of them.
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction): Ditto, and record the load the
check is made for.
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::setUpPolicyListener): Store it.
(WebKit::WebFrame::newerNavigationOwnsDownloadAttributePolicyCheckLoad): Added.
(WebKit::WebFrame::didReceivePolicyDecision): Answer a decision whose load a newer navigation has taken over
Ignore, unless it is a download, which is all that is still meaningful.
* Source/WebKit/WebProcess/WebPage/WebFrame.h: Added the load to PolicyCheck and to setUpPolicyListener().
Declared newerNavigationOwnsDownloadAttributePolicyCheckLoad().
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Download.mm:
(TEST(WKDownload, DownloadAttributeRedirectCheckIsCancelledWithItsNavigation)): Added. Holds the redirect
decision, cancels the navigation, then answers Download, and round trips through the server so that a
download started by the answer has been served before the check. No layout test: WebKitTestRunner answers
Download for every download attribute action, so it never reaches a redirect in one.
(TEST(WKDownload, DownloadAttributeDecisionDoesNotApplyPoliciesToNewerNavigation)): Added. Answers the newer
navigation first so the download&apos;s decision is the last word on the policies of a load that is still
provisional, and checks that load&apos;s script still runs. The navigation identifier in the same decision is not
covered: for a main frame the newer navigation&apos;s own decision re-stamps the right one immediately, so the
damage does not survive. The sandbox extension is not covered either: only a file: URL is granted one, and
swapping which load it belongs to changes nothing observable while the process holds read access to the file
by other grants.

Canonical link: <a href="https://commits.webkit.org/319378@main">https://commits.webkit.org/319378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89cd79196b71b51e364a791ecfaac284290a9656

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145492 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141379 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98063 "3 flakes 10 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121830 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43718 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41997 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41654 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2545 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193318 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54780 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150766 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40418 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55468 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150482 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45073 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127736 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123293 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53985 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16650 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53367 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53604 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53432 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->