### PR TITLE
Broken <img> with alt text is given a square aspect ratio, overflowing a definite CSS Grid area

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-036-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-036-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL display:block img should be 200px high assert_equals: expected 200 but got 100
-FAIL display:inline-block img should be 200px high assert_equals: expected 200 but got 100
+PASS display:block img should be 200px high
+PASS display:inline-block img should be 200px high
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio-alt-text-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio-alt-text-expected.txt
@@ -1,0 +1,6 @@
+
+
+
+PASS An error image with alt text and height:100% fills its definite grid area
+PASS An error image with alt text does not transfer its inline size through an aspect ratio
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio-alt-text.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio-alt-text.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<title>The width and height attributes do not give an aspect ratio to an image that renders alt text</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#images-3">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #grid {
+    display: grid;
+    width: 420px;
+    height: 200px;
+  }
+  #grid > img {
+    width: 100%;
+    height: 100%;
+  }
+  #stretched {
+    width: 100%;
+    height: auto;
+  }
+  #natural {
+    width: auto;
+    height: auto;
+  }
+</style>
+
+<div id="grid"><img id="grid-item" src="error.png" width="1600" height="900" alt="alt text"></div>
+<div style="width: 420px"><img id="stretched" src="error.png" width="1600" height="900" alt="alt text"></div>
+<img id="natural" src="error.png" width="1600" height="900" alt="alt text">
+
+<script>
+setup({ explicit_done: true });
+
+onload = () => {
+  test(() => {
+    let rect = document.getElementById("grid-item").getBoundingClientRect();
+    assert_equals(rect.width, 420, "inline size fills the grid area");
+    assert_equals(rect.height, 200, "block size fills the grid area and does not overflow it");
+  }, "An error image with alt text and height:100% fills its definite grid area");
+
+  test(() => {
+    let stretched = document.getElementById("stretched").getBoundingClientRect();
+    let natural = document.getElementById("natural").getBoundingClientRect();
+    assert_not_equals(stretched.height, stretched.width, "the box is not square");
+    assert_equals(stretched.height, natural.height, "the block size comes from the alt text box");
+  }, "An error image with alt text does not transfer its inline size through an aspect ratio");
+
+  done();
+};
+</script>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3788,7 +3788,7 @@ template<typename SizeType> std::optional<LayoutUnit> RenderBox::computeSizingKe
         if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(this)) {
             auto computedFixedLogicalWidth = style().logicalWidth().tryFixed();
             auto preferredRatio = renderImage->preferredAspectRatioAsSize();
-            if (computedFixedLogicalWidth && !style().aspectRatio().hasRatio()) {
+            if (computedFixedLogicalWidth && !style().aspectRatio().hasRatio() && !preferredRatio.isEmpty()) {
                 return resolveHeightForRatio(
                     borderAndPaddingLogicalWidth(),
                     borderAndPaddingLogicalHeight(),

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -979,10 +979,20 @@ FloatSize RenderImage::preferredAspectRatioAsSize() const
     if (shouldApplySizeOrInlineSizeContainment())
         return RenderReplaced::preferredAspectRatioAsSize();
 
-    // Don't compute an intrinsic ratio to preserve historical WebKit behavior if we're painting alt text and/or a broken image.
     if (shouldDisplayBrokenImageIcon()) {
-        if (style().aspectRatio().isAutoAndRatio() && !isShowingAltText())
+        auto ratioFromStyle = [&] {
             return FloatSize::narrowPrecision(style().aspectRatioLogicalWidth().value, style().aspectRatioLogicalHeight().value);
+        };
+
+        if (isShowingAltText()) {
+            if (style().aspectRatio().isRatio() && style().display() != Style::DisplayType::InlineFlow)
+                return ratioFromStyle();
+            return { };
+        }
+
+        if (style().aspectRatio().hasRatio())
+            return ratioFromStyle();
+
         return { 1.0, 1.0 };
     }
 


### PR DESCRIPTION
#### 3d735c20e8d47951b5644320a9d41add0c9538a3
<pre>
Broken &lt;img&gt; with alt text is given a square aspect ratio, overflowing a definite CSS Grid area
<a href="https://bugs.webkit.org/show_bug.cgi?id=321082">https://bugs.webkit.org/show_bug.cgi?id=321082</a>
<a href="https://rdar.apple.com/184712865">rdar://184712865</a>

Reviewed by NOBODY (OOPS!).

RenderImage::preferredAspectRatioAsSize() fabricated a 1:1 aspect ratio for any
broken image and discarded the ratio from the width/height attributes whenever
alt text was rendered. A square ratio makes the used block size follow the used
inline size: an alt-text &lt;img&gt; with width:100%/height:100% in a definite grid
area grew its automatic minimum block size to the column width and overflowed
the row (min-height:0 hid it), and outside grid width:100% laid the box out as a
square instead of taking its block size from the alt text box.

An &lt;img&gt; rendering alt text is not sized as a replaced element, so it has no
preferred aspect ratio and the &quot;auto &lt;ratio&gt;&quot; from the dimension attributes does
not apply. An explicit aspect-ratio still applies unless the box is an inline
box. This matches Chromium and Firefox: replaced-element-036.html now passes
(explicit ratio applies for block and inline-block) and replaced-element-028.html
keeps passing (it does not apply for inline).

Also guard the one RenderBox consumer that divided by the preferred ratio without
checking it exists, now reachable for an alt-text image with no ratio.

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-036-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio-alt-text-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio-alt-text.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeSizingKeywordLogicalContentHeightUsingGeneric const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::preferredAspectRatioAsSize const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d735c20e8d47951b5644320a9d41add0c9538a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193787 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147856 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/357bccbc-fc29-4eb0-9741-2d16cdb14048) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143269 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99472 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5b7b17f-9557-4e38-8cd6-d538886a7f64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123692 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b55b1205-4bd3-4e3b-80ff-bba671ef690d) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182893 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45738 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43967 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5661 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12500 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156131 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43557 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4965 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44841 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195725 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182969 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163519 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152801 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57863 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152482 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47029 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130142 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126441 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56371 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18567 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55742 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55981 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55809 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->