### PR TITLE
GraphicsContextCG::strokeRect modifies stroke thickness state

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1307,7 +1307,7 @@ void GraphicsContextCG::strokeRect(const FloatRect& rect, float lineWidth)
             CGContextDrawLayerInRect(context, CGRectMake(destinationX, destinationY, adjustedWidth, adjustedHeight), layer.get());
         } else {
             CGContextStateSaver stateSaver(context);
-            setStrokeThickness(lineWidth);
+            CGContextSetLineWidth(context, std::max(lineWidth, 0.f));
             CGContextAddRect(context, rect);
             CGContextReplacePathWithStrokedPath(context);
             CGContextClip(context);
@@ -1325,11 +1325,10 @@ void GraphicsContextCG::strokeRect(const FloatRect& rect, float lineWidth)
     // The convenience functions currently (in at least OSX 10.9.4) fail to
     // apply some attributes of the graphics state in certain cases
     // (as identified in https://bugs.webkit.org/show_bug.cgi?id=132948)
-    CGContextStateSaver stateSaver(context);
-    setStrokeThickness(lineWidth);
-
+    CGContextSetLineWidth(context, std::max(lineWidth, 0.f));
     CGContextAddRect(context, rect);
     CGContextStrokePath(context);
+    CGContextSetLineWidth(context, std::max(strokeThickness(), 0.f));
 }
 
 void GraphicsContextCG::strokeArc(const PathArc& arc)

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm
@@ -35,6 +35,7 @@
 #import <WebCore/GraphicsContextCG.h>
 #import <WebCore/IOSurface.h>
 #import <WebCore/NativeImage.h>
+#import <WebCore/Path.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 
 @interface TestDrawingLayer : CALayer
@@ -132,6 +133,62 @@ TEST(GraphicsContextTests, FillRectWithBlendModePreservesActiveBlendMode)
 
     EXPECT_EQ(ctx.compositeOperation(), CompositeOperator::SourceOver);
     EXPECT_EQ(ctx.blendMode(), BlendMode::Multiply);
+}
+
+TEST(GraphicsContextTests, StrokeRectPreservesStrokeThickness)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    RetainPtr cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    GraphicsContextCG ctx(cgContext.get());
+
+    // strokeRect() strokes with the width it is passed rather than the context's, which it used to do
+    // by calling setStrokeThickness() inside a CGContextStateSaver. That restored the CGContext's line
+    // width but left the new value in the context's own state, so the two disagreed from then on and
+    // every later stroke used the wrong width.
+    ctx.setStrokeThickness(3);
+    EXPECT_EQ(3, ctx.strokeThickness());
+
+    ctx.strokeRect(FloatRect(0, 0, contextWidth, contextHeight), 7);
+
+    EXPECT_EQ(3, ctx.strokeThickness());
+}
+
+TEST(GraphicsContextTests, StrokeRectDoesNotDesynchroniseLineWidth)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    constexpr int width = 16;
+    constexpr int height = 16;
+    RetainPtr cgContext = adoptCF(CGBitmapContextCreate(nullptr, width, height, 8, 4 * width, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    GraphicsContextCG ctx(cgContext.get());
+
+    // The same desynchronisation as above, observed through what actually gets drawn. strokeRect()
+    // used to leave its line width in the context's state while the CGContext kept the old one, and
+    // the damage only shows up later: asking for the width the state wrongly believes it already has
+    // is then a no-op, so the CGContext never gets it and the stroke comes out at the old width.
+    ctx.setStrokeColor(Color::green);
+    ctx.setStrokeThickness(2);
+    ctx.strokeRect(FloatRect(2, 2, 12, 12), 10);
+
+    // Discard whatever the stroked rect drew; only the line below should be visible.
+    ctx.clearRect(FloatRect(0, 0, width, height));
+
+    ctx.setStrokeThickness(10);
+    Path linePath;
+    linePath.moveTo({ 0, height / 2 });
+    linePath.addLineTo({ width, height / 2 });
+    ctx.strokePath(linePath);
+    CGContextFlush(cgContext.get());
+
+    auto* data = static_cast<uint8_t*>(CGBitmapContextGetData(cgContext.get()));
+    auto isGreenAtRow = [&](int row) {
+        auto* pixel = data + row * CGBitmapContextGetBytesPerRow(cgContext.get()) + (width / 2) * 4;
+        return pixel[1] > 128;
+    };
+    // A 10 unit wide horizontal line down the middle covers rows 3 to 12 but not row 1. If the line
+    // width had stayed at 2 it would only cover rows 7 and 8.
+    EXPECT_TRUE(isGreenAtRow(4));
+    EXPECT_TRUE(isGreenAtRow(8));
+    EXPECT_FALSE(isGreenAtRow(1));
 }
 
 TEST(GraphicsContextTests, CGBitmapRenderingModeIsUnaccelerated)


### PR DESCRIPTION
#### ac0b3b11540ea30b21025ae0f09143755c4e029b
<pre>
GraphicsContextCG::strokeRect modifies stroke thickness state
<a href="https://bugs.webkit.org/show_bug.cgi?id=321910">https://bugs.webkit.org/show_bug.cgi?id=321910</a>
<a href="https://rdar.apple.com/185084876">rdar://185084876</a>

Reviewed by Mike Wyrzykowski.

Avoid calling the public GraphicsContext state setter function. This
will modify the context state, which is not the intention of the
strokeRect.
Instead, use the CGContext API directly.

Currently not possible to invoke the bug from web, but prevents future
state-related optimizations.

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::strokeRect):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm:
(TestWebKitAPI::TEST(GraphicsContextTests, StrokeRectPreservesStrokeThickness)):
(TestWebKitAPI::TEST(GraphicsContextTests, StrokeRectDoesNotDesynchroniseLineWidth)):

Canonical link: <a href="https://commits.webkit.org/319296@main">https://commits.webkit.org/319296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d01108a406b411f3f461eb52de823ab736850d71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191239 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145348 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04f2a1d8-8052-42fe-9348-7e4be62243dc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141247 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7fbfbd47-f52e-4f1b-88cd-2385142fddaf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121699 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5217b11c-1bdc-4239-9eae-510214e1db14) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43586 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41863 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41523 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2399 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193174 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54636 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150632 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40320 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55324 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150349 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44940 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127590 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123111 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53841 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16519 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53223 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53288 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->