### PR TITLE
[AppKit Gestures] Optimize the speed of the tests a little bit

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -518,12 +518,10 @@ extension AppKitGesturesTests.Basic {
     }
 
     @Test(
+        .disabled("This test is flaky"),
         .bug("https://webkit.org/b/314804", "Triple click does not generate a line selection on PDF"),
-        arguments: [true, false]
     )
-    func tripleClickingInPDFSelectsLine(useAlternatePDFHUD: Bool) async throws {
-        page.setWebFeature("UseAlternatePDFHUD", enabled: useAlternatePDFHUD)
-
+    func tripleClickingInPDFSelectsLine() async throws {
         let pdfURL = try #require(Bundle.testResources.url(forResource: "test", withExtension: "pdf"))
         try await page.load(pdfURL).wait()
         await page.waitForNextPresentationUpdate()
@@ -545,10 +543,8 @@ extension AppKitGesturesTests.Basic {
         #expect(selectedText == "Test PDF Content")
     }
 
-    @Test(arguments: [true, false])
-    func clickingOnPDFHUDButtonPerformsAction(useAlternatePDFHUD: Bool) async throws {
-        page.setWebFeature("UseAlternatePDFHUD", enabled: useAlternatePDFHUD)
-
+    @Test
+    func clickingOnPDFHUDButtonPerformsAction() async throws {
         let pdfURL = try #require(Bundle.testResources.url(forResource: "test", withExtension: "pdf"))
         try await page.load(pdfURL).wait()
         await page.waitForNextPresentationUpdate()
@@ -570,10 +566,8 @@ extension AppKitGesturesTests.Basic {
         #expect(scaleAfterZooming > scaleBeforeZooming)
     }
 
-    @Test(arguments: [true, false])
-    func clickingOnPDFShowsHUD(useAlternatePDFHUD: Bool) async throws {
-        page.setWebFeature("UseAlternatePDFHUD", enabled: useAlternatePDFHUD)
-
+    @Test
+    func clickingOnPDFShowsHUD() async throws {
         let pdfURL = try #require(Bundle.testResources.url(forResource: "test", withExtension: "pdf"))
         try await page.load(pdfURL).wait()
         await page.waitForNextPresentationUpdate()
@@ -588,12 +582,7 @@ extension AppKitGesturesTests.Basic {
         // which is dependent on the implementation.
         // FIXME: Depending on implementation-specific details like this is very not great.
 
-        let visibleView =
-            if useAlternatePDFHUD {
-                try #require(hud.subviews.first?.subviews.first)
-            } else {
-                try #require(hud.subviews.first)
-            }
+        let visibleView = try #require(hud.subviews.first?.subviews.first)
 
         try await Task.sleep(for: .seconds(1))
         #expect(visibleView.alphaValue == 0)
@@ -680,8 +669,8 @@ extension AppKitGesturesTests.Basic {
         #expect(selection == expected)
     }
 
-    @Test(arguments: [6, 8], [Duration.seconds(0.1), .seconds(0.5), .seconds(1.0)])
-    func scrollingOnScrollBarChangesScrollPosition(inset: Int, pressAndWait: Duration) async throws {
+    @Test(arguments: [Duration.seconds(0.1), .seconds(0.5), .seconds(1.0)])
+    func scrollingOnScrollBarChangesScrollPosition(pressAndWait: Duration) async throws {
         let html = """
             <body style="width: 100%; height: 2000px; margin: 0; background: repeating-linear-gradient(to bottom, blue 0 50px, white 50px 100px);">
             </body>
@@ -689,12 +678,12 @@ extension AppKitGesturesTests.Basic {
 
         try await page.load(html: html).wait()
 
-        let topOfScrollBarInWindowCoordinates = NSPoint(x: window.frame.maxX - CGFloat(inset), y: window.frame.maxY - 160)
+        let topOfScrollBarInWindowCoordinates = NSPoint(x: window.frame.maxX - 8, y: window.frame.maxY - 160)
         let start = screenBounds(ofPointInWindowCoordinates: topOfScrollBarInWindowCoordinates)
         let end = CGPoint(x: start.x, y: start.y + 200)
 
         await recap.play { composer in
-            composer._wk_drag(withStart: start, end: end, duration: .seconds(1.0), pressAndWait: pressAndWait)
+            composer._wk_drag(withStart: start, end: end, duration: .seconds(0.5), pressAndWait: pressAndWait)
         }
 
         try await Task.sleep(for: .seconds(1))
@@ -1286,7 +1275,7 @@ extension AppKitGesturesTests.Basic {
 
         await withMockedImageAnalyzer(response: .success(analysis), after: delay) {
             await recap.play { composer in
-                composer._wk_drag(withStart: start, end: end, duration: .seconds(2), pressAndWait: .seconds(1.0))
+                composer._wk_drag(withStart: start, end: end, duration: .seconds(1.5), pressAndWait: .seconds(1.0))
             }
         }
 
@@ -1330,7 +1319,7 @@ extension AppKitGesturesTests.Basic {
         // The test succeeds if it does not timeout.
     }
 
-    @Test
+    @Test(.disabled("This test takes an unavoidable ~10 seconds to run"))
     func consecutiveQuickFlicksAccelerateScrolling() async throws {
         let html = """
             <body style="margin: 0; width: 100%; height: 200000px;


### PR DESCRIPTION
#### 28968f31f8a3ee4dadb286441aa0b3029b51cd64
<pre>
[AppKit Gestures] Optimize the speed of the tests a little bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=321884">https://bugs.webkit.org/show_bug.cgi?id=321884</a>
<a href="https://rdar.apple.com/185062994">rdar://185062994</a>

Reviewed by Wenson Hsieh.

- Disable flaky tests
- Disable super long tests
- Remove some unnecessary parameterized conditions
- Reduce some hard-coded delays

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:
(AppKitGesturesTests.tripleClickingInPDFSelectsLine):
(AppKitGesturesTests.clickingOnPDFHUDButtonPerformsAction):
(AppKitGesturesTests.clickingOnPDFShowsHUD):
(AppKitGesturesTests.scrollingOnScrollBarChangesScrollPosition(_:)):
(AppKitGesturesTests.tripleClickingInPDFSelectsLine(_:)): Deleted.
(AppKitGesturesTests.clickingOnPDFHUDButtonPerformsAction(_:)): Deleted.
(AppKitGesturesTests.clickingOnPDFShowsHUD(_:)): Deleted.
(AppKitGesturesTests.scrollingOnScrollBarChangesScrollPosition(_:pressAndWait:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/319304@main">https://commits.webkit.org/319304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b70007a20356b0daf680b3dced1f773d0cfbdae9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145309 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d5c03257-0218-497b-aa0b-0ab322c1e5d5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141211 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0db831e-53d4-45dd-859f-84ad1ddcae8f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121663 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a60e4166-2b60-4712-a974-255e1c0f08d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43551 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41825 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41490 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2360 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193135 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54597 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150596 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55285 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150313 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27487 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44900 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123045 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53802 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16484 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53184 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53421 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53249 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->