### PR TITLE
DataTransferItemList's indexed property getter should be anonymous and length should be unsigned long

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-indexed-getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-indexed-getter-expected.txt
@@ -1,0 +1,8 @@
+
+PASS DataTransferItemList.prototype exposes exactly length, add(), remove() and clear()
+PASS Supported property indices return a DataTransferItem
+PASS Unsupported property indices return undefined
+PASS length is the number of items in the drag data store item list
+PASS Indexed properties are enumerable, configurable and non-writable
+PASS Indexed properties are enumerated and iterated in index order
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-indexed-getter.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-indexed-getter.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>DataTransferItemList indexed property getter and length</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitemlist-interface">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+function itemListWithTwoStrings() {
+  const dt = new DataTransfer();
+  dt.items.add("hello", "text/plain");
+  dt.items.add("<b>hello</b>", "text/html");
+  return dt.items;
+}
+
+test(() => {
+  // The indexed property getter is declared without an identifier, so it must
+  // not be exposed as an operation on the interface prototype object.
+  assert_false("item" in DataTransferItemList.prototype, "item");
+  assert_array_equals(Object.getOwnPropertyNames(DataTransferItemList.prototype).sort(),
+                      ["add", "clear", "constructor", "length", "remove"]);
+}, "DataTransferItemList.prototype exposes exactly length, add(), remove() and clear()");
+
+test(() => {
+  const items = itemListWithTwoStrings();
+  assert_equals(items.length, 2);
+  assert_true(items[0] instanceof DataTransferItem, "items[0]");
+  assert_true(items[1] instanceof DataTransferItem, "items[1]");
+  assert_equals(items[0].type, "text/plain");
+  assert_equals(items[1].type, "text/html");
+}, "Supported property indices return a DataTransferItem");
+
+test(() => {
+  const items = itemListWithTwoStrings();
+  assert_equals(items[2], undefined, "index === length");
+  assert_equals(items[100], undefined, "index > length");
+  assert_equals(items[4294967294], undefined, "index === 2 ** 32 - 2");
+  assert_equals(items[4294967295], undefined, "2 ** 32 - 1 is not an array index");
+  assert_equals(items[-1], undefined, "negative index");
+}, "Unsupported property indices return undefined");
+
+test(() => {
+  const items = itemListWithTwoStrings();
+  assert_equals(items.length, 2);
+  items.remove(0);
+  assert_equals(items.length, 1, "after remove()");
+  assert_equals(items[0].type, "text/html");
+  assert_equals(items[1], undefined);
+  items.clear();
+  assert_equals(items.length, 0, "after clear()");
+  assert_equals(items[0], undefined);
+}, "length is the number of items in the drag data store item list");
+
+test(() => {
+  const items = itemListWithTwoStrings();
+  const descriptor = Object.getOwnPropertyDescriptor(items, 0);
+  assert_equals(descriptor.value, items[0], "value");
+  assert_false(descriptor.writable, "writable: there is no indexed property setter");
+  assert_true(descriptor.enumerable, "enumerable");
+  assert_true(descriptor.configurable, "configurable");
+  assert_equals(Object.getOwnPropertyDescriptor(items, 2), undefined, "unsupported index");
+}, "Indexed properties are enumerable, configurable and non-writable");
+
+test(() => {
+  const items = itemListWithTwoStrings();
+  assert_array_equals(Object.keys(items), ["0", "1"]);
+  assert_array_equals(Array.from(items, item => item.type), ["text/plain", "text/html"]);
+}, "Indexed properties are enumerated and iterated in index order");
+</script>

--- a/Source/WebCore/dom/DataTransferItemList.idl
+++ b/Source/WebCore/dom/DataTransferItemList.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -30,14 +30,14 @@
  */
 
 // https://html.spec.whatwg.org/multipage/dnd.html#datatransferitemlist
+
 [
     EnabledBySetting=DataTransferItemsEnabled,
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface DataTransferItemList {
-    readonly attribute long length;
-    // FIXME: The spec says this should be anonymous. If the name gets removed, the nullable annotation should also be removed, as it is implicit for anonymous getters.
-    getter DataTransferItem? item(unsigned long index);
+    readonly attribute unsigned long length;
+    getter DataTransferItem (unsigned long index);
 
     [CallWith=CurrentDocument] DataTransferItem? add(DOMString data, DOMString type);
     DataTransferItem? add(File file);

--- a/Tools/TestWebKitAPI/Resources/cocoa/DataTransferItem-getAsEntry.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/DataTransferItem-getAsEntry.html
@@ -85,7 +85,7 @@ html, body {
     {
         output.value = "";
         for (let index = 0; index < items.length; index++) {
-            let item = items.item(index);
+            let item = items[index];
             output.value += `Found data transfer item (kind: '${item.kind}', type: '${item.type}')\n`;
             let entry = item.webkitGetAsEntry();
             if (entry)


### PR DESCRIPTION
#### 628689a39d8ee9639725c857f3526b4267e4336b
<pre>
DataTransferItemList&apos;s indexed property getter should be anonymous and length should be unsigned long
<a href="https://bugs.webkit.org/show_bug.cgi?id=321861">https://bugs.webkit.org/show_bug.cgi?id=321861</a>
<a href="https://rdar.apple.com/185019165">rdar://185019165</a>

Reviewed by Chris Dumez.

Two IDL declarations for DataTransferItemList do not match the HTML spec [1]:

    readonly attribute unsigned long length;
    getter DataTransferItem (unsigned long index);

* `length` was declared `long`, even though DataTransferItemList::length()
  returns unsigned. This is not observable from JS for realistic list sizes,
  but the declaration was simply wrong.

* The indexed property getter was declared with an identifier, `item`, which
  the spec does not have. That exposed a WebKit-only
  DataTransferItemList.prototype.item() operation; neither Chrome nor Firefox
  has it. Removing the identifier also removes the nullable annotation, as the
  pre-existing FIXME noted: nullability is implicit for an anonymous getter,
  and keeping the identifier while dropping `?` would not compile, since
  JSConverter&lt;IDLInterface&lt;T&gt;&gt; has no RefPtr overload.

The generated indexed getter is unaffected other than losing the prototype
function: it still null-checks the result of DataTransferItemList::item()
and unwraps it with IDLInterface&lt;DataTransferItem&gt;::extractValueFromNullable(),
so the implementation continues to return RefPtr&lt;DataTransferItem&gt; and
out-of-range indices continue to report the property as absent.

The only in-tree caller of the removed operation was the API test page
DataTransferItem-getAsEntry.html, used by DragAndDropTests
ExternalSourceDataTransferItemGetFolderAsEntry and
ExternalSourceDataTransferItemGetPlainTextFileAsEntry on iOS. It now uses
the indexed getter, `items[index]`. Previously the TypeError from calling
items.item() rejected handleDrop()&apos;s await, so the page never posted its
&quot;dropped&quot; message and both tests timed out.

[1] <a href="https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitemlist-interface">https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitemlist-interface</a>

Test: imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-indexed-getter.html

* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-indexed-getter-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-indexed-getter.html: Added.
* Source/WebCore/dom/DataTransferItemList.idl:
* Tools/TestWebKitAPI/Resources/cocoa/DataTransferItem-getAsEntry.html:

Canonical link: <a href="https://commits.webkit.org/319259@main">https://commits.webkit.org/319259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c59b47d04146a78e5d2933926ac6fd84cff21a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191179 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145288 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/99ef7b8e-023b-4b22-a8ba-504b1f510ee0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141191 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50fe3b73-bb28-410d-8f3f-24ff5b088af5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121643 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0947b64-302a-4d7f-a602-e7dc36dac717) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43524 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41805 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153928 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41463 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2339 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193114 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150577 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40290 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55264 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150294 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44881 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127530 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122995 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53781 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16457 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53163 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53400 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53228 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->