### PR TITLE
REGRESSION(19099@main): [macOS iOS] media/video-multiple-concurrent-playback.html is flaky failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8710,5 +8710,3 @@ webkit.org/b/321691 [ Release ] imported/w3c/web-platform-tests/web-locks/bfcach
 webkit.org/b/321726 imported/w3c/web-platform-tests/largest-contentful-paint/observe-svg-data-uri-image.html [ Pass Failure ]
 
 webkit.org/b/321701 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover.html [ Failure ]
-
-webkit.org/b/321819 media/video-multiple-concurrent-playback.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2464,6 +2464,4 @@ webkit.org/b/321524 [ Debug ] imported/w3c/web-platform-tests/payment-request/pa
 
 webkit.org/b/321726 imported/w3c/web-platform-tests/largest-contentful-paint/observe-svg-data-uri-image.html [ Pass Failure ]
 
-webkit.org/b/321819 media/video-multiple-concurrent-playback.html [ Pass Failure ]
-
 webkit.org/b/321823 [ Debug ] imported/w3c/web-platform-tests/fullscreen/model/move-to-fullscreen-iframe.html [ Pass Crash ]

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -629,7 +629,11 @@ void MediaSessionManagerInterface::sessionWillEndPlayback(PlatformMediaSessionIn
     RefPtr<PlatformMediaSessionInterface> firstPausedSession;
     for (auto it = sessions.begin(); it != sessions.end(); ++it) {
         RefPtr session = *it.get();
-        if (&pausingSession == session.get() || session->state() == PlatformMediaSession::State::Playing)
+        // preparingToPlay() counts as playing here, as it does in enforceConcurrentPlaybackRestriction().
+        // A session whose admission is in flight is not Playing yet, and the session it evicts must not be
+        // inserted ahead of it: currentSession() is the front of the list, and the guard in
+        // enforceConcurrentPlaybackRestriction() relies on it naming the session that claimed playback last.
+        if (&pausingSession == session.get() || session->state() == PlatformMediaSession::State::Playing || session->preparingToPlay())
             continue;
 
         firstPausedSession = session.get();


### PR DESCRIPTION
#### d642eeea6966a9805e01d25cfe44c2478a412dc5
<pre>
REGRESSION(19099@main): [macOS iOS] media/video-multiple-concurrent-playback.html is flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=321819">https://bugs.webkit.org/show_bug.cgi?id=321819</a>
<a href="https://rdar.apple.com/184960798">rdar://184960798</a>

Reviewed by Eric Carlson.

The test plays four videos, calling play() on the next one from the previous
element&apos;s &apos;playing&apos; handler. videos[2] and videos[3] can&apos;t play concurrently, so
videos[2] should end up paused and videos[3] playing. Sometimes both were paused.

Since 319099@main the &apos;playing&apos; event no longer waits for the session admission, so
videos[3].play() runs while videos[2]&apos;s admission is still outstanding: videos[2] had
to activate the audio session (the first two videos have no audio) and completes from
the task whenSettled() queued, while videos[3]&apos;s playability is known and resolves
immediately. videos[3] pauses videos[2] there, and sessionWillEndPlayback() moves videos[2]
ahead of videos[3], which isn&apos;t Playing yet; currentSession() is the front of the
list, so videos[2] becomes current and pauses videos[3] when its own admission task
runs.

sessionWillEndPlayback() now counts a session with preparingToPlay() as playing, as
enforceConcurrentPlaybackRestriction() already does, so the pausing session moves to
the end of the list and the session that evicted it stays current.

This is a workaround. Treating the front of the session list as &quot;the session that
claimed playback last&quot; is fragile while two functions reorder that list and the
claiming session isn&apos;t Playing yet. Tracking the session whose admission started last
is left for a follow-up.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::sessionWillEndPlayback): Treat a session whose
admission is in flight as playing.

Canonical link: <a href="https://commits.webkit.org/319254@main">https://commits.webkit.org/319254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/221513a3e81b6ee972cfd675c15860a571115b89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145269 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f87c9c58-9806-4362-9db8-437862c3f680) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141173 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31415e09-3e65-40af-99ae-92ac20fdc365) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121625 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7edf68b9-1172-45a5-b0ef-b778ab4a2258) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43509 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41789 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41448 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2320 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193095 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54557 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150558 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40286 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55245 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150275 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44867 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127511 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122945 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53762 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16442 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53144 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53209 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->