### PR TITLE
Keep observed nodes alive across MutationObserver delivery

### DIFF
--- a/LayoutTests/fast/dom/MutationObserver/observed-node-collected-during-delivery-crash-expected.txt
+++ b/LayoutTests/fast/dom/MutationObserver/observed-node-collected-during-delivery-crash-expected.txt
@@ -1,0 +1,10 @@
+An observed node must stay alive for as long as MutationObserver::deliver() keeps its registration alive.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/MutationObserver/observed-node-collected-during-delivery-crash.html
+++ b/LayoutTests/fast/dom/MutationObserver/observed-node-collected-during-delivery-crash.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("An observed node must stay alive for as long as MutationObserver::deliver() keeps its registration alive.");
+jsTestIsAsync = true;
+
+function callback(records, observer)
+{
+    // deliver() dropped the transient registration that kept div alive, but still holds the
+    // registration. disconnect() and gc() both dereference its reference to div.
+    observer.disconnect();
+    gc();
+    testPassed("did not crash");
+    finishJSTest();
+}
+
+let observer = new MutationObserver(callback);
+
+let div = document.createElement("div");
+let span = div.appendChild(document.createElement("span"));
+observer.observe(div, {attributes: true, subtree: true});
+div.removeChild(span); // Creates a transient registration for span, which keeps div alive.
+div = null;
+gc(); // Collects div's wrapper, leaving the registration as div's only owner.
+span.setAttribute("foo", "bar"); // Enqueues a record targeting span, not div.
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -203,6 +203,11 @@ void MutationObserver::deliver()
 {
     ASSERT(canDeliver());
 
+    // takeTransientRegistrations() below drops each registration's only strong reference to its
+    // observed node. Keep those nodes alive, declared first so they outlive the registrations.
+    // GCReachableRef keeps their JS wrappers alive too.
+    Vector<GCReachableRef<Node>, 1> observedNodesToKeepAlive;
+
     // Calling takeTransientRegistrations() can modify m_registrations, so it's necessary
     // to make a copy of the transient registrations before operating on them.
     Vector<Ref<MutationObserverRegistration>, 1> transientRegistrations;
@@ -213,8 +218,10 @@ void MutationObserver::deliver()
         if (registration->hasTransientRegistrations())
             transientRegistrations.append(WTF::move(registration));
     }
-    for (auto& registration : transientRegistrations)
+    for (auto& registration : transientRegistrations) {
+        observedNodesToKeepAlive.append(registration->node());
         nodesToKeepAlive.append(registration->takeTransientRegistrations());
+    }
 
     if (m_records.isEmpty()) {
         ASSERT(m_pendingTargets.isEmpty());


### PR DESCRIPTION
#### 9c6099bea06bf812084dc9118bbae1dcda5937a0
<pre>
Keep observed nodes alive across MutationObserver delivery
<a href="https://bugs.webkit.org/show_bug.cgi?id=321878">https://bugs.webkit.org/show_bug.cgi?id=321878</a>
<a href="https://rdar.apple.com/183913289">rdar://183913289</a>

Reviewed by David Kilzer.

MutationObserver::deliver() collects the observer&apos;s registrations that have transient
registrations into a Vector&lt;Ref&lt;MutationObserverRegistration&gt;&gt; and keeps them alive for
the rest of the function, including across the mutation callback. It then calls
takeTransientRegistrations() on each of them, which clears
MutationObserverRegistration::m_nodeKeptAlive, the registration&apos;s only strong reference
to the node it observes.

When that was the last reference to the observed node, the node is destroyed while
deliver() still holds its registration alive, and the registration is still in
MutationObserver::m_registrations. Its reference to the observed node is a
WeakRef&lt;Node&gt;, so it is now dangling, and dereferencing it hits the RELEASE_ASSERT in
WeakRef::ptr(). MutationObserverRegistration::isReachableFromOpaqueRoots() does so on a
GC thread, and MutationObserver::disconnect() does so on the main thread.

Keep the observed nodes alive for as long as deliver() keeps their registrations alive.
Declare the vector before transientRegistrations so that the nodes outlive the
registrations, and use GCReachableRef so that the nodes&apos; JS wrappers are kept alive as
well, matching how deliver() already handles the transient registration nodes.

Test: fast/dom/MutationObserver/observed-node-collected-during-delivery-crash.html

* LayoutTests/fast/dom/MutationObserver/observed-node-collected-during-delivery-crash-expected.txt: Added.
* LayoutTests/fast/dom/MutationObserver/observed-node-collected-during-delivery-crash.html: Added.
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::deliver):

Canonical link: <a href="https://commits.webkit.org/319335@main">https://commits.webkit.org/319335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37f610de5c4716bc8b79c9673fbf82025d98ddbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145298 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141202 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97896 "1 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e54e3462-baf1-4318-becc-6c5406144402) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121654 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2924450-5a0c-438f-838f-25cbeff3405f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43535 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41814 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41474 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2349 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193124 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40385 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55274 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38092 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150304 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44892 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127540 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123019 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53791 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16468 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53173 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53410 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53238 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->