### PR TITLE
[EvaluationTimeZoom] Container-percentage units should use the fully unscaled contentBoxWidth/Height

### DIFF
--- a/LayoutTests/fast/css/container-query-units-css-zoom-expected.txt
+++ b/LayoutTests/fast/css/container-query-units-css-zoom-expected.txt
@@ -1,0 +1,19 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x150
+  RenderBlock {HTML} at (0,0) size 800x150
+    RenderBody {BODY} at (0,0) size 800x150
+      RenderBlock (anonymous) at (0,0) size 800x18
+        RenderInline {SPAN} at (0,0) size 71x18
+          RenderText {#text} at (0,0) size 71x18
+            text run at (0,0) width 71: "Unzoomed"
+        RenderText {#text} at (0,0) size 0x0
+      RenderBlock {DIV} at (0,18) size 800x132
+        RenderBlock {DIV} at (0,0) size 800x132
+layer at (0,18) size 264x132
+  RenderBlock (relative positioned) {DIV} at (0,0) size 264x132 [bgcolor=#FF0000]
+    RenderBlock {DIV} at (0,0) size 264x132 [bgcolor=#008000]
+layer at (0,142) size 264x8
+  RenderBlock (positioned) {DIV} at (0,124) size 264x8 [color=#FFFFFF] [bgcolor=#000000]
+    RenderText {#text} at (114,0) size 36x8
+      text run at (114,0) width 36: "Caption Text"

--- a/LayoutTests/fast/css/container-query-units-css-zoom.html
+++ b/LayoutTests/fast/css/container-query-units-css-zoom.html
@@ -1,10 +1,18 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Container query units with page zoom</title>
+    <title>Container query units with css zoom</title>
     <meta name="assert" content="Container query units should use unzoomed lengths">
     <style>
         body {
+            margin: 0;
+        }
+        .outer-1 {
+            zoom: 1.1;
+            margin: 0;
+        }
+        .outer-2 {
+            zoom: 1.2;
             margin: 0;
         }
         .container {
@@ -34,13 +42,14 @@
     </style>
 </head>
 <body>
-    <div class="container">
-        <div class="inner"></div>
-        <div class="caption">Caption Text</div>
+  <span>Unzoomed</span>
+  <div class="outer-1">
+    <div class="outer-2">
+      <div class="container">
+          <div class="inner"></div>
+          <div class="caption">Caption Text</div>
+      </div>
     </div>
+  </div>
 </body>
-<script>
-    if (window.internals)
-        window.internals.setPageZoomFactor(2);
-</script>
 </html>

--- a/LayoutTests/fast/css/container-query-units-page-zoom-expected.html
+++ b/LayoutTests/fast/css/container-query-units-page-zoom-expected.html
@@ -4,31 +4,32 @@
     <title>Container query units with page zoom - expected</title>
     <style>
         body {
+            zoom: 2;
             margin: 0;
         }
         .container {
-            /* 200px * 2x zoom = 400px */
-            width: 400px;
-            /* 100px * 2x zoom = 200px */
-            height: 200px;
+            width: 200px;
+            height: 100px;
             background-color: red;
             overflow: hidden;
             position: relative;
         }
         .inner {
-            width: 400px;
-            height: 200px;
+            /* 100cqw = 100% of 200px = 200px */
+            width: 200px;
+            /* 100cqh = 100% of 100px = 100px */
+            height: 100px;
             background-color: green;
         }
         .caption {
             position: absolute;
             bottom: 0;
             left: 0;
-            /* 100cqw = 200px CSS * 2x zoom = 400px */
-            width: 400px;
+            /* 100cqw = 100% of 200px = 200px */
+            width: 200px;
             text-align: center;
-            /* 5cqmin = 5% of min(400,200) = 10px CSS, 2x zoom = 20px */
-            font-size: 20px;
+            /* 5cqmin = 5% of min(200px,100px) = 5px */
+            font-size: 5px;
             line-height: 1.2;
             color: white;
             background: black;

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -250,13 +250,7 @@ static std::optional<double> resolveContainerUnit(CQ::Axis physicalAxis, const a
         auto* containerRenderer = dynamicDowncast<RenderBox>(element->renderer());
         if (containerRenderer && containerRenderer->hasEligibleContainmentForSizeQuery()) {
             auto widthOrHeight = physicalAxis == CQ::Axis::Width ? containerRenderer->contentBoxWidth() : containerRenderer->contentBoxHeight();
-            auto adjustedWidthOrHeight = widthOrHeight.toDouble();
-
-            // FIXME: Document why `font-size` is excluded or remove this special case.
-            if (adaptor.property() != CSSPropertyFontSize)
-                adjustedWidthOrHeight = adjustedWidthOrHeight / adaptor.renderViewForViewportUnits()->pageZoomFactor();
-
-            return adjustedWidthOrHeight / 100;
+            return widthOrHeight.toDouble() / containerRenderer->style().usedZoomForLength().value / 100;
         }
         // For pseudo-elements the element itself can be the container. Avoid looping forever.
         mode = ContainerQueryEvaluator::SelectionMode::Element;


### PR DESCRIPTION
#### 8a95dbda48c922f79bfa6fcc29c409233edba621
<pre>
[EvaluationTimeZoom] Container-percentage units should use the fully unscaled contentBoxWidth/Height
<a href="https://bugs.webkit.org/show_bug.cgi?id=321853">https://bugs.webkit.org/show_bug.cgi?id=321853</a>

Reviewed by NOBODY (OOPS!).

Container-percentage units previously only unscaled the contentBoxWidth/Height by the
page&apos;s zoom factor but really needed to be unscaling based on the renderer&apos;s own zoom
factor. Also removes the special case for `font-size` so it doesn&apos;t get scaled twice.

Updates tests and adds a parallel test using CSS zoom.

Test: fast/css/container-query-units-css-zoom.html
* LayoutTests/fast/css/container-query-units-css-zoom-expected.html: Copied from LayoutTests/fast/css/container-query-units-page-zoom.html.
* LayoutTests/fast/css/container-query-units-css-zoom.html: Copied from LayoutTests/fast/css/container-query-units-page-zoom.html.
* LayoutTests/fast/css/container-query-units-page-zoom-expected.html:
* LayoutTests/fast/css/container-query-units-page-zoom.html:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a95dbda48c922f79bfa6fcc29c409233edba621

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193574 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147645 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57013 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143122 "Found 2 new test failures: fast/css/container-query-units-css-zoom.html fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99385 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123541 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45572 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43804 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43418 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4749 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195514 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163381 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152618 "Found 1 new test failure: fast/css/container-query-units-css-zoom.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57652 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152305 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46860 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129931 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126230 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56160 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18428 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55770 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->