### PR TITLE
MiniBrowser should support downloads for testing purposes

### DIFF
--- a/ManualTests/download-triggers.html
+++ b/ManualTests/download-triggers.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>Download triggers</title>
+<style>
+li { margin-bottom: 0.75em; }
+code { background-color: #eee; padding: 0 2px; }
+</style>
+</head>
+<body>
+<p>Test for <a href="https://bugs.webkit.org/show_bug.cgi?id=138673">bug 138673</a>:
+MiniBrowser should support downloads for testing purposes.</p>
+
+<p><b>Open this in a WK2 window</b>, from <code>file://</code> or over HTTP,
+either works. One thing that will look like a failure and is not: in a
+<b>WK1</b> window steps 1 to 4 do nothing whatever the browser does with
+downloads, because the <code>download</code> attribute is off by default in
+legacy WebKit (<code>DownloadAttributeEnabled</code> in
+<code>Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml</code>).</p>
+
+<p>Steps 5 and 7 use blob URLs on purpose. They are decided from the response
+rather than from the link, so they need a navigation the browser will really
+perform, and a top-frame navigation to a <code>data:</code> URL is refused
+whatever the response says &mdash; see <code>disallowDataRequest</code> in
+<code>Source/WebCore/loader/DocumentLoader.cpp</code>. Do not simplify them back
+to <code>data:</code>; both would then report the wrong result, the control
+loudest of all.</p>
+
+<p><b>STEPS TO TEST:</b> click every link and button below. None of them should
+navigate this page away, and none of them should show the file's contents
+inline.</p>
+
+<p id="success" style="background-color: palegreen; padding: 3px;"><b>TEST PASS:</b>
+each of the six numbered steps saves a file, and the control link in step 7
+navigates. Three of the files are named by the browser rather than by the test,
+so the expected set is: <code>download-attribute.txt</code>,
+<code>blob.txt</code>, <code>Unknown.txt</code>, <code>from-script.txt</code>,
+<code>Unknown</code>, <code>Unknown-1.txt</code>.</p>
+
+<p id="failure" style="background-color: #FF3300; padding: 3px;"><b>TEST FAIL:</b>
+any step leaves the download folder unchanged, or replaces this page with the
+file's contents, or shows a blank page.</p>
+
+<ol>
+<li>
+    <a download="download-attribute.txt" href="data:text/plain,download attribute on a data: URL">
+    download attribute, named
+    </a>
+    &mdash; saves <code>download-attribute.txt</code>.
+</li>
+<li>
+    <a id="blob-link" download="blob.txt">
+    download attribute on a blob: URL
+    </a>
+    &mdash; saves <code>blob.txt</code>. The response here is synthesized by
+    WebKit rather than coming from a server.
+</li>
+<li>
+    <a download href="data:text/plain,bare download attribute">
+    download attribute, unnamed
+    </a>
+    &mdash; saves a file whose name the browser picks, with a
+    <code>.txt</code> extension taken from the MIME type.
+</li>
+<li>
+    <button id="programmatic">download attribute, clicked from script</button>
+    &mdash; saves <code>from-script.txt</code>. Same code path as step 1, but
+    with no user click on the link itself.
+</li>
+<li>
+    <a id="octet-stream-link">
+    no download attribute, MIME type the browser cannot display
+    </a>
+    &mdash; saves a file. A blob URL carries no filename and
+    <code>application/octet-stream</code> implies no extension, so expect a
+    browser-picked name with no extension, currently <code>Unknown</code>. That
+    is what tells it apart from step 3's file. Here the decision comes from the
+    response, not from the link, so it exercises a different delegate than steps
+    1 to 4.
+</li>
+<li>
+    Right-click <a href="data:text/plain,downloaded from the context menu">this
+    link</a> and choose <b>Download Linked File</b> &mdash; saves a file. This
+    is a third code path again: the download is created by the context menu,
+    with no policy decision involved.
+</li>
+<li>
+    <b>Control:</b>
+    <a id="control-link">
+    no download attribute, MIME type the browser can display
+    </a>
+    &mdash; must <em>navigate</em> and show its text, not download. If this one
+    downloads, the fix is too aggressive.
+</li>
+</ol>
+
+<p>Downloading a file whose name is already taken should also work: run step 1
+twice and check that the second file is saved next to the first under a
+different name, rather than failing silently.</p>
+
+<p>A response carrying <code>Content-Disposition: attachment</code> with a
+displayable MIME type is a further case that this page cannot cover, because it
+needs a server that sets the header. See bug 138673 for a page and a server
+command that do.</p>
+
+<script>
+document.getElementById("blob-link").href =
+    URL.createObjectURL(new Blob(["download attribute on a blob: URL"], { type: "text/plain" }));
+
+// Steps 5 and 7 are decided from the response rather than from the link, so they
+// have to be navigations the browser will actually perform. A data: URL is no use
+// here: a top-frame navigation to one is refused outright, whatever the response
+// says, so both steps would report the wrong thing. See DocumentLoader's
+// disallowDataRequest. Blob URLs are same origin and navigable.
+document.getElementById("octet-stream-link").href =
+    URL.createObjectURL(new Blob(["This is a download.\n"], { type: "application/octet-stream" }));
+
+document.getElementById("control-link").href =
+    URL.createObjectURL(new Blob(["This page should have replaced the test.\n"], { type: "text/plain" }));
+
+document.getElementById("programmatic").addEventListener("click", () => {
+    const link = document.createElement("a");
+    link.href = "data:text/plain,download attribute clicked from script";
+    link.download = "from-script.txt";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+});
+</script>
+</body>
+</html>

--- a/Tools/MiniBrowser/MiniBrowser.entitlements
+++ b/Tools/MiniBrowser/MiniBrowser.entitlements
@@ -10,6 +10,8 @@
 	<true/>
 	<key>com.apple.security.device.usb</key>
 	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -34,9 +34,12 @@
 #import <QuartzCore/CATextLayer.h>
 #import <SecurityInterface/SFCertificateTrustPanel.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#import <WebKit/WKDownload.h>
+#import <WebKit/WKDownloadDelegate.h>
 #import <WebKit/WKFrameInfo.h>
 #import <WebKit/WKNavigationActionPrivate.h>
 #import <WebKit/WKNavigationDelegate.h>
+#import <WebKit/WKNavigationDelegatePrivate.h>
 #import <WebKit/WKOpenPanelParametersPrivate.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKUIDelegate.h>
@@ -98,7 +101,7 @@ static const int testFooterBannerHeight = 58;
 
 @end
 
-@interface WK2BrowserWindowController () <NSTextFinderBarContainer, _WKFindDelegate, NSSearchFieldDelegate, WKNavigationDelegate, WKUIDelegate, WKUIDelegatePrivate, _WKIconLoadingDelegate>
+@interface WK2BrowserWindowController () <NSTextFinderBarContainer, _WKFindDelegate, NSSearchFieldDelegate, WKDownloadDelegate, WKNavigationDelegate, WKNavigationDelegatePrivate, WKUIDelegate, WKUIDelegatePrivate, _WKIconLoadingDelegate>
 @end
 
 @implementation WK2BrowserWindowController {
@@ -977,6 +980,19 @@ static BOOL isJavaScriptURL(NSURL *url)
     return [url.scheme isEqualToString:@"javascript"];
 }
 
+static BOOL responseIsAttachment(NSURLResponse *response)
+{
+    if (![response isKindOfClass:[NSHTTPURLResponse class]])
+        return NO;
+
+    NSString *disposition = [(NSHTTPURLResponse *)response valueForHTTPHeaderField:@"Content-Disposition"];
+    if (!disposition.length)
+        return NO;
+
+    NSString *type = [[disposition componentsSeparatedByString:@";"].firstObject stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    return [type caseInsensitiveCompare:@"attachment"] == NSOrderedSame;
+}
+
 #pragma mark WKNavigationDelegate
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
@@ -994,6 +1010,13 @@ static BOOL isJavaScriptURL(NSURL *url)
     }();
 
     preferences.allowsContentJavaScript = NSApplication.sharedApplication.browserAppDelegate.settingsController.allowsContentJavascript;
+
+    // This has to be tested before _canHandleRequest, which is true for the http and https
+    // URLs that a download attribute usually points at.
+    if (navigationAction.shouldPerformDownload) {
+        decisionHandler(WKNavigationActionPolicyDownload, preferences);
+        return;
+    }
 
     if (navigationAction._canHandleRequest) {
         decisionHandler(WKNavigationActionPolicyAllow, preferences);
@@ -1014,7 +1037,11 @@ static BOOL isJavaScriptURL(NSURL *url)
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler
 {
     LOG(@"decidePolicyForNavigationResponse");
-    decisionHandler(WKNavigationResponsePolicyAllow);
+
+    // WebKit does not turn these into downloads on the client's behalf, so a browser that wants
+    // them downloaded has to ask for it here.
+    BOOL shouldDownload = responseIsAttachment(navigationResponse.response) || (!navigationResponse.canShowMIMEType && navigationResponse.forMainFrame);
+    decisionHandler(shouldDownload ? WKNavigationResponsePolicyDownload : WKNavigationResponsePolicyAllow);
     [self validateToolbar];
 }
 
@@ -1088,6 +1115,24 @@ static BOOL isJavaScriptURL(NSURL *url)
     LOG(@"didFailNavigation: %@, error %@", navigation, error);
 }
 
+- (void)webView:(WKWebView *)webView navigationAction:(WKNavigationAction *)navigationAction didBecomeDownload:(WKDownload *)download
+{
+    LOG(@"navigationAction didBecomeDownload: %@", download);
+    download.delegate = self;
+}
+
+- (void)webView:(WKWebView *)webView navigationResponse:(WKNavigationResponse *)navigationResponse didBecomeDownload:(WKDownload *)download
+{
+    LOG(@"navigationResponse didBecomeDownload: %@", download);
+    download.delegate = self;
+}
+
+- (void)_webView:(WKWebView *)webView contextMenuDidCreateDownload:(WKDownload *)download
+{
+    LOG(@"contextMenuDidCreateDownload: %@", download);
+    download.delegate = self;
+}
+
 - (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView
 {
     NSLog(@"WebContent process crashed; reloading");
@@ -1117,6 +1162,52 @@ static BOOL isJavaScriptURL(NSURL *url)
     completionHandler(^void (NSData *data) {
         LOG(@"Icon URL %@ received icon data of length %u", parameters.url, (unsigned)data.length);
     });
+}
+
+#pragma mark WKDownloadDelegate
+
+static NSURL *availableDownloadURLWithFilename(NSString *filename)
+{
+    NSURL *downloadsDirectory = [NSFileManager.defaultManager URLsForDirectory:NSDownloadsDirectory inDomains:NSUserDomainMask].firstObject;
+    if (!downloadsDirectory)
+        return nil;
+
+    NSURL *candidate = [downloadsDirectory URLByAppendingPathComponent:filename];
+
+    // WebKit refuses a destination that already exists rather than overwriting it, so keep
+    // looking until the name is free.
+    NSString *base = candidate.URLByDeletingPathExtension.lastPathComponent;
+    NSString *extension = candidate.pathExtension;
+    for (unsigned suffix = 1; [NSFileManager.defaultManager fileExistsAtPath:candidate.path]; ++suffix) {
+        candidate = [downloadsDirectory URLByAppendingPathComponent:[NSString stringWithFormat:@"%@-%u", base, suffix]];
+        if (extension.length)
+            candidate = [candidate URLByAppendingPathExtension:extension];
+    }
+
+    return candidate;
+}
+
+- (void)download:(WKDownload *)download decideDestinationUsingResponse:(NSURLResponse *)response suggestedFilename:(NSString *)suggestedFilename completionHandler:(void (^)(NSURL *))completionHandler
+{
+    NSURL *destination = availableDownloadURLWithFilename(suggestedFilename.length ? suggestedFilename : @"download");
+    if (!destination) {
+        NSLog(@"Cancelling download of %@: no download folder.", download.originalRequest.URL);
+        completionHandler(nil);
+        return;
+    }
+
+    NSLog(@"Downloading %@ to %@", download.originalRequest.URL, destination.path);
+    completionHandler(destination);
+}
+
+- (void)downloadDidFinish:(WKDownload *)download
+{
+    NSLog(@"Finished downloading %@", download.progress.fileURL.path);
+}
+
+- (void)download:(WKDownload *)download didFailWithError:(NSError *)error resumeData:(NSData *)resumeData
+{
+    NSLog(@"Failed downloading %@: %@", download.originalRequest.URL, error);
 }
 
 #pragma mark Find in Page


### PR DESCRIPTION
#### 619a552127eb2f2f6e9383823edd3dccb81f008a
<pre>
MiniBrowser should support downloads for testing purposes
<a href="https://bugs.webkit.org/show_bug.cgi?id=138673">https://bugs.webkit.org/show_bug.cgi?id=138673</a>
<a href="https://rdar.apple.com/185001852">rdar://185001852</a>

Reviewed by Zak Ridouh.

Clicking a link with a download attribute in Mac MiniBrowser saves nothing: the
page navigates to the file, or goes blank. Same for a response carrying
Content-Disposition: attachment, and for Download Linked File in the context menu.

Three things were missing, each one enough on its own.
decidePolicyForNavigationAction returned Allow for anything _canHandleRequest,
which is true for the http and https URLs a download attribute points at. There
was no WKDownloadDelegate, so a download that did start was never told where to
write. And MiniBrowser is sandboxed with no entitlement for the download folder.

This answers download for a download attribute, and for a response that is an
attachment or a MIME type we cannot display in the main frame. It saves under a
name that is still free, since WebKit refuses a destination that already exists.

Note the WK1 window is untouched; the download attribute is off by default there.

Test: ManualTests/download-triggers.html

* ManualTests/download-triggers.html: Added.
* Tools/MiniBrowser/MiniBrowser.entitlements:
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(responseIsAttachment):
(-[WK2BrowserWindowController webView:decidePolicyForNavigationAction:preferences:decisionHandler:]):
(-[WK2BrowserWindowController webView:decidePolicyForNavigationResponse:decisionHandler:]):
(-[WK2BrowserWindowController webView:navigationAction:didBecomeDownload:]):
(-[WK2BrowserWindowController webView:navigationResponse:didBecomeDownload:]):
(-[WK2BrowserWindowController _webView:contextMenuDidCreateDownload:]):
(availableDownloadURLWithFilename):
(-[WK2BrowserWindowController download:decideDestinationUsingResponse:suggestedFilename:completionHandler:]):
(-[WK2BrowserWindowController downloadDidFinish:]):
(-[WK2BrowserWindowController download:didFailWithError:resumeData:]):

Canonical link: <a href="https://commits.webkit.org/319251@main">https://commits.webkit.org/319251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ace45c40d947c4058b7205678fa041499ed817c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145273 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b88342d1-651d-41e6-8334-0c6e3ba45f4a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141177 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6413a1b4-1b7e-4309-84ce-1fa777e8cbff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121629 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa60ebc4-8e64-43e7-9d5e-f65c2041ad8c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43513 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41792 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153917 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/41452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2324 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193099 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54561 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150562 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40283 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55249 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150279 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44870 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122950 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53766 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16446 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53148 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53213 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->