### PR TITLE
[WTF] StringImpl::replace(char16_t, char16_t) scans for the target with a scalar loop instead of SIMD find()

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -1123,31 +1123,18 @@ Ref<StringImpl> StringImpl::replace(char16_t target, char16_t replacement)
     if (target == replacement)
         return *this;
 
-    if (is8Bit()) {
-        if (!isLatin1(target)) {
-            // Looking for a 16-bit character in an 8-bit string, so we're done.
+    auto replaceAll = [&](auto characters) -> Ref<StringImpl> {
+        // find() is SIMD-accelerated, and its Latin1 overload returns notFound for a
+        // non-Latin1 target, so an 8-bit string with a 16-bit target is handled here too.
+        size_t i = WTF::find(characters, target);
+        if (i == notFound)
             return *this;
-        }
-        auto span8 = this->span8();
-        unsigned i;
-        for (i = 0; i < span8.size(); ++i) {
-            if (static_cast<char16_t>(span8[i]) == target)
-                break;
-        }
-        if (i == span8.size())
-            return *this;
-        return createByReplacingInCharacters(span8, target, replacement, i);
-    }
+        return createByReplacingInCharacters(characters, target, replacement, i);
+    };
 
-    auto span16 = this->span16();
-    unsigned i;
-    for (i = 0; i < span16.size(); ++i) {
-        if (span16[i] == target)
-            break;
-    }
-    if (i == span16.size())
-        return *this;
-    return createByReplacingInCharacters(span16, target, replacement, i);
+    if (is8Bit())
+        return replaceAll(span8());
+    return replaceAll(span16());
 }
 
 Ref<StringImpl> StringImpl::replace(size_t position, size_t lengthToReplace, StringView string)


### PR DESCRIPTION
#### 1969cf2d9ec209dbb6724b43c5e618cac5a4fae6
<pre>
[WTF] StringImpl::replace(char16_t, char16_t) scans for the target with a scalar loop instead of SIMD find()
<a href="https://bugs.webkit.org/show_bug.cgi?id=321836">https://bugs.webkit.org/show_bug.cgi?id=321836</a>
<a href="https://rdar.apple.com/184981918">rdar://184981918</a>

Reviewed by Yusuke Suzuki.

Both the 8-bit and 16-bit paths of StringImpl::replace(char16_t, char16_t)
hand-rolled a byte-at-a-time loop to locate the first occurrence of the
target before handing off to createByReplacingInCharacters(). This is the
same defect fixed for makeStringByReplacingAll() in bug 321055
(6cb1077d85c8), which was applied to StringView.cpp but missed this
sibling in StringImpl.cpp.

Replace both loops with WTF::find(), which is SIMD-accelerated. Collapsing
the two paths into a generic lambda also lets the isLatin1(target)
early-out go: find(std::span&lt;const Latin1Character&gt;, char16_t) already
returns notFound for a non-Latin1 target, so an 8-bit string searched for
a 16-bit character still bails out without touching the characters. No
behavior change.

* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::replace):

Canonical link: <a href="https://commits.webkit.org/319277@main">https://commits.webkit.org/319277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e011f4783a179c2d9b3e082e66aa26d9978f3da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191084 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145193 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2de212d-796b-4b2c-b61e-5ff3676302a4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141102 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97796 "6 flakes 8 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5a14f0a-b211-471b-b11d-0d073e6b3578) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121553 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43438 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41714 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3519 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10332 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153842 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41376 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2244 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42144 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193019 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54481 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150482 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40303 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55169 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37994 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150201 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44793 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127435 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122759 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53686 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16369 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53068 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53305 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53133 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->