### PR TITLE
[GStreamer] Web process aborts in gstStructureGetList() when a capture device's caps have no framerate field

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -309,7 +309,12 @@ void GStreamerVideoCaptureSource::generatePresets()
         }
 
         IntSize size = { width, height };
-        double framerate;
+
+        if (!gst_structure_has_field(str, "framerate")) {
+            presets.append(VideoPreset { { size, { } } });
+            continue;
+        }
+
         Vector<FrameRateRange> frameRates;
         int32_t minFrameRateNumerator, minFrameRateDenominator, maxFrameRateNumerator, maxFrameRateDenominator, framerateNumerator, framerateDenominator;
         if (gst_structure_get(str, "framerate", GST_TYPE_FRACTION_RANGE, &minFrameRateNumerator, &minFrameRateDenominator, &maxFrameRateNumerator, &maxFrameRateDenominator, nullptr)) {
@@ -320,8 +325,10 @@ void GStreamerVideoCaptureSource::generatePresets()
 
             frameRates.append(range);
         } else if (gst_structure_get(str, "framerate", GST_TYPE_FRACTION, &framerateNumerator, &framerateDenominator, nullptr)) {
+            double framerate = 0;
             gst_util_fraction_to_double(framerateNumerator, framerateDenominator, &framerate);
-            frameRates.append({ framerate, framerate});
+            if (framerate)
+                frameRates.append({ framerate, framerate });
         } else {
             for (const auto& framerate : gstStructureGetList<double>(str, "framerate"_s))
                 frameRates.append({ framerate, framerate });


### PR DESCRIPTION
#### e9140a53f779a7e6e9aede43133b41002ef451ad
<pre>
[GStreamer] Web process aborts in gstStructureGetList() when a capture device&apos;s caps have no framerate field
<a href="https://bugs.webkit.org/show_bug.cgi?id=321875">https://bugs.webkit.org/show_bug.cgi?id=321875</a>

Reviewed by Nikolas Zimmermann.

Check for the presence of framerate field in caps before attempting to fill video presets.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::generatePresets):

Canonical link: <a href="https://commits.webkit.org/319364@main">https://commits.webkit.org/319364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c118343677d82eeacdec70132ed640a03a09c59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141440 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45117 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162204 "") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121891 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43812 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42074 "") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154215 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41730 "") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2628 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47825 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46329 "") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54863 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150834 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40401 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55550 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38352 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150551 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45144 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127837 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123385 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54067 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16723 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53449 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->