### PR TITLE
Convert SkipEmptySectionsValue to a scoped enum class

### DIFF
--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -1067,7 +1067,7 @@ RenderTableSection* RenderTable::topNonEmptySection() const
 {
     RenderTableSection* section = topSection();
     if (section && !section->numRows())
-        section = sectionBelow(section, SkipEmptySections);
+        section = sectionBelow(section, SkipEmptySections::Yes);
     return section;
 }
 
@@ -1075,7 +1075,7 @@ RenderTableSection* RenderTable::bottomNonEmptySection() const
 {
     auto* section = bottomSection();
     if (section && !section->numRows())
-        section = sectionAbove(section, SkipEmptySections);
+        section = sectionAbove(section, SkipEmptySections::Yes);
     return section;
 }
 
@@ -1582,7 +1582,7 @@ LayoutUnit RenderTable::outerBorderEnd() const
     return borderWidth;
 }
 
-RenderTableSection* RenderTable::sectionAbove(const RenderTableSection* section, SkipEmptySectionsValue skipEmptySections) const
+RenderTableSection* RenderTable::sectionAbove(const RenderTableSection* section, SkipEmptySections skipEmptySections) const
 {
     recalcSectionsIfNeeded();
 
@@ -1592,16 +1592,16 @@ RenderTableSection* RenderTable::sectionAbove(const RenderTableSection* section,
     RenderObject* prevSection = section == m_foot ? lastChild() : section->previousSibling();
     while (prevSection) {
         auto* tableSection = dynamicDowncast<RenderTableSection>(*prevSection);
-        if (tableSection && prevSection != m_head && prevSection != m_foot && (skipEmptySections == DoNotSkipEmptySections || tableSection->numRows()))
+        if (tableSection && prevSection != m_head && prevSection != m_foot && (skipEmptySections == SkipEmptySections::No || tableSection->numRows()))
             return tableSection;
         prevSection = prevSection->previousSibling();
     }
-    if (!prevSection && m_head && (skipEmptySections == DoNotSkipEmptySections || m_head->numRows()))
+    if (!prevSection && m_head && (skipEmptySections == SkipEmptySections::No || m_head->numRows()))
         return m_head.get();
     return nullptr;
 }
 
-RenderTableSection* RenderTable::sectionBelow(const RenderTableSection* section, SkipEmptySectionsValue skipEmptySections) const
+RenderTableSection* RenderTable::sectionBelow(const RenderTableSection* section, SkipEmptySections skipEmptySections) const
 {
     recalcSectionsIfNeeded();
 
@@ -1611,11 +1611,11 @@ RenderTableSection* RenderTable::sectionBelow(const RenderTableSection* section,
     RenderObject* nextSection = section == m_head ? firstChild() : section->nextSibling();
     while (nextSection) {
         auto* tableSection = dynamicDowncast<RenderTableSection>(*nextSection);
-        if (tableSection && nextSection != m_head && nextSection != m_foot && (skipEmptySections  == DoNotSkipEmptySections || tableSection->numRows()))
+        if (tableSection && nextSection != m_head && nextSection != m_foot && (skipEmptySections == SkipEmptySections::No || tableSection->numRows()))
             return tableSection;
         nextSection = nextSection->nextSibling();
     }
-    if (!nextSection && m_foot && (skipEmptySections == DoNotSkipEmptySections || m_foot->numRows()))
+    if (!nextSection && m_foot && (skipEmptySections == SkipEmptySections::No || m_foot->numRows()))
         return m_foot.get();
     return nullptr;
 }
@@ -1633,7 +1633,7 @@ RenderTableCell* RenderTable::cellAbove(const RenderTableCell* cell) const
         section = cell->section();
         rAbove = r - 1;
     } else {
-        section = sectionAbove(cell->section(), SkipEmptySections);
+        section = sectionAbove(cell->section(), SkipEmptySections::Yes);
         if (section) {
             ASSERT(section->numRows());
             rAbove = section->numRows() - 1;
@@ -1662,7 +1662,7 @@ RenderTableCell* RenderTable::cellBelow(const RenderTableCell* cell) const
         section = cell->section();
         rBelow = r + 1;
     } else {
-        section = sectionBelow(cell->section(), SkipEmptySections);
+        section = sectionBelow(cell->section(), SkipEmptySections::Yes);
         if (section)
             rBelow = 0;
     }

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -41,7 +41,7 @@ class RenderTableRow;
 class RenderTableSection;
 class TableLayout;
 
-enum SkipEmptySectionsValue { DoNotSkipEmptySections, SkipEmptySections };
+enum class SkipEmptySections : bool { No, Yes };
 enum class TableIntrinsics : uint8_t { ForLayout, ForKeyword };
 
 class RenderTable : public RenderBlock {
@@ -171,8 +171,8 @@ public:
     bool needsSectionRecalc() const { return m_needsSectionRecalc; }
     void setNeedsSectionRecalc();
 
-    RenderTableSection* sectionAbove(const RenderTableSection*, SkipEmptySectionsValue = DoNotSkipEmptySections) const;
-    RenderTableSection* sectionBelow(const RenderTableSection*, SkipEmptySectionsValue = DoNotSkipEmptySections) const;
+    RenderTableSection* sectionAbove(const RenderTableSection*, SkipEmptySections = SkipEmptySections::No) const;
+    RenderTableSection* sectionBelow(const RenderTableSection*, SkipEmptySections = SkipEmptySections::No) const;
 
     RenderTableCell* cellAbove(const RenderTableCell*) const;
     RenderTableCell* cellBelow(const RenderTableCell*) const;

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1034,7 +1034,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedBeforeBorder(IncludeBorder
             return result;
         
         // (6) Previous row group's after border.
-        currSection = table->sectionAbove(currSection, SkipEmptySections);
+        currSection = table->sectionAbove(currSection, SkipEmptySections::Yes);
         if (currSection) {
             result = chooseBorder(CollapsedBorderValue(currSection->style().borderAfter(tableWritingMode()), includeColor ? resolvedBorderColor(currSection->style(), afterColorProperty) : Color(), BorderPrecedence::RowGroup, currSection->style().usedZoomForLength(), deviceScaleFactor), result);
             if (!result.exists())
@@ -1129,7 +1129,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
             return result;
         
         // (6) Following row group's before border.
-        currSection = table->sectionBelow(currSection, SkipEmptySections);
+        currSection = table->sectionBelow(currSection, SkipEmptySections::Yes);
         if (currSection) {
             result = chooseBorder(result, CollapsedBorderValue(currSection->style().borderBefore(tableWritingMode()), includeColor ? resolvedBorderColor(currSection->style(), beforeColorProperty) : Color(), BorderPrecedence::RowGroup, currSection->style().usedZoomForLength(), deviceScaleFactor));
             if (!result.exists())


### PR DESCRIPTION
#### be49eaa31fa4b97d4d39adafa618a3ab9ec5162e
<pre>
Convert SkipEmptySectionsValue to a scoped enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=321901">https://bugs.webkit.org/show_bug.cgi?id=321901</a>
<a href="https://rdar.apple.com/185077973">rdar://185077973</a>

Reviewed by Alan Baradlay.

Replace the unscoped `enum SkipEmptySectionsValue { DoNotSkipEmptySections,
SkipEmptySections }` in RenderTable.h with `enum class SkipEmptySections : bool
{ No, Yes }`, so the enumerators no longer leak into the WebCore namespace and
the underlying type is explicit.

The only clients are RenderTable itself and RenderTableCell&apos;s collapsed-border
computation, so all fifteen references are updated here; no behavior change.

Also drop a stray double space in one of the comparisons in sectionBelow().

* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::topNonEmptySection const):
(WebCore::RenderTable::bottomNonEmptySection const):
(WebCore::RenderTable::sectionAbove const):
(WebCore::RenderTable::sectionBelow const):
(WebCore::RenderTable::cellAbove const):
(WebCore::RenderTable::cellBelow const):
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::computeCollapsedBeforeBorder const):
(WebCore::RenderTableCell::computeCollapsedAfterBorder const):

Canonical link: <a href="https://commits.webkit.org/319315@main">https://commits.webkit.org/319315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bec3972e1f1a086325dbb0109d2149511cfd49a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191226 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145335 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b44a3c5-e5ca-4ccc-8bb9-a3a37894363e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141234 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/573088fc-6252-48c0-956d-2113dd425b2b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121686 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a3f33505-4ff7-4b1e-974d-e33d9b3f102a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43570 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41850 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41510 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2386 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193161 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54623 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150620 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40344 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55311 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150337 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44927 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127577 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123084 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53828 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16506 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53210 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53447 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53275 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->