### PR TITLE
[JSC] Implement radix-sort for TypedArrays

### DIFF
--- a/JSTests/microbenchmarks/float32array-sort-large-array.js
+++ b/JSTests/microbenchmarks/float32array-sort-large-array.js
@@ -1,0 +1,22 @@
+var length = 4096;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+// Two draws per element so the mantissa has entropy in every byte. A single 32-bit draw leaves
+// the low mantissa bytes zero, which lets the sort skip digit passes that real data would not.
+var source = new Float32Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom() + nextRandom() * 2.3283064365386963e-10;
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Float32Array(length);
+for (var i = 0; i < 4000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/float64array-sort-large-array.js
+++ b/JSTests/microbenchmarks/float64array-sort-large-array.js
@@ -1,0 +1,22 @@
+var length = 16384;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+// Two draws per element so the mantissa has entropy in every byte. A single 32-bit draw leaves
+// the low mantissa bytes zero, which lets the sort skip digit passes that real data would not.
+var source = new Float64Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom() + nextRandom() * 2.3283064365386963e-10;
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Float64Array(length);
+for (var i = 0; i < 300; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/float64array-sort-low-entropy.js
+++ b/JSTests/microbenchmarks/float64array-sort-low-entropy.js
@@ -1,0 +1,20 @@
+var length = 16384;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+var source = new Float64Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = (nextRandom() & 1) ? 1e10 : 7.5;
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Float64Array(length);
+for (var i = 0; i < 5000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/float64array-sort-medium-array.js
+++ b/JSTests/microbenchmarks/float64array-sort-medium-array.js
@@ -1,0 +1,22 @@
+var length = 8192;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+// Two draws per element so the mantissa has entropy in every byte. A single 32-bit draw leaves
+// the low mantissa bytes zero, which lets the sort skip digit passes that real data would not.
+var source = new Float64Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom() + nextRandom() * 2.3283064365386963e-10;
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Float64Array(length);
+for (var i = 0; i < 1000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/float64array-sort-presorted.js
+++ b/JSTests/microbenchmarks/float64array-sort-presorted.js
@@ -1,0 +1,12 @@
+var length = 16384;
+
+var source = new Float64Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = i * 0.5;
+
+// Keep the input sorted every iteration; sorting it again must stay cheap.
+var array = new Float64Array(length);
+for (var i = 0; i < 7500; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/float64array-sort-small-array.js
+++ b/JSTests/microbenchmarks/float64array-sort-small-array.js
@@ -1,0 +1,22 @@
+var length = 512;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+// Two draws per element so the mantissa has entropy in every byte. A single 32-bit draw leaves
+// the low mantissa bytes zero, which lets the sort skip digit passes that real data would not.
+var source = new Float64Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom() + nextRandom() * 2.3283064365386963e-10;
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Float64Array(length);
+for (var i = 0; i < 50000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/int16array-sort-large-array.js
+++ b/JSTests/microbenchmarks/int16array-sort-large-array.js
@@ -1,0 +1,20 @@
+var length = 4096;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+var source = new Int16Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom();
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Int16Array(length);
+for (var i = 0; i < 6000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/int16array-sort-low-entropy.js
+++ b/JSTests/microbenchmarks/int16array-sort-low-entropy.js
@@ -1,0 +1,20 @@
+var length = 4096;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+var source = new Int16Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = (nextRandom() & 1) ? 30000 : 7;
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Int16Array(length);
+for (var i = 0; i < 13000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/int32array-sort-large-array.js
+++ b/JSTests/microbenchmarks/int32array-sort-large-array.js
@@ -1,0 +1,20 @@
+var length = 4096;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+var source = new Int32Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom();
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Int32Array(length);
+for (var i = 0; i < 6000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/int32array-sort-low-entropy.js
+++ b/JSTests/microbenchmarks/int32array-sort-low-entropy.js
@@ -1,0 +1,20 @@
+var length = 4096;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+var source = new Int32Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = (nextRandom() & 1) ? 200000 : 7;
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Int32Array(length);
+for (var i = 0; i < 12000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/int32array-sort-medium-array.js
+++ b/JSTests/microbenchmarks/int32array-sort-medium-array.js
@@ -1,0 +1,20 @@
+var length = 512;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+var source = new Int32Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom();
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Int32Array(length);
+for (var i = 0; i < 60000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/int32array-sort-presorted.js
+++ b/JSTests/microbenchmarks/int32array-sort-presorted.js
@@ -1,0 +1,12 @@
+var length = 4096;
+
+var source = new Int32Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = i * 1024;
+
+// Keep the input sorted every iteration; sorting it again must stay cheap.
+var array = new Int32Array(length);
+for (var i = 0; i < 40000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/int32array-sort-small-array.js
+++ b/JSTests/microbenchmarks/int32array-sort-small-array.js
@@ -1,0 +1,20 @@
+var length = 192;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+var source = new Int32Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom();
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Int32Array(length);
+for (var i = 0; i < 190000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/uint16array-sort-large-array.js
+++ b/JSTests/microbenchmarks/uint16array-sort-large-array.js
@@ -1,0 +1,20 @@
+var length = 4096;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+var source = new Uint16Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom();
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Uint16Array(length);
+for (var i = 0; i < 6000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/microbenchmarks/uint32array-sort-large-array.js
+++ b/JSTests/microbenchmarks/uint32array-sort-large-array.js
@@ -1,0 +1,20 @@
+var length = 4096;
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed;
+}
+
+var source = new Uint32Array(length);
+for (var i = 0; i < length; ++i)
+    source[i] = nextRandom() >>> 0;
+
+// Restore the unsorted input every iteration so the sort never sees an already sorted array.
+var array = new Uint32Array(length);
+for (var i = 0; i < 6000; ++i) {
+    array.set(source);
+    array.sort();
+}

--- a/JSTests/stress/typed-array-sort-radix-sort.js
+++ b/JSTests/stress/typed-array-sort-radix-sort.js
@@ -1,0 +1,492 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' (expected ' + expected + ')');
+}
+
+var seed = 1;
+function nextRandom() {
+    seed ^= seed << 13; seed |= 0;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5; seed |= 0;
+    return seed >>> 8;
+}
+
+function isBigIntArray(ctor) {
+    return ctor === BigInt64Array || ctor === BigUint64Array;
+}
+
+function compareNumbers(a, b) {
+    return a - b;
+}
+
+function compareBigInts(a, b) {
+    if (a < b)
+        return -1;
+    if (a > b)
+        return 1;
+    return 0;
+}
+
+function sortedReference(array) {
+    return Array.from(array).sort(isBigIntArray(array.constructor) ? compareBigInts : compareNumbers);
+}
+
+function shouldMatchReference(array) {
+    var expected = sortedReference(array);
+    shouldBe(array.sort(), array);
+    for (var i = 0; i < expected.length; ++i)
+        shouldBe(array[i], expected[i]);
+}
+
+function coerce(ctor, value) {
+    return isBigIntArray(ctor) ? BigInt(value) : value;
+}
+
+var integerConstructors = [Int16Array, Uint16Array, Int32Array, Uint32Array, BigInt64Array, BigUint64Array];
+
+// Straddle every length at which the engine switches to radix sort, from well below the lowest to
+// above the highest.
+var lengths = [0, 1, 2, 8, 64, 255, 256, 257, 511, 512, 513, 1023, 1024, 1025, 1100];
+
+var integerPatterns = {
+    random: function (i, length) { return nextRandom(); },
+    identical: function (i, length) { return 42; },
+    ascending: function (i, length) { return i; },
+    descending: function (i, length) { return length - i; },
+    // Only the low byte varies, so every higher digit holds one value and is skipped.
+    lowDigitOnly: function (i, length) { return nextRandom() & 0xff; },
+    // Only the second byte varies, so the lowest digit is skipped instead.
+    secondDigitOnly: function (i, length) { return (nextRandom() & 0xff) * 0x100; },
+    twoValues: function (i, length) { return (i % 2) ? 30000 : 7; },
+    alternatingSign: function (i, length) { return (i % 2) ? -nextRandom() : nextRandom(); },
+};
+
+for (var ctor of integerConstructors) {
+    for (var length of lengths) {
+        for (var name in integerPatterns) {
+            var array = new ctor(length);
+            for (var i = 0; i < length; ++i)
+                array[i] = coerce(ctor, integerPatterns[name](i, length));
+            shouldMatchReference(array);
+        }
+    }
+}
+
+// Extreme values must land at the ends, which is where a wrong sign bit flip shows up.
+var extremes = new Map([
+    [Int16Array, [-32768, 32767]],
+    [Uint16Array, [0, 65535]],
+    [Int32Array, [-2147483648, 2147483647]],
+    [Uint32Array, [0, 4294967295]],
+    [BigInt64Array, [-9223372036854775808n, 9223372036854775807n]],
+    [BigUint64Array, [0n, 18446744073709551615n]],
+]);
+
+for (var ctor of integerConstructors) {
+    var bounds = extremes.get(ctor);
+    var low = bounds[0];
+    var high = bounds[1];
+    var array = new ctor(2048);
+    for (var i = 0; i < array.length; ++i)
+        array[i] = (i % 3 === 0) ? low : ((i % 3 === 1) ? high : coerce(ctor, 0));
+    shouldMatchReference(array);
+    shouldBe(array[0], low);
+    shouldBe(array[array.length - 1], high);
+}
+
+// toSorted takes the same no-comparator path, and must not disturb the receiver.
+for (var ctor of integerConstructors) {
+    var array = new ctor(2048);
+    for (var i = 0; i < array.length; ++i)
+        array[i] = coerce(ctor, nextRandom());
+    var expectedReceiver = Array.from(array);
+    var expected = sortedReference(array);
+
+    var sorted = array.toSorted();
+    shouldBe(sorted instanceof ctor, true);
+    shouldBe(sorted === array, false);
+    shouldBe(sorted.length, array.length);
+    for (var i = 0; i < expected.length; ++i) {
+        shouldBe(sorted[i], expected[i]);
+        shouldBe(array[i], expectedReceiver[i]);
+    }
+}
+
+// A view over part of a buffer must not write outside its own range. The scatter passes derive write
+// cursors from a histogram, so a mismatch between the two escapes the view.
+for (var ctor of integerConstructors) {
+    var elementCount = 2048;
+    var guardBytes = 16 * ctor.BYTES_PER_ELEMENT;
+    var dataBytes = elementCount * ctor.BYTES_PER_ELEMENT;
+    var buffer = new ArrayBuffer(dataBytes + guardBytes * 2);
+    var whole = new Uint8Array(buffer);
+    whole.fill(0xab);
+
+    var view = new ctor(buffer, guardBytes, elementCount);
+    for (var i = 0; i < elementCount; ++i)
+        view[i] = coerce(ctor, nextRandom());
+    var expected = sortedReference(view);
+
+    shouldBe(view.sort(), view);
+    for (var i = 0; i < elementCount; ++i)
+        shouldBe(view[i], expected[i]);
+    for (var i = 0; i < guardBytes; ++i) {
+        shouldBe(whole[i], 0xab);
+        shouldBe(whole[guardBytes + dataBytes + i], 0xab);
+    }
+}
+
+// Auto-length views over a resizable buffer read their length through a different path.
+for (var ctor of integerConstructors) {
+    var elementCount = 2048;
+    var dataBytes = elementCount * ctor.BYTES_PER_ELEMENT;
+    var buffer = new ArrayBuffer(dataBytes, { maxByteLength: dataBytes * 2 });
+    var array = new ctor(buffer);
+    for (var i = 0; i < array.length; ++i)
+        array[i] = coerce(ctor, nextRandom());
+    shouldMatchReference(array);
+
+    buffer.resize(dataBytes * 2);
+    shouldBe(array.length, elementCount * 2);
+    for (var i = 0; i < array.length; ++i)
+        array[i] = coerce(ctor, nextRandom());
+    shouldMatchReference(array);
+
+    buffer.resize(dataBytes / 4);
+    shouldBe(array.length, elementCount / 4);
+    for (var i = 0; i < array.length; ++i)
+        array[i] = coerce(ctor, nextRandom());
+    shouldMatchReference(array);
+}
+
+// An array that is sorted apart from one adjacent pair. This pins the block-at-a-time presortedness
+// scan, where an inversion straddling a block boundary is the case most likely to be missed. The
+// loop's special cases are its opening blocks and its separately handled trailing block, so every
+// position in those is covered, plus a few in between where every block is treated alike.
+function inversionPositions(length, stride) {
+    var positions = [];
+    var head = Math.min(length - 1, 4 * stride);
+    for (var i = 0; i < head; ++i)
+        positions.push(i);
+    for (var i = head; i + 1 < length; i += length >> 3)
+        positions.push(i);
+    for (var i = Math.max(head, length - 1 - 4 * stride); i + 1 < length; ++i)
+        positions.push(i);
+    return positions;
+}
+
+// Comparing the raw storage keeps this cheap enough to sweep, and is exact: every value here is an
+// ordinary finite number, so the sorted result must match the ascending base bit for bit. The widest
+// view that divides the storage evenly costs the fewest reads.
+function storageView(buffer) {
+    if (!(buffer.byteLength % 4))
+        return new Uint32Array(buffer);
+    return new Uint16Array(buffer);
+}
+
+function sweepInversions(ctor, base) {
+    var length = base.length;
+    var array = new ctor(length);
+    var expectedStorage = storageView(base.buffer);
+    var actualStorage = storageView(array.buffer);
+
+    for (var position of inversionPositions(length, 16 / ctor.BYTES_PER_ELEMENT)) {
+        array.set(base);
+        // Swapping neighbours leaves this as the only descending pair.
+        var lower = array[position];
+        array[position] = array[position + 1];
+        array[position + 1] = lower;
+
+        array.sort();
+        for (var i = 0; i < actualStorage.length; ++i) {
+            if (actualStorage[i] !== expectedStorage[i])
+                throw new Error('unsorted for inversion at ' + position + ', length ' + length + ', ' + ctor.name);
+        }
+    }
+}
+
+// At or above the radix sort thresholds for 2 and 4 byte elements, so the scan under test runs for
+// those. 8 byte elements have a much higher threshold and get their own lengths further down. One
+// length is a multiple of every block size and one is not, covering a trailing partial block.
+var sweepLengths = [1024, 1031];
+
+for (var ctor of integerConstructors) {
+    for (var length of sweepLengths) {
+        var base = new ctor(length);
+        for (var i = 0; i < length; ++i)
+            base[i] = coerce(ctor, i);
+        sweepInversions(ctor, base);
+    }
+}
+
+if (typeof SharedArrayBuffer !== 'undefined') {
+    for (var ctor of integerConstructors) {
+        var elementCount = 2048;
+        var dataBytes = elementCount * ctor.BYTES_PER_ELEMENT;
+
+        var buffer = new SharedArrayBuffer(dataBytes);
+        var array = new ctor(buffer);
+        for (var i = 0; i < array.length; ++i)
+            array[i] = coerce(ctor, nextRandom());
+        shouldMatchReference(array);
+
+        var growable = new SharedArrayBuffer(dataBytes, { maxByteLength: dataBytes * 2 });
+        var growableArray = new ctor(growable);
+        for (var i = 0; i < growableArray.length; ++i)
+            growableArray[i] = coerce(ctor, nextRandom());
+        shouldMatchReference(growableArray);
+
+        growable.grow(dataBytes * 2);
+        shouldBe(growableArray.length, elementCount * 2);
+        for (var i = 0; i < growableArray.length; ++i)
+            growableArray[i] = coerce(ctor, nextRandom());
+        shouldMatchReference(growableArray);
+    }
+}
+
+// -Infinity < negative finite < -0.0 < +0.0 < positive finite < +Infinity < NaN, and NaN bit patterns
+// are canonicalized rather than ordered among themselves.
+function compareFloats(a, b) {
+    var aIsNaN = Number.isNaN(a);
+    var bIsNaN = Number.isNaN(b);
+    if (aIsNaN)
+        return bIsNaN ? 0 : 1;
+    if (bIsNaN)
+        return -1;
+    if (a < b)
+        return -1;
+    if (a > b)
+        return 1;
+    if (a === 0 && b === 0) {
+        var aIsNegativeZero = Object.is(a, -0);
+        if (aIsNegativeZero === Object.is(b, -0))
+            return 0;
+        return aIsNegativeZero ? -1 : 1;
+    }
+    return 0;
+}
+
+function shouldMatchFloatReference(array) {
+    var expected = Array.from(array).sort(compareFloats);
+    shouldBe(array.sort(), array);
+    for (var i = 0; i < expected.length; ++i) {
+        // NaN !== NaN, so compare NaN-ness rather than value.
+        if (Number.isNaN(expected[i])) {
+            if (!Number.isNaN(array[i]))
+                throw new Error('expected NaN at index ' + i + ', got ' + array[i] + ' in ' + array.constructor.name);
+        } else
+            shouldBe(array[i], expected[i]);
+    }
+}
+
+var floatConstructors = [Float16Array, Float32Array, Float64Array];
+
+var floatPatterns = {
+    random: function (i, length) { return (nextRandom() - 8388608) / 1024; },
+    identical: function (i, length) { return 1.5; },
+    ascending: function (i, length) { return i * 0.5; },
+    descending: function (i, length) { return (length - i) * 0.5; },
+    subnormalAndTiny: function (i, length) { return (i % 2) ? 5e-8 : 6e-8; },
+    largeMagnitude: function (i, length) { return (i % 2) ? -1e30 : 1e30; },
+    withZeros: function (i, length) { return (i % 3 === 0) ? -0 : ((i % 3 === 1) ? 0 : (nextRandom() / 65536)); },
+    withInfinities: function (i, length) { return (i % 4 === 0) ? -Infinity : ((i % 4 === 1) ? Infinity : (nextRandom() / 65536 - 64)); },
+    withNaN: function (i, length) { return (i % 5 === 0) ? NaN : (nextRandom() / 65536 - 64); },
+    allNaN: function (i, length) { return NaN; },
+    negativeNaN: function (i, length) { return (i % 2) ? -NaN : 1; },
+};
+
+for (var ctor of floatConstructors) {
+    for (var length of lengths) {
+        for (var name in floatPatterns) {
+            var array = new ctor(length);
+            for (var i = 0; i < length; ++i)
+                array[i] = floatPatterns[name](i, length);
+            shouldMatchFloatReference(array);
+        }
+    }
+}
+
+// -0.0 sorts before +0.0, which === cannot see. This is the case a plain float comparison in the
+// presortedness scan would miss, so check the sign of each zero directly.
+for (var ctor of floatConstructors) {
+    for (var length of [256, 512, 1024, 2048]) {
+        var array = new ctor(length);
+        var negativeZeroCount = 0;
+        for (var i = 0; i < length; ++i) {
+            // Start in the wrong order, so the sort has to move the zeros.
+            array[i] = (i % 2) ? -0 : 0;
+            if (i % 2)
+                ++negativeZeroCount;
+        }
+        array.sort();
+        for (var i = 0; i < length; ++i) {
+            if (Object.is(array[i], -0) !== (i < negativeZeroCount))
+                throw new Error('zero sign wrong at index ' + i + ' of ' + length + ' in ' + ctor.name);
+        }
+    }
+}
+
+// A NaN written through another view over the same buffer keeps whatever bit pattern it was given,
+// including a set sign bit. It must still sort last, which is what canonicalizing NaN buys.
+var rawNaNs = new Map([
+    [Float16Array, [Uint16Array, 0xfe01, 0x7e55]],
+    [Float32Array, [Uint32Array, 0xffc00001, 0x7fc00123]],
+    [Float64Array, [BigUint64Array, 0xfff8000000000001n, 0x7ff8000000000123n]],
+]);
+
+for (var ctor of floatConstructors) {
+    var length = 1024;
+    var array = new ctor(length);
+    for (var i = 0; i < length; ++i)
+        array[i] = i - 512;
+
+    var recipe = rawNaNs.get(ctor);
+    var raw = new recipe[0](array.buffer);
+    raw[0] = recipe[1];
+    raw[length - 1] = recipe[2];
+
+    var nanCount = 0;
+    for (var i = 0; i < length; ++i) {
+        if (Number.isNaN(array[i]))
+            ++nanCount;
+    }
+    shouldBe(nanCount, 2);
+
+    array.sort();
+    shouldBe(Number.isNaN(array[length - 1]), true);
+    shouldBe(Number.isNaN(array[length - 2]), true);
+    for (var i = 0; i < length - 2; ++i) {
+        if (Number.isNaN(array[i]))
+            throw new Error('NaN did not sort last, found at index ' + i + ' in ' + ctor.name);
+        if (i && array[i] < array[i - 1])
+            throw new Error('unsorted at index ' + i + ' in ' + ctor.name);
+    }
+}
+
+// A view over part of a buffer must not write outside its own range, for floats too.
+for (var ctor of floatConstructors) {
+    var elementCount = 2048;
+    var guardBytes = 16 * ctor.BYTES_PER_ELEMENT;
+    var dataBytes = elementCount * ctor.BYTES_PER_ELEMENT;
+    var buffer = new ArrayBuffer(dataBytes + guardBytes * 2);
+    var whole = new Uint8Array(buffer);
+    whole.fill(0xab);
+
+    var view = new ctor(buffer, guardBytes, elementCount);
+    for (var i = 0; i < elementCount; ++i)
+        view[i] = (nextRandom() - 8388608) / 1024;
+    var expected = Array.from(view).sort(compareFloats);
+
+    shouldBe(view.sort(), view);
+    for (var i = 0; i < elementCount; ++i)
+        shouldBe(view[i], expected[i]);
+    for (var i = 0; i < guardBytes; ++i) {
+        shouldBe(whole[i], 0xab);
+        shouldBe(whole[guardBytes + dataBytes + i], 0xab);
+    }
+}
+
+// The same inversion sweep over the float presortedness scan, which additionally has to compute the
+// key transform per lane.
+for (var ctor of floatConstructors) {
+    for (var length of sweepLengths) {
+        var base = new ctor(length);
+        for (var i = 0; i < length; ++i)
+            base[i] = (i - length / 2) * 0.5;
+        sweepInversions(ctor, base);
+    }
+}
+
+if (typeof SharedArrayBuffer !== 'undefined') {
+    for (var ctor of floatConstructors) {
+        var elementCount = 2048;
+        var buffer = new SharedArrayBuffer(elementCount * ctor.BYTES_PER_ELEMENT);
+        var array = new ctor(buffer);
+        for (var i = 0; i < array.length; ++i)
+            array[i] = (i % 7 === 0) ? NaN : (nextRandom() - 8388608) / 1024;
+        shouldMatchFloatReference(array);
+    }
+}
+
+// The radix sort threshold for 8-byte elements sits far above every length used above, so 8-byte
+// types need their own cases to reach the radix path at all. Sorting a shuffled permutation of a
+// strictly ascending base has to reproduce that base exactly, which verifies the result without a
+// reference sort of BigInt values.
+var wideConstructors = [BigInt64Array, BigUint64Array, Float64Array];
+
+// Strictly ascending, and spread so that no digit holds a single value: an all-integral double would
+// leave its low mantissa bytes zero, and consecutive integers would leave the high bytes constant.
+function ascendingWideBase(ctor, length) {
+    var base = new ctor(length);
+    if (isBigIntArray(ctor)) {
+        for (var i = 0; i < length; ++i)
+            base[i] = BigInt(i) * 2654435761n + 12345n;
+    } else {
+        for (var i = 0; i < length; ++i)
+            base[i] = i * 3 + 1 + i * 1e-9;
+    }
+    return base;
+}
+
+function shouldRestoreBase(ctor, base, array, description) {
+    var expected = storageView(base.buffer);
+    var actual = storageView(array.buffer);
+    array.sort();
+    for (var i = 0; i < actual.length; ++i) {
+        if (actual[i] !== expected[i])
+            throw new Error(description + ' at storage index ' + i + ', length ' + base.length + ', ' + ctor.name);
+    }
+}
+
+var wideLengths = [8192, 8193, 8199];
+
+for (var ctor of wideConstructors) {
+    for (var length of wideLengths) {
+        var base = ascendingWideBase(ctor, length);
+        var array = new ctor(length);
+        array.set(base);
+        // Deterministic Fisher-Yates, so the sort sees a thoroughly unsorted permutation.
+        for (var i = length - 1; i > 0; --i) {
+            var j = nextRandom() % (i + 1);
+            var swapped = array[i];
+            array[i] = array[j];
+            array[j] = swapped;
+        }
+        shouldRestoreBase(ctor, base, array, 'shuffled permutation not restored');
+    }
+}
+
+// Reversed input reaches the radix path with every digit maximally out of order.
+for (var ctor of wideConstructors) {
+    var base = ascendingWideBase(ctor, 8192);
+    var array = new ctor(8192);
+    for (var i = 0; i < 8192; ++i)
+        array[i] = base[8191 - i];
+    shouldRestoreBase(ctor, base, array, 'reversed input not sorted');
+}
+
+// Two distinct values over a long array: few enough that the sort declines radix sort and hands off,
+// so this covers the handoff rather than the radix passes.
+for (var ctor of wideConstructors) {
+    var length = 8192;
+    var low = coerce(ctor, 7);
+    var high = coerce(ctor, 30000);
+    var array = new ctor(length);
+    var highCount = 0;
+    for (var i = 0; i < length; ++i) {
+        var useHigh = !!(nextRandom() & 1);
+        array[i] = useHigh ? high : low;
+        if (useHigh)
+            ++highCount;
+    }
+    array.sort();
+    for (var i = 0; i < length; ++i) {
+        var expected = (i < length - highCount) ? low : high;
+        if (array[i] !== expected)
+            throw new Error('two value sort wrong at ' + i + ' of ' + length + ', ' + ctor.name);
+    }
+}
+
+// The inversion sweep again, at a length that reaches the radix path for 8-byte elements.
+for (var ctor of wideConstructors)
+    sweepInversions(ctor, ascendingWideBase(ctor, 8192));

--- a/JSTests/stress/typedarray-sort-out-of-memory.js
+++ b/JSTests/stress/typedarray-sort-out-of-memory.js
@@ -2,8 +2,24 @@
 
 let ar = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 1073741824));
 
-// No comparator version.
+// A freshly allocated buffer is all zeros, so it is already sorted. Detecting that needs no scratch
+// allocation, so this succeeds rather than running out of memory.
 var exception;
+try {
+    ar.sort();
+} catch (e) {
+    exception = e;
+}
+
+if (exception !== undefined)
+    throw "FAILED: expected no exception for an already sorted array, got " + exception;
+
+// Swapping neighbours leaves one descending pair, so sorting now has to allocate.
+ar[0] = 1;
+ar[1] = 0;
+
+// No comparator version.
+exception = undefined;
 try {
     ar.sort();
 } catch (e) {
@@ -23,4 +39,3 @@ try {
 
 if (exception != "RangeError: Out of memory")
     throw "FAILED: " + exception;
-

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -215,6 +215,24 @@ protected:
 
     template<typename IntegralType> inline void sortFloat(ElementType* begin, ElementType* end);
 
+    // The unsigned integer of the same width as ElementType, used as the sort key. Ordering
+    // elements by this key gives the order sorting a typed array requires: for signed integers,
+    // flipping the sign bit; for floats, flipping every bit of a negative value and only the sign
+    // bit of a positive one, which lines IEEE 754 up with unsigned integer order.
+    using SortKeyType = std::conditional_t<elementSize == 1, uint8_t,
+        std::conditional_t<elementSize == 2, uint16_t,
+        std::conditional_t<elementSize == 4, uint32_t, uint64_t>>>;
+    static_assert(sizeof(SortKeyType) == elementSize);
+
+    static constexpr SortKeyType sortKeySignBit = static_cast<SortKeyType>(1) << (elementSize * 8 - 1);
+
+    static ALWAYS_INLINE SortKeyType sortKey(ElementType);
+    static inline bool isNonDescending(std::span<const ElementType>);
+    static inline bool hasFewDistinctValues(std::span<const ElementType>);
+
+    NEVER_INLINE bool radixSort(std::span<ElementType>);
+    template<typename CounterType> inline bool radixSortWithCounters(std::span<ElementType>);
+
     inline void countingSort(std::span<ElementType>);
     template<typename CounterType> inline void countingSortWithCounters(std::span<ElementType>);
 };

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -907,13 +907,22 @@ template<typename Adaptor> inline auto JSGenericTypedArrayView<Adaptor>::sort() 
 
     auto originalSpan = typedSpan();
 
-    if constexpr (Adaptor::typeValue == TypeInt8 || Adaptor::typeValue == TypeUint8 || Adaptor::typeValue == TypeUint8Clamped) {
+    if constexpr (elementSize == 1) {
         // Measured crossover. Below this, clearing the histograms costs more than std::sort, which
         // uses insertion sort on inputs this short.
         constexpr size_t countingSortThreshold = 128;
         if (length >= countingSortThreshold) {
             countingSort(originalSpan.first(length));
             return SortResult::Success;
+        }
+    } else {
+        // Measured crossovers against std::sort on randomly distributed input. Below these, the histogram
+        // pass and the scratch allocation cost more than std::sort, which uses insertion sort on short
+        // inputs. The crossover climbs with the element size because a wider element needs more passes.
+        constexpr size_t radixSortThreshold = elementSize == 2 ? 128 : (elementSize == 4 ? 512 : 8192);
+        if (length >= radixSortThreshold) {
+            if (radixSort(originalSpan.first(length)))
+                return SortResult::Success;
         }
     }
 
@@ -1013,31 +1022,81 @@ inline void JSGenericTypedArrayView<Adaptor>::sortFloat(ElementType* begin, Elem
 }
 
 template<typename Adaptor>
+ALWAYS_INLINE auto JSGenericTypedArrayView<Adaptor>::sortKey(ElementType value) -> SortKeyType
+{
+    auto bits = std::bit_cast<SortKeyType>(value);
+    if constexpr (Adaptor::isFloat) {
+        // A negative float's magnitude bits run backwards relative to unsigned order, so every bit
+        // is flipped; a positive one only needs its sign bit set to sort above every negative.
+        auto negative = static_cast<SortKeyType>(-static_cast<SortKeyType>(bits >= sortKeySignBit));
+        return bits ^ (negative | sortKeySignBit);
+    } else if constexpr (std::is_signed_v<ElementType>)
+        return bits ^ sortKeySignBit;
+    else
+        return bits;
+}
+
+template<typename Adaptor>
+inline bool JSGenericTypedArrayView<Adaptor>::isNonDescending(std::span<const ElementType> elements)
+{
+    constexpr size_t stride = SIMD::stride<SortKeyType>;
+    ASSERT(elements.size() > stride);
+
+    auto* bits = std::bit_cast<const SortKeyType*>(elements.data());
+    auto signBitVector = SIMD::splat<SortKeyType>(sortKeySignBit);
+    auto magnitudeMaskVector = SIMD::splat<SortKeyType>(static_cast<SortKeyType>(~sortKeySignBit));
+
+    auto toKey = [&](auto value) ALWAYS_INLINE_LAMBDA {
+        if constexpr (Adaptor::isFloat) {
+            auto negative = SIMD::lessThan(magnitudeMaskVector, value);
+            return SIMD::bitXor(value, SIMD::bitOr(negative, signBitVector));
+        } else if constexpr (std::is_signed_v<ElementType>)
+            return SIMD::bitXor(value, signBitVector);
+        else
+            return value;
+    };
+
+    // A NaN is reported as an inversion. Distinct NaN bit patterns have distinct keys and a negative
+    // NaN keys below -Infinity, so key order is only the order a typed array sort requires once NaN
+    // has been canonicalized, which the full sort does and this scan does not.
+    auto hasInversion = [&](size_t index) ALWAYS_INLINE_LAMBDA {
+        auto lower = SIMD::load(bits + index);
+        auto upper = SIMD::load(bits + index + 1);
+        auto inversions = SIMD::lessThan(toKey(upper), toKey(lower));
+        if constexpr (Adaptor::isFloat) {
+            constexpr SortKeyType infinityBits = [] {
+                if constexpr (elementSize == 2) {
+                    // Float16 https://en.wikipedia.org/wiki/Half-precision_floating-point_format
+                    return static_cast<SortKeyType>(0b0'11111'0000000000U);
+                } else if constexpr (elementSize == 4) {
+                    // Float32 https://en.wikipedia.org/wiki/Single-precision_floating-point_format
+                    return static_cast<SortKeyType>(0b0'11111111'00000000000000000000000U);
+                } else {
+                    // Float64 https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+                    return static_cast<SortKeyType>(0b0'11111111111'0000000000000000000000000000000000000000000000000000ULL);
+                }
+            }();
+            auto infinityVector = SIMD::splat<SortKeyType>(infinityBits);
+            auto isNaN = [&](auto value) ALWAYS_INLINE_LAMBDA {
+                return SIMD::lessThan(infinityVector, SIMD::bitAnd(value, magnitudeMaskVector));
+            };
+            inversions = SIMD::bitOr(inversions, isNaN(lower), isNaN(upper));
+        }
+        return SIMD::isNonZero(inversions);
+    };
+
+    size_t lastBlock = elements.size() - 1 - stride;
+    for (size_t index = 0; index < lastBlock; index += stride) {
+        if (hasInversion(index))
+            return false;
+    }
+    return !hasInversion(lastBlock);
+}
+
+template<typename Adaptor>
 inline void JSGenericTypedArrayView<Adaptor>::countingSort(std::span<ElementType> elements)
 {
     static_assert(sizeof(ElementType) == 1);
-
-    auto isNonDescending = [](std::span<ElementType> elements) ALWAYS_INLINE_LAMBDA {
-        constexpr size_t stride = SIMD::stride<ElementType>;
-        ASSERT(elements.size() > stride);
-
-        auto* data = elements.data();
-        auto hasInversion = [&](size_t index) ALWAYS_INLINE_LAMBDA {
-            simde_uint8x16_t inversions;
-            if constexpr (std::is_signed_v<ElementType>)
-                inversions = simde_vcltq_s8(simde_vld1q_s8(data + index + 1), simde_vld1q_s8(data + index));
-            else
-                inversions = simde_vcltq_u8(simde_vld1q_u8(data + index + 1), simde_vld1q_u8(data + index));
-            return SIMD::isNonZero(inversions);
-        };
-
-        size_t lastBlock = elements.size() - 1 - stride;
-        for (size_t index = 0; index < lastBlock; index += stride) {
-            if (hasInversion(index))
-                return false;
-        }
-        return !hasInversion(lastBlock);
-    };
 
     // This stops at the first inversion, so it costs one block of comparisons on unsorted input, and
     // it reduces the already sorted case to a single scan.
@@ -1106,6 +1165,159 @@ inline void JSGenericTypedArrayView<Adaptor>::countingSortWithCounters(std::span
         }
     }
     ASSERT(cursor == elements.data() + elements.size());
+}
+
+template<typename Adaptor>
+inline bool JSGenericTypedArrayView<Adaptor>::hasFewDistinctValues(std::span<const ElementType> elements)
+{
+    // std::sort is close to linear on an input holding very few distinct values, and it beats radix
+    // sort there no matter how few digits vary, because the histogram pass alone costs a large
+    // fraction of the whole sort. Recognizing such an input has to happen before that pass is paid
+    // for, so this samples instead of counting exactly. Samples are spread over the whole span rather
+    // than taken from the front, so a sorted-looking prefix cannot stand in for the rest.
+    constexpr size_t sampleCount = 32;
+    constexpr unsigned distinctLimit = 4;
+
+    std::array<SortKeyType, distinctLimit> seen;
+    unsigned seenCount = 0;
+    size_t step = std::max<size_t>(1, elements.size() / sampleCount);
+    for (size_t index = 0; index < elements.size(); index += step) {
+        auto bits = std::bit_cast<SortKeyType>(elements[index]);
+        bool isKnown = false;
+        for (unsigned seenIndex = 0; seenIndex < seenCount; ++seenIndex) {
+            if (seen[seenIndex] == bits) {
+                isKnown = true;
+                break;
+            }
+        }
+        if (!isKnown) {
+            if (seenCount == distinctLimit)
+                return false;
+            seen[seenCount++] = bits;
+        }
+    }
+    return true;
+}
+
+template<typename Adaptor>
+NEVER_INLINE bool JSGenericTypedArrayView<Adaptor>::radixSort(std::span<ElementType> elements)
+{
+    static_assert(elementSize > 1);
+    ASSERT(elements.size() > SIMD::stride<SortKeyType>);
+
+    // This stops at the first inversion, so it costs one block of comparisons on unsorted input, and
+    // it reduces the already sorted case to a single scan.
+    if (isNonDescending(elements))
+        return true;
+
+    // Both checks come before any allocation, so handing off to std::sort costs nothing but the scans.
+    if (hasFewDistinctValues(elements))
+        return false;
+
+    if constexpr (sizeof(size_t) > sizeof(uint32_t)) {
+        if (elements.size() > std::numeric_limits<uint32_t>::max()) [[unlikely]]
+            return radixSortWithCounters<uint64_t>(elements);
+    }
+    return radixSortWithCounters<uint32_t>(elements);
+}
+
+template<typename Adaptor>
+template<typename CounterType>
+inline bool JSGenericTypedArrayView<Adaptor>::radixSortWithCounters(std::span<ElementType> elements)
+{
+    constexpr unsigned digitCount = elementSize;
+    constexpr size_t bucketCount = 256;
+
+    // Interleaving several histograms keeps repeated values from serializing: incrementing a counter
+    // otherwise has to wait for the previous increment of that same counter to forward out of the
+    // store buffer. Each element already performs digitCount independent increments, which covers
+    // that latency on its own once there are enough of them, and measurement only found interleaving
+    // worth its larger table for two digit elements.
+    constexpr size_t histogramCount = digitCount == 2 ? 4 : 1;
+
+    size_t length = elements.size();
+
+    auto source = elements;
+
+    Vector<ElementType, 0> snapshot;
+    if (isShared()) {
+        if (!snapshot.tryGrow(length)) [[unlikely]]
+            return false;
+        WTF::copyElements(snapshot.mutableSpan(), spanConstCast<const ElementType>(elements));
+        source = snapshot.mutableSpan();
+    }
+
+    std::array<std::array<std::array<CounterType, bucketCount>, digitCount>, histogramCount> counts { };
+
+    auto accumulate = [&](size_t index, size_t histogram) ALWAYS_INLINE_LAMBDA {
+        ElementType value = source[index];
+        if constexpr (Adaptor::isFloat) {
+            // Canonicalizing NaN here is what makes the key ordering correct: a negative NaN would
+            // otherwise key below -Infinity, and a typed array sort must place NaN last.
+            value = purifyNaN(value);
+            source[index] = value;
+        }
+        SortKeyType key = sortKey(value);
+        for (unsigned digit = 0; digit < digitCount; ++digit)
+            ++counts[histogram][digit][static_cast<uint8_t>(key >> (digit * 8))];
+    };
+
+    size_t index = 0;
+    for (; index + histogramCount <= length; index += histogramCount) {
+        for (size_t histogram = 0; histogram < histogramCount; ++histogram)
+            accumulate(index + histogram, histogram);
+    }
+    for (; index < length; ++index)
+        accumulate(index, 0);
+
+    // Merge the interleaved histograms into the first, and while scanning each digit note how many buckets it uses.
+    // A digit holding one value for every element cannot change the order, so it needs no pass.
+    std::array<unsigned, digitCount> activeDigits;
+    unsigned activeDigitCount = 0;
+    for (unsigned digit = 0; digit < digitCount; ++digit) {
+        unsigned usedBuckets = 0;
+        for (size_t bucket = 0; bucket < bucketCount; ++bucket) {
+            CounterType count = counts[0][digit][bucket];
+            for (size_t histogram = 1; histogram < histogramCount; ++histogram)
+                count += counts[histogram][digit][bucket];
+            counts[0][digit][bucket] = count;
+            if (count)
+                ++usedBuckets;
+        }
+        if (usedBuckets > 1)
+            activeDigits[activeDigitCount++] = digit;
+    }
+
+    Vector<ElementType, 0> scratch;
+    if (!scratch.tryGrow(length)) [[unlikely]]
+        return false;
+    auto destination = scratch.mutableSpan();
+
+    std::array<CounterType, bucketCount> cursors;
+    for (unsigned active = 0; active < activeDigitCount; ++active) {
+        unsigned digit = activeDigits[active];
+        unsigned shift = digit * 8;
+
+        CounterType offset = 0;
+        for (size_t bucket = 0; bucket < bucketCount; ++bucket) {
+            cursors[bucket] = offset;
+            offset += counts[0][digit][bucket];
+        }
+        ASSERT(offset == length);
+
+        // Stability is what makes the least-significant-digit-first order work: a later pass must
+        // preserve the relative order an earlier one established.
+        for (size_t cursor = 0; cursor < length; ++cursor) {
+            ElementType value = source[cursor];
+            destination[cursors[static_cast<uint8_t>(sortKey(value) >> shift)]++] = value;
+        }
+
+        std::swap(source, destination);
+    }
+
+    if (source.data() != elements.data())
+        WTF::copyElements(elements, spanConstCast<const ElementType>(source));
+    return true;
 }
 
 template<typename PassedAdaptor> inline Structure* JSGenericResizableOrGrowableSharedTypedArrayView<PassedAdaptor>::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -315,6 +315,26 @@ ALWAYS_INLINE simde_uint64x2_t bitAnd2(simde_uint64x2_t accumulated, simde_uint6
     return simde_vandq_u64(accumulated, input);
 }
 
+ALWAYS_INLINE simde_uint8x16_t bitXor2(simde_uint8x16_t accumulated, simde_uint8x16_t input)
+{
+    return simde_veorq_u8(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint16x8_t bitXor2(simde_uint16x8_t accumulated, simde_uint16x8_t input)
+{
+    return simde_veorq_u16(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint32x4_t bitXor2(simde_uint32x4_t accumulated, simde_uint32x4_t input)
+{
+    return simde_veorq_u32(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint64x2_t bitXor2(simde_uint64x2_t accumulated, simde_uint64x2_t input)
+{
+    return simde_veorq_u64(accumulated, input);
+}
+
 template<typename VectorType, typename... Args>
 ALWAYS_INLINE decltype(auto) merge(VectorType a0, VectorType a1, Args... args)
 {
@@ -340,6 +360,15 @@ ALWAYS_INLINE decltype(auto) bitAnd(VectorType a0, VectorType a1, Args... args)
         return bitAnd2(a0, a1);
     else
         return bitAnd2(a0, bitAnd(a1, std::forward<Args>(args)...));
+}
+
+template<typename VectorType, typename... Args>
+ALWAYS_INLINE decltype(auto) bitXor(VectorType a0, VectorType a1, Args... args)
+{
+    if constexpr (!sizeof...(args))
+        return bitXor2(a0, a1);
+    else
+        return bitXor2(a0, bitXor(a1, std::forward<Args>(args)...));
 }
 
 ALWAYS_INLINE simde_uint8x16_t bitNot(simde_uint8x16_t input)

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -122,6 +122,7 @@ set(TestWTF_SOURCES
     Tests/WTF/RobinHoodHashSet.cpp
     Tests/WTF/RunLoop.cpp
     Tests/WTF/SHA1.cpp
+    Tests/WTF/SIMDHelpers.cpp
     Tests/WTF/SafeStrerror.cpp
     Tests/WTF/SaturatingArithmeticOperations.cpp
     Tests/WTF/Scope.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1280,6 +1280,7 @@
 				WTF/SetForScope.cpp,
 				WTF/SHA1.cpp,
 				WTF/Signals.cpp,
+				WTF/SIMDHelpers.cpp,
 				WTF/SmallSet.cpp,
 				WTF/SortedArrayMap.cpp,
 				WTF/SparseBitVector.cpp,

--- a/Tools/TestWebKitAPI/Tests/WTF/SIMDHelpers.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SIMDHelpers.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/SIMDHelpers.h>
+
+#include <array>
+
+namespace TestWebKitAPI {
+
+template<typename LaneType, size_t laneCount>
+static std::array<LaneType, laneCount> extractLanes(WTF::SIMD::VectorType<LaneType> vector)
+{
+    std::array<LaneType, laneCount> lanes { };
+    WTF::SIMD::store(vector, lanes.data());
+    return lanes;
+}
+
+TEST(WTF_SIMDHelpers, LessThanUnsigned8)
+{
+    std::array<uint8_t, 16> left { 0, 1, 127, 128, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    std::array<uint8_t, 16> right { 1, 0, 128, 127, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    auto result = extractLanes<uint8_t, 16>(WTF::SIMD::lessThan(WTF::SIMD::load(left.data()), WTF::SIMD::load(right.data())));
+    EXPECT_EQ(0xffu, result[0]);
+    EXPECT_EQ(0x00u, result[1]);
+    EXPECT_EQ(0xffu, result[2]);
+    EXPECT_EQ(0x00u, result[3]);
+    EXPECT_EQ(0x00u, result[4]);
+}
+
+TEST(WTF_SIMDHelpers, LessThanUnsigned16)
+{
+    std::array<uint16_t, 8> left { 0, 1, 0x7fff, 0x8000, 0xffff, 0, 0, 0 };
+    std::array<uint16_t, 8> right { 1, 0, 0x8000, 0x7fff, 0xffff, 0, 0, 0 };
+    auto result = extractLanes<uint16_t, 8>(WTF::SIMD::lessThan(WTF::SIMD::load(left.data()), WTF::SIMD::load(right.data())));
+    EXPECT_EQ(0xffffu, result[0]);
+    EXPECT_EQ(0x0000u, result[1]);
+    EXPECT_EQ(0xffffu, result[2]);
+    EXPECT_EQ(0x0000u, result[3]);
+    EXPECT_EQ(0x0000u, result[4]);
+}
+
+TEST(WTF_SIMDHelpers, LessThanUnsigned32)
+{
+    std::array<uint32_t, 4> left { 0, 0x7fffffffu, 0x80000000u, 0xffffffffu };
+    std::array<uint32_t, 4> right { 1, 0x80000000u, 0x7fffffffu, 0xffffffffu };
+    auto result = extractLanes<uint32_t, 4>(WTF::SIMD::lessThan(WTF::SIMD::load(left.data()), WTF::SIMD::load(right.data())));
+    EXPECT_EQ(0xffffffffu, result[0]);
+    EXPECT_EQ(0xffffffffu, result[1]);
+    EXPECT_EQ(0x00000000u, result[2]);
+    EXPECT_EQ(0x00000000u, result[3]);
+}
+
+// The unsigned 64-bit compare has no single x86 instruction behind it, so simde emulates it. These
+// are the cases that distinguish it from a signed compare.
+TEST(WTF_SIMDHelpers, LessThanUnsigned64)
+{
+    std::array<uint64_t, 2> left { 0x7fffffffffffffffull, 0x8000000000000000ull };
+    std::array<uint64_t, 2> right { 0x8000000000000000ull, 0x7fffffffffffffffull };
+    auto result = extractLanes<uint64_t, 2>(WTF::SIMD::lessThan(WTF::SIMD::load(left.data()), WTF::SIMD::load(right.data())));
+    EXPECT_EQ(0xffffffffffffffffull, result[0]);
+    EXPECT_EQ(0x0000000000000000ull, result[1]);
+}
+
+TEST(WTF_SIMDHelpers, Bitwise32)
+{
+    std::array<uint32_t, 4> left { 0xf0f0f0f0u, 0xffffffffu, 0x00000000u, 0x12345678u };
+    std::array<uint32_t, 4> right { 0x0ff00ff0u, 0x00000000u, 0xffffffffu, 0x87654321u };
+    auto leftVector = WTF::SIMD::load(left.data());
+    auto rightVector = WTF::SIMD::load(right.data());
+
+    auto andResult = extractLanes<uint32_t, 4>(WTF::SIMD::bitAnd(leftVector, rightVector));
+    auto orResult = extractLanes<uint32_t, 4>(WTF::SIMD::bitOr(leftVector, rightVector));
+    auto xorResult = extractLanes<uint32_t, 4>(WTF::SIMD::bitXor(leftVector, rightVector));
+
+    for (unsigned lane = 0; lane < 4; ++lane) {
+        EXPECT_EQ(left[lane] & right[lane], andResult[lane]);
+        EXPECT_EQ(left[lane] | right[lane], orResult[lane]);
+        EXPECT_EQ(left[lane] ^ right[lane], xorResult[lane]);
+    }
+}
+
+TEST(WTF_SIMDHelpers, Bitwise64)
+{
+    std::array<uint64_t, 2> left { 0xf0f0f0f0f0f0f0f0ull, 0x0123456789abcdefull };
+    std::array<uint64_t, 2> right { 0x0ff00ff00ff00ff0ull, 0xfedcba9876543210ull };
+    auto leftVector = WTF::SIMD::load(left.data());
+    auto rightVector = WTF::SIMD::load(right.data());
+
+    auto andResult = extractLanes<uint64_t, 2>(WTF::SIMD::bitAnd(leftVector, rightVector));
+    auto orResult = extractLanes<uint64_t, 2>(WTF::SIMD::bitOr(leftVector, rightVector));
+    auto xorResult = extractLanes<uint64_t, 2>(WTF::SIMD::bitXor(leftVector, rightVector));
+
+    for (unsigned lane = 0; lane < 2; ++lane) {
+        EXPECT_EQ(left[lane] & right[lane], andResult[lane]);
+        EXPECT_EQ(left[lane] | right[lane], orResult[lane]);
+        EXPECT_EQ(left[lane] ^ right[lane], xorResult[lane]);
+    }
+}
+
+// isNonZero over a lessThan result is the shape callers use to turn a lane comparison into a scalar
+// early exit.
+TEST(WTF_SIMDHelpers, LessThanFeedsIsNonZero)
+{
+    auto hasInversion = [](const uint16_t* data) {
+        return WTF::SIMD::isNonZero(WTF::SIMD::lessThan(WTF::SIMD::load(data + 1), WTF::SIMD::load(data)));
+    };
+
+    std::array<uint16_t, 9> ascending { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    std::array<uint16_t, 9> withInversion { 1, 2, 3, 4, 5, 6, 8, 7, 9 };
+    EXPECT_FALSE(hasInversion(ascending.data()));
+    EXPECT_TRUE(hasInversion(withInversion.data()));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 6b13bfa7ba4341e5041b6f02566d2dd89fd2b855
<pre>
[JSC] Implement radix-sort for TypedArrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=321877">https://bugs.webkit.org/show_bug.cgi?id=321877</a>
<a href="https://rdar.apple.com/185056908">rdar://185056908</a>

Reviewed by Sosuke Suzuki.

Since TypedArrays&apos; element size are fixed, we can apply radix-sort. For
1-byte sized elements, we already introduced counting-sort. And for the
rest of the element types, we use radix-sort: uint16_t becomes two
uint8_t digits. Performing the counting-sort onto the lower uint8_t
side, and then doing the counting-sort onto the upper uint8_t.

                                               ToT                     Patched

    uint8array-sort-large-array          49.7578+-1.6459           49.7540+-0.8851
    uint32array-sort-large-array        132.7664+-5.3124     ^     53.1423+-0.6340        ^ definitely 2.4983x faster
    float64array-sort-large-array        97.6190+-4.4608     ^     37.8412+-0.1655        ^ definitely 2.5797x faster
    int32array-sort-large-array         130.4901+-5.7267     ^     56.2865+-0.5195        ^ definitely 2.3183x faster
    float64array-sort-medium-array       69.3409+-4.0941     ^     63.3630+-0.8433        ^ definitely 1.0943x faster
    uint32array-sort-custom               9.6304+-0.1055     ?      9.6732+-0.1015        ?
    uint16array-sort-large-array        127.9445+-0.7055     ^     28.0103+-1.0780        ^ definitely 4.5678x faster
    int8array-sort-large-array           51.9604+-0.7734     ?     53.1044+-1.9928        ? might be 1.0220x slower
    uint8array-sort-medium-array        114.3740+-2.3787          113.5297+-3.5727
    int16array-sort-large-array         128.7244+-0.4794     ^     29.1688+-0.5807        ^ definitely 4.4131x faster
    float64array-sort-small-array       133.8621+-2.3568     ?    134.3342+-3.1311        ?
    int32array-sort-small-array         124.7704+-0.5951     ?    124.9305+-0.6441        ?
    float64array-sort-presorted         129.4033+-2.1667     ^     70.1832+-0.1949        ^ definitely 1.8438x faster
    uint8array-sort-small-array          88.8232+-6.2246           88.5175+-2.4005
    float32array-sort-large-array       115.9230+-0.9632     ^     62.4550+-0.3878        ^ definitely 1.8561x faster
    uint8array-sort-presorted             8.3450+-0.2152            8.2700+-0.2215
    uint8array-sort-low-entropy          50.0322+-0.2387           49.9000+-0.3350
    float64array-sort-low-entropy       117.3185+-1.2640     ?    119.8619+-1.7623        ? might be 1.0217x slower
    int32array-sort-low-entropy         115.2864+-3.2295          114.4655+-2.0151
    uint8array-sort-tiny-array           97.7407+-0.9797     ?     97.9517+-1.0774        ?
    int32array-sort-medium-array        130.4366+-1.6415     ^     91.3443+-0.2602        ^ definitely 1.4280x faster
    int32array-sort-presorted           115.2502+-1.0671     ^     17.0865+-0.9215        ^ definitely 6.7451x faster
    int16array-sort-low-entropy         121.2838+-0.7962     ?    121.5654+-2.7104        ?

    &lt;geometric&gt;                          82.5904+-0.3588     ^     55.2056+-0.1905        ^ definitely 1.4961x faster

Tests: JSTests/microbenchmarks/float32array-sort-large-array.js
       JSTests/microbenchmarks/float64array-sort-large-array.js
       JSTests/microbenchmarks/float64array-sort-low-entropy.js
       JSTests/microbenchmarks/float64array-sort-medium-array.js
       JSTests/microbenchmarks/float64array-sort-presorted.js
       JSTests/microbenchmarks/float64array-sort-small-array.js
       JSTests/microbenchmarks/int16array-sort-large-array.js
       JSTests/microbenchmarks/int16array-sort-low-entropy.js
       JSTests/microbenchmarks/int32array-sort-large-array.js
       JSTests/microbenchmarks/int32array-sort-low-entropy.js
       JSTests/microbenchmarks/int32array-sort-medium-array.js
       JSTests/microbenchmarks/int32array-sort-presorted.js
       JSTests/microbenchmarks/int32array-sort-small-array.js
       JSTests/microbenchmarks/uint16array-sort-large-array.js
       JSTests/microbenchmarks/uint32array-sort-large-array.js
       JSTests/stress/typed-array-sort-radix-sort.js
       Tools/TestWebKitAPI/Tests/WTF/SIMDHelpers.cpp

* JSTests/microbenchmarks/float32array-sort-large-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/float64array-sort-large-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/float64array-sort-low-entropy.js: Added.
(nextRandom):
* JSTests/microbenchmarks/float64array-sort-medium-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/float64array-sort-presorted.js: Added.
* JSTests/microbenchmarks/float64array-sort-small-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/int16array-sort-large-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/int16array-sort-low-entropy.js: Added.
(nextRandom):
* JSTests/microbenchmarks/int32array-sort-large-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/int32array-sort-low-entropy.js: Added.
(nextRandom):
* JSTests/microbenchmarks/int32array-sort-medium-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/int32array-sort-presorted.js: Added.
* JSTests/microbenchmarks/int32array-sort-small-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/uint16array-sort-large-array.js: Added.
(nextRandom):
* JSTests/microbenchmarks/uint32array-sort-large-array.js: Added.
(nextRandom):
* JSTests/stress/typed-array-sort-radix-sort.js: Added.
(shouldBe):
(nextRandom):
(isBigIntArray):
(compareNumbers):
(compareBigInts):
(sortedReference):
(coerce):
(integerPatterns.random):
(integerPatterns.identical):
(integerPatterns.ascending):
(integerPatterns.descending):
(integerPatterns.lowDigitOnly):
(integerPatterns.secondDigitOnly):
(integerPatterns.twoValues):
(integerPatterns.alternatingSign):
(inversionPositions):
(storageView):
(sweepInversions):
(compareFloats):
(shouldMatchFloatReference):
(floatPatterns.random):
(floatPatterns.identical):
(floatPatterns.ascending):
(floatPatterns.descending):
(floatPatterns.subnormalAndTiny):
(floatPatterns.largeMagnitude):
(floatPatterns.withZeros):
(floatPatterns.withInfinities):
(floatPatterns.withNaN):
(floatPatterns.allNaN):
(floatPatterns.negativeNaN):
(ascendingWideBase):
(shouldRestoreBase):
* JSTests/stress/typedarray-sort-out-of-memory.js:
(catch):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::sort):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::sortKey):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::sortKeyDigit):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::isNonDescending):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::countingSort):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::hasFewDistinctValues):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::radixSort):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::radixSortWithCounters):
* Source/WTF/wtf/SIMDHelpers.h:
(WTF::SIMD::bitXor2):
(WTF::SIMD::bitXor):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/SIMDHelpers.cpp: Added.
(TestWebKitAPI::extractLanes):
(TestWebKitAPI::TEST(WTF_SIMDHelpers, LessThanUnsigned8)):
(TestWebKitAPI::TEST(WTF_SIMDHelpers, LessThanUnsigned16)):
(TestWebKitAPI::TEST(WTF_SIMDHelpers, LessThanUnsigned32)):
(TestWebKitAPI::TEST(WTF_SIMDHelpers, LessThanUnsigned64)):
(TestWebKitAPI::TEST(WTF_SIMDHelpers, Bitwise32)):
(TestWebKitAPI::TEST(WTF_SIMDHelpers, Bitwise64)):
(TestWebKitAPI::TEST(WTF_SIMDHelpers, LessThanFeedsIsNonZero)):

Canonical link: <a href="https://commits.webkit.org/319339@main">https://commits.webkit.org/319339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16d3449e321fb8a7fdd5d7e5b2b0bb783b794f10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55160 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191432 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/716d5d88-c4a1-4fe4-90c0-8eea3ca62786) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54876 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2848db49-d976-4fe4-ab36-f72d141fab48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184170 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/121870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c79f4fb-12ae-408e-aa1e-f70b7b58adea) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/3835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/10653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/41698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2592 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42489 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47772 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193364 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54827 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/161686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55514 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/150522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27509 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/45116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127782 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123342 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54031 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/16696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53413 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53650 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53478 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->