### PR TITLE
[Site Isolation] Broadcast WindowScreenDidChange to remote frame processes

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -161,6 +161,9 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 
 - (void)_numberOfLiveDocumentsForTesting:(void (^)(NSUInteger count))completionHandler;
 
+- (void)_setDisplayForTesting:(uint32_t)displayID nominalFramesPerSecond:(unsigned)nominalFramesPerSecond;
+- (void)_preferredRenderingUpdateIntervalsForTesting:(void (^)(NSArray<NSNumber *> *intervalsInMillisecondsForEachWebProcess))completionHandler;
+
 - (void)_computePagesForPrinting:(_WKFrameHandle *)handle completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 - (void)_setConnectedToHardwareConsoleForTesting:(BOOL)connected;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -770,6 +770,25 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     });
 }
 
+- (void)_setDisplayForTesting:(uint32_t)displayID nominalFramesPerSecond:(unsigned)nominalFramesPerSecond
+{
+    if (RefPtr pageForTesting = _page->pageForTesting())
+        pageForTesting->setDisplayForTesting(displayID, nominalFramesPerSecond);
+}
+
+- (void)_preferredRenderingUpdateIntervalsForTesting:(void (^)(NSArray<NSNumber *> *))completionHandler
+{
+    RefPtr pageForTesting = _page->pageForTesting();
+    if (!pageForTesting)
+        return completionHandler(@[ ]);
+
+    pageForTesting->preferredRenderingUpdateIntervalsInMilliseconds([completionHandler = makeBlockPtr(completionHandler)](Vector<double>&& intervals) {
+        completionHandler(createNSArray(intervals, [](double interval) {
+            return @(interval);
+        }).get());
+    });
+}
+
 - (void)_computePagesForPrinting:(_WKFrameHandle *)handle completionHandler:(void(^)(void))completionHandler
 {
     WebKit::PrintInfo printInfo;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1648,7 +1648,9 @@ void WebPageProxy::swapToProvisionalPage(Ref<ProvisionalPageProxy>&& provisional
     if (m_drawingArea)
         nominalFramesPerSecond = protect(m_drawingArea)->displayNominalFramesPerSecond();
     // FIXME: We may want to send WindowScreenDidChange on non-iOS platforms too.
-    send(Messages::WebPage::WindowScreenDidChange(*m_displayID, nominalFramesPerSecond));
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.send(Messages::WebPage::WindowScreenDidChange(*m_displayID, nominalFramesPerSecond), pageID);
+    });
 #endif
 
 #if PLATFORM(COCOA)
@@ -6853,11 +6855,17 @@ void WebPageProxy::windowScreenDidChange(PlatformDisplayID displayID)
         return;
 
     std::optional<FramesPerSecond> nominalFramesPerSecond;
-    if (drawingArea)
+    if (RefPtr pageForTesting = m_pageForTesting)
+        nominalFramesPerSecond = pageForTesting->displayNominalFramesPerSecondOverride();
+    if (!nominalFramesPerSecond && drawingArea)
         nominalFramesPerSecond = drawingArea->displayNominalFramesPerSecond();
 
+    // FIXME (rdar://185159815): should we broadcast this to remote frame processes?
     send(Messages::EventDispatcher::PageScreenDidChange(m_webPageID, displayID, nominalFramesPerSecond));
-    send(Messages::WebPage::WindowScreenDidChange(displayID, nominalFramesPerSecond));
+
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.send(Messages::WebPage::WindowScreenDidChange(displayID, nominalFramesPerSecond), pageID);
+    });
 #if HAVE(DISPLAY_LINK)
     updateDisplayLinkFrequency();
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -94,6 +94,37 @@ void WebPageProxyTesting::numberOfLiveDocuments(CompletionHandler<void(uint64_t)
     sendWithAsyncReply(Messages::WebPageTesting::NumberOfLiveDocuments(), WTF::move(completionHandler));
 }
 
+void WebPageProxyTesting::setDisplayForTesting(uint32_t displayID, unsigned nominalFramesPerSecond)
+{
+    m_displayNominalFramesPerSecondOverride = nominalFramesPerSecond;
+    protect(page())->windowScreenDidChange(displayID);
+}
+
+void WebPageProxyTesting::preferredRenderingUpdateIntervalsInMilliseconds(CompletionHandler<void(Vector<double>&&)>&& completionHandler)
+{
+    class IntervalAggregator : public RefCounted<IntervalAggregator> {
+    public:
+        static Ref<IntervalAggregator> create(CompletionHandler<void(Vector<double>&&)>&& completionHandler) { return adoptRef(*new IntervalAggregator(WTF::move(completionHandler))); }
+        void add(double interval) { m_intervals.append(interval); }
+        ~IntervalAggregator()
+        {
+            m_completionHandler(WTF::move(m_intervals));
+        }
+    private:
+        explicit IntervalAggregator(CompletionHandler<void(Vector<double>&&)>&& completionHandler)
+            : m_completionHandler(WTF::move(completionHandler)) { }
+        CompletionHandler<void(Vector<double>&&)> m_completionHandler;
+        Vector<double> m_intervals;
+    };
+
+    Ref aggregator = IntervalAggregator::create(WTF::move(completionHandler));
+    protect(page())->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.sendWithAsyncReply(Messages::WebPageTesting::PreferredRenderingUpdateIntervalInMilliseconds(), [aggregator](double interval) {
+            aggregator->add(interval);
+        }, pageID);
+    });
+}
+
 void WebPageProxyTesting::setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&& completionHandler)
 {
     protect(protect(protect(page())->websiteDataStore())->networkProcess())->setCrossSiteLoadWithLinkDecorationForTesting(protect(page())->sessionID(), WebCore::RegistrableDomain { fromURL }, WebCore::RegistrableDomain { toURL }, wasFiltered, WTF::move(completionHandler));

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -47,6 +47,10 @@ public:
 
     void isLayerTreeFrozen(CompletionHandler<void(bool)>&&);
     void numberOfLiveDocuments(CompletionHandler<void(uint64_t)>&&);
+
+    void setDisplayForTesting(uint32_t displayID, unsigned nominalFramesPerSecond);
+    std::optional<unsigned> displayNominalFramesPerSecondOverride() const { return m_displayNominalFramesPerSecondOverride; }
+    void preferredRenderingUpdateIntervalsInMilliseconds(CompletionHandler<void(Vector<double>&&)>&&);
     void dispatchActivityStateUpdate();
     void setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&&);
     void setPermissionLevel(const String& origin, bool allowed);
@@ -100,6 +104,7 @@ private:
     WebPageProxy& page() const { return m_page; }
 
     WeakRef<WebPageProxy> m_page;
+    std::optional<unsigned> m_displayNominalFramesPerSecondOverride;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -79,6 +79,12 @@ void WebPageTesting::numberOfLiveDocuments(CompletionHandler<void(uint64_t)>&& c
     completionHandler(WebCore::Document::allDocuments().size());
 }
 
+void WebPageTesting::preferredRenderingUpdateIntervalInMilliseconds(CompletionHandler<void(double)>&& completionHandler)
+{
+    RefPtr page = m_page ? m_page->corePage() : nullptr;
+    completionHandler(page ? page->preferredRenderingUpdateInterval().milliseconds() : 0);
+}
+
 void WebPageTesting::setPermissionLevel(const String& origin, bool allowed)
 {
 #if ENABLE(NOTIFICATIONS)

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -57,6 +57,7 @@ private:
 
     void isLayerTreeFrozen(CompletionHandler<void(bool)>&&);
     void numberOfLiveDocuments(CompletionHandler<void(uint64_t)>&&);
+    void preferredRenderingUpdateIntervalInMilliseconds(CompletionHandler<void(double)>&&);
     void setPermissionLevel(const String& origin, bool allowed);
     void isEditingCommandEnabled(const String& commandName, CompletionHandler<void(bool)>&&);
     void resetStateBetweenTests();

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -27,6 +27,7 @@
 messages -> WebPageTesting {
     IsLayerTreeFrozen() -> (bool isFrozen)
     NumberOfLiveDocuments() -> (uint64_t count)
+    PreferredRenderingUpdateIntervalInMilliseconds() -> (double interval)
     SetPermissionLevel(String origin, bool allowed)
     IsEditingCommandEnabled(String commandName) -> (bool result) Synchronous
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -12847,6 +12847,52 @@ TEST(SiteIsolation, RestoredPageWithIframeIsRenderedAfterCrossSiteBFCacheRoundTr
     checkFrameTreesInProcesses(webView.get(), { { "https://b.com"_s } });
 }
 
+static Vector<double> preferredRenderingUpdateIntervals(TestWKWebView *webView)
+{
+    Vector<double> result;
+    __block bool done { false };
+    __block Vector<double>* values = &result;
+    [webView _preferredRenderingUpdateIntervalsForTesting:^(NSArray<NSNumber *> *intervals) {
+        for (NSNumber *interval in intervals)
+            values->append(interval.doubleValue);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    return result;
+}
+
+TEST(SiteIsolation, DisplayRefreshRateReachesSubframeProcess)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/webkit'></iframe>"_s } },
+        { "/webkit"_s, { "<p>hi</p>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://example.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://webkit.org"_s } } }
+    });
+
+    [webView _setDisplayForTesting:1 nominalFramesPerSecond:120];
+    auto fastIntervals = preferredRenderingUpdateIntervals(webView.get());
+    EXPECT_EQ(fastIntervals.size(), 2u);
+    for (auto interval : fastIntervals)
+        EXPECT_EQ(interval, fastIntervals[0]);
+
+
+    [webView _setDisplayForTesting:2 nominalFramesPerSecond:30];
+    auto slowIntervals = preferredRenderingUpdateIntervals(webView.get());
+    EXPECT_EQ(slowIntervals.size(), 2u);
+    for (auto interval : slowIntervals)
+        EXPECT_EQ(interval, slowIntervals[0]);
+
+    EXPECT_NE(slowIntervals[0], fastIntervals[0]);
+}
+
 enum class SiteIsolationHighValueFraudTargetDomainsEnabled : bool { No, Yes };
 
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> siteIsolatedViewWithHighValueFraudTargetDomains(const HTTPServer& server, NSArray<NSString *> *domains, SiteIsolationHighValueFraudTargetDomainsEnabled enabled)


### PR DESCRIPTION
#### cfaa7420dd35be9747e23d977c84d45f27e2d752
<pre>
[Site Isolation] Broadcast WindowScreenDidChange to remote frame processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=321904">https://bugs.webkit.org/show_bug.cgi?id=321904</a>
<a href="https://rdar.apple.com/problem/185078141">rdar://problem/185078141</a>

Reviewed by Simon Fraser.

This fixes WebPageProxy::windowScreenDidChange() to broadcast the WindowScreenDidChange message to
all of the page&apos;s processes rather than just the main frame&apos;s process.

There&apos;s another message above (PageScreenDidChange) which looks like it might need to be broadcast
as well (it&apos;s used by the momentum dispatcher), but I&apos;m not really sure. I left a FIXME there and
will ping the layout and rendering team about it.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _setDisplayForTesting:nominalFramesPerSecond:]):
(-[WKWebView _preferredRenderingUpdateIntervalsForTesting:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::windowScreenDidChange):
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::setDisplayForTesting):
(WebKit::WebPageProxyTesting::preferredRenderingUpdateIntervalsInMilliseconds):
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
(WebKit::WebPageProxyTesting::displayNominalFramesPerSecondOverride const):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::preferredRenderingUpdateIntervalInMilliseconds):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::preferredRenderingUpdateIntervals):
(TestWebKitAPI::TEST(SiteIsolation, DisplayRefreshRateReachesSubframeProcess)):
(TestWebKitAPI::(SiteIsolation, DisplayRefreshRateReachesSubframeProcess)):

Canonical link: <a href="https://commits.webkit.org/319372@main">https://commits.webkit.org/319372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b75e910f5b91c288da0de3b12b14bbd9308e66b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191451 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145557 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/145d020a-56d0-4373-ac83-37f42d630537) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141425 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c9fea5e9-b542-404b-8b6b-b53f8e1384ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121876 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65261b4d-9287-41b5-a0a1-472272abe3c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43773 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42051 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41709 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2611 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193383 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54846 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150818 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40414 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55533 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150534 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45127 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127801 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123362 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54050 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16707 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53432 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53497 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->