### PR TITLE
beforeunload is not dispatched synchronously when setting location.href

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-synchronous-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-synchronous-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL beforeunload event is emitted synchronously assert_equals: invoked synchronously exactly once expected 1 but got 0
+PASS beforeunload event is emitted synchronously
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2184,6 +2184,21 @@ void DocumentLoader::startLoadingMainResource()
         return;
     }
 
+    // A navigation started synchronously by its initiating script must not also commit
+    // synchronously, or script that queued a microtask from beforeunload would observe the new
+    // document instead of the one it is unloading. Empty documents are the only ones that commit
+    // inline, so hand this one to a task.
+    if (m_triggeringAction.needsSynchronousPolicyDecision() && !m_hasDeferredEmptyLoad && frame && frame->document()) {
+        m_hasDeferredEmptyLoad = true;
+        protect(frame->document())->eventLoop().queueTask(TaskSource::Networking, [this, protectedThis = Ref { *this }]() {
+            if (!m_loadingMainResource)
+                return;
+            m_loadingMainResource = false;
+            startLoadingMainResource();
+        });
+        return;
+    }
+
     if (maybeLoadEmpty()) {
         DOCUMENTLOADER_RELEASE_LOG_FORWARDABLE(DocumentLoaderStartLoadingMainResourceEmptyDocument);
         return;

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -664,6 +664,7 @@ private:
     // The action that triggered loading - we keep this around for the
     // benefit of the various policy handlers.
     NavigationAction m_triggeringAction;
+    bool m_hasDeferredEmptyLoad { false };
 
     Markable<NavigationIdentifier> m_navigationID;
 

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -82,6 +82,9 @@ public:
     bool isFromNavigationAPI() const { return m_isFromNavigationAPI; }
     void setIsFromNavigationAPI(bool isFromNavigationAPI) { m_isFromNavigationAPI = isFromNavigationAPI; }
 
+    bool needsSynchronousPolicyDecision() const { return m_needsSynchronousPolicyDecision; }
+    void setNeedsSynchronousPolicyDecision(bool value) { m_needsSynchronousPolicyDecision = value; }
+
     const std::optional<BackForwardItemIdentifier>& targetBackForwardItemIdentifier() const LIFETIME_BOUND { return m_targetBackForwardItemIdentifier; }
     void setTargetBackForwardItemIdentifier(BackForwardItemIdentifier itemID) { m_targetBackForwardItemIdentifier = itemID; }
 
@@ -110,6 +113,7 @@ private:
     bool m_isInitialFrameSrcLoad { false };
     bool m_isContentRuleListRedirect { false };
     bool m_isFromNavigationAPI { false };
+    bool m_needsSynchronousPolicyDecision { false };
 };
 
 class FrameLoadRequest : public FrameLoadRequestBase {

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1678,6 +1678,7 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
     action.setShouldReplaceDocumentIfJavaScriptURL(frameLoadRequest.shouldReplaceDocumentIfJavaScriptURL());
     action.setIsInitialFrameSrcLoad(frameLoadRequest.isInitialFrameSrcLoad());
     action.setIsFromNavigationAPI(frameLoadRequest.isFromNavigationAPI());
+    action.setNeedsSynchronousPolicyDecision(frameLoadRequest.needsSynchronousPolicyDecision());
     action.setNewFrameOpenerPolicy(frameLoadRequest.newFrameOpenerPolicy());
     auto historyHandling = frameLoadRequest.navigationHistoryBehavior();
     RefPtr document = m_frame->document();
@@ -2025,7 +2026,7 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
         return;
     }
 
-    auto policyDecisionMode = loader->triggeringAction().isFromNavigationAPI() ? PolicyDecisionMode::Synchronous : PolicyDecisionMode::Asynchronous;
+    auto policyDecisionMode = loader->triggeringAction().needsSynchronousPolicyDecision() ? PolicyDecisionMode::Synchronous : PolicyDecisionMode::Asynchronous;
     RELEASE_ASSERT(!isBackForwardLoadType(policyChecker().loadType()) || history().provisionalItem());
     policyChecker().checkNavigationPolicy(ResourceRequest(loader->request()), ResourceResponse { } /* redirectResponse */, loader, WTF::move(formSubmission), [
         this,
@@ -4002,6 +4003,10 @@ bool FrameLoader::shouldClose()
             if (!targetFrames[i]->tree().isDescendantOf(frame.ptr()))
                 continue;
             if (RefPtr localTargetFrame = dynamicDowncast<LocalFrame>(targetFrames[i])) {
+                // A beforeunload handler may navigate an ancestor frame, which prompts to unload
+                // this subtree again. Don't dispatch beforeunload re-entrantly for such a frame.
+                if (localTargetFrame->loader().pageDismissalEventBeingDispatched() != PageDismissalType::None)
+                    continue;
                 if (!localTargetFrame->loader().dispatchBeforeUnloadEvent(page->chrome(), this))
                     break;
             } else if (RefPtr remoteTargetFrame = dynamicDowncast<RemoteFrame>(targetFrames[i])) {

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -33,12 +33,15 @@
 #include "NavigationScheduler.h"
 
 #include "BackForwardController.h"
+#include "Chrome.h"
 #include "CommonAtomStrings.h"
 #include "CommonVM.h"
 #include "DocumentLoader.h"
 #include "DocumentPage.h"
 #include "DocumentSecurityOrigin.h"
 #include "Event.h"
+#include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "FormState.h"
 #include "FormSubmission.h"
 #include "FrameInlines.h"
@@ -58,6 +61,7 @@
 #include "PolicyChecker.h"
 #include "ScriptController.h"
 #include "Settings.h"
+#include "Site.h"
 #include "URLKeepingBlobAlive.h"
 #include "UserGestureIndicator.h"
 #include <wtf/Ref.h>
@@ -247,11 +251,12 @@ private:
 
 class ScheduledLocationChange : public ScheduledURLNavigation {
 public:
-    ScheduledLocationChange(Document& initiatingDocument, SecurityOrigin* securityOrigin, const URL& url, const String& referrer, LockHistory lockHistory, LockBackForwardList lockBackForwardList, bool duringLoad, NavigationHistoryBehavior navigationHandling, bool hasDispatchedNavigateEvent, CompletionHandler<void(bool)>&& completionHandler)
+    ScheduledLocationChange(Document& initiatingDocument, SecurityOrigin* securityOrigin, const URL& url, const String& referrer, LockHistory lockHistory, LockBackForwardList lockBackForwardList, bool duringLoad, NavigationHistoryBehavior navigationHandling, bool hasDispatchedNavigateEvent, bool needsSynchronousPolicyDecision, CompletionHandler<void(bool)>&& completionHandler)
         : ScheduledURLNavigation(initiatingDocument, 0.0, securityOrigin, url, referrer, lockHistory, lockBackForwardList, duringLoad, true)
         , m_completionHandler(WTF::move(completionHandler))
         , m_navigationHistoryBehavior(navigationHandling)
         , m_hasDispatchedNavigateEvent(hasDispatchedNavigateEvent)
+        , m_needsSynchronousPolicyDecision(needsSynchronousPolicyDecision)
     {
     }
 
@@ -273,6 +278,7 @@ public:
         frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLs());
         frameLoadRequest.setNavigationHistoryBehavior(m_navigationHistoryBehavior);
         frameLoadRequest.setSkipNavigateEvent(m_hasDispatchedNavigateEvent);
+        frameLoadRequest.setNeedsSynchronousPolicyDecision(m_needsSynchronousPolicyDecision);
 
         auto completionHandler = std::exchange(m_completionHandler, nullptr);
         frame.changeLocation(WTF::move(frameLoadRequest));
@@ -283,6 +289,7 @@ private:
     CompletionHandler<void(bool)> m_completionHandler;
     NavigationHistoryBehavior m_navigationHistoryBehavior;
     bool m_hasDispatchedNavigateEvent { false };
+    bool m_needsSynchronousPolicyDecision { false };
 };
 
 class ScheduledRefresh : public ScheduledURLNavigation {
@@ -655,6 +662,47 @@ inline bool NavigationScheduler::shouldScheduleNavigation() const
     return m_frame->page();
 }
 
+// Whether dispatching beforeunload for a navigation of `frame` could run script. This mirrors the
+// set of frames FrameLoader::shouldClose() dispatches the event to.
+static bool subtreeHasBeforeUnloadHandler(LocalFrame& frame)
+{
+    RefPtr page = frame.page();
+    if (!page || !page->chrome().canRunBeforeUnloadConfirmPanel())
+        return false;
+
+    auto hasHandler = [](Frame& candidate) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(candidate);
+        if (!localFrame)
+            return false;
+        RefPtr document = localFrame->document();
+        if (!document || !document->bodyOrFrameset())
+            return false;
+        RefPtr window = document->window();
+        return window && window->hasEventListeners(eventNames().beforeunloadEvent);
+    };
+
+    if (hasHandler(frame))
+        return true;
+    for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().traverseNext(&frame)) {
+        if (hasHandler(*child))
+            return true;
+    }
+    return false;
+}
+
+// Whether the navigation stays within the current document's site. Cross-site navigations are the
+// ones a process swap is keyed on, and a synchronous policy decision cannot express a swap: the UI
+// process decides that asynchronously, and its synchronous reply path falls back to
+// PolicyAction::Use, which would leave this process continuing a load meant to move elsewhere.
+// about:blank and empty URLs are committed without a network load and stay put.
+static bool isSameSiteNavigation(LocalFrame& frame, const URL& url)
+{
+    if (url.isEmpty() || url.isAboutBlank() || url.isAboutSrcDoc())
+        return true;
+    RefPtr document = frame.document();
+    return document && Site { protect(document->securityOrigin())->data() } == Site { url };
+}
+
 inline bool NavigationScheduler::shouldScheduleNavigation(const URL& url) const
 {
     if (!shouldScheduleNavigation())
@@ -757,9 +805,25 @@ void NavigationScheduler::scheduleLocationChange(Document& initiatingDocument, S
     // This may happen when a frame changes the location of another frame.
     bool duringLoad = loader && !loader->stateMachine().committedFirstRealDocumentLoad();
 
-    schedule(makeUnique<ScheduledLocationChange>(initiatingDocument, &securityOrigin, url, referrer, lockHistory, lockBackForwardList, duringLoad, historyHandling, hasDispatchedNavigateEvent, [completionHandler = WTF::move(completionHandler)] (bool hasStarted) mutable {
+    // "Prompt to unload" has to run before the script that started the navigation continues, so
+    // that beforeunload is observable there, as it is in other engines.
+    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
+    bool needsSynchronousPolicyDecision = localFrame && !url.protocolIsJavaScript() && isSameSiteNavigation(*localFrame, url) && subtreeHasBeforeUnloadHandler(*localFrame);
+
+    schedule(makeUnique<ScheduledLocationChange>(initiatingDocument, &securityOrigin, url, referrer, lockHistory, lockBackForwardList, duringLoad, historyHandling, hasDispatchedNavigateEvent, needsSynchronousPolicyDecision, [completionHandler = WTF::move(completionHandler)] (bool hasStarted) mutable {
         completionHandler(hasStarted ? ScheduleLocationChangeResult::Started : ScheduleLocationChangeResult::Stopped);
     }));
+
+    // schedule() has done its bookkeeping; collapse the zero-delay timer so that the navigation,
+    // and therefore beforeunload, happens in this task. The load itself still starts from a task,
+    // see DocumentLoader::startLoadingMainResource().
+    // Not while loading is deferred, since timerFired() would decline to fire and leave the
+    // navigation waiting for an unrelated startTimer(): keep the timer for it in that case.
+    RefPtr page = m_frame->page();
+    if (needsSynchronousPolicyDecision && m_redirect && page && !page->defersLoading()) {
+        m_timer.stop();
+        timerFired();
+    }
 }
 
 void NavigationScheduler::scheduleFormSubmission(Ref<FormSubmission>&& submission)

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -510,6 +510,7 @@ Navigation::Result Navigation::navigate(JSC::JSGlobalObject& globalObject, const
     auto request = FrameLoadRequest(*frame(), WTF::move(newURL));
     request.setNavigationHistoryBehavior(options.history);
     request.setIsFromNavigationAPI(true);
+    request.setNeedsSynchronousPolicyDecision(true);
     frame()->loader().loadFrameRequest(WTF::move(request), nullptr, { });
 
     // If the load() call never made it to the point that NavigateEvent was emitted, thus the upcoming-non-traverse slot was never promoted, this returns the tracker so we can reject it.

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10286,7 +10286,11 @@ void WebPageProxy::decidePolicyForNavigationActionSync(IPC::Connection& connecti
     auto sender = PolicyDecisionSender::create(WTF::move(reply));
 
     auto navigationID = data.navigationID;
-    decidePolicyForNavigationAction(WTF::move(process), *frame, WTF::move(data), [sender] (auto&& policyDecision) {
+    auto url = data.request.url();
+    decidePolicyForNavigationAction(process.copyRef(), *frame, WTF::move(data), [sender, process, url = WTF::move(url)] (auto&& policyDecision) mutable {
+        if (policyDecision.policyAction == PolicyAction::Use && url.protocolIsFile())
+            process->addPreviouslyApprovedFileURL(url);
+
         sender->send(WTF::move(policyDecision));
     });
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -227,7 +227,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
 #if PLATFORM(COCOA)
         shouldUseSyncIPCForFragmentNavigations = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AsyncFragmentNavigationPolicyDecision);
 #endif
-        if (navigationAction.processingUserGesture() || navigationAction.isFromNavigationAPI() || shouldUseSyncIPCForFragmentNavigations) {
+        if (navigationAction.processingUserGesture() || navigationAction.needsSynchronousPolicyDecision() || shouldUseSyncIPCForFragmentNavigations) {
             auto sendResult = webPage->sendSync(Messages::WebPageProxy::DecidePolicyForNavigationActionSync(*navigationActionData));
             if (!sendResult.succeeded()) {
                 WebFrameLoaderClient_RELEASE_LOG_ERROR(WebFrameLoaderClientDispatchDecidePolicyForNavigationActionSyncIpcFailed, (uint8_t)sendResult.error());

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ModalAlerts.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ModalAlerts.mm
@@ -27,6 +27,7 @@
 
 #import "Helpers/DeprecatedGlobalValues.h"
 #import "Helpers/PlatformUtilities.h"
+#import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <WebKit/WKPreferences.h>
 #import <WebKit/WKUIDelegatePrivate.h>
@@ -309,6 +310,80 @@ TEST(WebKit, SlowBeforeUnloadHandlerSingleClosePageCall)
 
     EXPECT_EQ(1U, viewDidCloseCallCount);
     EXPECT_FALSE([webView _isClosed]);
+}
+
+// A UI delegate that merely implements the beforeunload panel, so that
+// Chrome::canRunBeforeUnloadConfirmPanel() is true and beforeunload gets dispatched at all.
+@interface BeforeUnloadPanelUIDelegate : NSObject <WKUIDelegate>
+@end
+
+@implementation BeforeUnloadPanelUIDelegate
+
+- (void)_webView:(WKWebView *)webView runBeforeUnloadConfirmPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL result))completionHandler
+{
+    completionHandler(YES);
+}
+
+@end
+
+// Sets a beforeunload handler on the subframe, navigates it, and reports how many times
+// beforeunload had run by the time the location setter returned.
+static NSString * const navigateSubframeAndCountBeforeUnloadScript =
+    @"window.beforeUnloadCount = 0;"
+    @"const childWindow = document.getElementById('child').contentWindow;"
+    @"childWindow.onbeforeunload = () => { window.beforeUnloadCount++; };"
+    @"childWindow.location.href = 'about:blank?target';"
+    @"window.beforeUnloadCount";
+
+// "Prompt to unload" is part of navigating, so beforeunload has to have been dispatched by the time
+// the location setter returns.
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
+TEST(WebKit, BeforeUnloadIsDispatchedByLocationSetter)
+{
+    RetainPtr uiDelegate = adoptNS([[BeforeUnloadPanelUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView setUIDelegate:uiDelegate.get()];
+    [webView synchronouslyLoadHTMLString:@"<iframe id='child' src='about:blank'></iframe>"];
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    __block bool consultedPolicyDelegate = false;
+    navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *, void (^decisionHandler)(WKNavigationActionPolicy)) {
+        consultedPolicyDelegate = true;
+        decisionHandler(WKNavigationActionPolicyAllow);
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    id count = [webView objectByEvaluatingJavaScript:navigateSubframeAndCountBeforeUnloadScript];
+
+    EXPECT_TRUE(consultedPolicyDelegate);
+    EXPECT_EQ(1, [count intValue]);
+}
+
+// The client gets to decide the navigation policy before beforeunload is dispatched, so a
+// navigation the client rejects must not run beforeunload handlers at all.
+TEST(WebKit, BeforeUnloadNotDispatchedWhenNavigationPolicyCancels)
+{
+    RetainPtr uiDelegate = adoptNS([[BeforeUnloadPanelUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView setUIDelegate:uiDelegate.get()];
+    [webView synchronouslyLoadHTMLString:@"<iframe id='child' src='about:blank'></iframe>"];
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    __block bool consultedPolicyDelegate = false;
+    navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *, void (^decisionHandler)(WKNavigationActionPolicy)) {
+        consultedPolicyDelegate = true;
+        decisionHandler(WKNavigationActionPolicyCancel);
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    id count = [webView objectByEvaluatingJavaScript:navigateSubframeAndCountBeforeUnloadScript];
+
+    EXPECT_TRUE(consultedPolicyDelegate);
+    EXPECT_EQ(0, [count intValue]);
+
+    // Nor asynchronously, once the canceled navigation has had a chance to settle.
+    TestWebKitAPI::Util::runFor(0.1_s);
+    EXPECT_EQ(0, [[webView objectByEvaluatingJavaScript:@"window.beforeUnloadCount"] intValue]);
 }
 
 #endif


### PR DESCRIPTION
#### 678691a41a80ae8b44927e6d725acd8b22d01eae
<pre>
beforeunload is not dispatched synchronously when setting location.href
<a href="https://bugs.webkit.org/show_bug.cgi?id=321914">https://bugs.webkit.org/show_bug.cgi?id=321914</a>

Reviewed by NOBODY (OOPS!).

Setting location.href did not dispatch beforeunload before the assignment
returned. Chrome and Firefox both do, and beforeunload-synchronous.html passes in
both; it now passes here too.

scheduleLocationChange() left the navigation to a zero-delay timer, and
beforeunload is dispatched later still, from continueLoadAfterNavigationPolicy()
once the asynchronous policy decision returns. Start the navigation in the
initiating task instead, and ask for a synchronous policy decision so the client
still gets decidePolicyForNavigationAction first: a navigation it rejects must not
run beforeunload handlers at all. PolicyDecisionMode::Synchronous already exists
for this and is what the Navigation API uses.

Only do this when a beforeunload handler could observe it, so
scheduleLocationChange() checks the target subtree for one, mirroring the frames
shouldClose() dispatches to. Every other location change keeps its asynchronous
timer and policy decision.

Starting the navigation in this task must not also finish it: maybeLoadEmpty()
commits about:blank inline, so a microtask queued from beforeunload would see the
document it is unloading already replaced. Chrome commits about:blank
synchronously only on a frame&apos;s initial empty document; startLoadingMainResource()
likewise now starts the load from a task here.

The synchronous policy decision cannot express a process swap: the UI process
decides that asynchronously, and decidePolicyForNavigationActionSync() falls back
to PolicyAction::Use, leaving this process to continue a load meant to move
elsewhere. A swap is keyed on the site, so scheduleLocationChange() also requires the
navigation to be same-site, comparing the document&apos;s security origin rather than
its URL so that an about:blank frame uses the origin it inherited. about:blank and
empty URLs are committed without a network load and stay put. Cross-site location
changes keep dispatching beforeunload from a task.

Firing from scheduleLocationChange() has to skip a page whose loading is deferred,
which PageGroupLoadDeferrer does to every other page in the group while a modal
dialog runs. timerFired() declines to fire in that state, and Page::setDefersLoading()
does not restart scheduler timers, so the navigation would sit waiting for an
unrelated startTimer() with beforeunload never dispatched. Leave the timer in place
for that case.

decidePolicyForNavigationActionSync() also has to approve the navigated file path,
as the asynchronous handler already did, or the back/forward item the web process
reports fails messageCheckItemURLs() and the process is killed. Only the
Navigation API used the synchronous path before, over HTTP, so no file URL ever
reached that check.

A beforeunload handler may navigate an ancestor and so prompt to unload its own
subtree again, so shouldClose() skips frames already dispatching a page dismissal
event rather than treating that as a cancellation.

Also stop keying the policy decision mode off isFromNavigationAPI(), which keeps
its unrelated uses.

Test: imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-synchronous.html
      TestWebKitAPI.WebKit.BeforeUnloadIsDispatchedByLocationSetter
      TestWebKitAPI.WebKit.BeforeUnloadNotDispatchedWhenNavigationPolicyCancels

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-synchronous-expected.txt:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::startLoadingMainResource):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequestBase::needsSynchronousPolicyDecision const):
(WebCore::FrameLoadRequestBase::setNeedsSynchronousPolicyDecision):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::shouldClose):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledLocationChange::ScheduledLocationChange):
(WebCore::ScheduledLocationChange::fire):
(WebCore::subtreeHasBeforeUnloadHandler):
(WebCore::NavigationScheduler::scheduleLocationChange):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::navigate):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationActionSync):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ModalAlerts.mm:
(-[BeforeUnloadPanelUIDelegate _webView:runBeforeUnloadConfirmPanelWithMessage:initiatedByFrame:completionHandler:]):
(TestWebKitAPI::TEST(WebKit, BeforeUnloadIsDispatchedByLocationSetter)):
(TestWebKitAPI::TEST(WebKit, BeforeUnloadNotDispatchedWhenNavigationPolicyCancels)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/678691a41a80ae8b44927e6d725acd8b22d01eae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191687 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145790 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd97f148-83ca-4743-a859-c2b11441292c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141629 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98280 "1 flakes 13 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/501ff4d0-0fd9-4528-bb55-895fda0e24b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122069 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc552536-3186-4591-9023-e8b2f4114510) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43990 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42259 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41901 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2848 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193615 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55080 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151031 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55767 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38524 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150737 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45316 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128048 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123662 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54283 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16900 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53665 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53903 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53730 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->