### PR TITLE
[JSC] Add small-sized fast fill before memset in operationMemoryFill

### DIFF
--- a/Source/JavaScriptCore/b3/B3Operations.cpp
+++ b/Source/JavaScriptCore/b3/B3Operations.cpp
@@ -38,12 +38,13 @@ namespace JSC::B3 {
 namespace {
 
 #if HAVE(INT128_T)
-using WidestCopyUnit = UInt128;
+using WidestUnit = UInt128;
 #else
-using WidestCopyUnit = uint64_t;
+using WidestUnit = uint64_t;
 #endif
 
-constexpr size_t maxFastCopyCount = 4 * sizeof(WidestCopyUnit);
+constexpr size_t maxFastCopyCount = 4 * sizeof(WidestUnit);
+constexpr size_t maxFastFillCount = 4 * sizeof(WidestUnit);
 
 // Copies count bytes as two overlapping sizeof(T) accesses, so it needs
 // sizeof(T) <= count <= 2 * sizeof(T). Both source reads happen before either destination write,
@@ -72,6 +73,18 @@ ALWAYS_INLINE void copyOverlappingEndPairs(uint8_t* dst, const uint8_t* src, siz
     WTF::unalignedStore<T>(dst + count - sizeof(T), high1);
 }
 
+// Writes count bytes as two overlapping runs of unitsPerEnd stores, so it needs
+// unitsPerEnd * sizeof(T) <= count <= 2 * unitsPerEnd * sizeof(T). Every store writes the same
+// splatted value, so unlike the copy case the order of the stores does not matter.
+template<typename T, unsigned unitsPerEnd>
+ALWAYS_INLINE void fillOverlappingEnds(uint8_t* dst, T value, size_t count)
+{
+    for (unsigned i = 0; i < unitsPerEnd; ++i)
+        WTF::unalignedStore<T>(dst + i * sizeof(T), value);
+    for (unsigned i = 0; i < unitsPerEnd; ++i)
+        WTF::unalignedStore<T>(dst + count - (unitsPerEnd - i) * sizeof(T), value);
+}
+
 } // namespace
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryCopy, void, (void* dst, const void* src, size_t count))
@@ -87,10 +100,10 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryCopy, void, (void* dst, const v
             copyOverlappingEnds<uint32_t>(to, from, count);
         else if (count < 2 * sizeof(uint64_t))
             copyOverlappingEnds<uint64_t>(to, from, count);
-        else if (count < 2 * sizeof(WidestCopyUnit))
-            copyOverlappingEnds<WidestCopyUnit>(to, from, count);
+        else if (count < 2 * sizeof(WidestUnit))
+            copyOverlappingEnds<WidestUnit>(to, from, count);
         else
-            copyOverlappingEndPairs<WidestCopyUnit>(to, from, count);
+            copyOverlappingEndPairs<WidestUnit>(to, from, count);
         return;
     }
     memmove(dst, src, count);
@@ -98,6 +111,26 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryCopy, void, (void* dst, const v
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryFill, void, (void* dst, int32_t target, size_t count))
 {
+    if (count - 1 <= maxFastFillCount - 1) {
+        auto* to = static_cast<uint8_t*>(dst);
+        uint64_t splat = static_cast<uint8_t>(target) * 0x0101010101010101ULL;
+        WidestUnit widest = splat;
+        if constexpr (sizeof(WidestUnit) > sizeof(uint64_t))
+            widest = (static_cast<WidestUnit>(splat) << 64) | splat;
+        if (count < sizeof(uint16_t))
+            fillOverlappingEnds<uint8_t, 1>(to, static_cast<uint8_t>(splat), count);
+        else if (count < sizeof(uint32_t))
+            fillOverlappingEnds<uint16_t, 1>(to, static_cast<uint16_t>(splat), count);
+        else if (count < sizeof(uint64_t))
+            fillOverlappingEnds<uint32_t, 1>(to, static_cast<uint32_t>(splat), count);
+        else if (count < 2 * sizeof(uint64_t))
+            fillOverlappingEnds<uint64_t, 1>(to, splat, count);
+        else if (count < 2 * sizeof(WidestUnit))
+            fillOverlappingEnds<WidestUnit, 1>(to, widest, count);
+        else
+            fillOverlappingEnds<WidestUnit, 2>(to, widest, count);
+        return;
+    }
     memset(dst, target, count);
 }
 


### PR DESCRIPTION
#### 31f35870966c055d8ffb5cac2be896174cd513c1
<pre>
[JSC] Add small-sized fast fill before memset in operationMemoryFill
<a href="https://bugs.webkit.org/show_bug.cgi?id=321850">https://bugs.webkit.org/show_bug.cgi?id=321850</a>
<a href="https://rdar.apple.com/185002028">rdar://185002028</a>

Reviewed by Justin Michaud.

As the same to 319202@main, we do inlined small-sized memset in
operationMemoryFill function before calling memset.
We do not do the same to MemoryCopy about paired approach as using FPR
etc. would be costly in filling case than copying case.

* Source/JavaScriptCore/b3/B3Operations.cpp:
(JSC::B3::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/319238@main">https://commits.webkit.org/319238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/384dcdf24f257bea2f52bd3d99d532f05d6fdc3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145222 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52fc36fd-e117-4fd3-9efc-0ab32aa8e42b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141130 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31387eb9-ad02-450c-98dc-614ab8b70c3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121581 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74f21c0c-c3ad-4924-a1c7-c9236c205c84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41743 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3547 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10361 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41405 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2273 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42173 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193048 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54510 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150510 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55198 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150229 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44822 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127464 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122819 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53715 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16398 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53097 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53334 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53162 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->