### PR TITLE
DataTransfer.types should list "Files" after the text item types, not before

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-expected.txt
@@ -3,5 +3,5 @@ FAIL type's state on DataTransfer creation assert_equals: types must return the 
 FAIL Relationship between types and items assert_equals: expected ["text/plain"] but got ["text/plain"]
 FAIL type's identity assert_equals: expected ["text/plain"] but got ["text/plain"]
 FAIL Verify type is a read-only attribute assert_equals: expected [] but got []
-FAIL DataTransfer containing files assert_array_equals: expected property 0 to be "text/plain" but got "Files" (expected array ["text/plain", "Files"] got ["Files", "text/plain"])
+PASS DataTransfer containing files
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-files-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-files-last-expected.txt
@@ -1,0 +1,7 @@
+
+PASS "Files" is last when the File is added before the text item
+PASS "Files" is last when the File is added after the text item
+PASS The text item types keep their relative order and "Files" comes after all of them
+PASS Multiple File items add a single trailing "Files" entry
+PASS The order of types does not have to match the order of the item list
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-files-last.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-files-last.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>DataTransfer types attribute lists "Files" after the text item types</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dnd.html#the-datatransfer-interface">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+function makeFile(name = "test.txt") {
+  return new File(["abc"], name);
+}
+
+test(() => {
+  const dt = new DataTransfer();
+  dt.items.add(makeFile());
+  dt.setData("text/plain", "foo");
+  assert_array_equals(dt.types, ["text/plain", "Files"]);
+}, '"Files" is last when the File is added before the text item');
+
+test(() => {
+  const dt = new DataTransfer();
+  dt.setData("text/plain", "foo");
+  dt.items.add(makeFile());
+  assert_array_equals(dt.types, ["text/plain", "Files"]);
+}, '"Files" is last when the File is added after the text item');
+
+test(() => {
+  const dt = new DataTransfer();
+  dt.setData("text/plain", "foo");
+  dt.setData("text/uri-list", "https://webkit.org/");
+  dt.items.add(makeFile());
+  dt.setData("text/html", "<b>bar</b>");
+  assert_array_equals(dt.types, ["text/plain", "text/uri-list", "text/html", "Files"]);
+}, 'The text item types keep their relative order and "Files" comes after all of them');
+
+test(() => {
+  const dt = new DataTransfer();
+  dt.setData("text/plain", "foo");
+  dt.items.add(makeFile("one.txt"));
+  dt.items.add(makeFile("two.txt"));
+  assert_equals(dt.files.length, 2);
+  assert_array_equals(dt.types, ["text/plain", "Files"],
+                      '"Files" is listed once regardless of the number of File items');
+}, 'Multiple File items add a single trailing "Files" entry');
+
+test(() => {
+  const dt = new DataTransfer();
+  dt.items.add(makeFile());
+  dt.setData("text/plain", "foo");
+  assert_array_equals(dt.types, ["text/plain", "Files"]);
+
+  // The item list keeps its own order; only types moves "Files" to the end.
+  assert_equals(dt.items.length, 2);
+  assert_equals(dt.items[0].kind, "file");
+  assert_equals(dt.items[1].kind, "string");
+  assert_equals(dt.items[1].type, "text/plain");
+}, 'The order of types does not have to match the order of the item list');
+</script>

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -365,21 +365,22 @@ Vector<String> DataTransfer::types(Document& document, AddFilesType addFilesType
     auto fileContentState = m_pasteboard->fileContentState();
     if (hasFileBackedItem || fileContentState != Pasteboard::FileContentState::NoFileOrImageData) {
         Vector<String> types;
+        if (fileContentState == Pasteboard::FileContentState::MayContainFilePaths) {
+            if (safeTypes.contains("text/uri-list"_s))
+                types.append("text/uri-list"_s);
+            if (safeTypes.contains(textHTMLContentTypeAtom()) && DeprecatedGlobalSettings::customPasteboardDataEnabled())
+                types.append(textHTMLContentTypeAtom());
+        } else
+            types = WTF::move(safeTypes);
+
+        // Per the steps to update the types array in https://html.spec.whatwg.org/multipage/dnd.html#the-datatransfer-interface,
+        // the type strings of the text items are added to L first, and only then is "Files" added, so
+        // "Files" must be the last entry.
         if (!hideFilesType && addFilesType == AddFilesType::Yes) {
             types.append("Files"_s);
             if (document.quirks().needsMozillaFileTypeForDataTransfer())
                 types.append("application/x-moz-file"_s);
         }
-
-        if (fileContentState != Pasteboard::FileContentState::MayContainFilePaths) {
-            types.appendVector(WTF::move(safeTypes));
-            return types;
-        }
-
-        if (safeTypes.contains("text/uri-list"_s))
-            types.append("text/uri-list"_s);
-        if (safeTypes.contains(textHTMLContentTypeAtom()) && DeprecatedGlobalSettings::customPasteboardDataEnabled())
-            types.append(textHTMLContentTypeAtom());
         return types;
     }
 


### PR DESCRIPTION
#### 22e12e1092f05da5925c0a90acee062069215459
<pre>
DataTransfer.types should list &quot;Files&quot; after the text item types, not before
<a href="https://bugs.webkit.org/show_bug.cgi?id=321842">https://bugs.webkit.org/show_bug.cgi?id=321842</a>
<a href="https://rdar.apple.com/184988758">rdar://184988758</a>

Reviewed by NOBODY (OOPS!).

HTML, 6.11.3 The DataTransfer interface, the steps to update a DataTransfer
object&apos;s types array
&lt;<a href="https://html.spec.whatwg.org/multipage/dnd.html#the-datatransfer-interface">https://html.spec.whatwg.org/multipage/dnd.html#the-datatransfer-interface</a>&gt;:

  1. Let L be an empty sequence.
  2. If the DataTransfer object is still associated with a drag data store:
    1. For each item in the DataTransfer object&apos;s drag data store item list
    whose kind is text, add an entry to L consisting of the item&apos;s type
    string.
    2. If there are any items in the DataTransfer object&apos;s drag data store
    item list whose kind is File, then add an entry to L consisting of
    the string &quot;Files&quot;.

Step 2.1 populates L with the text items&apos; type strings and step 2.2 only then
appends &quot;Files&quot;, so &quot;Files&quot; is always the last entry. WebKit appended it first
instead, before appendVector(safeTypes), so dropping a file alongside plain
text produced [&quot;Files&quot;, &quot;text/plain&quot;] where the spec, Chrome and Firefox all
produce [&quot;text/plain&quot;, &quot;Files&quot;]. The Pasteboard::FileContentState::
MayContainFilePaths branch had the same inversion, placing &quot;Files&quot; ahead of
&quot;text/uri-list&quot; and &quot;text/html&quot;.

Build the text item types first and append &quot;Files&quot; (and the
application/x-moz-file quirk that trails it) afterwards, so both file branches
agree with the spec. The !customPasteboardDataEnabled() path already appended
&quot;Files&quot; last and is unchanged.

This turns the &quot;DataTransfer containing files&quot; subtest of the imported
datatransfer-types.html green. Its four remaining failures are a separate
issue: types returns a freshly built array on each access rather than the
cached FrozenArray the same section requires.

Test: imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-files-last.html

* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-files-last-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-files-last.html: Added.
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::types const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22e12e1092f05da5925c0a90acee062069215459

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191097 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145206 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/529fa612-07d6-4aa4-bba3-135a4ed72c37) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141113 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97807 "2 flakes 6 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d88399b3-cfdc-4843-9a17-afded4cf94f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183838 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44774 "Found 2 new test failures: editing/pasteboard/data-transfer-item-list-add-file-multiple-times.html editing/pasteboard/data-transfer-item-list-add-file-on-copy.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161859 "Found 7 new API test failures: TestWebKitAPI.PasteMixedContent.ImageDataAndPlainTextAndURLAndHTML, TestWebKitAPI.PasteMixedContent.ImageFileAndWebArchive, TestWebKitAPI.PasteMixedContent.ImageFileAndRTF, TestWebKitAPI.PasteMixedContent.ImageFileAndURL, TestWebKitAPI.PasteMixedContent.ImageFileWithHTMLAndURL, TestWebKitAPI.PasteMixedContent.ImageFileAndHTML, TestWebKitAPI.PasteMixedContent.ImageDataAndPlainText (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121564 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8b098f4-14b1-44a8-8f47-63e8a79b1ed7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43447 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41726 "Found 7 new API test failures: TestWebKitAPI.PasteMixedContent.ImageDataAndPlainTextAndURLAndHTML, TestWebKitAPI.PasteMixedContent.ImageFileAndWebArchive, TestWebKitAPI.PasteMixedContent.ImageFileAndRTF, TestWebKitAPI.PasteMixedContent.ImageFileAndURL, TestWebKitAPI.PasteMixedContent.ImageFileWithHTMLAndURL, TestWebKitAPI.PasteMixedContent.ImageFileAndHTML, TestWebKitAPI.PasteMixedContent.ImageDataAndPlainText (failure)") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153851 "Found 2 new API test failures: TestWebKitAPI.UIPasteboardTests.DataTransferGetDataWhenPastingImageAndText, TestWebKitAPI.DragAndDropTests.DataTransferGetDataWhenDroppingImageAndMarkup (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41386 "Found 3 new test failures: editing/pasteboard/data-transfer-item-list-add-file-multiple-times.html editing/pasteboard/data-transfer-item-list-add-file-on-copy.html editing/pasteboard/data-transfer-item-list-add-file-on-drag.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2257 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47440 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45981 "Found 3 new test failures: editing/pasteboard/data-transfer-item-list-add-file-multiple-times.html editing/pasteboard/data-transfer-item-list-add-file-on-copy.html editing/pasteboard/data-transfer-item-list-add-file-on-drag.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193032 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161375 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150494 "Found 2 new test failures: editing/pasteboard/data-transfer-item-list-add-file-multiple-times.html editing/pasteboard/data-transfer-item-list-add-file-on-copy.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55182 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38004 "Found 3 new test failures: editing/pasteboard/data-transfer-item-list-add-file-multiple-times.html editing/pasteboard/data-transfer-item-list-add-file-on-copy.html editing/pasteboard/data-transfer-item-list-add-file-on-drag.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150213 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44804 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127448 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122775 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53699 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16379 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53081 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53318 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53146 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->