### PR TITLE
[GLIB] imported/w3c/web-platform-tests/css/css-fonts/font-feature-resolution-002.html is failing

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4195,9 +4195,6 @@ webkit.org/b/212202 fast/scrolling/iframe-scrollable-after-back.html [ Skip ]
 webkit.org/b/212202 fast/scrolling/programmatic-scroll-to-zero-zero.html [ Skip ]
 webkit.org/b/212202 fast/scrolling/rtl-point-in-iframe.html [ Skip ]
 
-# Failing since r277091.
-webkit.org/b/225499 imported/w3c/web-platform-tests/css/css-fonts/font-feature-resolution-002.html [ ImageOnlyFailure ]
-
 webkit.org/b/227053 fast/canvas/canvas-imageSmoothingQuality.html [ Failure ]
 
 # Require expect file for dumped render tree.

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -278,15 +278,18 @@ Vector<hb_feature_t> FontCache::computeFeatures(const FontDescription& fontDescr
         featuresToBeApplied.set(fontFeatureTag("clig"), 0);
     }
 
-    // dlig is off by default in HarfBuzz.
-    auto discretionaryLigatures = fontDescription.variantDiscretionaryLigatures();
-    if (!shouldDisableLigaturesForSpacing && discretionaryLigatures == FontVariantLigatures::Yes)
-        featuresToBeApplied.set(fontFeatureTag("dlig"), 1);
+    if (shouldDisableLigaturesForSpacing) {
+        featuresToBeApplied.set(fontFeatureTag("dlig"), 0);
+        featuresToBeApplied.set(fontFeatureTag("hlig"), 0);
+    } else {
+        auto discretionaryLigatures = fontDescription.variantDiscretionaryLigatures();
+        if (discretionaryLigatures == FontVariantLigatures::Yes)
+            featuresToBeApplied.set(fontFeatureTag("dlig"), 1);
 
-    // hlig is off by default in HarfBuzz.
-    auto historicalLigatures = fontDescription.variantHistoricalLigatures();
-    if (!shouldDisableLigaturesForSpacing && historicalLigatures == FontVariantLigatures::Yes)
-        featuresToBeApplied.set(fontFeatureTag("hlig"), 1);
+        auto historicalLigatures = fontDescription.variantHistoricalLigatures();
+        if (historicalLigatures == FontVariantLigatures::Yes)
+            featuresToBeApplied.set(fontFeatureTag("hlig"), 1);
+    }
 
     // calt is on by default in HarfBuzz.
     auto contextualAlternates = fontDescription.variantContextualAlternates();


### PR DESCRIPTION
#### 96e4dba01e0addf7ec87e81103891bb066a1db3b
<pre>
[GLIB] imported/w3c/web-platform-tests/css/css-fonts/font-feature-resolution-002.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=225499">https://bugs.webkit.org/show_bug.cgi?id=225499</a>

Reviewed by Carlos Garcia Campos.

This test turns font feature &apos;dlig&apos; (discretionary ligatures) ON and OFF
several times. The former code only turned ON this feature, but it never
turned it OFF again. As a result of that, the test was failing because it shown
some characters with ligatures enabled when it shouldn&apos;t.

Now the &apos;dlig&apos; and &apos;hlig&apos; features are always disabled when
&apos;shouldDisableLigaturesForSpacing&apos; is true. Otherwise, those feature tags
are added if each corresponding feature is enabled.

* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
(WebCore::FontCache::computeFeatures):
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/319250@main">https://commits.webkit.org/319250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/974b5f77eca2f25dde9108b3c4080828870de800

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145229 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141135 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121586 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43473 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41750 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41409 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2280 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193055 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54517 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150517 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55205 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150236 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27465 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44830 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127471 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122844 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53722 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16402 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->