### PR TITLE
[LBSE] Collecting pattern attributes walks an xlink:href cycle forever

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8530,3 +8530,10 @@ imported/w3c/web-platform-tests/css/css-box/margin-trim/multicol-spanner-003.htm
 imported/w3c/web-platform-tests/css/css-box/margin-trim/multicol-spanner-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-box/margin-trim/multicol-spanner-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-box/margin-trim/multicol-spanner-007.html [ ImageOnlyFailure ]
+
+# The legacy SVG engine does not resolve a pattern xlink:href inside a shadow tree, so the pattern
+# inherits nothing and paints nothing. The layer based engine renders these correctly, see the
+# overrides in LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations.
+fast/shadow-dom/svg-multiple-references-in-multiple-shadows-pattern.html [ ImageOnlyFailure ]
+fast/shadow-dom/svg-pattern-dynamic-update-href-in-shadow-tree.html [ ImageOnlyFailure ]
+fast/shadow-dom/svg-pattern-href-in-shadow-tree.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/shadow-dom/svg-multiple-references-in-multiple-shadows-pattern-expected.html
+++ b/LayoutTests/fast/shadow-dom/svg-multiple-references-in-multiple-shadows-pattern-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <style>
+        div {
+            width: 100px;
+            height: 100px;
+        }
+    </style>
+</head>
+<body>
+    <div>
+        <svg>
+            <pattern id="pattern" width="1" height="1" patternContentUnits="objectBoundingBox">
+                <rect width="1" height="1" fill="green" />
+            </pattern>
+            <rect id="rect" width="100" height="100" fill="url(#pattern)">
+        </svg>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/svg-multiple-references-in-multiple-shadows-pattern.html
+++ b/LayoutTests/fast/shadow-dom/svg-multiple-references-in-multiple-shadows-pattern.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <style>
+        div {
+            width: 100px;
+            height: 100px;
+        }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+        window.onload = () => {
+            const shadowRoot1 = container1.attachShadow({mode: "closed"});
+            shadowRoot1.appendChild(template.content.cloneNode(true));
+
+            const shadowRoot2 = container2.attachShadow({mode: "closed"});
+            shadowRoot2.appendChild(template.content.cloneNode(true));
+
+            requestAnimationFrame(() => {
+                container2.style.display = "none";
+                shadowRoot1.querySelector("rect").style.filter = "url(#flood-color)";
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        }
+    </script>
+</head>
+<body>
+    <template id="template">
+        <svg>
+            <pattern id="pattern" width="1" height="1" patternContentUnits="objectBoundingBox">
+                <rect width="1" height="1" fill="green" />
+            </pattern>
+            <pattern id="patternUse" href="#pattern"></pattern>
+            <rect id="rect" width="100" height="100" fill="url(#patternUse)">
+        </svg>
+    </template>
+    <div id="container1"></div>
+    <div id="container2"></div>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/svg-pattern-dynamic-update-href-in-shadow-tree-expected.html
+++ b/LayoutTests/fast/shadow-dom/svg-pattern-dynamic-update-href-in-shadow-tree-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <p>Test passes if you see a single 100px by 100px green box below.</p>
+    <div style="width: 100px; height: 100px; background: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/svg-pattern-dynamic-update-href-in-shadow-tree.html
+++ b/LayoutTests/fast/shadow-dom/svg-pattern-dynamic-update-href-in-shadow-tree.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<style>
+    #host {
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<body>
+    <p>Test passes if you see a single 100px by 100px green box below.</p>
+    <div id="host"></div>
+    <svg>
+        <pattern id="pattern" width="1" height="1" patternContentUnits="objectBoundingBox">
+            <rect width="1" height="1" fill="red" />
+        </pattern>
+    </svg>
+    <template>
+        <svg viewbox="0 0 100 100">
+            <pattern id="pattern" width="1" height="1" patternContentUnits="objectBoundingBox">
+                <rect width="1" height="1" fill="green" />
+            </pattern>
+            <pattern id="blue-pattern" width="1" height="1" patternContentUnits="objectBoundingBox">
+                <rect width="1" height="1" fill="blue" />
+            </pattern>
+            <pattern id="patternUse" href="#blue-pattern" />
+            <rect id="rect" width="100" height="100" fill="url(#patternUse)" />
+        </svg>
+    </template>
+    <script>
+        window.onload = () => {
+            if (window.testRunner)
+                testRunner.waitUntilDone();
+
+            const shadowRoot = host.attachShadow({mode: 'closed'});
+            shadowRoot.appendChild(document.querySelector('template').content.cloneNode(true));
+
+            requestAnimationFrame(() => {
+                shadowRoot.querySelector('#patternUse').setAttribute('href', '#pattern');
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        }
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/svg-pattern-href-in-shadow-tree-expected.html
+++ b/LayoutTests/fast/shadow-dom/svg-pattern-href-in-shadow-tree-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <p>Test passes if you see a single 100px by 100px green box below.</p>
+    <div style="width: 100px; height: 100px; background: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/svg-pattern-href-in-shadow-tree.html
+++ b/LayoutTests/fast/shadow-dom/svg-pattern-href-in-shadow-tree.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if you see a single 100px by 100px green box below.</p>
+<div id="host" style="width: 100px; height: 100px;"></div>
+<svg>
+    <pattern id="pattern" width="1" height="1" patternContentUnits="objectBoundingBox">
+        <rect width="1" height="1" fill="red" />
+    </pattern>
+</svg>
+<template>
+    <svg viewbox="0 0 100 100">
+        <pattern id="pattern" width="1" height="1" patternContentUnits="objectBoundingBox">
+            <rect width="1" height="1" fill="green" />
+        </pattern>
+        <pattern id="patternUse" href="#pattern"></pattern>
+        <rect id="rect" width="100" height="100" fill="url(#patternUse)">
+    </svg>
+</template>
+<script>
+
+const shadowRoot = host.attachShadow({mode: 'closed'});
+shadowRoot.appendChild(document.querySelector('template').content.cloneNode(true));
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -195,13 +195,14 @@ svg/dynamic-updates/SVGFEImageElement-dom-preserveAspectRatio-attr.html         
 # Crash / Timeout #
 ###################
 
-svg/custom/pattern-3-step-cycle-dynamic-4.html [ Pass Crash ]
-
 ###############
 #  OVERRIDES  #
 ###############
 
 # Reset results inherited from TestExpectations chaining
+fast/shadow-dom/svg-multiple-references-in-multiple-shadows-pattern.html                                          [ Pass ]
+fast/shadow-dom/svg-pattern-dynamic-update-href-in-shadow-tree.html                                               [ Pass ]
+fast/shadow-dom/svg-pattern-href-in-shadow-tree.html                                                              [ Pass ]
 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-scale-scroll.html                  [ Pass ]
 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-with-position-under-clip-path.html [ Pass ]
 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/isolation-with-html.html                          [ Pass ]
@@ -210,7 +211,6 @@ imported/w3c/web-platform-tests/svg/extensibility/foreignObject/scroll-transform
 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/will-change-in-foreign-object-paint-order.html    [ Pass ]
 imported/w3c/web-platform-tests/svg/layout/svg-foreign-relayout-001.html                                          [ Pass ]
 imported/w3c/web-platform-tests/svg/layout/svg-foreign-relayout-002.html                                          [ Pass ]
-imported/w3c/web-platform-tests/svg/linking/reftests/media-fragment-override-multiple.html                        [ Pass ]
 imported/w3c/web-platform-tests/svg/linking/reftests/media-fragment-override-multiple.html                        [ Pass ]
 imported/w3c/web-platform-tests/svg/painting/mask-containing-image-with-clip-path.svg                             [ Pass ]
 imported/w3c/web-platform-tests/svg/painting/reftests/non-scaling-stroke-003.html                                 [ Pass ]

--- a/LayoutTests/svg/custom/pattern-href-cycle-detection-expected.svg
+++ b/LayoutTests/svg/custom/pattern-href-cycle-detection-expected.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="100">
+    <defs>
+        <pattern id="rotated" patternUnits="userSpaceOnUse" width="20" height="20" patternTransform="rotate(45)">
+            <rect width="10" height="10" fill="green"/>
+        </pattern>
+        <pattern id="rotated-shifted" patternUnits="userSpaceOnUse" x="5" width="20" height="20" patternTransform="rotate(45)">
+            <rect width="10" height="10" fill="green"/>
+        </pattern>
+    </defs>
+
+    <rect x="10" y="10" width="80" height="80" fill="url(#rotated)"/>
+    <rect x="110" y="10" width="80" height="80" fill="url(#rotated)"/>
+    <rect x="210" y="10" width="80" height="80" fill="url(#rotated-shifted)"/>
+</svg>

--- a/LayoutTests/svg/custom/pattern-href-cycle-detection.svg
+++ b/LayoutTests/svg/custom/pattern-href-cycle-detection.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" height="100">
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-2000"/>
+    <!-- An xlink:href cycle has to stop at the first pattern it reaches twice, no earlier and no
+         later. All three squares show the same green checkerboard rotated by 45 degrees, the last
+         one shifted right by 5 units. -->
+    <defs>
+        <!-- Two patterns pointing at each other. #two-b contributes the patternTransform. -->
+        <pattern id="two-a" xlink:href="#two-b" patternUnits="userSpaceOnUse" width="20" height="20">
+            <rect width="10" height="10" fill="green"/>
+        </pattern>
+        <pattern id="two-b" xlink:href="#two-a" patternUnits="userSpaceOnUse" width="40" height="40" patternTransform="rotate(45)">
+            <rect width="20" height="20" fill="red"/>
+        </pattern>
+
+        <!-- A pattern pointing at itself. -->
+        <pattern id="self" xlink:href="#self" patternUnits="userSpaceOnUse" width="20" height="20" patternTransform="rotate(45)">
+            <rect width="10" height="10" fill="green"/>
+        </pattern>
+
+        <!-- Three patterns in a ring. #three-b contributes the patternTransform, #three-c the x. -->
+        <pattern id="three-a" xlink:href="#three-b" patternUnits="userSpaceOnUse" width="20" height="20">
+            <rect width="10" height="10" fill="green"/>
+        </pattern>
+        <pattern id="three-b" xlink:href="#three-c" patternUnits="userSpaceOnUse" width="40" height="40" patternTransform="rotate(45)">
+            <rect width="20" height="20" fill="red"/>
+        </pattern>
+        <pattern id="three-c" xlink:href="#three-a" patternUnits="userSpaceOnUse" x="5" width="60" height="60">
+            <rect width="30" height="30" fill="blue"/>
+        </pattern>
+    </defs>
+
+    <rect x="10" y="10" width="80" height="80" fill="url(#two-a)"/>
+    <rect x="110" y="10" width="80" height="80" fill="url(#self)"/>
+    <rect x="210" y="10" width="80" height="80" fill="url(#three-a)"/>
+</svg>

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -399,7 +399,6 @@ svg/SVGPathByteStream.h
 svg/SVGPathElement.cpp
 svg/SVGPatternElement.cpp
 svg/SVGPolyElement.cpp
-svg/SVGRadialGradientElement.cpp
 svg/SVGSVGElement.cpp
 svg/SVGTRefElement.cpp
 svg/SVGTextPositioningElement.cpp

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -51,28 +51,11 @@ void RenderSVGResourcePattern::collectPatternAttributesIfNeeded()
     if (m_attributes.has_value())
         return;
 
+    Ref patternElement = this->patternElement();
+
     auto attributes = PatternAttributes { };
-
-    RefPtr current = patternElement();
-
-    while (current) {
-        if (!current->renderer())
-            break;
-        current->collectPatternAttributes(attributes);
-
-        auto target = SVGURIReference::targetElementFromIRIString(current->href(), protect(current->treeScopeForSVGReferences()));
-        current = dynamicDowncast<SVGPatternElement>(target.element.get());
-    }
-
-    // If we couldn't determine the pattern content element root, stop here.
-    if (!attributes.patternContentElement())
-        return;
-
-    // An empty viewBox disables rendering.
-    if (attributes.hasViewBox() && attributes.viewBox().isEmpty())
-        return;
-
-    m_attributes = WTF::move(attributes);
+    if (patternElement->collectPatternAttributes(attributes))
+        m_attributes = WTF::move(attributes);
 }
 
 RefPtr<Pattern> RenderSVGResourcePattern::buildPattern(GraphicsContext& context, const RenderLayerModelObject& renderer)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -77,7 +77,7 @@ void LegacyRenderSVGResourcePattern::collectPatternAttributes(PatternAttributes&
 
     while (current) {
         Ref pattern = current->patternElement();
-        pattern->collectPatternAttributes(attributes);
+        pattern->collectOwnPatternAttributes(attributes);
 
         auto* resources = SVGResourcesCache::cachedResourcesForRenderer(*current);
         ASSERT_IMPLIES(resources && resources->linkedResource(), is<LegacyRenderSVGResourcePattern>(resources->linkedResource()));

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -110,7 +110,7 @@ RenderPtr<RenderElement> SVGLinearGradientElement::createElementRenderer(Style::
     return createRenderer<LegacyRenderSVGResourceLinearGradient>(*this, WTF::move(style));
 }
 
-static void setGradientAttributes(SVGGradientElement& element, LinearGradientAttributes& attributes, bool isLinear = true)
+static void setGradientAttributes(SVGGradientElement& element, LinearGradientAttributes& attributes, bool isLinear)
 {
     element.collectCommonGradientAttributes(attributes);
 
@@ -137,32 +137,28 @@ bool SVGLinearGradientElement::collectGradientAttributes(LinearGradientAttribute
         return false;
 
     HashSet<Ref<SVGGradientElement>> processedGradients;
-    Ref<SVGGradientElement> current { *this };
+    RefPtr<SVGGradientElement> current { this };
 
-    setGradientAttributes(current.get(), attributes);
-    processedGradients.add(current.copyRef());
+    while (current) {
+        setGradientAttributes(*current, attributes, current->hasTagName(SVGNames::linearGradientTag));
 
-    while (true) {
         // Respect xlink:href, take attributes from referenced element
         auto target = SVGURIReference::targetElementFromIRIString(current->href(), protect(treeScopeForSVGReferences()));
-        if (RefPtr gradientElement = dynamicDowncast<SVGGradientElement>(target.element.get())) {
-            current = *gradientElement;
+        RefPtr next = dynamicDowncast<SVGGradientElement>(target.element.get());
+        if (!next)
+            break;
 
-            // Cycle detection
-            if (processedGradients.contains(current))
-                return true;
+        processedGradients.add(current.releaseNonNull());
+        if (processedGradients.contains(*next))
+            break;
 
-            if (!current->renderer())
-                return false;
+        if (!next->renderer())
+            return false;
 
-            setGradientAttributes(current.get(), attributes, current->hasTagName(SVGNames::linearGradientTag));
-            processedGradients.add(current.copyRef());
-        } else
-            return true;
+        current = WTF::move(next);
     }
 
-    ASSERT_NOT_REACHED();
-    return false;
+    return true;
 }
 
 bool SVGLinearGradientElement::selfHasRelativeLengths() const

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -34,6 +34,7 @@
 #include "PatternAttributes.h"
 #include "RenderSVGResourcePattern.h"
 #include "SVGElementInlines.h"
+#include "SVGElementTypeHelpers.h"
 #include "SVGFitToViewBox.h"
 #include "SVGGraphicsElement.h"
 #include "SVGNames.h"
@@ -41,6 +42,7 @@
 #include "SVGRenderSupport.h"
 #include "SVGStringList.h"
 #include "Settings.h"
+#include <wtf/HashSet.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -157,7 +159,44 @@ bool SVGPatternElement::hasPatternTransformAttribute() const
     return !m_patternTransform->baseVal()->isEmpty();
 }
 
-void SVGPatternElement::collectPatternAttributes(PatternAttributes& attributes) const
+bool SVGPatternElement::collectPatternAttributes(PatternAttributes& attributes)
+{
+    if (!renderer())
+        return false;
+
+    HashSet<Ref<SVGPatternElement>> processedPatterns;
+    RefPtr current { this };
+
+    while (current) {
+        current->collectOwnPatternAttributes(attributes);
+
+        auto target = SVGURIReference::targetElementFromIRIString(current->href(), protect(treeScopeForSVGReferences()));
+        RefPtr next = dynamicDowncast<SVGPatternElement>(target.element.get());
+        if (!next)
+            break;
+
+        processedPatterns.add(current.releaseNonNull());
+        if (processedPatterns.contains(*next))
+            break;
+
+        if (!next->renderer())
+            return false;
+
+        current = WTF::move(next);
+    }
+
+    // If we couldn't determine the pattern content element root, stop here.
+    if (!attributes.patternContentElement())
+        return false;
+
+    // An empty viewBox disables rendering.
+    if (attributes.hasViewBox() && attributes.viewBox().isEmpty())
+        return false;
+
+    return true;
+}
+
+void SVGPatternElement::collectOwnPatternAttributes(PatternAttributes& attributes) const
 {
     if (!attributes.hasX() && hasAttribute(SVGNames::xAttr))
         attributes.setX(x());

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -39,7 +39,8 @@ class SVGPatternElement final : public SVGElement, public SVGFitToViewBox, publi
 public:
     static Ref<SVGPatternElement> create(const QualifiedName&, Document&);
 
-    void collectPatternAttributes(PatternAttributes&) const;
+    bool collectPatternAttributes(PatternAttributes&);
+    void collectOwnPatternAttributes(PatternAttributes&) const;
 
     AffineTransform localCoordinateSpaceTransform(CTMScope) const final;
 

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -116,7 +116,7 @@ RenderPtr<RenderElement> SVGRadialGradientElement::createElementRenderer(Style::
     return createRenderer<LegacyRenderSVGResourceRadialGradient>(*this, WTF::move(style));
 }
 
-static void setGradientAttributes(SVGGradientElement& element, RadialGradientAttributes& attributes, bool isRadial = true)
+static void setGradientAttributes(SVGGradientElement& element, RadialGradientAttributes& attributes, bool isRadial)
 {
     element.collectCommonGradientAttributes(attributes);
 
@@ -149,28 +149,25 @@ bool SVGRadialGradientElement::collectGradientAttributes(RadialGradientAttribute
         return false;
 
     HashSet<Ref<SVGGradientElement>> processedGradients;
-    Ref<SVGGradientElement> current { *this };
+    RefPtr<SVGGradientElement> current { this };
 
-    setGradientAttributes(current, attributes);
-    processedGradients.add(current);
+    while (current) {
+        setGradientAttributes(*current, attributes, current->hasTagName(SVGNames::radialGradientTag));
 
-    while (true) {
         // Respect xlink:href, take attributes from referenced element
-        auto target = SVGURIReference::targetElementFromIRIString(current->href(), treeScopeForSVGReferences());
-        if (RefPtr gradientElement = dynamicDowncast<SVGGradientElement>(protect(target.element).get())) {
-            current = gradientElement.releaseNonNull();
-
-            // Cycle detection
-            if (processedGradients.contains(current))
-                break;
-
-            if (!current->renderer())
-                return false;
-
-            setGradientAttributes(current, attributes, current->hasTagName(SVGNames::radialGradientTag));
-            processedGradients.add(current);
-        } else
+        auto target = SVGURIReference::targetElementFromIRIString(current->href(), protect(treeScopeForSVGReferences()));
+        RefPtr next = dynamicDowncast<SVGGradientElement>(target.element.get());
+        if (!next)
             break;
+
+        processedGradients.add(current.releaseNonNull());
+        if (processedGradients.contains(*next))
+            break;
+
+        if (!next->renderer())
+            return false;
+
+        current = WTF::move(next);
     }
 
     // Handle default values for fx/fy


### PR DESCRIPTION
#### 19a32ddd271368e7c6c774883950f1ac119b64f0
<pre>
[LBSE] Collecting pattern attributes walks an xlink:href cycle forever
<a href="https://bugs.webkit.org/show_bug.cgi?id=321882">https://bugs.webkit.org/show_bug.cgi?id=321882</a>

Reviewed by Rob Buis.

RenderSVGResourcePattern::collectPatternAttributesIfNeeded() followed the
xlink:href chain without remembering where it had been, so two patterns pointing
at each other, or one pointing at itself, hang the WebContent process on the
first paint.

Gradients never had that problem, their walk and its cycle detection live in
SVGLinearGradientElement::collectGradientAttributes(). Switch patterns to the
same kind of logic: move the walk into SVGPatternElement::collectPatternAttributes(),
which now returns whether the pattern can be rendered. The legacy renderer keeps its
SVGResourcesCache walk and only follows the rename.

Two further differences turned out to be accidental and now follow the gradient
rule: patterns kept the attributes collected so far when the chain reached an
element without a renderer aand they resolved each href in the tree scope of the
element holding it, not the one the walk started from which is incorrect.

Finally, unify both code paths as much as possible, so gradient/pattern attribute
collection has the very same shape - less confusing this way.

Update expectations, and add new fast/shadow-dom tests to cover the tree scope
change.

* LayoutTests/TestExpectations:
* LayoutTests/fast/shadow-dom/svg-multiple-references-in-multiple-shadows-pattern-expected.html: Added.
* LayoutTests/fast/shadow-dom/svg-multiple-references-in-multiple-shadows-pattern.html: Added.
* LayoutTests/fast/shadow-dom/svg-pattern-dynamic-update-href-in-shadow-tree-expected.html: Added.
* LayoutTests/fast/shadow-dom/svg-pattern-dynamic-update-href-in-shadow-tree.html: Added.
* LayoutTests/fast/shadow-dom/svg-pattern-href-in-shadow-tree-expected.html: Added.
* LayoutTests/fast/shadow-dom/svg-pattern-href-in-shadow-tree.html: Added.
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* LayoutTests/svg/custom/pattern-href-cycle-detection-expected.svg: Added.
* LayoutTests/svg/custom/pattern-href-cycle-detection.svg: Added.
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::collectPatternAttributesIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp:
(WebCore::LegacyRenderSVGResourcePattern::collectPatternAttributes const):
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::setGradientAttributes):
(WebCore::SVGLinearGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::collectPatternAttributes):
(WebCore::SVGPatternElement::collectOwnPatternAttributes const):
(WebCore::SVGPatternElement::collectPatternAttributes const): Deleted.
* Source/WebCore/svg/SVGPatternElement.h:
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::setGradientAttributes):
(WebCore::SVGRadialGradientElement::collectGradientAttributes):

Canonical link: <a href="https://commits.webkit.org/319850@main">https://commits.webkit.org/319850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d586f1dbd5de9edd886b4d0b3b8495715a0cb9e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147290 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56660 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163597 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123261 "Found 1 new API test failure: TestWTF.WTF_ParkingLot.UnparkOneFiftyThenFiftyAllFast (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45247 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155643 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43125 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4392 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195160 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152302 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40798 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57299 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151998 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46557 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125680 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55807 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18136 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55178 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->