### PR TITLE
DisplayList::Recorder has a copy of GraphicsContext state

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -122,9 +122,9 @@ FloatSize GraphicsContext::platformShadowOffset(const FloatSize& shadowOffset) c
     return shadowOffset;
 }
 
-void GraphicsContext::mergeLastChanges(const GraphicsContextState& state, const std::optional<GraphicsContextState>& lastDrawingState)
+void GraphicsContext::mergeLastChanges(const GraphicsContextState& state)
 {
-    m_state.mergeLastChanges(state, lastDrawingState);
+    m_state.mergeLastChanges(state);
     didUpdateState(m_state);
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -96,80 +96,79 @@ public:
     Gradient* fillGradient() const { return fillBrush().gradient(); }
     const AffineTransform& fillGradientSpaceTransform() const { return fillBrush().gradientSpaceTransform(); }
     Pattern* fillPattern() const { return fillBrush().pattern(); }
-    void setFillBrush(const SourceBrush& brush) { m_state.setFillBrush(brush); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
-    void setFillColor(const Color& color) { m_state.setFillColor(color); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
-    void setFillGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setFillGradient(WTF::move(gradient), spaceTransform); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
-    void setFillPattern(Ref<Pattern>&& pattern) { m_state.setFillPattern(WTF::move(pattern)); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
+    void setFillBrush(const SourceBrush& brush) { m_state.setFillBrush(brush); didUpdateState(m_state); }
+    void setFillColor(const Color& color) { m_state.setFillColor(color); didUpdateState(m_state); }
+    void setFillGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setFillGradient(WTF::move(gradient), spaceTransform); didUpdateState(m_state); }
+    void setFillPattern(Ref<Pattern>&& pattern) { m_state.setFillPattern(WTF::move(pattern)); didUpdateState(m_state); }
 
     WindRule fillRule() const { return m_state.fillRule(); }
-    void setFillRule(WindRule fillRule) { m_state.setFillRule(fillRule); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillRule)); }
+    void setFillRule(WindRule fillRule) { m_state.setFillRule(fillRule); didUpdateState(m_state); }
 
     const SourceBrush& strokeBrush() const LIFETIME_BOUND { return m_state.strokeBrush(); }
     const Color& strokeColor() const { return strokeBrush().color(); }
     Gradient* strokeGradient() const { return strokeBrush().gradient(); }
     const AffineTransform& strokeGradientSpaceTransform() const { return strokeBrush().gradientSpaceTransform(); }
     Pattern* strokePattern() const { return strokeBrush().pattern(); }
-    void setStrokeBrush(const SourceBrush& brush) { m_state.setStrokeBrush(brush); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
-    void setStrokeColor(const Color& color) { m_state.setStrokeColor(color); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
-    void setStrokeGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setStrokeGradient(WTF::move(gradient), spaceTransform); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
-    void setStrokePattern(Ref<Pattern>&& pattern) { m_state.setStrokePattern(WTF::move(pattern)); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
+    void setStrokeBrush(const SourceBrush& brush) { m_state.setStrokeBrush(brush); didUpdateState(m_state); }
+    void setStrokeColor(const Color& color) { m_state.setStrokeColor(color); didUpdateState(m_state); }
+    void setStrokeGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setStrokeGradient(WTF::move(gradient), spaceTransform); didUpdateState(m_state); }
+    void setStrokePattern(Ref<Pattern>&& pattern) { m_state.setStrokePattern(WTF::move(pattern)); didUpdateState(m_state); }
 
     float strokeThickness() const { return m_state.strokeThickness(); }
-    void setStrokeThickness(float thickness) { m_state.setStrokeThickness(thickness); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeThickness)); }
+    void setStrokeThickness(float thickness) { m_state.setStrokeThickness(thickness); didUpdateState(m_state); }
 
     StrokeStyle strokeStyle() const { return m_state.strokeStyle(); }
-    void setStrokeStyle(StrokeStyle style) { m_state.setStrokeStyle(style); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeStyle)); }
+    void setStrokeStyle(StrokeStyle style) { m_state.setStrokeStyle(style); didUpdateState(m_state); }
 
     std::optional<GraphicsDropShadow> dropShadow() const { return m_state.dropShadow(); }
-    void setDropShadow(const GraphicsDropShadow& dropShadow) { m_state.setDropShadow(dropShadow); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::DropShadow)); }
-    void clearDropShadow() { m_state.setDropShadow(std::nullopt); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::DropShadow)); }
+    void setDropShadow(const GraphicsDropShadow& dropShadow) { m_state.setDropShadow(dropShadow); didUpdateState(m_state); }
+    void clearDropShadow() { m_state.setDropShadow(std::nullopt); didUpdateState(m_state); }
     bool hasBlurredDropShadow() const { return dropShadow() && dropShadow()->isBlurred(); }
     bool hasDropShadow() const { return dropShadow() && dropShadow()->hasOutsets(); }
 
     std::optional<GraphicsStyle> style() const { return m_state.style(); }
-    void setStyle(const std::optional<GraphicsStyle>& style) { m_state.setStyle(style); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::Style)); }
+    void setStyle(const std::optional<GraphicsStyle>& style) { m_state.setStyle(style); didUpdateState(m_state); }
 
     CompositeMode compositeMode() const { return m_state.compositeMode(); }
     CompositeOperator compositeOperation() const { return compositeMode().operation; }
     BlendMode blendMode() const { return compositeMode().blendMode; }
-    void setCompositeMode(CompositeMode compositeMode) { m_state.setCompositeMode(compositeMode); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::CompositeMode)); }
+    void setCompositeMode(CompositeMode compositeMode) { m_state.setCompositeMode(compositeMode); didUpdateState(m_state); }
     void setCompositeOperation(CompositeOperator operation, BlendMode blendMode = BlendMode::Normal) { setCompositeMode({ operation, blendMode }); }
 
     float alpha() const { return m_state.alpha(); }
-    void setAlpha(float alpha) { m_state.setAlpha(alpha); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::Alpha)); }
+    void setAlpha(float alpha) { m_state.setAlpha(alpha); didUpdateState(m_state); }
 
     TextDrawingModeFlags textDrawingMode() const { return m_state.textDrawingMode(); }
-    void setTextDrawingMode(TextDrawingModeFlags textDrawingMode) { m_state.setTextDrawingMode(textDrawingMode); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::TextDrawingMode)); }
+    void setTextDrawingMode(TextDrawingModeFlags textDrawingMode) { m_state.setTextDrawingMode(textDrawingMode); didUpdateState(m_state); }
 
     InterpolationQuality imageInterpolationQuality() const { return m_state.imageInterpolationQuality(); }
-    void setImageInterpolationQuality(InterpolationQuality imageInterpolationQuality) { m_state.setImageInterpolationQuality(imageInterpolationQuality); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::ImageInterpolationQuality)); }
+    void setImageInterpolationQuality(InterpolationQuality imageInterpolationQuality) { m_state.setImageInterpolationQuality(imageInterpolationQuality); didUpdateState(m_state); }
 
     bool shouldAntialias() const { return m_state.shouldAntialias(); }
-    void setShouldAntialias(bool shouldAntialias) { m_state.setShouldAntialias(shouldAntialias); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::ShouldAntialias)); }
+    void setShouldAntialias(bool shouldAntialias) { m_state.setShouldAntialias(shouldAntialias); didUpdateState(m_state); }
 
     bool shouldSmoothFonts() const { return m_state.shouldSmoothFonts(); }
-    void setShouldSmoothFonts(bool shouldSmoothFonts) { m_state.setShouldSmoothFonts(shouldSmoothFonts); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::ShouldSmoothFonts)); }
+    void setShouldSmoothFonts(bool shouldSmoothFonts) { m_state.setShouldSmoothFonts(shouldSmoothFonts); didUpdateState(m_state); }
 
     // Normally CG enables subpixel-quantization because it improves the performance of aligning glyphs.
     // In some cases we have to disable to to ensure a high-quality output of the glyphs.
     bool shouldSubpixelQuantizeFonts() const { return m_state.shouldSubpixelQuantizeFonts(); }
-    void setShouldSubpixelQuantizeFonts(bool shouldSubpixelQuantizeFonts) { m_state.setShouldSubpixelQuantizeFonts(shouldSubpixelQuantizeFonts); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::ShouldSubpixelQuantizeFonts)); }
+    void setShouldSubpixelQuantizeFonts(bool shouldSubpixelQuantizeFonts) { m_state.setShouldSubpixelQuantizeFonts(shouldSubpixelQuantizeFonts); didUpdateState(m_state); }
 
     bool shadowsIgnoreTransforms() const { return m_state.shadowsIgnoreTransforms(); }
-    void setShadowsIgnoreTransforms(bool shadowsIgnoreTransforms) { m_state.setShadowsIgnoreTransforms(shadowsIgnoreTransforms); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::ShadowsIgnoreTransforms)); }
+    void setShadowsIgnoreTransforms(bool shadowsIgnoreTransforms) { m_state.setShadowsIgnoreTransforms(shadowsIgnoreTransforms); didUpdateState(m_state); }
     FloatSize NODELETE platformShadowOffset(const FloatSize&) const;
 
     bool drawLuminanceMask() const { return m_state.drawLuminanceMask(); }
-    void setDrawLuminanceMask(bool drawLuminanceMask) { m_state.setDrawLuminanceMask(drawLuminanceMask); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::DrawLuminanceMask)); }
+    void setDrawLuminanceMask(bool drawLuminanceMask) { m_state.setDrawLuminanceMask(drawLuminanceMask); didUpdateState(m_state); }
 
-    virtual const GraphicsContextState& state() const { return m_state; }
-    void mergeLastChanges(const GraphicsContextState&, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
+    const GraphicsContextState& state() const LIFETIME_BOUND { return m_state; }
+    void mergeLastChanges(const GraphicsContextState&);
     void mergeAllChanges(const GraphicsContextState&);
 
     // Called *after* any change to GraphicsContextState; generally used to propagate changes
     // to the platform context's state.
     virtual void didUpdateState(GraphicsContextState&) = 0;
-    virtual void didUpdateSingleState(GraphicsContextState& state, GraphicsContextState::ChangeIndex) { didUpdateState(state); }
 
     WEBCORE_EXPORT virtual void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
     WEBCORE_EXPORT virtual void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -62,108 +62,69 @@ GraphicsContextState GraphicsContextState::clone(Purpose purpose) const
     return clone;
 }
 
-void GraphicsContextState::mergeLastChanges(const GraphicsContextState& state, const std::optional<GraphicsContextState>& lastDrawingState)
+template<typename Functor>
+constexpr void GraphicsContextState::forEachProperty(NOESCAPE const Functor& functor)
 {
-    for (auto change : state.changes())
-        mergeSingleChange(state, toIndex(change), lastDrawingState);
+    functor(Change::FillBrush, &GraphicsContextState::m_fillBrush);
+    functor(Change::FillRule, &GraphicsContextState::m_fillRule);
+    functor(Change::StrokeBrush, &GraphicsContextState::m_strokeBrush);
+    functor(Change::StrokeThickness, &GraphicsContextState::m_strokeThickness);
+    functor(Change::StrokeStyle, &GraphicsContextState::m_strokeStyle);
+    functor(Change::CompositeMode, &GraphicsContextState::m_compositeMode);
+    functor(Change::DropShadow, &GraphicsContextState::m_dropShadow);
+    functor(Change::Style, &GraphicsContextState::m_style);
+    functor(Change::Alpha, &GraphicsContextState::m_alpha);
+    functor(Change::ImageInterpolationQuality, &GraphicsContextState::m_imageInterpolationQuality);
+    functor(Change::TextDrawingMode, &GraphicsContextState::m_textDrawingMode);
+    functor(Change::ShouldAntialias, &GraphicsContextState::m_shouldAntialias);
+    functor(Change::ShouldSmoothFonts, &GraphicsContextState::m_shouldSmoothFonts);
+    functor(Change::ShouldSubpixelQuantizeFonts, &GraphicsContextState::m_shouldSubpixelQuantizeFonts);
+    functor(Change::ShadowsIgnoreTransforms, &GraphicsContextState::m_shadowsIgnoreTransforms);
+    functor(Change::DrawLuminanceMask, &GraphicsContextState::m_drawLuminanceMask);
 }
 
-void GraphicsContextState::mergeSingleChange(const GraphicsContextState& state, ChangeIndex changeIndex, const std::optional<GraphicsContextState>& lastDrawingState)
+void GraphicsContextState::mergeLastChanges(const GraphicsContextState& state)
 {
-    auto mergeChange = [&](auto GraphicsContextState::*property) {
-        if (this->*property == state.*property)
+    auto changes = state.changes();
+    if (!changes)
+        return;
+    forEachProperty([&](Change change, auto property) {
+        if (!changes.contains(change) || this->*property == state.*property)
             return;
         this->*property = state.*property;
-        m_changeFlags.set(changeIndex.toChange(), !lastDrawingState || (*lastDrawingState).*property != this->*property);
-    };
-
-    switch (changeIndex.value) {
-    case toIndex(Change::FillBrush).value:
-        mergeChange(&GraphicsContextState::m_fillBrush);
-        break;
-    case toIndex(Change::FillRule).value:
-        mergeChange(&GraphicsContextState::m_fillRule);
-        break;
-
-    case toIndex(Change::StrokeBrush).value:
-        mergeChange(&GraphicsContextState::m_strokeBrush);
-        break;
-    case toIndex(Change::StrokeThickness).value:
-        mergeChange(&GraphicsContextState::m_strokeThickness);
-        break;
-    case toIndex(Change::StrokeStyle).value:
-        mergeChange(&GraphicsContextState::m_strokeStyle);
-        break;
-
-    case toIndex(Change::CompositeMode).value:
-        mergeChange(&GraphicsContextState::m_compositeMode);
-        break;
-    case toIndex(Change::DropShadow).value:
-        mergeChange(&GraphicsContextState::m_dropShadow);
-        break;
-    case toIndex(Change::Style).value:
-        mergeChange(&GraphicsContextState::m_style);
-        break;
-
-    case toIndex(Change::Alpha).value:
-        mergeChange(&GraphicsContextState::m_alpha);
-        break;
-    case toIndex(Change::TextDrawingMode).value:
-        mergeChange(&GraphicsContextState::m_textDrawingMode);
-        break;
-    case toIndex(Change::ImageInterpolationQuality).value:
-        mergeChange(&GraphicsContextState::m_imageInterpolationQuality);
-        break;
-
-    case toIndex(Change::ShouldAntialias).value:
-        mergeChange(&GraphicsContextState::m_shouldAntialias);
-        break;
-    case toIndex(Change::ShouldSmoothFonts).value:
-        mergeChange(&GraphicsContextState::m_shouldSmoothFonts);
-        break;
-    case toIndex(Change::ShouldSubpixelQuantizeFonts).value:
-        mergeChange(&GraphicsContextState::m_shouldSubpixelQuantizeFonts);
-        break;
-    case toIndex(Change::ShadowsIgnoreTransforms).value:
-        mergeChange(&GraphicsContextState::m_shadowsIgnoreTransforms);
-        break;
-    case toIndex(Change::DrawLuminanceMask).value:
-        mergeChange(&GraphicsContextState::m_drawLuminanceMask);
-        break;
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-    }
+        m_changeFlags.add(change);
+    });
 }
 
 void GraphicsContextState::mergeAllChanges(const GraphicsContextState& state)
 {
-    auto mergeChange = [&](Change change, auto GraphicsContextState::*property) {
+    forEachProperty([&](Change change, auto property) {
         if (this->*property == state.*property)
             return;
         this->*property = state.*property;
         m_changeFlags.add(change);
-    };
+    });
+}
 
-    mergeChange(Change::FillBrush,                   &GraphicsContextState::m_fillBrush);
-    mergeChange(Change::FillRule,                    &GraphicsContextState::m_fillRule);
+void GraphicsContextState::filterLastChangesForMatching(const GraphicsContextState& state)
+{
+    if (!m_changeFlags)
+        return;
+    forEachProperty([&](Change change, auto property) {
+        if (m_changeFlags.contains(change) && this->*property == state.*property)
+            m_changeFlags.remove(change);
+    });
+}
 
-    mergeChange(Change::StrokeBrush,                 &GraphicsContextState::m_strokeBrush);
-    mergeChange(Change::StrokeThickness,             &GraphicsContextState::m_strokeThickness);
-    mergeChange(Change::StrokeStyle,                 &GraphicsContextState::m_strokeStyle);
-
-    mergeChange(Change::CompositeMode,               &GraphicsContextState::m_compositeMode);
-    mergeChange(Change::DropShadow,                  &GraphicsContextState::m_dropShadow);
-    mergeChange(Change::Style,                       &GraphicsContextState::m_style);
-
-    mergeChange(Change::Alpha,                       &GraphicsContextState::m_alpha);
-    mergeChange(Change::ImageInterpolationQuality,   &GraphicsContextState::m_imageInterpolationQuality);
-    mergeChange(Change::TextDrawingMode,             &GraphicsContextState::m_textDrawingMode);
-
-    mergeChange(Change::ShouldAntialias,             &GraphicsContextState::m_shouldAntialias);
-    mergeChange(Change::ShouldSmoothFonts,           &GraphicsContextState::m_shouldSmoothFonts);
-    mergeChange(Change::ShouldSubpixelQuantizeFonts, &GraphicsContextState::m_shouldSubpixelQuantizeFonts);
-    mergeChange(Change::ShadowsIgnoreTransforms,     &GraphicsContextState::m_shadowsIgnoreTransforms);
-    mergeChange(Change::DrawLuminanceMask,           &GraphicsContextState::m_drawLuminanceMask);
+void GraphicsContextState::copyLastChangesFrom(const GraphicsContextState& state)
+{
+    auto changes = state.m_changeFlags;
+    if (!changes)
+        return;
+    forEachProperty([&](Change change, auto property) {
+        if (changes.contains(change))
+            this->*property = state.*property;
+    });
 }
 
 static ASCIILiteral stateChangeName(GraphicsContextState::Change change)
@@ -223,33 +184,22 @@ static ASCIILiteral stateChangeName(GraphicsContextState::Change change)
 
 TextStream& GraphicsContextState::dump(TextStream& ts) const
 {
-    auto dump = [&](Change change, auto GraphicsContextState::*property) {
-        if (m_changeFlags.contains(change))
-            ts.dumpProperty(stateChangeName(change), this->*property);
+    constexpr auto numberOfProperties = [] {
+        size_t count = 0;
+        forEachProperty([&](Change, auto) { ++count; });
+        return count;
     };
+    // DrawLuminanceMask is the highest Change bit, so its index plus one is the number of changes.
+    static_assert(numberOfProperties() == WTF::ctz(std::to_underlying(Change::DrawLuminanceMask)) + 1,
+        "forEachProperty() must list every Change enumerator");
 
     ts.dumpProperty("change-flags"_s, m_changeFlags);
-
-    dump(Change::FillBrush,                     &GraphicsContextState::m_fillBrush);
-    dump(Change::FillRule,                      &GraphicsContextState::m_fillRule);
-
-    dump(Change::StrokeBrush,                   &GraphicsContextState::m_strokeBrush);
-    dump(Change::StrokeThickness,               &GraphicsContextState::m_strokeThickness);
-    dump(Change::StrokeStyle,                   &GraphicsContextState::m_strokeStyle);
-
-    dump(Change::CompositeMode,                 &GraphicsContextState::m_compositeMode);
-    dump(Change::DropShadow,                    &GraphicsContextState::m_dropShadow);
-    dump(Change::Style,                         &GraphicsContextState::m_style);
-
-    dump(Change::Alpha,                         &GraphicsContextState::m_alpha);
-    dump(Change::ImageInterpolationQuality,     &GraphicsContextState::m_imageInterpolationQuality);
-    dump(Change::TextDrawingMode,               &GraphicsContextState::m_textDrawingMode);
-
-    dump(Change::ShouldAntialias,               &GraphicsContextState::m_shouldAntialias);
-    dump(Change::ShouldSmoothFonts,             &GraphicsContextState::m_shouldSmoothFonts);
-    dump(Change::ShouldSubpixelQuantizeFonts,   &GraphicsContextState::m_shouldSubpixelQuantizeFonts);
-    dump(Change::ShadowsIgnoreTransforms,       &GraphicsContextState::m_shadowsIgnoreTransforms);
-    dump(Change::DrawLuminanceMask,             &GraphicsContextState::m_drawLuminanceMask);
+    if (m_changeFlags) {
+        forEachProperty([&](Change change, auto property) {
+            if (m_changeFlags.contains(change))
+                ts.dumpProperty(stateChangeName(change), this->*property);
+        });
+    }
     return ts;
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -61,13 +61,6 @@ public:
     };
     using ChangeFlags = OptionSet<Change>;
 
-    struct ChangeIndex {
-        Change toChange() { return static_cast<Change>(1 << value); }
-
-        uint32_t value;
-    };
-    static constexpr ChangeIndex toIndex(GraphicsContextState::Change change) { return { WTF::ctz(std::to_underlying(change)) }; }
-
     static constexpr ChangeFlags basicChangeFlags { Change::StrokeThickness, Change::StrokeBrush, Change::FillBrush };
     static constexpr ChangeFlags strokeChangeFlags { Change::StrokeThickness, Change::StrokeBrush };
 
@@ -141,9 +134,14 @@ public:
     bool drawLuminanceMask() const { return m_drawLuminanceMask; }
     void setDrawLuminanceMask(bool drawLuminanceMask) { setProperty(Change::DrawLuminanceMask, &GraphicsContextState::m_drawLuminanceMask, drawLuminanceMask); }
 
-    void mergeLastChanges(const GraphicsContextState&, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
-    void mergeSingleChange(const GraphicsContextState&, ChangeIndex, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
+    void mergeLastChanges(const GraphicsContextState&);
     void mergeAllChanges(const GraphicsContextState&);
+
+    // Removes change bit for each property that matches another state property.
+    WEBCORE_EXPORT void filterLastChangesForMatching(const GraphicsContextState&);
+
+    // Copies properties that are marked changed in another state.
+    WEBCORE_EXPORT void copyLastChangesFrom(const GraphicsContextState&);
 
     Purpose purpose() const { return m_purpose; }
 
@@ -151,6 +149,8 @@ public:
 
 private:
     friend struct IPC::ArgumentCoder<GraphicsContextState>;
+
+    template<typename Functor> static constexpr void forEachProperty(NOESCAPE const Functor&);
 
     template<typename T>
     void setProperty(Change change, T GraphicsContextState::*property, const T& value)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -55,7 +55,7 @@ Recorder::Recorder(IsDeferred isDeferred, const GraphicsContextState& state, con
 #endif
 {
     ASSERT(!state.changes());
-    m_stateStack.append({ state, initialCTM, initialCTM.mapRect(initialClip) });
+    m_stateStack.append({ initialCTM, initialCTM.mapRect(initialClip) });
 }
 
 Recorder::~Recorder()
@@ -68,22 +68,8 @@ void Recorder::appendDisplayList(const DisplayList& displayList)
     GraphicsContext::drawDisplayList(displayList, Ref { ControlFactory::singleton() });
 }
 
-const GraphicsContextState& Recorder::state() const
+void Recorder::didUpdateState(GraphicsContextState&)
 {
-    return currentState().state;
-}
-
-void Recorder::didUpdateState(GraphicsContextState& state)
-{
-    currentState().state.mergeLastChanges(state, currentState().lastDrawingState);
-    state.didApplyChanges();
-}
-
-void Recorder::didUpdateSingleState(GraphicsContextState& state, GraphicsContextState::ChangeIndex changeIndex)
-{
-    ASSERT(state.changes() - changeIndex.toChange() == GraphicsContextState::ChangeFlags { });
-    currentState().state.mergeSingleChange(state, changeIndex, currentState().lastDrawingState);
-    state.didApplyChanges();
 }
 
 bool Recorder::decomposeDrawGlyphsIfNeeded(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -78,18 +78,16 @@ protected:
     WEBCORE_EXPORT Recorder(IsDeferred, const GraphicsContextState&, const FloatRect& initialClip, const AffineTransform&, const DestinationColorSpace&, DrawGlyphsMode);
 
     struct ContextState {
-        GraphicsContextState state;
         AffineTransform ctm;
         FloatRect clipBounds;
         std::optional<GraphicsContextState> lastDrawingState { std::nullopt };
 
         ContextState cloneForTransparencyLayer() const
         {
-            auto stateClone = state.clone(GraphicsContextState::Purpose::TransparencyLayer);
             std::optional<GraphicsContextState> lastDrawingStateClone;
             if (lastDrawingState)
                 lastDrawingStateClone = lastDrawingState->clone(GraphicsContextState::Purpose::TransparencyLayer);
-            return ContextState { WTF::move(stateClone), ctm, clipBounds, WTF::move(lastDrawingStateClone) };
+            return ContextState { ctm, clipBounds, WTF::move(lastDrawingStateClone) };
         }
 
         void NODELETE translate(float x, float y);
@@ -140,10 +138,8 @@ private:
 
     void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) final { ASSERT_NOT_REACHED(); }
 
-    WEBCORE_EXPORT const GraphicsContextState& state() const final;
-
     WEBCORE_EXPORT void didUpdateState(GraphicsContextState&) final;
-    WEBCORE_EXPORT void didUpdateSingleState(GraphicsContextState&, GraphicsContextState::ChangeIndex) final;
+
     WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
     WEBCORE_EXPORT AffineTransform getCTM(GraphicsContext::IncludeDeviceScale = PossiblyIncludeDeviceScale) const final;
     WEBCORE_EXPORT IntRect clipBounds() const final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -500,15 +500,27 @@ void RecorderImpl::setURLForRect(const URL& link, const FloatRect& destRect)
 
 void RecorderImpl::appendStateChangeItemIfNecessary()
 {
-    auto& state = currentState().state;
+    auto& state = m_state;
+    auto& lastDrawingState = currentState().lastDrawingState;
+    if (lastDrawingState)
+        state.filterLastChangesForMatching(*lastDrawingState);
     auto changes = state.changes();
     if (!changes)
         return;
 
+    auto didApplyChanges = [&] {
+        if (lastDrawingState)
+            lastDrawingState->copyLastChangesFrom(state);
+        else {
+            lastDrawingState = state;
+            lastDrawingState->didApplyChanges();
+        }
+        state.didApplyChanges();
+    };
+
     auto recordFullItem = [&] {
         m_items.append(SetState(state));
-        state.didApplyChanges();
-        currentState().lastDrawingState = state;
+        didApplyChanges();
     };
 
     if (!changes.containsOnly({ GraphicsContextState::Change::FillBrush, GraphicsContextState::Change::StrokeBrush, GraphicsContextState::Change::StrokeThickness })) {
@@ -540,8 +552,7 @@ void RecorderImpl::appendStateChangeItemIfNecessary()
     if (strokeColor || strokeThickness)
         m_items.append(SetInlineStroke(strokeColor, strokeThickness));
 
-    state.didApplyChanges();
-    currentState().lastDrawingState = state;
+    didApplyChanges();
 }
 
 void RecorderImpl::drawPlaceholder(Function<void(GraphicsContext&)>&& function)

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -868,10 +868,6 @@ void GraphicsContextSkia::didUpdateState(GraphicsContextState&)
 {
 }
 
-void GraphicsContextSkia::didUpdateSingleState(GraphicsContextState&, GraphicsContextState::ChangeIndex)
-{
-}
-
 void GraphicsContextSkia::concatCTM(const AffineTransform& ctm)
 {
     m_canvas.concat(ctm);

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -65,7 +65,6 @@ public:
     void replayStateOnCanvas(SkCanvas&) const;
 
     void didUpdateState(GraphicsContextState&) final;
-    void didUpdateSingleState(GraphicsContextState&, GraphicsContextState::ChangeIndex) final;
 
     void setLineCap(LineCap) final;
     void setLineDash(const DashArray&, float) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -884,7 +884,10 @@ RefPtr<ImageBuffer> RemoteGraphicsContextProxy::createAlignedImageBuffer(const F
 
 void RemoteGraphicsContextProxy::appendStateChangeItemIfNecessary()
 {
-    auto& state = currentState().state;
+    auto& state = m_state;
+    auto& lastDrawingState = currentState().lastDrawingState;
+    if (lastDrawingState)
+        state.filterLastChangesForMatching(*lastDrawingState);
     auto changes = state.changes();
     if (!changes)
         return;
@@ -963,13 +966,21 @@ void RemoteGraphicsContextProxy::appendStateChangeItemIfNecessary()
     if (changes.contains(GraphicsContextState::Change::DrawLuminanceMask))
         send(Messages::RemoteGraphicsContext::SetDrawLuminanceMask(state.drawLuminanceMask()));
 
+    if (lastDrawingState)
+        lastDrawingState->copyLastChangesFrom(state);
+    else {
+        lastDrawingState = state;
+        lastDrawingState->didApplyChanges();
+    }
     state.didApplyChanges();
-    currentState().lastDrawingState = state;
 }
 
 std::optional<RemoteGraphicsContextProxy::InlineStrokeData> RemoteGraphicsContextProxy::inlineStrokeStateIfBatchable()
 {
-    auto& state = currentState().state;
+    auto& state = m_state;
+    auto& lastDrawingState = currentState().lastDrawingState;
+    if (lastDrawingState)
+        state.filterLastChangesForMatching(*lastDrawingState);
     auto changes = state.changes();
     // Only fold the line into the batch if the sole pending state changes are
     // stroke color and/or thickness; anything else has to go through the normal
@@ -984,12 +995,12 @@ std::optional<RemoteGraphicsContextProxy::InlineStrokeData> RemoteGraphicsContex
     if (changes) {
         // The stroke color/thickness travel inline with each buffered line, so
         // mark them applied and keep lastDrawingState in sync for future diffs.
-        auto& lastDrawingState = currentState().lastDrawingState;
         if (!lastDrawingState)
             lastDrawingState = state;
         else {
             if (changes.contains(GraphicsContextState::Change::StrokeBrush)) {
-                // Set through strokeBrush() to avoid comparison.
+                // Set through strokeBrush() to avoid comparison. Only the color is copied: the GPU
+                // process applies the inline color on top of whatever brush it already has.
                 lastDrawingState->strokeBrush().setColor(state.strokeBrush().color());
             }
             if (changes.contains(GraphicsContextState::Change::StrokeThickness))


### PR DESCRIPTION
#### 6c4ecf631b202a0278763bd5aba21b04651f2b51
<pre>
DisplayList::Recorder has a copy of GraphicsContext state
<a href="https://bugs.webkit.org/show_bug.cgi?id=321918">https://bugs.webkit.org/show_bug.cgi?id=321918</a>
<a href="https://rdar.apple.com/185092232">rdar://185092232</a>

Reviewed by Mike Wyrzykowski and Nikolas Zimmermann.

Recorder held a GraphicsContextState per level in its own state stack
while GraphicsContext::m_state held the same values as a shadow copy.
Every setter wrote both: setProperty() compared and assigned on m_state,
then didUpdateSingleState() dispatched through a 16-way switch in
mergeSingleChange() to compare and assign again on the authoritative
copy. Every save() copied both, 312 bytes plus 696, and every state
flush assigned a whole 312-byte state to lastDrawingState for
bookkeeping.

Make GraphicsContext::m_state the single current state.
Recorder::ContextState now holds only the data GraphicsContext does not
track: the CTM, the clip bounds and lastDrawingState.

This reduces save() / restore() overhead.

The redundancy filtering that mergeSingleChange() did per setter moves
to the flush: changes() is now conservative, and
appendStateChangeItemIfNecessary() calls removeChangesAlreadyIn() once
before deciding which items to record.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::mergeLastChanges):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::didUpdateSingleState):
(WebCore::GraphicsContext::state const): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::mergeLastChanges):
(WebCore::GraphicsContextState::mergeSingleChange):
(WebCore::GraphicsContextState::mergeAllChanges):
(WebCore::GraphicsContextState::propertyEquals const):
(WebCore::GraphicsContextState::copyProperty const):
(WebCore::GraphicsContextState::changesDifferingFrom const):
(WebCore::GraphicsContextState::removeChangesAlreadyIn):
(WebCore::GraphicsContextState::copyChangesTo const):
(WebCore::GraphicsContextState::dump const):
* Source/WebCore/platform/graphics/GraphicsContextState.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::Recorder):
(WebCore::DisplayList::Recorder::didUpdateState):
(WebCore::DisplayList::Recorder::state const): Deleted.
(WebCore::DisplayList::Recorder::didUpdateSingleState): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
(WebCore::DisplayList::Recorder::ContextState::cloneForTransparencyLayer const):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::appendStateChangeItemIfNecessary):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::didUpdateSingleState): Deleted.
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::appendStateChangeItemIfNecessary):
(WebKit::RemoteGraphicsContextProxy::inlineStrokeStateIfBatchable):

Canonical link: <a href="https://commits.webkit.org/319507@main">https://commits.webkit.org/319507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bef2685dbc372e0282dfce3bde9e4b92e093467

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191917 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e149c092-86a7-4abc-8a81-7358b6a06684) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141823 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/824f05e3-9ea4-4094-9720-91915a91be8a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45513 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122260 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/050f0c3d-c1d7-450a-8fd6-979a0973074e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44197 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42102 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3079 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48271 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193844 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55310 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151235 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40490 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55999 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150939 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45520 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128282 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123977 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54512 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17098 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53894 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54133 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53959 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->