### PR TITLE
Resync `html/rendering/non-replaced-elements/tables` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/WEB_FEATURES.yml
@@ -1,11 +1,9 @@
-features:
-- name: table-discouraged
-  files:
-  - table-attribute.html
-  - table-align-float.xhtml
-  - "table-width*"
-  - "table-border*"
-  - "table-bordercolor-*"
-  - "table-valign-baseline*"
-  - "table-cell-width*"
-  - "colgroup_valign*"
+rules:
+- table-attribute.html: [table-discouraged]
+- table-align-float.xhtml: [table-discouraged]
+- table-width*: [table-discouraged]
+- table-bordercolor-*: [table-discouraged, table-discouraged]
+- table-border*: [table-discouraged]
+- table-valign-baseline*: [table-discouraged]
+- table-cell-width*: [table-discouraged]
+- colgroup_valign*: [table-discouraged]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/resources/aqua-yellow-32x32.png

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style-expected.txt
@@ -1,0 +1,11 @@
+
+PASS border-color on its own gives the table no border
+PASS border-color on its own gives the cell no border
+PASS the border attribute gives the table an outset border
+PASS the border attribute gives the cells an inset border
+PASS adding bordercolor does not change which borders exist
+PASS setting rules=cols replaces the cells' inset border with a rule on their inline edges
+FAIL setting rules=rows leaves the cells with no border assert_equals: cell of a table with rules=rows: border-top-width expected "0px" but got "1px"
+FAIL setting rules=rows puts the rule on the row assert_equals: row border-block-start-style expected "solid" but got "none"
+PASS removing the border attribute while rules is set hides the table's own border
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Table border and bordercolor attributes: computed borders, including when they change</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#tables-2">
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="author" title="Apple" href="https://www.apple.com/">
+<meta name="assert" content="A border colour on its own never creates a visible border; the border attribute creates an outset border on the table and inset borders on the cells; adding bordercolor does not change which borders exist.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!--
+  Two things are checked here, in one table that is mutated step by step so that
+  the effect of each attribute is isolated.
+
+  1. A colour alone must not produce a border. Neither the bordercolor content
+     attribute nor the border-color CSS property sets a border style or width, and
+     the initial border style is none, so there is nothing to paint. There is
+     already a reftest for the rendering of this (table-bordercolor-001.html);
+     this test pins the computed values, and pins that adding bordercolor to a
+     table that already has borders does not alter which borders exist.
+
+  2. The border attribute:
+
+       table[border] { border-style: outset; }        /* only if not zero */
+       table[border] > tbody > tr > td, ... {
+         border-width: 1px;
+         border-style: inset;
+       }
+
+     and then what happens when rules is added on top of it, which replaces the
+     cells' inset border.
+
+  border="1" is used rather than border="" throughout: the UA stylesheet entry is
+  annotated "only if border is not equivalent to zero", and whether the empty
+  string counts as zero is not something this test takes a position on.
+
+  The table and the cell each carry their own inline border-color so that the
+  colour assertions test the presentational hints rather than inheritance.
+-->
+
+<div id="log"></div>
+<div id="container"></div>
+
+<script>
+const YELLOW = "rgb(255, 255, 0)";
+const RED = "rgb(255, 0, 0)";
+
+const table = document.createElement("table");
+table.setAttribute("style", "border-color: yellow");
+const row = table.insertRow(-1);
+const cell = row.insertCell(-1);
+cell.setAttribute("style", "border-color: red");
+document.getElementById("container").append(table);
+
+const SIDES = ["top", "right", "bottom", "left"];
+
+function assertUniformBorder(element, width, style, label) {
+  const computed = getComputedStyle(element);
+  for (const side of SIDES) {
+    assert_equals(computed.getPropertyValue(`border-${side}-width`), width,
+                  `${label}: border-${side}-width`);
+    assert_equals(computed.getPropertyValue(`border-${side}-style`), style,
+                  `${label}: border-${side}-style`);
+  }
+}
+
+function assertBorderColor(element, color, label) {
+  const computed = getComputedStyle(element);
+  for (const side of SIDES) {
+    assert_equals(computed.getPropertyValue(`border-${side}-color`), color,
+                  `${label}: border-${side}-color`);
+  }
+}
+
+// A colour with no style and no width paints nothing.
+test(() => {
+  assertUniformBorder(table, "0px", "none", "table with only border-color");
+  assertBorderColor(table, YELLOW, "table");
+}, "border-color on its own gives the table no border");
+
+test(() => {
+  assertUniformBorder(cell, "0px", "none", "cell with only border-color");
+  assertBorderColor(cell, RED, "cell");
+}, "border-color on its own gives the cell no border");
+
+// The border attribute is what actually creates the borders.
+test(() => {
+  table.setAttribute("border", "1");
+  assertUniformBorder(table, "1px", "outset", "table with border=1");
+  assertBorderColor(table, YELLOW, "table");
+}, "the border attribute gives the table an outset border");
+
+test(() => {
+  assertUniformBorder(cell, "1px", "inset", "cell of a table with border=1");
+  assertBorderColor(cell, RED, "cell");
+}, "the border attribute gives the cells an inset border");
+
+// Adding a colour must not change which borders exist.
+test(() => {
+  table.setAttribute("bordercolor", "green");
+  assertUniformBorder(table, "1px", "outset", "table with border=1 and bordercolor");
+  assertUniformBorder(cell, "1px", "inset", "cell with border=1 and bordercolor");
+}, "adding bordercolor does not change which borders exist");
+
+// rules replaces the cells' inset border. Under rules=cols the rule belongs to
+// the cells' inline edges; the block edges get nothing.
+test(() => {
+  table.rules = "cols";
+  const computed = getComputedStyle(cell);
+  assert_equals(computed.borderInlineStartStyle, "solid", "cell border-inline-start-style");
+  assert_equals(computed.borderInlineEndStyle, "solid", "cell border-inline-end-style");
+  assert_equals(computed.borderInlineStartWidth, "1px", "cell border-inline-start-width");
+  assert_equals(computed.borderInlineEndWidth, "1px", "cell border-inline-end-width");
+  assert_equals(computed.borderBlockStartStyle, "none", "cell border-block-start-style");
+  assert_equals(computed.borderBlockEndStyle, "none", "cell border-block-end-style");
+  assert_equals(computed.borderBlockStartWidth, "0px", "cell border-block-start-width");
+  assert_equals(computed.borderBlockEndWidth, "0px", "cell border-block-end-width");
+}, "setting rules=cols replaces the cells' inset border with a rule on their inline edges");
+
+// Under rules=rows the rule moves off the cells entirely and onto the row, even
+// though the border attribute is still present.
+test(() => {
+  table.rules = "rows";
+  assertUniformBorder(cell, "0px", "none", "cell of a table with rules=rows");
+  assertBorderColor(cell, RED, "cell");
+}, "setting rules=rows leaves the cells with no border");
+
+test(() => {
+  const computed = getComputedStyle(row);
+  assert_equals(computed.borderBlockStartStyle, "solid", "row border-block-start-style");
+  assert_equals(computed.borderBlockEndStyle, "solid", "row border-block-end-style");
+  assert_equals(computed.borderBlockStartWidth, "1px", "row border-block-start-width");
+  assert_equals(computed.borderBlockEndWidth, "1px", "row border-block-end-width");
+  assert_equals(computed.borderInlineStartStyle, "none", "row border-inline-start-style");
+  assert_equals(computed.borderInlineEndStyle, "none", "row border-inline-end-style");
+}, "setting rules=rows puts the rule on the row");
+
+// With rules still set and the border attribute gone, the table's own border
+// becomes hidden so that it wins over any border set on the cells.
+test(() => {
+  table.removeAttribute("border");
+  assertUniformBorder(table, "0px", "hidden", "table with rules=rows and no border attribute");
+  assertBorderColor(table, YELLOW, "table");
+}, "removing the border attribute while rules is set hides the table's own border");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-color-not-inherited-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-color-not-inherited-expected.txt
@@ -1,0 +1,8 @@
+cell
+cell
+cell
+
+FAIL A <table border> cell border does not inherit the table's CSS border-color; it resolves to the cell's currentColor assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
+FAIL A <table rules=all> cell border does not inherit the table's CSS border-color; it resolves to the cell's currentColor assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
+PASS The legacy bordercolor attribute still propagates to interior cell borders
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-color-not-inherited.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-color-not-inherited.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:navoda.munasinha@codimite.com">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#the-border-color">
+<link rel="help" href="https://crbug.com/40745409">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- border-color is not an inherited property. A border-color set on the
+     <table> must not cascade onto the borders of interior cells created by
+     the `border`/`rules` attributes; those should resolve to currentColor.
+     The legacy `bordercolor` attribute, however, still propagates. -->
+
+<table id="css-border" border="1"
+       style="border-collapse: collapse; border-color: red;">
+  <tbody><tr><td id="css-cell" style="color: blue;">cell</td></tr></tbody>
+</table>
+
+<table id="css-rules" rules="all" style="border-color: red;">
+  <tbody><tr><td id="rules-cell" style="color: blue;">cell</td></tr></tbody>
+</table>
+
+<table id="attr-table" border="1" bordercolor="red"
+       style="border-collapse: collapse;">
+  <tbody><tr><td id="attr-cell" style="color: blue;">cell</td></tr></tbody>
+</table>
+
+<script>
+const BLUE = 'rgb(0, 0, 255)';
+const RED = 'rgb(255, 0, 0)';
+
+function cellBorderColor(id) {
+  return window.getComputedStyle(document.getElementById(id)).borderTopColor;
+}
+
+test(() => {
+  assert_equals(cellBorderColor('css-cell'), BLUE);
+}, 'A <table border> cell border does not inherit the table\'s CSS ' +
+   'border-color; it resolves to the cell\'s currentColor');
+
+test(() => {
+  assert_equals(cellBorderColor('rules-cell'), BLUE);
+}, 'A <table rules=all> cell border does not inherit the table\'s CSS ' +
+   'border-color; it resolves to the cell\'s currentColor');
+
+test(() => {
+  assert_equals(cellBorderColor('attr-cell'), RED);
+}, 'The legacy bordercolor attribute still propagates to interior cell ' +
+   'borders');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style-expected.txt
@@ -1,0 +1,37 @@
+
+PASS rules=none collapses the table's borders and hides its own border
+PASS rules=none gives the cells the expected border
+PASS rules=none gives the rows the expected border
+PASS rules=none gives the row groups the expected border
+PASS rules=none gives the column group the expected border
+PASS rules=groups collapses the table's borders and hides its own border
+PASS rules=groups gives the cells the expected border
+PASS rules=groups gives the rows the expected border
+PASS rules=groups gives the row groups the expected border
+PASS rules=groups gives the column group the expected border
+PASS rules=rows collapses the table's borders and hides its own border
+FAIL rules=rows gives the cells the expected border assert_equals: td: border-block-start-style expected "none" but got "solid"
+FAIL rules=rows gives the rows the expected border assert_equals: tbody > tr: border-block-start-style expected "solid" but got "none"
+PASS rules=rows gives the row groups the expected border
+PASS rules=rows gives the column group the expected border
+PASS rules=cols collapses the table's borders and hides its own border
+PASS rules=cols gives the cells the expected border
+PASS rules=cols gives the rows the expected border
+PASS rules=cols gives the row groups the expected border
+PASS rules=cols gives the column group the expected border
+PASS rules=all collapses the table's borders and hides its own border
+PASS rules=all gives the cells the expected border
+PASS rules=all gives the rows the expected border
+PASS rules=all gives the row groups the expected border
+PASS rules=all gives the column group the expected border
+FAIL rules=rows applies to a row that is a direct child of the table assert_equals: table > tr: border-block-start-style expected "solid" but got "none"
+FAIL rules=ROWS is matched ASCII case-insensitively assert_equals: tbody > tr: border-block-start-style expected "solid" but got "none"
+PASS rules with an unrecognised value sets no rule
+PASS rules with U+017F, which is not an ASCII case match for s sets no rule
+PASS rules with the empty string sets no rule
+PASS rules with no value sets no rule
+PASS rules with no attribute at all sets no rule
+FAIL rules=rows follows the writing mode: the rule is on the row's block edges assert_equals: tbody > tr in vertical-rl: border-block-start-style expected "solid" but got "none"
+FAIL rules=cols follows the writing mode: the rule is on the cells' inline edges assert_equals: td in vertical-rl: border-block-start-style expected "none" but got "solid"
+FAIL rules=groups follows the writing mode: the rules are on the groups' block and inline edges assert_equals: tbody in vertical-rl: border-block-start-style expected "solid" but got "none"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Table rules attribute: computed borders on the table, row groups, rows, cells and column groups</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#tables-2">
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="author" title="Apple" href="https://www.apple.com/">
+<meta name="assert" content="The rules attribute puts the rule between rows on the row itself and the rule between columns on the cells, and gives the cells no border where the rule is not theirs.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!--
+  The rendering section gives the rules attribute five presentational hints. The
+  part that is easy to get wrong, and that no test covered before this one, is
+  WHICH ELEMENT owns each rule:
+
+    table[rules=rows i] > tr, table[rules=rows i] > thead > tr,
+    table[rules=rows i] > tbody > tr, table[rules=rows i] > tfoot > tr {
+      border-block-width: 1px;
+      border-block-style: solid;
+    }
+
+  while the cells of rules=none, rules=groups and rules=rows are explicitly
+  given no border:
+
+    ... table[rules=rows i] > tbody > tr > td, ... {
+      border-width: 1px;
+      border-style: none;
+    }
+
+  so under rules=rows the horizontal rule belongs to the ROW and the cells have
+  no border, whereas under rules=cols the vertical rule belongs to the CELLS.
+
+  Two things worth knowing before reading the expectations below:
+
+  * The spec says border-width: 1px even on sides whose style is none. A computed
+    border width is 0px whenever the style is none, so those sides are asserted
+    as 0px. That is not a contradiction with the spec text.
+  * The rules are written with the flow-relative border properties
+    (border-block-*, border-inline-*), so they follow the writing mode. These
+    tests read the same flow-relative properties, and the vertical-rl section at
+    the end pins the mapping explicitly.
+-->
+
+<div id="log"></div>
+<div id="container"></div>
+
+<script>
+const SOLID = { style: "solid", width: "1px" };
+const NONE = { style: "none", width: "0px" };
+
+// Build an expectation for all four flow-relative sides.
+function borders(block, inline) {
+  return {
+    "block-start": block, "block-end": block,
+    "inline-start": inline, "inline-end": inline,
+  };
+}
+const NO_BORDER = borders(NONE, NONE);
+const BLOCK_ONLY = borders(SOLID, NONE);
+const INLINE_ONLY = borders(NONE, SOLID);
+const ALL_SIDES = borders(SOLID, SOLID);
+
+function assertBorders(element, expected, label) {
+  const style = getComputedStyle(element);
+  for (const side of ["block-start", "block-end", "inline-start", "inline-end"]) {
+    assert_equals(style.getPropertyValue(`border-${side}-style`), expected[side].style,
+                  `${label}: border-${side}-style`);
+    assert_equals(style.getPropertyValue(`border-${side}-width`), expected[side].width,
+                  `${label}: border-${side}-width`);
+  }
+}
+
+const container = document.getElementById("container");
+
+// One table per case, with a column group, all three row groups, and both cell
+// element types. Nothing here styles the elements under test, and the cells are
+// deliberately empty: these tests only read computed values, and text in the
+// cells would otherwise be dumped into implementations' text baselines.
+function buildTable(rulesAttribute) {
+  const html = `
+    <table${rulesAttribute}>
+      <colgroup><col><col></colgroup>
+      <thead><tr><th></th><th></th></tr></thead>
+      <tbody><tr><td></td><td></td></tr></tbody>
+      <tfoot><tr><td></td><td></td></tr></tfoot>
+    </table>`;
+  const host = document.createElement("div");
+  host.innerHTML = html;
+  container.append(host);
+  const table = host.querySelector("table");
+  return {
+    table,
+    colgroup: host.querySelector("colgroup"),
+    thead: host.querySelector("thead"),
+    tbody: host.querySelector("tbody"),
+    tfoot: host.querySelector("tfoot"),
+    headerRow: host.querySelector("thead > tr"),
+    bodyRow: host.querySelector("tbody > tr"),
+    footerRow: host.querySelector("tfoot > tr"),
+    th: host.querySelector("th"),
+    td: host.querySelector("tbody td"),
+  };
+}
+
+// The rule between rows lives on the row; the rule between columns lives on the
+// cells; the rule between groups lives on the row groups and column groups.
+const CASES = [
+  {
+    value: "none",
+    cells: NO_BORDER, rows: NO_BORDER, rowGroups: NO_BORDER, columnGroups: NO_BORDER,
+  },
+  {
+    value: "groups",
+    cells: NO_BORDER, rows: NO_BORDER, rowGroups: BLOCK_ONLY, columnGroups: INLINE_ONLY,
+  },
+  {
+    value: "rows",
+    cells: NO_BORDER, rows: BLOCK_ONLY, rowGroups: NO_BORDER, columnGroups: NO_BORDER,
+  },
+  {
+    value: "cols",
+    cells: INLINE_ONLY, rows: NO_BORDER, rowGroups: NO_BORDER, columnGroups: NO_BORDER,
+  },
+  {
+    value: "all",
+    cells: ALL_SIDES, rows: NO_BORDER, rowGroups: NO_BORDER, columnGroups: NO_BORDER,
+  },
+];
+
+for (const testCase of CASES) {
+  const value = testCase.value;
+
+  test(() => {
+    const parts = buildTable(` rules="${value}"`);
+    // table[rules=...] { border-style: hidden; border-collapse: collapse; }
+    assert_equals(getComputedStyle(parts.table).borderCollapse, "collapse",
+                  "border-collapse on the table");
+    for (const side of ["top", "right", "bottom", "left"]) {
+      assert_equals(getComputedStyle(parts.table).getPropertyValue(`border-${side}-style`),
+                    "hidden", `border-${side}-style on the table`);
+    }
+  }, `rules=${value} collapses the table's borders and hides its own border`);
+
+  test(() => {
+    const parts = buildTable(` rules="${value}"`);
+    assertBorders(parts.td, testCase.cells, "td");
+    assertBorders(parts.th, testCase.cells, "th");
+  }, `rules=${value} gives the cells the expected border`);
+
+  test(() => {
+    const parts = buildTable(` rules="${value}"`);
+    assertBorders(parts.bodyRow, testCase.rows, "tbody > tr");
+    assertBorders(parts.headerRow, testCase.rows, "thead > tr");
+    assertBorders(parts.footerRow, testCase.rows, "tfoot > tr");
+  }, `rules=${value} gives the rows the expected border`);
+
+  test(() => {
+    const parts = buildTable(` rules="${value}"`);
+    assertBorders(parts.thead, testCase.rowGroups, "thead");
+    assertBorders(parts.tbody, testCase.rowGroups, "tbody");
+    assertBorders(parts.tfoot, testCase.rowGroups, "tfoot");
+  }, `rules=${value} gives the row groups the expected border`);
+
+  test(() => {
+    const parts = buildTable(` rules="${value}"`);
+    assertBorders(parts.colgroup, testCase.columnGroups, "colgroup");
+  }, `rules=${value} gives the column group the expected border`);
+}
+
+// table[rules=rows i] > tr is its own selector in the spec. The parser always
+// inserts a tbody, so this shape has to be built with DOM calls.
+test(() => {
+  const table = document.createElement("table");
+  table.setAttribute("rules", "rows");
+  const row = document.createElement("tr");
+  const cell = document.createElement("td");
+  row.append(cell);
+  table.append(row);
+  container.append(table);
+
+  assertBorders(row, BLOCK_ONLY, "table > tr");
+  assertBorders(cell, NO_BORDER, "table > tr > td");
+}, "rules=rows applies to a row that is a direct child of the table");
+
+// The attribute value is matched ASCII case-insensitively.
+test(() => {
+  const parts = buildTable(` rules="ROWS"`);
+  assert_equals(getComputedStyle(parts.table).borderCollapse, "collapse");
+  assertBorders(parts.bodyRow, BLOCK_ONLY, "tbody > tr");
+  assertBorders(parts.td, NO_BORDER, "td");
+}, "rules=ROWS is matched ASCII case-insensitively");
+
+// Case-insensitive matching is ASCII-only, so U+017F LATIN SMALL LETTER LONG S
+// must not match the "s" of "rows".
+for (const { label, attribute } of [
+  { label: "an unrecognised value", attribute: ` rules="rowz"` },
+  { label: "U+017F, which is not an ASCII case match for s", attribute: ` rules="rowſ"` },
+  { label: "the empty string", attribute: ` rules=""` },
+  { label: "no value", attribute: ` rules` },
+  { label: "no attribute at all", attribute: `` },
+]) {
+  test(() => {
+    const parts = buildTable(attribute);
+    assert_equals(getComputedStyle(parts.table).borderCollapse, "separate",
+                  "border-collapse on the table");
+    for (const side of ["top", "right", "bottom", "left"]) {
+      assert_equals(getComputedStyle(parts.table).getPropertyValue(`border-${side}-style`),
+                    "none", `border-${side}-style on the table`);
+    }
+    assertBorders(parts.bodyRow, NO_BORDER, "tbody > tr");
+    assertBorders(parts.td, NO_BORDER, "td");
+    assertBorders(parts.tbody, NO_BORDER, "tbody");
+    assertBorders(parts.colgroup, NO_BORDER, "colgroup");
+  }, `rules with ${label} sets no rule`);
+}
+
+// The hints use the flow-relative properties, so in a vertical writing mode the
+// rule between rows runs down the page rather than across it. Reading the
+// physical properties as well pins which way round the mapping goes: in
+// vertical-rl the block axis is horizontal, so block-start is the right edge.
+test(() => {
+  const parts = buildTable(` rules="rows"`);
+  parts.table.style.writingMode = "vertical-rl";
+
+  assertBorders(parts.bodyRow, BLOCK_ONLY, "tbody > tr in vertical-rl");
+
+  const rowStyle = getComputedStyle(parts.bodyRow);
+  assert_equals(rowStyle.borderRightStyle, "solid", "physical right edge is the block-start edge");
+  assert_equals(rowStyle.borderLeftStyle, "solid", "physical left edge is the block-end edge");
+  assert_equals(rowStyle.borderTopStyle, "none", "physical top edge is an inline edge");
+  assert_equals(rowStyle.borderBottomStyle, "none", "physical bottom edge is an inline edge");
+}, "rules=rows follows the writing mode: the rule is on the row's block edges");
+
+test(() => {
+  const parts = buildTable(` rules="cols"`);
+  parts.table.style.writingMode = "vertical-rl";
+
+  assertBorders(parts.td, INLINE_ONLY, "td in vertical-rl");
+
+  const cellStyle = getComputedStyle(parts.td);
+  assert_equals(cellStyle.borderTopStyle, "solid", "physical top edge is the inline-start edge");
+  assert_equals(cellStyle.borderBottomStyle, "solid", "physical bottom edge is the inline-end edge");
+  assert_equals(cellStyle.borderRightStyle, "none", "physical right edge is a block edge");
+  assert_equals(cellStyle.borderLeftStyle, "none", "physical left edge is a block edge");
+}, "rules=cols follows the writing mode: the rule is on the cells' inline edges");
+
+test(() => {
+  const parts = buildTable(` rules="groups"`);
+  parts.table.style.writingMode = "vertical-rl";
+
+  assertBorders(parts.tbody, BLOCK_ONLY, "tbody in vertical-rl");
+  assertBorders(parts.colgroup, INLINE_ONLY, "colgroup in vertical-rl");
+
+  const groupStyle = getComputedStyle(parts.tbody);
+  assert_equals(groupStyle.borderRightStyle, "solid", "row group: physical right edge is the block-start edge");
+  assert_equals(groupStyle.borderTopStyle, "none", "row group: physical top edge is an inline edge");
+
+  const columnGroupStyle = getComputedStyle(parts.colgroup);
+  assert_equals(columnGroupStyle.borderTopStyle, "solid", "column group: physical top edge is the inline-start edge");
+  assert_equals(columnGroupStyle.borderRightStyle, "none", "column group: physical right edge is a block edge");
+}, "rules=groups follows the writing mode: the rules are on the groups' block and inline edges");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/WEB_FEATURES.yml
@@ -41,6 +39,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-3q.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-3s-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-3s.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-color-not-inherited.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-presentational-hints-ascii-case-insensitive-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-presentational-hints-ascii-case-insensitive-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-presentational-hints-ascii-case-insensitive.html
@@ -83,6 +83,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-row-pagination-002-print-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-row-pagination-002-print.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rowspan-height-distribution.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-ua-stylesheet.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-valign-baseline-ascii-case-insensitive.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-vspace-hspace-s.html


### PR DESCRIPTION
#### 1db7869c348654dc302272c7cac766027f6c20cc
<pre>
Resync `html/rendering/non-replaced-elements/tables` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=321840">https://bugs.webkit.org/show_bug.cgi?id=321840</a>
<a href="https://rdar.apple.com/184987223">rdar://184987223</a>

Reviewed by Abrar Rahman Protyasha.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/92a794da495dde310f299d992b94ae02f47659cf">https://github.com/web-platform-tests/wpt/commit/92a794da495dde310f299d992b94ae02f47659cf</a>

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-color-not-inherited-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-color-not-inherited.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/319235@main">https://commits.webkit.org/319235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecdbe20038b40bcad0d5e368b6497d01d7a559b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145203 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141111 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121562 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43446 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41724 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41384 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2254 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193029 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150492 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40275 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55179 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150211 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44803 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122772 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53696 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16377 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53078 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53315 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53143 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->