### PR TITLE
Add a style checker rule to enforce better API header hygiene

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -1232,6 +1232,21 @@ _RE_PATTERN_XCODE_MAX_ALLOWED_MACRO = re.compile(
 _RE_PATTERN_PLATFORM_HEADER = re.compile(
     r'Source/WTF/wtf/Platform[a-zA-Z]+\.h')
 
+# Macros defined by WKFoundation.h which are now just aliases for the
+# identically named NS_ macro, and so should no longer be used.
+_WK_MACROS_WITH_NS_EQUIVALENTS = (
+    'WK_HEADER_AUDIT_BEGIN',
+    'WK_HEADER_AUDIT_END',
+    'WK_NULLABLE_RESULT',
+    'WK_SWIFT_ASYNC',
+    'WK_SWIFT_ASYNC_NAME',
+    'WK_SWIFT_ASYNC_THROWS_ON_FALSE',
+    'WK_SWIFT_UI_ACTOR',
+)
+
+_RE_PATTERN_WK_FOUNDATION_HEADER = re.compile(
+    r'(?:.*[\\/])?WKFoundation\.h$')
+
 
 def check_os_version_checks(filename, clean_lines, line_number, error):
     """ Checks for mistakes using VERSION_MIN_REQUIRED and VERSION_MAX_ALLOWED macros:
@@ -3785,6 +3800,35 @@ def check_arguments_for_wk_api_available(clean_lines, line_number, error):
         return
 
 
+def check_objc_annotation_macros(filename, clean_lines, line_number, error):
+    """Looks for Objective-C annotation macros which have a preferred spelling:
+    1. The WK_ prefixed macros in WKFoundation.h, which should be spelled using their NS_ equivalents.
+    2. NS_ASSUME_NONNULL_BEGIN / NS_ASSUME_NONNULL_END, which should be spelled using NS_HEADER_AUDIT_BEGIN / NS_HEADER_AUDIT_END.
+
+    Args:
+      filename: The name of the current file.
+      clean_lines: A CleansedLines instance containing the file.
+      line_number: The number of the line to check.
+      error: The function to call with any errors found.
+    """
+
+    # WKFoundation.h is where these macros are defined in terms of their preferred spellings.
+    if _RE_PATTERN_WK_FOUNDATION_HEADER.match(filename):
+        return
+
+    line = clean_lines.elided[line_number]  # Get rid of comments and strings.
+
+    for macro in _WK_MACROS_WITH_NS_EQUIVALENTS:
+        # Word boundaries keep WK_SWIFT_ASYNC from matching WK_SWIFT_ASYNC_NAME.
+        if search(r'\b%s\b' % macro, line):
+            error(line_number, 'build/wk_macros', 5, "Use '%s' instead of '%s'." % ('NS' + macro[len('WK'):], macro))
+
+    for macro in ('NS_ASSUME_NONNULL_BEGIN', 'NS_ASSUME_NONNULL_END'):
+        if search(r'\b%s\b' % macro, line):
+            replacement = 'NS_HEADER_AUDIT_%s' % macro.rsplit('_', 1)[-1]
+            error(line_number, 'build/header_audit', 5, "Use '%s(nullability, sendability)' instead of '%s'." % (replacement, macro))
+
+
 def check_objc_protocol(clean_lines, line_number, file_extension, error):
     """Looks for spaces between type names and protocol names.
 
@@ -5167,6 +5211,7 @@ def process_line(filename, file_extension,
     check_posix_threading(clean_lines, line, error)
     check_invalid_increment(clean_lines, line, error)
     check_os_version_checks(filename, clean_lines, line, error)
+    check_objc_annotation_macros(filename, clean_lines, line, error)
     check_callonmainthread(filename, clean_lines, line, file_state, error)
     check_ismainthread(filename, clean_lines, line, file_state, error)
     check_mainthreadneverdestroyed(filename, clean_lines, line, file_state, error)
@@ -5251,6 +5296,7 @@ class CppChecker(object):
         'build/forward_decl',
         'build/header_guard',
         'build/header_guard_missing',
+        'build/header_audit',
         'build/include',
         'build/include_order',
         'build/include_what_you_use',
@@ -5264,6 +5310,7 @@ class CppChecker(object):
         'build/cpp_comment',
         'build/webcore_export',
         'build/wk_api_available',
+        'build/wk_macros',
         'build/version_check',
         'build/self_include',
         'build-speed/inlines',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -7723,6 +7723,58 @@ class WebKitStyleTest(CppStyleTestBase):
                          ['ios(WK_MAC_TBA) is invalid; expected WK_IOS_TBA or a major.minor version  [build/wk_api_available] [5]',
                           'visionos(WK_MAC_TBA) is invalid; expected WK_XROS_TBA or a major.minor version  [build/wk_api_available] [5]'])
 
+    def test_wk_macros(self):
+        header = 'Source/WebKit/UIProcess/API/Cocoa/WKWebView.h'
+
+        self.assert_lint('WK_HEADER_AUDIT_BEGIN(nullability, sendability)',
+                         "Use 'NS_HEADER_AUDIT_BEGIN' instead of 'WK_HEADER_AUDIT_BEGIN'.  [build/wk_macros] [5]", header)
+        self.assert_lint('WK_HEADER_AUDIT_END(nullability, sendability)',
+                         "Use 'NS_HEADER_AUDIT_END' instead of 'WK_HEADER_AUDIT_END'.  [build/wk_macros] [5]", header)
+        self.assert_lint('@property (nonatomic, readonly, copy) NSString * WK_NULLABLE_RESULT title;',
+                         "Use 'NS_NULLABLE_RESULT' instead of 'WK_NULLABLE_RESULT'.  [build/wk_macros] [5]", header)
+        self.assert_lint('- (void)fooWithCompletionHandler:(void (^)(void))completionHandler WK_SWIFT_ASYNC(2);',
+                         "Use 'NS_SWIFT_ASYNC' instead of 'WK_SWIFT_ASYNC'.  [build/wk_macros] [5]", header)
+        self.assert_lint('- (void)fooWithCompletionHandler:(void (^)(void))completionHandler WK_SWIFT_ASYNC_NAME(foo());',
+                         "Use 'NS_SWIFT_ASYNC_NAME' instead of 'WK_SWIFT_ASYNC_NAME'.  [build/wk_macros] [5]", header)
+        self.assert_lint('- (void)fooWithCompletionHandler:(void (^)(BOOL))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);',
+                         "Use 'NS_SWIFT_ASYNC_THROWS_ON_FALSE' instead of 'WK_SWIFT_ASYNC_THROWS_ON_FALSE'.  [build/wk_macros] [5]", header)
+        self.assert_lint('- (void)foo:(WK_SWIFT_UI_ACTOR void (^)(void))handler;',
+                         "Use 'NS_SWIFT_UI_ACTOR' instead of 'WK_SWIFT_UI_ACTOR'.  [build/wk_macros] [5]", header)
+
+        # Multiple macros on one line are all reported.
+        self.assert_lint('- (void)foo:(void (^)(void))handler WK_SWIFT_ASYNC_NAME(foo()) WK_SWIFT_ASYNC(1);',
+                         ["Use 'NS_SWIFT_ASYNC' instead of 'WK_SWIFT_ASYNC'.  [build/wk_macros] [5]",
+                          "Use 'NS_SWIFT_ASYNC_NAME' instead of 'WK_SWIFT_ASYNC_NAME'.  [build/wk_macros] [5]"], header)
+
+        # The NS_ spellings and other WK_ macros are fine.
+        self.assert_lint('NS_HEADER_AUDIT_BEGIN(nullability, sendability)', '', header)
+        self.assert_lint('- (void)foo WK_API_AVAILABLE(macos(WK_MAC_TBA));', '', header)
+        self.assert_lint('- (void)foo:(NS_SWIFT_UI_ACTOR void (^)(void))handler;', '', header)
+        self.assert_lint('- (void)foo:(void (^)(void))handler NS_SWIFT_ASYNC_NAME(foo());', '', header)
+
+        # WKFoundation.h is where these macros are defined.
+        self.assert_lint('#define WK_SWIFT_ASYNC_NAME(...) NS_SWIFT_ASYNC_NAME(__VA_ARGS__)', '',
+                         'Source/WebKit/Shared/API/Cocoa/WKFoundation.h')
+        self.assert_lint('#define WK_SWIFT_UI_ACTOR NS_SWIFT_UI_ACTOR', '',
+                         'Source/WebKit/Shared/API/Cocoa/WKFoundation.h')
+        self.assert_lint('#define WK_HEADER_AUDIT_BEGIN NS_HEADER_AUDIT_BEGIN', '',
+                         'Source/WebKit/Shared/API/Cocoa/WKFoundation.h')
+
+    def test_header_audit(self):
+        header = 'Source/WebKit/UIProcess/API/Cocoa/WKWebView.h'
+
+        self.assert_lint('NS_ASSUME_NONNULL_BEGIN',
+                         "Use 'NS_HEADER_AUDIT_BEGIN(nullability, sendability)' instead of 'NS_ASSUME_NONNULL_BEGIN'.  [build/header_audit] [5]", header)
+        self.assert_lint('NS_ASSUME_NONNULL_END',
+                         "Use 'NS_HEADER_AUDIT_END(nullability, sendability)' instead of 'NS_ASSUME_NONNULL_END'.  [build/header_audit] [5]", header)
+
+        self.assert_lint('NS_HEADER_AUDIT_BEGIN(nullability, sendability)', '', header)
+        self.assert_lint('NS_HEADER_AUDIT_END(nullability, sendability)', '', header)
+
+        # WKFoundation.h defines WK_HEADER_AUDIT_BEGIN / WK_HEADER_AUDIT_END in terms of these.
+        self.assert_lint('#define WK_HEADER_AUDIT_BEGIN(...) NS_ASSUME_NONNULL_BEGIN', '',
+                         'Source/WebKit/Shared/API/Cocoa/WKFoundation.h')
+
     def test_os_version_checks(self):
         self.assert_lint('#if PLATFORM(IOS_FAMILY) && __IPHONE_OS_VERSION_MIN_REQUIRED < 110000', 'Misplaced OS version check. Please use a named macro in one of headers in the wtf/Platform.h suite of files or an appropriate internal file.  [build/version_check] [5]')
         self.assert_lint('#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000', 'Misplaced OS version check. Please use a named macro in one of headers in the wtf/Platform.h suite of files or an appropriate internal file.  [build/version_check] [5]')


### PR DESCRIPTION
#### 78207cb5dcf7665cf25d51e1d7c18d0b0346f1d7
<pre>
Add a style checker rule to enforce better API header hygiene
<a href="https://bugs.webkit.org/show_bug.cgi?id=321909">https://bugs.webkit.org/show_bug.cgi?id=321909</a>
<a href="https://rdar.apple.com/185083115">rdar://185083115</a>

Reviewed by Abrar Rahman Protyasha.

Add two rules:

1. Do not use `WK_SWIFT_UI_ACTOR` instead of the normal `NS_SWIFT_UI_ACTOR` (and likewise for the other macros)
2. Use the NS_HEADER_AUDIT_BEGIN/NS_HEADER_AUDIT_END macros instead of the old NS_ASSUME_NONNULL_BEGIN/NS_ASSUME_NONNULL_END ones

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_objc_annotation_macros):
(process_line):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest):

Canonical link: <a href="https://commits.webkit.org/319318@main">https://commits.webkit.org/319318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c455993442e8ae95f691e077bbca5c7ac1e9a82b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145347 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141246 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3bdaf711-6dc2-46da-8999-f385088a9e79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121698 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180348 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43582 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41862 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41522 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2398 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193173 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54635 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150631 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55323 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150348 "Passed tests") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/27500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44939 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123110 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53840 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16518 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53222 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53459 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53287 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->