### PR TITLE
DataTransferItem.kind should return the empty string for an item in the disabled mode

### DIFF
--- a/LayoutTests/editing/pasteboard/datatransfer-items-copy-html-expected.txt
+++ b/LayoutTests/editing/pasteboard/datatransfer-items-copy-html-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: ReferenceError: Can't find variable: string
 This tests copying HTML markup using dataTransfer.items. To manually test, click on "Copy text" and paste (Command+V on Mac Control+V elsewhere).
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
@@ -15,7 +14,7 @@ PASS clipboardData.items[0] is initialItem
 PASS clipboardData.clearData(); clipboardData.items.length is 0
 PASS clipboardData.items.add("<!DOCTYPE html><!-- hello --><script>alert('Test failed');</script>", "TEXT/html"); clipboardData.items.length is 1
 PASS clipboardData.items[0] is not initialItem
-PASS initialItem.kind is "string"
+PASS initialItem.kind is ""
 PASS initialItem.type is ""
 PASS initialItem.getAsFile() is null
 PASS initialItem.getAsString(() => testFailed("getAsString should exit immeidately if item is disabled 1")) is undefined
@@ -38,10 +37,19 @@ PASS clipboardData.getData("text/html") is "<!DOCTYPE html><!-- hello --><script
 PASS firstItem.getAsString(checkContent(4, "<!DOCTYPE html><!-- hello --><script>alert('Test failed');</script>")) is undefined
 PASS clipboardData.items.remove(0); clipboardData.items.length is 1
 PASS clipboardData.items[0] is secondItem
+PASS firstItem.kind is ""
+PASS firstItem.type is ""
+PASS firstItem.getAsFile() is null
+PASS firstItem.getAsString(() => testFailed("getAsString should exit immeidately if item is disabled 2")) is undefined
+PASS secondItem.kind is "string"
+PASS secondItem.type is "text/plain"
+PASS secondItem.getAsFile() is null
+PASS secondItem.getAsString(checkContent(5, "some content")) is undefined
 PASS actualContent1 is "rock"
 PASS actualContent2 is "<!DOCTYPE html><!-- hello --><script>alert('Test failed');</script>"
 PASS actualContent3 is "some content"
 PASS actualContent4 is "<!DOCTYPE html><!-- hello --><script>alert('Test failed');</script>"
+PASS actualContent5 is "some content"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/editing/pasteboard/datatransfer-items-copy-html.html
+++ b/LayoutTests/editing/pasteboard/datatransfer-items-copy-html.html
@@ -30,7 +30,7 @@ function copy(event)
     const markup = `<!DOCTYPE html><!-- hello --><script>alert('Test failed');</scr` + `ipt>`;
     shouldBe(`clipboardData.items.add("${markup}", "TEXT/html"); clipboardData.items.length`, '1');
     shouldNotBe('clipboardData.items[0]', 'initialItem');
-    shouldBeEqualToString('initialItem.kind', 'string');
+    shouldBeEqualToString('initialItem.kind', '');
     shouldBeEqualToString('initialItem.type', '');
     shouldBe('initialItem.getAsFile()', 'null');
     shouldBe('initialItem.getAsString(() => testFailed("getAsString should exit immeidately if item is disabled 1"))', 'undefined');
@@ -57,14 +57,14 @@ function copy(event)
 
     shouldBe('clipboardData.items.remove(0); clipboardData.items.length', '1');
     shouldBe('clipboardData.items[0]', 'secondItem');
-    shouldBe('firstItem.kind', 'string');
-    shouldBe('firstItem.type', 'text/html');
+    shouldBeEqualToString('firstItem.kind', '');
+    shouldBeEqualToString('firstItem.type', '');
     shouldBe('firstItem.getAsFile()', 'null');
     shouldBe('firstItem.getAsString(() => testFailed("getAsString should exit immeidately if item is disabled 2"))', 'undefined');
-    shouldBe('secondItem.kind', 'string');
-    shouldBe('secondItem.type', 'text/plain');
+    shouldBeEqualToString('secondItem.kind', 'string');
+    shouldBeEqualToString('secondItem.type', 'text/plain');
     shouldBe('secondItem.getAsFile()', 'null');
-    shouldBe('secondItem.getAsString(checkContent(4, "some content"))', 'undefined');
+    shouldBe('secondItem.getAsString(checkContent(5, "some content"))', 'undefined');
 
 }
 

--- a/LayoutTests/editing/pasteboard/datatransfer-items-copy-plaintext-expected.txt
+++ b/LayoutTests/editing/pasteboard/datatransfer-items-copy-plaintext-expected.txt
@@ -14,7 +14,7 @@ PASS clipboardData.items[0] is initialItem
 PASS clipboardData.clearData(); clipboardData.items.length is 0
 PASS clipboardData.items.add("scissors", "text/plain"); clipboardData.items.length is 1
 PASS clipboardData.items[0] is not initialItem
-PASS initialItem.kind is "string"
+PASS initialItem.kind is ""
 PASS initialItem.type is ""
 PASS initialItem.getAsFile() is null
 PASS initialItem.getAsString(() => testFailed("getAsString should exit immeidately if item is disabled")) is undefined

--- a/LayoutTests/editing/pasteboard/datatransfer-items-copy-plaintext.html
+++ b/LayoutTests/editing/pasteboard/datatransfer-items-copy-plaintext.html
@@ -29,7 +29,7 @@ function copy(event)
 
     shouldBe('clipboardData.items.add("scissors", "text/plain"); clipboardData.items.length', '1');
     shouldNotBe('clipboardData.items[0]', 'initialItem');
-    shouldBeEqualToString('initialItem.kind', 'string');
+    shouldBeEqualToString('initialItem.kind', '');
     shouldBeEqualToString('initialItem.type', '');
     shouldBe('initialItem.getAsFile()', 'null');
     shouldBe('initialItem.getAsString(() => testFailed("getAsString should exit immeidately if item is disabled"))', 'undefined');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitem-disabled-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitem-disabled-mode-expected.txt
@@ -1,0 +1,7 @@
+
+PASS remove() puts a string item into the disabled mode
+PASS remove() puts a File item into the disabled mode
+PASS clear() puts every item into the disabled mode
+PASS clearData() puts the removed string item into the disabled mode
+PASS setData() puts the replaced string item into the disabled mode
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitem-disabled-mode.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitem-disabled-mode.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>DataTransferItem kind and type in the disabled mode</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitem-interface">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+// The kind attribute must return the empty string if the DataTransferItem object
+// is in the disabled mode, which it is once the item it represents has been
+// removed from the drag data store item list.
+test(() => {
+  const dt = new DataTransfer();
+  const item = dt.items.add("data", "text/plain");
+  assert_equals(item.kind, "string", "kind before removal");
+  assert_equals(item.type, "text/plain", "type before removal");
+
+  dt.items.remove(0);
+
+  assert_equals(item.kind, "", "kind after removal");
+  assert_equals(item.type, "", "type after removal");
+}, "remove() puts a string item into the disabled mode");
+
+test(() => {
+  const dt = new DataTransfer();
+  const item = dt.items.add(new File(["abc"], "test.txt", { type: "text/plain" }));
+  assert_equals(item.kind, "file", "kind before removal");
+  assert_equals(item.type, "text/plain", "type before removal");
+
+  dt.items.remove(0);
+
+  assert_equals(item.kind, "", "kind after removal");
+  assert_equals(item.type, "", "type after removal");
+  assert_equals(item.getAsFile(), null, "getAsFile() after removal");
+}, "remove() puts a File item into the disabled mode");
+
+test(() => {
+  const dt = new DataTransfer();
+  const stringItem = dt.items.add("data", "text/plain");
+  const fileItem = dt.items.add(new File(["abc"], "test.txt", { type: "image/png" }));
+
+  dt.items.clear();
+
+  assert_equals(stringItem.kind, "", "kind of the cleared string item");
+  assert_equals(stringItem.type, "", "type of the cleared string item");
+  assert_equals(fileItem.kind, "", "kind of the cleared File item");
+  assert_equals(fileItem.type, "", "type of the cleared File item");
+}, "clear() puts every item into the disabled mode");
+
+test(() => {
+  const dt = new DataTransfer();
+  const item = dt.items.add("data", "text/plain");
+
+  dt.clearData("text/plain");
+
+  assert_equals(item.kind, "", "kind after clearData()");
+  assert_equals(item.type, "", "type after clearData()");
+}, "clearData() puts the removed string item into the disabled mode");
+
+// setData() removes the item whose type string matches before adding the new
+// one, so the DataTransferItem representing the old item ends up disabled.
+test(() => {
+  const dt = new DataTransfer();
+  const oldItem = dt.items.add("data", "text/plain");
+
+  dt.setData("text/plain", "other data");
+
+  assert_equals(oldItem.kind, "", "kind of the replaced item");
+  assert_equals(oldItem.type, "", "type of the replaced item");
+
+  assert_equals(dt.items.length, 1);
+  assert_equals(dt.items[0].kind, "string", "kind of the replacement item");
+  assert_equals(dt.items[0].type, "text/plain", "type of the replacement item");
+}, "setData() puts the replaced string item into the disabled mode");
+</script>

--- a/Source/WebCore/dom/DataTransferItem.cpp
+++ b/Source/WebCore/dom/DataTransferItem.cpp
@@ -84,6 +84,9 @@ bool DataTransferItem::isFile() const
 
 String DataTransferItem::kind() const
 {
+    if (isInDisabledMode())
+        return { };
+
     switch (m_kind) {
     case Kind::String:
         return "string"_s;


### PR DESCRIPTION
#### e22461b30ac3b924ecdf82c6639e28f36b482266
<pre>
DataTransferItem.kind should return the empty string for an item in the disabled mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=321855">https://bugs.webkit.org/show_bug.cgi?id=321855</a>
<a href="https://rdar.apple.com/185010027">rdar://185010027</a>

Reviewed by Chris Dumez.

HTML, 6.11.3.2 The DataTransferItem interface
&lt;<a href="https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitem-interface">https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitem-interface</a>&gt;:

    When the DataTransferItem object&apos;s DataTransfer object is not associated with
    a drag data store, or if the item that the DataTransferItem object represents
    has been removed from the relevant drag data store item list, the
    DataTransferItem object&apos;s mode is the disabled mode.

    The kind attribute must return the empty string if the DataTransferItem
    object is in the disabled mode; otherwise it must return the string given in
    the cell from the second column of the following table [...]

WebKit already tracks removal from the item list: DataTransferItemList&apos;s
remove(), clear(), didClearStringData() and didSetStringData() clear the item&apos;s
list back-pointer, which is what isInDisabledMode() tests. type(),
getAsString() and getAsFile() all honor it; kind() was the one getter that did
not, so an item removed by items.remove(), items.clear(), clearData(), or a
setData() call replacing the same type string ended up self-inconsistent, with
an empty type but a kind still reporting &quot;string&quot; or &quot;file&quot;.

Return the empty string from kind() when the item is in the disabled mode, as
type() already does.

The two editing/pasteboard tests that cover the disabled mode expected the old
self-inconsistent behavior, so their kind expectations move from &quot;string&quot; to the
empty string. While here, the tail of datatransfer-items-copy-html.html was dead
code: it used shouldBe() with a bare &apos;string&apos; / &apos;text/html&apos; as the expected
*expression*, so the first of those threw &quot;ReferenceError: Can&apos;t find variable:
string&quot; out of the copy event handler and silently skipped the remaining eight
assertions (the ReferenceError was baked into the baseline). Those become
shouldBeEqualToString(), which is what the rest of the file uses, and the
now-running assertions cover kind and type of an item disabled by items.remove().
The last getAsString() there also reused checkContent(4), whose expected content
belongs to a different item; it becomes checkContent(5).

Test: imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitem-disabled-mode.html

* LayoutTests/editing/pasteboard/datatransfer-items-copy-html-expected.txt:
* LayoutTests/editing/pasteboard/datatransfer-items-copy-html.html:
* LayoutTests/editing/pasteboard/datatransfer-items-copy-plaintext-expected.txt:
* LayoutTests/editing/pasteboard/datatransfer-items-copy-plaintext.html:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitem-disabled-mode-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitem-disabled-mode.html: Added.
* Source/WebCore/dom/DataTransferItem.cpp:
(WebCore::DataTransferItem::kind const):

Canonical link: <a href="https://commits.webkit.org/320874@main">https://commits.webkit.org/320874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d9f3be85d6b81332445161caac73f5a0c72eff4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145290 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4083f4b3-033f-4e8e-b3d7-f1ce6a0d3a3e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141194 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97889 "2 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d82a5c0-2a0f-42ce-99c0-c2f0df5964dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44855 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161938 "Found 1 new API test failure: TestWebKitAPI.IsolatedSiteStore.PersistsAcrossSessions (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121646 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fee94f9c-0612-48d3-8dd9-037cc035c746) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43528 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41807 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41465 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2341 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193116 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150579 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41528 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55266 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150296 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44885 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127532 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123001 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53783 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16459 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53165 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53402 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->