### PR TITLE
[JSC] Remove `UnlinkedCodeBlock::m_jumpTargets`

### DIFF
--- a/Source/JavaScriptCore/bytecode/BytecodeRewriter.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeRewriter.cpp
@@ -58,7 +58,7 @@ void BytecodeRewriter::execute()
         return lhs.index < rhs.index;
     });
 
-    m_codeBlock->applyModification(*this, m_writer);
+    m_codeBlock->applyModification(*this);
 }
 
 void BytecodeRewriter::adjustJumpTargetsInFragment(unsigned finalOffset, Insertion& insertion)

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -415,9 +415,6 @@ public:
     unsigned sourceOffset() const { return m_ownerExecutable->source().startOffset(); }
     unsigned firstLineColumnOffset() const { return m_ownerExecutable->startColumn(); }
 
-    size_t numberOfJumpTargets() const { return m_unlinkedCode->numberOfJumpTargets(); }
-    unsigned jumpTarget(int index) const { return m_unlinkedCode->jumpTarget(index); }
-
     String nameForRegister(VirtualRegister);
 
     static constexpr ptrdiff_t offsetOfArgumentValueProfiles() { return OBJECT_OFFSETOF(CodeBlock, m_argumentValueProfiles); }

--- a/Source/JavaScriptCore/bytecode/PreciseJumpTargets.cpp
+++ b/Source/JavaScriptCore/bytecode/PreciseJumpTargets.cpp
@@ -43,20 +43,11 @@ static void getJumpTargetsForInstruction(Block* codeBlock, const JSInstructionSt
         out.append(instruction.offset());
 }
 
-enum class ComputePreciseJumpTargetsMode {
-    FollowCodeBlockClaim,
-    ForceCompute,
-};
-
-template<ComputePreciseJumpTargetsMode Mode, typename Block, size_t vectorSize>
-void computePreciseJumpTargetsInternal(Block* codeBlock, const JSInstructionStream& instructions, Vector<JSInstructionStream::Offset, vectorSize>& out)
+template<typename Block>
+void computePreciseJumpTargetsInternal(Block* codeBlock, const JSInstructionStream& instructions, Vector<JSInstructionStream::Offset, 32>& out)
 {
     ASSERT(out.isEmpty());
 
-    // The code block has a superset of the jump targets. So if it claims to have none, we are done.
-    if (Mode == ComputePreciseJumpTargetsMode::FollowCodeBlockClaim && !codeBlock->numberOfJumpTargets())
-        return;
-    
     for (unsigned i = codeBlock->numberOfExceptionHandlers(); i--;) {
         out.append(codeBlock->exceptionHandler(i).target);
         out.append(codeBlock->exceptionHandler(i).start);
@@ -85,22 +76,22 @@ void computePreciseJumpTargetsInternal(Block* codeBlock, const JSInstructionStre
 
 void computePreciseJumpTargets(CodeBlock* codeBlock, Vector<JSInstructionStream::Offset, 32>& out)
 {
-    computePreciseJumpTargetsInternal<ComputePreciseJumpTargetsMode::FollowCodeBlockClaim>(codeBlock, codeBlock->instructions(), out);
+    computePreciseJumpTargetsInternal(codeBlock, codeBlock->instructions(), out);
 }
 
 void computePreciseJumpTargets(CodeBlock* codeBlock, const JSInstructionStream& instructions, Vector<JSInstructionStream::Offset, 32>& out)
 {
-    computePreciseJumpTargetsInternal<ComputePreciseJumpTargetsMode::FollowCodeBlockClaim>(codeBlock, instructions, out);
+    computePreciseJumpTargetsInternal(codeBlock, instructions, out);
+}
+
+void computePreciseJumpTargets(UnlinkedCodeBlock* codeBlock, Vector<JSInstructionStream::Offset, 32>& out)
+{
+    computePreciseJumpTargetsInternal(codeBlock, codeBlock->instructions(), out);
 }
 
 void computePreciseJumpTargets(UnlinkedCodeBlockGenerator* codeBlock, const JSInstructionStream& instructions, Vector<JSInstructionStream::Offset, 32>& out)
 {
-    computePreciseJumpTargetsInternal<ComputePreciseJumpTargetsMode::FollowCodeBlockClaim>(codeBlock, instructions, out);
-}
-
-void recomputePreciseJumpTargets(UnlinkedCodeBlockGenerator* codeBlock, const JSInstructionStream& instructions, Vector<JSInstructionStream::Offset>& out)
-{
-    computePreciseJumpTargetsInternal<ComputePreciseJumpTargetsMode::ForceCompute>(codeBlock, instructions, out);
+    computePreciseJumpTargetsInternal(codeBlock, instructions, out);
 }
 
 void findJumpTargetsForInstruction(CodeBlock* codeBlock, const JSInstructionStream::Ref& instruction, Vector<JSInstructionStream::Offset, 1>& out)

--- a/Source/JavaScriptCore/bytecode/PreciseJumpTargets.h
+++ b/Source/JavaScriptCore/bytecode/PreciseJumpTargets.h
@@ -34,9 +34,8 @@ class UnlinkedCodeBlock;
 // Return a sorted list of bytecode index that are the destination of a jump.
 void computePreciseJumpTargets(CodeBlock*, Vector<JSInstructionStream::Offset, 32>& out);
 void computePreciseJumpTargets(CodeBlock*, const JSInstructionStream& instructions, Vector<JSInstructionStream::Offset, 32>& out);
+void computePreciseJumpTargets(UnlinkedCodeBlock*, Vector<JSInstructionStream::Offset, 32>& out);
 void computePreciseJumpTargets(UnlinkedCodeBlockGenerator*, const JSInstructionStream&, Vector<JSInstructionStream::Offset, 32>& out);
-
-void recomputePreciseJumpTargets(UnlinkedCodeBlockGenerator*, const JSInstructionStream&, Vector<JSInstructionStream::Offset>& out);
 
 void findJumpTargetsForInstruction(CodeBlock*, const JSInstructionStream::Ref&, Vector<JSInstructionStream::Offset, 1>& out);
 void findJumpTargetsForInstruction(UnlinkedCodeBlockGenerator*, const JSInstructionStream::Ref&, Vector<JSInstructionStream::Offset, 1>& out);

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -113,7 +113,6 @@ void UnlinkedCodeBlock::visitChildrenImpl(JSCell* cell, Visitor& visitor)
         extraMemory += thisObject->m_rareData->sizeInBytes(locker);
     if (thisObject->m_expressionInfo)
         extraMemory += thisObject->m_expressionInfo->byteSize();
-    extraMemory += thisObject->m_jumpTargets.byteSize();
     extraMemory += thisObject->m_identifiers.byteSize();
     extraMemory += thisObject->m_constantRegisters.byteSize();
     extraMemory += thisObject->m_constantsSourceCodeRepresentation.byteSize();

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -218,11 +218,6 @@ public:
     unsigned numberOfConstantIdentifierSets() const { return m_rareData ? m_rareData->m_constantIdentifierSets.size() : 0; }
     const FixedVector<IdentifierSet>& constantIdentifierSets() { ASSERT(m_rareData); return m_rareData->m_constantIdentifierSets; }
 
-    // Jumps
-    size_t numberOfJumpTargets() const { return m_jumpTargets.size(); }
-    unsigned jumpTarget(int index) const { return m_jumpTargets[index]; }
-    unsigned lastJumpTarget() const { return m_jumpTargets.last(); }
-
     UnlinkedHandlerInfo* NODELETE handlerForBytecodeIndex(BytecodeIndex, RequiredHandler = RequiredHandler::AnyHandler);
     UnlinkedHandlerInfo* NODELETE handlerForIndex(unsigned, RequiredHandler = RequiredHandler::AnyHandler);
 
@@ -426,7 +421,6 @@ private:
     OptionSet<CodeGenerationMode> m_codeGenerationMode;
     BaselineExecutionCounter m_llintExecuteCounter;
 
-    FixedVector<JSInstructionStream::Offset> m_jumpTargets;
     const Ref<UnlinkedMetadataTable> m_metadata;
     std::unique_ptr<JSInstructionStream> m_instructions;
     std::unique_ptr<BytecodeLivenessAnalysis> m_liveness;

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
@@ -30,7 +30,6 @@
 #include "ExpressionInfoInlines.h"
 #include "InstructionStream.h"
 #include "JSCJSValueInlines.h"
-#include "PreciseJumpTargets.h"
 #include "StrongInlines.h"
 #include "UnlinkedMetadataTableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -67,7 +66,6 @@ void UnlinkedCodeBlockGenerator::finalize(std::unique_ptr<JSInstructionStream> i
         m_codeBlock->allocateSharedProfiles(m_numBinaryArithProfiles, m_numUnaryArithProfiles);
         m_codeBlock->m_metadata->finalize();
 
-        m_codeBlock->m_jumpTargets = WTF::move(m_jumpTargets);
         m_codeBlock->m_identifiers = WTF::move(m_identifiers);
         m_codeBlock->m_constantRegisters = WTF::move(m_constantRegisters);
         m_codeBlock->m_constantsSourceCodeRepresentation = WTF::move(m_constantsSourceCodeRepresentation);
@@ -114,7 +112,7 @@ UnlinkedHandlerInfo* UnlinkedCodeBlockGenerator::handlerForIndex(unsigned index,
     return UnlinkedHandlerInfo::handlerForIndex<UnlinkedHandlerInfo>(m_exceptionHandlers, index, requiredHandler);
 }
 
-void UnlinkedCodeBlockGenerator::applyModification(BytecodeRewriter& rewriter, JSInstructionStreamWriter& instructions)
+void UnlinkedCodeBlockGenerator::applyModification(BytecodeRewriter& rewriter)
 {
     // Before applying the changes, we adjust the jumps based on the original bytecode offset, the offset to the jump target, and
     // the insertion information.
@@ -148,10 +146,6 @@ void UnlinkedCodeBlockGenerator::applyModification(BytecodeRewriter& rewriter, J
 
     // Then, modify the unlinked instructions.
     rewriter.applyModification();
-
-    // And recompute the jump target based on the modified unlinked instructions.
-    m_jumpTargets.clear();
-    recomputePreciseJumpTargets(this, instructions, m_jumpTargets);
 }
 
 void UnlinkedCodeBlockGenerator::addOutOfLineJumpTarget(JSInstructionStream::Offset bytecodeOffset, int target)

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
@@ -81,11 +81,6 @@ public:
         m_opProfileControlFlowBytecodeOffsets.append(offset);
     }
 
-    size_t numberOfJumpTargets() const { return m_jumpTargets.size(); }
-    void addJumpTarget(unsigned jumpTarget) { m_jumpTargets.append(jumpTarget); }
-    unsigned jumpTarget(int index) const { return m_jumpTargets[index]; }
-    unsigned lastJumpTarget() const { return m_jumpTargets.last(); }
-
     size_t numberOfUnlinkedSwitchJumpTables() const { return m_unlinkedSwitchJumpTables.size(); }
     UnlinkedSimpleJumpTable& addUnlinkedSwitchJumpTable() { m_unlinkedSwitchJumpTables.append(UnlinkedSimpleJumpTable()); return m_unlinkedSwitchJumpTables.last(); }
     UnlinkedSimpleJumpTable& unlinkedSwitchJumpTable(int tableIndex) { return m_unlinkedSwitchJumpTables[tableIndex]; }
@@ -188,7 +183,7 @@ public:
 
     size_t metadataSizeInBytes() { return m_codeBlock->metadataSizeInBytes(); }
 
-    void applyModification(BytecodeRewriter&, JSInstructionStreamWriter&);
+    void applyModification(BytecodeRewriter&);
 
     void finalize(std::unique_ptr<JSInstructionStream>);
 
@@ -201,7 +196,6 @@ private:
     VM& m_vm;
     Strong<UnlinkedCodeBlock> m_codeBlock;
     // In non-RareData.
-    Vector<JSInstructionStream::Offset> m_jumpTargets;
     Vector<Identifier> m_identifiers;
     Vector<WriteBarrier<Unknown>> m_constantRegisters;
     Vector<SourceCodeRepresentation> m_constantsSourceCodeRepresentation;

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -297,8 +297,6 @@ ParserError BytecodeGenerator::generate(unsigned& size)
                 : CompletionType::Normal;
             emitLoad(&completionTypeRegister, completionType);
         }
-        m_codeBlock->addJumpTarget(m_lastInstruction.offset());
-
 
         emitJump(tryData->target.get());
         tryData->target = WTF::move(realCatchTarget);
@@ -1460,7 +1458,6 @@ void BytecodeGenerator::emitEnter()
     if (Options::optimizeRecursiveTailCalls()) [[likely]] {
         // We must add the end of op_enter as a potential jump target, because the bytecode parser may decide to split its basic block
         // to have somewhere to jump to if there is a recursive tail-call that points to this function.
-        m_codeBlock->addJumpTarget(instructions().size());
         // This disables peephole optimizations when an instruction is a jump target
         disablePeepholeOptimization();
     }

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBaseInlines.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBaseInlines.h
@@ -74,20 +74,7 @@ void BytecodeGeneratorBase<Traits>::reclaimFreeRegisters()
 template<typename Traits>
 void BytecodeGeneratorBase<Traits>::emitLabel(GenericLabel<Traits>& label)
 {
-    unsigned newLabelIndex = m_writer.position();
-    label.setLocation(*this, newLabelIndex);
-
-    if (m_codeBlock->numberOfJumpTargets()) {
-        unsigned lastLabelIndex = m_codeBlock->lastJumpTarget();
-        ASSERT(lastLabelIndex <= newLabelIndex);
-        if (newLabelIndex == lastLabelIndex) {
-            // Peephole optimizations have already been disabled by emitting the last label
-            return;
-        }
-    }
-
-    m_codeBlock->addJumpTarget(newLabelIndex);
-
+    label.setLocation(*this, m_writer.position());
     m_lastOpcodeID = Traits::opcodeForDisablingOptimizations;
 }
 

--- a/Source/JavaScriptCore/lol/LOLJIT.cpp
+++ b/Source/JavaScriptCore/lol/LOLJIT.cpp
@@ -53,6 +53,7 @@
 #include "MaxFrameExtentForSlowPathCall.h"
 #include "ModuleProgramCodeBlock.h"
 #include "PCToCodeOriginMap.h"
+#include "PreciseJumpTargets.h"
 #include "ProbeContext.h"
 #include "ProfilerDatabase.h"
 #include "ProgramCodeBlock.h"
@@ -105,6 +106,8 @@ RefPtr<BaselineJITCode> LOLJIT::compileAndLinkWithoutFinalizing(JITCompilationEf
         if (m_unlinkedCodeBlock->numberOfUnlinkedStringSwitchJumpTables())
             m_stringSwitchJumpTables = FixedVector<StringJumpTable>(m_unlinkedCodeBlock->numberOfUnlinkedStringSwitchJumpTables());
     }
+
+    computePreciseJumpTargets(m_unlinkedCodeBlock, m_jumpTargets);
 
     if (Options::dumpDisassembly() || Options::dumpBaselineDisassembly() || (m_vm->m_perBytecodeProfiler && Options::disassembleBaselineForProfiler())) [[unlikely]] {
         // FIXME: build a disassembler off of UnlinkedCodeBlock.

--- a/Source/JavaScriptCore/lol/LOLJIT.h
+++ b/Source/JavaScriptCore/lol/LOLJIT.h
@@ -302,7 +302,7 @@ private:
     void nextBytecodeIndexWithFlushForJumpTargetsIfNeeded(auto& allocator, bool shouldSetFastPathResumePoint)
     {
         auto next = BytecodeIndex(m_bytecodeIndex.offset() + m_currentInstruction->size());
-        if (m_currentJumpTargetIndex < m_unlinkedCodeBlock->numberOfJumpTargets() && next.offset() == m_unlinkedCodeBlock->jumpTarget(m_currentJumpTargetIndex)) {
+        if (m_currentJumpTargetIndex < m_jumpTargets.size() && next.offset() == m_jumpTargets[m_currentJumpTargetIndex]) {
             if (shouldSetFastPathResumePoint) {
                 // We need to set a resume point for slow paths to jump back to prior to flushing since the next instruction wouldn't have the flushes and we don't want to re-emit them in the slow path.
                 // It's generally ok if a resume point is already set before here, it should still be correct w.r.t. flushing.
@@ -456,6 +456,7 @@ private:
     Vector<RegisterSet> m_liveTempsForSlowPaths;
     Vector<JSValueRegs> m_slowPathOperandRegs;
     unsigned m_currentSlowPathOperandIndex;
+    Vector<JSInstructionStream::Offset, 32> m_jumpTargets;
     unsigned m_currentJumpTargetIndex;
 
     // This is laid out as [ locals, constants, headers, arguments ]

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -2070,7 +2070,6 @@ private:
     CachedPtr<CachedCodeBlockRareData> m_rareData;
 
     CachedPtr<CachedInstructionStream> m_instructions;
-    CachedVector<JSInstructionStream::Offset> m_jumpTargets;
     CachedVector<CachedJSValue> m_constantRegisters;
     CachedVector<SourceCodeRepresentation> m_constantsSourceCodeRepresentation;
     CachedPtr<CachedExpressionInfo> m_expressionInfo;
@@ -2314,7 +2313,6 @@ ALWAYS_INLINE void CachedCodeBlock<CodeBlockType>::decode(Decoder& decoder, Unli
     m_constantsSourceCodeRepresentation.decode(decoder, codeBlock.m_constantsSourceCodeRepresentation);
     codeBlock.m_expressionInfo = m_expressionInfo->decode(decoder);
     m_outOfLineJumpTargets.decode(decoder, codeBlock.m_outOfLineJumpTargets);
-    m_jumpTargets.decode(decoder, codeBlock.m_jumpTargets);
     m_identifiers.decode(decoder, codeBlock.m_identifiers);
     m_functionDecls.decode(decoder, codeBlock.m_functionDecls, &codeBlock);
     m_functionExprs.decode(decoder, codeBlock.m_functionExprs, &codeBlock);
@@ -2493,7 +2491,6 @@ ALWAYS_INLINE void CachedCodeBlock<CodeBlockType>::encode(Encoder& encoder, cons
     m_constantRegisters.encode(encoder, codeBlock.m_constantRegisters);
     m_constantsSourceCodeRepresentation.encode(encoder, codeBlock.m_constantsSourceCodeRepresentation);
     m_expressionInfo.encode(encoder, codeBlock.m_expressionInfo.get());
-    m_jumpTargets.encode(encoder, codeBlock.m_jumpTargets);
     m_outOfLineJumpTargets.encode(encoder, codeBlock.m_outOfLineJumpTargets);
 
     m_identifiers.encode(encoder, codeBlock.m_identifiers);


### PR DESCRIPTION
#### 0b92c2bcd0d55ced7be0cbbd1fa38009b5138f4c
<pre>
[JSC] Remove `UnlinkedCodeBlock::m_jumpTargets`
<a href="https://bugs.webkit.org/show_bug.cgi?id=321843">https://bugs.webkit.org/show_bug.cgi?id=321843</a>

Reviewed by Yusuke Suzuki.

BytecodeGenerator records the offset of every label it emits, and UnlinkedCodeBlockGenerator::finalize
copies the list into UnlinkedCodeBlock::m_jumpTargets, where it stays for the lifetime of the code block
and is also written to the bytecode cache. Nothing in a shipping configuration reads the contents: DFG and
the liveness analysis recompute the targets from the instruction stream with computePreciseJumpTargets(),
Baseline labels every instruction, and computePreciseJumpTargets() only checks whether the list is empty.
It never is, because emitEnter() adds an entry to every code block. The one reader of the contents is
LOLJIT, which is off by default.

Remove the list from the generator, UnlinkedCodeBlock, CodeBlock and CachedCodeBlock, along with the
empty check and the recomputation after generatorification. emitLabel() only needs to disable peephole
optimizations. LOLJIT computes the targets with computePreciseJumpTargets() like DFG does, which also
gives it the op_catch offsets of handlers with a completion register; the label list recorded the
following mov instead. The generated bytecode is unchanged.

After loading typescript.js and compiling one file, this saves 4 bytes per label (7,040 labels in 944 code
blocks, about 38 KB with malloc rounding) and 46 KB (1.4%) of bytecode cache. sizeof(UnlinkedFunctionCodeBlock)
goes from 216 to 208 bytes, so its cell goes from 224 to 208 bytes as well.

* Source/JavaScriptCore/bytecode/BytecodeRewriter.cpp:
(JSC::BytecodeRewriter::execute):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
(JSC::CodeBlock::numberOfJumpTargets const): Deleted.
(JSC::CodeBlock::jumpTarget const): Deleted.
* Source/JavaScriptCore/bytecode/PreciseJumpTargets.cpp:
(JSC::computePreciseJumpTargetsInternal):
(JSC::computePreciseJumpTargets):
(JSC::recomputePreciseJumpTargets): Deleted.
* Source/JavaScriptCore/bytecode/PreciseJumpTargets.h:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp:
(JSC::UnlinkedCodeBlock::visitChildrenImpl):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
(JSC::UnlinkedCodeBlock::numberOfJumpTargets const): Deleted.
(JSC::UnlinkedCodeBlock::jumpTarget const): Deleted.
(JSC::UnlinkedCodeBlock::lastJumpTarget const): Deleted.
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp:
(JSC::UnlinkedCodeBlockGenerator::finalize):
(JSC::UnlinkedCodeBlockGenerator::applyModification):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h:
(JSC::UnlinkedCodeBlockGenerator::numberOfJumpTargets const): Deleted.
(JSC::UnlinkedCodeBlockGenerator::addJumpTarget): Deleted.
(JSC::UnlinkedCodeBlockGenerator::jumpTarget const): Deleted.
(JSC::UnlinkedCodeBlockGenerator::lastJumpTarget const): Deleted.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::generate):
(JSC::BytecodeGenerator::emitEnter):
* Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBaseInlines.h:
(JSC::BytecodeGeneratorBase&lt;Traits&gt;::emitLabel):
* Source/JavaScriptCore/lol/LOLJIT.cpp:
(JSC::LOL::LOLJIT::compileAndLinkWithoutFinalizing):
* Source/JavaScriptCore/lol/LOLJIT.h:
(JSC::LOL::LOLJIT::nextBytecodeIndexWithFlushForJumpTargetsIfNeeded):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedCodeBlock&lt;CodeBlockType&gt;::decode const):
(JSC::CachedCodeBlock&lt;CodeBlockType&gt;::encode):

Canonical link: <a href="https://commits.webkit.org/319376@main">https://commits.webkit.org/319376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d23d07c5b0fa1a10a1cbede7cdd7e0ab09abec72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145615 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141485 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121927 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43844 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42115 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3893 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10716 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41769 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2666 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42565 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193440 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54905 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150879 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40413 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55592 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38392 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150587 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45175 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127873 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123452 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54108 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16767 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53490 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53728 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53555 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->