### PR TITLE
[Site Isolation] User interaction and last user gesture timestamp flags aren't updated on remote frames

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/user-gesture-innermost-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/user-gesture-innermost-frame.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<body style="margin: 0; width: 100vw; height: 100vh">
+<input id="field">
+<script>
+
+window.addEventListener("keydown", function() {
+    window.top.postMessage("innermost-keydown", "*");
+}, false);
+
+// Focus the innermost frame so that the eventual UIHelper.keyDown() call sends its event here.
+document.getElementById("field").focus();
+
+window.top.postMessage("innermost-ready", "*");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/user-gesture-middle-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/user-gesture-middle-frame.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body style="margin: 0">
+<iframe src="http://127.0.0.1:8000/site-isolation/resources/user-gesture-innermost-frame.html" style="border: 0; width: 200px; height: 150px"></iframe>
+<script>
+
+// Make the controller now. Document adds NonInteractedCrossOriginFrame when it makes the controller, which
+// happens at the first requestAnimationFrame call.
+function step()
+{
+    requestAnimationFrame(step);
+}
+
+requestAnimationFrame(step);
+
+window.addEventListener("message", function() {
+    var reasons = window.internals ? internals.requestAnimationFrameThrottlingReasons() : "no internals";
+    window.top.postMessage("middle:" + reasons.includes("NonInteractedCrossOriginFrame"), "*");
+}, false);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/user-gesture-in-cross-origin-iframe-reaches-ancestor-in-another-process-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/user-gesture-in-cross-origin-iframe-reaches-ancestor-in-another-process-expected.txt
@@ -1,0 +1,14 @@
+Tests that a user gesture in an out-of-process subframe reaches the ancestors of that subframe in other processes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Nothing has been interacted with, so the middle frame throttles requestAnimationFrame.
+PASS middleFrameIsThrottled became "true"
+Sending a key to the innermost frame, which has the focus.
+PASS innermostFrameGotTheKey became "true"
+PASS middleFrameIsThrottled became "false"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/user-gesture-in-cross-origin-iframe-reaches-ancestor-in-another-process.html
+++ b/LayoutTests/http/tests/site-isolation/user-gesture-in-cross-origin-iframe-reaches-ancestor-in-another-process.html
@@ -1,0 +1,72 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body style="margin: 0">
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Tests that a user gesture in an out-of-process subframe reaches the ancestors of that subframe in other processes");
+
+var jsTestIsAsync = true;
+var middleFrameIsThrottled = "";
+var innermostFrameGotTheKey = "false";
+var testFrame;
+
+window.addEventListener("message", function(event) {
+    if (event.data.startsWith("middle:"))
+        middleFrameIsThrottled = event.data.substring("middle:".length);
+    else if (event.data == "innermost-keydown")
+        innermostFrameGotTheKey = "true";
+    else if (event.data == "innermost-ready")
+        runTest();
+}, false);
+
+function runTest()
+{
+    testFrame = document.getElementById("testFrame");
+
+    // Ask in a loop, because the gesture reaches the process of the middle frame asynchronously.
+    setInterval(function() {
+        testFrame.contentWindow.postMessage("report", "*");
+    }, 50);
+
+    debug("Nothing has been interacted with, so the middle frame throttles requestAnimationFrame.");
+    shouldBecomeEqualToString("middleFrameIsThrottled", "true", sendKeyToInnermostFrame);
+}
+
+function sendKeyToInnermostFrame()
+{
+    debug("Sending a key to the innermost frame, which has the focus.");
+    prepareForKeyEvents().then(function() {
+        UIHelper.typeCharacter("a");
+        shouldBecomeEqualToString("innermostFrameGotTheKey", "true", checkMiddleFrameIsUnthrottled);
+    });
+}
+
+function prepareForKeyEvents()
+{
+    if (!UIHelper.isIOSFamily())
+        return Promise.resolve();
+
+    // On iOS, a key only reaches the page if a hardware keyboard is attached and the web view is
+    // the first responder.
+    return new Promise(function(resolve) {
+        testRunner.runUIScript(`(function() {
+            uiController.setHardwareKeyboardAttached(true);
+            uiController.becomeFirstResponder();
+            uiController.doAfterPresentationUpdate(function() { uiController.uiScriptComplete(""); });
+        })();`, resolve);
+    });
+}
+
+function checkMiddleFrameIsUnthrottled()
+{
+    shouldBecomeEqualToString("middleFrameIsThrottled", "false", finishJSTest);
+}
+</script>
+
+<!-- Frame hierarchy: mainFrame => testFrame => innermostFrame; keyDown sent to innermostFrame -->
+<iframe id="testFrame" src="http://localhost:8000/site-isolation/resources/user-gesture-middle-frame.html" style="border: 0; width: 400px; height: 300px"></iframe>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1545,7 +1545,7 @@ public:
 
     MonotonicTime lastHandledUserGestureTimestamp() const { return m_lastHandledUserGestureTimestamp; }
     bool hasHadUserInteraction() const { return static_cast<bool>(m_lastHandledUserGestureTimestamp); }
-    void updateLastHandledUserGestureTimestamp(MonotonicTime);
+    WEBCORE_EXPORT void updateLastHandledUserGestureTimestamp(MonotonicTime);
     bool processingUserGestureForMedia() const;
 
     // Identifies which branch of processingUserGestureForMedia() authorizes media playback.

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -31,10 +31,13 @@
 #include "DocumentSettingsValues.h"
 #include "EventLoop.h"
 #include "FrameDestructionObserverInlines.h"
+#include "FrameLoader.h"
+#include "FrameLoaderClient.h"
 #include "JSDOMGlobalObject.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
+#include "LocalFrameLoaderClient.h"
 #include "Logging.h"
 #include "Microtasks.h"
 #include "ResourceLoadObserver.h"
@@ -202,13 +205,18 @@ UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture
             page->setUserDidInteractWithPageExcludingForcedUserGestures(processInteractionStyle != ProcessInteractionStyle::Never);
         }
         if (RefPtr frame = document->frame(); frame && !frame->hasHadUserInteraction()) {
-            for (RefPtr<Frame> ancestor = WTF::move(frame); ancestor; ancestor = ancestor->tree().parent()) {
+            bool hasRemoteAncestor = false;
+            for (RefPtr<Frame> ancestor = frame; ancestor; ancestor = ancestor->tree().parent()) {
                 if (RefPtr localAncestor = dynamicDowncast<LocalFrame>(ancestor)) {
                     localAncestor->setHasHadUserInteraction();
                     if (RefPtr ancestorDocument = localAncestor->document())
                         ancestorDocument->updateLastHandledUserGestureTimestamp(currentToken(vm)->startTime());
-                }
+                } else
+                    hasRemoteAncestor = true;
             }
+
+            if (hasRemoteAncestor)
+                frame->loader().client().didHandleFirstUserGesture(currentToken(vm)->startTime());
         }
 
         // https://html.spec.whatwg.org/multipage/interaction.html#user-activation-processing-model

--- a/Source/WebCore/loader/FrameLoaderClient.h
+++ b/Source/WebCore/loader/FrameLoaderClient.h
@@ -57,6 +57,7 @@ public:
     virtual void setPrinting(bool printing, FloatSize pageSize, FloatSize originalPageSize, float maximumShrinkRatio, AdjustViewSize) = 0;
     virtual void didNotifyUserActivation(MonotonicTime) { }
     virtual void didConsumeUserActivation() { }
+    virtual void didHandleFirstUserGesture(MonotonicTime) { }
     virtual ~FrameLoaderClient() = default;
 };
 

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -564,7 +564,10 @@ FocusableElementSearchResult FocusController::findFocusableElementStartingWithLo
 
     // We are advancing focus in this frame's process in response to a keypress in a different frame's process.
     // We therefore assume we have an active user gesture, which is necessary for element-finding and focus-advancing to work.
-    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, document.get());
+    // Avoid doing this for ShouldFocusElement::No, since that is just a query.
+    std::optional<UserGestureIndicator> gestureIndicator;
+    if (shouldFocusElement == ShouldFocusElement::Yes)
+        gestureIndicator.emplace(IsProcessingUserGesture::Yes, document.get());
 
     return findFocusableElementInDocumentOrderStartingWithFrame(frame, document->documentElement(), nullptr, direction, focusEventData, InitialFocus::No, ContinuingRemoteSearch::Yes, shouldFocusElement);
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9050,6 +9050,29 @@ void WebPageProxy::didNotifyUserActivation(IPC::Connection& connection, FrameIde
         protect(process)->send(Messages::WebPage::UpdateUserActivationState(frameIDs, activationTime), webPageIDInProcess(process));
 }
 
+void WebPageProxy::didHandleFirstUserGesture(IPC::Connection& connection, FrameIdentifier sourceFrameID, MonotonicTime gestureTime)
+{
+    Ref senderProcess = WebProcessProxy::fromConnection(connection);
+
+    RefPtr sourceFrame = WebFrameProxy::webFrame(sourceFrameID);
+    if (!sourceFrame)
+        return;
+
+    if (&sourceFrame->process() != senderProcess.ptr())
+        return;
+
+    HashMap<Ref<WebProcessProxy>, Vector<FrameIdentifier>> framesByProcess;
+    for (RefPtr ancestor = sourceFrame->parentFrame(); ancestor; ancestor = ancestor->parentFrame()) {
+        Ref process = ancestor->process();
+        if (process.ptr() == senderProcess.ptr())
+            continue;
+        framesByProcess.add(process, Vector<FrameIdentifier> { }).iterator->value.append(ancestor->frameID());
+    }
+
+    for (auto& [process, frameIDs] : framesByProcess)
+        protect(process)->send(Messages::WebPage::UpdateLastHandledUserGestureTimestamp(frameIDs, gestureTime), webPageIDInProcess(process));
+}
+
 void WebPageProxy::didConsumeUserActivation(IPC::Connection& connection, FrameIdentifier sourceFrameID)
 {
     Ref senderProcess = WebProcessProxy::fromConnection(connection);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2693,6 +2693,7 @@ public:
 
     void didNotifyUserActivation(IPC::Connection&, WebCore::FrameIdentifier, MonotonicTime);
     void didConsumeUserActivation(IPC::Connection&, WebCore::FrameIdentifier);
+    void didHandleFirstUserGesture(IPC::Connection&, WebCore::FrameIdentifier, MonotonicTime);
 
     void addOpenedPage(WebPageProxy&);
     bool NODELETE hasOpenedPage() const;

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -652,6 +652,7 @@ messages -> WebPageProxy {
 
     [EnabledBy=SiteIsolationEnabled] DidNotifyUserActivation(WebCore::FrameIdentifier sourceFrameID, MonotonicTime activationTime)
     [EnabledBy=SiteIsolationEnabled] DidConsumeUserActivation(WebCore::FrameIdentifier sourceFrameID)
+    [EnabledBy=SiteIsolationEnabled] DidHandleFirstUserGesture(WebCore::FrameIdentifier sourceFrameID, MonotonicTime gestureTime)
 
     [EnabledBy=SiteIsolationEnabled] DispatchLoadEventToFrameOwnerElement(WebCore::FrameIdentifier frameID)
     [EnabledBy=SiteIsolationEnabled] AddResourceTimingFromSubframe(WebCore::FrameIdentifier parentFrameID, WebCore::ResourceTiming resourceTiming)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -292,4 +292,10 @@ void WebFrameLoaderClient::didConsumeUserActivation()
         webPage->send(Messages::WebPageProxy::DidConsumeUserActivation(m_frame->frameID()));
 }
 
+void WebFrameLoaderClient::didHandleFirstUserGesture(MonotonicTime gestureTime)
+{
+    if (RefPtr webPage = m_frame->page())
+        webPage->send(Messages::WebPageProxy::DidHandleFirstUserGesture(m_frame->frameID(), gestureTime));
+}
+
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
@@ -86,6 +86,7 @@ protected:
 
     void didNotifyUserActivation(MonotonicTime);
     void didConsumeUserActivation();
+    void didHandleFirstUserGesture(MonotonicTime);
 
     const Ref<WebFrame> m_frame;
     ScopeExit<Function<void()>> m_frameInvalidator;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1135,6 +1135,11 @@ void WebLocalFrameLoaderClient::didConsumeUserActivation()
     WebFrameLoaderClient::didConsumeUserActivation();
 }
 
+void WebLocalFrameLoaderClient::didHandleFirstUserGesture(MonotonicTime gestureTime)
+{
+    WebFrameLoaderClient::didHandleFirstUserGesture(gestureTime);
+}
+
 void WebLocalFrameLoaderClient::cancelPolicyCheck()
 {
     m_frame->invalidatePolicyListeners();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -296,6 +296,7 @@ private:
 
     void didNotifyUserActivation(MonotonicTime) final;
     void didConsumeUserActivation() final;
+    void didHandleFirstUserGesture(MonotonicTime) final;
 
     void dispatchDecidePolicyForBackForwardNavigationAction(WebCore::FrameLoadRequest&&, const String& referer, WebCore::FrameLoadType);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1565,6 +1565,21 @@ void WebPage::updateUserActivationState(const Vector<FrameIdentifier>& frameIDs,
     }
 }
 
+void WebPage::updateLastHandledUserGestureTimestamp(const Vector<FrameIdentifier>& frameIDs, MonotonicTime gestureTime)
+{
+    for (auto frameID : frameIDs) {
+        RefPtr webFrame = WebProcess::singleton().webFrame(frameID);
+        if (!webFrame || webFrame->page() != this)
+            continue;
+        RefPtr localFrame = webFrame->coreLocalFrame();
+        if (!localFrame)
+            continue;
+        localFrame->setHasHadUserInteraction();
+        if (RefPtr document = localFrame->document())
+            document->updateLastHandledUserGestureTimestamp(gestureTime);
+    }
+}
+
 void WebPage::consumeUserActivations(const Vector<FrameIdentifier>& frameIDs)
 {
     for (auto frameID : frameIDs) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -885,6 +885,7 @@ public:
 
     void updateUserActivationState(const Vector<WebCore::FrameIdentifier>&, MonotonicTime);
     void consumeUserActivations(const Vector<WebCore::FrameIdentifier>&);
+    void updateLastHandledUserGestureTimestamp(const Vector<WebCore::FrameIdentifier>&, MonotonicTime);
 
     std::optional<WebCore::SimpleRange> currentSelectionAsRange();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -235,6 +235,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     UpdateUserActivationState(Vector<WebCore::FrameIdentifier> frameIDs, MonotonicTime activationTime)
     ConsumeUserActivations(Vector<WebCore::FrameIdentifier> frameIDs)
+    UpdateLastHandledUserGestureTimestamp(Vector<WebCore::FrameIdentifier> frameIDs, MonotonicTime gestureTime)
 
     GetPDFFirstPageSize(WebCore::FrameIdentifier frameID) -> (WebCore::FloatSize size)
 


### PR DESCRIPTION
#### 7f8277fb2bb0cb76b0b575ecf7e599878e63c438
<pre>
[Site Isolation] User interaction and last user gesture timestamp flags aren&apos;t updated on remote frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=321900">https://bugs.webkit.org/show_bug.cgi?id=321900</a>
<a href="https://rdar.apple.com/185076535">rdar://185076535</a>

Reviewed by Wenson Hsieh.

When a user gesture occurs, UserGestureIndicator currently only updates the user interaction and
last user gesture timestamp flags on local ancestors. This can lead to issues like iframes being
unexpectedly throttled.

Fix this by telling the UIProcess about the user gesture if there is any remote frame ancestor.
UIProcess then broadcasts the user gesture state to the ancestor remote frames.

A one-way broadcast IPC is sufficient here as we only ever set the hasHadUserInteraction and and
lastHandledUserGestureTimestamp flags on ancestor documents; we don&apos;t reset them.

This contains a drive-by fix to `FocusController::findFocusableElementStartingWithLocalFrame` to
avoid setting the user gesture flags on a query. iOS makes those queries to e.g. figure out whether
to show the next/prev buttons in the accessory bar on focus. Fixing this is necessary for the layout
test to actually test the change on iOS. Previously, with site isolation enabled, a focusable
element query would send the FindFocusableElementDescendingIntoRemoteFrame IPC with
ShouldFocusElement::No, and we set the user gesture indicator for it unconditionally. So a
programmatic focus() without direct user interaction could set the user gesture indicator.

* LayoutTests/http/tests/site-isolation/resources/user-gesture-innermost-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/user-gesture-middle-frame.html: Added.
* LayoutTests/http/tests/site-isolation/user-gesture-in-cross-origin-iframe-reaches-ancestor-in-another-process-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/user-gesture-in-cross-origin-iframe-reaches-ancestor-in-another-process.html: Added.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::UserGestureIndicator::UserGestureIndicator):
* Source/WebCore/loader/FrameLoaderClient.h:
(WebCore::FrameLoaderClient::didHandleFirstUserGesture):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementStartingWithLocalFrame):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didNotifyUserActivation):
(WebKit::WebPageProxy::didHandleFirstUserGesture):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::didHandleFirstUserGesture):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didHandleFirstUserGesture):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateLastHandledUserGestureTimestamp):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/319332@main">https://commits.webkit.org/319332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd9d286118a4c3fc82b3adfb7c744265e7bdeaa9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145448 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a7f23ac-c651-480a-ae66-1631998a2a32) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141348 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d66799e5-4595-4ba9-b50e-d68a08caead1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121799 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36aae347-bde4-495a-8c10-d95fe3db285c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43681 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41956 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41621 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2499 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193274 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150731 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40380 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55424 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150447 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45037 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127690 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123239 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53941 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16617 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53323 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53388 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->