### PR TITLE
git-webkit does not sort or update the Tests: section of a commit message

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -17,6 +17,9 @@ CHERRY_PICK_COMMIT_RE = re.compile(r'^(?P<a>\S+)( \((?P<b>\S+)\))?$')
 REFNAME_RE = re.compile(r'^refs/remotes/(?P<remote>[^/ ]+)/(?P<branch>\S+)$')
 HASH_RE = re.compile(r'^[a-f0-9A-F]+$')
 IDENTIFIER_RE = re.compile(r'(\d+\.)?\d+@\S+')
+TESTS_HEADER_RE = re.compile(r'^Tests?: ')
+TESTS_NO_NEW_RE = re.compile(r'^No new tests \(OOPS!\)\.$')
+TESTS_CONTINUATION_RE = re.compile(r'^ +\S')
 PREFER_RADAR = {{ prefer_radar }}
 
 DEFAULT_BRANCH = '{{ default_branch }}'
@@ -112,30 +115,44 @@ def parseChanges(command, commit_message):
         return
     return changes
 
-def message(source=None, sha=None, mention_tests=True):
+def split_test_lines(changes):
+    """Split prepare-ChangeLog output into its tests section and its file list."""
+    tests = []
+    files = []
+    in_tests = False
+    for line in changes or []:
+        if TESTS_HEADER_RE.match(line) or TESTS_NO_NEW_RE.match(line):
+            in_tests = True
+            tests.append(line)
+        elif in_tests and TESTS_CONTINUATION_RE.match(line):
+            tests.append(line)
+        else:
+            in_tests = False
+            files.append(line)
+    return tests, files
+
+def message(source=None, sha=None):
     commit_message = []
     amend_changes = None
-    command = PREPARE_CHANGELOG_CMD
-
-    if not mention_tests:
-        command = command + ["--no-mention-tests"]
+    # A copy, because the amend case appends to it.
+    command = list(PREPARE_CHANGELOG_CMD)
 
     if sha:
         commit_message.append('Amend changes:')
-        amend_changes = parseChanges(command, commit_message)
+        _, amend_changes = split_test_lines(parseChanges(command, commit_message))
         commit_message.append('')
 
         commit_message.append('Combined changes:')
         command += ['--git-commit', 'HEAD']
 
-    combined_changes = parseChanges(command, commit_message)
+    combined_tests, combined_changes = split_test_lines(parseChanges(command, commit_message))
 
     revert_msg = os.environ.get('COMMIT_MESSAGE_REVERT', '')
     if revert_msg:
         return '''{title}\n{revert}'''.format(
             title=os.environ.get('COMMIT_MESSAGE_TITLE', ''),
             revert=revert_msg,
-        ), combined_changes, amend_changes
+        ), combined_tests, combined_changes, amend_changes
     else:
         bugs_string = get_bugs_string()
         return '''{title}
@@ -150,7 +167,7 @@ Explanation of why this fixes the bug (OOPS!).
         title=os.environ.get('COMMIT_MESSAGE_TITLE', '') or 'Need a short description (OOPS!).',
         bugs=bugs_string,
         content='\n'.join(commit_message) + os.environ.get('COMMIT_MESSAGE_CONTENT', ''),
-    ), combined_changes, amend_changes
+    ), combined_tests, combined_changes, amend_changes
 
 def source_branches():
     proc = None
@@ -321,19 +338,21 @@ def annotate_deleted_lines(amend_changes, combined_changes):
         annotated_lines.append(line)
     return annotated_lines
 
-def amended_message(full_message, combined_changes, amend_changes, update_changelog):
+def amended_message(full_message, combined_tests, combined_changes, amend_changes, update_changelog):
     if amend_changes and update_changelog:
         try:
             from webkitscmpy.commit_parser import CommitMessageParser
         except ImportError as e:
             sys.stderr.write(f'{e}: Could not update changelog automatically. Falling back to the default template.\n')
-        else:
-            commit_message_parser = CommitMessageParser()
+            return full_message
+
+        commit_message_parser = CommitMessageParser()
         commit_message_parser.parse_message(full_message)
         updated_changelog_lines = commit_message_parser.reconcile_with_changed_files(combined_changes)
         reviewed_by_lines = (commit_message_parser.reviewed_by_lines or ['Reviewed by NOBODY (OOPS!).'])
         description_lines = (commit_message_parser.description_lines or ['Explanation of why this fixes the bug (OOPS!).'])
-        tests_lines = commit_message_parser.tests_lines + [''] if commit_message_parser.tests_lines else []
+        updated_tests_lines = commit_message_parser.reconcile_tests(combined_tests)
+        tests_lines = updated_tests_lines + [''] if updated_tests_lines else []
         amended_message = commit_message_parser.title_lines + [''] + reviewed_by_lines + [''] + description_lines + [''] + tests_lines + updated_changelog_lines
         removed_changelog_lines = commit_message_parser.apply_comments_to_modified_files_lines(annotate_deleted_lines(amend_changes, combined_changes), return_deleted=True)
         return '''{message_body}
@@ -404,16 +423,16 @@ def main(file_name=None, source=None, sha=None):
 
     with open(file_name, 'w') as commit_message_file:
         if sha:
-            generated_msg, combined_changes, amend_changes = message(source=source, sha=sha, mention_tests=False)
+            generated_msg, combined_tests, combined_changes, amend_changes = message(source=source, sha=sha)
             git_log_msg = subprocess.run(
                 ['git', 'log', sha, '-1', '--pretty=format:%B'],
                 encoding='utf-8',
                 capture_output=True,
                 check=True
             ).stdout
-            commit_message_file.write(amended_message(git_log_msg, combined_changes, amend_changes, update_changelog))
+            commit_message_file.write(amended_message(git_log_msg, combined_tests, combined_changes, amend_changes, update_changelog))
         else:
-            generated_msg, combined_changes, amend_changes = message(source=source, sha=sha)
+            generated_msg, combined_tests, combined_changes, amend_changes = message(source=source, sha=sha)
             commit_message_file.write(generated_msg)
 
         commit_message_file.write('''

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py
@@ -41,6 +41,9 @@ MODIFIED_FILE_REMOVED_PATTERN = re.compile('^\\*.*: Removed.$')
 MODIFIED_FUNCTION_PATTERN = re.compile('^(\\(.*\\):)(.*)$')
 MODIFIED_FUNCTION_DELETED_PATTERN = re.compile('^\\(.*\\): Deleted.$')
 TEST_PATTERN = re.compile('^Tests?: .*$')
+# TEST_PATTERN, with the test name captured.
+TEST_PATTERN_HEADER = re.compile('^Tests?: (.*)$')
+TEST_PATTERN_EXTENSION = re.compile('\\.[a-zA-Z0-9]+$')
 NO_TEST_PATTERN = re.compile('^No new tests \\(OOPS!\\)\\.$')
 TEST_CONTENT_PATTERN = re.compile('^ +.*$')
 REVIEWED_BY_PATTERN = re.compile('^Reviewed by .*$')
@@ -359,6 +362,83 @@ class CommitMessageParser:
         if return_deleted:
             return deleted_result
         return result
+
+    def _test_entries(self, tests_lines):
+        # A tests section holds one entry per line: the first on the "Tests:" line itself,
+        # the rest indented underneath it. "No new tests (OOPS!)." is a placeholder for an
+        # entry rather than one, so it is left out.
+        entries = []
+        for line in tests_lines:
+            if NO_TEST_PATTERN.match(line):
+                continue
+            match = TEST_PATTERN_HEADER.match(line)
+            entry = (match.group(1) if match else line).strip()
+            # prepare-ChangeLog prints layout tests without their LayoutTests prefix, so
+            # drop it here too and a hand-written full path won't become a duplicate.
+            entry = entry.removeprefix('LayoutTests/')
+            if entry:
+                entries.append(entry)
+        return entries
+
+    def _is_test_name(self, entry):
+        # A test name is one path, so an entry carrying prose is not a name. Some real
+        # paths contain a space, such as "Tools/TestWebKitAPI/Tests/WebKit
+        # Swift/WebPageTests.swift", so an entry with whitespace is still a name when it
+        # ends in a file extension.
+        if not re.search(r'\s', entry):
+            return True
+        return bool(TEST_PATTERN_EXTENSION.search(entry))
+
+    def _tests_indent(self):
+        # Continuation lines line up under the first test name.
+        for line in self.tests_lines:
+            if not TEST_PATTERN_HEADER.match(line) and TEST_CONTENT_PATTERN.match(line):
+                return ' ' * (len(line) - len(line.lstrip()))
+        for line in self.tests_lines:
+            if TEST_PATTERN_HEADER.match(line):
+                return ' ' * (line.index(':') + 2)
+        return ' ' * len('Tests: ')
+
+    def _mentions_test(self, entry, name):
+        # An entry the author annotated, such as "fast/a.html: only fails with the flag
+        # on", already names that test and must not gain a duplicate line.
+        if not entry.startswith(name):
+            return False
+        remainder = entry[len(name):]
+        return not remainder or not (remainder[0].isalnum() or remainder[0] in '-_./')
+
+    def reconcile_tests(self, tests_lines):
+        """Update the original tests section to match the tests the current diff adds.
+
+        Tests the original section names are kept, tests new to the diff are added, and
+        the result is sorted so the section doesn't depend on the order the tests were
+        written in. A section that names no test, such as "No new tests (OOPS!).", is
+        kept only while the diff adds no test.
+
+        A section that says anything beyond test names is returned as written, with the
+        new tests appended, because sorting would reorder the author's sentences and
+        could move one of them onto the "Tests:" line.
+
+        tests_lines is the regenerated tests section (prepare-ChangeLog format).
+        """
+        original = self._test_entries(self.tests_lines)
+        added = self._test_entries(tests_lines)
+        if not original and not added:
+            return list(self.tests_lines)
+
+        if not all(self._is_test_name(entry) for entry in original):
+            new = [
+                name for name in added
+                if not any(self._mentions_test(entry, name) for entry in original)
+            ]
+            if not new:
+                return list(self.tests_lines)
+            indent = self._tests_indent()
+            return list(self.tests_lines) + [indent + name for name in new]
+
+        names = sorted(set(original) | set(added))
+        lead = 'Test{}: '.format('' if len(names) == 1 else 's')
+        return [lead + names[0]] + [' ' * len(lead) + name for name in names[1:]]
 
     def _file_identity(self, line):
         # The "* path:" prefix is identical whether the file is modified, Added. or

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_parser_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_parser_unittest.py
@@ -481,3 +481,206 @@ class TestCommitParser(unittest.TestCase):
 * Kept.cpp:
 ''',
         )
+
+    def assert_reconcile_tests(self, before, added, after):
+        # `added` is the tests section prepare-ChangeLog regenerates for the whole commit.
+        commit_message_parser = CommitMessageParser()
+        commit_message_parser.parse_message(COMMIT_MSG_BASE + before)
+        self.assertEqual(
+            self.lines(after) if after else [],
+            commit_message_parser.reconcile_tests(self.lines(added) if added else []),
+        )
+
+    def test_reconcile_tests_adds_and_sorts(self):
+        self.assert_reconcile_tests(
+            before='''
+Test: fast/parser/window-stop.xhtml
+''',
+            added='''
+Tests: fast/parser/frame-removal.html
+       fast/parser/window-stop.xhtml
+''',
+            after='''
+Tests: fast/parser/frame-removal.html
+       fast/parser/window-stop.xhtml
+''',
+        )
+
+    def test_reconcile_tests_sorts_an_unsorted_original(self):
+        self.assert_reconcile_tests(
+            before='''
+Tests: fast/parser/window-stop.xhtml
+       fast/parser/frame-removal.html
+''',
+            added='',
+            after='''
+Tests: fast/parser/frame-removal.html
+       fast/parser/window-stop.xhtml
+''',
+        )
+
+    def test_reconcile_tests_creates_missing_section(self):
+        self.assert_reconcile_tests(
+            before='''
+* Source/A.cpp:
+''',
+            added='''
+Test: fast/parser/frame-removal.html
+''',
+            after='''
+Test: fast/parser/frame-removal.html
+''',
+        )
+
+    def test_reconcile_tests_replaces_no_new_tests(self):
+        self.assert_reconcile_tests(
+            before='''
+No new tests (OOPS!).
+''',
+            added='''
+Test: fast/parser/frame-removal.html
+''',
+            after='''
+Test: fast/parser/frame-removal.html
+''',
+        )
+
+    def test_reconcile_tests_keeps_no_new_tests_when_none_added(self):
+        self.assert_reconcile_tests(
+            before='''
+No new tests (OOPS!).
+''',
+            added='''
+No new tests (OOPS!).
+''',
+            after='''
+No new tests (OOPS!).
+''',
+        )
+
+    def test_reconcile_tests_without_original_or_added(self):
+        self.assert_reconcile_tests(
+            before='''
+* Source/A.cpp:
+''',
+            added='',
+            after='',
+        )
+
+    def test_reconcile_tests_keeps_test_not_in_diff(self):
+        # A test the author named by hand but did not add, e.g. an existing test they
+        # extended, is not in prepare-ChangeLog's list and must survive the amend.
+        self.assert_reconcile_tests(
+            before='''
+Test: fast/parser/pre-existing.html
+''',
+            added='''
+Test: fast/parser/frame-removal.html
+''',
+            after='''
+Tests: fast/parser/frame-removal.html
+       fast/parser/pre-existing.html
+''',
+        )
+
+    def test_reconcile_tests_deduplicates_layouttests_prefix(self):
+        self.assert_reconcile_tests(
+            before='''
+Test: LayoutTests/fast/parser/frame-removal.html
+''',
+            added='''
+Test: fast/parser/frame-removal.html
+''',
+            after='''
+Test: fast/parser/frame-removal.html
+''',
+        )
+
+    def test_reconcile_tests_sorts_api_tests_with_layout_tests(self):
+        self.assert_reconcile_tests(
+            before='',
+            added='''
+Tests: Tools/TestWebKitAPI/Tests/WebKit/Foo.cpp
+       fast/parser/frame-removal.html
+''',
+            after='''
+Tests: Tools/TestWebKitAPI/Tests/WebKit/Foo.cpp
+       fast/parser/frame-removal.html
+''',
+        )
+
+    def test_reconcile_tests_sorts_a_path_containing_spaces(self):
+        # Real paths have spaces in them, so a space alone does not make an entry prose.
+        self.assert_reconcile_tests(
+            before='''
+Test: Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
+''',
+            added='''
+Test: fast/parser/frame-removal.html
+''',
+            after='''
+Tests: Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
+       fast/parser/frame-removal.html
+''',
+        )
+
+    def test_reconcile_tests_keeps_prose_section_verbatim(self):
+        # Sorting would reorder the sentences and put one of them on the Tests: line.
+        self.assert_reconcile_tests(
+            before='''
+Tests: fast/text/font-size-zero-ligatures.html: Uses system font (macOS only)
+       imported/w3c/web-platform-tests/css/css-fonts/font-size-zero-ligatures.html: Uses web font
+''',
+            added='''
+Test: fast/parser/frame-removal.html
+''',
+            after='''
+Tests: fast/text/font-size-zero-ligatures.html: Uses system font (macOS only)
+       imported/w3c/web-platform-tests/css/css-fonts/font-size-zero-ligatures.html: Uses web font
+       fast/parser/frame-removal.html
+''',
+        )
+
+    def test_reconcile_tests_keeps_prose_section_when_nothing_added(self):
+        self.assert_reconcile_tests(
+            before='''
+Tests: Covered by existing tests.
+''',
+            added='',
+            after='''
+Tests: Covered by existing tests.
+''',
+        )
+
+    def test_reconcile_tests_does_not_duplicate_an_annotated_test(self):
+        # The author already named this test, then annotated it. Adding it again would
+        # leave the same path on two lines.
+        self.assert_reconcile_tests(
+            before='''
+Tests: fast/parser/frame-removal.html: only fails with the flag on
+       Covered by existing tests otherwise.
+''',
+            added='''
+Tests: fast/parser/frame-removal.html
+       fast/parser/window-stop.xhtml
+''',
+            after='''
+Tests: fast/parser/frame-removal.html: only fails with the flag on
+       Covered by existing tests otherwise.
+       fast/parser/window-stop.xhtml
+''',
+        )
+
+    def test_reconcile_tests_appends_under_a_singular_prose_header(self):
+        self.assert_reconcile_tests(
+            before='''
+Test: media/video-timeupdate-before-seeking.html. Reproduces the race
+''',
+            added='''
+Test: fast/parser/frame-removal.html
+''',
+            after='''
+Test: media/video-timeupdate-before-seeking.html. Reproduces the race
+      fast/parser/frame-removal.html
+''',
+        )

--- a/Tools/Scripts/prepare-ChangeLog
+++ b/Tools/Scripts/prepare-ChangeLog
@@ -663,7 +663,7 @@ sub generateNewChangeLogs($$$$$$$$$$$$$$$$)
 
         if ($shouldMentionTests) {
             if (@$addedRegressionTests) {
-                print CHANGE_LOG normalizeLineEndings(testListForChangeLog(sort @$addedRegressionTests), $endl);
+                print CHANGE_LOG normalizeLineEndings(testListForChangeLog(@$addedRegressionTests), $endl);
             } else {
                 print CHANGE_LOG normalizeLineEndings("        No new tests (OOPS!).\n\n", $endl);
             }
@@ -2312,13 +2312,15 @@ sub testListForChangeLog(@)
 
     return "" unless @tests;
 
+    # Drop the LayoutTests prefix before sorting, so the list is alphabetical as printed.
+    # Sorting the full paths instead puts Tools/TestWebKitAPI tests after LayoutTests ones.
+    @tests = sort map { my $test = $_; $test =~ s/^LayoutTests\///; $test } @tests;
+
     my $leadString = "        Test" . (@tests == 1 ? "" : "s") . ": ";
     my $list = $leadString;
     foreach my $i (0..$#tests) {
         $list .= " " x length($leadString) if $i;
-        my $test = $tests[$i];
-        $test =~ s/^LayoutTests\///;
-        $list .= "$test\n";
+        $list .= "$tests[$i]\n";
     }
     $list .= "\n";
 

--- a/Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/testListForChangeLog.pl
+++ b/Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/testListForChangeLog.pl
@@ -1,0 +1,97 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+
+use Test::More;
+use FindBin;
+use lib File::Spec->catdir($FindBin::Bin, "..");
+use LoadAsModule qw(PrepareChangeLog prepare-ChangeLog);
+
+# Continuation lines line up under the first test name, past the 15 character
+# "        Tests: " lead string.
+my $multipleIndent = " " x 15;
+
+my @testCaseHashRefs = (
+{
+    testName => "No tests",
+    inputTests => [],
+    expected => ""
+},
+{
+    testName => "Single layout test drops the LayoutTests prefix",
+    inputTests => ["LayoutTests/fast/dom/added-test.html"],
+    expected => "        Test: fast/dom/added-test.html\n\n"
+},
+{
+    testName => "Single API test keeps its full path",
+    inputTests => ["Tools/TestWebKitAPI/Tests/WebKit/AddedTest.mm"],
+    expected => "        Test: Tools/TestWebKitAPI/Tests/WebKit/AddedTest.mm\n\n"
+},
+{
+    testName => "Multiple layout tests are sorted",
+    inputTests => [
+        "LayoutTests/fast/dom/zebra.html",
+        "LayoutTests/fast/dom/apple.html",
+        "LayoutTests/fast/css/middle.html",
+    ],
+    expected => "        Tests: fast/css/middle.html\n"
+        . $multipleIndent . "fast/dom/apple.html\n"
+        . $multipleIndent . "fast/dom/zebra.html\n"
+        . "\n"
+},
+{
+    # Sorting the full paths put every Tools test after every LayoutTests test,
+    # so the printed list was not alphabetical once the prefix was stripped.
+    testName => "Layout and API tests are sorted as printed",
+    inputTests => [
+        "LayoutTests/fast/dom/added-test.html",
+        "Tools/TestWebKitAPI/Tests/WebKit/AddedTest.mm",
+        "LayoutTests/http/tests/added-test.html",
+    ],
+    expected => "        Tests: Tools/TestWebKitAPI/Tests/WebKit/AddedTest.mm\n"
+        . $multipleIndent . "fast/dom/added-test.html\n"
+        . $multipleIndent . "http/tests/added-test.html\n"
+        . "\n"
+},
+{
+    testName => "Test path containing a space",
+    inputTests => ["Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift"],
+    expected => "        Test: Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift\n\n"
+},
+{
+    testName => "LayoutTests prefix is only stripped from the start of a path",
+    inputTests => ["Source/WebCore/LayoutTests/not-a-prefix.html"],
+    expected => "        Test: Source/WebCore/LayoutTests/not-a-prefix.html\n\n"
+},
+);
+
+my $testCasesCount = @testCaseHashRefs;
+plan(tests => $testCasesCount);
+
+foreach my $testCase (@testCaseHashRefs) {
+    my $got = PrepareChangeLog::testListForChangeLog(@{$testCase->{inputTests}});
+    is($got, $testCase->{expected}, $testCase->{testName});
+}


### PR DESCRIPTION
#### 7c93fbd030b4def3bcfb152b52ea9f8aaa12073b
<pre>
git-webkit does not sort or update the Tests: section of a commit message
<a href="https://bugs.webkit.org/show_bug.cgi?id=321859">https://bugs.webkit.org/show_bug.cgi?id=321859</a>
<a href="https://rdar.apple.com/185018520">rdar://185018520</a>

Reviewed by David Kilzer.

testListForChangeLog() sorted full paths and then stripped the LayoutTests
prefix when printing, so a Tools/TestWebKitAPI test printed after the layout
tests. Strip the prefix before sorting instead. testListForChangeLog.pl covers
the printed order.

Amending never regenerated the section. prepare-commit-msg passed
--no-mention-tests, so no test list was computed and the old section was copied
through, leaving new tests in the file list at the end. Compute the list and
reconcile it against the existing section.

reconcile_tests() rebuilds the section sorted when every entry is a test name.
When an entry carries prose, it keeps the section as written and appends only
the new tests, so hand-written notes keep their text and position. A name with
a space in it still counts as a path when it ends in a file extension, which
covers Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift.

Also fixes the ImportError fallback in amended_message(), which raised
NameError instead of falling back to the template.

Additionally, folks will need to run `git-webkit install-hooks` to pick up
this new behavior.

* Tools/Scripts/hooks/prepare-commit-msg:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py:
(CommitMessageParser._test_entries):
(CommitMessageParser):
(CommitMessageParser._is_test_name):
(CommitMessageParser._tests_indent):
(CommitMessageParser._mentions_test):
(CommitMessageParser.reconcile_tests):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_parser_unittest.py:
* Tools/Scripts/prepare-ChangeLog:
(generateNewChangeLogs):
(testListForChangeLog):
* Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/testListForChangeLog.pl: Added.

Canonical link: <a href="https://commits.webkit.org/319270@main">https://commits.webkit.org/319270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48e2633868029dd2644079468eaab4dd6429841d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191191 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145300 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34eceb1c-7607-4daf-ab1a-dd3a671fb559) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141204 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7d71b07-9021-4203-93e8-3fa56de58167) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121656 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/511900c4-1b58-46f5-9253-e1ae55792d71) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180301 "Found 1 webkitpy test failure: webkitcorepy.tests.file_lock_unittest.FileLockTestCase.test_race") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43537 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41816 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41476 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2351 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193126 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/180378 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54588 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150589 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40300 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55276 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38094 "Too many flaky failures: http/tests/media/video-useragent.html, http/tests/misc/submit-get-in-utf16le.html, http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection.html, http/tests/resourceLoadStatistics/ping-to-prevalent-resource.html, http/tests/security/contentSecurityPolicy/shared-worker-blob-url-inherits-csp-importScripts-blocked.html, http/tests/security/cors-post-redirect-301.html, http/tests/site-isolation/iframe-with-transform.html, http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html, http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup.html, http/tests/workers/service/page-cache-service-worker-pending-promise.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150306 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44894 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123021 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53793 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16470 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53175 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53412 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53240 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->