### PR TITLE
[WTF] Add small inlined memcpy for copyElements

### DIFF
--- a/Source/JavaScriptCore/b3/B3Operations.cpp
+++ b/Source/JavaScriptCore/b3/B3Operations.cpp
@@ -37,41 +37,9 @@ namespace JSC::B3 {
 
 namespace {
 
-#if HAVE(INT128_T)
-using WidestUnit = UInt128;
-#else
-using WidestUnit = uint64_t;
-#endif
+using WTF::WidestUnalignedUnit;
 
-constexpr size_t maxFastCopyCount = 4 * sizeof(WidestUnit);
-constexpr size_t maxFastFillCount = 4 * sizeof(WidestUnit);
-
-// Copies count bytes as two overlapping sizeof(T) accesses, so it needs
-// sizeof(T) <= count <= 2 * sizeof(T). Both source reads happen before either destination write,
-// which is what makes this safe for overlapping ranges without comparing the two pointers.
-template<typename T>
-ALWAYS_INLINE void copyOverlappingEnds(uint8_t* dst, const uint8_t* src, size_t count)
-{
-    T low = WTF::unalignedLoad<T>(src);
-    T high = WTF::unalignedLoad<T>(src + count - sizeof(T));
-    WTF::unalignedStore<T>(dst, low);
-    WTF::unalignedStore<T>(dst + count - sizeof(T), high);
-}
-
-// The same idea one step wider: two overlapping pairs, for
-// 2 * sizeof(T) <= count <= 4 * sizeof(T).
-template<typename T>
-ALWAYS_INLINE void copyOverlappingEndPairs(uint8_t* dst, const uint8_t* src, size_t count)
-{
-    T low0 = WTF::unalignedLoad<T>(src);
-    T low1 = WTF::unalignedLoad<T>(src + sizeof(T));
-    T high0 = WTF::unalignedLoad<T>(src + count - 2 * sizeof(T));
-    T high1 = WTF::unalignedLoad<T>(src + count - sizeof(T));
-    WTF::unalignedStore<T>(dst, low0);
-    WTF::unalignedStore<T>(dst + sizeof(T), low1);
-    WTF::unalignedStore<T>(dst + count - 2 * sizeof(T), high0);
-    WTF::unalignedStore<T>(dst + count - sizeof(T), high1);
-}
+constexpr size_t maxFastFillCount = 4 * sizeof(WidestUnalignedUnit);
 
 // Writes count bytes as two overlapping runs of unitsPerEnd stores, so it needs
 // unitsPerEnd * sizeof(T) <= count <= 2 * unitsPerEnd * sizeof(T). Every store writes the same
@@ -93,17 +61,8 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryCopy, void, (void* dst, const v
     // emits for memcpy. libc's memmove spends more on dispatching by size than a short copy costs,
     // so handle the short counts here. One unsigned compare rejects both the too-short and the
     // too-long counts.
-    if (count - sizeof(uint32_t) <= maxFastCopyCount - sizeof(uint32_t)) {
-        auto* to = static_cast<uint8_t*>(dst);
-        const auto* from = static_cast<const uint8_t*>(src);
-        if (count < sizeof(uint64_t))
-            copyOverlappingEnds<uint32_t>(to, from, count);
-        else if (count < 2 * sizeof(uint64_t))
-            copyOverlappingEnds<uint64_t>(to, from, count);
-        else if (count < 2 * sizeof(WidestUnit))
-            copyOverlappingEnds<WidestUnit>(to, from, count);
-        else
-            copyOverlappingEndPairs<WidestUnit>(to, from, count);
+    if (count - sizeof(uint32_t) <= WTF::maxSmallCopySize - sizeof(uint32_t)) {
+        WTF::copySmallMemory<sizeof(uint32_t)>(static_cast<uint8_t*>(dst), static_cast<const uint8_t*>(src), count);
         return;
     }
     memmove(dst, src, count);
@@ -114,9 +73,9 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryFill, void, (void* dst, int32_t
     if (count - 1 <= maxFastFillCount - 1) {
         auto* to = static_cast<uint8_t*>(dst);
         uint64_t splat = static_cast<uint8_t>(target) * 0x0101010101010101ULL;
-        WidestUnit widest = splat;
-        if constexpr (sizeof(WidestUnit) > sizeof(uint64_t))
-            widest = (static_cast<WidestUnit>(splat) << 64) | splat;
+        WidestUnalignedUnit widest = splat;
+        if constexpr (sizeof(WidestUnalignedUnit) > sizeof(uint64_t))
+            widest = (static_cast<WidestUnalignedUnit>(splat) << 64) | splat;
         if (count < sizeof(uint16_t))
             fillOverlappingEnds<uint8_t, 1>(to, static_cast<uint8_t>(splat), count);
         else if (count < sizeof(uint32_t))
@@ -125,10 +84,10 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryFill, void, (void* dst, int32_t
             fillOverlappingEnds<uint32_t, 1>(to, static_cast<uint32_t>(splat), count);
         else if (count < 2 * sizeof(uint64_t))
             fillOverlappingEnds<uint64_t, 1>(to, splat, count);
-        else if (count < 2 * sizeof(WidestUnit))
-            fillOverlappingEnds<WidestUnit, 1>(to, widest, count);
+        else if (count < 2 * sizeof(WidestUnalignedUnit))
+            fillOverlappingEnds<WidestUnalignedUnit, 1>(to, widest, count);
         else
-            fillOverlappingEnds<WidestUnit, 2>(to, widest, count);
+            fillOverlappingEnds<WidestUnalignedUnit, 2>(to, widest, count);
         return;
     }
     memset(dst, target, count);

--- a/Source/WTF/wtf/UnalignedAccess.h
+++ b/Source/WTF/wtf/UnalignedAccess.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <type_traits>
+#include <wtf/Int128.h>
 #include <wtf/Platform.h>
 #include <wtf/StdLibExtras.h>
 
@@ -50,5 +51,82 @@ inline void unalignedStore(void* pointer, Type value)
     memcpy(pointer, &value, sizeof(Type));
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
+
+// The widest type a single unaligned load or store lowers to one machine access.
+#if HAVE(INT128_T)
+using WidestUnalignedUnit = UInt128;
+#else
+using WidestUnalignedUnit = uint64_t;
+#endif
+
+constexpr size_t maxSmallCopySize = 4 * sizeof(WidestUnalignedUnit);
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+// Both source reads happen before either destination write, which is what makes this safe for
+// overlapping ranges without comparing the two pointers.
+template<typename Type>
+ALWAYS_INLINE void copyOverlappingEnds(uint8_t* destination, const uint8_t* source, size_t count)
+{
+    ASSERT(count >= sizeof(Type) && count <= 2 * sizeof(Type));
+    Type low = unalignedLoad<Type>(source);
+    Type high = unalignedLoad<Type>(source + count - sizeof(Type));
+    unalignedStore<Type>(destination, low);
+    unalignedStore<Type>(destination + count - sizeof(Type), high);
+}
+
+template<typename Type>
+ALWAYS_INLINE void copyOverlappingEndPairs(uint8_t* destination, const uint8_t* source, size_t count)
+{
+    ASSERT(count >= 2 * sizeof(Type) && count <= 4 * sizeof(Type));
+    Type low0 = unalignedLoad<Type>(source);
+    Type low1 = unalignedLoad<Type>(source + sizeof(Type));
+    Type high0 = unalignedLoad<Type>(source + count - 2 * sizeof(Type));
+    Type high1 = unalignedLoad<Type>(source + count - sizeof(Type));
+    unalignedStore<Type>(destination, low0);
+    unalignedStore<Type>(destination + sizeof(Type), low1);
+    unalignedStore<Type>(destination + count - 2 * sizeof(Type), high0);
+    unalignedStore<Type>(destination + count - sizeof(Type), high1);
+}
+
+// Copies a count the caller already knows to be in [minimumCount, maximumCount] without calling
+// libc, which spends more on dispatching by size than a copy this short costs. Overlapping ranges
+// are safe, as with memmove. Each bound the caller can tighten drops a compare and an arm.
+template<size_t minimumCount = sizeof(uint16_t), size_t maximumCount = maxSmallCopySize>
+ALWAYS_INLINE void copySmallMemory(uint8_t* destination, const uint8_t* source, size_t count)
+{
+    static_assert(minimumCount >= sizeof(uint16_t));
+    static_assert(maximumCount <= maxSmallCopySize);
+    ASSERT(count >= minimumCount);
+    ASSERT(count <= maximumCount);
+
+    if constexpr (minimumCount < 2 * sizeof(uint16_t)) {
+        if (maximumCount <= 2 * sizeof(uint16_t) || count < 2 * sizeof(uint16_t)) {
+            copyOverlappingEnds<uint16_t>(destination, source, count);
+            return;
+        }
+    }
+    if constexpr (minimumCount < 2 * sizeof(uint32_t)) {
+        if (maximumCount <= 2 * sizeof(uint32_t) || count < 2 * sizeof(uint32_t)) {
+            copyOverlappingEnds<uint32_t>(destination, source, count);
+            return;
+        }
+    }
+    if constexpr (minimumCount < 2 * sizeof(uint64_t)) {
+        if (maximumCount <= 2 * sizeof(uint64_t) || count < 2 * sizeof(uint64_t)) {
+            copyOverlappingEnds<uint64_t>(destination, source, count);
+            return;
+        }
+    }
+    if constexpr (minimumCount < 2 * sizeof(WidestUnalignedUnit)) {
+        if (maximumCount <= 2 * sizeof(WidestUnalignedUnit) || count < 2 * sizeof(WidestUnalignedUnit)) {
+            copyOverlappingEnds<WidestUnalignedUnit>(destination, source, count);
+            return;
+        }
+    }
+    copyOverlappingEndPairs<WidestUnalignedUnit>(destination, source, count);
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1474,16 +1474,27 @@ inline bool equalIgnoringASCIICase(ASCIILiteral a, ASCIILiteral b)
 }
 
 template<typename ElementType>
-inline void copyElements(std::span<ElementType> destinationSpan, std::span<const ElementType> sourceSpan)
+ALWAYS_INLINE void copyElements(std::span<ElementType> destinationSpan, std::span<const ElementType> sourceSpan)
 {
     ASSERT(!spansOverlap(destinationSpan, sourceSpan));
     RELEASE_ASSERT(destinationSpan.size() >= sourceSpan.size());
     auto* __restrict destination = destinationSpan.data();
     auto* __restrict source = sourceSpan.data();
-    if (sourceSpan.size() == 1)
+    if (sourceSpan.size() == 1) {
         *destination = *source;
-    else if (!sourceSpan.empty())
-        std::memcpy(destination, source, sourceSpan.size_bytes());
+        return;
+    }
+
+    // memcpy cannot inline itself for a count it does not know, and copies short enough to pass
+    // through a few registers are common enough here to be worth keeping out of libc.
+    constexpr size_t maxInlineCopySize = 32;
+    size_t count = sourceSpan.size_bytes();
+    if (isInRange<size_t>(count, 2, maxInlineCopySize)) {
+        copySmallMemory<2, maxInlineCopySize>(reinterpret_cast<uint8_t*>(destination), reinterpret_cast<const uint8_t*>(source), count);
+        return;
+    }
+    if (count)
+        std::memcpy(destination, source, count); // NOLINT
 }
 
 inline void copyElements(std::span<uint16_t> destinationSpan, std::span<const uint8_t> sourceSpan)


### PR DESCRIPTION
#### 2d0855229c8f35a87c7bca8f36456ed76f86a5fb
<pre>
[WTF] Add small inlined memcpy for copyElements
<a href="https://bugs.webkit.org/show_bug.cgi?id=321902">https://bugs.webkit.org/show_bug.cgi?id=321902</a>
<a href="https://rdar.apple.com/185078337">rdar://185078337</a>

Reviewed by Yijia Huang.

We found that our memcpy / memmove is not efficient enough for small
copying, and it is commonly happening in practice. This patch moves B3&apos;s
MemoryCopy&apos;s preceding small copying code to WTF so that we can apply
the same optimizations to copyElements.

* Source/JavaScriptCore/b3/B3Operations.cpp:
(JSC::B3::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/WTF/wtf/UnalignedAccess.h:
(WTF::copyOverlappingEnds):
(WTF::copyOverlappingEndPairs):
(WTF::copySmallMemory):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::copyElements):

Canonical link: <a href="https://commits.webkit.org/319274@main">https://commits.webkit.org/319274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3a8a908d01785fb4d9161194a4870c2397c8628

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145340 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd740663-a524-4373-90f5-626f5481ed98) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54678 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10398303-7e43-4f84-9ea5-8f1c793248da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161990 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/121697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ed52588-44ee-4818-823e-deee2cb90bd5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43577 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41857 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/3662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/10473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41517 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2391 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42291 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47574 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193166 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54628 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150627 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55316 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150344 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27472 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44934 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127582 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123092 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53833 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16513 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53215 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53452 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53280 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->