### PR TITLE
inspector/heap/getRemoteObject.html is a flaky text failure

### DIFF
--- a/LayoutTests/inspector/heap/getRemoteObject.html
+++ b/LayoutTests/inspector/heap/getRemoteObject.html
@@ -80,6 +80,14 @@ function test()
         name: "GetRemoteObjectCollectedObject",
         description: "Calling Heap.getRemoteObject for an object that has been collected should result in an error.",
         test(resolve, reject) {
+            function findNodeByPropertyName(objectId, maps, propertyName, callback) {
+                for (let node of maps) {
+                    WI.HeapSnapshotWorkerProxy.singleton().callMethod(objectId, "retainers", node.id, ({edges}) => {
+                        if (edges.some((edge) => (edge.type === "Property" || edge.type === "Variable") && edge.data === propertyName))
+                            callback(node);
+                    });
+                }
+            }
             HeapAgent.snapshot((error, timestamp, snapshotStringData) => { // All pre-existing objects.
                 InspectorTest.evaluateInPage("triggerCreateMapObject()");
                 HeapAgent.snapshot((error, timestamp, snapshotStringData) => { // Newly created objects.
@@ -93,11 +101,12 @@ function test()
                             InspectorTest.evaluateInPage("triggerDeleteMapObject()");
                             HeapAgent.gc();
 
-                            let heapSnapshotNode = maps.reduce((result, x) => result.id < x.id ? x : result, maps[0]);
-                            HeapAgent.getRemoteObject(heapSnapshotNode.id, "test", (error, remoteObjectPayload) => {
-                                InspectorTest.expectThat(error, "Should get an error when object has been collected.");
-                                InspectorTest.pass(error);
-                                resolve();
+                            findNodeByPropertyName(objectId, maps, "myMap", (heapSnapshotNode) => {
+                                HeapAgent.getRemoteObject(heapSnapshotNode.id, "test", (error, remoteObjectPayload) => {
+                                    InspectorTest.expectThat(error, "Should get an error when object has been collected.");
+                                    InspectorTest.pass(error);
+                                    resolve();
+                                });
                             });
                         });
                     });

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5217,8 +5217,6 @@ webkit.org/b/315517 imported/w3c/web-platform-tests/css/css-values/attr-pseudo-e
 
 webkit.org/b/315756 fast/css/container-query-orientation-modal-dialog-crash.html [ Crash Pass ]
 
-webkit.org/b/315925 inspector/heap/getRemoteObject.html [ Failure Pass ]
-
 webkit.org/b/316158 fullscreen/full-screen-enter-while-exiting-mid-completion-handler.html [ Crash Pass ]
 
 webkit.org/b/316192 [ Release ] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/no-cors.https.html [ Crash Pass ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -830,7 +830,7 @@ webkit.org/b/206708 fast/animation/request-animation-frame-iframe.html [ Pass Fa
 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-write-twice-transform.https.html [ Pass Failure ]
 
-webkit.org/b/206903 inspector/heap/getRemoteObject.html [ Pass Crash Failure ]
+webkit.org/b/206903 inspector/heap/getRemoteObject.html [ Pass Crash ]
 
 webkit.org/b/207141 [ Debug ] inspector/canvas/create-context-bitmaprenderer.html [ Pass Failure ]
 


### PR DESCRIPTION
#### c8774020913be0fbd355d7e147e1f48389d1ce55
<pre>
inspector/heap/getRemoteObject.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=315925">https://bugs.webkit.org/show_bug.cgi?id=315925</a>

Reviewed by Alexey Proskuryakov.

At the moment of running the test &apos;GetRemoteObjectCollectedObject&apos;, the
&apos;maps&apos; collection always contains two elements. The code assummes that
it&apos;s always the element in &apos;maps&apos; with the highest &apos;id&apos; the one who
corresponds to the global object &apos;myMap&apos;, the target object the test
needs to later inspect.

The test was flaky because the heuristic to retrieve the
&apos;myMap&apos; object was not correct and sometimes the other map object in the
collection was returned instead. Since that object still exists, the test
fails.

The test has been refactored to guarantee always the &apos;myMap&apos; object is
returned. To do that, the collection of retainer objects is iterated.
The property or variable object with name equals to &apos;myMap&apos; will be the
one used for inspection.

* LayoutTests/inspector/heap/getRemoteObject.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/319586@main">https://commits.webkit.org/319586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad1bc1bace9ab72f1d19938ae57013c7d9c35bec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146261 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142038 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122473 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44398 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42666 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154795 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42296 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3321 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194085 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151447 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56238 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151152 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27632 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45722 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124293 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54752 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17292 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54133 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54372 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->