### PR TITLE
getComputedStyle is stale in a display:none shadow tree after an inherited change on the host

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-display-none-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-display-none-001-expected.txt
@@ -1,4 +1,4 @@
 
 PASS getComputedStyle gets invalidated in display: none subtrees due to inherited changes to an ancestor
-FAIL getComputedStyle gets invalidated in display: none subtrees due to inherited changes to an ancestor shadow host assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS getComputedStyle gets invalidated in display: none subtrees due to inherited changes to an ancestor shadow host
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-display-none-shadow-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-display-none-shadow-invalidation-expected.txt
@@ -1,0 +1,4 @@
+
+PASS getComputedStyle gets invalidated for slotted content of a display: none shadow host
+PASS getComputedStyle gets invalidated in nested shadow trees of a display: none shadow host
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-display-none-shadow-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-display-none-shadow-invalidation.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM: getComputedStyle gets invalidated inside shadow trees of a display: none host</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#slotHost, #nestedHost {
+  display: none;
+  color: red;
+}
+</style>
+<div id="slotHost"><div id="slotted"></div></div>
+<div id="nestedHost"></div>
+<script>
+  test(function() {
+    slotHost.attachShadow({ mode: 'open' }).innerHTML = `
+      <div><slot></slot></div>
+    `;
+
+    // Read before mutating so there is a cached computed style that can go stale.
+    let slotted_style = getComputedStyle(slotted);
+    assert_equals(slotted_style.color, "rgb(255, 0, 0)");
+
+    slotHost.style.color = "green";
+    // Force a style update: a stale cache is only observable once the host itself has been
+    // re-resolved, which is what drops the invalidation flag the lookup would otherwise use.
+    document.body.offsetHeight;
+    assert_equals(slotted_style.color, "rgb(0, 128, 0)");
+    assert_equals(getComputedStyle(slotted).color, "rgb(0, 128, 0)");
+  }, "getComputedStyle gets invalidated for slotted content of a display: none shadow host");
+
+  test(function() {
+    nestedHost.attachShadow({ mode: 'open' }).innerHTML = `
+      <div id="inner"></div>
+    `;
+    let inner = nestedHost.shadowRoot.getElementById("inner");
+    inner.attachShadow({ mode: 'open' }).innerHTML = `
+      <div></div>
+    `;
+    let innermost = inner.shadowRoot.firstElementChild;
+
+    let inner_style = getComputedStyle(inner);
+    let innermost_style = getComputedStyle(innermost);
+    assert_equals(inner_style.color, "rgb(255, 0, 0)");
+    assert_equals(innermost_style.color, "rgb(255, 0, 0)");
+
+    nestedHost.style.color = "green";
+    document.body.offsetHeight;
+    assert_equals(inner_style.color, "rgb(0, 128, 0)");
+    assert_equals(innermost_style.color, "rgb(0, 128, 0)");
+    assert_equals(getComputedStyle(innermost).color, "rgb(0, 128, 0)");
+  }, "getComputedStyle gets invalidated in nested shadow trees of a display: none shadow host");
+</script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5964,10 +5964,13 @@ void Element::resetComputedStyle()
         element.elementRareData()->setComputedStyle(nullptr);
     };
     reset(*this);
-    for (Ref child : descendantsOfType<Element>(*this)) {
+    for (Ref descendant : composedTreeDescendants(*this)) {
+        RefPtr child = dynamicDowncast<Element>(descendant.get());
+        if (!child)
+            continue;
         if (!child->hasRareData() || !child->elementRareData()->computedStyle() || child->hasDisplayContents() || child->hasDisplayNone())
             continue;
-        reset(child);
+        reset(*child);
     }
 }
 


### PR DESCRIPTION
#### 2146a0ef0339f6ec61ed43d1004949256e1a6e1b
<pre>
getComputedStyle is stale in a display:none shadow tree after an inherited change on the host
<a href="https://bugs.webkit.org/show_bug.cgi?id=321906">https://bugs.webkit.org/show_bug.cgi?id=321906</a>
<a href="https://rdar.apple.com/185079066">rdar://185079066</a>

Reviewed by Antti Koivisto.

This path aligns WebKit with Gecko / Firefox and Blink / Chromium.

resetComputedStyle() only cleared the DOM subtree (descendantsOfType), so cached
computed style inside a shadow tree survived a recalc triggered by an inherited
property change on the host, and getComputedStyle() returned the stale value. It is
observable on a display:none host because TreeResolver calls resetComputedStyle() on
it and then stops, never descending into the subtree, so nothing else clears the cache
or sets IsComputedStyleInvalidFlag. A light DOM child of the same host was already
handled, being a DOM descendant the old walk reached, which is why only the shadow
subtest of getComputedStyle-display-none-001.html was failing.

Walk composedTreeDescendants() instead, which matches how computed style inherits, so
shadow trees are reset too; equivalent when no shadow tree exists. Unslotted light DOM
children drop out of the walk, but they do not inherit through the host, so no stale
inherited value can be left behind, and their own invalidation is still honored because
composedTreeLineage() includes the element itself.

Test: imported/w3c/web-platform-tests/css/cssom/getComputedStyle-display-none-shadow-invalidation.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-display-none-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-display-none-shadow-invalidation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-display-none-shadow-invalidation.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resetComputedStyle):

Canonical link: <a href="https://commits.webkit.org/319292@main">https://commits.webkit.org/319292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff0b54f0df066a878ed18325d960d588b3123596

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145342 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7a96404-7337-44aa-82dc-a6445030e5ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141239 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84681b7d-0954-4113-a40b-f085ae720c33) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121691 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f9b4fd6-2a31-418d-b720-21decab68924) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43575 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41856 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41514 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2393 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193168 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150626 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55318 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38133 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150343 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44932 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127584 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123095 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53835 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16510 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53217 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->