### PR TITLE
[css-values-5 random-item()] Parse <random-ua-ident> in a <random-key>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt
@@ -157,5 +157,5 @@ PASS random() shared by shorthand property in var(), test random() value index
 PASS random() shared by property in attr()
 PASS random() shared by property in typed attr()
 PASS Test collision with property name and identifier
-FAIL Test user specified <random-ua-ident> assert_true: Random values should be equal expected true got false
+PASS Test user specified <random-ua-ident>
 

--- a/Source/WebCore/css/CSSRandomKeyParser.cpp
+++ b/Source/WebCore/css/CSSRandomKeyParser.cpp
@@ -28,15 +28,40 @@
 
 #include "CSSParserTokenRange.h"
 #include "CSSParserTokenRangeGuard.h"
+#include "CSSPropertyParser.h"
 #include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CSSPropertyParserConsumer+NumberDefinitions.h"
 #include "CSSPropertyParserState.h"
 #include "CSSValueKeywords.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
+
+// <random-ua-ident> = ua- PROPERTY [ - INDEX ]?, where INDEX is 1-based. Returns nullopt when the
+// ident does not name a known property, which makes the whole <random-key> invalid.
+// FIXME: § 9.4.1 also spells an in-custom-function form, ua-FUNCTIONNAME-PROPERTY[-INDEX]. Both names
+// can contain hyphens, so splitting it is ambiguous; see https://github.com/w3c/csswg-drafts/issues/14330
+static std::optional<Variant<CSSCalc::Random::Key::PropertyScoped, CSSCalc::Random::Key::PropertyIndexScoped>> parseRandomUAIdent(StringView ident)
+{
+    auto body = ident.substring(3);
+
+    if (auto lastHyphen = body.reverseFind('-'); lastHyphen != notFound) {
+        if (auto index = parseInteger<unsigned>(body.substring(lastHyphen + 1)); index >= 1) {
+            auto property = cssPropertyID(body.left(lastHyphen));
+            if (property == CSSPropertyInvalid)
+                return { };
+            return { CSSCalc::Random::Key::PropertyIndexScoped { CSSCalc::RandomScopedProperty { property, nullAtom() }, *index - 1 } };
+        }
+    }
+
+    auto property = cssPropertyID(body);
+    if (property == CSSPropertyInvalid)
+        return { };
+    return { CSSCalc::Random::Key::PropertyScoped { CSSCalc::RandomScopedProperty { property, nullAtom() } } };
+}
 
 std::optional<CSSCalc::Random::Sharing> consumeUnresolvedRandomKey(CSSParserTokenRange& tokens, CSS::PropertyParserState& state, const RandomKeySource& source, NOESCAPE const Function<unsigned()>& consumeIndex)
 {
@@ -111,6 +136,20 @@ std::optional<CSSCalc::Random::Sharing> consumeUnresolvedRandomKey(CSSParserToke
             tokens.consumeIncludingWhitespace();
             key.propertyScoped = CSSCalc::Random::Key::PropertyIndexScoped { source.property, consumeIndex() };
             return true;
+        }
+        // <random-ua-ident> = <custom-ident> starting with `ua-`. It spells out the property, and
+        // optionally the index, that the keywords derive implicitly, so `ua-height-1` names the same
+        // key as property-index-scoped does while parsing `height`. The index is 1-based in the ident.
+        // No index is consumed from the caller: the ident says which one it means.
+        if (tokens.peek().type() == IdentToken) {
+            if (auto identValue = tokens.peek().value(); startsWithLettersIgnoringASCIICase(identValue, "ua-"_s)) {
+                if (auto scoped = parseRandomUAIdent(identValue)) {
+                    tokens.consumeIncludingWhitespace();
+                    key.propertyScoped = WTF::move(*scoped);
+                    return true;
+                }
+                return false;
+            }
         }
         return false;
     };


### PR DESCRIPTION
#### dea374507ed3eab9cdeb7e85308ff2ec2091431f
<pre>
[css-values-5 random-item()] Parse &lt;random-ua-ident&gt; in a &lt;random-key&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=321552">https://bugs.webkit.org/show_bug.cgi?id=321552</a>
<a href="https://rdar.apple.com/184659364">rdar://184659364</a>

Reviewed by Antti Koivisto.

&lt;random-ua-ident&gt; is the third alternative in the property-scoping slot of
&lt;random-cache-key&gt; and was unimplemented, so an author writing one made the whole
declaration invalid at computed-value time.

It is a &lt;custom-ident&gt; that must start with `ua-`, and it spells out the property,
and optionally the index, that property-scoped and property-index-scoped derive
implicitly. `ua-height-1` therefore names the same key that property-index-scoped
builds while parsing `height`. The index in the ident is 1-based. An ident naming
no known property, or carrying an index of 0, is invalid, which invalidates the
whole &lt;random-key&gt;.

No index is taken from the caller when one of these is consumed, since the ident
already says which index it means, so an ident cannot shift the index of a later
`auto` or property-index-scoped in the same value.

This is the parse half of the bug. Serialization is still to do, and § 9.4.1 also
spells an in-custom-function form, ua-FUNCTIONNAME-PROPERTY[-INDEX], which is not
handled: both names can contain hyphens, so splitting it is ambiguous. Asked about
in <a href="https://github.com/w3c/csswg-drafts/issues/14330">https://github.com/w3c/csswg-drafts/issues/14330</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-computed.tentative-expected.txt:
* Source/WebCore/css/CSSRandomKeyParser.cpp:
(WebCore::CSSPropertyParserHelpers::parseRandomUAIdent):
(WebCore::CSSPropertyParserHelpers::consumeUnresolvedRandomKey):

Canonical link: <a href="https://commits.webkit.org/319393@main">https://commits.webkit.org/319393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56480a11d23e7d60c6b297317499af7b2a132489

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191379 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145485 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b40d417-3bad-4014-be38-5c1ef10b0076) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141369 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98061 "1 flakes 10 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21dadef9-9e1f-44f5-9c99-e6f0bca7e34d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121820 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12ac63a3-c2b4-473b-8197-9e68cf865e44) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43710 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41991 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41644 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2538 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193311 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54773 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150759 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40429 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55461 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150475 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45062 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127728 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123284 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53978 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16640 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53360 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53597 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53425 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->