### PR TITLE
[JSC] Pack `UnlinkedMetadataTable` flags into the same word as `m_numValueProfiles` to shrink it from 24 to 16 bytes

### DIFF
--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
@@ -98,8 +98,8 @@ public:
 
     unsigned numValueProfiles() const { return m_numValueProfiles; }
 
-    TriState didOptimize() const { return m_didOptimize; }
-    void setDidOptimize(TriState didOptimize) { m_didOptimize = didOptimize; }
+    TriState didOptimize() const { return static_cast<TriState>(m_didOptimize); }
+    void setDidOptimize(TriState didOptimize) { m_didOptimize = static_cast<unsigned>(didOptimize); }
 
 private:
     enum EmptyTag { Empty };
@@ -165,12 +165,15 @@ private:
         return std::bit_cast<Offset32*>(m_rawBuffer + m_numValueProfiles * sizeof(ValueProfile) + sizeof(LinkingData) + s_offset16TableSize);
     }
 
-    bool m_hasMetadata : 1;
-    bool m_isFinalized : 1;
-    bool m_isLinked : 1;
-    bool m_is32Bit : 1;
-    TriState m_didOptimize : 2 { TriState::Indeterminate };
-    unsigned m_numValueProfiles { 0 };
+    static constexpr unsigned s_numValueProfilesBits = 26;
+    static constexpr unsigned s_maxNumValueProfiles = (1U << s_numValueProfilesBits) - 1;
+
+    unsigned m_hasMetadata : 1;
+    unsigned m_isFinalized : 1;
+    unsigned m_isLinked : 1;
+    unsigned m_is32Bit : 1;
+    unsigned m_didOptimize : 2 { static_cast<unsigned>(TriState::Indeterminate) };
+    unsigned m_numValueProfiles : s_numValueProfilesBits { 0 };
     uint8_t* m_rawBuffer;
 };
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTableInlines.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTableInlines.h
@@ -71,6 +71,7 @@ ALWAYS_INLINE unsigned UnlinkedMetadataTable::addEntry(OpcodeID opcodeID)
 ALWAYS_INLINE unsigned UnlinkedMetadataTable::addValueProfile()
 {
     ASSERT(!m_isFinalized);
+    RELEASE_ASSERT(m_numValueProfiles < s_maxNumValueProfiles);
     m_hasMetadata = true;
     // Preinecrement because we want the first value profile's offset to be 1, since it's negative indexed.
     return ++m_numValueProfiles;


### PR DESCRIPTION
#### f6cb6f0adc5b1553b6899a51acb52fed79e85a7c
<pre>
[JSC] Pack `UnlinkedMetadataTable` flags into the same word as `m_numValueProfiles` to shrink it from 24 to 16 bytes
<a href="https://bugs.webkit.org/show_bug.cgi?id=321844">https://bugs.webkit.org/show_bug.cgi?id=321844</a>

Reviewed by NOBODY (OOPS!).

UnlinkedMetadataTable is 24 bytes: the refcount takes 4 bytes, the six flag
bits take 1 byte, then m_numValueProfiles is padded to offset 8 and
m_rawBuffer to offset 16. fastMalloc rounds 24 up to a 32 byte chunk.

Every UnlinkedCodeBlock owns one, so this is 32 bytes per function.
m_numValueProfiles never needs 32 bits, so this patch narrows it to 26 bits
and packs the flags into the same word, bringing the object to 16 bytes and
the malloc chunk to 16 bytes. All bit-fields are declared as unsigned so that
MSVC also packs them into one word. addValueProfile() RELEASE_ASSERTs that
the count fits.

Measured with --dumpGeneratedBytecodes on JetStream startup workloads
(unique UnlinkedCodeBlocks): typescript-lib 4615 (-74 KB), babylonjs-startup-es6
3835 (-61 KB), jsdom-d3-startup 2104 (-34 KB), typescript-octane 1132 (-18 KB).

* Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h:
(JSC::UnlinkedMetadataTable::didOptimize const):
(JSC::UnlinkedMetadataTable::setDidOptimize):
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTableInlines.h:
(JSC::UnlinkedMetadataTable::addValueProfile):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6cb6f0adc5b1553b6899a51acb52fed79e85a7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191099 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141116 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97810 "3 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43451 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41729 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3533 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10345 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41389 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2259 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42159 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193034 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54496 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150497 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55184 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150216 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44808 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127450 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122783 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53701 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16382 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53083 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53320 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->