### PR TITLE
Unreviewed, upgrade WPT harness for JSC stress tests

### DIFF
--- a/JSTests/wasm/wpt/wpt-harness-post.js
+++ b/JSTests/wasm/wpt/wpt-harness-post.js
@@ -11,18 +11,32 @@
 // is in place for the results; done() then releases the wait, and completion fires once the
 // promise/timer chain drains via deferredWorkTimer->runRunLoop() before exit.
 
-// Title passed by the runner as a trailing `-- <title>` argument (the test's file name). The
-// browser names an unnamed block-body test after the page title; the shell's ShellTestEnvironment
-// hardcodes "Untitled"/"Untitled N" instead (that environment object is a closure local, so it
-// cannot be patched from here). Remapping the "Untitled" prefix to the title reproduces the
-// committed baseline. Single-line arrow tests derive their name from the function source in both
+// Title passed by the runner as a trailing `-- <title> <baseURL>` argument pair. The browser names
+// an unnamed block-body test after the page title; the shell's ShellTestEnvironment hardcodes
+// "Untitled"/"Untitled N" instead (that environment object is a closure local, so it cannot be
+// patched from here). Remapping the "Untitled" prefix to the title reproduces the committed
+// baseline. Single-line arrow tests derive their name from the function source in both
 // environments, so they are unaffected.
-const WPT_TITLE = (globalThis.arguments && globalThis.arguments.length) ? globalThis.arguments[0] : null;
+const WPT_TITLE = (globalThis.arguments && globalThis.arguments.length > 0) ? globalThis.arguments[0] : null;
+
+// URL the WPT server serves this test's directory from. The WAST harness bakes a stack string into
+// each assertion description, and a frame's location is the URL the browser loaded the script from
+// but a bare relative load path in the shell. Prefixing each frame with this reproduces the URLs in
+// the committed baselines.
+const WPT_BASE_URL = (globalThis.arguments && globalThis.arguments.length > 1) ? globalThis.arguments[1] : null;
 
 function titledName(name) {
     if (WPT_TITLE && /^Untitled( \d+)?$/.test(name))
         return name.replace(/^Untitled/, () => WPT_TITLE);
     return name;
+}
+
+// Rewrites the `name@path:line:column` frames of an assertion description so each path becomes the
+// URL the WPT server would serve it from.
+function urlifyStackFrames(message) {
+    if (!WPT_BASE_URL)
+        return message;
+    return message.replace(/@(?=[A-Za-z0-9_./-]+\.js:\d+:\d+)/g, () => "@" + WPT_BASE_URL);
 }
 
 function convertResult(status) {
@@ -55,7 +69,7 @@ add_completion_callback(function (tests, harness_status) {
         }
         // Append the message only when present; the committed baselines have no trailing
         // space after the name for passing subtests, and diff does not ignore trailing spaces.
-        out += convertResult(test.status) + " " + titledName(sanitize(test.name)) + (message ? " " + message : "") + "\n";
+        out += convertResult(test.status) + " " + titledName(sanitize(test.name)) + (message ? " " + urlifyStackFrames(message) : "") + "\n";
     }
 
     print(out); // print() appends the final newline, reproducing the trailing blank line.

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -2052,6 +2052,12 @@ end
 # the committed -expected.txt baselines.
 WPT_PATH = LAYOUTTESTS_PATH + "imported/w3c/web-platform-tests"
 
+# Origin the WPT server serves the imported tree from during a browser layout-test run, as
+# configured by LayoutTests/imported/w3c/resources/config.json. Stack locations that the WAST
+# harness bakes into assertion descriptions are these URLs in the committed baselines, so
+# wpt-harness-post.js rewrites the shell's relative load paths against this.
+WPT_BASE_URL = "http://web-platform.test:8800/"
+
 # The wasm JIT-configuration matrix, mirroring runWebAssemblySpecTestBase. Returns [kind, options].
 def wasmWPTConfigs(*extraOptions)
     configs = [["default-wasm", FTL_OPTIONS + extraOptions]]
@@ -2103,6 +2109,13 @@ def wptCopyBeside(relativeName, sourceDir)
     prepareExtraRelativeFilesWithBaseDirectory([relativeName], $benchmarkDirectory, sourceDir)
 end
 
+# The collection root's path within the served WPT tree (e.g. "wasm/core/js"). Load paths in the
+# run directory are relative to this root, so it is also the prefix that turns one into the URL
+# the WPT server would serve it from.
+def wptCollectionPrefix
+    $extraFilesBaseDir.relative_path_from(WPT_PATH.realpath)
+end
+
 # Maps each `// META: script=` dependency to a load path relative to the run's working directory
 # (the collection root). prepareCollection copies the whole collection tree into the bundle, so a
 # dependency within it is already present: a /-absolute (/wasm/...) dep resolves to its
@@ -2110,11 +2123,10 @@ end
 # pointing outside the collection would not be in the bundle, so raise rather than reference a
 # missing file (no jsshell test does this today).
 def wptPrepareScripts(scripts)
-    collectionPrefix = $extraFilesBaseDir.relative_path_from(WPT_PATH.realpath)
     scripts.map { | s |
         if s.start_with?("/")
-            rel = Pathname.new(s.sub(%r{^/}, '')).relative_path_from(collectionPrefix)
-            raise "WPT script dependency #{s} is outside the #{collectionPrefix} collection" if rel.to_s.start_with?("..")
+            rel = Pathname.new(s.sub(%r{^/}, '')).relative_path_from(wptCollectionPrefix)
+            raise "WPT script dependency #{s} is outside the #{wptCollectionPrefix} collection" if rel.to_s.start_with?("..")
             rel.to_s
         else
             ($benchmark.dirname + s).to_s
@@ -2135,7 +2147,7 @@ def runWebAssemblyWPT(expectedFile, harnessBeforeBenchmark, *extraOptions)
     wptCopyBeside("wpt-harness-post.js", WASMTESTS_PATH + "wpt")
 
     before = ["wpt-harness-pre.js", "resources/testharness.js"] + harnessBeforeBenchmark + ["wpt-harness-mid.js"]
-    after = ["wpt-harness-post.js", "--", wptTitle($benchmark)]
+    after = ["wpt-harness-post.js", "--", wptTitle($benchmark), WPT_BASE_URL + wptCollectionPrefix.to_s + "/"]
 
     # Enable the in-development JSC features the same way WebKitTestRunner does for the browser
     # layout-test run, so these tests exercise the same feature set (and match the baselines the


### PR DESCRIPTION
#### 4822aad691b2bf76f196b138ea2a30996563c4ac
<pre>
Unreviewed, upgrade WPT harness for JSC stress tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=321898">https://bugs.webkit.org/show_bug.cgi?id=321898</a>
<a href="https://rdar.apple.com/185076328">rdar://185076328</a>

* JSTests/wasm/wpt/wpt-harness-post.js:
(urlifyStackFrames):
(add_completion_callback):
(convertResult): Deleted.
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/319272@main">https://commits.webkit.org/319272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d506dd976bafdb71ca3bb29e18c51d6d5f8e0149

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191224 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145333 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54d2ca60-3041-472b-a032-3acbb1ee744b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141233 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/298ab0d0-b00c-4c00-99c7-e1c3abb88a09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161981 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121685 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fcd21f0d-ca1c-48b8-a3bc-ae27001a9e2c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43568 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41848 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3650 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10464 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41508 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2384 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42284 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193159 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54621 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150618 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55309 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38127 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150335 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27470 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44925 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123077 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53826 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16504 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53208 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53445 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53273 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->