### PR TITLE
[JSC] Move `PropertyInlineCache`'s buffered-structures set to `RepatchingPropertyInlineCache`

### DIFF
--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
@@ -43,12 +43,13 @@ static constexpr bool verbose = false;
 PropertyInlineCache::~PropertyInlineCache() = default;
 
 RepatchingPropertyInlineCache::RepatchingPropertyInlineCache()
-    : PropertyInlineCache(PropertyInlineCacheType::Repatching)
+    : RepatchingPropertyInlineCache(AccessType::GetById, { })
 {
 }
 
 RepatchingPropertyInlineCache::RepatchingPropertyInlineCache(AccessType accessType, CodeOrigin codeOrigin)
     : PropertyInlineCache(PropertyInlineCacheType::Repatching, accessType, codeOrigin)
+    , bufferingCountdown(Options::initialRepatchBufferingCountdown())
 {
 }
 
@@ -177,21 +178,11 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
             if (result.shouldResetStubAndFireWatchpoints())
                 return result;
 
-            if (!result.buffered()) {
-                clearBufferedStructures();
+            if (!result.buffered())
                 return result;
-            }
             setCacheType(locker, CacheType::Stub);
 
             RELEASE_ASSERT(!result.generatedSomeCode());
-
-            // If we didn't buffer any cases then bail. If this made no changes then we'll just try again
-            // subject to cool-down.
-            if (!result.buffered()) {
-                dataLogLnIf(PropertyInlineCacheInternal::verbose, "Didn't buffer anything, bailing.");
-                clearBufferedStructures();
-                return result;
-            }
 
             InlineCacheCompiler compiler(codeBlock->jitType(), vm, globalObject, ecmaMode, *this);
             return compiler.compileHandler(locker, WTF::move(list), codeBlock, accessCase.get());
@@ -207,7 +198,7 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
                 return result;
 
             if (!result.buffered()) {
-                clearBufferedStructures();
+                repatchingIC.clearBufferedStructures();
                 return result;
             }
         } else {
@@ -220,7 +211,7 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
                 return result;
 
             if (!result.buffered()) {
-                clearBufferedStructures();
+                repatchingIC.clearBufferedStructures();
                 return result;
             }
 
@@ -231,23 +222,15 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
         ASSERT(m_cacheType == CacheType::Stub);
         RELEASE_ASSERT(!result.generatedSomeCode());
 
-        // If we didn't buffer any cases then bail. If this made no changes then we'll just try again
-        // subject to cool-down.
-        if (!result.buffered()) {
-            dataLogLnIf(PropertyInlineCacheInternal::verbose, "Didn't buffer anything, bailing.");
-            clearBufferedStructures();
-            return result;
-        }
-
         // The buffering countdown tells us if we should be repatching now.
-        if (bufferingCountdown) {
-            dataLogLnIf(PropertyInlineCacheInternal::verbose, "Countdown is too high: ", bufferingCountdown, ".");
+        if (repatchingIC.bufferingCountdown) {
+            dataLogLnIf(PropertyInlineCacheInternal::verbose, "Countdown is too high: ", repatchingIC.bufferingCountdown, ".");
             return result;
         }
 
         // Forget the buffered structures so that all future attempts to cache get fully handled by the
         // PolymorphicAccess.
-        clearBufferedStructures();
+        repatchingIC.clearBufferedStructures();
 
         InlineCacheCompiler compiler(codeBlock->jitType(), vm, globalObject, ecmaMode, *this);
         result = compiler.compile(locker, *repatchingIC.m_stub, codeBlock);
@@ -270,7 +253,7 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
 
         // If we generated some code then we don't want to attempt to repatch in the future until we
         // gather enough cases.
-        bufferingCountdown = Options::repatchBufferingCountdown();
+        repatchingIC.bufferingCountdown = Options::repatchBufferingCountdown();
         return result;
     })(accessCase.releaseNonNull());
     if (result.generatedSomeCode()) {
@@ -286,12 +269,12 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
 
 void PropertyInlineCache::reset(const ConcurrentJSLockerBase& locker, CodeBlock* codeBlock)
 {
-    clearBufferedStructures();
     m_inlineAccessBaseStructureID.clear();
     if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
         if (handlerIC->m_inlinedHandler)
             handlerIC->clearInlinedHandler(codeBlock);
-    }
+    } else
+        downcast<RepatchingPropertyInlineCache>(*this).clearBufferedStructures();
 
     if (m_cacheType == CacheType::Unset)
         return;
@@ -398,19 +381,39 @@ void PropertyInlineCache::reset(const ConcurrentJSLockerBase& locker, CodeBlock*
 }
 
 template<typename Visitor>
+void RepatchingPropertyInlineCache::visitBufferedStructures(Visitor& visitor)
+{
+    Locker locker { m_bufferedStructuresLock };
+    WTF::switchOn(m_bufferedStructures,
+        [&](std::monostate) { },
+        [&](Vector<StructureID>&) { },
+        [&](Vector<std::tuple<StructureID, CacheableIdentifier>>& structures) {
+            for (auto& [bufferedStructureID, bufferedCacheableIdentifier] : structures)
+                bufferedCacheableIdentifier.visitAggregate(visitor);
+        });
+}
+
+void RepatchingPropertyInlineCache::pruneDeadBufferedStructures(VM& vm)
+{
+    Locker locker { m_bufferedStructuresLock };
+    WTF::switchOn(m_bufferedStructures,
+        [&](std::monostate) { },
+        [&](Vector<StructureID>& structures) {
+            structures.removeAllMatching([&](StructureID structureID) {
+                return !vm.heap.isMarked(structureID.decode());
+            });
+        },
+        [&](Vector<std::tuple<StructureID, CacheableIdentifier>>& structures) {
+            structures.removeAllMatching([&](auto& tuple) {
+                return !vm.heap.isMarked(std::get<0>(tuple).decode());
+            });
+        });
+}
+
+template<typename Visitor>
 void PropertyInlineCache::visitAggregateImpl(Visitor& visitor)
 {
-    if (!m_identifier) {
-        Locker locker { m_bufferedStructuresLock };
-        WTF::switchOn(m_bufferedStructures,
-            [&](std::monostate) { },
-            [&](Vector<StructureID>&) { },
-            [&](Vector<std::tuple<StructureID, CacheableIdentifier>>& structures) {
-                for (auto& [bufferedStructureID, bufferedCacheableIdentifier] : structures)
-                    bufferedCacheableIdentifier.visitAggregate(visitor);
-            });
-    } else
-        m_identifier.visitAggregate(visitor);
+    m_identifier.visitAggregate(visitor);
 
     if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
         if (handlerIC->m_inlinedHandler)
@@ -424,6 +427,7 @@ void PropertyInlineCache::visitAggregateImpl(Visitor& visitor)
     }
 
     if (auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(*this)) {
+        repatchingIC->visitBufferedStructures(visitor);
         if (repatchingIC->m_stub)
             repatchingIC->m_stub->visitAggregate(visitor);
     }
@@ -434,22 +438,6 @@ DEFINE_VISIT_AGGREGATE(PropertyInlineCache);
 void PropertyInlineCache::reconcileWeakReferencesAtGCEnd(const ConcurrentJSLockerBase& locker, CodeBlock* codeBlock)
 {
     VM& vm = codeBlock->vm();
-    {
-        Locker locker { m_bufferedStructuresLock };
-        WTF::switchOn(m_bufferedStructures,
-            [&](std::monostate) { },
-            [&](Vector<StructureID>& structures) {
-                structures.removeAllMatching([&](StructureID structureID) {
-                    return !vm.heap.isMarked(structureID.decode());
-                });
-            },
-            [&](Vector<std::tuple<StructureID, CacheableIdentifier>>& structures) {
-                structures.removeAllMatching([&](auto& tuple) {
-                    return !vm.heap.isMarked(std::get<0>(tuple).decode());
-                });
-            });
-    }
-
     bool isValid = true;
     if (Structure* structure = inlineAccessBaseStructure())
         isValid &= vm.heap.isMarked(structure);
@@ -466,6 +454,7 @@ void PropertyInlineCache::reconcileWeakReferencesAtGCEnd(const ConcurrentJSLocke
     }
 
     if (auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(*this)) {
+        repatchingIC->pruneDeadBufferedStructures(vm);
         if (repatchingIC->m_stub)
             isValid &= repatchingIC->m_stub->isStillLive(vm);
     }
@@ -780,9 +769,6 @@ void HandlerPropertyInlineCache::initializeFromUnlinkedPropertyInlineCache(VM& v
     propertyIsInt32 = unlinkedPropertyCache.propertyIsInt32;
     canBeMegamorphic = unlinkedPropertyCache.canBeMegamorphic;
 
-    if (unlinkedPropertyCache.canBeMegamorphic)
-        bufferingCountdown = 1;
-
     m_slowOperation = slowOperationFromUnlinkedPropertyInlineCache(unlinkedPropertyCache);
 }
 
@@ -814,9 +800,6 @@ void HandlerPropertyInlineCache::initializeFromDFGUnlinkedPropertyInlineCache(Co
     propertyIsString = unlinkedPropertyCache.propertyIsString;
     prototypeIsKnownObject = unlinkedPropertyCache.prototypeIsKnownObject;
     canBeMegamorphic = unlinkedPropertyCache.canBeMegamorphic;
-
-    if (unlinkedPropertyCache.canBeMegamorphic)
-        bufferingCountdown = 1;
 
     m_slowOperation = slowOperationFromUnlinkedPropertyInlineCache(unlinkedPropertyCache);
 }

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
@@ -218,122 +218,14 @@ public:
 private:
     AccessGenerationResult upgradeForPolyProtoIfNecessary(const GCSafeConcurrentJSLocker&, VM&, CodeBlock*, const Vector<AccessCase*, 16>&, AccessCase&);
 
-    ALWAYS_INLINE bool considerRepatchingCacheImpl(VM& vm, CodeBlock* codeBlock, Structure* structure, CacheableIdentifier impl)
-    {
-        AssertNoGC assertNoGC;
-
-
-        // This method is called from the Optimize variants of IC slow paths. The first part of this
-        // method tries to determine if the Optimize variant should really behave like the
-        // non-Optimize variant and leave the IC untouched.
-        //
-        // If we determine that we should do something to the IC then the next order of business is
-        // to determine if this Structure would impact the IC at all. We know that it won't, if we
-        // have already buffered something on its behalf. That's what the m_bufferedStructures set is
-        // for.
-
-        everConsidered = true;
-        if (!countdown) {
-            // Check if we have been doing repatching too frequently. If so, then we should cool off
-            // for a while.
-            WTF::incrementWithSaturation(repatchCount);
-            if (repatchCount > Options::repatchCountForCoolDown()) {
-                // We've been repatching too much, so don't do it now.
-                repatchCount = 0;
-                // The amount of time we require for cool-down depends on the number of times we've
-                // had to cool down in the past. The relationship is exponential. The max value we
-                // allow here is 2^256 - 2, since the slow paths may increment the count to indicate
-                // that they'd like to temporarily skip patching just this once.
-                countdown = WTF::leftShiftWithSaturation(
-                    static_cast<uint8_t>(Options::initialCoolDownCount()),
-                    numberOfCoolDowns,
-                    static_cast<uint8_t>(std::numeric_limits<uint8_t>::max() - 1));
-                WTF::incrementWithSaturation(numberOfCoolDowns);
-
-                // We may still have had something buffered. Trigger generation now.
-                bufferingCountdown = 0;
-                return true;
-            }
-
-            // We don't want to return false due to buffering indefinitely.
-            if (!bufferingCountdown) {
-                // Note that when this returns true, it's possible that we will not even get an
-                // AccessCase because this may cause Repatch.cpp to simply do an in-place
-                // repatching.
-                return true;
-            }
-
-            bufferingCountdown--;
-
-            if (!structure)
-                return true;
-
-            // Now protect the IC buffering. We want to proceed only if this is a structure that
-            // we don't already have a case buffered for. Note that if this returns true but the
-            // bufferingCountdown is not zero then we will buffer the access case for later without
-            // immediately generating code for it.
-            //
-            // NOTE: This will behave oddly for InstanceOf if the user varies the prototype but not
-            // the base's structure. That seems unlikely for the canonical use of instanceof, where
-            // the prototype is fixed.
-            bool isNewlyAdded = false;
-            StructureID structureID = structure->id();
-            {
-                Locker locker { m_bufferedStructuresLock };
-                if (std::holds_alternative<std::monostate>(m_bufferedStructures)) {
-                    if (m_identifier)
-                        m_bufferedStructures = Vector<StructureID>();
-                    else
-                        m_bufferedStructures = Vector<std::tuple<StructureID, CacheableIdentifier>>();
-                }
-                WTF::switchOn(m_bufferedStructures,
-                    [&](std::monostate) { },
-                    [&](Vector<StructureID>& structures) {
-                        for (auto bufferedStructureID : structures) {
-                            if (bufferedStructureID == structureID)
-                                return;
-                        }
-                        structures.append(structureID);
-                        isNewlyAdded = true;
-                    },
-                    [&](Vector<std::tuple<StructureID, CacheableIdentifier>>& structures) {
-                        ASSERT(!m_identifier);
-                        for (auto& [bufferedStructureID, bufferedCacheableIdentifier] : structures) {
-                            if (bufferedStructureID == structureID && bufferedCacheableIdentifier == impl)
-                                return;
-                        }
-                        structures.append(std::tuple { structureID, impl });
-                        isNewlyAdded = true;
-                    });
-            }
-            if (isNewlyAdded)
-                vm.writeBarrier(codeBlock);
-            return isNewlyAdded;
-        }
-        countdown--;
-        return false;
-    }
+    ALWAYS_INLINE bool considerRepatchingCacheImpl(VM&, CodeBlock*, Structure*, CacheableIdentifier);
 
     void setCacheType(const ConcurrentJSLockerBase&, CacheType);
-
-    void clearBufferedStructures()
-    {
-        Locker locker { m_bufferedStructuresLock };
-        WTF::switchOn(m_bufferedStructures,
-            [&](std::monostate) { },
-            [&](Vector<StructureID>& structures) {
-                structures.shrink(0);
-            },
-            [&](Vector<std::tuple<StructureID, CacheableIdentifier>>& structures) {
-                structures.shrink(0);
-            });
-    }
 
 protected:
     PropertyInlineCache(PropertyInlineCacheType icType, AccessType accessType, CodeOrigin codeOrigin)
         : codeOrigin(codeOrigin)
         , accessType(accessType)
-        , bufferingCountdown(Options::initialRepatchBufferingCountdown())
         , m_icType(icType)
     {
     }
@@ -408,11 +300,6 @@ private:
     // (accessed from JIT via offsetOfHandler()). Repatching IC uses it in
     // rewireStubAsJumpInAccess() and initializeWithUnitHandler().
     RefPtr<InlineCacheHandler> m_handler;
-    // Represents those structures that already have buffered AccessCases in the PolymorphicAccess.
-    // Note that it's always safe to clear this. If we clear it prematurely, then if we see the same
-    // structure again during this buffering countdown, we will create an AccessCase object for it.
-    // That's not so bad - we'll get rid of the redundant ones once we regenerate.
-    Variant<std::monostate, Vector<StructureID>, Vector<std::tuple<StructureID, CacheableIdentifier>>> m_bufferedStructures WTF_GUARDED_BY_LOCK(m_bufferedStructuresLock);
 public:
 
     CallSiteIndex callSiteIndex;
@@ -427,10 +314,6 @@ public:
     uint8_t countdown { 1 };
     uint8_t repatchCount { 0 };
     uint8_t numberOfCoolDowns { 0 };
-    uint8_t bufferingCountdown;
-private:
-    Lock m_bufferedStructuresLock;
-public:
     bool resetByGC : 1 { false };
     bool tookSlowPath : 1 { false };
     bool everConsidered : 1 { false };
@@ -647,14 +530,43 @@ public:
     RepatchingPropertyInlineCache(AccessType, CodeOrigin);
     ~RepatchingPropertyInlineCache();
 
+    ALWAYS_INLINE bool considerBufferingStructure(VM&, CodeBlock*, Structure*, CacheableIdentifier);
+    template<typename Visitor> void visitBufferedStructures(Visitor&);
+    void pruneDeadBufferedStructures(VM&);
+
+    void clearBufferedStructures()
+    {
+        Locker locker { m_bufferedStructuresLock };
+        WTF::switchOn(m_bufferedStructures,
+            [&](std::monostate) { },
+            [&](Vector<StructureID>& structures) {
+                structures.shrink(0);
+            },
+            [&](Vector<std::tuple<StructureID, CacheableIdentifier>>& structures) {
+                structures.shrink(0);
+            });
+    }
+
     // This is either the start of the inline IC for *byId caches, or the location of patchable jump for 'instanceof' caches.
     CodeLocationLabel<JITStubRoutinePtrTag> startLocation;
     CodeLocationLabel<JITStubRoutinePtrTag> slowPathStartLocation;
     CodeLocationCall<JSInternalPtrTag> m_slowPathCallLocation;
     std::unique_ptr<PolymorphicAccess> m_stub;
 
+private:
+    // Represents those structures that already have buffered AccessCases in the PolymorphicAccess.
+    // Note that it's always safe to clear this. If we clear it prematurely, then if we see the same
+    // structure again during this buffering countdown, we will create an AccessCase object for it.
+    // That's not so bad - we'll get rid of the redundant ones once we regenerate.
+    Variant<std::monostate, Vector<StructureID>, Vector<std::tuple<StructureID, CacheableIdentifier>>> m_bufferedStructures WTF_GUARDED_BY_LOCK(m_bufferedStructuresLock);
+public:
+
     ScalarRegisterSet m_usedRegisters;
     Registers m_registers;
+    uint8_t bufferingCountdown;
+private:
+    Lock m_bufferedStructuresLock;
+public:
 
     uint32_t inlineCodeSize() const
     {
@@ -663,6 +575,110 @@ public:
         return inlineSize;
     }
 };
+
+ALWAYS_INLINE bool PropertyInlineCache::considerRepatchingCacheImpl(VM& vm, CodeBlock* codeBlock, Structure* structure, CacheableIdentifier impl)
+{
+    AssertNoGC assertNoGC;
+
+    // This method is called from the Optimize variants of IC slow paths. The first part of this
+    // method tries to determine if the Optimize variant should really behave like the
+    // non-Optimize variant and leave the IC untouched.
+    //
+    // If we determine that we should do something to the IC then the next order of business is
+    // to determine if this Structure would impact the IC at all. We know that it won't, if we
+    // have already buffered something on its behalf. That's what the m_bufferedStructures set is
+    // for.
+
+    everConsidered = true;
+    if (!countdown) {
+        auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(*this);
+        // Check if we have been doing repatching too frequently. If so, then we should cool off
+        // for a while.
+        WTF::incrementWithSaturation(repatchCount);
+        if (repatchCount > Options::repatchCountForCoolDown()) {
+            // We've been repatching too much, so don't do it now.
+            repatchCount = 0;
+            // The amount of time we require for cool-down depends on the number of times we've
+            // had to cool down in the past. The relationship is exponential. The max value we
+            // allow here is 2^256 - 2, since the slow paths may increment the count to indicate
+            // that they'd like to temporarily skip patching just this once.
+            countdown = WTF::leftShiftWithSaturation(
+                static_cast<uint8_t>(Options::initialCoolDownCount()),
+                numberOfCoolDowns,
+                static_cast<uint8_t>(std::numeric_limits<uint8_t>::max() - 1));
+            WTF::incrementWithSaturation(numberOfCoolDowns);
+
+            // We may still have had something buffered. Trigger generation now.
+            if (repatchingIC)
+                repatchingIC->bufferingCountdown = 0;
+            return true;
+        }
+
+        if (repatchingIC)
+            return repatchingIC->considerBufferingStructure(vm, codeBlock, structure, impl);
+        return true;
+    }
+    countdown--;
+    return false;
+}
+
+ALWAYS_INLINE bool RepatchingPropertyInlineCache::considerBufferingStructure(VM& vm, CodeBlock* codeBlock, Structure* structure, CacheableIdentifier impl)
+{
+    // We don't want to return false due to buffering indefinitely.
+    if (!bufferingCountdown) {
+        // Note that when this returns true, it's possible that we will not even get an
+        // AccessCase because this may cause Repatch.cpp to simply do an in-place
+        // repatching.
+        return true;
+    }
+
+    bufferingCountdown--;
+
+    if (!structure)
+        return true;
+
+    // Now protect the IC buffering. We want to proceed only if this is a structure that
+    // we don't already have a case buffered for. Note that if this returns true but the
+    // bufferingCountdown is not zero then we will buffer the access case for later without
+    // immediately generating code for it.
+    //
+    // NOTE: This will behave oddly for InstanceOf if the user varies the prototype but not
+    // the base's structure. That seems unlikely for the canonical use of instanceof, where
+    // the prototype is fixed.
+    bool isNewlyAdded = false;
+    StructureID structureID = structure->id();
+    {
+        Locker locker { m_bufferedStructuresLock };
+        if (std::holds_alternative<std::monostate>(m_bufferedStructures)) {
+            if (m_identifier)
+                m_bufferedStructures = Vector<StructureID>();
+            else
+                m_bufferedStructures = Vector<std::tuple<StructureID, CacheableIdentifier>>();
+        }
+        WTF::switchOn(m_bufferedStructures,
+            [&](std::monostate) { },
+            [&](Vector<StructureID>& structures) {
+                for (auto bufferedStructureID : structures) {
+                    if (bufferedStructureID == structureID)
+                        return;
+                }
+                structures.append(structureID);
+                isNewlyAdded = true;
+            },
+            [&](Vector<std::tuple<StructureID, CacheableIdentifier>>& structures) {
+                ASSERT(!m_identifier);
+                for (auto& [bufferedStructureID, bufferedCacheableIdentifier] : structures) {
+                    if (bufferedStructureID == structureID && bufferedCacheableIdentifier == impl)
+                        return;
+                }
+                structures.append(std::tuple { structureID, impl });
+                isNewlyAdded = true;
+            });
+    }
+    if (isNewlyAdded)
+        vm.writeBarrier(codeBlock);
+    return isNewlyAdded;
+}
 
 inline ScalarRegisterSet PropertyInlineCache::usedRegisters() const
 {


### PR DESCRIPTION
#### 70eb5015aec426e421fad75c7df80b0e82417da6
<pre>
[JSC] Move `PropertyInlineCache`&apos;s buffered-structures set to `RepatchingPropertyInlineCache`
<a href="https://bugs.webkit.org/show_bug.cgi?id=321903">https://bugs.webkit.org/show_bug.cgi?id=321903</a>

Reviewed by Yusuke Suzuki.

m_bufferedStructures exists so that a repatching IC does not buffer the same (Structure, identifier)
twice while it waits for bufferingCountdown before regenerating its stub. Handler ICs never buffer:
they generate a handler as soon as they see a new case. But the set, its lock and the countdown lived
in the shared base class, so every handler IC paid 24 bytes for them, plus a 64 or 256 byte Vector
buffer once it took the slow path twice.

Move them to RepatchingPropertyInlineCache and let considerRepatchingCacheImpl() return true for
handler ICs after the countdown / cool-down checks. Handler ICs that fail to cache a structure now
retry tryCache on the first few visits instead of skipping them; repatching ICs are unchanged.
sizeof(HandlerPropertyInlineCache) 112 -&gt; 88, embedded per IC site in Baseline and DFG JITData.

Octane typescript x3, libpas Common Primitive Alloc after gc(): 27,657,088 -&gt; 26,386,064 bytes (-1.27 MB).

* Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp:
(JSC::RepatchingPropertyInlineCache::RepatchingPropertyInlineCache):
(JSC::PropertyInlineCache::addAccessCase):
(JSC::PropertyInlineCache::reset):
(JSC::RepatchingPropertyInlineCache::visitBufferedStructures):
(JSC::RepatchingPropertyInlineCache::pruneDeadBufferedStructures):
(JSC::PropertyInlineCache::visitAggregateImpl):
(JSC::PropertyInlineCache::reconcileWeakReferencesAtGCEnd):
(JSC::HandlerPropertyInlineCache::initializeFromUnlinkedPropertyInlineCache):
(JSC::HandlerPropertyInlineCache::initializeFromDFGUnlinkedPropertyInlineCache):
* Source/JavaScriptCore/bytecode/PropertyInlineCache.h:
(JSC::PropertyInlineCache::PropertyInlineCache):
(JSC::PropertyInlineCache::considerRepatchingCacheImpl):
(JSC::RepatchingPropertyInlineCache::considerBufferingStructure):
(JSC::PropertyInlineCache::clearBufferedStructures): Deleted.

Canonical link: <a href="https://commits.webkit.org/319282@main">https://commits.webkit.org/319282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c0d28d9e03eab45ce462ceb71c2181f0afbc5d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191228 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141235 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43572 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41852 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3652 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10469 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41513 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2388 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42288 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193163 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54625 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150621 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40305 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55313 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150338 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44930 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127579 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123086 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53830 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16509 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53212 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->