### PR TITLE
REGRESSION(318278@main?)[macOS]: ASSERTION FAILED: !m_waitingForContentPolicy /Volumes/Data/worker/Apple-Tahoe-Debug-Build/build/Source/WebCore/loader/DocumentLoader.cpp

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2439,8 +2439,6 @@ webkit.org/b/319798 [ arm64 ] imported/w3c/web-platform-tests/media-source/media
 
 webkit.org/b/320245 [ Release x86_64 ] imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html [ Pass Crash ]
 
-webkit.org/b/320913 http/tests/security/contentSecurityPolicy/multipart-three-part.py [ Pass Crash Timeout ]
-
 webkit.org/b/320326 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-dynamic-font-metrics-001.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/321103 [ Debug ] imported/w3c/web-platform-tests/uievents/textInput/enter-textarea-contenteditable.html [ Pass Failure ]

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1992,3 +1992,10 @@
     || PLATFORM(IOS_FAMILY)
 #define HAVE_NETWORK_FRAMEWORK_HTTP_MESSAGING 1
 #endif
+
+// The CFNetwork network loader delivers multipart/x-mixed-replace parts, their data and the end of the load without
+// waiting for the previous part's response completion handler, which NetworkResourceLoader has to serialize itself.
+// FIXME: Turn this off on platforms that have the CFNetwork fix (rdar://185073080).
+#if !defined(HAVE_BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL) && PLATFORM(COCOA)
+#define HAVE_BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL 1
+#endif

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -118,6 +118,14 @@
 namespace WebKit {
 using namespace WebCore;
 
+#if HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
+// Upper bounds on what may accumulate in m_deferredMessages while the WebProcess has not yet answered
+// ContinueDidReceiveResponse. Generous for a fast load whose data outruns the content-policy check, but keeps a
+// WebProcess that never answers from growing the network process' memory without limit.
+static constexpr size_t maximumDeferredMessagesSize = 100 * MB;
+static constexpr size_t maximumDeferredMessageCount = 1024;
+#endif
+
 struct NetworkResourceLoader::SynchronousLoadData {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(NetworkResourceLoader);
 
@@ -196,6 +204,11 @@ NetworkResourceLoader::~NetworkResourceLoader()
     ASSERT(!m_networkLoad);
     ASSERT(!isSynchronous() || !m_synchronousLoadData->delayedReply);
     ASSERT(m_fileReferences.isEmpty());
+#if HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
+    // Before answering the handlers: answering one runs the wrapper installed by didReceiveResponse(), which would
+    // otherwise try to deliver deferred messages from here.
+    cancelDeferredMessages();
+#endif
     while (!m_responseCompletionHandlers.isEmpty())
         m_responseCompletionHandlers.takeFirst()(PolicyAction::Ignore);
 }
@@ -656,6 +669,9 @@ void NetworkResourceLoader::convertToDownload(DownloadID downloadID, const Resou
 
     if (!m_responseCompletionHandlers.isEmpty()) {
         auto firstHandler = m_responseCompletionHandlers.takeFirst();
+#if HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
+        cancelDeferredMessages();
+#endif
         while (!m_responseCompletionHandlers.isEmpty())
             m_responseCompletionHandlers.takeFirst()(PolicyAction::Ignore);
         protect(connectionToWebProcess().networkProcess().downloadManager())->convertNetworkLoadToDownload(downloadID, networkLoad.releaseNonNull(), WTF::move(firstHandler), WTF::move(m_fileReferences), request, response);
@@ -945,6 +961,25 @@ void NetworkResourceLoader::didReceiveInformationalResponse(ResourceResponse&& r
 
 void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedResponse, PrivateRelayed privateRelayed, ResponseCompletionHandler&& completionHandler)
 {
+#if HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
+    if (m_isProcessingResponse) {
+        m_deferredMessages.append(DeferredResponse { WTF::move(receivedResponse), privateRelayed, WTF::move(completionHandler) });
+        if (m_deferredMessages.size() > maximumDeferredMessageCount)
+            failDueToExcessiveDeferredMessages();
+        return;
+    }
+
+    // Claim the pipeline before any of the asynchronous steps below (e.g. processClearSiteDataHeader()), so a follow-up
+    // message cannot overtake this response while it is still being processed. Released once this response is resolved,
+    // which for a main resource is when the WebProcess answers ContinueDidReceiveResponse.
+    m_isProcessingResponse = true;
+    completionHandler = [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](PolicyAction policyAction) mutable {
+        completionHandler(policyAction);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->responseProcessingCompleted(policyAction);
+    };
+#endif
+
     LOADER_RELEASE_LOG("didReceiveResponse: (httpStatusCode=%d, MIMEType=%" PUBLIC_LOG_STRING ", expectedContentLength=%lld, hasCachedEntryForValidation=%d, hasNetworkLoadChecker=%d)", receivedResponse.httpStatusCode(), receivedResponse.mimeType().utf8().data(), receivedResponse.expectedContentLength(), !!m_cacheEntryForValidation, !!m_networkLoadChecker);
 
 #if ENABLE(CONTENT_FILTERING)
@@ -1175,6 +1210,19 @@ void NetworkResourceLoader::sendDidReceiveResponseWithPotentialProcessSwap(const
 
 void NetworkResourceLoader::didReceiveBuffer(const WebCore::FragmentedSharedBuffer& buffer)
 {
+#if HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
+    if (m_isProcessingResponse) {
+        // The WebProcess has not validated the response this data belongs to yet (see didReceiveResponse()).
+        if (m_deferredMessagesSize + buffer.size() > maximumDeferredMessagesSize) {
+            failDueToExcessiveDeferredMessages();
+            return;
+        }
+        m_deferredMessagesSize += buffer.size();
+        m_deferredMessages.append(Ref { buffer });
+        return;
+    }
+#endif
+
     if (!m_numBytesReceived)
         LOADER_RELEASE_LOG("didReceiveData: Started receiving data");
     m_numBytesReceived += buffer.size();
@@ -1202,6 +1250,13 @@ void NetworkResourceLoader::didReceiveBuffer(const WebCore::FragmentedSharedBuff
 
 void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& originalNetworkLoadMetrics)
 {
+#if HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
+    if (m_isProcessingResponse) {
+        m_deferredMessages.append(originalNetworkLoadMetrics);
+        return;
+    }
+#endif
+
     // https://fetch.spec.whatwg.org/#navigation-tao-check
     std::optional<NetworkLoadMetrics> navigationMetrics;
     if (parameters().options.mode == FetchOptions::Mode::Navigate && originalNetworkLoadMetrics.hasCrossOriginRedirect
@@ -1269,6 +1324,13 @@ void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& originalN
 
 void NetworkResourceLoader::didFailLoading(const ResourceError& error)
 {
+#if HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
+    if (m_isProcessingResponse) {
+        m_deferredMessages.append(error);
+        return;
+    }
+#endif
+
     bool wasServiceWorkerLoad = false;
     wasServiceWorkerLoad = !!m_serviceWorkerFetchTask;
     LOADER_RELEASE_LOG_ERROR("didFailLoading: (wasServiceWorkerLoad=%d, isTimeout=%d, isCancellation=%d, isAccessControl=%d, errorCode=%d)", wasServiceWorkerLoad, error.isTimeout(), error.isCancellation(), error.isAccessControl(), error.errorCode());
@@ -1683,7 +1745,85 @@ void NetworkResourceLoader::continueDidReceiveResponse()
 
     if (!m_responseCompletionHandlers.isEmpty())
         m_responseCompletionHandlers.takeFirst()(PolicyAction::Use);
+
+#if HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
+    // Answering the handler above runs the wrapper installed by didReceiveResponse(), which releases the pipeline and
+    // delivers what arrived while we waited. Cover the case where there was no handler left to answer.
+    deliverDeferredMessages();
+#endif
 }
+
+#if HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
+
+// Called once the response being processed is resolved, so whatever arrived while it was outstanding can be delivered,
+// up to the next response (which will again claim the pipeline and wait for its own ContinueDidReceiveResponse).
+void NetworkResourceLoader::responseProcessingCompleted(PolicyAction policyAction)
+{
+    m_isProcessingResponse = false;
+
+    // Anything queued behind a response that was not accepted belongs to a part the WebProcess must never see: the
+    // response was blocked (CSP frame-ancestors, X-Frame-Options, COOP/COEP, content filtering) or the load is being
+    // abandoned, and no DidReceiveResponse was sent for it. Delivering its body would hand WebContent the bytes of a
+    // blocked part, and WebResourceLoader would get DidReceiveData with no preceding DidReceiveResponse.
+    if (policyAction != PolicyAction::Use) {
+        LOADER_RELEASE_LOG("responseProcessingCompleted: Dropping deferred messages, response was not accepted (deferredMessageCount=%zu)", m_deferredMessages.size());
+        cancelDeferredMessages();
+        return;
+    }
+
+    deliverDeferredMessages();
+}
+
+void NetworkResourceLoader::deliverDeferredMessages()
+{
+    while (!m_isProcessingResponse && !m_deferredMessages.isEmpty()) {
+        WTF::switchOn(m_deferredMessages.takeFirst(),
+            [&](DeferredResponse&& deferredResponse) {
+                didReceiveResponse(WTF::move(deferredResponse.response), deferredResponse.privateRelayed, WTF::move(deferredResponse.completionHandler));
+            }, [&](Ref<const WebCore::FragmentedSharedBuffer>&& buffer) {
+                m_deferredMessagesSize -= buffer->size();
+                didReceiveBuffer(buffer.get());
+            }, [&](WebCore::NetworkLoadMetrics&& metrics) {
+                didFinishLoading(metrics);
+            }, [&](WebCore::ResourceError&& error) {
+                didFailLoading(error);
+            });
+    }
+}
+
+void NetworkResourceLoader::cancelDeferredMessages()
+{
+    auto deferredMessages = std::exchange(m_deferredMessages, { });
+    m_deferredMessagesSize = 0;
+    for (auto& message : deferredMessages) {
+        WTF::switchOn(message,
+            [](DeferredResponse& deferredResponse) { deferredResponse.completionHandler(PolicyAction::Ignore); },
+            [](auto&) { });
+    }
+}
+
+void NetworkResourceLoader::failDueToExcessiveDeferredMessages()
+{
+    LOADER_RELEASE_LOG_ERROR("failDueToExcessiveDeferredMessages: Cancelling load, too much deferred while waiting for ContinueDidReceiveResponse (deferredMessageCount=%zu, deferredMessagesSize=%zu)", m_deferredMessages.size(), m_deferredMessagesSize);
+
+    Ref protectedThis { *this };
+
+    // Empty both queues before failing so that the failure is not itself deferred, and answer the response handler
+    // only once the load is torn down so that a reentrant network callback cannot fail the load a second time.
+    auto responseCompletionHandlers = std::exchange(m_responseCompletionHandlers, { });
+    m_isProcessingResponse = false;
+    cancelDeferredMessages();
+
+    if (RefPtr networkLoad = m_networkLoad)
+        networkLoad->cancel();
+
+    didFailLoading(ResourceError { errorDomainWebKitInternal, 0, m_parameters.request.url(), "Too much data buffered while waiting for the previous multipart part to be handled"_s, ResourceError::Type::General });
+
+    while (!responseCompletionHandlers.isEmpty())
+        responseCompletionHandlers.takeFirst()(PolicyAction::Ignore);
+}
+
+#endif // HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
 
 void NetworkResourceLoader::pendingStreamAppendData(IPC::SharedBufferReference&& chunk)
 {

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -38,8 +38,10 @@
 #include <WebCore/ContentFilterUnblockHandler.h>
 #include <WebCore/ContentSecurityPolicyClient.h>
 #include <WebCore/CrossOriginAccessControl.h>
+#include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/ReportingClient.h>
+#include <WebCore/ResourceError.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SWServerRegistration.h>
 #include <WebCore/SecurityPolicyViolationEvent.h>
@@ -47,6 +49,7 @@
 #include <WebCore/Timer.h>
 #include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/Variant.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -156,6 +159,18 @@ public:
     void didBlockAuthenticationChallenge() final;
     void didReceiveChallenge(const WebCore::AuthenticationChallenge&) final;
     bool shouldCaptureExtraNetworkLoadMetrics() const final;
+
+#if HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
+    // Releases the pipeline claimed by didReceiveResponse(), then delivers what was deferred behind that response if it
+    // was accepted, or drops it if it was not.
+    void responseProcessingCompleted(WebCore::PolicyAction);
+    // Replays the messages that were deferred while waiting for ContinueDidReceiveResponse.
+    void deliverDeferredMessages();
+    // Drops any deferred messages on teardown, answering their still-pending completion handlers with Ignore.
+    void cancelDeferredMessages();
+    // Cancels the load when the WebProcess is too slow (or refuses) to answer ContinueDidReceiveResponse.
+    void failDueToExcessiveDeferredMessages();
+#endif
 
     // CrossOriginAccessControlCheckDisabler
     bool crossOriginAccessControlCheckEnabled() const override;
@@ -350,9 +365,35 @@ private:
     std::unique_ptr<NetworkCache::Entry> m_cacheEntryWaitingForContinueDidReceiveResponse;
     RefPtr<NetworkLoadChecker> m_networkLoadChecker;
     bool m_shouldRestartLoad { false };
-    // A Deque (rather than a single handler) is needed because multipart/x-mixed-replace responses
-    // can deliver follow-up parts before the WebProcess has approved the first one via ContinueDidReceiveResponse.
+    // Holds the completion handler of the response currently awaiting ContinueDidReceiveResponse from the WebProcess.
+    // Multipart/x-mixed-replace can add more than one when the network layer does not serialize the parts itself
+    // (see HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)), hence a Deque rather than a single handler: every handler
+    // is still answered rather than destroyed. Added by 313118@main.
     Deque<ResponseCompletionHandler> m_responseCompletionHandlers;
+
+#if HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL)
+    // The network layer can deliver follow-up multipart/x-mixed-replace parts (and their data, and the end of the
+    // load) before the WebProcess has answered ContinueDidReceiveResponse for the previous part, whose content-policy
+    // check is asynchronous. The WebProcess must not see anything past a response it has not validated yet, so while a
+    // response is outstanding every message is queued here and replayed in order from continueDidReceiveResponse().
+    // See deliverDeferredMessages() / didReceiveResponse().
+    struct DeferredResponse {
+        WebCore::ResourceResponse response;
+        PrivateRelayed privateRelayed;
+        ResponseCompletionHandler completionHandler;
+    };
+    using DeferredMessage = WTF::Variant<DeferredResponse, Ref<const WebCore::FragmentedSharedBuffer>, WebCore::NetworkLoadMetrics, WebCore::ResourceError>;
+    Deque<DeferredMessage> m_deferredMessages;
+    // Bounds how much data we retain on behalf of a WebProcess that never answers ContinueDidReceiveResponse,
+    // so that it cannot grow the network process' memory without limit.
+    size_t m_deferredMessagesSize { 0 };
+    // Whether a response is being processed, from the moment didReceiveResponse() starts on it until its completion
+    // handler runs. Tracked explicitly rather than derived from m_responseCompletionHandlers, because
+    // didReceiveResponse() can take asynchronous steps (processClearSiteDataHeader()) before appending the handler,
+    // and nothing may be delivered to the WebProcess in that window.
+    bool m_isProcessingResponse { false };
+#endif
+
     bool m_shouldCaptureExtraNetworkLoadMetrics { false };
     bool m_isKeptAlive { false };
     std::unique_ptr<EarlyHintsResourceLoader> m_earlyHintsResourceLoader;


### PR DESCRIPTION
#### cc7a6821b7cceb7cb9e2836a9dfc11a42691683a
<pre>
REGRESSION(318278@main?)[macOS]: ASSERTION FAILED: !m_waitingForContentPolicy /Volumes/Data/worker/Apple-Tahoe-Debug-Build/build/Source/WebCore/loader/DocumentLoader.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=320913">https://bugs.webkit.org/show_bug.cgi?id=320913</a>
<a href="https://rdar.apple.com/183941470">rdar://183941470</a>

Reviewed by Alex Christensen.

318278@main turned the CFNetwork NW loader on unconditionally. For
multipart/x-mixed-replace it hands the network process the follow-up parts, their
data and the end of the load without waiting for the previous part&apos;s response
completion handler, whose content-policy check is asynchronous
(DocumentLoader::responseReceived() -&gt; checkContentPolicy() IPCs to the
UIProcess).

313118@main made NetworkResourceLoader tolerate the extra responses by queuing
the response completion handlers in a Deque instead of overwriting a single one,
but it kept forwarding every message to the WebProcess immediately. The
WebProcess cannot process anything past a response it has not validated yet: a
follow-up response hits ASSERT(!m_waitingForContentPolicy) in
DocumentLoader::responseReceived(), and a follow-up didFinishLoading() runs
SubresourceLoader::didFinishLoading() through releaseResources(), which clears
the loader&apos;s identifier, so WebResourceLoader never sends
ContinueDidReceiveResponse and the load hangs.

Re-serialize delivery, restoring the one-part-at-a-time semantics the legacy
NSURLSession loader provided. didReceiveResponse() claims the pipeline via
m_isProcessingResponse and wraps the completion handler so that it is released
once the response is resolved, which for a main resource is when the WebProcess
answers ContinueDidReceiveResponse. While the pipeline is claimed, every
follow-up message is held in m_deferredMessages, and it is replayed in order once
the response is released, stopping at the next response so it too waits.

The state is tracked explicitly rather than derived from
m_responseCompletionHandlers for two reasons. didReceiveResponse() can take
asynchronous steps before appending the handler (processClearSiteDataHeader()),
and nothing may be delivered in that window. It also resolves responses without
appending anything at all: when a main resource is blocked by CSP frame-ancestors
or X-Frame-Options, by COOP/COEP, by NetworkLoadChecker::validateResponse(), by
content filtering, or is dropped for keepalive, it answers PolicyAction::Ignore
having sent no DidReceiveResponse. Messages queued behind such a response are
dropped rather than replayed, so that WebContent is never handed the body of a
part the network process just blocked, nor a DidReceiveData with no preceding
DidReceiveResponse. Deferred messages are likewise dropped with
PolicyAction::Ignore on teardown so their completion handlers are still answered,
and the queue is bounded so a WebProcess that never answers cannot grow the
network process&apos; memory without limit.

This is a workaround for the CFNetwork bug, so it is gated on the new
HAVE(BROKEN_MULTIPART_RESPONSE_FLOW_CONTROL), on by default on COCOA ports. A
FIXME points at <a href="https://rdar.apple.com/185073080">rdar://185073080</a> to turn it off on platforms that have the
CFNetwork fix.

Nothing outside multipart is affected: m_isProcessingResponse is false when those
messages arrive for subresources and for single-response loads.

No new tests, unskipped existing test.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WTF/wtf/PlatformHave.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::~NetworkResourceLoader):
(WebKit::NetworkResourceLoader::convertToDownload):
(WebKit::NetworkResourceLoader::didReceiveResponse):
(WebKit::NetworkResourceLoader::didReceiveBuffer):
(WebKit::NetworkResourceLoader::didFinishLoading):
(WebKit::NetworkResourceLoader::didFailLoading):
(WebKit::NetworkResourceLoader::continueDidReceiveResponse):
(WebKit::NetworkResourceLoader::responseProcessingCompleted):
(WebKit::NetworkResourceLoader::deliverDeferredMessages):
(WebKit::NetworkResourceLoader::cancelDeferredMessages):
(WebKit::NetworkResourceLoader::failDueToExcessiveDeferredMessages):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:

Canonical link: <a href="https://commits.webkit.org/319418@main">https://commits.webkit.org/319418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92d474b1bfc56366dbe2c28d2b4932274debbb6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145588 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/edf8ef01-3293-4de2-826b-20149f8ad804) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141462 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8f770e5-66eb-4429-9b7c-9a943552feeb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121905 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34c638d2-2c87-4521-ac4e-ec0ebe5a0428) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43826 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42085 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3871 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10697 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41748 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2637 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42539 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193410 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54878 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150849 "") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40439 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55565 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150561 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45156 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127845 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123407 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54081 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16746 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53464 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53701 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53528 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->