### PR TITLE
webkit-sysprof analyze needs to analyze more marks, to see where a frame time goes

### DIFF
--- a/Tools/Scripts/webkit-sysprof/README.md
+++ b/Tools/Scripts/webkit-sysprof/README.md
@@ -68,8 +68,8 @@ Counters: 53
 ### `analyze`
 
 Compute rendering statistics (vblank intervals, theoretical FPS, frame compositions per
-vblank) and duration/count statistics for a fixed set of WebKit-specific marks (e.g.
-`EventLoopRun`, `PerformLayout`, `StyleRecalc`).
+vblank) and duration/count statistics for a fixed set of WebKit-specific marks (styling,
+layout, rendering, compositing and tiles).
 
 ```
 webkit-sysprof analyze CAPTURE_FILE [-f text|json] [-t TIMESPAN]
@@ -92,6 +92,24 @@ Rendering:
 $ webkit-sysprof analyze -f json -t 0-2000 capture.syscap
 {"document": {...}, "statistics": {...}, "rendering": {...}}
 ```
+
+Restricting the timespan matters more than it looks: page load dominates the tail of
+most metrics, so a whole-capture run largely measures startup. Skipping the first
+seconds is usually what you want when comparing configurations.
+
+#### Reading the mark statistics
+
+Three marks are easy to misread:
+
+- `StyleRecalc` is an umbrella mark that nests `RenderTreeBuild`,
+  `PerformSubtreesLayout` and `CompositingUpdate`. Its duration is not style resolution
+  alone. Subtract the nested marks to get that.
+- `CompositingUpdate` runs twice per rendering update, once inside `StyleRecalc` and
+  once after it, and the second one is much shorter. Its percentiles are therefore
+  bimodal rather than centered on a typical value.
+- `PaintTile` runs on the painting threads, so summing it over a frame gives aggregate
+  work rather than elapsed time. Its `#pixels` statistic is the dirty area taken from
+  the mark's `dirty region <x>x<y>+<width>+<height>` message.
 
 ### `delta-histogram`
 

--- a/Tools/Scripts/webkit-sysprof/tests/test_subcommands_e2e.py
+++ b/Tools/Scripts/webkit-sysprof/tests/test_subcommands_e2e.py
@@ -97,6 +97,22 @@ def test_analyze_json(capsys):
     assert report["rendering"]["vblanks"] == 35
 
 
+def test_analyze_json_statistics_cover_all_relevant_marks(capsys):
+    args = argparse.Namespace(
+        capture_file=SAMPLE_CAPTURE_FILE, format="json", timespan="-"
+    )
+    analyze.analyze(args)
+
+    statistics = json.loads(capsys.readouterr().out)["statistics"]
+    assert set(statistics) == set(analyze.MARKS_RELEVANT_FOR_STATISTICS)
+    assert statistics["CompositingUpdate"]["duration"]["n"] == 7
+    assert statistics["RenderTreeBuild"]["duration"]["n"] == 3
+    # Tile geometry depends on the rendering backend, so only check that the
+    # dirty area was extracted from every PaintTile message.
+    assert statistics["PaintTile"]["dirty_pixels"]["n"] == 80
+    assert statistics["PaintTile"]["dirty_pixels"]["min"] > 0
+
+
 def test_analyze_with_custom_timespan(capsys):
     args = argparse.Namespace(
         capture_file=SAMPLE_CAPTURE_FILE, format="text", timespan="0-0"

--- a/Tools/Scripts/webkit-sysprof/webkitsysprof/analyze/__init__.py
+++ b/Tools/Scripts/webkit-sysprof/webkitsysprof/analyze/__init__.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import re
 import statistics
 import collections
 import json
@@ -15,16 +16,55 @@ from ..utils import (
 )
 
 RELEVANT_PERCENTILES = [25, 50, 75, 99]
+
+# Columns of the statistics tables, as (label, statistics key, percentile) triples.
+# The percentile is None for statistics that are not percentiles. The median is taken
+# from the "median" key rather than from the 50th percentile: both describe the same
+# quantity, but the former is exact while the latter is interpolated.
+STATISTICS_COLUMNS: List[Tuple[str, str, Optional[int]]] = [
+    ("#", "n", None),
+    ("mean", "mean", None),
+    ("min", "min", None),
+    ("P25", "percentiles", 25),
+    ("median", "median", None),
+    ("P75", "percentiles", 75),
+    ("P99", "percentiles", 99),
+    ("max", "max", None),
+]
+
 MARKS_RELEVANT_FOR_STATISTICS = [
     "EventLoopRun",
     "RAFCallback",
     "LayerTreeHostRenderingUpdate",
+    "FinalizeRenderingUpdate",
     "PerformLayout",
     "PerformSubtreesLayout",
-    "FlushCompositingState",
-    "PaintToGLContext",
     "StyleRecalc",
+    "RenderTreeBuild",
+    "CompositingUpdate",
+    "FlushCompositingState",
+    "RenderLayerTree",
+    "PaintToGLContext",
+    "WaitForCompositionCompletion",
+    "RecordTile",
+    "UpdateTiles",
+    "PaintTile",
+    "UpdateTile",
+    "SkiaBackingStoreTileUpdate",
 ]
+
+# PaintTile messages look like "Skia/CPU threaded, dirty region 768x512+256+56",
+# where the geometry is "<x>x<y>+<width>+<height>".
+DIRTY_REGION_RE = re.compile(r"(\d+)x(\d+)\+(\d+)\+(\d+)")
+
+
+def _dirty_region_pixels(message: str) -> Optional[int]:
+    match = DIRTY_REGION_RE.search(message)
+    if match is None:
+        return None
+    return int(match.group(3)) * int(match.group(4))
+
+
 STATISTICAL_DATA_EXTRACTORS: Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]]] = {
     "_": lambda data: {
         "duration": nsec_to_msec(data["duration"]),
@@ -36,6 +76,14 @@ STATISTICAL_DATA_EXTRACTORS: Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]
     "PerformSubtreesLayout": lambda data: STATISTICAL_DATA_EXTRACTORS["_"](data)
     | {
         "subtrees": int(data["message"].split()[1]) if data["message"] != "" else None,
+    },
+    "UpdateTiles": lambda data: STATISTICAL_DATA_EXTRACTORS["_"](data)
+    | {
+        "tiles": int(data["message"].split()[2]) if data["message"] != "" else None,
+    },
+    "PaintTile": lambda data: STATISTICAL_DATA_EXTRACTORS["_"](data)
+    | {
+        "dirty_pixels": _dirty_region_pixels(data["message"]),
     },
 }
 
@@ -326,16 +374,37 @@ def _render_text_report(report: Dict[str, Any]) -> None:
         _prepare_statistics_rows(
             [
                 ("JS", "EventLoopRun", "ms", "duration"),
+                ("Styling", "StyleRecalc", "ms", "duration"),
+                ("Styling", "RenderTreeBuild", "ms", "duration"),
                 ("Layout", "PerformSubtreesLayout", "ms", "duration"),
                 ("Layout", "PerformLayout", "ms", "duration"),
-                ("Styling", "StyleRecalc", "ms", "duration"),
                 ("Rendering", "LayerTreeHostRenderingUpdate", "ms", "duration"),
+                ("Rendering", "FinalizeRenderingUpdate", "ms", "duration"),
                 ("Rendering/JS", "RAFCallback", "ms", "duration"),
+                ("Compositing", "CompositingUpdate", "ms", "duration"),
                 ("Compositing", "FlushCompositingState", "ms", "duration"),
+                ("Compositing", "RenderLayerTree", "ms", "duration"),
                 ("Compositing", "PaintToGLContext", "ms", "duration"),
+                ("Compositing", "WaitForCompositionCompletion", "ms", "duration"),
+                ("Tiles", "RecordTile", "ms", "duration"),
+                ("Tiles", "UpdateTiles", "ms", "duration"),
+                ("Tiles", "PaintTile", "ms", "duration"),
+                ("Tiles", "UpdateTile", "ms", "duration"),
+                ("Tiles", "SkiaBackingStoreTileUpdate", "ms", "duration"),
             ],
             report,
         )
+    )
+    print()
+    print(
+        "  StyleRecalc is an umbrella mark: it nests RenderTreeBuild,\n"
+        "  PerformSubtreesLayout and CompositingUpdate, so its duration is not\n"
+        "  style resolution alone. Subtract the nested marks to get that.\n"
+        "  CompositingUpdate runs twice per rendering update, once inside\n"
+        "  StyleRecalc and once after it, and the second one is much shorter, so\n"
+        "  its percentiles are bimodal rather than centered on a typical value.\n"
+        "  PaintTile runs on the painting threads, so summing it across a frame\n"
+        "  yields aggregate work rather than elapsed time."
     )
 
     print()
@@ -345,6 +414,8 @@ def _render_text_report(report: Dict[str, Any]) -> None:
             [
                 ("JS", "EventLoopRun", "#tasks", "tasks"),
                 ("Layout", "PerformSubtreesLayout", "#subtrees", "subtrees"),
+                ("Tiles", "UpdateTiles", "#tiles", "tiles"),
+                ("Tiles", "PaintTile", "#pixels", "dirty_pixels"),
             ],
             report,
         )
@@ -367,9 +438,7 @@ def _prepare_statistics_rows(
     keys: List[Tuple[str, str, str, str]], report: Dict[str, Any]
 ) -> List[List[str]]:
     statistics_rows = [
-        ["category", "mark", "unit", "#", "min"]
-        + [f"P{percentile}" for percentile in RELEVANT_PERCENTILES]
-        + ["max"],
+        ["category", "mark", "unit"] + [label for label, _, _ in STATISTICS_COLUMNS],
     ]
     for category, mark, unit, data_key in keys:
         data = {}
@@ -383,11 +452,10 @@ def _prepare_statistics_row(
     category: str, mark: str, unit: str, raw_data: Dict[str, Any]
 ) -> List[str]:
     data = _statistics_to_strings(raw_data)
-    return (
-        [category, mark, unit, data["n"], data["min"]]
-        + [data["percentiles"][percentile] for percentile in RELEVANT_PERCENTILES]
-        + [data["max"]]
-    )
+    return [category, mark, unit] + [
+        data[key] if percentile is None else data["percentiles"][percentile]
+        for _, key, percentile in STATISTICS_COLUMNS
+    ]
 
 
 def _statistics_to_strings(statistics: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
#### 6881be5d93f56631897bf8c341bca5203ebca5e8
<pre>
webkit-sysprof analyze needs to analyze more marks, to see where a frame time goes
<a href="https://bugs.webkit.org/show_bug.cgi?id=321920">https://bugs.webkit.org/show_bug.cgi?id=321920</a>

Reviewed by Justin Michaud.

Add the remaining marks emitted along the rendering pipeline:
RenderTreeBuild and CompositingUpdate for styling and compositing,
FinalizeRenderingUpdate and RenderLayerTree for the rendering update,
WaitForCompositionCompletion for the composition wait, and the tile marks
(RecordTile, UpdateTiles, PaintTile, UpdateTile and
SkiaBackingStoreTileUpdate).

Two of those marks carry data in their message: UpdateTiles reports how
many tiles it touched and PaintTile reports the dirty region, so extract
both as count statistics next to the durations.

The statistics tables gain mean and median columns. Both tables are now
driven by a single STATISTICS_COLUMNS list instead of spelling the
columns out once in the header and once in the row builder. The median
column uses the exact median rather than the interpolated 50th
percentile, since the two describe the same quantity.

Three of these marks are easy to misread: StyleRecalc nests other marks,
CompositingUpdate runs twice per rendering update, and PaintTile runs on
the painting threads rather than the main thread. The text report and the
README now say so.

* Tools/Scripts/webkit-sysprof/README.md:
* Tools/Scripts/webkit-sysprof/tests/test_subcommands_e2e.py:
(test_analyze_json_statistics_cover_all_relevant_marks):
* Tools/Scripts/webkit-sysprof/webkitsysprof/analyze/__init__.py:
(_dirty_region_pixels):
(_render_text_report):

Canonical link: <a href="https://commits.webkit.org/319307@main">https://commits.webkit.org/319307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27d585bb72ad702f3c11b24adc38fa7967605723

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145366 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141263 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121715 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43599 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41880 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41540 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2417 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193192 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54654 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150646 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55342 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150363 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44955 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123138 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53859 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16536 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53241 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->