### PR TITLE
Deduplicate the collapsed-border painting pass loop between paintObject() and paintCollapsedBordersForRow()

### DIFF
--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -887,19 +887,12 @@ void RenderTable::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
     }
     
     if (collapseBorders() && paintPhase == PaintPhase::ChildBlockBackground && style().usedVisibility() == Visibility::Visible) {
-        recalcCollapsedBorders();
-        // Using our cached sorted styles, we then do individual passes,
-        // painting each style of border from lowest precedence to highest precedence.
-        info.phase = PaintPhase::CollapsedTableBorders;
-        size_t count = m_collapsedBorders.size();
-        for (size_t i = 0; i < count; ++i) {
-            m_currentBorder = &m_collapsedBorders[i];
+        paintCollapsedBorderPasses(info, [&](PaintInfo& borderPaintInfo) {
             for (RenderTableSection* section = bottomSection(); section; section = sectionAbove(section)) {
                 LayoutPoint childPoint = flipForWritingModeForChild(*section, paintOffset);
-                section->paint(info, childPoint);
+                section->paint(borderPaintInfo, childPoint);
             }
-        }
-        m_currentBorder = nullptr;
+        });
     }
 
     // Paint outline.
@@ -907,7 +900,8 @@ void RenderTable::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
         paintOutline(paintInfo, LayoutRect(paintOffset, borderBoxSize()));
 }
 
-void RenderTable::paintCollapsedBordersForRow(PaintInfo& paintInfo, RenderTableRow& row, const LayoutPoint& paintOffset)
+template<typename Function>
+void RenderTable::paintCollapsedBorderPasses(const PaintInfo& paintInfo, NOESCAPE const Function& paintPass)
 {
     ASSERT(collapseBorders());
     recalcCollapsedBorders();
@@ -915,16 +909,23 @@ void RenderTable::paintCollapsedBordersForRow(PaintInfo& paintInfo, RenderTableR
     PaintInfo borderPaintInfo(paintInfo);
     borderPaintInfo.phase = PaintPhase::CollapsedTableBorders;
 
-    for (size_t i = 0; i < m_collapsedBorders.size(); ++i) {
-        m_currentBorder = &m_collapsedBorders[i];
+    for (auto& border : m_collapsedBorders) {
+        m_currentBorder = &border;
+        paintPass(borderPaintInfo);
+    }
+    m_currentBorder = nullptr;
+}
+
+void RenderTable::paintCollapsedBordersForRow(PaintInfo& paintInfo, RenderTableRow& row, const LayoutPoint& paintOffset)
+{
+    paintCollapsedBorderPasses(paintInfo, [&](PaintInfo& borderPaintInfo) {
         for (CheckedPtr cell = row.firstCell(); cell; cell = cell->nextCell()) {
             if (!cell->hasSelfPaintingLayer()) {
                 auto cellPoint = row.flipForWritingModeForChild(*cell, paintOffset);
                 cell->paintCollapsedBorders(borderPaintInfo, cellPoint);
             }
         }
-    }
-    m_currentBorder = nullptr;
+    });
 }
 
 void RenderTable::adjustBorderBoxRectForPainting(LayoutRect& rect)

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -226,6 +226,8 @@ protected:
     void paintObject(PaintInfo&, const LayoutPoint&) final;
     void paintBoxDecorations(PaintInfo&, const LayoutPoint&) final;
     void paintMask(PaintInfo&, const LayoutPoint&) final;
+
+    template<typename Function> void paintCollapsedBorderPasses(const PaintInfo&, NOESCAPE const Function& paintPass);
     void layout() final;
     std::pair<LayoutUnit, LayoutUnit> computeIntrinsicLogicalWidths(TableIntrinsics) const;
     std::pair<LayoutUnit, LayoutUnit> computeIntrinsicLogicalWidths() const final;


### PR DESCRIPTION
#### 4d60710e3813177c975e9b8a632555ad105ec3ca
<pre>
Deduplicate the collapsed-border painting pass loop between paintObject() and paintCollapsedBordersForRow()
<a href="https://bugs.webkit.org/show_bug.cgi?id=321905">https://bugs.webkit.org/show_bug.cgi?id=321905</a>
<a href="https://rdar.apple.com/185078582">rdar://185078582</a>

Reviewed by Simon Fraser.

RenderTable::paintObject() and RenderTable::paintCollapsedBordersForRow() both
implement the same collapsed-border painting protocol: recalculate the collapsed
borders, make a PaintInfo copy in PaintPhase::CollapsedTableBorders, then do one
pass per cached border value from lowest to highest precedence with
m_currentBorder pointing at the border being painted, and finally clear
m_currentBorder. Only the innermost step differs: paintObject() walks the
sections bottom-up, while paintCollapsedBordersForRow() walks the row&apos;s cells.

Move the shared part into a paintCollapsedBorderPasses() helper that takes the
per-pass painting work as a NOESCAPE callable, so the m_currentBorder lifecycle
exists in one place instead of two. Both instantiations are in RenderTable.cpp,
so the template is defined there.

paintObject() previously mutated its own PaintInfo&apos;s phase in place rather than
copying; the copy is equivalent because that PaintInfo is not used again
afterwards (the outline paint below it uses the original paintInfo). The pass
loop also becomes a range-for over m_collapsedBorders instead of an index loop.

No change in behavior.

* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::paintObject):
(WebCore::RenderTable::paintCollapsedBorderPasses):
(WebCore::RenderTable::paintCollapsedBordersForRow):
* Source/WebCore/rendering/RenderTable.h:

Canonical link: <a href="https://commits.webkit.org/319312@main">https://commits.webkit.org/319312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0e004762671b24de5e59c98c66741b628d118fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191349 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/edf8f9e2-a805-4e6a-8574-65ea08b5a91f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141339 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79d733fc-2d32-4ab4-ade6-5a75da11fd6a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45009 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121790 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd385355-2f47-419a-be8f-b61516a9ae62) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43682 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41619 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2508 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47689 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193281 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54743 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150730 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40334 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55431 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150446 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45036 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127698 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123246 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53948 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16615 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53330 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53567 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53395 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->