### PR TITLE
DataTransfer.getData("url") returns the whole text/uri-list instead of its first URL

### DIFF
--- a/LayoutTests/editing/pasteboard/dataTransfer-setData-getData-expected.txt
+++ b/LayoutTests/editing/pasteboard/dataTransfer-setData-getData-expected.txt
@@ -8,8 +8,7 @@ PASS getDataResultType is "string"
 PASS getDataResult is "http://test.com"
 --- Test set/get 'URL' with multiple URLs:
 PASS getDataResultType is "string"
-FAIL getDataResult should be http://test.com. Was http://test.com
-http://check.com.
+PASS getDataResult is "http://test.com"
 --- Test set/get 'text/uri-list':
 PASS getDataResultType is "string"
 PASS getDataResult is "http://test.com\r\nhttp://check.com"
@@ -18,28 +17,22 @@ PASS getDataResultType is "string"
 PASS getDataResult is "http://test.com\nhttp://check.com"
 --- Test set 'text/uri-list', get 'URL':
 PASS getDataResultType is "string"
-FAIL getDataResult should be http://test.com. Was http://test.com
-http://check.com.
+PASS getDataResult is "http://test.com"
 --- Test set 'URL', get 'text/uri-list':
 PASS getDataResultType is "string"
 PASS getDataResult is "http://test.com\r\nhttp://check.com"
 --- Test set 'text/uri-list', get 'URL', using only '\n':
 PASS getDataResultType is "string"
-FAIL getDataResult should be http://test.com. Was http://test.com
-http://check.com.
+PASS getDataResult is "http://test.com"
 --- Test set/get 'text/uri-list' with comments:
 PASS getDataResultType is "string"
 PASS getDataResult is "# comment\r\nhttp://test.com\r\nhttp://check.com"
 --- Test set 'text/uri-list', get 'URL' with comments:
 PASS getDataResultType is "string"
-FAIL getDataResult should be http://test.com. Was # comment
-http://test.com
-http://check.com.
+PASS getDataResult is "http://test.com"
 --- Test set 'text/uri-list', get 'URL' with only comments:
 PASS getDataResultType is "string"
-FAIL getDataResult should be . Was # comment
-# comment 2
-# comment 3.
+PASS getDataResult is ""
 --- Test set/get 'text/plain':
 PASS getDataResultType is "string"
 PASS getDataResult is "Lorem ipsum dolor sit amet."

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-getdata-url-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-getdata-url-expected.txt
@@ -1,0 +1,13 @@
+
+PASS A single URL is returned unchanged
+PASS Only the first URL is returned, for LF line endings
+PASS Only the first URL is returned, for CRLF line endings
+PASS A trailing line ending is not part of the URL
+PASS Comment lines are skipped
+PASS A blank line after the first URL does not affect the result
+PASS The empty string is returned when the list contains no URL
+PASS The empty string is returned when there is no text/uri-list item
+PASS The format is matched ASCII case-insensitively after stripping whitespace
+PASS Requesting text/uri-list does not convert to a URL
+PASS Leading blank lines are skipped
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-getdata-url.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-getdata-url.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>DataTransfer.getData("url") converts text/uri-list to a single URL</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+// getData() step 6 sets the convert-to-URL flag when the requested format is "url", and
+// step 9 then parses the text/uri-list data and returns only its first URL. Comment lines
+// are those beginning with "#", per RFC 2483.
+
+function uriListDataTransfer(uriList) {
+  const dt = new DataTransfer();
+  dt.setData("text/uri-list", uriList);
+  return dt;
+}
+
+test(() => {
+  assert_equals(uriListDataTransfer("https://a.example/1").getData("url"),
+                "https://a.example/1");
+}, "A single URL is returned unchanged");
+
+test(() => {
+  assert_equals(uriListDataTransfer("https://a.example/1\nhttps://b.example/2").getData("url"),
+                "https://a.example/1");
+}, "Only the first URL is returned, for LF line endings");
+
+test(() => {
+  assert_equals(uriListDataTransfer("https://a.example/1\r\nhttps://b.example/2").getData("url"),
+                "https://a.example/1");
+}, "Only the first URL is returned, for CRLF line endings");
+
+test(() => {
+  assert_equals(uriListDataTransfer("https://a.example/1\n").getData("url"),
+                "https://a.example/1");
+  assert_equals(uriListDataTransfer("https://a.example/1\r\n").getData("url"),
+                "https://a.example/1");
+}, "A trailing line ending is not part of the URL");
+
+test(() => {
+  assert_equals(uriListDataTransfer("# comment\nhttps://a.example/1").getData("url"),
+                "https://a.example/1");
+  assert_equals(uriListDataTransfer("# one\n# two\nhttps://a.example/1\n# three").getData("url"),
+                "https://a.example/1");
+}, "Comment lines are skipped");
+
+test(() => {
+  assert_equals(uriListDataTransfer("https://a.example/1\n\nhttps://b.example/2").getData("url"),
+                "https://a.example/1");
+}, "A blank line after the first URL does not affect the result");
+
+test(() => {
+  assert_equals(uriListDataTransfer("").getData("url"), "");
+  assert_equals(uriListDataTransfer("# only a comment").getData("url"), "");
+  assert_equals(uriListDataTransfer("\r\n\r\n").getData("url"), "");
+}, "The empty string is returned when the list contains no URL");
+
+test(() => {
+  assert_equals(new DataTransfer().getData("url"), "",
+                "no text/uri-list item is present");
+}, "The empty string is returned when there is no text/uri-list item");
+
+test(() => {
+  const uriList = "https://a.example/1\nhttps://b.example/2";
+  for (const format of ["url", "URL", "Url", " url ", "\turl\n"]) {
+    assert_equals(uriListDataTransfer(uriList).getData(format), "https://a.example/1",
+                  `format ${JSON.stringify(format)} must convert to a URL`);
+  }
+}, "The format is matched ASCII case-insensitively after stripping whitespace");
+
+test(() => {
+  const uriList = "# comment\nhttps://a.example/1\nhttps://b.example/2";
+  assert_equals(uriListDataTransfer(uriList).getData("text/uri-list"), uriList,
+                "text/uri-list must be returned unchanged");
+  assert_equals(uriListDataTransfer(uriList).getData("text/uri-list;charset=utf-8"), uriList,
+                "a text/uri-list parameter must not set the convert-to-URL flag");
+}, "Requesting text/uri-list does not convert to a URL");
+
+// Blank lines are not URLs, so "the first URL from the list" skips them. RFC 2483 only
+// specifies the treatment of comment lines, so this case is under-specified; Gecko returns
+// the empty string here instead of the first URL.
+test(() => {
+  assert_equals(uriListDataTransfer("\n\nhttps://a.example/1").getData("url"),
+                "https://a.example/1");
+  assert_equals(uriListDataTransfer("\r\n\r\nhttps://a.example/1").getData("url"),
+                "https://a.example/1");
+}, "Leading blank lines are skipped");
+</script>

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -156,6 +156,20 @@ static String normalizeType(const String& type)
     return lowercaseType;
 }
 
+// Parses text/uri-list data as described by RFC 2483 and returns the first URL it contains,
+// skipping the comment lines that specification defines as well as lines that cannot be URLs.
+static String firstURLFromURIList(StringView uriList)
+{
+    // split() elides empty entries, and trimming removes the CR of a CRLF line ending.
+    for (auto line : uriList.split('\n')) {
+        auto url = line.trim(isASCIIWhitespace);
+        if (url.isEmpty() || url.startsWith('#'))
+            continue;
+        return url.toString();
+    }
+    return emptyString();
+}
+
 void DataTransfer::clearData(const String& type)
 {
     if (!canWriteData())
@@ -252,7 +266,16 @@ String DataTransfer::readStringFromPasteboard(Document& document, const String& 
 
 String DataTransfer::getData(Document& document, const String& type) const
 {
-    return getDataForItem(document, normalizeType(type));
+    // https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata
+    // Step 6 sets the convert-to-URL flag when the requested format is "url", and step 9
+    // then replaces the text/uri-list data with the first URL it contains.
+    bool convertToURL = equalLettersIgnoringASCIICase(StringView { type }.trim(isASCIIWhitespace), "url"_s);
+
+    auto data = getDataForItem(document, normalizeType(type));
+    if (!convertToURL)
+        return data;
+
+    return firstURLFromURIList(data);
 }
 
 bool DataTransfer::shouldSuppressGetAndSetDataToAvoidExposingFilePaths() const


### PR DESCRIPTION
#### 880962714e11143450d39dae76d4b1987171369c
<pre>
DataTransfer.getData(&quot;url&quot;) returns the whole text/uri-list instead of its first URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=321841">https://bugs.webkit.org/show_bug.cgi?id=321841</a>
<a href="https://rdar.apple.com/184988378">rdar://184988378</a>

Reviewed by Chris Dumez.

Per the specification [1], getData() step 6 says:

    &quot;If format equals &quot;url&quot;, change it to &quot;text/uri-list&quot; and set
     convert-to-URL to true.&quot;

and step 9 then acts on that flag:

    &quot;If convert-to-URL is true, then parse result as appropriate for
     text/uri-list data, and then set result to the first URL from the list,
     if any, or the empty string otherwise.&quot;

Comment lines - those beginning with &quot;#&quot; per RFC 2483 [2] - are not URLs and are
skipped when finding that first URL.

WebKit implemented only half of this. normalizeType() performs the step 6 rename
of &quot;url&quot; to &quot;text/uri-list&quot;, but nothing ever performed step 9, so getData(&quot;url&quot;)
handed back the raw list: every URL joined by its original line endings, comment
lines included. Even a single URL followed by a trailing newline came back with
the newline attached.

The reason this went unnoticed for so long is that the platform read path
collapses to one URL by accident of implementation - urlStringsFromPasteboard()
goes through [NSURL URLFromPasteboard:], which yields a single absolute URL - so
getData(&quot;url&quot;) looked correct for anything copied from another application. The
bug was only observable for a text/uri-list a page wrote itself with setData(),
which is served by the same-origin custom data path.

Compute the convert-to-URL flag from the requested format before normalizeType()
collapses it, so text/uri-list and text/uri-list;charset=utf-8 keep returning
their data verbatim, then reduce the result to its first URL.
DataTransferItem.getAsString() reads through getDataForItem() and is left alone,
since the specification puts this step in getData() only.

Testing across engines: Chrome matches [1] in all cases. Firefox matches except
when a blank line precedes the first URL, where it returns the empty string - it
discards comment lines but not blank ones. RFC 2483 [2] only specifies the
treatment of comment lines, so that case is under-specified; this change follows
Chrome and the &quot;first URL from the list&quot; wording of step 9, and the new test
isolates it in its own subtest.

editing/pasteboard/dataTransfer-setData-getData.html has asserted the correct
behavior since it was written, with five FAIL lines checked into its expected
results - one per convert-to-URL case. Those now pass; rebaseline.

[1] <a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata</a>
[2] <a href="https://datatracker.ietf.org/doc/html/rfc2483#section-5">https://datatracker.ietf.org/doc/html/rfc2483#section-5</a>

Test: imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-getdata-url.html

* LayoutTests/editing/pasteboard/dataTransfer-setData-getData-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-getdata-url-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-getdata-url.html: Added.
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::firstURLFromURIList):
(WebCore::DataTransfer::getData const):

Canonical link: <a href="https://commits.webkit.org/319267@main">https://commits.webkit.org/319267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adf12763d279b4c2f806d8455cf2c3a1633c9153

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145204 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f140f99a-9596-42cd-8052-a90b8ca06c09) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141112 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97806 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e599bbb5-dc74-4b6d-9210-784bfc91f1fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44775 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161858 "Found 1 new API test failure: TestWebKitAPI.IsolatedSiteStore.PersistsAcrossSessions (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121563 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f72e982-a9e9-4b95-a77b-dfc820482036) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43448 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41725 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41385 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2255 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193030 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54492 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150493 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40297 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55180 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150212 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44805 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127446 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122773 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53697 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16378 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53079 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53316 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53144 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->