### PR TITLE
Web Inspector: selecting a CDATA section in the DOM tree throws "node.truncateEnd is not a function"

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/DOMSearchMatchObject.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMSearchMatchObject.js
@@ -71,7 +71,7 @@ WI.DOMSearchMatchObject = class DOMSearchMatchObject
             return title + ">";
 
         case Node.CDATA_SECTION_NODE:
-            return "<![CDATA[" + domNode + "]]>";
+            return "<![CDATA[" + domNode.nodeValue() + "]]>";
 
         case Node.PROCESSING_INSTRUCTION_NODE:
             var data = domNode.nodeValue();

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElementPathComponent.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElementPathComponent.js
@@ -57,7 +57,7 @@ WI.DOMTreeElementPathComponent = class DOMTreeElementPathComponent extends WI.Hi
             break;
 
         case Node.CDATA_SECTION_NODE:
-            title = "<![CDATA[" + node.truncateEnd(32) + "]]>";
+            title = "<![CDATA[" + node.nodeValue().truncateEnd(32) + "]]>";
             break;
 
         case Node.DOCUMENT_FRAGMENT_NODE:


### PR DESCRIPTION
#### 3b7282ac21bbb0cbe93af6bf69cca280968fa183
<pre>
Web Inspector: selecting a CDATA section in the DOM tree throws &quot;node.truncateEnd is not a function&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=321865">https://bugs.webkit.org/show_bug.cgi?id=321865</a>
<a href="https://rdar.apple.com/185027124">rdar://185027124</a>

Reviewed by Devin Rousso.

WI.DOMTreeElementPathComponent builds its title from the WI.DOMNode, but the
CDATA_SECTION_NODE case calls truncateEnd() on the node instead of on the node&apos;s
value. truncateEnd() is a String.prototype extension, so selecting a CDATA
section throws a TypeError out of the constructor, which leaves
ContentBrowser._updateContentViewSelectionPathNavigationItem() half done and
takes down the frontend. XML documents are the only ones that parse CDATA
sections, so this is reachable by selecting the CSS inside &lt;style&gt; when
inspecting an SVG document.

WI.DOMSearchMatchObject.titleForDOMNode() has the same mistake in its
CDATA_SECTION_NODE case, where it concatenates the WI.DOMNode itself and
produces &quot;&lt;![CDATA[[object Object]]]&gt;&quot; as the search result title.

* Source/WebInspectorUI/UserInterface/Models/DOMSearchMatchObject.js:
(WI.DOMSearchMatchObject.titleForDOMNode):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElementPathComponent.js:
(WI.DOMTreeElementPathComponent):

Canonical link: <a href="https://commits.webkit.org/319252@main">https://commits.webkit.org/319252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4cf2c0713ffb5f1bc81c42000cea31438cb54e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145286 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de2f3ea8-d31e-4853-9823-55e3a28add1b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141190 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7ab8187-f91b-477f-854f-b6393c61be4d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121642 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aad5bead-e480-44c1-acf5-61ab21a26406) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43523 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41803 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153927 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41461 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2337 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193112 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54574 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150575 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40284 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55262 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150292 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44879 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127528 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122993 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53779 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16455 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53161 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53398 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53226 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->