### PR TITLE
::selection fails to repaint on style change

### DIFF
--- a/LayoutTests/fast/repaint/highlight-pseudo-rule-change-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-pseudo-rule-change-expected.txt
@@ -5,5 +5,5 @@ PASS CONTROL element's own background-color
 PASS CSSOM edit of a matching ::highlight() rule
 PASS CSSOM edit after getComputedStyle() cached the pseudo style
 PASS class change that starts matching .classy::highlight()
-FAIL (no repaint) CSSOM edit of a matching ::selection rule
+PASS CSSOM edit of a matching ::selection rule
 

--- a/LayoutTests/fast/repaint/highlight-pseudo-rule-change.html
+++ b/LayoutTests/fast/repaint/highlight-pseudo-rule-change.html
@@ -32,8 +32,6 @@ getSelection().addRange(range(selectionTarget));
 const ruleFor = id => [...document.styleSheets[0].cssRules].find(rule => rule.selectorText && rule.selectorText.includes(id));
 
 // A mutation confined to a highlight pseudo-element must still repaint the originating element.
-// FIXME: ::selection still reports NO REPAINT, because selectionPseudoStyle() resolves without
-// caching, so there is no previous value to compare against.
 // These cases depend on the highlight pseudo styles having been resolved and cached by painting,
 // the way they are on a real page. A display with nothing dirty may not repaint the text at all, so
 // dirty the page first, otherwise there is no previous style to compare against and the test is flaky.

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2001,7 +2001,7 @@ Color RenderElement::selectionColor() const
         || (view().frameView().paintBehavior().containsAny({ PaintBehavior::SelectionOnly, PaintBehavior::SelectionAndBackgroundsOnly })))
         return Color();
 
-    if (auto pseudoStyle = selectionPseudoStyle()) {
+    if (CheckedPtr pseudoStyle = selectionPseudoStyle()) {
         Style::ColorPropertyResolver<Style::ColorPropertyTraits<Property>> colorPropertyResolver { *pseudoStyle };
         auto color = colorPropertyResolver.visitedDependentColorApplyingColorFilter();
         if (!color.isValid())
@@ -2014,22 +2014,9 @@ Color RenderElement::selectionColor() const
     return theme().inactiveSelectionForegroundColor(styleColorOptions());
 }
 
-std::unique_ptr<Style::ComputedStyle> RenderElement::selectionPseudoStyle() const
+const Style::ComputedStyle* RenderElement::selectionPseudoStyle() const
 {
-    if (isAnonymous())
-        return nullptr;
-
-    if (auto selectionStyle = resolvePseudoElementStyle({ PseudoElementType::Selection })) {
-        // We intentionally return the pseudo selection style here if it exists before ascending to
-        // the shadow host element. This allows us to apply selection pseudo styles in user agent
-        // shadow roots, instead of always deferring to the shadow host's selection pseudo style.
-        return selectionStyle;
-    }
-
-    if (auto* renderer = rendererForPseudoStyleAcrossShadowBoundary())
-        return renderer->resolvePseudoElementStyle({ PseudoElementType::Selection });
-
-    return nullptr;
+    return textSegmentPseudoStyle(PseudoElementType::Selection);
 }
 
 Color RenderElement::selectionForegroundColor() const
@@ -2055,7 +2042,7 @@ Color RenderElement::selectionBackgroundColor() const
         pseudoStyleCandidate = pseudoStyleCandidate->firstNonAnonymousAncestor();
 
     if (pseudoStyleCandidate) {
-        auto pseudoStyle = pseudoStyleCandidate->selectionPseudoStyle();
+        CheckedPtr pseudoStyle = pseudoStyleCandidate->selectionPseudoStyle();
         if (pseudoStyle && pseudoStyle->visitedDependentBackgroundColorApplyingColorFilter().isValid())
             return theme().transformSelectionBackgroundColor(pseudoStyle->visitedDependentBackgroundColorApplyingColorFilter(), styleColorOptions());
     }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -122,7 +122,7 @@ public:
 
     bool hasEligibleContainmentForSizeQuery() const;
 
-    std::unique_ptr<Style::ComputedStyle> selectionPseudoStyle() const;
+    const Style::ComputedStyle* selectionPseudoStyle() const LIFETIME_BOUND;
 
     // Obtains the selection colors that should be used when painting a selection.
     Color selectionBackgroundColor() const;

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -70,7 +70,7 @@ public:
     Color selectionBackgroundColor() const;
     Color selectionForegroundColor() const;
     Color selectionEmphasisMarkColor() const;
-    std::unique_ptr<Style::ComputedStyle> selectionPseudoStyle() const;
+    const Style::ComputedStyle* selectionPseudoStyle() const LIFETIME_BOUND;
 
     const Style::ComputedStyle* spellingErrorPseudoStyle() const LIFETIME_BOUND;
     const Style::ComputedStyle* grammarErrorPseudoStyle() const LIFETIME_BOUND;
@@ -318,7 +318,7 @@ inline Color RenderText::selectionEmphasisMarkColor() const
     return Color();
 }
 
-inline std::unique_ptr<Style::ComputedStyle> RenderText::selectionPseudoStyle() const
+inline const Style::ComputedStyle* RenderText::selectionPseudoStyle() const
 {
     if (auto* ancestor = firstNonAnonymousAncestor())
         return ancestor->selectionPseudoStyle();

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -155,7 +155,7 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
     case MarkedText::Type::Selection: {
         style.textStyles = computeTextSelectionPaintStyle(style.textStyles, renderer, lineStyle, paintInfo, style.textShadow);
 
-        if (auto selectionStyle = renderer.selectionPseudoStyle())
+        if (CheckedPtr selectionStyle = renderer.selectionPseudoStyle())
             computeDecorationStylesForPseudoElementStyle(style, *selectionStyle, paintInfo);
 
         Color selectionBackgroundColor = renderer.selectionBackgroundColor();

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -411,7 +411,7 @@ void TextBoxPainter::paintForegroundAndDecorations()
     auto hasSelectionDecoration = [&] {
         if (!shouldPaintSelectionForeground)
             return false;
-        auto selectionStyle = m_renderer->selectionPseudoStyle();
+        CheckedPtr selectionStyle = m_renderer->selectionPseudoStyle();
         return selectionStyle && !selectionStyle->textDecorationLineInEffect().isNone();
     };
 

--- a/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -167,7 +167,7 @@ TextPaintStyle computeTextSelectionPaintStyle(const TextPaintStyle& textPaintSty
         selectionPaintStyle.emphasisMarkColor = emphasisMarkForeground;
 
     RefPtr view = renderer.frame().view();
-    if (auto pseudoStyle = renderer.selectionPseudoStyle()) {
+    if (CheckedPtr pseudoStyle = renderer.selectionPseudoStyle()) {
         selectionPaintStyle.hasExplicitlySetFillColor = pseudoStyle->hasExplicitlySetColor();
         selectionShadow = paintInfo.forceTextColor() ? Style::TextShadows { CSS::Keyword::None { } } : pseudoStyle->textShadow();
         auto viewportSize = view ? view->size() : IntSize();


### PR DESCRIPTION
#### 5dd82e774cf8a2ead554aa962a73e855606b1d4c
<pre>
::selection fails to repaint on style change
<a href="https://bugs.webkit.org/show_bug.cgi?id=321846">https://bugs.webkit.org/show_bug.cgi?id=321846</a>
<a href="https://rdar.apple.com/184994906">rdar://184994906</a>

Reviewed by Alan Baradlay.

Active selections fail to visually update if ::selection style changes. The repaint code compares
the highlight pseudo-element styles cached in the parent ComputedStyle, and ::selection was still
resolving without caching, so there was never a previous style to compare against.

* LayoutTests/fast/repaint/highlight-pseudo-rule-change-expected.txt:
* LayoutTests/fast/repaint/highlight-pseudo-rule-change.html:

The ::selection case passes now.

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::selectionPseudoStyle const):

Use textSegmentPseudoStyle(), which already does this with lazyPseudoElementStyle(). It was an
exact copy of what selectionPseudoStyle() was doing, minus the caching.

* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderText.h:
(WebCore::RenderText::selectionPseudoStyle const):

* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paintForegroundAndDecorations):
* Source/WebCore/rendering/TextPaintStyle.cpp:
(WebCore::computeTextSelectionPaintStyle):

The returned style is now owned by the parent ComputedStyle rather than the caller, so the locals
need to be CheckedPtr.

Canonical link: <a href="https://commits.webkit.org/319662@main">https://commits.webkit.org/319662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84e556b3af91776d0b8b24b8071619d69716a482

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191122 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145231 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182770 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141141 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97837 "3 flakes 6 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2e2592b-1939-478d-bd89-02f6157dfb9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161888 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121592 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c050b14-83b1-4c54-ab43-c007ec5fcfbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43479 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41753 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153883 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41415 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2282 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193057 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150521 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55207 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150239 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44835 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127473 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122846 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53724 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16408 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53106 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53343 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->