### PR TITLE
TestWebKitAPI.wkbundle is unloadable outside the TestWebKitAPI binary in CMake builds

### DIFF
--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -407,6 +407,12 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework Cocoa")
 # This is a separate product from InjectedBundleTestWebKitAPI.bundle above,
 # which implements the legacy C-API injected bundle.
 add_library(TestWebKitAPIWebProcessPlugIn MODULE
+    # Matches the Xcode WebProcessPlugIn target's Helpers membership. Without
+    # PlatformUtilitiesCocoa.mm's Util::TestPlugInClassNameParameter the bundle
+    # still links, but fails to dlopen outside the TestWebKitAPI binary. It is in
+    # SourcesCocoa.txt, hence the #include shim below.
+    ${CMAKE_CURRENT_BINARY_DIR}/WebProcessPlugIn-PlatformUtilitiesCocoa.mm
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/UtilitiesCocoa.mm
     ${TESTWEBKITAPI_DIR}/InjectedBundle/cocoa/WebProcessPlugIn/WebProcessPlugIn.mm
     ${TESTWEBKITAPI_DIR}/InjectedBundle/cocoa/WebProcessPlugIn/WebProcessPlugInWithInternals.mm
     ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKWebView/AccessibilityTestPlugin.mm
@@ -458,6 +464,11 @@ foreach (_dual_src
         @ONLY)
 endforeach ()
 
+file(CONFIGURE
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/WebProcessPlugIn-PlatformUtilitiesCocoa.mm"
+    CONTENT "#include \"${TESTWEBKITAPI_DIR}/Helpers/cocoa/PlatformUtilitiesCocoa.mm\"\n"
+    @ONLY)
+
 target_include_directories(TestWebKitAPIWebProcessPlugIn PRIVATE
     ${CMAKE_BINARY_DIR}
     ${_testapi_framework_headers}
@@ -469,6 +480,10 @@ target_include_directories(TestWebKitAPIWebProcessPlugIn PRIVATE
 
 # Some pulgins still call -[WKWebProcessPlugInBrowserContextController mainFrame];
 target_compile_options(TestWebKitAPIWebProcessPlugIn PRIVATE -Wno-deprecated-declarations)
+
+# PlatformUtilitiesCocoa.mm uses the WebKit C API, which config.h only pulls in
+# under BUILDING_TestWebKit, as the sibling test targets also define.
+target_compile_definitions(TestWebKitAPIWebProcessPlugIn PRIVATE BUILDING_TestWebKit)
 
 # configure_file substitutes ${EXECUTABLE_NAME}/${PRODUCT_NAME}/
 # ${PRODUCT_BUNDLE_IDENTIFIER} in the Info.plist shared with the Xcode build.


### PR DESCRIPTION
#### 36195809a5ca24048b466eed2fde07f3c9bb54f0
<pre>
TestWebKitAPI.wkbundle is unloadable outside the TestWebKitAPI binary in CMake builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=321917">https://bugs.webkit.org/show_bug.cgi?id=321917</a>
<a href="https://rdar.apple.com/185091735">rdar://185091735</a>

Reviewed by Zak Ridouh and Wenson Hsieh.

The CMake TestWebKitAPIWebProcessPlugIn target doesn&apos;t build
PlatformUtilitiesCocoa.mm, which defines Util::TestPlugInClassNameParameter.
WebProcessPlugIn.mm reads that bundle parameter to pick the principal test
plug-in class. The target links -undefined,dynamic_lookup, so the missing
definition isn&apos;t a link error, just an undefined flat-namespace symbol. It
resolves when the TestWebKitAPI binary is the host, since that binary exports
it. Any other host fails:

    dlopen(.../TestWebKitAPI.wkbundle/Contents/MacOS/TestWebKitAPI):
    symbol not found in flat namespace
    &apos;__ZN13TestWebKitAPI4Util28TestPlugInClassNameParameterE&apos;

InjectedBundle::initialize bails there, so no plug-in callback runs and a
client loading this bundle to get window.internals sees it undefined with no
error. The Xcode WebProcessPlugIn target already lists PlatformUtilitiesCocoa.mm
and UtilitiesCocoa.mm in its Helpers membership exceptions, so only CMake builds
are affected. WebKitTestRunner isn&apos;t: it has its own injected bundle and calls
injectInternalsObject() directly, which is why layout tests never caught this.

Build both files into the bundle. PlatformUtilitiesCocoa.mm is listed in
SourcesCocoa.txt, so WEBKIT_COMPUTE_SOURCES marks it HEADER_FILE_ONLY and it has
to come in through an #include shim, the same way this target already builds its
dual-built sources. It also uses the WebKit C API, which config.h only exposes
under BUILDING_TestWebKit, as TestWebKitAPIBase and TestWebKitAPIInjectedBundle
both define.

* Tools/TestWebKitAPI/PlatformCocoa.cmake:

Add PlatformUtilitiesCocoa.mm (via shim) and UtilitiesCocoa.mm to
TestWebKitAPIWebProcessPlugIn, and define BUILDING_TestWebKit so the former
compiles.

Canonical link: <a href="https://commits.webkit.org/319345@main">https://commits.webkit.org/319345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/432a4a263233a5cab3f6f92218f9ea94face08e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191253 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145362 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a81be44e-763f-4eb8-9e97-606f7f9e6328) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141261 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e8c9b24-36a2-4830-ade1-ef6d4823f5bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121713 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ecba351-ecf0-47dd-81a8-c4bdb0e1237f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43595 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41877 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41536 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2413 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193188 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54650 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150645 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40392 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55338 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150362 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44953 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123133 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53855 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16532 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53237 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53474 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53302 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->