### PR TITLE
[Site Isolation] Fix offscreen frame throttling

### DIFF
--- a/LayoutTests/http/tests/site-isolation/animated-image-in-display-none-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/animated-image-in-display-none-cross-origin-iframe-expected.txt
@@ -1,0 +1,15 @@
+Tests that an animated image is paused in an out-of-process subframe that becomes display:none
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The frame is inside the viewport, so its animated image should be animating.
+PASS imageIsAnimating became "true"
+Hiding the frame with display:none.
+PASS imageIsAnimating became "false"
+Showing the frame again.
+PASS imageIsAnimating became "true"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/animated-image-in-display-none-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/animated-image-in-display-none-cross-origin-iframe.html
@@ -1,0 +1,52 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that an animated image is paused in an out-of-process subframe that becomes display:none");
+
+var jsTestIsAsync = true;
+var imageIsAnimating = "";
+var testFrame;
+
+// The subframe is cross-origin, so its internals object cannot be reached directly.
+window.addEventListener("message", function(event) {
+    imageIsAnimating = event.data;
+}, false);
+
+function runTest()
+{
+    testFrame = document.getElementById("testFrame");
+
+    // Ask repeatedly: the rect reaches the subframe's process asynchronously, one rendering update later.
+    setInterval(function() {
+        testFrame.contentWindow.postMessage("report-image-animating", "*");
+    }, 50);
+
+    debug("The frame is inside the viewport, so its animated image should be animating.");
+    shouldBecomeEqualToString("imageIsAnimating", "true", hideFrame);
+}
+
+function hideFrame()
+{
+    // With site isolation off, an owner element with no renderer gives the frame an empty window clip rect,
+    // which pauses its animated images. The subframe cannot see that its owner has no box, so the owning
+    // process has to report it. Throttling stays suppressed separately, so this is not the same question as
+    // the requestAnimationFrame display:none test.
+    debug("Hiding the frame with display:none.");
+    testFrame.style.display = "none";
+    shouldBecomeEqualToString("imageIsAnimating", "false", showFrame);
+}
+
+function showFrame()
+{
+    debug("Showing the frame again.");
+    testFrame.style.display = "block";
+    shouldBecomeEqualToString("imageIsAnimating", "true", finishJSTest);
+}
+</script>
+<iframe id="testFrame" src="http://localhost:8000/site-isolation/resources/animated-image-frame.html" onload="runTest()"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/animated-image-outside-viewport-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/animated-image-outside-viewport-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,15 @@
+Tests that an animated image is paused in an out-of-process subframe that leaves the viewport
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Scrolling the frame into view.
+PASS imageIsAnimating became "true"
+Scrolling the frame out of view.
+PASS imageIsAnimating became "false"
+Scrolling the frame back into view.
+PASS imageIsAnimating became "true"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/animated-image-outside-viewport-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/animated-image-outside-viewport-in-cross-origin-iframe.html
@@ -1,0 +1,56 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that an animated image is paused in an out-of-process subframe that leaves the viewport");
+
+var jsTestIsAsync = true;
+var imageIsAnimating = "";
+var testFrame;
+
+// The subframe is cross-origin, so its internals object cannot be reached directly.
+window.addEventListener("message", function(event) {
+    imageIsAnimating = event.data;
+}, false);
+
+function runTest()
+{
+    testFrame = document.getElementById("testFrame");
+
+    // Ask repeatedly: the embedder-visible rect reaches the subframe's process asynchronously, one
+    // rendering update after the scroll.
+    setInterval(function() {
+        testFrame.contentWindow.postMessage("report-image-animating", "*");
+    }, 50);
+
+    // Start by scrolling the frame into view rather than asserting the initial offscreen state. An
+    // animated image is only marked paused from RenderElement::imageFrameAvailable(), which needs a
+    // decoded frame to arrive, and a frame that has never been on screen never paints -- on iOS its
+    // tile coverage is zero, so nothing is ever decoded and the animation is never revisited.
+    debug("Scrolling the frame into view.");
+    window.scroll(0, 1000);
+    shouldBecomeEqualToString("imageIsAnimating", "true", scrollFrameOutOfView);
+}
+
+function scrollFrameOutOfView()
+{
+    // The subframe cannot compute this itself: the clip that hides it is in the embedder's process.
+    debug("Scrolling the frame out of view.");
+    window.scroll(0, 0);
+    shouldBecomeEqualToString("imageIsAnimating", "false", scrollFrameBackIntoView);
+}
+
+function scrollFrameBackIntoView()
+{
+    debug("Scrolling the frame back into view.");
+    window.scroll(0, 1000);
+    shouldBecomeEqualToString("imageIsAnimating", "true", finishJSTest);
+}
+</script>
+<div style="width: 100px; height: 1000px;"></div>
+<iframe id="testFrame" src="http://localhost:8000/site-isolation/resources/animated-image-frame.html" onload="runTest()"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/find-in-page-marker-rects-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/find-in-page-marker-rects-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,15 @@
+Tests that the rects of a find-in-page match in an out-of-process subframe are clipped by the part of the frame that the embedder can show
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The frame starts outside the viewport, so the match has no rect.
+PASS hasMarkerRects became "false"
+Scrolling the frame into view.
+PASS hasMarkerRects became "true"
+Scrolling the frame out of view again.
+PASS hasMarkerRects became "false"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/find-in-page-marker-rects-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/find-in-page-marker-rects-in-cross-origin-iframe.html
@@ -1,0 +1,52 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body style="margin: 0">
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that the rects of a find-in-page match in an out-of-process subframe are clipped by the part of the frame that the embedder can show");
+
+var jsTestIsAsync = true;
+var hasMarkerRects = "";
+var testFrame;
+
+// The subframe is cross-origin, so its internals object cannot be reached directly.
+window.addEventListener("message", function(event) {
+    if (event.data.startsWith("hasMarkerRects:"))
+        hasMarkerRects = event.data.substring("hasMarkerRects:".length);
+}, false);
+
+function runTest()
+{
+    testFrame = document.getElementById("testFrame");
+
+    // Ask repeatedly: the embedder-visible rect reaches the subframe's process asynchronously, one
+    // rendering update after the scroll.
+    setInterval(function() {
+        testFrame.contentWindow.postMessage("report", "*");
+    }, 50);
+
+    // The subframe cannot compute this itself: the clip that hides it is in the embedder's process.
+    debug("The frame starts outside the viewport, so the match has no rect.");
+    shouldBecomeEqualToString("hasMarkerRects", "false", scrollFrameIntoView);
+}
+
+function scrollFrameIntoView()
+{
+    debug("Scrolling the frame into view.");
+    window.scroll(0, 1000);
+    shouldBecomeEqualToString("hasMarkerRects", "true", scrollFrameOutOfView);
+}
+
+function scrollFrameOutOfView()
+{
+    debug("Scrolling the frame out of view again.");
+    window.scroll(0, 0);
+    shouldBecomeEqualToString("hasMarkerRects", "false", finishJSTest);
+}
+</script>
+<div style="width: 100px; height: 1000px;"></div>
+<iframe id="testFrame" src="http://localhost:8000/site-isolation/resources/marker-rects-frame.html" onload="runTest()"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-clipped-out-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-clipped-out-cross-origin-iframe-expected.txt
@@ -1,0 +1,16 @@
+Tests that requestAnimationFrame and DOM timers are throttled in an out-of-process subframe clipped away by an overflow:hidden ancestor
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The frame is visible inside the clipping container, so it should not be throttled.
+PASS throttlingState became "requestAnimationFrame=false,timers=false"
+Scrolling the frame out of the clipping container.
+PASS throttlingState became "requestAnimationFrame=true,timers=true"
+Scrolling the frame back into the clipping container.
+PASS throttlingState became "requestAnimationFrame=false,timers=false"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-clipped-out-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-clipped-out-cross-origin-iframe.html
@@ -1,0 +1,53 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that requestAnimationFrame and DOM timers are throttled in an out-of-process subframe clipped away by an overflow:hidden ancestor");
+
+var jsTestIsAsync = true;
+var throttlingState = "";
+var testFrame;
+
+// The subframe is cross-origin, so its internals object cannot be reached directly.
+window.addEventListener("message", function(event) {
+    throttlingState = event.data;
+}, false);
+
+function runTest()
+{
+    testFrame = document.getElementById("testFrame");
+
+    setInterval(function() {
+        testFrame.contentWindow.postMessage("report-throttling-reasons", "*");
+    }, 50);
+
+    debug("The frame is visible inside the clipping container, so it should not be throttled.");
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=false,timers=false", clipFrameAway);
+}
+
+function clipFrameAway()
+{
+    // The frame has a renderer, but the clip that hides it lives entirely in the parent frame process, so
+    // the frame cannot discover this itself. Unlike display:none, the frame does have a box here, so it
+    // must be throttled rather than exempted.
+    debug("Scrolling the frame out of the clipping container.");
+    document.getElementById("clipper").scrollTop = 800;
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=true,timers=true", unclipFrame);
+}
+
+function unclipFrame()
+{
+    debug("Scrolling the frame back into the clipping container.");
+    document.getElementById("clipper").scrollTop = 0;
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=false,timers=false", finishJSTest);
+}
+</script>
+<div id="clipper" style="width: 200px; height: 200px; overflow: hidden;">
+<iframe id="testFrame" src="http://localhost:8000/site-isolation/resources/request-animation-frame-throttling-frame.html" onload="runTest()"></iframe>
+<div style="width: 100px; height: 800px;"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-cross-origin-iframe-expected.txt
@@ -1,0 +1,13 @@
+Tests that requestAnimationFrame and DOM timers are not throttled in an out-of-process subframe that becomes display:none
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The frame is inside the viewport, so requestAnimationFrame and DOM timers should not be throttled.
+PASS throttlingState became "requestAnimationFrame=false,timers=false"
+Hiding the frame with display:none.
+PASS The frame stayed unthrottled
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-cross-origin-iframe.html
@@ -1,0 +1,65 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that requestAnimationFrame and DOM timers are not throttled in an out-of-process subframe that becomes display:none");
+
+var jsTestIsAsync = true;
+var throttlingState = "";
+var unthrottledState = "requestAnimationFrame=false,timers=false";
+var testFrame;
+var remainingChecks = 10;
+
+// The subframe is cross-origin, so its internals object cannot be reached directly.
+window.addEventListener("message", function(event) {
+    throttlingState = event.data;
+}, false);
+
+function runTest()
+{
+    testFrame = document.getElementById("testFrame");
+
+    setInterval(function() {
+        testFrame.contentWindow.postMessage("report-throttling-reasons", "*");
+    }, 50);
+
+    debug("The frame is inside the viewport, so requestAnimationFrame and DOM timers should not be throttled.");
+    shouldBecomeEqualToString("throttlingState", unthrottledState, hideFrame);
+}
+
+function hideFrame()
+{
+    // A display:none frame has no box at all, which must stay distinct from a frame whose box is clipped
+    // out. The frame has already been laid out at this point, so its own size cannot tell it apart, and its
+    // visible rect is empty either way. What keeps it unthrottled is that its parent reports that the owner
+    // element has no renderer, which the frame cannot determine itself.
+    debug("Hiding the frame with display:none.");
+    testFrame.style.display = "none";
+    checkStaysUnthrottled();
+}
+
+function checkStaysUnthrottled()
+{
+    if (throttlingState != unthrottledState) {
+        testFailed("The frame became throttled for being outside the viewport: " + throttlingState);
+        finishJSTest();
+        return;
+    }
+
+    // Keep checking for several rendering updates: the embedder broadcasts the frame's geometry once per
+    // rendering update, so a wrong answer would only arrive after the first report.
+    if (!--remainingChecks) {
+        testPassed("The frame stayed unthrottled");
+        finishJSTest();
+        return;
+    }
+
+    requestAnimationFrame(checkStaysUnthrottled);
+}
+</script>
+<iframe id="testFrame" src="http://localhost:8000/site-isolation/resources/request-animation-frame-throttling-frame.html" onload="runTest()"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-while-outside-viewport-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-while-outside-viewport-cross-origin-iframe-expected.txt
@@ -1,0 +1,13 @@
+Tests that an out-of-process subframe stops being throttled when it becomes display:none while already outside the viewport
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The frame starts outside the viewport, so it should be throttled.
+PASS throttlingState became "requestAnimationFrame=true,timers=true"
+Hiding the already-offscreen frame with display:none.
+PASS throttlingState became "requestAnimationFrame=false,timers=false"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-while-outside-viewport-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-while-outside-viewport-cross-origin-iframe.html
@@ -1,0 +1,44 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that an out-of-process subframe stops being throttled when it becomes display:none while already outside the viewport");
+
+var jsTestIsAsync = true;
+var throttlingState = "";
+var testFrame;
+
+// The subframe is cross-origin, so its internals object cannot be reached directly.
+window.addEventListener("message", function(event) {
+    throttlingState = event.data;
+}, false);
+
+function runTest()
+{
+    testFrame = document.getElementById("testFrame");
+
+    setInterval(function() {
+        testFrame.contentWindow.postMessage("report-throttling-reasons", "*");
+    }, 50);
+
+    debug("The frame starts outside the viewport, so it should be throttled.");
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=true,timers=true", hideFrame);
+}
+
+function hideFrame()
+{
+    // The frame's visible rect is already empty, so making it display:none does not change it. Only the
+    // owner-has-renderer report changes, so that alone has to be enough to re-evaluate throttling --
+    // otherwise the frame stays throttled and never gets the display:none exemption.
+    debug("Hiding the already-offscreen frame with display:none.");
+    testFrame.style.display = "none";
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=false,timers=false", finishJSTest);
+}
+</script>
+<div style="width: 100px; height: 1000px;"></div>
+<iframe id="testFrame" src="http://localhost:8000/site-isolation/resources/request-animation-frame-throttling-frame.html" onload="runTest()"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-outside-viewport-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-outside-viewport-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,15 @@
+Tests that requestAnimationFrame and DOM timers are throttled in an out-of-process subframe that is outside the viewport
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The frame starts outside the viewport, so requestAnimationFrame and DOM timers should be throttled.
+PASS throttlingState became "requestAnimationFrame=true,timers=true"
+Scrolling the frame into view.
+PASS throttlingState became "requestAnimationFrame=false,timers=false"
+Scrolling the frame out of view again.
+PASS throttlingState became "requestAnimationFrame=true,timers=true"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-outside-viewport-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-outside-viewport-in-cross-origin-iframe.html
@@ -1,0 +1,50 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that requestAnimationFrame and DOM timers are throttled in an out-of-process subframe that is outside the viewport");
+
+var jsTestIsAsync = true;
+var throttlingState = "";
+var testFrame;
+
+// The subframe is cross-origin, so its internals object cannot be reached directly.
+window.addEventListener("message", function(event) {
+    throttlingState = event.data;
+}, false);
+
+function runTest()
+{
+    testFrame = document.getElementById("testFrame");
+
+    // Ask repeatedly: the embedder-visible rect reaches the subframe's process asynchronously, one
+    // rendering update after the scroll.
+    setInterval(function() {
+        testFrame.contentWindow.postMessage("report-throttling-reasons", "*");
+    }, 50);
+
+    debug("The frame starts outside the viewport, so requestAnimationFrame and DOM timers should be throttled.");
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=true,timers=true", scrollFrameIntoView);
+}
+
+function scrollFrameIntoView()
+{
+    debug("Scrolling the frame into view.");
+    window.scroll(0, 1000);
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=false,timers=false", scrollFrameOutOfView);
+}
+
+function scrollFrameOutOfView()
+{
+    debug("Scrolling the frame out of view again.");
+    window.scroll(0, 0);
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=true,timers=true", finishJSTest);
+}
+</script>
+<div style="width: 100px; height: 1000px;"></div>
+<iframe id="testFrame" src="http://localhost:8000/site-isolation/resources/request-animation-frame-throttling-frame.html" onload="runTest()"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/marker-rects-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/marker-rects-frame.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body style="margin: 0">
+<p id="text">Quo usque tandem abutere, Catilina, patientia nostra?</p>
+<script>
+
+if (window.internals)
+    internals.countMatchesForText("tandem", [], "mark");
+
+window.addEventListener("message", function() {
+    // renderedRectsForMarkers() drops a rect that the clip of the frame makes empty, so the presence of a
+    // rect says whether the frame believes the match is on screen.
+    var rects = window.internals ? internals.dumpMarkerRects("TextMatch") : "no internals";
+    window.top.postMessage("hasMarkerRects:" + rects.includes("("), "*");
+}, false);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/request-animation-frame-throttling-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/request-animation-frame-throttling-frame.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+if (window.internals) {
+    // The OutsideViewport override is per-Page, and this frame has its own Page in its own process, so it
+    // has to be enabled here as well as in the embedder.
+    internals.setOutsideViewportThrottlingEnabled(true);
+}
+
+function step()
+{
+    requestAnimationFrame(step);
+}
+
+requestAnimationFrame(step);
+
+window.addEventListener("message", function() {
+    // Report only the viewport reason. A cross-origin frame that has had no user interaction also carries
+    // NonInteractedCrossOriginFrame, which is not what these tests are about.
+    var reasons = window.internals ? internals.requestAnimationFrameThrottlingReasons() : "no internals";
+    var throttlesAnimationFrames = reasons.includes("OutsideViewport");
+
+    // The DOM timer half of the same throttle. Unlike the reason above, it does not depend on the
+    // OutsideViewport override, so it also covers the configuration that ships.
+    var throttlesTimers = window.internals ? internals.areTimersThrottled() : false;
+
+    parent.postMessage("requestAnimationFrame=" + throttlesAnimationFrames + ",timers=" + throttlesTimers, "*");
+}, false);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3861,7 +3861,8 @@ void LocalFrameView::updateScriptedAnimationsAndTimersThrottlingState(const IntR
         return;
 
     // We don't throttle zero-size or display:none frames because those are usually utility frames.
-    bool shouldThrottle = visibleRect.isEmpty() && !m_lastUsedSizeForLayout.isEmpty() && m_frame->ownerRenderer();
+    bool ownerHasRenderer = m_frame->ownerRenderer() || (m_frame->isRootFrame() && m_ownerHasRendererInParentFrameProcess);
+    bool shouldThrottle = visibleRect.isEmpty() && !m_lastUsedSizeForLayout.isEmpty() && ownerHasRenderer;
     document->setTimerThrottlingEnabled(shouldThrottle);
 
     RefPtr page = m_frame->page();
@@ -5311,8 +5312,13 @@ IntRect LocalFrameView::windowClipRect() const
     // Set our clip rect to be our contents.
     IntRect clipRect = contentsToWindow(visibleContentRect(LegacyIOSDocumentVisibleRect));
 
-    if (!m_frame->ownerElement())
+    if (!m_frame->ownerElement()) {
+        // When SI is enabled, this frame has no local owner element. Apply the visible rect that
+        // the parent frame process passed to us over IPC instead.
+        if (m_visibleRectFromParentFrameProcess)
+            clipRect.intersect(*m_visibleRectFromParentFrameProcess);
         return clipRect;
+    }
 
     // Take our owner element and get its clip rect.
     RefPtr ownerElement = m_frame->ownerElement();

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -343,7 +343,7 @@ public:
 
     LayoutRect rectForFixedPositionLayout() const;
 
-    void viewportContentsChanged();
+    WEBCORE_EXPORT void viewportContentsChanged();
     WEBCORE_EXPORT void resumeVisibleImageAnimationsIncludingSubframes();
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     void updatePlayStateForAllAnimationsIncludingSubframes();
@@ -694,6 +694,13 @@ public:
     // so a compositing flush that precedes the first sync doesn't clamp coverage to a stale/empty rect.
     void setHasSetExposedContentRectFromEmbedder() { m_hasSetExposedContentRectFromEmbedder = true; }
     bool hasEverSetExposedContentRectFromEmbedder() const { return m_hasSetExposedContentRectFromEmbedder; }
+
+    // The part of this frame that the parent remote frame thinks is visible in the current view's window coordinates.
+    void setVisibleRectFromParentFrameProcess(std::optional<IntRect> rect) { m_visibleRectFromParentFrameProcess = rect; }
+    std::optional<IntRect> visibleRectFromParentFrameProcess() const { return m_visibleRectFromParentFrameProcess; }
+
+    void setOwnerHasRendererInParentFrameProcess(bool hasRenderer) { m_ownerHasRendererInParentFrameProcess = hasRenderer; }
+    bool ownerHasRendererInParentFrameProcess() const { return m_ownerHasRendererInParentFrameProcess; }
 
     void updateSnapOffsets() final;
     bool isScrollSnapInProgress() const final;
@@ -1048,7 +1055,10 @@ private:
     std::optional<LayoutRect> m_visualViewportOverrideRect; // Used when the iOS keyboard is showing.
 
     std::optional<FloatRect> m_viewExposedRect;
+    std::optional<IntRect> m_visibleRectFromParentFrameProcess;
+
     bool m_hasSetExposedContentRectFromEmbedder { false };
+    bool m_ownerHasRendererInParentFrameProcess { true };
 
     OptionSet<PaintBehavior> m_paintBehavior;
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2271,23 +2271,40 @@ void Page::syncLocalFrameInfoToRemote()
         frameView->updateContentsSizeForRemoteFrames();
 
         HashMap<FrameIdentifier, Ref<RemoteFrameLayoutInfo>> childrenFrameLayoutInfo;
-        for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-            auto childVisibleRect = frameView->visibleRectOfChild(*child.get());
+        auto windowClipRectInContentCoordinates = [&frameView, rect = std::optional<LayoutRect> { }]() mutable {
+            if (!rect)
+                rect = LayoutRect { frameView->windowToContents(frameView->windowClipRect()) };
+            return *rect;
+        };
+#if PLATFORM(IOS_FAMILY)
+        auto exposedContentRect = [&frameView, rect = std::optional<LayoutRect> { }]() mutable {
+            if (!rect)
+                rect = LayoutRect { frameView->exposedContentRect() };
+            return *rect;
+        };
+#endif
 
+        for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+            auto visibleRectInParent = frameView->visibleRectOfChild(*child.get());
+
+#if PLATFORM(IOS_FAMILY)
             // Clamp the child's visible rect to the portion of the page actually on-screen, so an offscreen
             // iframe commits ~0 tiles — matching the single-tiled-backing coverage decision the page makes
             // with site isolation off. visibleRectOfChild() clips through the compositor tree but not the
             // top-level viewport, so a fully-below-fold iframe can still return a non-empty box; intersect
             // it here with the parent's exposed viewport.
-#if PLATFORM(IOS_FAMILY)
-            if (childVisibleRect && frame.settings().siteIsolationEnabled()) {
-                auto viewport = LayoutRect { frameView->exposedContentRect() };
-                childVisibleRect->intersect(viewport);
-            }
+            auto exposedContentRectInParent = visibleRectInParent;
+            if (exposedContentRectInParent)
+                exposedContentRectInParent->intersect(exposedContentRect());
 #endif
 
             childrenFrameLayoutInfo.add(child->frameID(), RemoteFrameLayoutInfo::create(
-                childVisibleRect,
+                windowClipRectInContentCoordinates(),
+                visibleRectInParent,
+#if PLATFORM(IOS_FAMILY)
+                exposedContentRectInParent,
+#endif
+                !!child->ownerRenderer(),
                 frameView->childFrameOwnerToRootContentTransform(*child),
                 frameView->absoluteToChildFrameOwnerLocalTransform(*child),
                 frame.usedZoomForChild(*child),

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
@@ -33,13 +33,25 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteFrameLayoutInfo);
 
-Ref<RemoteFrameLayoutInfo> RemoteFrameLayoutInfo::create(std::optional<LayoutRect> visibleRectInParent, TransformationMatrix childFrameOwnerToRootContentTransform, TransformationMatrix absoluteToChildFrameOwnerLocalTransform, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
-{
-    return adoptRef(*new RemoteFrameLayoutInfo(visibleRectInParent, WTF::move(childFrameOwnerToRootContentTransform), WTF::move(absoluteToChildFrameOwnerLocalTransform), usedZoom, contentBoxLocation, ownerElementAppearance));
-}
-
-RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(std::optional<LayoutRect> visibleRectInParent, TransformationMatrix childFrameOwnerToRootContentTransform, TransformationMatrix absoluteToChildFrameOwnerLocalTransform, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
-    : m_visibleRectInParent(visibleRectInParent)
+RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(
+    LayoutRect windowClipRectInParent,
+    std::optional<LayoutRect> visibleRectInParent,
+#if PLATFORM(IOS_FAMILY)
+    std::optional<LayoutRect> exposedContentRectInParent,
+#endif
+    bool ownerHasRenderer,
+    TransformationMatrix childFrameOwnerToRootContentTransform,
+    TransformationMatrix absoluteToChildFrameOwnerLocalTransform,
+    float usedZoom,
+    LayoutPoint contentBoxLocation,
+    OptionSet<FrameOwnerElementAppearance> ownerElementAppearance
+)
+    : m_windowClipRectInParent(windowClipRectInParent)
+    , m_visibleRectInParent(visibleRectInParent)
+#if PLATFORM(IOS_FAMILY)
+    , m_exposedContentRectInParent(exposedContentRectInParent)
+#endif
+    , m_ownerHasRenderer(ownerHasRenderer)
     , m_childFrameOwnerToRootContentTransform(WTF::move(childFrameOwnerToRootContentTransform))
     , m_absoluteToChildFrameOwnerLocalTransform(WTF::move(absoluteToChildFrameOwnerLocalTransform))
     , m_usedZoom(usedZoom)
@@ -48,17 +60,18 @@ RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(std::optional<LayoutRect> visibleRe
 {
 }
 
-std::optional<FloatRect> RemoteFrameLayoutInfo::projectVisibleRectToChildContent() const
+std::optional<FloatRect> RemoteFrameLayoutInfo::mapParentContentsToChildWindow(const LayoutRect& rectInParent) const
 {
-    if (!m_visibleRectInParent)
+    // A non-affine owner transform (a 3D transform, say) has no meaningful rect inverse, so report
+    // that the rect is unknown.
+    if (!m_absoluteToChildFrameOwnerLocalTransform.isAffine())
         return std::nullopt;
 
-    ASSERT(m_absoluteToChildFrameOwnerLocalTransform.isAffine());
     // Inverse of LocalFrameView::visibleRectOfChild(): visibleRectInParent is in the parent document's
     // coordinates. Map it into the iframe owner element's local space, subtract the owner content-box
     // offset so the rect is relative to the iframe content origin, and undo the owner's used CSS zoom so
     // the result is in the child frame's unzoomed root-content coordinates (its RenderView space).
-    auto ownerLocal = m_absoluteToChildFrameOwnerLocalTransform.mapRect(FloatRect { *m_visibleRectInParent });
+    auto ownerLocal = m_absoluteToChildFrameOwnerLocalTransform.mapRect(FloatRect { rectInParent });
     ownerLocal.moveBy(-FloatPoint { m_contentBoxLocation });
     if (m_usedZoom > 0)
         ownerLocal.scale(1.0f / m_usedZoom);

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.h
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.h
@@ -48,25 +48,57 @@ class RemoteFrameLayoutInfo : public RefCounted<RemoteFrameLayoutInfo> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(RemoteFrameLayoutInfo, WEBCORE_EXPORT);
 
 public:
-    WEBCORE_EXPORT static Ref<RemoteFrameLayoutInfo> create(std::optional<LayoutRect>, TransformationMatrix, TransformationMatrix, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
+    template<typename... Args> static Ref<RemoteFrameLayoutInfo> create(Args&&... args) { return adoptRef(*new RemoteFrameLayoutInfo(std::forward<Args>(args)...)); }
 
+    LayoutRect windowClipRectInParent() const { return m_windowClipRectInParent; }
     std::optional<LayoutRect> visibleRectInParent() const { return m_visibleRectInParent; }
+#if PLATFORM(IOS_FAMILY)
+    std::optional<LayoutRect> exposedContentRectInParent() const { return m_exposedContentRectInParent; }
+#endif
+    bool ownerHasRenderer() const { return m_ownerHasRenderer; }
     const TransformationMatrix& childFrameOwnerToRootContentTransform() const { return m_childFrameOwnerToRootContentTransform; }
     const TransformationMatrix& absoluteToChildFrameOwnerLocalTransform() const { return m_absoluteToChildFrameOwnerLocalTransform; }
     float usedZoom() const { return m_usedZoom; }
     LayoutPoint contentBoxLocation() const { return m_contentBoxLocation; }
     OptionSet<FrameOwnerElementAppearance> ownerElementAppearance() const { return m_ownerElementAppearance; }
 
-    // Inverse of LocalFrameView::visibleRectOfChild - iframes use this to clamp its
-    // tiled-backing coverage to the embedder-visible region (setExposedContentRect).
-    WEBCORE_EXPORT std::optional<FloatRect> projectVisibleRectToChildContent() const;
+    // This maps a rect from the parent frame's content coordinate space into this frame's
+    // window space. This may fail and return std::nullopt for non-affine transforms.
+    WEBCORE_EXPORT std::optional<FloatRect> mapParentContentsToChildWindow(const LayoutRect&) const;
 
 private:
-    RemoteFrameLayoutInfo(std::optional<LayoutRect>, TransformationMatrix, TransformationMatrix, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
+    WEBCORE_EXPORT RemoteFrameLayoutInfo(
+        LayoutRect windowClipRectInParent,
+        std::optional<LayoutRect> visibleRectInParent,
+#if PLATFORM(IOS_FAMILY)
+        std::optional<LayoutRect> exposedContentRectInParent,
+#endif
+        bool ownerHasRenderer,
+        TransformationMatrix childFrameOwnerToRootContentTransform,
+        TransformationMatrix absoluteToChildFrameOwnerLocalTransform,
+        float usedZoom,
+        LayoutPoint contentBoxLocation,
+        OptionSet<FrameOwnerElementAppearance>
+    );
 
+    // The parent frame's windowClipRect in the parent's content coordinate space.
+    LayoutRect m_windowClipRectInParent;
+
+    // The visible portion of this frame in the parent frame's content coordinate space. This is
+    // clipped by the compositor tree but not by the viewport, because IntersectionObserver applies
+    // its own viewport clip (layoutViewportRect) at each recursion step.
+    //
+    // To get the part of this frame that is on screen, intersect with windowClipRectInParent.
+    std::optional<LayoutRect> m_visibleRectInParent;
+
+#if PLATFORM(IOS_FAMILY)
     // Rectangle of the visible portion of the frame in its parent frame,
     // in the coordinate space of the document of the parent frame.
-    std::optional<LayoutRect> m_visibleRectInParent;
+    std::optional<LayoutRect> m_exposedContentRectInParent;
+#endif
+
+    // Whether the frame's owner element has a renderer (e.g. not display:none).
+    bool m_ownerHasRenderer;
 
     // The transformation matrix to project from the frame owner's
     // coordinate space to its RenderView's (root) coordinate space.

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1328,7 +1328,12 @@ class WebCore::LayoutRect {
 using WebCore::ScrollPosition = WebCore::IntPoint;
 
 [RefCounted] class WebCore::RemoteFrameLayoutInfo {
+    WebCore::LayoutRect windowClipRectInParent();
     std::optional<WebCore::LayoutRect> visibleRectInParent();
+#if PLATFORM(IOS_FAMILY)
+    std::optional<WebCore::LayoutRect> exposedContentRectInParent();
+#endif
+    bool ownerHasRenderer();
     WebCore::TransformationMatrix childFrameOwnerToRootContentTransform();
     WebCore::TransformationMatrix absoluteToChildFrameOwnerLocalTransform();
     float usedZoom();

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1382,14 +1382,11 @@ void WebFrame::updateLocalFrameRect(WebCore::LocalFrame& localFrame, WebCore::In
     }
 
 #if PLATFORM(IOS_FAMILY)
-    // The iframe root's unobscured content size is its natural frame size: it drives the scrolling
-    // tree's scrollable-area size and CSS viewport units, so it must never be clamped to the visible
-    // region (doing so collapses an off-screen frame's scrolling node to 0x0).
+    // Only the main frame has obscured insets, so the unobscured size here is just the frame size.
     frameView->setUnobscuredContentSize(frameView->size());
-    // Tile coverage (exposedContentRect) is normally driven by the embedder-visible rect in
-    // WebPage::updateExposedRectFromParent, so a below-fold frame commits ~0 tiles. Until that
-    // path has supplied a rect at least once, back the whole frame so nothing blanks if the first
-    // compositor flush precedes the first childrenFrameLayoutInfo sync (see rdar://122429810 history).
+
+    // Default to covering the entire view until the parent frame process sends an
+    // exposedContentRect to us at least once to minimize blanking issues (see rdar://122429810).
     if (!frameView->hasEverSetExposedContentRectFromEmbedder())
         frameView->setExposedContentRect(FloatRect { { }, frameView->size() });
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1451,7 +1451,7 @@ void WebPage::frameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameID, 
         break;
 
     case FrameTreeSyncDataType::ChildrenFrameLayoutInfo:
-        updateExposedRectFromParent(*coreFrame);
+        updateChildFrameVisibleRectsFromParent(*coreFrame);
         break;
 
     default:
@@ -1483,18 +1483,12 @@ void WebPage::allFrameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameI
     RefPtr coreFrame = frame->coreFrame();
     if (coreFrame) {
         coreFrame->updateFrameTreeSyncData(WTF::move(data));
-        updateExposedRectFromParent(*coreFrame);
+        updateChildFrameVisibleRectsFromParent(*coreFrame);
     }
 }
 
-void WebPage::updateExposedRectFromParent(WebCore::Frame& parentCoreFrame)
+void WebPage::updateChildFrameVisibleRectsFromParent(WebCore::Frame& parentCoreFrame)
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=320601 - Align iOS and macOS behavior regarding m_exposedContentRect
-#if PLATFORM(IOS_FAMILY)
-    // When a RemoteFrame parent broadcasts childrenFrameLayoutInfo, each entry carries the child's visible
-    // rect in the parent (already clamped to the top-level viewport on the sender side).
-    // Project that rect into the child's own root-content coords and use it as the frame's exposedContentRect,
-    // so its tiled backing covers only the on-screen portion, matching the rect with site isolation off.
     if (!m_page || !m_page->settings().siteIsolationEnabled())
         return;
 
@@ -1507,50 +1501,90 @@ void WebPage::updateExposedRectFromParent(WebCore::Frame& parentCoreFrame)
         RefPtr localChild = dynamicDowncast<LocalFrame>(child.get());
         if (!localChild)
             continue;
+
         RefPtr childView = localChild->view();
         if (!childView)
             continue;
+
         auto it = childrenInfo.find(localChild->frameID());
         if (it == childrenInfo.end())
             continue;
 
-        // Project the parent-supplied visible rect into this child's root-content coordinates. A missing
-        // rect (fully below the fold / clipped out) maps to an empty rect so all tiles can be released.
         Ref layoutInfo = it->value;
-        auto visibleRectInParent = layoutInfo->visibleRectInParent();
-        bool visibleRectInParentIsEmpty = !visibleRectInParent || visibleRectInParent->isEmpty();
-        auto projected = layoutInfo->projectVisibleRectToChildContent().value_or(FloatRect { });
+        bool needsViewportContentsChanged = false;
+
+        auto ownerHasRenderer = layoutInfo->ownerHasRenderer();
+        if (childView->ownerHasRendererInParentFrameProcess() != ownerHasRenderer) {
+            childView->setOwnerHasRendererInParentFrameProcess(ownerHasRenderer);
+
+            // We need to re-run viewportContentsChanged() when display:none state changes, as the
+            // frame throttling logic in updateScriptedAnimationsAndTimersThrottlingState depends
+            // on it.
+            needsViewportContentsChanged = true;
+        }
+
+        auto visibleRectFromParentFrameProcess = [&]() -> std::optional<IntRect> {
+            // This is the portion of the child frame that is on screen in the parent's content
+            // coordinate space.
+            auto onScreenRectInParent = layoutInfo->visibleRectInParent();
+            if (!onScreenRectInParent) {
+                // Either the owner element has no renderer, or this frame is entirely clipped by an
+                // ancestor in the parent frame process.
+                return IntRect { };
+            }
+            onScreenRectInParent->intersect(layoutInfo->windowClipRectInParent());
+
+            auto onScreenRectInChild = layoutInfo->mapParentContentsToChildWindow(*onScreenRectInParent);
+            if (onScreenRectInChild) {
+                onScreenRectInChild->intersect(FloatRect { { }, childView->size() });
+                return enclosingIntRect(*onScreenRectInChild);
+            }
+
+            // We couldn't map the rect into the child's coordinate space (e.g. non-affine
+            // transform). Return std::nullopt, which will cause LocalFrameView::windowClipRect
+            // to make the conservative assumption that the visibleContentRect is unclipped.
+            return std::nullopt;
+        }();
+
+        if (childView->visibleRectFromParentFrameProcess() != visibleRectFromParentFrameProcess) {
+            childView->setVisibleRectFromParentFrameProcess(visibleRectFromParentFrameProcess);
+            needsViewportContentsChanged = true;
+        }
+
+        if (needsViewportContentsChanged)
+            childView->viewportContentsChanged();
+
+#if PLATFORM(IOS_FAMILY)
+        // FIXME (320601): this only affects tile coverage on iOS by setting exposedContentRect on
+        // this child frame based on the exposedContentRect from the parent frame process. We need
+        // to do something similar on macOS (see visibleRectForLayerFlushing).
+        auto exposedContentRectInParent = layoutInfo->exposedContentRectInParent();
+        bool exposedContentRectInParentIsEmpty = !exposedContentRectInParent || exposedContentRectInParent->isEmpty();
+        auto projected = exposedContentRectInParentIsEmpty ? FloatRect { } : layoutInfo->mapParentContentsToChildWindow(*exposedContentRectInParent).value_or(FloatRect { });
         projected.intersect(FloatRect { { }, childView->size() });
 
-        // If the main WCP says this frame is visible but the projection is empty, fallback to the full
-        // rect until we get updated geometry from the main WCP
-        if (!visibleRectInParentIsEmpty && projected.isEmpty())
+        // The parent frame process thinks this frame is visible, but we think it isn't. Err on the
+        // side of tiling the full view until we get updated geometry from the parent frame process.
+        if (!exposedContentRectInParentIsEmpty && projected.isEmpty())
             projected = FloatRect { { }, childView->size() };
 
-        // This runs once per parent rendering update, so only touch the frame (and schedule a rendering
-        // update) when the coverage rect actually changes — or the first time the embedder supplies a rect,
-        // which flips WebFrame's full-size fallback off. This keeps steady-state (no scroll/resize)
-        // broadcasts from scheduling redundant rendering updates.
-        // exposedContentRect tracks the main WCP visible region, while unobscured content size stays at
-        // the child view's size (setUnobscuredContentSize is itself a no-op when unchanged).
         if (childView->exposedContentRect() != projected) {
             childView->setExposedContentRect(projected);
             needsRenderingUpdate = true;
         }
+
         childView->setUnobscuredContentSize(childView->size());
         if (!childView->hasEverSetExposedContentRectFromEmbedder()) {
             childView->setHasSetExposedContentRectFromEmbedder();
             needsRenderingUpdate = true;
         }
+#endif
     }
 
     if (needsRenderingUpdate) {
         if (RefPtr drawingArea = this->drawingArea())
             drawingArea->triggerRenderingUpdate();
     }
-#else
-    UNUSED_PARAM(parentCoreFrame);
-#endif
 }
 
 void WebPage::updateUserActivationState(const Vector<FrameIdentifier>& frameIDs, MonotonicTime activationTime)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -878,9 +878,9 @@ public:
     void frameTreeSyncDataChangedInAnotherProcess(WebCore::FrameIdentifier, const WebCore::FrameTreeSyncSerializationData&);
     void allFrameTreeSyncDataChangedInAnotherProcess(WebCore::FrameIdentifier, Ref<WebCore::FrameTreeSyncData>&&);
 
-    // Clamps local iframe-root children's exposedContentRect to the embedder-visible rect carried in
-    // the parent's childrenFrameLayoutInfo.
-    void updateExposedRectFromParent(WebCore::Frame& parentCoreFrame);
+    // Updates visible rect state (e.g. windowClipRect and exposedContentRect) in this process using
+    // clipping rects from a parent frame process.
+    void updateChildFrameVisibleRectsFromParent(WebCore::Frame& parentCoreFrame);
 
     void updateUserActivationState(const Vector<WebCore::FrameIdentifier>&, MonotonicTime);
     void consumeUserActivations(const Vector<WebCore::FrameIdentifier>&);


### PR DESCRIPTION
#### 76bb85cfc990489e5e5faa2de158ee8243d021ce
<pre>
[Site Isolation] Fix offscreen frame throttling
<a href="https://bugs.webkit.org/show_bug.cgi?id=321885">https://bugs.webkit.org/show_bug.cgi?id=321885</a>
<a href="https://rdar.apple.com/problem/185063323">rdar://problem/185063323</a>

Reviewed by Simon Fraser.

LocalFrameView::windowClipRect doesn&apos;t work correctly when Site Isolation is enabled. It tries to
apply the clip rect from its ancestors by using ownerElement, which is null once reaching a root
frame with SI enabled. When it doesn&apos;t find a clip rect to apply, it assumes the whole view is
visible.

This leads to a number of visibility-based heuristics being broken when Site Isolation is enabled,
e.g. offscreen remote frames never throttle rAF or timer callbacks, animated images in offscreen
frames never pause, find in page marker rects are incorrect, etc.

To fix this, we now send three extra pieces of state per rendering update for each child frame in
RemoteFrameLayoutInfo:

a. visibleRectInParent and windowClipRectInParent: These are the visible rect of the child frame and
the parent frame&apos;s windowClipRect, both in the parent&apos;s content coordinate space.

On the receiving side, we intersect the rects, project it into the child&apos;s window space, and give
that to LocalFrameView::setVisibleRectFromParentFrameProcess. (The projection is necessary because
when SI is enabled, each root frame has its own window coordinate space, whereas with SI disabled,
all frames share the same window coordinate space.) LocalFrameView::windowClipRect then intersects
against that visibleRectFromParentFrameProcess instead of bailing out, which is the main fix in this
patch.

Note there was already a visibleRectInParent member in RemoteFrameLayoutInfo which was actually carrying
exposedContentRect info. I renamed that field exposedContentRectInParent.

b. ownerHasRenderer: whether the frame&apos;s owning element has a renderer. The receiving frame process
uses this to avoid throttling display:none frames, which is an existing heuristic.

This is in the same area as the previous tile coverage change (318269@main), but I purposely avoided
changing any of the tile-coverage related logic in this patch outside of renames.

* LayoutTests/http/tests/site-isolation/animated-image-in-display-none-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/animated-image-in-display-none-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/animated-image-outside-viewport-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/animated-image-outside-viewport-in-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/find-in-page-marker-rects-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/find-in-page-marker-rects-in-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-clipped-out-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-clipped-out-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-while-outside-viewport-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-display-none-while-outside-viewport-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-outside-viewport-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-outside-viewport-in-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/marker-rects-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/request-animation-frame-throttling-frame.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateScriptedAnimationsAndTimersThrottlingState):
(WebCore::LocalFrameView::windowClipRect const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
* Source/WebCore/page/RemoteFrameLayoutInfo.cpp:
(WebCore::RemoteFrameLayoutInfo::RemoteFrameLayoutInfo):
(WebCore::RemoteFrameLayoutInfo::mapParentContentsToChildWindow const):
(WebCore::RemoteFrameLayoutInfo::create): Deleted.
(WebCore::RemoteFrameLayoutInfo::projectVisibleRectToChildContent const): Deleted.
* Source/WebCore/page/RemoteFrameLayoutInfo.h:
(WebCore::RemoteFrameLayoutInfo::create):
(WebCore::RemoteFrameLayoutInfo::windowClipRectInParent const):
(WebCore::RemoteFrameLayoutInfo::exposedContentRectInParent const):
(WebCore::RemoteFrameLayoutInfo::ownerHasRenderer const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::updateLocalFrameRect):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::frameTreeSyncDataChangedInAnotherProcess):
(WebKit::WebPage::allFrameTreeSyncDataChangedInAnotherProcess):
(WebKit::WebPage::updateChildFrameVisibleRectsFromParent):
(WebKit::WebPage::updateExposedRectFromParent): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/319536@main">https://commits.webkit.org/319536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0ec15c9074d26e13fd829cd20dd0799560282c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181786 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146115 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b81a89f-5a41-4cab-b174-8ef4acf1527d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55454 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141910 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b48bc87b-0bcc-4727-960c-87132ebe8967) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122345 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/297e21dd-b316-4535-afb5-411dd821e69e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44273 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42545 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42175 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3172 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48364 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193937 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151321 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40515 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56092 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151024 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45595 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128375 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124127 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54605 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17171 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53987 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54052 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->