### PR TITLE
[LBSE] An empty viewBox does not disable rendering of the outermost <svg>

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -108,15 +108,6 @@ svg/zoom/page/non-scaling-stroke-textRendering-geometricPrecision.svg [ ImageOnl
 # SMIL animation issues
 svg/stroke/animated-non-scaling-stroke.html [ ImageOnlyFailure ]
 
-# Empty/zero viewBox doesn't disable rendering under LBSE (see bug 320095).
-# DRAFT: these WPT tests replace svg/custom/viewBox-empty.html (removed). Confirm
-# against an LBSE-text run and delete any line that actually PASSES before landing
-# (a passing test marked ImageOnlyFailure reports as an unexpected pass).
-imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-zero-disables-rendering-contexts.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-zero-disables-rendering-001.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-zero-disables-rendering-002.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/coordinate-systems/viewBox-zero-disables-rendering-003.svg [ ImageOnlyFailure ]
-
 # SVG <image> (buffered-rendering) issues
 svg/repaint/buffered-rendering-static-image.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
@@ -49,6 +49,7 @@
 #include "RenderSVGViewportContainer.h"
 #include "SVGFilterElement.h"
 #include "SVGRenderSupport.h"
+#include "SVGSVGElement.h"
 #include "Settings.h"
 #include "StyleTransformResolver.h"
 #include "TransformPaintScope.h"
@@ -221,9 +222,26 @@ void RenderLayer::paintNegativeZOrderChildrenForSVG(GraphicsContext& context, co
     // (paintChildrenInDOMOrderForSVG handles all children including negative z-index).
 }
 
+static bool viewBoxDisablesPaintingForSVG(RenderLayerModelObject& renderer)
+{
+    if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(renderer))
+        return protect(svgRoot->svgSVGElement())->viewBoxDisablesPainting();
+
+    if (CheckedPtr viewportContainer = dynamicDowncast<RenderSVGViewportContainer>(renderer))
+        return protect(viewportContainer->svgSVGElement())->viewBoxDisablesPainting();
+
+    return false;
+}
+
 void RenderLayer::paintForegroundChildrenForSVG(GraphicsContext& context, const LayerPaintingInfo& paintingInfo, const LayerPaintingInfo& localPaintingInfo, OptionSet<PaintLayerFlag> paintFlags, const LayerFragments& layerFragments, OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRoot, std::optional<WTF::Range<unsigned>> svgPaintOrderItemRange, LayoutSize svgFilterChildLayerCorrection)
 {
     ASSERT(m_svgData);
+
+    // An empty viewBox disables rendering of the content. Non-layer descendants are flattened into
+    // this layer's DOM-order list (see collectChildrenInDOMOrderForSVG), so the whole list has to be
+    // gated here -- RenderSVGViewportContainer::paint() alone would not catch the flattened ones.
+    if (viewBoxDisablesPaintingForSVG(renderer()))
+        return;
 
     // foreignObject uses HTML-style z-order painting.
     if (renderer().isRenderSVGForeignObject()) {

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -174,12 +174,8 @@ void RenderSVGViewportContainer::updateLayerTransform()
     } else if (!m_viewport.location().isZero())
         m_supplementalLayerTransform.translate(m_viewport.location());
 
-    bool hasCurrentViewEmptyViewBox = true;
-    if (useSVGSVGElement->useCurrentView())
-        hasCurrentViewEmptyViewBox = useSVGSVGElement->currentView().hasEmptyViewBox();
-
-    // An empty viewBox disables the rendering -- dirty the visible descendant status!
-    if (useSVGSVGElement->hasEmptyViewBox() && hasCurrentViewEmptyViewBox) {
+    // An empty viewBox disables painting -- dirty the visible descendant status!
+    if (useSVGSVGElement->viewBoxDisablesPainting()) {
         if (hasLayer())
             layer()->dirtyVisibleContentStatus();
     } else if (auto viewBoxTransform = viewBoxToViewTransform(useSVGSVGElement, viewportSize); !viewBoxTransform.isIdentity()) {
@@ -191,6 +187,15 @@ void RenderSVGViewportContainer::updateLayerTransform()
 
     // After updating the supplemental layer transform we're able to use it in RenderLayerModelObjects::updateLayerTransform().
     RenderSVGContainer::updateLayerTransform();
+}
+
+void RenderSVGViewportContainer::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
+{
+    Ref useSVGSVGElement = svgSVGElement();
+    if (useSVGSVGElement->viewBoxDisablesPainting())
+        return;
+
+    RenderSVGContainer::paint(paintInfo, paintOffset);
 }
 
 void RenderSVGViewportContainer::applyTransform(TransformationMatrix& transform, const Style::ComputedStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
@@ -47,6 +47,8 @@ public:
 private:
     ASCIILiteral renderName() const final { return "RenderSVGViewportContainer"_s; }
 
+    void paint(PaintInfo&, const LayoutPoint&) final;
+
     void element() const = delete;
 
     bool isOutermostSVGViewportContainer() const { return isAnonymous(); }

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -631,6 +631,14 @@ bool SVGSVGElement::hasSynthesizedViewBoxForSVGImage() const
     return !m_useCurrentView && viewBox().isEmpty() && isEmbeddedThroughSVGImage(*this);
 }
 
+bool SVGSVGElement::viewBoxDisablesPainting()
+{
+    if (!hasEmptyViewBox())
+        return false;
+
+    return m_useCurrentView ? currentView().hasEmptyViewBox() : true;
+}
+
 FloatRect SVGSVGElement::currentViewBoxRect() const
 {
     if (m_useCurrentView) {

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -113,6 +113,8 @@ public:
     FloatRect currentViewBoxRect() const;
     bool hasSynthesizedViewBoxForSVGImage() const;
 
+    bool viewBoxDisablesPainting();
+
     AffineTransform viewBoxToViewTransform(float viewWidth, float viewHeight) const;
     bool hasTransformRelatedAttributes() const final;
 


### PR DESCRIPTION
#### 3797ce8cd607e61062785e52afb0170fd9319640
<pre>
[LBSE] An empty viewBox does not disable rendering of the outermost &lt;svg&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=321883">https://bugs.webkit.org/show_bug.cgi?id=321883</a>

Reviewed by Rob Buis.

A viewBox with a zero width or height disables painting of the element. Legacy
does that with an early return in LegacyRenderSVGRoot::paintReplaced() and
LegacyRenderSVGViewportContainer::paint(). LBSE has no equivalent: A nested &lt;svg&gt;
still rendered right, as its empty overflow clip drops the content, but the
outermost &lt;svg&gt; is clipped by RenderSVGRoot and kept painting.

Add SVGSVGElement::viewBoxDisablesPainting() and check for it during
in both RenderSVGViewportContainer::paint() and
RenderLayer::paintForegroundChildrenForSVG().
The latter is needed because collectChildrenInDOMOrderForSVG() can flatten a
container into the root layer&apos;s child list, which bypasses its own paint()...

The four WPT tests covering this no longer need an LBSE expectation.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* Source/WebCore/rendering/RenderLayerSVGAdditions.cpp:
(WebCore::viewBoxDisablesPaintingForSVG):
(WebCore::RenderLayer::paintForegroundChildrenForSVG):
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::updateLayerTransform):
(WebCore::RenderSVGViewportContainer::paint):
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.h:
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::viewBoxDisablesPainting):
* Source/WebCore/svg/SVGSVGElement.h:

Canonical link: <a href="https://commits.webkit.org/319284@main">https://commits.webkit.org/319284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e475404855e88991f0d96678a237a1338dcb088

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191260 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54707 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141260 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44928 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121712 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43601 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41882 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41544 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2420 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47603 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193195 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54657 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55345 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150368 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27479 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44958 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127611 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123141 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53862 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16540 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53244 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53481 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->