### PR TITLE
Fix -Wthread-safety-precise and constexpr for clang 18

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -376,13 +376,14 @@ bool CalleeGroup::installOptimizedCallee(Locker<Lock>& locker, const ModuleInfor
 #endif
 #if ENABLE(WEBASSEMBLY_BBQJIT)
     if (callee->compilationMode() == CompilationMode::BBQMode) {
-        Locker bbqLocker { slot->m_bbqCallee.lock() };
+        auto& bbqCallee = slot->m_bbqCallee;
+        Locker bbqLocker { bbqCallee.lock() };
         // A retired BBQCallee may still be here: releaseBBQCallee re-arms IPInt's tier-up counter, so
         // a function can be compiled to BBQ again before the previous callee is destroyed. Overwriting
         // that weak reference is fine, it does not own the callee. Overwriting a strong one would drop
         // the last reference to code that may still be executing.
-        RELEASE_ASSERT(!slot->m_bbqCallee.isStrong() || !slot->m_bbqCallee.get());
-        slot->m_bbqCallee = Ref { uncheckedDowncast<BBQCallee>(callee.get()) };
+        RELEASE_ASSERT(!bbqCallee.isStrong() || !bbqCallee.get());
+        bbqCallee = Ref { uncheckedDowncast<BBQCallee>(callee.get()) };
     }
 #endif
 

--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -69,7 +69,7 @@ class LayoutUnit {
 public:
     constexpr LayoutUnit() : m_value(0) { }
     LayoutUnit(const LayoutUnit&) = default;
-    LayoutUnit(int value) { setValue(value); }
+    constexpr LayoutUnit(int value) { setValue(value); }
     LayoutUnit(unsigned short value) { setValue(value); }
     LayoutUnit(unsigned value) { setValue(value); }
     explicit LayoutUnit(unsigned long value)
@@ -227,7 +227,7 @@ private:
         return ::abs(value) <= std::numeric_limits<int>::max() / kFixedPointDenominator;
     }
 
-    inline void setValue(int value)
+    constexpr void setValue(int value)
     {
         if (value > intMaxForLayoutUnit)
             m_value = std::numeric_limits<int>::max();
@@ -361,7 +361,7 @@ inline double operator*(const double a, const LayoutUnit& b)
     return a * b.toDouble();
 }
 
-inline LayoutUnit operator/(const LayoutUnit& a, const LayoutUnit& b)
+constexpr LayoutUnit operator/(const LayoutUnit& a, const LayoutUnit& b)
 {
     long long rawVal = static_cast<long long>(kFixedPointDenominator) * a.rawValue() / b.rawValue();
     return LayoutUnit::fromRawValue(clampTo<int>(rawVal));
@@ -377,7 +377,7 @@ inline double operator/(const LayoutUnit& a, double b)
     return a.toDouble() / b;
 }
 
-inline LayoutUnit operator/(const LayoutUnit& a, int b)
+constexpr LayoutUnit operator/(const LayoutUnit& a, int b)
 {
     return a / LayoutUnit(b);
 }

--- a/Source/WebCore/platform/graphics/LayoutPoint.h
+++ b/Source/WebCore/platform/graphics/LayoutPoint.h
@@ -39,7 +39,7 @@ namespace WebCore {
 class LayoutPoint {
 public:
     constexpr LayoutPoint() = default;
-    template<typename T, typename U> LayoutPoint(T x, U y) : m_x(x), m_y(y) { }
+    template<typename T, typename U> constexpr LayoutPoint(T x, U y) : m_x(x), m_y(y) { }
     LayoutPoint(const IntPoint& point) : m_x(point.x()), m_y(point.y()) { }
     explicit LayoutPoint(const FloatPoint& size)
         : m_x(size.x()), m_y(size.y()) { }
@@ -240,4 +240,3 @@ struct LayoutPointLimits {
 };
 
 } // namespace WebCore
-

--- a/Source/WebCore/platform/graphics/LayoutRect.h
+++ b/Source/WebCore/platform/graphics/LayoutRect.h
@@ -50,7 +50,7 @@ public:
     LayoutRect(const LayoutPoint& location, const LayoutSize& size)
         : m_location(location), m_size(size) { }
     template<typename T1, typename T2, typename U1, typename U2>
-    LayoutRect(T1 x, T2 y, U1 width, U2 height)
+    constexpr LayoutRect(T1 x, T2 y, U1 width, U2 height)
         : m_location(LayoutPoint(x, y)), m_size(LayoutSize(width, height)) { }
     LayoutRect(const LayoutPoint& topLeft, const LayoutPoint& bottomRight)
         : m_location(topLeft), m_size(LayoutSize(bottomRight.x() - topLeft.x(), bottomRight.y() - topLeft.y())) { }
@@ -314,4 +314,3 @@ FloatRect encloseRectToDevicePixels(const LayoutRect&, float pixelSnappingFactor
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const LayoutRect&);
 
 } // namespace WebCore
-

--- a/Source/WebCore/platform/graphics/LayoutSize.h
+++ b/Source/WebCore/platform/graphics/LayoutSize.h
@@ -51,7 +51,7 @@ class LayoutSize {
 public:
     LayoutSize() = default;
     LayoutSize(const IntSize& size) : m_width(size.width()), m_height(size.height()) { }
-    template<typename T, typename U> LayoutSize(T width, U height) : m_width(width), m_height(height) { }
+    template<typename T, typename U> constexpr LayoutSize(T width, U height) : m_width(width), m_height(height) { }
 
     explicit LayoutSize(const FloatSize& size) : m_width(size.width()), m_height(size.height()) { }
     
@@ -215,4 +215,3 @@ struct LayoutSizeLimits {
 };
 
 } // namespace WebCore
-


### PR DESCRIPTION
#### 3c64729cefbca0dc42bfa07e6f0c301ae663fbbf
<pre>
Fix -Wthread-safety-precise and constexpr for clang 18
<a href="https://bugs.webkit.org/show_bug.cgi?id=321848">https://bugs.webkit.org/show_bug.cgi?id=321848</a>

Unreviewed build fix.

Canonical link: <a href="https://commits.webkit.org/319233@main">https://commits.webkit.org/319233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6d5274d9856db5c0d5d8957879b39c7ce0cbccf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191110 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145219 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54557 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141128 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121579 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43462 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41740 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3545 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10357 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/153866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41401 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2270 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42170 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193045 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54507 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150507 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55195 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150226 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27455 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44819 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127461 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122814 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53712 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16394 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53094 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->