### PR TITLE
Adopt CSS parser machinery for parsing SVGAngleValue

### DIFF
--- a/LayoutTests/svg/dom/SVGAngle-expected.txt
+++ b/LayoutTests/svg/dom/SVGAngle-expected.txt
@@ -105,20 +105,69 @@ PASS angle.valueAsString is "0"
 PASS angle.value is 0
 PASS angle.valueInSpecifiedUnits is 0
 PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
-PASS angle.valueAsString = '5graD' threw exception SyntaxError: The string did not match the expected pattern..
-PASS angle.valueAsString is "0"
-PASS angle.value is 0
-PASS angle.valueInSpecifiedUnits is 0
-PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
-PASS angle.valueAsString = '5Rad' threw exception SyntaxError: The string did not match the expected pattern..
-PASS angle.valueAsString is "0"
-PASS angle.value is 0
-PASS angle.valueInSpecifiedUnits is 0
-PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
 PASS angle.valueAsString = ',5 rad' threw exception SyntaxError: The string did not match the expected pattern..
 PASS angle.valueAsString is "0"
 PASS angle.value is 0
 PASS angle.valueInSpecifiedUnits is 0
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
+
+Check setting calc() 'valueAsString' arguments
+FAIL angle.valueAsString = 'calc(30deg + 30deg)' should be calc(30deg + 30deg). Threw exception SyntaxError: The string did not match the expected pattern.
+FAIL angle.valueInSpecifiedUnits should be 60. Was 0.
+FAIL angle.unitType should be 2. Was 1.
+FAIL angle.valueAsString = 'calc(5 * 10)' should be calc(5 * 10). Threw exception SyntaxError: The string did not match the expected pattern.
+FAIL angle.valueInSpecifiedUnits should be 50. Was 0.
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
+
+Check setting 'valueAsString' arguments outside the float range
+PASS angle.valueAsString = '1e39' threw exception SyntaxError: The string did not match the expected pattern..
+PASS angle.valueAsString is "0"
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
+PASS angle.valueAsString = '-1e39' threw exception SyntaxError: The string did not match the expected pattern..
+PASS angle.valueAsString is "0"
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
+PASS angle.valueAsString = '1e39deg' threw exception SyntaxError: The string did not match the expected pattern..
+PASS angle.valueAsString is "0"
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
+PASS angle.valueAsString = '-1e39grad' threw exception SyntaxError: The string did not match the expected pattern..
+PASS angle.valueAsString is "0"
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
+PASS angle.valueAsString = '1e309rad' threw exception SyntaxError: The string did not match the expected pattern..
+PASS angle.valueAsString is "0"
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
+PASS angle.valueAsString = '-1e309turn' threw exception SyntaxError: The string did not match the expected pattern..
+PASS angle.valueAsString is "0"
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
+
+Check setting 'valueAsString' arguments at the edges of the float range
+PASS angle.valueAsString = '3.4e38deg' is "3.4e38deg"
+PASS angle.valueInSpecifiedUnits.toExponential(1) is "3.4e+38"
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_DEG
+PASS angle.valueAsString = '-3.4e38deg' is "-3.4e38deg"
+PASS angle.valueInSpecifiedUnits.toExponential(1) is "-3.4e+38"
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_DEG
+PASS angle.valueAsString = '1e-46grad' is "1e-46grad"
+PASS angle.valueInSpecifiedUnits is 0
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_GRAD
+
+Check that 'valueAsString' unit parsing is case-insensitive
+PASS angle.valueAsString = '5graD' is "5graD"
+PASS angle.valueAsString is "5grad"
+PASS angle.valueInSpecifiedUnits is 5
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_GRAD
+PASS angle.valueAsString = '5Rad' is "5Rad"
+PASS angle.valueAsString is "5rad"
+PASS angle.valueInSpecifiedUnits is 5
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_RAD
+PASS angle.valueAsString = '5DEG' is "5DEG"
+PASS angle.valueAsString is "5deg"
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_DEG
+PASS angle.valueAsString = '5TurN' is "5TurN"
+PASS angle.valueAsString is "5turn"
+PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNKNOWN
+
+Reset to initial angle state
+PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_UNSPECIFIED, 0) is undefined.
 PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
 
 Check setting invalid 'valueInSpecifiedUnits' arguments
@@ -199,6 +248,7 @@ PASS angle.valueInSpecifiedUnits.toFixed(1) is "180.0"
 PASS angle.valueAsString is "180deg"
 PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_DEG
 PASS successfullyParsed is true
+Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/svg/dom/SVGAngle.html
+++ b/LayoutTests/svg/dom/SVGAngle.html
@@ -137,22 +137,95 @@ shouldBe("angle.value", "0");
 shouldBe("angle.valueInSpecifiedUnits", "0");
 shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
 
-shouldThrow("angle.valueAsString = '5graD'");
-shouldBeEqualToString("angle.valueAsString", "0");
-shouldBe("angle.value", "0");
-shouldBe("angle.valueInSpecifiedUnits", "0");
-shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
-
-shouldThrow("angle.valueAsString = '5Rad'");
-shouldBeEqualToString("angle.valueAsString", "0");
-shouldBe("angle.value", "0");
-shouldBe("angle.valueInSpecifiedUnits", "0");
-shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
-
 shouldThrow("angle.valueAsString = ',5 rad'");
 shouldBeEqualToString("angle.valueAsString", "0");
 shouldBe("angle.value", "0");
 shouldBe("angle.valueInSpecifiedUnits", "0");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
+
+// FIXME: SVGAngleValue cannot hold a calculated value yet, so these assignments
+// throw and the checks below are expected to fail for now.
+debug("");
+debug("Check setting calc() 'valueAsString' arguments");
+shouldBeEqualToString("angle.valueAsString = 'calc(30deg + 30deg)'", "calc(30deg + 30deg)");
+shouldBe("angle.valueInSpecifiedUnits", "60");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_DEG");
+
+shouldBeEqualToString("angle.valueAsString = 'calc(5 * 10)'", "calc(5 * 10)");
+shouldBe("angle.valueInSpecifiedUnits", "50");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
+
+// 'valueInSpecifiedUnits' is a float, so magnitudes above FLT_MAX cannot be
+// represented and are rejected rather than clamped.
+debug("");
+debug("Check setting 'valueAsString' arguments outside the float range");
+shouldThrow("angle.valueAsString = '1e39'");
+shouldBeEqualToString("angle.valueAsString", "0");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
+
+shouldThrow("angle.valueAsString = '-1e39'");
+shouldBeEqualToString("angle.valueAsString", "0");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
+
+shouldThrow("angle.valueAsString = '1e39deg'");
+shouldBeEqualToString("angle.valueAsString", "0");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
+
+shouldThrow("angle.valueAsString = '-1e39grad'");
+shouldBeEqualToString("angle.valueAsString", "0");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
+
+// Above DBL_MAX the tokenizer produces an infinity, which the CSS consumers
+// reject before the float range is considered at all.
+shouldThrow("angle.valueAsString = '1e309rad'");
+shouldBeEqualToString("angle.valueAsString", "0");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
+
+shouldThrow("angle.valueAsString = '-1e309turn'");
+shouldBeEqualToString("angle.valueAsString", "0");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
+
+debug("");
+debug("Check setting 'valueAsString' arguments at the edges of the float range");
+shouldBeEqualToString("angle.valueAsString = '3.4e38deg'", "3.4e38deg");
+shouldBeEqualToString("angle.valueInSpecifiedUnits.toExponential(1)", "3.4e+38");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_DEG");
+
+shouldBeEqualToString("angle.valueAsString = '-3.4e38deg'", "-3.4e38deg");
+shouldBeEqualToString("angle.valueInSpecifiedUnits.toExponential(1)", "-3.4e+38");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_DEG");
+
+// Magnitudes below the smallest subnormal float round to zero rather than throwing.
+shouldBeEqualToString("angle.valueAsString = '1e-46grad'", "1e-46grad");
+shouldBe("angle.valueInSpecifiedUnits", "0");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_GRAD");
+
+// Spec: The <angle> in SVG attributes is a CSS <angle>, whose unit is matched
+// ASCII case-insensitively.
+debug("");
+debug("Check that 'valueAsString' unit parsing is case-insensitive");
+shouldBeEqualToString("angle.valueAsString = '5graD'", "5graD");
+shouldBeEqualToString("angle.valueAsString", "5grad");
+shouldBe("angle.valueInSpecifiedUnits", "5");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_GRAD");
+
+shouldBeEqualToString("angle.valueAsString = '5Rad'", "5Rad");
+shouldBeEqualToString("angle.valueAsString", "5rad");
+shouldBe("angle.valueInSpecifiedUnits", "5");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_RAD");
+
+shouldBeEqualToString("angle.valueAsString = '5DEG'", "5DEG");
+shouldBeEqualToString("angle.valueAsString", "5deg");
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_DEG");
+
+shouldBeEqualToString("angle.valueAsString = '5TurN'", "5TurN");
+shouldBeEqualToString("angle.valueAsString", "5turn");
+// SVGAngle has no SVG_ANGLETYPE_TURN constant, so 'turn' reports UNKNOWN per spec.
+shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNKNOWN");
+
+debug("");
+debug("Reset to initial angle state");
+shouldBeUndefined("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_UNSPECIFIED, 0)");
 shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
 
 debug("");

--- a/Source/WebCore/svg/SVGAngleValue.cpp
+++ b/Source/WebCore/svg/SVGAngleValue.cpp
@@ -22,13 +22,16 @@
 #include "config.h"
 #include "SVGAngleValue.h"
 
+#include "CSSParserContext.h"
+#include "CSSParserTokenRange.h"
+#include "CSSPropertyParserConsumer+AngleDefinitions.h"
+#include "CSSPropertyParserConsumer+MetaConsumer.h"
+#include "CSSPropertyParserConsumer+NumberDefinitions.h"
+#include "CSSTokenizer.h"
 #include "ExceptionOr.h"
-#include "SVGParserUtilities.h"
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/text/FastCharacterComparison.h>
 #include <wtf/text/MakeString.h>
-#include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {
 
@@ -93,24 +96,15 @@ String SVGAngleValue::valueAsString() const
     return String();
 }
 
-template<typename CharacterType> static inline SVGAngleValue::Type NODELETE parseAngleType(StringParsingBuffer<CharacterType> buffer)
+static inline SVGAngleValue::Type NODELETE cssAngleUnitToSVGAngleType(CSS::AngleUnit unit)
 {
-    switch (buffer.lengthRemaining()) {
-    case 0:
-        return SVGAngleValue::SVG_ANGLETYPE_UNSPECIFIED;
-    case 3:
-        if (compareCharacters(buffer.position(), 'd', 'e', 'g'))
-            return SVGAngleValue::SVG_ANGLETYPE_DEG;
-        if (compareCharacters(buffer.position(), 'r', 'a', 'd'))
-            return SVGAngleValue::SVG_ANGLETYPE_RAD;
-        break;
-    case 4:
-        if (compareCharacters(buffer.position(), 'g', 'r', 'a', 'd'))
-            return SVGAngleValue::SVG_ANGLETYPE_GRAD;
-        if (compareCharacters(buffer.position(), 't', 'u', 'r', 'n'))
-            return SVGAngleValue::SVG_ANGLETYPE_TURN;
-        break;
+    switch (unit) {
+    case CSS::AngleUnit::Deg:   return SVGAngleValue::SVG_ANGLETYPE_DEG;
+    case CSS::AngleUnit::Rad:   return SVGAngleValue::SVG_ANGLETYPE_RAD;
+    case CSS::AngleUnit::Grad:  return SVGAngleValue::SVG_ANGLETYPE_GRAD;
+    case CSS::AngleUnit::Turn:  return SVGAngleValue::SVG_ANGLETYPE_TURN;
     }
+    ASSERT_NOT_REACHED();
     return SVGAngleValue::SVG_ANGLETYPE_UNKNOWN;
 }
 
@@ -121,19 +115,49 @@ ExceptionOr<void> SVGAngleValue::setValueAsString(const String& value)
         return { };
     }
 
-    return readCharactersForParsing(value, [&](auto buffer) -> ExceptionOr<void> {
-        auto valueInSpecifiedUnits = parseNumber(buffer, SuffixSkippingPolicy::DontSkip);
-        if (!valueInSpecifiedUnits)
-            return Exception { ExceptionCode::SyntaxError };
+    // Unresolved CSS primitive numeric types always hold their value as a double, and
+    // CSS::All neither rejects nor clamps, so guard against values that are not
+    // representable as the float this stores.
+    auto isFloatOverflow = [](double value) {
+        return value > FLT_MAX || value < -FLT_MAX;
+    };
 
-        auto unitType = parseAngleType(buffer);
-        if (unitType == SVGAngleValue::SVG_ANGLETYPE_UNKNOWN)
-            return Exception { ExceptionCode::SyntaxError };
+    auto parserContext = CSSParserContext { SVGAttributeMode };
+    auto parserState = CSS::PropertyParserState {
+        .context = parserContext
+    };
 
-        m_unitType = unitType;
-        m_valueInSpecifiedUnits = *valueInSpecifiedUnits;
-        return { };
-    });
+    CSSTokenizer tokenizer(value);
+    auto tokenRange = tokenizer.tokenRange();
+
+    // Leading whitespace is allowed; the consumers below take care of the trailing
+    // whitespace by way of CSSParserTokenRange::consumeIncludingWhitespace().
+    tokenRange.consumeWhitespace();
+
+    // A unitless value must stay SVG_ANGLETYPE_UNSPECIFIED rather than becoming
+    // SVG_ANGLETYPE_DEG, so consume <number> ahead of <angle>. The raw types are used
+    // so that calc() is not consumed at all.
+    // FIXME: Add support for calculated angles.
+    auto parsedValue = CSSPropertyParserHelpers::MetaConsumer<CSS::NumberRaw<>, CSS::AngleRaw<>>::consume(tokenRange, parserState, { });
+    if (!parsedValue || !tokenRange.atEnd())
+        return Exception { ExceptionCode::SyntaxError };
+
+    return WTF::switchOn(*parsedValue,
+        [&](const CSS::NumberRaw<>& number) -> ExceptionOr<void> {
+            if (isFloatOverflow(number.value))
+                return Exception { ExceptionCode::SyntaxError };
+            m_unitType = SVG_ANGLETYPE_UNSPECIFIED;
+            m_valueInSpecifiedUnits = number.value;
+            return { };
+        },
+        [&](const CSS::AngleRaw<>& angle) -> ExceptionOr<void> {
+            if (isFloatOverflow(angle.value))
+                return Exception { ExceptionCode::SyntaxError };
+            m_unitType = cssAngleUnitToSVGAngleType(angle.unit);
+            m_valueInSpecifiedUnits = angle.value;
+            return { };
+        }
+    );
 }
 
 ExceptionOr<void> SVGAngleValue::newValueSpecifiedUnits(unsigned short unitType, float valueInSpecifiedUnits)


### PR DESCRIPTION
#### 0ca045f5e7c02f2ed6935cb5131f40643cc5ee3f
<pre>
Adopt CSS parser machinery for parsing SVGAngleValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=321907">https://bugs.webkit.org/show_bug.cgi?id=321907</a>
<a href="https://rdar.apple.com/185080341">rdar://185080341</a>

Reviewed by Sam Weinig.

SVGAngleValue::setValueAsString() hand-rolled its parsing on top of
SVGParserUtilities: parseNumber() followed by a parseAngleType() helper that
switched on the buffer&apos;s remaining length and compared characters directly.
Replace it with the shared CSS property-parser machinery, the way SVGLengthValue
was modernized in 298731@main: tokenize with CSSTokenizer under a
SVGAttributeMode parser context, then consume via
MetaConsumer&lt;CSS::NumberRaw&lt;&gt;, CSS::AngleRaw&lt;&gt;&gt;.

MetaConsumer avoids allocating a throwaway CSSPrimitiveValue, and the Raw types
have no FunctionToken consumer, so calc() is rejected structurally rather than
consumed and then discarded (FIXME to support it, matching SVGLengthValue and
every other engine). CSS::NumberRaw&lt;&gt; must come first: the unroller tries types
in order, and CSS::AngleRaw&lt;&gt; would otherwise take a unitless value as degrees
instead of leaving it SVG_ANGLETYPE_UNSPECIFIED.

Whitespace is handled on the token range, not the string: consumeWhitespace()
for the leading run, and each consumer already ends with
consumeIncludingWhitespace() so the trailing run is gone before atEnd() is
checked. The tokenizer&apos;s whitespace set is exactly isASCIIWhitespace()&apos;s, so
this accepts what a StringView::trim() would have without the copy.

An FLT_MAX check remains because unresolved CSS numeric types always store a
double regardless of their ResolvedValueType (see CSSPrimitiveNumericRaw.h) and
CSS::All neither rejects nor clamps; it keeps the old rejection of values like
&quot;1e39deg&quot; that the float member cannot represent. Past DBL_MAX the tokenizer
yields an infinity that the consumers reject on their own.

Since the &lt;angle&gt; in SVG attributes is a CSS &lt;angle&gt;, its unit is now matched
ASCII case-insensitively, so &quot;5Rad&quot; and &quot;5graD&quot; parse instead of throwing, in
line with SVG length attributes. Sharing the tokenizer likewise means comments
and identifier escapes are accepted, as they already are for lengths.

Precision improves as a side effect: the old parser accumulated in float and
multiplied by a float-narrowed power of ten, so &quot;5e-2deg&quot; landed on 0.049999997.
It now computes 0.05 as a double and narrows once.

SVGAngle.html asserted that &quot;5graD&quot; and &quot;5Rad&quot; throw; those are replaced by a
block covering all four units in mixed case, where &quot;5TurN&quot; reports
SVG_ANGLETYPE_UNKNOWN because SVGAngle.idl exposes no TURN constant and
unitType() clamps above GRAD per specification, while valueAsString still
round-trips &quot;5turn&quot;. Added coverage for the float and double boundaries in both
directions, and a calc() block written against the behavior we want, so the
FIXME is tracked by the baseline rather than only by a comment.

* LayoutTests/svg/dom/SVGAngle-expected.txt: Rebaselined.
* LayoutTests/svg/dom/SVGAngle.html: Add test cases for case-insensitive units,
calc(), and the float/double range boundaries.
* Source/WebCore/svg/SVGAngleValue.cpp:
(WebCore::cssAngleUnitToSVGAngleType):
(WebCore::SVGAngleValue::setValueAsString):
(WebCore::parseAngleType): Deleted.

Canonical link: <a href="https://commits.webkit.org/319893@main">https://commits.webkit.org/319893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2f6912c9857151e4701f55db644c76825d60792

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193296 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147367 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2980c0f1-ffb6-466b-9011-19d0d9f73977) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142904 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b201c216-80c6-4a88-8920-5997fa108583) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123331 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2a74224-d019-4a17-af05-2461b12fbfba) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45316 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43559 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43192 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4470 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195237 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40830 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57376 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39811 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152067 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46625 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129649 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125794 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55884 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18203 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55255 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55494 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55322 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->