### PR TITLE
[JSC] Check maxLength == 0 when specified in fromBase64

### DIFF
--- a/JSTests/stress/uint8array-setFromBase64-zero-length-reads-nothing.js
+++ b/JSTests/stress/uint8array-setFromBase64-zero-length-reads-nothing.js
@@ -1,0 +1,46 @@
+// FromBase64 returns before examining any character when maxLength is 0, so a zero length destination
+// accepts input that is not valid base64 at all.
+// https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+function shouldThrow(callback, errorConstructor) {
+    try {
+        callback();
+    } catch (e) {
+        shouldBe(e instanceof errorConstructor, true);
+        return;
+    }
+    throw new Error('FAIL: should have thrown');
+}
+
+var lastChunkHandlings = ["loose", "strict", "stop-before-partial"];
+// "aa==" is deliberately absent: it is valid base64 under loose and stop-before-partial.
+var invalidStrings = ["#", "a#", "aa#", "aaa#", "aaaa#", "=", "a=", "aa=a", "===="];
+
+for (var lastChunkHandling of lastChunkHandlings) {
+    for (var string of invalidStrings) {
+        var empty = new Uint8Array(0);
+        var result = empty.setFromBase64(string, { lastChunkHandling });
+        shouldBe(result.read, 0);
+        shouldBe(result.written, 0);
+    }
+
+    // A zero length view onto a larger buffer behaves the same way.
+    for (var string of invalidStrings) {
+        var view = new Uint8Array(new ArrayBuffer(8), 4, 0);
+        var result = view.setFromBase64(string, { lastChunkHandling });
+        shouldBe(result.read, 0);
+        shouldBe(result.written, 0);
+    }
+
+    // Uint8Array.fromBase64 has no maxLength, so it still rejects the same input.
+    for (var string of invalidStrings) {
+        shouldThrow(() => {
+            Uint8Array.fromBase64(string, { lastChunkHandling });
+        }, SyntaxError);
+    }
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -64,9 +64,6 @@ test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-of
 test/built-ins/TypedArrayConstructors/ctors/object-arg/iterated-array-changed-by-tonumber.js:
   default: 3
   strict mode: 3
-test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage-empty.js:
-  default: 3
-  strict mode: 3
 test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage.js:
   default: 3
   strict mode: 3

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
@@ -92,7 +92,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
 
     Vector<uint8_t, 128> output;
     output.grow(maxLengthFromBase64(view));
-    auto [shouldThrowError, readLength, writeLength] = fromBase64(view, output.mutableSpan(), alphabet, lastChunkHandling);
+    auto [shouldThrowError, readLength, writeLength] = fromBase64(view, output.mutableSpan(), alphabet, lastChunkHandling, WTF::OutputSizeIsMaxLength::No);
     if (shouldThrowError == WTF::FromBase64ShouldThrowError::Yes) [[unlikely]]
         return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.fromBase64 requires a valid base64 string"_s));
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
@@ -100,7 +100,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
     StringView view = gcOwnedData;
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto [shouldThrowError, readLength, writeLength] = fromBase64(view, std::span { uint8Array->typedVector(), uint8Array->length() }, alphabet, lastChunkHandling);
+    auto [shouldThrowError, readLength, writeLength] = fromBase64(view, std::span { uint8Array->typedVector(), uint8Array->length() }, alphabet, lastChunkHandling, WTF::OutputSizeIsMaxLength::Yes);
     ASSERT(readLength <= view.length());
     if (shouldThrowError == WTF::FromBase64ShouldThrowError::Yes) [[unlikely]]
         return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires a valid base64 string"_s));

--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -338,8 +338,13 @@ static inline simdutf::last_chunk_handling_options NODELETE toSIMDUTFLastChunkHa
 }
 
 template<typename CharacterType>
-static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64Impl(std::span<const CharacterType> span, std::span<uint8_t> output, Alphabet alphabet, LastChunkHandling lastChunkHandling)
+static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64Impl(std::span<const CharacterType> span, std::span<uint8_t> output, Alphabet alphabet, LastChunkHandling lastChunkHandling, OutputSizeIsMaxLength outputSizeIsMaxLength)
 {
+    // Step 3 of https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64 returns before looking at
+    // a single character when maxLength is 0, so even invalid input is accepted.
+    if (outputSizeIsMaxLength == OutputSizeIsMaxLength::Yes && output.empty())
+        return { FromBase64ShouldThrowError::No, 0, 0 };
+
     constexpr bool decodeUpToBadChar = true;
     auto [result, outputLength] = simdutf::base64_to_binary_safe(span, output, toSIMDUTFDecodeOptions(alphabet), toSIMDUTFLastChunkHandling(lastChunkHandling), decodeUpToBadChar);
     switch (result.error) {
@@ -352,11 +357,11 @@ static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64Impl(std
     }
 }
 
-std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64(StringView string, std::span<uint8_t> output, Alphabet alphabet, LastChunkHandling lastChunkHandling)
+std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64(StringView string, std::span<uint8_t> output, Alphabet alphabet, LastChunkHandling lastChunkHandling, OutputSizeIsMaxLength outputSizeIsMaxLength)
 {
     if (string.is8Bit())
-        return fromBase64Impl(string.span8(), output, alphabet, lastChunkHandling);
-    return fromBase64Impl(string.span16(), output, alphabet, lastChunkHandling);
+        return fromBase64Impl(string.span8(), output, alphabet, lastChunkHandling, outputSizeIsMaxLength);
+    return fromBase64Impl(string.span16(), output, alphabet, lastChunkHandling, outputSizeIsMaxLength);
 }
 
 size_t maxLengthFromBase64(StringView string)

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -206,7 +206,9 @@ private:
 enum class Alphabet : uint8_t { Base64, Base64URL };
 enum class LastChunkHandling : uint8_t { Loose, Strict, StopBeforePartial };
 enum class FromBase64ShouldThrowError: bool { No, Yes };
-WTF_EXPORT_PRIVATE std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64(StringView, std::span<uint8_t>, Alphabet, LastChunkHandling);
+enum class OutputSizeIsMaxLength : bool { No, Yes };
+
+WTF_EXPORT_PRIVATE std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64(StringView, std::span<uint8_t>, Alphabet, LastChunkHandling, OutputSizeIsMaxLength);
 WTF_EXPORT_PRIVATE size_t maxLengthFromBase64(StringView);
 
 } // namespace WTF
@@ -224,3 +226,4 @@ using WTF::base64URLEncoded;
 using WTF::isBase64OrBase64URLCharacter;
 using WTF::fromBase64;
 using WTF::maxLengthFromBase64;
+using WTF::OutputSizeIsMaxLength;


### PR DESCRIPTION
#### b1701b34890898dc083648cfc97f038bb6566131
<pre>
[JSC] Check maxLength == 0 when specified in fromBase64
<a href="https://bugs.webkit.org/show_bug.cgi?id=321895">https://bugs.webkit.org/show_bug.cgi?id=321895</a>
<a href="https://rdar.apple.com/185073630">rdar://185073630</a>

Reviewed by Sosuke Suzuki.

When maxLength is specified (setFromBase64 case), we stop processing
before touching anything[1] (see step 3). This patch correctly
implements it.

[1]: <a href="https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64">https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64</a>

Test: JSTests/stress/uint8array-setFromBase64-zero-length-reads-nothing.js

* JSTests/stress/uint8array-setFromBase64-zero-length-reads-nothing.js: Added.
(shouldBe):
(lastChunkHandling.of.lastChunkHandlings.string.of.invalidStrings.shouldThrow):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/text/Base64.cpp:
(WTF::fromBase64Impl):
(WTF::fromBase64):
* Source/WTF/wtf/text/Base64.h:

Canonical link: <a href="https://commits.webkit.org/319275@main">https://commits.webkit.org/319275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f2d28550fd32ef2a57c05699f23682d9c04b982

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145331 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0356f60-f9ed-4661-aab5-5b7f74fc7c48) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141231 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65de39b5-e4e6-4ff3-8dc5-7d83925ef86b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121683 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4d09480-0f1e-4b75-a4bd-81b231acc320) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43567 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41846 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3648 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10462 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41506 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2382 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42282 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47565 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46101 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/core/float_literals.wast.js.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193157 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54619 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150616 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55307 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150333 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27473 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44923 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127573 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123076 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53824 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16501 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53206 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53443 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->