### PR TITLE
[Site Isolation] Web inspector extension panels cannot find the inspected tab

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3071,8 +3071,18 @@ HashSet<Ref<WebProcessProxy>> WebExtensionContext::processes(const API::Inspecto
     ASSERT(m_inspectorContextMap.contains(*inspectorProxy));
 
     const auto& inspectorContext = m_inspectorContextMap.get(*inspectorProxy);
-    if (auto *backgroundWebView = inspectorContext.backgroundWebView.get())
-        result.add(backgroundWebView._page->siteIsolatedProcess());
+    if (auto *backgroundWebView = inspectorContext.backgroundWebView.get()) {
+        Ref backgroundPage = *backgroundWebView._page;
+        backgroundPage->forEachWebContentProcess([&](auto& webProcess, auto) {
+            result.addVoid(webProcess);
+        });
+    }
+
+    if (RefPtr inspectorFrontendPage = inspectorProxy->inspectorPage()) {
+        inspectorFrontendPage->forEachWebContentProcess([&](auto& webProcess, auto) {
+            result.addVoid(webProcess);
+        });
+    }
 
     return result;
 }
@@ -3233,17 +3243,12 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
         Ref inspectorExtension = result.value();
         inspectorExtension->setClient(makeUniqueRef<InspectorExtensionClient>(inspectorExtension, *this));
 
-        // Use foreground activity to keep background content responsive to events.
-        Ref inspectorPage = *inspectorBackgroundWebView._page;
-        Ref process = inspectorPage->legacyMainFrameProcess();
+        // Use foreground activity to keep background content responsive to events. A ProcessActivityGroup
+        // also covers processes the page later spreads to.
+        Ref inspectorBackgroundPage = *inspectorBackgroundWebView._page;
 
-        Variant<std::monostate, Ref<ProcessThrottlerActivity>, Ref<ProcessActivityGroup>> inspectorBackgroundWebViewActivity;
         constexpr ASCIILiteral activityName = "Web Extension Inspector background content"_s;
-
-        if (siteIsolationEnabled)
-            inspectorBackgroundWebViewActivity = protect(inspectorPage->activityGroupContext())->foregroundProcessActivityGroup(activityName);
-        else
-            inspectorBackgroundWebViewActivity = protect(process->throttler())->foregroundActivity(activityName);
+        Variant<std::monostate, Ref<ProcessThrottlerActivity>, Ref<ProcessActivityGroup>> inspectorBackgroundWebViewActivity = protect(inspectorBackgroundPage->activityGroupContext())->foregroundProcessActivityGroup(activityName);
 
         InspectorContext inspectorContext {
             tab->identifier(),
@@ -3259,10 +3264,16 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
 
         auto appearance = protect(inspector->inspectorPage())->useDarkAppearance() ? Inspector::ExtensionAppearance::Dark : Inspector::ExtensionAppearance::Light;
 
-        ASSERT(siteIsolationEnabled || inspectorWebView._page->legacyMainFrameProcess() == process);
-        process->send(Messages::WebExtensionContextProxy::AddInspectorPageIdentifier(inspectorWebView._page->webPageIDInMainFrameProcess(), tab->identifier(), windowIdentifier), identifier());
-        process->send(Messages::WebExtensionContextProxy::AddInspectorBackgroundPageIdentifier(inspectorBackgroundWebView._page->webPageIDInMainFrameProcess(), tab->identifier(), windowIdentifier), identifier());
-        process->send(Messages::WebExtensionContextProxy::DispatchDevToolsPanelsThemeChangedEvent(appearance), identifier());
+        Ref inspectorFrontendPage = *inspectorWebView._page;
+        inspectorFrontendPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+            webProcess.send(Messages::WebExtensionContextProxy::AddInspectorPageIdentifier(pageID, tab->identifier(), windowIdentifier), identifier());
+        });
+
+        inspectorBackgroundPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+            webProcess.send(Messages::WebExtensionContextProxy::AddInspectorBackgroundPageIdentifier(pageID, tab->identifier(), windowIdentifier), identifier());
+        });
+
+        sendToProcesses(processes(inspectorExtension.get()), Messages::WebExtensionContextProxy::DispatchDevToolsPanelsThemeChangedEvent(appearance));
 
         [inspectorBackgroundWebView loadRequest:[NSURLRequest requestWithURL:inspectorBackgroundPageURL().createNSURL().get()]];
     });

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm
@@ -31,6 +31,7 @@
 #import "Helpers/cocoa/WebExtensionUtilities.h"
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKInspectorPrivate.h>
+#import <wtf/SetForScope.h>
 
 namespace TestWebKitAPI {
 
@@ -651,6 +652,58 @@ TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToDevToolsBackground)
 
         @"  browser.test.notifyPass()",
         @"})"
+    ]);
+
+    auto *iconSVG = @"<svg width='16' height='16' xmlns='http://www.w3.org/2000/svg'><circle cx='8' cy='8' r='8' fill='red' /></svg>";
+
+    auto *resources = @{
+        @"background.js": @"// This script is intentionally left blank.",
+        @"devtools.html": @"<script type='module' src='devtools.js'></script>",
+        @"devtools.js": devToolsScript,
+        @"panel.html": @"<script type='module' src='panel.js'></script>",
+        @"panel.js": panelScript,
+        @"icon.svg": iconSVG,
+    };
+
+    auto manager = Util::loadExtension(devToolsManifest, resources);
+
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
+
+    [manager runUntilTestMessage:@"Panel Created"];
+
+    auto *extensionIdentifier = [NSString stringWithFormat:@"WebExtensionTab-%@-1", manager.get().context.uniqueIdentifier];
+    [manager.get().defaultTab.webView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
+        EXPECT_NULL(error);
+    }];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIDevTools, InspectedWindowTabIdFromPanel)
+{
+    SetForScope siteIsolation { Util::shouldEnableSiteIsolationForWebExtensionsTest, true };
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *devToolsScript = Util::constructScript(@[
+        @"let panel = await browser.devtools.panels.create('Test Panel', 'icon.svg', 'panel.html')",
+        @"browser.test.assertEq(typeof panel, 'object', 'Panel should be created successfully')",
+
+        // The devtools_page resolves through its own process, so this half holds either way.
+        @"browser.test.assertTrue(browser.devtools.inspectedWindow.tabId > 0, 'inspectedWindow.tabId should identify the inspected tab from the devtools page')",
+
+        @"browser.test.sendMessage('Panel Created')",
+    ]);
+
+    auto *panelScript = Util::constructScript(@[
+        @"const tabId = browser.devtools.inspectedWindow.tabId",
+        @"browser.test.assertEq(typeof tabId, 'number', 'inspectedWindow.tabId should be a number in a panel')",
+        @"browser.test.assertTrue(tabId > 0, 'inspectedWindow.tabId should identify the inspected tab from a panel, not be the none value')",
+
+        @"browser.test.notifyPass()",
     ]);
 
     auto *iconSVG = @"<svg width='16' height='16' xmlns='http://www.w3.org/2000/svg'><circle cx='8' cy='8' r='8' fill='red' /></svg>";


### PR DESCRIPTION
#### e6b1ae8c27562cc0f913af77a29b4c64bd94c454
<pre>
[Site Isolation] Web inspector extension panels cannot find the inspected tab
<a href="https://rdar.apple.com/185031280">rdar://185031280</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321866">https://bugs.webkit.org/show_bug.cgi?id=321866</a>

Reviewed by NOBODY (OOPS!).

With site isolation the Web Inspector frontend page and the extension&apos;s dev tools background
page are in different web content processes. We sent the frontend page&apos;s identifier to the
background page&apos;s process, where it means nothing, so the frontend page was never registered.
Panels look up their tab through that page, so devtools.inspectedWindow.tabId returned the
&quot;none&quot; value instead of the inspected tab.

Now we send each identifier to the processes hosting the page it names, and include the frontend
page&apos;s processes in processes(), since panels live there and listen for those events too.

Also replaced the foreground activity branch with a ProcessActivityGroup, which covers the
page&apos;s current process and any it later spreads to.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::processes const):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDevTools.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToDevToolsBackground)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, InspectedWindowTabIdFromPanel)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6b1ae8c27562cc0f913af77a29b4c64bd94c454

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145266 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d19a1a4-ac4e-4356-a69d-682689104da4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141170 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97867 "33 flakes 7 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d5082d8-acd3-4941-ae18-3822ebd865b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121622 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/615969b7-fde4-4bab-8760-a2f2b34d46f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43505 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41785 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41445 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2317 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193092 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54554 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150555 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40324 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55242 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150272 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44863 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127508 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122936 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53759 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16439 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53141 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53378 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53206 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->