### PR TITLE
PlatformMediaSession::clientWillBeginPlayback() should return a GenericPromise

### DIFF
--- a/LayoutTests/media/video-playback-quality-webm-expected.txt
+++ b/LayoutTests/media/video-playback-quality-webm-expected.txt
@@ -7,7 +7,7 @@ EXPECTED (originalQuality.totalVideoFrames >= '0') OK
 EXPECTED (originalQuality.droppedVideoFrames == '0') OK
 EXPECTED (originalQuality.totalFrameDelay == '0') OK
 RUN(video.play())
-EVENT(playing)
+EVENT(timeupdate)
 RUN(newQuality = video.getVideoPlaybackQuality())
 EXPECTED (newQuality.creationTime > originalQuality.creationTime == 'true') OK
 EXPECTED (newQuality.totalVideoFrames >= originalQuality.totalVideoFrames == 'true') OK

--- a/LayoutTests/media/video-playback-quality-webm.html
+++ b/LayoutTests/media/video-playback-quality-webm.html
@@ -18,7 +18,7 @@
         testExpected('originalQuality.totalFrameDelay', 0);
 
         runWithKeyDown('video.play()');
-        await waitFor(video, 'playing');
+        await waitFor(video, 'timeupdate');
 
         run(`newQuality = video.getVideoPlaybackQuality()`);
         testExpected('newQuality.creationTime > originalQuality.creationTime', true);

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7324,8 +7324,6 @@ webkit.org/b/206952 imported/w3c/IndexedDB-private-browsing/idbindex_getKey6.htm
 
 webkit.org/b/209234 [ Release ] platform/ios/ios/plugin/youtube-flash-plugin-iframe-no-height-or-width.html [ Pass Failure ]
 
-webkit.org/b/214422 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/suspend-after-construct.html [ Pass Failure ]
-
 webkit.org/b/214730 [ Debug ] imported/w3c/web-platform-tests/webrtc/RTCCertificate-postMessage.html [ Skip ]
 webkit.org/b/214730 [ Debug ] imported/w3c/web-platform-tests/webrtc/RTCCertificate.html [ Skip ]
 webkit.org/b/214730 [ Debug ] imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-generateCertificate.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1536,8 +1536,6 @@ fast/text/text-styles/-apple-system [ Pass ]
 
 webkit.org/b/214155 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/blob.https.html [ Pass Failure ]
 
-webkit.org/b/214422 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/suspend-after-construct.html [ Skip ]
-
 # Skipping `setSinkId` tests due to lack of implementation.
 webkit.org/b/280303  imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-sinkid-constructor.https.html [ Skip ]
 webkit.org/b/280303  imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-sinkid-setsinkid.https.html [ Skip ]

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -281,9 +281,14 @@ void MediaSession::setPlaybackState(MediaSessionPlaybackState state)
 
     updateReportedPosition();
 
-    if (state == MediaSessionPlaybackState::Playing)
-        m_platformSession->clientWillBeginPlayback([] (bool) { });
-    else if (m_playbackState == MediaSessionPlaybackState::Playing)
+    if (state == MediaSessionPlaybackState::Playing) {
+        // Registers this session in the manager's sessions() set synchronously, the same way
+        // HTMLMediaElement::playInternal() already does — independent of whether the admission below
+        // ever completes, so beginInterruption()'s forEachSession() can find this session immediately,
+        // not just once its (now always asynchronous) admission settles.
+        m_platformSession->setActive(true);
+        m_platformSession->clientWillBeginPlayback();
+    } else if (m_playbackState == MediaSessionPlaybackState::Playing)
         m_platformSession->clientWillPausePlayback();
 
     m_playbackState = state;

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -46,7 +46,9 @@
 #include "PlatformMediaSessionManager.h"
 #include "Settings.h"
 #include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/MainThread.h>
 #include <wtf/MediaTime.h>
+#include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MEDIA_STREAM)
@@ -251,6 +253,8 @@ void AudioContext::close(DOMPromiseDeferred<void>&& promise)
 
 void AudioContext::suspendRendering(DOMPromiseDeferred<void>&& promise)
 {
+    assertIsMainThread();
+
     if (isStopped() || isClosed()) {
         promise.reject(Exception { ExceptionCode::InvalidStateError, "Context is closed"_s });
         return;
@@ -258,25 +262,45 @@ void AudioContext::suspendRendering(DOMPromiseDeferred<void>&& promise)
 
     m_wasSuspendedByScript = true;
 
-    if (!willPausePlayback()) {
-        addReaction(State::Suspended, WTF::move(promise));
-        return;
-    }
-
-    lazyInitialize();
-
-    protect(destination())->suspend([activity = makePendingActivity(*this), promise = WTF::move(promise)](std::optional<Exception>&& exception) mutable {
-        if (exception) {
-            promise.reject(WTF::move(*exception));
-            return;
+    auto doSuspend = [this, protectedThis = Ref { *this }, promise = WTF::move(promise)]() mutable {
+        if (isStopped() || isClosed()) {
+            promise.reject(Exception { ExceptionCode::InvalidStateError, "Context is closed"_s });
+            return GenericPromise::createAndResolve();
         }
-        activity->object().setState(State::Suspended);
-        promise.resolve();
+
+        if (!willPausePlayback()) {
+            addReaction(State::Suspended, WTF::move(promise));
+            return GenericPromise::createAndResolve();
+        }
+
+        lazyInitialize();
+
+        GenericPromise::Producer producer;
+        Ref result = producer.promise();
+        protect(destination())->suspend([activity = makePendingActivity(*this), promise = WTF::move(promise), producer = WTF::move(producer)](std::optional<Exception>&& exception) mutable {
+            activity->object().queueTaskKeepingObjectAlive(activity->object(), TaskSource::InternalAsyncTask, [promise = WTF::move(promise), producer = WTF::move(producer), exception = WTF::move(exception)](auto& context) mutable {
+                if (exception) {
+                    promise.reject(WTF::move(*exception));
+                    producer.resolve();
+                    return;
+                }
+                context.setState(State::Suspended);
+                promise.resolve();
+                producer.resolve();
+            });
+        });
+        return result;
+    };
+
+    m_currentRenderingOperation = protect(m_currentRenderingOperation)->whenSettled(RunLoop::mainSingleton(), [doSuspend = WTF::move(doSuspend)](auto) mutable {
+        return doSuspend();
     });
 }
 
 void AudioContext::resumeRendering(DOMPromiseDeferred<void>&& promise)
 {
+    assertIsMainThread();
+
     if (isStopped() || isClosed()) {
         promise.reject(Exception { ExceptionCode::InvalidStateError, "Context is closed"_s });
         return;
@@ -284,44 +308,64 @@ void AudioContext::resumeRendering(DOMPromiseDeferred<void>&& promise)
 
     m_wasSuspendedByScript = false;
 
-    willBeginPlayback([weakThis = WeakPtr { *this }, promise = WTF::move(promise)](bool willBegin) mutable {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
+    auto doResume = [this, protectedThis = Ref { *this }, promise = WTF::move(promise)]() mutable {
+        GenericPromise::Producer producer;
+        Ref result = producer.promise();
 
-        if (!willBegin) {
-            protectedThis->addReaction(State::Running, WTF::move(promise));
-            return;
-        }
-
-        if (protectedThis->isStopped() || protectedThis->isClosed()) {
-            promise.reject(Exception { ExceptionCode::InvalidStateError, "Context is closed"_s });
-            return;
-        }
-
-        protectedThis->lazyInitialize();
-        Ref destination = protectedThis->destination();
-        if (!destination->isInitialized()) {
-            promise.reject(Exception { ExceptionCode::InvalidStateError, "AudioDestinationNode is not initialized"_s });
-            return;
-        }
-
-        destination->resume([activity = protectedThis->makePendingActivity(*protectedThis), promise = WTF::move(promise)](std::optional<Exception>&& exception) mutable {
-            if (exception) {
-                promise.reject(WTF::move(*exception));
+        willBeginPlayback([weakThis = WeakPtr { *this }, promise = WTF::move(promise), producer = WTF::move(producer)](bool willBegin) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis) {
+                producer.resolve();
                 return;
             }
 
-            // Since we update the state asynchronously, we may have been interrupted after the
-            // call to resume() and before this lambda runs. In this case, we don't want to
-            // reset the state to running.
-            bool interrupted = activity->object().m_mediaSession->state() == PlatformMediaSession::State::Interrupted;
-            activity->object().setState(interrupted ? State::Interrupted : State::Running);
-            if (interrupted)
-                activity->object().addReaction(State::Running, WTF::move(promise));
-            else
-                promise.resolve();
+            if (!willBegin) {
+                protectedThis->addReaction(State::Running, WTF::move(promise));
+                producer.resolve();
+                return;
+            }
+
+            if (protectedThis->isStopped() || protectedThis->isClosed()) {
+                promise.reject(Exception { ExceptionCode::InvalidStateError, "Context is closed"_s });
+                producer.resolve();
+                return;
+            }
+
+            protectedThis->lazyInitialize();
+            Ref destination = protectedThis->destination();
+            if (!destination->isInitialized()) {
+                promise.reject(Exception { ExceptionCode::InvalidStateError, "AudioDestinationNode is not initialized"_s });
+                producer.resolve();
+                return;
+            }
+
+            destination->resume([activity = protectedThis->makePendingActivity(*protectedThis), promise = WTF::move(promise), producer = WTF::move(producer)](std::optional<Exception>&& exception) mutable {
+                activity->object().queueTaskKeepingObjectAlive(activity->object(), TaskSource::InternalAsyncTask, [promise = WTF::move(promise), producer = WTF::move(producer), exception = WTF::move(exception)](auto& context) mutable {
+                    if (exception) {
+                        promise.reject(WTF::move(*exception));
+                        producer.resolve();
+                        return;
+                    }
+
+                    // Since we update the state asynchronously, we may have been interrupted after the
+                    // call to resume() and before this lambda runs. In this case, we don't want to
+                    // reset the state to running.
+                    bool interrupted = context.m_mediaSession->state() == PlatformMediaSession::State::Interrupted;
+                    context.setState(interrupted ? State::Interrupted : State::Running);
+                    if (interrupted)
+                        context.addReaction(State::Running, WTF::move(promise));
+                    else
+                        promise.resolve();
+                    producer.resolve();
+                });
+            });
         });
+
+        return result;
+    };
+
+    m_currentRenderingOperation = protect(m_currentRenderingOperation)->whenSettled(RunLoop::mainSingleton(), [doResume = WTF::move(doResume)](auto) mutable {
+        return doResume();
     });
 }
 
@@ -483,15 +527,15 @@ void AudioContext::willBeginPlayback(CompletionHandler<void(bool)>&& completionH
 
     m_mediaSession->setActive(true);
 
-    m_mediaSession->clientWillBeginPlayback([weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler), logSiteIdentifier = WTF::move(logSiteIdentifier)](bool willBegin) mutable {
+    m_mediaSession->clientWillBeginPlayback()->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler), logSiteIdentifier = WTF::move(logSiteIdentifier)](auto&& result) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             completionHandler(false);
             return;
         }
 
-        ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "returning ", willBegin);
-        completionHandler(willBegin);
+        ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "returning ", !!result);
+        completionHandler(!!result);
     });
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -172,6 +172,12 @@ private:
     // https://www.w3.org/TR/webaudio/#dom-audiocontext-suspended-by-user-slot
     bool m_wasSuspendedByScript { false };
 
+    // Serializes resumeRendering()/suspendRendering() against each other so their DOMPromiseDeferred
+    // arguments settle in call order — resume() then immediately suspend() must not let suspend's
+    // promise settle first just because clientWillPausePlayback() is synchronous while
+    // clientWillBeginPlayback() goes through the (async) session admission chain.
+    Ref<GenericPromise> m_currentRenderingOperation { GenericPromise::createAndResolve() };
+
     bool m_canOverrideBackgroundPlaybackRestriction { true };
 };
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3082,6 +3082,14 @@ void HTMLMediaElement::cancelPendingEventsAndCallbacks()
     for (auto& source : childrenOfType<HTMLSourceElement>(*this))
         source.cancelPendingErrorEvent();
 
+    // A new load racing an in-flight play() admission must not preempt a settlement that the
+    // admission's own callback is already guaranteed to deliver (see m_playPromiseSettlementGuaranteed).
+    if (m_beginPlaybackRequest->hasCallback()) {
+        if (m_playPromiseSettlementGuaranteed)
+            return;
+        m_beginPlaybackRequest->disconnect();
+    }
+
     rejectPendingPlayPromises(WTF::move(m_pendingPlayPromises), DOMException::create(ExceptionCode::AbortError));
 }
 
@@ -4733,16 +4741,7 @@ void HTMLMediaElement::playInternal()
         return;
     }
 
-    GenericPromise::Producer producer;
-    Ref promise = producer.promise();
-    mediaSession->clientWillBeginPlayback([producer = WTF::move(producer)](bool canBegin) mutable {
-        if (canBegin)
-            producer.resolve();
-        else
-            producer.reject();
-    });
-
-    promise->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, onAdmissionSettled = WTF::move(onAdmissionSettled)](auto&& result) {
+    mediaSession->clientWillBeginPlayback()->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, onAdmissionSettled = WTF::move(onAdmissionSettled)](auto&& result) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -6887,7 +6886,11 @@ void HTMLMediaElement::updatePlayState()
         invalidateOfficialPlaybackPosition();
 
         if (playerPaused) {
-            mediaSession->clientWillBeginPlayback([](bool) { });
+            // Only re-request admission if none is already in flight for this session — otherwise this
+            // would append a second, fully serialized admission (setCurrentSession, restriction
+            // enforcement) behind the current one, whose result nothing here consumes.
+            if (!mediaSession->preparingToPlay())
+                mediaSession->clientWillBeginPlayback();
 
             // Set rate, muted and volume before calling play in case they were set before the media engine was set up.
             // The media engine should just stash the rate, muted and volume values since it isn't already playing.
@@ -10105,7 +10108,9 @@ void HTMLMediaElement::updateShouldAutoplay()
 void HTMLMediaElement::updateShouldPlay()
 {
     if (!paused() && !protect(mediaSession())->playbackStateChangePermitted(MediaPlaybackState::Playing)) {
-        scheduleRejectPendingPlayPromises(DOMException::create(ExceptionCode::NotAllowedError));
+        // pauseInternal() rejects m_pendingPlayPromises itself, guarded by
+        // m_playPromiseSettlementGuaranteed — an in-flight play() admission that is
+        // guaranteed to settle this same promise must not be preempted here.
         pauseInternal();
         setAutoplayEventPlaybackState(AutoplayEventPlaybackState::PreventedAutoplay);
         return;

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -64,6 +64,7 @@
 #include "VideoTrackConfiguration.h"
 #include "VideoTrackList.h"
 #include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/RunLoop.h>
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
@@ -267,14 +268,12 @@ void MediaElementSession::clientWillBeginAutoplaying()
     updateClientDataBuffering();
 }
 
-void MediaElementSession::clientWillBeginPlayback(CompletionHandler<void(bool)>&& completionHandler)
+Ref<GenericPromise> MediaElementSession::clientWillBeginPlayback()
 {
-    PlatformMediaSession::clientWillBeginPlayback([weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](bool willBegin) mutable {
+    return PlatformMediaSession::clientWillBeginPlayback()->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }](auto&& result) {
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !willBegin) {
-            completionHandler(false);
-            return;
-        }
+        if (!protectedThis || !result)
+            return GenericPromise::createAndReject();
 
         protectedThis->m_elementIsHiddenBecauseItWasRemovedFromDOM = false;
         protectedThis->updateClientDataBuffering();
@@ -284,7 +283,7 @@ void MediaElementSession::clientWillBeginPlayback(CompletionHandler<void(bool)>&
             session->willBeginPlayback();
 #endif
 
-        completionHandler(true);
+        return GenericPromise::createAndResolve();
     });
 }
 

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -84,7 +84,7 @@ public:
     void unregisterWithDocument(Document&);
 
     void clientWillBeginAutoplaying() final;
-    void clientWillBeginPlayback(CompletionHandler<void(bool)>&&) final;
+    Ref<GenericPromise> clientWillBeginPlayback() final;
     bool clientWillPausePlayback() final;
     void clientCharacteristicsChanged(bool) final;
 

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -35,6 +35,7 @@
 #include "PlatformMediaSession.h"
 #include <algorithm>
 #include <ranges>
+#include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -518,7 +519,49 @@ MediaSessionRestrictions MediaSessionManagerInterface::restrictions(PlatformMedi
     return m_restrictions[indexFromMediaType(type)];
 }
 
-void MediaSessionManagerInterface::sessionWillBeginPlayback(PlatformMediaSessionInterface& session, CompletionHandler<void(bool)>&& completionHandler)
+Ref<GenericPromise> MediaSessionManagerInterface::sessionWillBeginPlayback(PlatformMediaSessionInterface& session)
+{
+    assertIsMainThread();
+
+    auto stateAtStart = session.state();
+
+    GenericPromise::Producer producer;
+    Ref promise = producer.promise();
+    m_currentPlaybackAdmission = protect(m_currentPlaybackAdmission)->whenSettled(RunLoop::mainSingleton(), [this, protectedThis = Ref { *this }, weakSession = WeakPtr { session }, stateAtStart, producer = WTF::move(producer)](auto) mutable -> Ref<GenericPromise> {
+        RefPtr session = weakSession.get();
+        if (!session) {
+            producer.reject();
+            return GenericPromise::createAndResolve();
+        }
+
+        // A pause() call between clientWillBeginPlayback() starting and this callback running means the
+        // client no longer intends to play — this turn must not touch setCurrentSession or evict anyone on
+        // its behalf. That gap exists on every call, not just a contended one: this link is always deferred
+        // by a run-loop turn, whether or not another admission preceded it in the chain. Resolve, not
+        // reject: commitPlaybackAdmission() handles the same race by skipping the claim to Playing while still
+        // settling successfully, and the play promise must settle the same way regardless of which of the two
+        // checks caught the race.
+        if (!session->admissionStillValid()) {
+            producer.resolve();
+            return GenericPromise::createAndResolve();
+        }
+
+        return startSessionAdmission(*session, stateAtStart)->whenSettled(RunLoop::mainSingleton(), [producer = WTF::move(producer)](auto&& result) mutable {
+            if (result)
+                producer.resolve();
+            else
+                producer.reject();
+            return GenericPromise::createAndResolve();
+        });
+    });
+    return promise;
+}
+
+void MediaSessionManagerInterface::sessionDidCompleteAdmission(PlatformMediaSessionInterface&)
+{
+}
+
+Ref<GenericPromise> MediaSessionManagerInterface::startSessionAdmission(PlatformMediaSessionInterface& session, PlatformMediaSessionState stateAtStart)
 {
     ALWAYS_LOG(LOGIDENTIFIER, session.logIdentifier());
 
@@ -527,10 +570,9 @@ void MediaSessionManagerInterface::sessionWillBeginPlayback(PlatformMediaSession
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
     auto sessionType = session.mediaType();
     auto restrictions = this->restrictions(sessionType);
-    if (session.state() == PlatformMediaSession::State::Interrupted && restrictions & MediaSessionRestriction::InterruptedPlaybackNotPermitted) {
-        ALWAYS_LOG(LOGIDENTIFIER, session.logIdentifier(), " returning false because session.state() is Interrupted, and InterruptedPlaybackNotPermitted");
-        completionHandler(false);
-        return;
+    if (stateAtStart == PlatformMediaSession::State::Interrupted && restrictions & MediaSessionRestriction::InterruptedPlaybackNotPermitted) {
+        ALWAYS_LOG(LOGIDENTIFIER, session.logIdentifier(), " returning false because stateAtStart is Interrupted, and InterruptedPlaybackNotPermitted");
+        return GenericPromise::createAndReject();
     }
 
     // Capture whether the session is already interrupted now. If activation is async and an
@@ -539,23 +581,26 @@ void MediaSessionManagerInterface::sessionWillBeginPlayback(PlatformMediaSession
     bool sessionWasAlreadyInterrupted = session.state() == PlatformMediaSession::State::Interrupted;
 
     auto logSiteIdentifier = LOGIDENTIFIER;
-    auto completeWillBeginPlayback = [this, protectedThis = Ref { *this }, weakSession = WeakPtr { session },
+    auto completeWillBeginPlayback = [this, protectedThis = Ref { *this }, weakSession = WeakPtr { session }, stateAtStart,
 #if !RELEASE_LOG_DISABLED
         sessionLogId = session.logIdentifier(),
 #endif
-        sessionWasAlreadyInterrupted, logSiteIdentifier, completionHandler = WTF::move(completionHandler)](bool activated) mutable {
+        sessionWasAlreadyInterrupted, logSiteIdentifier](bool activated) {
         if (!activated) {
             ALWAYS_LOG(logSiteIdentifier, " returning false, failed to activate AudioSession");
-            completionHandler(false);
-            return;
+            return GenericPromise::createAndReject();
         }
         if (m_currentInterruption && sessionWasAlreadyInterrupted)
             endInterruption(PlatformMediaSession::EndInterruptionFlags::NoFlags);
 
-        if (RefPtr session = weakSession.get())
-            enforceConcurrentPlaybackRestriction(*session);
+        if (RefPtr session = weakSession.get()) {
+            if (session->commitPlaybackAdmission(stateAtStart)) {
+                enforceConcurrentPlaybackRestriction(*session);
+                sessionDidCompleteAdmission(*session);
+            }
+        }
         ALWAYS_LOG(logSiteIdentifier, sessionLogId, " returning true");
-        completionHandler(true);
+        return GenericPromise::createAndResolve();
     };
 
 #if USE(AUDIO_SESSION)
@@ -576,29 +621,27 @@ void MediaSessionManagerInterface::sessionWillBeginPlayback(PlatformMediaSession
         // Video->VideoAudio transition), which would spuriously tear down an active
         // session and make internals.audioSessionActive() observably false at the
         // 'playing' event (Release-timing race). Consistent with B1.
-        AudioSession::singleton().tryToSetActive(true)->whenSettled(RunLoop::mainSingleton(),
-            [this, protectedThis = Ref { *this }, completeWillBeginPlayback = WTF::move(completeWillBeginPlayback)](auto&& result) mutable {
+        return AudioSession::singleton().tryToSetActive(true)->whenSettled(RunLoop::mainSingleton(),
+            [this, protectedThis = Ref { *this }, completeWillBeginPlayback = WTF::move(completeWillBeginPlayback)](auto&& result) {
                 if (result)
                     m_becameActive = true;
-                completeWillBeginPlayback(result.has_value());
+                Ref promise = completeWillBeginPlayback(result.has_value());
                 if (result && hasNoSession())
                     maybeDeactivateAudioSession();
+                return promise;
             });
-        return;
     }
 #endif
 
-    if (!activeAudioSessionRequired() || hasActiveAudioSession(session)) {
-        completeWillBeginPlayback(true);
-        return;
-    }
+    if (!activeAudioSessionRequired() || hasActiveAudioSession(session))
+        return completeWillBeginPlayback(true);
 
-    maybeActivateAudioSession()->whenSettled(RunLoop::mainSingleton(),
-        [completeWillBeginPlayback = WTF::move(completeWillBeginPlayback)](auto&& result) mutable {
-            completeWillBeginPlayback(result.has_value());
+    return maybeActivateAudioSession()->whenSettled(RunLoop::mainSingleton(),
+        [completeWillBeginPlayback = WTF::move(completeWillBeginPlayback)](auto&& result) {
+            return completeWillBeginPlayback(result.has_value());
         });
 #else
-    completionHandler(false);
+    return GenericPromise::createAndReject();
 #endif
 }
 
@@ -617,9 +660,12 @@ void MediaSessionManagerInterface::enforceConcurrentPlaybackRestriction(Platform
 
     forEachMatchingSession([&newSession](auto& otherSession) {
         bool isOther = &otherSession == &newSession;
-        // preparingToPlay() covers a session whose own admission has not completed yet: it intends to
-        // play, so it must not survive this restriction just because its state is not Playing.
-        bool isPlaying = otherSession.state() == PlatformMediaSession::State::Playing || otherSession.preparingToPlay();
+        // Only sessions that reached Playing are candidates. A session with preparingToPlay() set hasn't
+        // earned that yet — whether it's merely queued behind another admission (sessionWillBeginPlayback()
+        // serializes those) or a call from outside that chain (canProduceAudioChanged()) catches it mid-
+        // admission — and evicting it here preempts its own admission, which is the only place that should
+        // decide its fate.
+        bool isPlaying = otherSession.state() == PlatformMediaSession::State::Playing;
         bool canConcurrent = otherSession.canPlayConcurrently(newSession);
         if (isOther)
             return false;
@@ -648,11 +694,10 @@ void MediaSessionManagerInterface::sessionWillEndPlayback(PlatformMediaSessionIn
     RefPtr<PlatformMediaSessionInterface> firstPausedSession;
     for (auto it = sessions.begin(); it != sessions.end(); ++it) {
         RefPtr session = *it.get();
-        // preparingToPlay() counts as playing here, as it does in enforceConcurrentPlaybackRestriction().
-        // A session whose admission is in flight is not Playing yet, and the session it evicts must not be
-        // inserted ahead of it: currentSession() is the front of the list, and the guard in
-        // enforceConcurrentPlaybackRestriction() relies on it naming the session that claimed playback last.
-        if (&pausingSession == session.get() || session->state() == PlatformMediaSession::State::Playing || session->preparingToPlay())
+        // A session whose own admission is in flight must stay ahead of the pausing session: it is
+        // likely still at the front of the list, and enforceConcurrentPlaybackRestriction()'s guard
+        // relies on currentSession() still naming it once its admission completes.
+        if (&pausingSession == session.get() || session->isPlayingOrPreparingToPlay())
             continue;
 
         firstPausedSession = session.get();

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -125,7 +125,11 @@ public:
     virtual MediaSessionRestrictions restrictions(PlatformMediaSessionMediaType);
     virtual void resetRestrictions();
 
-    virtual void sessionWillBeginPlayback(PlatformMediaSessionInterface&, CompletionHandler<void(bool)>&&);
+    Ref<GenericPromise> sessionWillBeginPlayback(PlatformMediaSessionInterface&);
+    // Called after a session's admission commits to Playing, still inside the serialized admission region.
+    // Override for work that depends on that outcome (Now Playing/audio-session updates, wireless playback
+    // target assignment, cross-process notification) instead of overriding sessionWillBeginPlayback() itself.
+    virtual void sessionDidCompleteAdmission(PlatformMediaSessionInterface&);
     virtual void sessionWillEndPlayback(PlatformMediaSessionInterface&, DelayCallingUpdateNowPlaying);
     virtual void sessionStateChanged(PlatformMediaSessionInterface&);
     virtual void sessionDidEndRemoteScrubbing(PlatformMediaSessionInterface&) { }
@@ -226,10 +230,17 @@ protected:
 
 private:
     bool has(PlatformMediaSessionMediaType) const;
+    Ref<GenericPromise> startSessionAdmission(PlatformMediaSessionInterface&, PlatformMediaSessionState stateAtStart);
 
     std::array<MediaSessionRestrictions, static_cast<unsigned>(PlatformMediaSessionMediaType::DOMMediaSession) + 1> m_restrictions;
 
     std::optional<PlatformMediaSessionInterruptionType> m_currentInterruption;
+
+    // Used to serialize admissions; gets resolved when the current round completes. An admission whose
+    // AudioSession activation never replies stalls every later admission for this manager instance —
+    // page-wide, across every WebContent process, on the UI-process aggregator — and keeps this manager
+    // alive (each in-flight round holds a Ref to it). There is no watchdog for this today.
+    Ref<GenericPromise> m_currentPlaybackAdmission { GenericPromise::createAndResolve() };
 
     WeakHashSet<AudioCaptureSource> m_audioCaptureSources;
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -35,6 +35,7 @@
 #include "NowPlayingInfo.h"
 #include "PlatformMediaSessionManager.h"
 #include <wtf/MediaTime.h>
+#include <wtf/RunLoop.h>
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -267,12 +268,10 @@ void PlatformMediaSession::clientWillBeginAutoplaying()
     setState(State::Autoplaying);
 }
 
-void PlatformMediaSession::clientWillBeginPlayback(CompletionHandler<void(bool)>&& completionHandler)
+Ref<GenericPromise> PlatformMediaSession::clientWillBeginPlayback()
 {
-    if (m_notifyingClient) {
-        completionHandler(true);
-        return;
-    }
+    if (m_notifyingClient)
+        return GenericPromise::createAndResolve();
 
     ALWAYS_LOG(LOGIDENTIFIER, "state = ", m_state);
 
@@ -281,70 +280,52 @@ void PlatformMediaSession::clientWillBeginPlayback(CompletionHandler<void(bool)>
     // and ConcurrentCheck at completion time, potentially reordering session state
     // when async admissions interleave with the redundant clientWillBeginPlayback
     // call from updatePlayState).
-    if (state() == State::Playing) {
-        completionHandler(true);
-        return;
-    }
+    if (state() == State::Playing)
+        return GenericPromise::createAndResolve();
 
     RefPtr manager = sessionManager();
-    if (!manager) {
-        completionHandler(false);
-        return;
-    }
+    if (!manager)
+        return GenericPromise::createAndReject();
 
     // m_preparingToPlay tracks "play is still intended". It is cleared by
     // processClientWillPausePlayback if pause() is called while admission is
-    // in flight; it is also used by MediaElementSession::preferredBufferingPolicy
-    // and updateMediaUsageIfChanged to treat the in-flight state as Playing.
+    // in flight, and by commitPlaybackAdmission() once the manager's admission
+    // settles successfully.
     m_preparingToPlay = true;
 
-    // Capture the state at admission start. The pause-during-admission detection
-    // below compares state() at callback time against this captured value rather
-    // than against the (shared, mutable) m_preparingToPlay flag — m_preparingToPlay
-    // is cleared by an earlier admission's callback in the same session, so it
-    // cannot reliably distinguish "pause happened during my admission" from
-    // "another admission cleared the flag".
-    auto stateAtStart = state();
-
-    manager->sessionWillBeginPlayback(*this, [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler), stateAtStart](bool canBegin) mutable {
+    return manager->sessionWillBeginPlayback(*this)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }](auto&& result) {
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis) {
-            completionHandler(false);
-            return;
-        }
+        if (!protectedThis)
+            return GenericPromise::createAndReject();
 
-        protectedThis->m_preparingToPlay = false;
-
-        if (!canBegin) {
+        if (!result) {
+            protectedThis->m_preparingToPlay = false;
             if (protectedThis->state() == State::Interrupted)
                 protectedThis->m_stateToRestore = State::Playing;
-            completionHandler(false);
-            return;
+            return GenericPromise::createAndReject();
         }
 
-        // If state transitioned to Paused while admission was in flight (and
-        // it wasn't Paused at admission start), don't override the user's
-        // (or ended-path's) Paused state by setting state to Playing. But
-        // call completionHandler(true) — the manager-level admission did
-        // succeed, and we cannot reliably distinguish "user called pause()"
-        // from "player ended-path called setPaused(true)" (both call
-        // processClientWillPausePlayback identically). Returning true matches
-        // pre-branch behavior: scheduleNotifyAboutPlaying in the caller's
-        // success path will resolve the play promise. The trade-off is that
-        // for a genuine play()/pause() user race, the play promise resolves
-        // rather than rejecting with AbortError (spec deviation), but
-        // pre-branch sync admission had the same behavior because
-        // scheduleNotifyAboutPlaying ran before pauseInternal could reject
-        // the pending promises.
-        if (protectedThis->state() == State::Paused && stateAtStart != State::Paused) {
-            completionHandler(true);
-            return;
-        }
-
-        protectedThis->m_stateToRestore = State::Playing;
-        protectedThis->setState(State::Playing);
-        completionHandler(true);
+        return GenericPromise::createAndResolve();
     });
+}
+
+bool PlatformMediaSession::commitPlaybackAdmission(State stateAtStart)
+{
+    m_preparingToPlay = false;
+
+    // If state transitioned to Paused while admission was in flight (and it wasn't Paused
+    // at admission start), don't override the user's (or ended-path's) Paused state by
+    // setting state to Playing. The trade-off is that for a genuine play()/pause() user
+    // race, the play promise still resolves rather than rejecting with AbortError (spec
+    // deviation) — clientWillBeginPlayback()'s continuation resolves regardless of this
+    // result. What this return value controls is only whether the caller may enforce
+    // exclusivity on this session's behalf: a session that stayed paused never claimed it.
+    if (state() == State::Paused && stateAtStart != State::Paused)
+        return false;
+
+    m_stateToRestore = State::Playing;
+    setState(State::Playing);
+    return true;
 }
 
 bool PlatformMediaSession::processClientWillPausePlayback(DelayCallingUpdateNowPlaying shouldDelayCallingUpdateNowPlaying)

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -54,7 +54,8 @@ public:
     void endInterruption(OptionSet<EndInterruptionFlags>) final;
 
     void clientWillBeginAutoplaying() override;
-    void clientWillBeginPlayback(CompletionHandler<void(bool)>&&) override;
+    Ref<GenericPromise> clientWillBeginPlayback() override;
+    bool commitPlaybackAdmission(State stateAtStart) override;
     bool clientWillPausePlayback() override;
 
     void clientWillBeDOMSuspended() final;

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
@@ -157,7 +157,14 @@ public:
     virtual void clientCharacteristicsChanged(bool) = 0;
 
     virtual void clientWillBeginAutoplaying() = 0;
-    virtual void clientWillBeginPlayback(CompletionHandler<void(bool)>&&) = 0;
+    virtual Ref<GenericPromise> clientWillBeginPlayback() = 0;
+    // Called by the manager, inside the serialized admission region, once activation has succeeded and
+    // immediately before enforceConcurrentPlaybackRestriction(). stateAtStart is state() as captured
+    // synchronously when this admission began.
+    // Returns true if the session actually transitioned to Playing (so enforcing exclusivity on its behalf
+    // makes sense); false if it stayed paused (e.g. a pause() raced the admission), in which case the
+    // caller must not evict other sessions.
+    virtual bool commitPlaybackAdmission(State stateAtStart) = 0;
     virtual bool clientWillPausePlayback() = 0;
 
     virtual void clientWillBeDOMSuspended() = 0;
@@ -218,6 +225,21 @@ public:
 
     virtual bool preparingToPlay() const = 0;
 
+    // Whether a queued admission for this session, once its turn comes up in
+    // MediaSessionManagerInterface::sessionWillBeginPlayback()'s serialization chain, should still
+    // proceed. Defaults to preparingToPlay(): a local session may have had pause() called on it while
+    // queued, in which case it no longer wants to play. Overridden by RemoteMediaSessionProxy, whose
+    // preparingToPlay() mirrors a snapshot the WebContent process takes *after* it already committed the
+    // admission locally — always false for that message, which is not evidence of a race here; any real
+    // invalidation after commit arrives via a separate, later-ordered IPC message instead.
+    virtual bool admissionStillValid() const;
+
+    // A session whose own admission is in flight has not reached Playing yet but intends to; treat it
+    // as playing for the purpose of not disturbing it. Do not use this in enforceConcurrentPlaybackRestriction()'s
+    // eviction predicate — that one deliberately checks state() alone, since a merely-queued or
+    // in-flight session there is not a legitimate eviction target (see MediaSessionManagerInterface.cpp).
+    bool isPlayingOrPreparingToPlay() const;
+
     virtual bool canPlayConcurrently(const PlatformMediaSessionInterface&) const = 0;
     virtual bool shouldOverridePauseDuringRouteChange() const { return protect(client())->shouldOverridePauseDuringRouteChange(); }
 
@@ -277,5 +299,7 @@ inline void PlatformMediaSessionInterface::setMediaSessionIdentifier(MediaSessio
 inline PlatformMediaSessionClient& PlatformMediaSessionInterface::client() const { return m_client; }
 inline bool PlatformMediaSessionInterface::isRemoteSessionProxy() const { return false; }
 inline bool PlatformMediaSessionInterface::playbackPermitted() const { return true; }
+inline bool PlatformMediaSessionInterface::admissionStillValid() const { return preparingToPlay(); }
+inline bool PlatformMediaSessionInterface::isPlayingOrPreparingToPlay() const { return state() == State::Playing || preparingToPlay(); }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -88,7 +88,7 @@ protected:
     void addSession(PlatformMediaSessionInterface&) override;
     void setCurrentSession(PlatformMediaSessionInterface&) override;
 
-    void sessionWillBeginPlayback(PlatformMediaSessionInterface&, CompletionHandler<void(bool)>&&) override;
+    void sessionDidCompleteAdmission(PlatformMediaSessionInterface&) override;
     void sessionWillEndPlayback(PlatformMediaSessionInterface&, DelayCallingUpdateNowPlaying) override;
     void sessionDidEndRemoteScrubbing(PlatformMediaSessionInterface&) final;
     void clientCharacteristicsChanged(PlatformMediaSessionInterface&, bool) final;

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -276,18 +276,9 @@ void MediaSessionManagerCocoa::scheduleSessionStatusUpdate()
     });
 }
 
-void MediaSessionManagerCocoa::sessionWillBeginPlayback(PlatformMediaSessionInterface& session, CompletionHandler<void(bool)>&& completionHandler)
+void MediaSessionManagerCocoa::sessionDidCompleteAdmission(PlatformMediaSessionInterface&)
 {
-    PlatformMediaSessionManager::sessionWillBeginPlayback(session, [weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTF::move(completionHandler)](bool willBegin) mutable {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !willBegin) {
-            completionHandler(false);
-            return;
-        }
-
-        protectedThis->scheduleSessionStatusUpdate();
-        completionHandler(true);
-    });
+    scheduleSessionStatusUpdate();
 }
 
 void MediaSessionManagerCocoa::sessionDidEndRemoteScrubbing(PlatformMediaSessionInterface&)

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -31,6 +31,7 @@
 #include "PlatformMediaSession.h"
 #include "PlatformStrategies.h"
 #include <gio/gio.h>
+#include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GUniquePtr.h>
 
@@ -169,18 +170,9 @@ void MediaSessionManagerGLib::scheduleSessionStatusUpdate()
     });
 }
 
-void MediaSessionManagerGLib::sessionWillBeginPlayback(PlatformMediaSessionInterface& session, CompletionHandler<void(bool)>&& completionHandler)
+void MediaSessionManagerGLib::sessionDidCompleteAdmission(PlatformMediaSessionInterface&)
 {
-    PlatformMediaSessionManager::sessionWillBeginPlayback(session, [weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTF::move(completionHandler)](bool willBegin) mutable {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !willBegin) {
-            completionHandler(false);
-            return;
-        }
-
-        protectedThis->scheduleSessionStatusUpdate();
-        completionHandler(true);
-    });
+    scheduleSessionStatusUpdate();
 }
 
 void MediaSessionManagerGLib::sessionDidEndRemoteScrubbing(PlatformMediaSessionInterface&)

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
@@ -76,7 +76,7 @@ protected:
     void addSession(PlatformMediaSessionInterface&) final;
     void setCurrentSession(PlatformMediaSessionInterface&) final;
 
-    void sessionWillBeginPlayback(PlatformMediaSessionInterface&, CompletionHandler<void(bool)>&&) override;
+    void sessionDidCompleteAdmission(PlatformMediaSessionInterface&) override;
     void sessionWillEndPlayback(PlatformMediaSessionInterface&, DelayCallingUpdateNowPlaying) override;
     void sessionStateChanged(PlatformMediaSessionInterface&) override;
     void sessionDidEndRemoteScrubbing(PlatformMediaSessionInterface&) final;

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -70,7 +70,7 @@ protected:
     void resetRestrictions() override;
 #endif
 
-    void sessionWillBeginPlayback(PlatformMediaSessionInterface&, CompletionHandler<void(bool)>&&) override;
+    void sessionDidCompleteAdmission(PlatformMediaSessionInterface&) override;
 
 private:
     void configureWirelessTargetMonitoring() final;

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -132,34 +132,15 @@ void MediaSessionManageriOS::ensureMediaDeviceRouteControllerMonitoring()
 }
 #endif
 
-void MediaSessionManageriOS::sessionWillBeginPlayback(PlatformMediaSessionInterface& session, CompletionHandler<void(bool)>&& completionHandler)
+void MediaSessionManageriOS::sessionDidCompleteAdmission(PlatformMediaSessionInterface& session)
 {
-    auto logSiteIdentifier = LOGIDENTIFIER;
-    MediaSessionManagerCocoa::sessionWillBeginPlayback(session, [weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTF::move(completionHandler), strongSession = RefPtr { &session }, logSiteIdentifier = WTF::move(logSiteIdentifier)](bool canBegin) mutable {
+    MediaSessionManagerCocoa::sessionDidCompleteAdmission(session);
 
-        UNUSED_PARAM(logSiteIdentifier);
-
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis) {
-            completionHandler(false);
-            return;
-        }
-
-        if (!canBegin) {
-            completionHandler(false);
-            return;
-        }
-
-#if PLATFORM(IOS_FAMILY)
-        auto playbackTargetSupportsAirPlayVideo = MediaSessionHelper::sharedHelper().activeVideoRouteSupportsAirPlayVideo();
-        ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "Playback Target Supports AirPlay Video = ", playbackTargetSupportsAirPlayVideo);
-        if (RefPtr target = MediaSessionHelper::sharedHelper().playbackTarget(); target && playbackTargetSupportsAirPlayVideo)
-            strongSession->setPlaybackTarget(*target);
-        strongSession->setShouldPlayToPlaybackTarget(playbackTargetSupportsAirPlayVideo);
-#endif
-
-        completionHandler(true);
-    });
+    auto playbackTargetSupportsAirPlayVideo = MediaSessionHelper::sharedHelper().activeVideoRouteSupportsAirPlayVideo();
+    ALWAYS_LOG(LOGIDENTIFIER, "Playback Target Supports AirPlay Video = ", playbackTargetSupportsAirPlayVideo);
+    if (RefPtr target = MediaSessionHelper::sharedHelper().playbackTarget(); target && playbackTargetSupportsAirPlayVideo)
+        session.setPlaybackTarget(*target);
+    session.setShouldPlayToPlaybackTarget(playbackTargetSupportsAirPlayVideo);
 }
 
 void MediaSessionManageriOS::sessionWillEndPlayback(PlatformMediaSessionInterface& session, DelayCallingUpdateNowPlaying delayCallingUpdateNowPlaying)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -230,7 +230,7 @@ void RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback(IPC::Connecti
     // The content process decided whether playback may begin; this runs the part that needs every
     // process's sessions: making this one current, and the concurrent playback restriction.
     if (RefPtr session = findAndUpdateSession(connection, state))
-        REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionWillBeginPlayback(*session, [](bool) { });
+        REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionWillBeginPlayback(*session);
 }
 
 void RemoteMediaSessionManagerProxy::addMediaSessionRestriction(WebCore::PlatformMediaSessionMediaType type, WebCore::MediaSessionRestrictions restrictions)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
@@ -76,6 +76,14 @@ void RemoteMediaSessionProxy::setState(WebCore::PlatformMediaSessionState state)
     m_sessionState.state = state;
 }
 
+bool RemoteMediaSessionProxy::commitPlaybackAdmission(WebCore::PlatformMediaSessionState)
+{
+    // The content process already decided whether playback may begin — this proxy only mirrors
+    // that decision, so there is no pause-race to check locally; committing always succeeds.
+    setState(WebCore::PlatformMediaSessionState::Playing);
+    return true;
+}
+
 WeakPtr<WebCore::PlatformMediaSessionInterface> RemoteMediaSessionProxy::selectBestMediaSession(const Vector<WeakPtr<WebCore::PlatformMediaSessionInterface>>&, WebCore::PlatformMediaSessionPlaybackControlsPurpose)
 {
     // FIXME: Another synchronous API we need to fix.

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h
@@ -54,6 +54,7 @@ private:
 
     WebCore::PlatformMediaSessionState state() const  final { return m_sessionState.state; }
     void setState(WebCore::PlatformMediaSessionState) final;
+    bool commitPlaybackAdmission(WebCore::PlatformMediaSessionState) final;
 
     bool isPlayingToWirelessPlaybackTarget() const final { return m_sessionState.isPlayingToWirelessPlaybackTarget; }
 
@@ -68,6 +69,12 @@ private:
     bool hasMediaStreamSource() const final { return m_sessionState.hasMediaStreamSource; }
 
     bool preparingToPlay() const final { return m_sessionState.preparingToPlay; }
+
+    // The content process only sends MediaSessionWillBeginPlayback once it has already committed the
+    // admission locally, so there is nothing to revalidate here — unlike preparingToPlay(), which mirrors
+    // that message's post-commit snapshot and would otherwise always read false at this point.
+    bool admissionStillValid() const final { return true; }
+
     bool hasPlayedAudiblySinceLastInterruption() const final { return m_sessionState.hasPlayedAudiblySinceLastInterruption; }
 
     bool shouldOverridePauseDuringRouteChange() const final { return m_sessionState.shouldOverridePauseDuringRouteChange; }

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
@@ -110,16 +110,16 @@ void RemoteMediaSessionManager::setCurrentSession(WebCore::PlatformMediaSessionI
     send(Messages::RemoteMediaSessionManagerProxy::SetCurrentMediaSession(currentSessionState(session)));
 }
 
-void RemoteMediaSessionManager::sessionWillBeginPlayback(WebCore::PlatformMediaSessionInterface& session, CompletionHandler<void(bool)>&& completionHandler)
+void RemoteMediaSessionManager::sessionDidCompleteAdmission(WebCore::PlatformMediaSessionInterface& session)
 {
-    // Whether playback may begin is decided here: the session, its state and the restrictions are all
-    // in this process. The UI process is told so that it can make this session current and enforce the
-    // concurrent playback restriction across every process's sessions.
-    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionWillBeginPlayback(session, [protectedThis = Ref { *this }, state = currentSessionState(session), completionHandler = WTF::move(completionHandler)](bool granted) mutable {
-        if (granted)
-            protectedThis->send(Messages::RemoteMediaSessionManagerProxy::MediaSessionWillBeginPlayback(state));
-        completionHandler(granted);
-    });
+    REMOTE_MEDIA_SESSION_MANAGER_BASE_CLASS::sessionDidCompleteAdmission(session);
+
+    // Whether playback may begin was decided locally: the session, its state and the restrictions are
+    // all in this process. The UI process is told so that it can make this session current and enforce
+    // the concurrent playback restriction across every process's sessions. The snapshot is taken now,
+    // after commitPlaybackAdmission() has already run, so it carries State::Playing and
+    // preparingToPlay() == false.
+    send(Messages::RemoteMediaSessionManagerProxy::MediaSessionWillBeginPlayback(currentSessionState(session)));
 }
 
 void RemoteMediaSessionManager::addRestriction(WebCore::PlatformMediaSessionMediaType type, WebCore::MediaSessionRestrictions restrictions)

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h
@@ -95,7 +95,7 @@ private:
     void addSession(WebCore::PlatformMediaSessionInterface&) final;
     void removeSession(WebCore::PlatformMediaSessionInterface&) final;
     void setCurrentSession(WebCore::PlatformMediaSessionInterface&) final;
-    void sessionWillBeginPlayback(WebCore::PlatformMediaSessionInterface&, CompletionHandler<void(bool)>&&) final;
+    void sessionDidCompleteAdmission(WebCore::PlatformMediaSessionInterface&) final;
     void updateSessionState() final;
     void sessionStateChanged(WebCore::PlatformMediaSessionInterface&) final;
 


### PR DESCRIPTION
#### b989a866564b70d8e8507f2d773c8f8df6d342f4
<pre>
PlatformMediaSession::clientWillBeginPlayback() should return a GenericPromise
<a href="https://bugs.webkit.org/show_bug.cgi?id=321871">https://bugs.webkit.org/show_bug.cgi?id=321871</a>
<a href="https://rdar.apple.com/185043324">rdar://185043324</a>

Reviewed by Eric Carlson.

PlatformMediaSession::clientWillBeginPlayback() took a completion handler that
MediaSessionManagerInterface::sessionWillBeginPlayback() could call immediately,
inline, when admission needed no further work (the audio session was already
active), or only later, once AudioSession activation settled asynchronously.
Nothing guaranteed that two admissions requested close together completed in the
order they were requested: a video needing to activate the audio session stayed
pending while a second video, needing no activation, was admitted right away and
could evict the first video before the first video&apos;s own admission had even
finished. That inversion produced the flaky failure in bug 321819.

clientWillBeginPlayback() and the whole call chain down to
sessionWillBeginPlayback() now return a GenericPromise instead of taking a
completion handler, and each manager chains every new admission onto the promise
of whichever admission is currently outstanding: a request&apos;s own work does not
start until the previous one has fully settled, so completion always follows
request order and the inversion above cannot happen.
enforceConcurrentPlaybackRestriction()&apos;s eviction predicate no longer treats a
session whose own admission is preparingToPlay() as already playing: that let a
session which was still only queued, not yet given its turn, get evicted before
it ever started, which serialization makes both unnecessary and wrong.

Serializing admission this way also settles each one at least a run-loop turn
later than the completion-handler path did when no AudioSession activation was
needed. That wider window exposed two existing races: updateShouldPlay() and
cancelPendingEventsAndCallbacks() each rejected pending play promises
unconditionally, never checking whether an in-flight admission already promised
to settle them, producing an unhandled rejection in
media/audio-playback-restriction-play-muted.html and
imported/w3c/web-platform-tests/css/selectors/media/media-playback-state.html.
A session paused while its own admission sat queued behind another one&apos;s could
also still have setCurrentSession() called on its behalf, since nothing
revalidated its intent to play first.

Both rejection sites now defer to the same m_playPromiseSettlementGuaranteed
guard pauseInternal() already uses. PlatformMediaSessionInterface gains
commitPlaybackAdmission(), called by the manager right before
enforceConcurrentPlaybackRestriction(), and sessionWillBeginPlayback() gains an
earlier admissionStillValid() check (true by construction for
RemoteMediaSessionProxy, whose admission was already decided by the WebContent
process) so a paused, queued session never reaches setCurrentSession(). The
per-subclass sessionWillBeginPlayback() overrides are replaced by
sessionDidCompleteAdmission(), called only once commitPlaybackAdmission()
succeeds, keeping post-admission side effects inside the serialized region and
limited to a session that actually claimed Playing. updatePlayState() also
stopped requesting a second, redundant admission when one was already in flight
for the same session. commitPlaybackAdmission() takes the state captured at
admission start as a parameter rather than reading it from a member: a second,
overlapping admission for the same session would otherwise overwrite that member
before the first admission&apos;s commit reads it.

AudioContext hit a variant of the same ordering problem: suspendRendering()
calls clientWillPausePlayback(), which stays synchronous, while
resumeRendering() calls the now-always-asynchronous clientWillBeginPlayback().
Calling resume() then immediately suspend() could let suspend()&apos;s promise settle
first, in violation of the ordering
imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/suspend-after-construct.html
checks, which surfaced there as an unhandled rejection. resumeRendering() and
suspendRendering() now chain onto a new m_currentRenderingOperation the same way
sessionWillBeginPlayback() chains onto m_currentPlaybackAdmission, so a later
call&apos;s promise cannot settle before an earlier one already has; both now assert
they run on the main thread, since that chain is main-thread-only and nothing
enforced that before.

* LayoutTests/media/video-playback-quality-webm-expected.txt:
* LayoutTests/media/video-playback-quality-webm.html: Test was waiting on the playing event to check if playback quality has changed; this doesn&apos;t guarantee playback progressed.
* LayoutTests/platform/ios/TestExpectations: This commit resolved imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/suspend-after-construct.html
* LayoutTests/platform/mac/TestExpectations: This commit resolved imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/suspend-after-construct.html
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::setPlaybackState): Register the session synchronously
via setActive(true), the same way HTMLMediaElement::playInternal() already
does, so beginInterruption() can find it before its (now async) admission
settles.
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::suspendRendering): Chain onto
m_currentRenderingOperation and assert the main thread.
(WebCore::AudioContext::resumeRendering): Ditto.
(WebCore::AudioContext::willBeginPlayback):
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::cancelPendingEventsAndCallbacks): Ditto.
(WebCore::HTMLMediaElement::playInternal): Consume the promise directly; the
hand-built GenericPromise::Producer bridge is no longer needed now that
clientWillBeginPlayback() returns one.
(WebCore::HTMLMediaElement::updatePlayState): Skip re-requesting admission if
one is already in flight for the session.
(WebCore::HTMLMediaElement::updateShouldPlay): Let pauseInternal()&apos;s own
guarded rejection handle the pending play promise.
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::clientWillBeginPlayback):
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::sessionWillBeginPlayback): Assert the
main thread. Chain the request onto m_currentPlaybackAdmission and return a
GenericPromise. Resolve without starting the admission when
admissionStillValid() is false.
(WebCore::MediaSessionManagerInterface::sessionDidCompleteAdmission):
(WebCore::MediaSessionManagerInterface::startSessionAdmission): The former
body of sessionWillBeginPlayback(), returning a GenericPromise and taking the
caller&apos;s captured start state; call commitPlaybackAdmission() and only
enforce the restriction and call sessionDidCompleteAdmission() when it
returns true.
(WebCore::MediaSessionManagerInterface::enforceConcurrentPlaybackRestriction):
Drop the preparingToPlay() case from the eviction predicate.
(WebCore::MediaSessionManagerInterface::sessionWillEndPlayback): Use
isPlayingOrPreparingToPlay().
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::clientWillBeginPlayback): Capture the state
at admission start in a local, passed to commitPlaybackAdmission() as a
parameter rather than stored on the session.
(WebCore::PlatformMediaSession::commitPlaybackAdmission): Added.
* Source/WebCore/platform/audio/PlatformMediaSession.h:
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h:
(WebCore::PlatformMediaSessionInterface::admissionStillValid const):
(WebCore::PlatformMediaSessionInterface::isPlayingOrPreparingToPlay const):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::sessionDidCompleteAdmission): Replaces the
sessionWillBeginPlayback() override.
(WebCore::MediaSessionManagerCocoa::sessionWillBeginPlayback): Deleted.
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp:
(WebCore::MediaSessionManagerGLib::sessionDidCompleteAdmission): Ditto.
(WebCore::MediaSessionManagerGLib::sessionWillBeginPlayback): Deleted.
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::sessionDidCompleteAdmission): Ditto, keeping
the AirPlay playback target assignment.
(WebCore::MediaSessionManageriOS::sessionWillBeginPlayback): Deleted.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxy::mediaSessionWillBeginPlayback):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp:
(WebKit::RemoteMediaSessionProxy::commitPlaybackAdmission): Added.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h:
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp:
(WebKit::RemoteMediaSessionManager::sessionDidCompleteAdmission): Replaces the
sessionWillBeginPlayback() override; the session-state snapshot is now taken
after commitPlaybackAdmission() has run.
(WebKit::RemoteMediaSessionManager::sessionWillBeginPlayback): Deleted.
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.h:

Canonical link: <a href="https://commits.webkit.org/319455@main">https://commits.webkit.org/319455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f6d98e002cc2ae3ca3caab197f0c02bf26824d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191709 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145812 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141646 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122086 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44009 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41923 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2870 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48059 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46535 "Found 1 new test failure: imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193637 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151053 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40461 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55789 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150760 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45337 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128072 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123698 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54305 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16921 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53687 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53925 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53752 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->