### PR TITLE
Cherry-pick 305413.922@safari-7624.4-branch (883cc7576689). https://bugs.webkit.org/show_bug.cgi?id=314579

### DIFF
--- a/JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js
+++ b/JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js
@@ -1,0 +1,40 @@
+//@ runDefault("--forceEagerCompilation=1")
+
+let total = 0;
+function check(v3) {
+    if (++total > 10000)
+        quit(0);
+    transferArrayBuffer(v3);
+}
+noInline(check);
+
+function main() {
+    function v2(v3) {
+        for (let v9 = 0; v9 < 1024; v9 = v9 + 1) {
+            try {
+                check(v3);
+            } catch {
+                const x = (() => {
+                    const a = new Array(8);
+                    a[0] = {}, a[1] = {}, a[2] = {}, a[3] = {}, a[0] = {}, a[5] = {}, a[6] = {}, a[7] = {};
+                    return a;
+                })();
+                const y = (() => {
+                    const r = [];
+                    for (let i = 0; i < 16; i++) { }
+                })();
+                try {
+                    for (let i = 0; i < 16; i++) {
+                        const o = {};
+                        try {
+                            main(o);
+                            x.__proto__ = Math.LN2;
+                        } catch { }
+                    }
+                } catch { }
+            }
+        }
+    }
+    const v11 = v2();
+}
+main();

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -83,7 +83,8 @@ static void reboxAccordingToFormat(
         break;
     }
 
-    case DataFormatJS: {
+    case DataFormatJS:
+    case DataFormatStorage: {
         // Done already!
         break;
     }


### PR DESCRIPTION
#### 346d9afedd9ed94dc7bc15593416369a8257d0ad
<pre>
Cherry-pick 305413.922@safari-7624.4-branch (883cc7576689). <a href="https://bugs.webkit.org/show_bug.cgi?id=314579">https://bugs.webkit.org/show_bug.cgi?id=314579</a>

    [JSC] FTL OSR exit: handle DataFormatStorage in reboxAccordingToFormat
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314579">https://bugs.webkit.org/show_bug.cgi?id=314579</a>
    <a href="https://rdar.apple.com/176131036">rdar://176131036</a>

    Reviewed by Marcus Plutowski.

    300523@main relaxed validation so that PhantomNewArrayWithButterfly may
    reference a non-phantom NewButterflyWithSize, and taught
    FTLLowerDFGToB3::exitValueForNode to emit an ExitArgument with
    DataFormatStorage for the live butterfly. However, the FTL OSR exit
    compiler&apos;s reboxAccordingToFormat() was never updated, so when such an
    exit is compiled it falls into RELEASE_ASSERT_NOT_REACHED().

    The recovered storage value is the raw butterfly pointer that
    operationMaterializeObjectInOSR(PhantomNewArrayWithButterfly) consumes
    via std::bit_cast&lt;Butterfly*&gt;, so no boxing is required; treat it the
    same as DataFormatJS and pass it through unchanged.

    Test: JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js

    * JSTests/stress/ftl-osr-exit-materialize-phantom-array-with-live-butterfly.js: Added.
    (check):
    (main.v2):
    (main):
    * Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:
    (JSC::FTL::reboxAccordingToFormat):

    Identifier: 305413.922@safari-7624.4-branch

Canonical link: <a href="https://commits.webkit.org/305877.1096@webkitglib/2.52">https://commits.webkit.org/305877.1096@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/054b021c4dba260d27ee158a10168c935ce0ceec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180973 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/54918 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48716 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191187 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145296 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/56216 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54634 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141199 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145296 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183928 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/56216 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/48716 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121651 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/56216 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/54634 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3616 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/48716 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/56216 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48716 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2347 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/42247 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/47530 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/54634 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193122 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/54584 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/48716 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150585 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/55272 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/48716 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150302 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27467 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/55272 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127538 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/123016 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/53789 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/48716 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/53171 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53408 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53236 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->