### PR TITLE
NonSharedCharacterBreakIterator and NonSharedSentenceBreakIterator leak their UBreakIterator when setting the text fails

### DIFF
--- a/Source/WTF/wtf/text/TextBreakIterator.cpp
+++ b/Source/WTF/wtf/text/TextBreakIterator.cpp
@@ -23,6 +23,7 @@
 #include <wtf/text/TextBreakIterator.h>
 
 #include <wtf/Compiler.h>
+#include <wtf/Scope.h>
 #include <wtf/text/TextBreakIteratorInternalICU.h>
 #include <wtf/text/icu/UTextProviderLatin1.h>
 #include <atomic>
@@ -86,6 +87,9 @@ static UBreakIterator* setTextForIterator(UBreakIterator& iterator, StringView s
             LOG_ERROR("uTextOpenLatin1 failed with status %d", openStatus);
             return nullptr;
         }
+        auto closeText = makeScopeExit([&] {
+            utext_close(text);
+        });
 
         UErrorCode setTextStatus = U_ZERO_ERROR;
         ubrk_setUText(&iterator, text, &setTextStatus);
@@ -93,8 +97,6 @@ static UBreakIterator* setTextForIterator(UBreakIterator& iterator, StringView s
             LOG_ERROR("ubrk_setUText failed with status %d", setTextStatus);
             return nullptr;
         }
-
-        utext_close(text);
     } else {
         UErrorCode setTextStatus = U_ZERO_ERROR;
         auto characters = string.span16();
@@ -132,71 +134,65 @@ ALLOW_DEPRECATED_PRAGMA_BEGIN
 static std::atomic<UBreakIterator*> nonSharedCharacterBreakIterator = ATOMIC_VAR_INIT(nullptr);
 ALLOW_DEPRECATED_PRAGMA_END
 
-static inline UBreakIterator* getNonSharedCharacterBreakIterator()
+static inline UBreakIteratorPtr getNonSharedCharacterBreakIterator()
 {
-    if (auto *res = nonSharedCharacterBreakIterator.exchange(nullptr, std::memory_order_acquire))
-        return res;
-    return initializeIterator(UBRK_CHARACTER);
+    if (auto* cached = nonSharedCharacterBreakIterator.exchange(nullptr, std::memory_order_acquire))
+        return UBreakIteratorPtr { cached };
+    return UBreakIteratorPtr { initializeIterator(UBRK_CHARACTER) };
 }
 
-static inline void cacheNonSharedCharacterBreakIterator(UBreakIterator* cacheMe)
+static inline void cacheNonSharedCharacterBreakIterator(UBreakIteratorPtr&& cacheMe)
 {
-    if (auto *old = nonSharedCharacterBreakIterator.exchange(cacheMe, std::memory_order_release))
-        ubrk_close(old);
+    // Destroying `evicted` closes whichever iterator was cached before this one, if any.
+    UBreakIteratorPtr evicted { nonSharedCharacterBreakIterator.exchange(cacheMe.release(), std::memory_order_release) };
 }
 
 NonSharedCharacterBreakIterator::NonSharedCharacterBreakIterator(StringView string)
 {
-    if ((m_iterator = getNonSharedCharacterBreakIterator()))
-        m_iterator = setTextForIterator(*m_iterator, string);
+    auto iterator = getNonSharedCharacterBreakIterator();
+    if (iterator && setTextForIterator(*iterator, string))
+        m_iterator = WTF::move(iterator);
 }
 
 NonSharedCharacterBreakIterator::~NonSharedCharacterBreakIterator()
 {
     if (m_iterator)
-        cacheNonSharedCharacterBreakIterator(m_iterator);
+        cacheNonSharedCharacterBreakIterator(WTF::move(m_iterator));
 }
 
-NonSharedCharacterBreakIterator::NonSharedCharacterBreakIterator(NonSharedCharacterBreakIterator&& other)
-    : m_iterator(nullptr)
-{
-    std::swap(m_iterator, other.m_iterator);
-}
+NonSharedCharacterBreakIterator::NonSharedCharacterBreakIterator(NonSharedCharacterBreakIterator&&) = default;
 
 ALLOW_DEPRECATED_PRAGMA_BEGIN
 static std::atomic<UBreakIterator*> nonSharedSentenceBreakIterator = ATOMIC_VAR_INIT(nullptr);
 ALLOW_DEPRECATED_PRAGMA_END
 
-static inline UBreakIterator* getNonSharedSentenceBreakIterator()
+static inline UBreakIteratorPtr getNonSharedSentenceBreakIterator()
 {
-    if (auto *res = nonSharedSentenceBreakIterator.exchange(nullptr, std::memory_order_acquire))
-        return res;
-    return initializeIterator(UBRK_SENTENCE);
+    if (auto* cached = nonSharedSentenceBreakIterator.exchange(nullptr, std::memory_order_acquire))
+        return UBreakIteratorPtr { cached };
+    return UBreakIteratorPtr { initializeIterator(UBRK_SENTENCE) };
 }
 
-static inline void cacheNonSharedSentenceBreakIterator(UBreakIterator* cacheMe)
+static inline void cacheNonSharedSentenceBreakIterator(UBreakIteratorPtr&& cacheMe)
 {
-    if (auto *old = nonSharedSentenceBreakIterator.exchange(cacheMe, std::memory_order_release))
-        ubrk_close(old);
+    // Destroying `evicted` closes whichever iterator was cached before this one, if any.
+    UBreakIteratorPtr evicted { nonSharedSentenceBreakIterator.exchange(cacheMe.release(), std::memory_order_release) };
 }
 
 NonSharedSentenceBreakIterator::NonSharedSentenceBreakIterator(StringView string)
 {
-    if ((m_iterator = getNonSharedSentenceBreakIterator()))
-        m_iterator = setTextForIterator(*m_iterator, string);
+    auto iterator = getNonSharedSentenceBreakIterator();
+    if (iterator && setTextForIterator(*iterator, string))
+        m_iterator = WTF::move(iterator);
 }
 
 NonSharedSentenceBreakIterator::~NonSharedSentenceBreakIterator()
 {
     if (m_iterator)
-        cacheNonSharedSentenceBreakIterator(m_iterator);
+        cacheNonSharedSentenceBreakIterator(WTF::move(m_iterator));
 }
 
-NonSharedSentenceBreakIterator::NonSharedSentenceBreakIterator(NonSharedSentenceBreakIterator&& other)
-    : m_iterator(nullptr)
-{
-    std::swap(m_iterator, other.m_iterator);
-}
+NonSharedSentenceBreakIterator::NonSharedSentenceBreakIterator(NonSharedSentenceBreakIterator&&) = default;
 
 // Iterator implemenation.
 

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -355,6 +355,8 @@ private:
 // version 4.0 only supports "legacy grapheme clusters".
 // Use this for general text processing, e.g. string truncation.
 
+using UBreakIteratorPtr = std::unique_ptr<UBreakIterator, ICUDeleter<ubrk_close>>;
+
 class NonSharedCharacterBreakIterator {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NonSharedCharacterBreakIterator);
     WTF_MAKE_NONCOPYABLE(NonSharedCharacterBreakIterator);
@@ -364,10 +366,10 @@ public:
 
     NonSharedCharacterBreakIterator(NonSharedCharacterBreakIterator&&);
 
-    operator UBreakIterator*() const { return m_iterator; }
+    operator UBreakIterator*() const { return m_iterator.get(); }
 
 private:
-    UBreakIterator* m_iterator;
+    UBreakIteratorPtr m_iterator;
 };
 
 class NonSharedSentenceBreakIterator {
@@ -379,10 +381,10 @@ public:
 
     NonSharedSentenceBreakIterator(NonSharedSentenceBreakIterator&&);
 
-    operator UBreakIterator*() const { return m_iterator; }
+    operator UBreakIterator*() const { return m_iterator.get(); }
 
 private:
-    UBreakIterator* m_iterator;
+    UBreakIteratorPtr m_iterator;
 };
 
 // Counts the number of grapheme clusters. A surrogate pair or a sequence


### PR DESCRIPTION
#### 870de4ab779eacbf74616853e81b66e9275b8fc1
<pre>
NonSharedCharacterBreakIterator and NonSharedSentenceBreakIterator leak their UBreakIterator when setting the text fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=321873">https://bugs.webkit.org/show_bug.cgi?id=321873</a>
<a href="https://rdar.apple.com/185053056">rdar://185053056</a>

Reviewed by Chris Dumez.

Both constructors took ownership of a UBreakIterator from the one-entry cache
(or freshly ubrk_open()ed one) and then overwrote that pointer with the result
of setTextForIterator(), dropping the only reference to it when setting the
text failed:

    if ((m_iterator = getNonSharedCharacterBreakIterator()))
        m_iterator = setTextForIterator(*m_iterator, string);

Nothing else owns the iterator at that point, since getNonShared*() removes it
from the cache with an exchange(), so the iterator was leaked. This is
reachable: setTextForIterator() fails for a null StringView, because
openLatin1UTextProvider() rejects a null data pointer with
U_ILLEGAL_ARGUMENT_ERROR. StringView::GraphemeClusters guards against that case
already, but other callers do not.

Rather than adding a manual ubrk_close() on the failure path, make the
ownership explicit with the smart pointer WebKit already uses for ICU handles,
std::unique_ptr&lt;T, ICUDeleter&lt;close&gt;&gt;, so that the leak is not expressible:
getNonShared*BreakIterator() now returns ownership, cacheNonShared*BreakIterator()
now takes it, and no function passes a raw owning UBreakIterator* around. This
also removes the manual ubrk_close() of the evicted cache entry and lets both
move constructors be defaulted. CheckedPtr and Ref are not applicable here:
UBreakIterator is an opaque ICU C type that can be neither CanMakeCheckedPtr
nor refcounted.

As a drive-by, setTextForIterator() skipped utext_close() when ubrk_setUText()
failed; use makeScopeExit() so it runs on every path out of the 8-bit branch.
No memory was leaked by this, because the UText is set up over a stack buffer,
but the provider&apos;s close hook was not being run.

* Source/WTF/wtf/text/TextBreakIterator.cpp:
(WTF::setTextForIterator):
(WTF::getNonSharedCharacterBreakIterator):
(WTF::cacheNonSharedCharacterBreakIterator):
(WTF::NonSharedCharacterBreakIterator::NonSharedCharacterBreakIterator):
(WTF::NonSharedCharacterBreakIterator::~NonSharedCharacterBreakIterator):
(WTF::getNonSharedSentenceBreakIterator):
(WTF::cacheNonSharedSentenceBreakIterator):
(WTF::NonSharedSentenceBreakIterator::NonSharedSentenceBreakIterator):
(WTF::NonSharedSentenceBreakIterator::~NonSharedSentenceBreakIterator):
* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::NonSharedCharacterBreakIterator::operator UBreakIterator* const):
(WTF::NonSharedSentenceBreakIterator::operator UBreakIterator* const):

Canonical link: <a href="https://commits.webkit.org/319266@main">https://commits.webkit.org/319266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/383719604c2ed64f2663649d78b6feabe4f2785e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191175 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145284 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/464a6921-c379-419c-867a-5a8169d96e68) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141189 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fca432f5-7e81-43cf-9bab-4b073b89257d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121641 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f827bb3-477c-43f8-94e2-019bfac7a0b6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43522 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41801 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3606 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10418 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41462 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2335 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42235 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193110 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54572 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150574 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40295 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55260 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150291 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44880 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127526 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122991 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53777 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16456 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53159 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53396 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53224 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->