### PR TITLE
dragleave and dragend events should not be cancelable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable-expected.txt
@@ -1,0 +1,11 @@
+Drag me
+Zone A Zone B
+
+PASS dragstart should be cancelable
+PASS drag should be cancelable
+PASS dragenter should be cancelable
+PASS dragover should be cancelable
+PASS dragleave should not be cancelable
+PASS drop should be cancelable
+FAIL dragend should not be cancelable assert_true: dragend fired expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Every drag and drop event is cancelable except dragleave and dragend</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dnd.html#fire-a-dnd-event">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  #source        { width: 80px; height: 80px; background: cornflowerblue; }
+  #zoneA, #zoneB { width: 120px; height: 120px; display: inline-block; }
+  #zoneA         { background: salmon; }
+  #zoneB         { background: lightgreen; }
+</style>
+
+<div id="source" draggable="true">Drag me</div>
+<div id="zoneA">Zone A</div>
+<div id="zoneB">Zone B</div>
+
+<script>
+// "Fire a DND event" step: "If e is not dragleave or dragend, then initialize
+// event's cancelable attribute to true."
+const NOT_CANCELABLE = ["dragleave", "dragend"];
+
+const source = document.getElementById("source");
+const zoneA = document.getElementById("zoneA");
+const zoneB = document.getElementById("zoneB");
+
+// The drag, dragenter and dragover events fire repeatedly; only the first of
+// each is recorded so that a single drag yields one value per event type.
+const cancelable = new Map();
+function record(event) {
+    if (!cancelable.has(event.type))
+        cancelable.set(event.type, event.cancelable);
+}
+
+function acceptDrop(event) {
+    record(event);
+    event.preventDefault();
+}
+
+source.addEventListener("dragstart", event => {
+    record(event);
+    event.dataTransfer.setData("text/plain", "drag-test");
+});
+source.addEventListener("drag", record);
+source.addEventListener("dragend", record);
+
+for (const zone of [zoneA, zoneB]) {
+    zone.addEventListener("dragenter", acceptDrop);
+    zone.addEventListener("dragover", acceptDrop);
+}
+zoneA.addEventListener("dragleave", record);
+zoneB.addEventListener("drop", acceptDrop);
+
+function centerOf(element) {
+    const rect = element.getBoundingClientRect();
+    return { x: Math.round(rect.left + rect.width / 2),
+             y: Math.round(rect.top + rect.height / 2) };
+}
+
+// Drag the source across zone A (producing dragleave) and drop it on zone B.
+// Performed once and shared by every subtest below, so that one event type
+// going missing in an implementation does not mask the other assertions.
+let dragPromise = null;
+function performDrag() {
+    if (!dragPromise) {
+        const start = centerOf(source);
+        const a = centerOf(zoneA);
+        const b = centerOf(zoneB);
+        dragPromise = new test_driver.Actions()
+            .addPointer("mouse", "mouse")
+            .pointerMove(start.x, start.y)
+            .pointerDown()
+            .pause(200)  // Exceed the drag-start hysteresis threshold.
+            .pointerMove(a.x, a.y)
+            .pause(50)
+            .pointerMove(b.x, b.y)
+            .pause(50)
+            .pointerUp()
+            .pause(50)
+            .send();
+    }
+    return dragPromise;
+}
+
+function cancelableTest(type) {
+    const expected = !NOT_CANCELABLE.includes(type);
+    promise_test(async t => {
+        await performDrag();
+        assert_true(cancelable.has(type), `${type} fired`);
+        assert_equals(cancelable.get(type), expected,
+            `${type}.cancelable should be ${expected}`);
+    }, `${type} should${expected ? "" : " not"} be cancelable`);
+}
+
+for (const type of ["dragstart", "drag", "dragenter", "dragover", "dragleave", "drop", "dragend"])
+    cancelableTest(type);
+</script>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable-expected.txt
@@ -1,0 +1,11 @@
+Drag me
+Zone A Zone B
+
+PASS dragstart should be cancelable
+PASS drag should be cancelable
+PASS dragenter should be cancelable
+PASS dragover should be cancelable
+FAIL dragleave should not be cancelable assert_true: dragleave fired expected true got false
+PASS drop should be cancelable
+PASS dragend should not be cancelable
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6677,6 +6677,7 @@ imported/w3c/web-platform-tests/html/dom/render-blocking/remove-element-unblocks
 imported/w3c/web-platform-tests/html/editing/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-event.html [ Skip ]
 
 # Drag-and-drop testdriver automation is not supported on iOS.
+webkit.org/b/321858 imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable.html [ Skip ]
 webkit.org/b/66547 imported/w3c/web-platform-tests/html/editing/dnd/events/dragenter-dragleave-related-target.html [ Skip ]
 
 ######################################################

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2710,7 +2710,14 @@ bool EventHandler::dispatchDragEvent(const AtomString& eventType, Element& dragT
     if (relatedTarget && &relatedTarget->document() != &dragTarget.document())
         relatedTarget = nullptr;
 
-    auto dragEvent = DragEvent::create(eventType, Event::CanBubble::Yes, Event::IsCancelable::Yes, Event::IsComposed::Yes,
+    auto& eventNames = WebCore::eventNames();
+
+    // https://html.spec.whatwg.org/multipage/dnd.html#fire-a-dnd-event
+    // "If e is not dragleave or dragend, then initialize event's cancelable attribute to true."
+    auto cancelable = eventType == eventNames.dragleaveEvent || eventType == eventNames.dragendEvent
+        ? Event::IsCancelable::No : Event::IsCancelable::Yes;
+
+    auto dragEvent = DragEvent::create(eventType, Event::CanBubble::Yes, cancelable, Event::IsComposed::Yes,
         event.timestamp(), &frame->windowProxy(), 0,
         flooredIntPoint(event.globalPosition()), flooredIntPoint(event.position()), event.movementDelta().x(), event.movementDelta().y(),
         event.modifiers(), MouseButton::Left, 0, WTF::move(relatedTarget), event.force(), SyntheticClickType::NoTap, &dataTransfer);
@@ -2718,7 +2725,6 @@ bool EventHandler::dispatchDragEvent(const AtomString& eventType, Element& dragT
     dragTarget.dispatchEvent(dragEvent);
 
     if (CheckedPtr cache = protect(frame->document())->existingAXObjectCache()) {
-        auto& eventNames = WebCore::eventNames();
         if (eventType == eventNames.dragstartEvent)
             cache->onDraggingStarted(dragTarget);
         else if (eventType == eventNames.dragendEvent)


### PR DESCRIPTION
#### 68f7430ba7898942ce883b12277deb5e445e6f2c
<pre>
dragleave and dragend events should not be cancelable
<a href="https://bugs.webkit.org/show_bug.cgi?id=321858">https://bugs.webkit.org/show_bug.cgi?id=321858</a>
<a href="https://rdar.apple.com/185017679">rdar://185017679</a>

Reviewed by NOBODY (OOPS!).

EventHandler::dispatchDragEvent passed Event::IsCancelable::Yes for every
drag and drop event. The HTML Standard&apos;s &quot;fire a DND event&quot; algorithm
initializes cancelable to true for all DND events except two:

    &quot;If e is not dragleave or dragend, then initialize event&apos;s cancelable
     attribute to true.&quot;
    <a href="https://html.spec.whatwg.org/multipage/dnd.html#fire-a-dnd-event">https://html.spec.whatwg.org/multipage/dnd.html#fire-a-dnd-event</a>

So dragleave and dragend must be non-cancelable. WebKit was alone in
getting this wrong; both Chrome and Firefox already report cancelable as
false for those two events, so there is no interop risk in changing it.

No behavior depended on the old value. Both dragleave call sites discard
dispatchDragEvent&apos;s return value, and dragend is dispatched through
dispatchEventToDragSourceElement(), which returns void, so the
defaultPrevented() result was already ignored for both. The only
observable changes are the cancelable attribute itself and
preventDefault() becoming a no-op on those two events.

Also hoist the existing eventNames reference out of the AXObjectCache
block so the new cancelable check can share it, rather than shadowing it.

The new test covers each of the seven DND events as an independent
subtest sharing a single drag, so that one event type failing to fire
does not mask the assertions for the rest. Which subtests can actually
run is a property of each port&apos;s drag automation, not of this change, so
the two halves of the fix are each verified on the ports that can
dispatch the event:

- The dragend subtest FAILs in the generic (mac) baseline.
  testdriver-vendor.js sets eventSender.dragMode = false, and dragMode is
  unimplemented in WebKitTestRunner (webkit.org/b/68552), so no drag
  session is ever created in the UI process and dragend is never
  dispatched to the drag source. That is also why
  fast/events/moving-text-should-fire-drop-and-dragend-events.html and
  five sibling tests are skipped on wk2 and marked [ Pass ] only on
  mac-wk1.

- GTK and WPE are the other way around: they do complete the drag
  session, so dragend fires there and its subtest PASSes, giving the
  dragend half of this fix real CI coverage. What they lack is dragleave
  when the pointer moves between drop targets mid-drag, the same
  limitation that keeps
  imported/w3c/web-platform-tests/html/editing/dnd/events/dragenter-dragleave-related-target.html
  and fast/events/drag-relatedTarget.html skipped on glib
  (webkit.org/b/66547). A glib baseline records that, rather than
  skipping the test and losing the dragend coverage with it.

- iOS has no mouse drag automation at all, so none of the seven events
  fire and there is nothing left to assert. The test is skipped there
  next to the sibling dnd test, matching the &quot;Drag-and-drop is not
  supported&quot; block already in that file.

Both FAIL lines start passing on their own once the corresponding
automation gaps are closed. dragend was additionally verified manually
against a mac build with this change, where it reports cancelable as
false, matching Chrome and Firefox.

Test: imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable.html

* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable.html: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable-expected.txt: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dispatchDragEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68f7430ba7898942ce883b12277deb5e445e6f2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191180 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145289 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d3361673-b51e-43f3-8a53-438295e70f77) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141193 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97888 "1 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c957a09e-bbf0-4091-b6d1-2151daa1c9c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121645 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d5d33345-f371-4d7c-812e-5faf95966300) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43526 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41806 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41464 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2340 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193115 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161453 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150578 "Found 1 new test failure: imported/w3c/web-platform-tests/html/editing/dnd/events/drag-events-cancelable.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55265 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150295 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44883 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127531 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122996 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53782 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16458 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53164 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53401 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53229 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->