### PR TITLE
[AppKit Gestures] Gesture controller may not reflect preference changes driven through WebPage.setWebFeature()

### DIFF
--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.h
@@ -60,7 +60,7 @@ NS_SWIFT_UI_ACTOR
 
 - (instancetype)initWithView:(WKWebView *)view;
 - (void)setUp;
-- (void)enableGesturesIfNeeded;
+- (void)preferencesDidChange;
 - (void)beginSuppressingSingleClickGestureForTextSelection;
 - (void)endSuppressingSingleClickGestureForTextSelection;
 - (NSGestureRecognizer *)activeDragGestureRecognizer;

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -464,6 +464,12 @@ static NSString *gestureLogDescription(NSGestureRecognizer *gesture)
     // The deferring gesture recognizers are intentionally not enabled.
 }
 
+- (void)preferencesDidChange
+{
+    [self enableGesturesIfNeeded];
+    [self configureForScrolling:_panGestureRecognizer];
+}
+
 - (void)ensureGesturesAreNotArchived
 {
     // The set of gestures managed by WKAppKitGestureController are configured

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1545,6 +1545,14 @@ void WebViewImpl::didRelaunchProcess()
 
     accessibilityRegisterUIProcessTokens();
     windowDidChangeScreen(); // Make sure DisplayID is set.
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    // FIXME: Should we delay initialization till the end of the auxiliary process launch lifecycle?
+
+    // Ensure we pick up any preference changes between web view initialization and web process launch.
+    if (RetainPtr appKitGestureController = m_appKitGestureController)
+        [appKitGestureController preferencesDidChange];
+#endif
 }
 
 void WebViewImpl::scrollingCoordinatorWasCreated()
@@ -3952,7 +3960,7 @@ void WebViewImpl::preferencesDidChange()
 
 #if HAVE(APPKIT_GESTURES_SUPPORT)
     if (RetainPtr appKitGestureController = m_appKitGestureController)
-        [appKitGestureController enableGesturesIfNeeded];
+        [appKitGestureController preferencesDidChange];
 #endif
 }
 


### PR DESCRIPTION
#### 7b8132883f8ee3e1845ece781612c14b7d49ce77
<pre>
[AppKit Gestures] Gesture controller may not reflect preference changes driven through WebPage.setWebFeature()
<a href="https://bugs.webkit.org/show_bug.cgi?id=321835">https://bugs.webkit.org/show_bug.cgi?id=321835</a>
<a href="https://rdar.apple.com/184977998">rdar://184977998</a>

Reviewed by Richard Robinson.

When writing an API test like this:

```
@Test
func someTest() async {
    page.setWebFeature(&quot;UseAppKitGesturesForGestureEvents&quot;, enabled: true)
    ...
}
```

I noticed that the certain preference gated functionality was broken.
This is because WKAppKitGestureController initialization happens
directly under -[WKWebView initWithFrame:configuration:], and the
functionality in question was respecting a sticky preference value read
during initialization.

This is further exacerbated by the fact that WebPage.setWebFeature()
does not actually end up propagating preference changes to WebViewImpl,
since WebPageProxy::hasRunningProcess() reports that the associated web
content process is terminated/not launched (before we make a -loadHTML:
call). Not that it would be helpful in any way, though, since we only
pick up the preference at gesture controller initialization anyway.

While it is generally going to be useful to be able to set runtime
WebKit features before WebPage initialization -- tracked as an API
request in <a href="https://rdar.apple.com/184981081">rdar://184981081</a> -- there is no inherent reason for our
gesture controller to not reflect updated preferences. As such, we
expose a `-[WKAppKitGestureController preferencesDidChange]` method,
which is called from both the WebViewImpl::preferencesDidChange() hook,
and from the WebViewImpl::didRelaunchPorcess() hook. This latter call is
salient for this patch, since it ensures the controller is reactive to
preference changes after the web content process is brought up.

* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm:
(-[WKAppKitGestureController preferencesDidChange]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::didRelaunchProcess):
(WebKit::WebViewImpl::preferencesDidChange):

Canonical link: <a href="https://commits.webkit.org/319229@main">https://commits.webkit.org/319229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03a728458a1823b5c3e1f8200ebc95cefaec1ca1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191089 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145198 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d505a64-e97f-4ad1-ad19-08a3fe31d844) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141105 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b56ec2b1-2b29-4def-8d53-65f955daf1e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121556 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ddc36404-8456-47ca-8a7e-6a5cf204b74e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153844 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41378 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2249 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193024 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54486 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150486 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55174 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150205 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27454 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44796 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127440 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122767 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53691 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16371 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53073 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53310 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53138 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->