### PR TITLE
Changing href on an <image> referenced by <use> does not update the use instances

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/reference/use-image-href-mutating-ref.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/reference/use-image-href-mutating-ref.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference for mutating 'href' on an 'image' element referenced by 'use'</title>
+  <image x="25" y="25" width="100" height="50" href="/images/green-100x50.png"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-image-href-mutating-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-image-href-mutating-expected.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <title>Reference for mutating 'href' on an 'image' element referenced by 'use'</title>
+  <image x="25" y="25" width="100" height="50" href="/images/green-100x50.png"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-image-href-mutating.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-image-href-mutating.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" class="reftest-wait"
+     width="200" height="200">
+  <title>SVG use: mutating 'href' on the referenced 'image' element updates the instance</title>
+  <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement"/>
+  <h:link rel="match" href="reference/use-image-href-mutating-ref.svg"/>
+
+  <!-- The 'image' is inside 'defs', so it is never rendered directly: the use-element shadow tree
+       holds the only rendered copy of it. -->
+  <defs>
+    <image id="target" width="100" height="50"/>
+  </defs>
+
+  <use x="25" y="25" href="#target"/>
+
+  <script>
+    const image = document.getElementById("target");
+
+    // Flush layout so that the use-element shadow tree is generated before the href is set below,
+    // and the test therefore exercises an update of an existing instance.
+    document.documentElement.getBoundingClientRect();
+
+    image.addEventListener("load", () => {
+      // The instance has its own request for the image, which is only started once the shadow tree
+      // is regenerated, so it is not complete when the event above fires. Wait for a rendering
+      // update before comparing against the reference.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => document.documentElement.classList.remove("reftest-wait"));
+      });
+    });
+    image.setAttribute("href", "/images/green-100x50.png");
+  </script>
+</svg>

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -149,6 +149,7 @@ void SVGImageElement::svgAttributeChanged(const QualifiedName& attrName)
     }
 
     if (SVGURIReference::isKnownAttribute(attrName)) {
+        InstanceInvalidationGuard guard(*this);
         m_imageLoader->updateFromElementIgnoringPreviousError();
         invalidateResourceImageBuffersIfNeeded();
         updateSVGRendererForElementChange();


### PR DESCRIPTION
#### 68a544edb81fa4c689e1e988175a9db2f2c16811
<pre>
Changing href on an &lt;image&gt; referenced by &lt;use&gt; does not update the use instances
<a href="https://bugs.webkit.org/show_bug.cgi?id=320438">https://bugs.webkit.org/show_bug.cgi?id=320438</a>
<a href="https://rdar.apple.com/183402463">rdar://183402463</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

SVGImageElement::svgAttributeChanged() handles href in its own branch, and that branch does
not take an InstanceInvalidationGuard, so the &lt;use&gt; shadow tree instances are never rebuilt
and keep the href they were cloned with. Nothing else covers for it: an &lt;image&gt; inside &lt;defs&gt;
has no renderer of its own, so the updateSVGRendererForElementChange() call in that branch is
a no-op, and the instances are the only rendered copies. An &lt;image&gt; in &lt;defs&gt; whose href is
assigned from script therefore stays blank in every &lt;use&gt; that references it, whether directly
or through a &lt;pattern&gt;.

203463@main (Remove the SVG elements&apos; attributes macros) replaced the single function-scope
guard, which covered every branch including this one, with per-branch guards, and did not give
one to the href branch. Take the guard here: SVGFEImageElement and SVGMPathElement guard their
href branches, SVGGradientElement and SVGPatternElement cover href in the same condition as
their animated properties, and SVGUseElement guards the whole of svgAttributeChanged().

The test flushes layout before assigning the href, and that ordering is load-bearing.
SVGUseElement builds its shadow tree lazily during a style update, so an href assigned before
the tree exists is already in place when the instance is cloned, and the test would pass with
or without this change. Forcing the tree to be built first guarantees the instance has been
cloned from the empty href before it is changed.

The instance&apos;s image is loaded through the cloned element&apos;s own CachedImage request, which is
only started once the shadow tree has been regenerated, so it is still outstanding when the
referenced element&apos;s load event fires. The test therefore waits for a rendering update after
that event rather than sampling immediately, which was flaky on the stress and site-isolation
queues.

Tests: imported/w3c/web-platform-tests/svg/struct/reftests/use-image-href-mutating.svg

* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/reference/use-image-href-mutating-ref.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-image-href-mutating-expected.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-image-href-mutating.svg: Added.
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::svgAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/319264@main">https://commits.webkit.org/319264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8b16a90219ece66f706b6ecb14f9491d4ee4e3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145324 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5170ad27-fbc4-4845-b76a-66bb371c89a3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141224 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5986c0ba-2037-434b-ae46-27b7cb03a4ed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161972 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121676 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d156dcd-965f-491d-891a-6d723ff3dc91) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43560 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41839 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41499 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2375 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193150 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150610 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40294 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55300 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150327 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44917 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127566 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123062 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53817 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16494 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53199 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53436 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53264 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->