### PR TITLE
Cherry-pick 313485@main (72272dcc4feb). https://bugs.webkit.org/show_bug.cgi?id=315082

### DIFF
--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -1172,15 +1172,15 @@ class CachedScopedArgumentsTable : public CachedObject<ScopedArgumentsTable> {
 public:
     void encode(Encoder& encoder, const ScopedArgumentsTable& scopedArgumentsTable)
     {
-        m_length = scopedArgumentsTable.m_length;
-        m_arguments.encode(encoder, scopedArgumentsTable.m_arguments.get(), m_length);
+        m_length = scopedArgumentsTable.m_arguments.size();
+        m_arguments.encode(encoder, scopedArgumentsTable.m_arguments.span().data(), m_length);
     }
 
     ScopedArgumentsTable* decode(Decoder& decoder) const
     {
         ScopedArgumentsTable* scopedArgumentsTable = ScopedArgumentsTable::tryCreate(decoder.vm(), m_length);
         RELEASE_ASSERT(scopedArgumentsTable); // We crash here. This is unlikely to continue execution if we hit this condition when decoding UnlinkedCodeBlock.
-        m_arguments.decode(decoder, scopedArgumentsTable->m_arguments.get(), m_length);
+        m_arguments.decode(decoder, scopedArgumentsTable->m_arguments.mutableSpan().data(), m_length);
         return scopedArgumentsTable;
     }
 

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
@@ -38,7 +38,6 @@ const ClassInfo ScopedArgumentsTable::s_info = { "ScopedArgumentsTable"_s, nullp
 
 ScopedArgumentsTable::ScopedArgumentsTable(VM& vm)
     : Base(vm, vm.scopedArgumentsTableStructure.get())
-    , m_length(0)
     , m_locked(false)
 {
 }
@@ -66,21 +65,20 @@ ScopedArgumentsTable* ScopedArgumentsTable::tryCreate(VM& vm, uint32_t length)
     ScopedArgumentsTable* result = new (NotNull, buffer) ScopedArgumentsTable(vm);
     result->finishCreation(vm);
 
-    result->m_length = length;
-    result->m_arguments = ArgumentsPtr::tryCreate(length);
-    if (!result->m_arguments) [[unlikely]]
+    if (!result->m_arguments.tryGrow(length)) [[unlikely]]
         return nullptr;
-    result->m_watchpointSets.fill(nullptr, length);
+    if (!result->m_watchpointSets.tryGrow(length)) [[unlikely]]
+        return nullptr;
+    std::ranges::fill(result->m_watchpointSets.mutableSpan(), nullptr);
     return result;
 }
 
 ScopedArgumentsTable* ScopedArgumentsTable::tryClone(VM& vm)
 {
-    ScopedArgumentsTable* result = tryCreate(vm, m_length);
+    ScopedArgumentsTable* result = tryCreate(vm, m_arguments.size());
     if (!result) [[unlikely]]
         return nullptr;
-    for (unsigned i = m_length; i--;)
-        result->at(i) = this->at(i);
+    result->m_arguments = m_arguments;
     result->m_watchpointSets = this->m_watchpointSets;
     return result;
 }
@@ -88,23 +86,21 @@ ScopedArgumentsTable* ScopedArgumentsTable::tryClone(VM& vm)
 ScopedArgumentsTable* ScopedArgumentsTable::trySetLength(VM& vm, uint32_t newLength)
 {
     if (!m_locked) [[likely]] {
-        ArgumentsPtr newArguments = ArgumentsPtr::tryCreate(newLength, newLength);
-        if (!newArguments) [[unlikely]]
+        size_t oldSize = m_watchpointSets.size();
+        if (!m_arguments.tryGrow(newLength))
             return nullptr;
-        for (unsigned i = std::min(m_length, newLength); i--;)
-            newArguments.at(i) = this->at(i);
-        m_length = newLength;
-        m_arguments = WTF::move(newArguments);
-        m_watchpointSets.resize(newLength);
+        if (!m_watchpointSets.tryGrow(newLength))
+            return nullptr;
+        if (newLength > oldSize)
+            std::ranges::fill(m_watchpointSets.mutableSpan().subspan(oldSize), nullptr);
         return this;
     }
-    
+
     ScopedArgumentsTable* result = tryCreate(vm, newLength);
     if (!result) [[unlikely]]
         return nullptr;
-    m_watchpointSets.resize(newLength);
-    for (unsigned i = std::min(m_length, newLength); i--;) {
-        result->at(i) = this->at(i);
+    for (unsigned i = std::min<uint32_t>(m_arguments.size(), newLength); i--;) {
+        result->m_arguments[i] = this->m_arguments[i];
         result->m_watchpointSets[i] = this->m_watchpointSets[i];
     }
     return result;
@@ -121,7 +117,7 @@ ScopedArgumentsTable* ScopedArgumentsTable::trySet(VM& vm, uint32_t i, ScopeOffs
             return nullptr;
     } else
         result = this;
-    result->at(i) = value;
+    result->m_arguments[i] = value;
     return result;
 }
 

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.h
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.h
@@ -29,7 +29,7 @@
 #include <JavaScriptCore/ScopeOffset.h>
 #include <JavaScriptCore/VM.h>
 #include <wtf/Assertions.h>
-#include <wtf/CagedUniquePtr.h>
+#include <wtf/Vector.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -67,10 +67,10 @@ public:
 
     static void destroy(JSCell*);
 
-    uint32_t length() const { return m_length; }
+    uint32_t length() const { return m_arguments.size(); }
     ScopedArgumentsTable* trySetLength(VM&, uint32_t newLength);
     
-    ScopeOffset get(uint32_t i) const { return at(i); }
+    ScopeOffset get(uint32_t i) const { return m_arguments.at(i); }
     WatchpointSet* getWatchpointSet(uint32_t i) const { return m_watchpointSets.at(i); }
     
     void lock()
@@ -86,24 +86,17 @@ public:
     
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
 
-    static constexpr ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(ScopedArgumentsTable, m_length); }
-    static constexpr ptrdiff_t offsetOfArguments() { return OBJECT_OFFSETOF(ScopedArgumentsTable, m_arguments); }
+    using ArgumentScopeBufferType = Vector<ScopeOffset>;
 
-    typedef CagedUniquePtr<Gigacage::Primitive, ScopeOffset> ArgumentsPtr;
+    static constexpr ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(ScopedArgumentsTable, m_arguments) + ArgumentScopeBufferType::sizeMemoryOffset(); }
+    static constexpr ptrdiff_t offsetOfArguments() { return OBJECT_OFFSETOF(ScopedArgumentsTable, m_arguments) + ArgumentScopeBufferType::bufferMemoryOffset(); }
 
 private:
     ScopedArgumentsTable* tryClone(VM&);
-
-    ScopeOffset& at(uint32_t i) const
-    {
-        ASSERT_WITH_SECURITY_IMPLICATION(i < m_length);
-        return m_arguments.get()[i];
-    }
     
-    uint32_t m_length;
-    bool m_locked; // Being locked means that there are multiple references to this object and none of them expect to see the others' modifications. This means that modifications need to make a copy first.
-    ArgumentsPtr m_arguments;
+    ArgumentScopeBufferType m_arguments;
     Vector<WatchpointSet*> m_watchpointSets;
+    bool m_locked; // Being locked means that there are multiple references to this object and none of them expect to see the others' modifications. This means that modifications need to make a copy first.
 };
 
 } // namespace JSC

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -719,6 +719,7 @@ public:
     size_t size() const { return m_size; }
     size_t sizeInBytes() const { return static_cast<size_t>(m_size) * sizeof(T); }
     static constexpr ptrdiff_t sizeMemoryOffset() { return OBJECT_OFFSETOF(Vector, m_size); }
+    static constexpr ptrdiff_t bufferMemoryOffset() { return Base::bufferMemoryOffset(); }
     size_t capacity() const { return Base::capacity(); }
     bool isEmpty() const { return !size(); }
     std::span<const T> span() const LIFETIME_BOUND { return { data(), size() }; }


### PR DESCRIPTION
#### fff068bce4f6c2d55ca6487374ad100a8cfa1aab
<pre>
Cherry-pick 313485@main (72272dcc4feb). <a href="https://bugs.webkit.org/show_bug.cgi?id=315082">https://bugs.webkit.org/show_bug.cgi?id=315082</a>

Unreviewed backport.

    [JSC] ScopedArgumentsTable ScopeOffset buffer should allocate from fastMalloc
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315082">https://bugs.webkit.org/show_bug.cgi?id=315082</a>
    <a href="https://rdar.apple.com/175937787">rdar://175937787</a>

    Reviewed by Yusuke Suzuki.

    ScopedArgumentsTable::m_arguments is engine metadata, not user payload, but
    it was allocated from Gigacage::Primitive — making its ScopeOffsets reachable
    through any Primitive-cage write primitive and usable as an unchecked index
    into JSLexicalEnvironment::variables(). Replace the CagedUniquePtr with a
    Vector&lt;ScopeOffset&gt;. JIT/LLInt loads through offsetOfLength() / offsetOfArguments()
    are unchanged at the codegen level: m_size is unsigned (matches the prior
    uint32_t m_length) and m_buffer is a raw T*.

    Also, drop a stale m_watchpointSets.resize(newLength) from the m_locked
    branch of trySetLength: it mutated the supposedly-locked instance. The
    only caller (SymbolTable::trySetArgumentsLength) immediately swaps in the new
    table, so no caller observed the resized state.

    Canonical link: <a href="https://commits.webkit.org/313485@main">https://commits.webkit.org/313485@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1095@webkitglib/2.52">https://commits.webkit.org/305877.1095@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bb4b02f192dfcef2582a5c16f1eef05f7bedf39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180952 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/54897 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48695 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191166 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145275 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/56195 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54613 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141181 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145275 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183907 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/56195 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/48695 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121633 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/56195 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54613 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3598 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/48695 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/56195 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48695 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2326 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/42226 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/47509 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/54613 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193101 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/54563 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/48695 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150565 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/55251 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48695 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150282 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27466 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/55251 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127517 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122958 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/53768 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/48695 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/53150 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53387 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53215 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->