### PR TITLE
REGRESSION(315668@main) ManagedMediaSource: "startstreaming" is not emitted when seeking

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-resume-after-seek-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-resume-after-seek-expected.txt
@@ -1,0 +1,20 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+EVENT(startstreaming)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(source.duration = 300)
+EVENT(endstreaming)
+EXPECTED (source.streaming == 'false') OK
+RUN(video.currentTime = seekTime)
+EVENT(startstreaming)
+EXPECTED (source.streaming == 'true') OK
+EXPECTED (video.seeking == 'true') OK
+RUN(sourceBuffer.timestampOffset = seekTime)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(seeked)
+EXPECTED (video.currentTime >= seekTime == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-resume-after-seek.html
+++ b/LayoutTests/media/media-source/media-managedmse-resume-after-seek.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>managedmediasource-resume-after-seek</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script src="../utilities.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+    var seekTime;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        try {
+            findMediaElement();
+
+            let manifests = [ 'content/test-opus-manifest.json', 'content/test-vorbis-manifest.json', 'content/test-48khz-manifest.json', 'content/test-xhe-aac-manifest.json' ];
+            for (const manifest of manifests) {
+                loader = new MediaSourceLoader(manifest);
+                await loaderPromise(loader);
+                if (ManagedMediaSource.isTypeSupported(loader.type()))
+                    break;
+            }
+
+            waitFor(video, 'error').then(failTest);
+
+            video.disableRemotePlayback = true;
+            source = new ManagedMediaSource();
+            run('video.src = URL.createObjectURL(source)');
+
+            await waitFor(source, 'sourceopen');
+            await waitFor(source, 'startstreaming');
+
+            run('sourceBuffer = source.addSourceBuffer(loader.type())');
+            run('sourceBuffer.appendBuffer(loader.initSegment())');
+            await waitFor(sourceBuffer, 'update');
+
+            // Make the media longer than what will ever be buffered so that a position past the
+            // buffered range is still seekable.
+            run('source.duration = 300');
+
+            // Append content until enough is buffered for the ManagedMediaSource to stop streaming.
+            const endStreaming = waitFor(source, 'endstreaming');
+            while (source.streaming) {
+                sourceBuffer.appendBuffer(loader.mediaSegment(0));
+                await once(sourceBuffer, 'update');
+                sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1);
+            }
+            await endStreaming;
+            testExpected('source.streaming', false);
+
+            // Seeking to a time with no buffered media must resume streaming so that the content
+            // required to complete the seek can be appended.
+            seekTime = sourceBuffer.buffered.end(0) + 30;
+            run('video.currentTime = seekTime');
+            await waitFor(source, 'startstreaming');
+            testExpected('source.streaming', true);
+            testExpected('video.seeking', true);
+
+            run('sourceBuffer.timestampOffset = seekTime');
+            run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+            await waitFor(video, 'seeked');
+            testExpected('video.currentTime >= seekTime', true);
+
+            endTest();
+        } catch (e) {
+            failTest(`Caught exception: "${e}"`);
+        }
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -160,6 +160,13 @@ private:
         return m_private;
     }
 
+    void monitorSourceBuffers() final
+    {
+        ensureWeakOnDispatcher([](MediaSource& parent) {
+            parent.monitorSourceBuffers();
+        });
+    }
+
     void failedToCreateRenderer(RendererType type)
     {
         ensureWeakOnDispatcher([type](MediaSource& parent) {

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -165,6 +165,15 @@ Ref<MediaTimePromise> MediaSourcePrivate::waitForTarget(const SeekTarget& target
         }
 
         protectedThis->tryCompleteWaitForTarget();
+
+        if (protectedThis->m_waitForTargetPromise) {
+            // There's no data at the seek target: run the SourceBuffer Monitoring algorithm so that
+            // the readyState is lowered and a ManagedMediaSource resumes streaming, letting the
+            // content be appended and this seek complete.
+            if (RefPtr client = protectedThis->client())
+                client->monitorSourceBuffers();
+        }
+
         return promise;
     })->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
         RefPtr protectedThis = weakThis.get();
@@ -607,6 +616,11 @@ MediaTime MediaSourcePrivate::currentTime() const
         if (m_pendingSeekTarget)
             return m_pendingSeekTarget->time;
     }
+    return platformCurrentTime();
+}
+
+MediaTime MediaSourcePrivate::platformCurrentTime() const
+{
     if (RefPtr player = this->player())
         return player->currentOrPendingSeekTime();
     return MediaTime::zeroTime();

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -86,8 +86,8 @@ public:
     virtual RefPtr<MediaPlayerPrivateInterface> player() const = 0;
     virtual void setPlayer(MediaPlayerPrivateInterface*) = 0;
     void shutdown();
-    // Implementation override must be thread-safe. For the base implementation to be thread-safe, player() must be a ThreadSafeRefCounted object.
-    virtual MediaTime currentTime() const;
+    // Returns the target of the seek being waited on if any, the platform's current time otherwise.
+    MediaTime currentTime() const;
     virtual bool timeIsProgressing() const;
 
     virtual constexpr MediaPlatformType platformType() const = 0;
@@ -193,6 +193,9 @@ protected:
     MediaSourcePrivate(MediaSourcePrivateClient&, WorkQueue&);
     void ensureOnDispatcher(Function<void()>&&) const;
     void ensureOnDispatcherSync(NOESCAPE Function<void()>&&) const;
+
+    // Implementation override must be thread-safe. For the base implementation to be thread-safe, player() must be a ThreadSafeRefCounted object.
+    virtual MediaTime platformCurrentTime() const;
 
     mutable Lock m_lock;
     // FIXME: This should be a Vector<Ref<SourceBufferPrivate>>

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -49,6 +49,7 @@ public:
     virtual void setPrivateAndOpen(Ref<MediaSourcePrivate>&&) = 0;
     virtual void reOpen() = 0;
     virtual RefPtr<MediaSourcePrivate> mediaSourcePrivate() const = 0;
+    virtual void monitorSourceBuffers() = 0;
 
 #if !RELEASE_LOG_DISABLED
     virtual void setLogIdentifier(uint64_t) = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -117,7 +117,7 @@ private:
 
     void setSourceBufferWithSelectedVideo(SourceBufferPrivateAVFObjC*);
 
-    MediaTime currentTime() const final;
+    MediaTime platformCurrentTime() const final;
     bool timeIsProgressing() const final;
     void bufferedChanged(PlatformTimeRanges&&) final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -246,7 +246,7 @@ RefPtr<MediaPlayerPrivateMediaSourceAVFObjC> MediaSourcePrivateAVFObjC::platform
     return m_player.get();
 }
 
-MediaTime MediaSourcePrivateAVFObjC::currentTime() const
+MediaTime MediaSourcePrivateAVFObjC::platformCurrentTime() const
 {
     RefPtr renderer = m_renderer.get();
     return renderer ? renderer->currentTime() : MediaTime::zeroTime();


### PR DESCRIPTION
#### a3af5da09b5c80d0d49bedc0528d3bc6947f4690
<pre>
REGRESSION(315668@main) ManagedMediaSource: &quot;startstreaming&quot; is not emitted when seeking
<a href="https://bugs.webkit.org/show_bug.cgi?id=321919">https://bugs.webkit.org/show_bug.cgi?id=321919</a>
<a href="https://rdar.apple.com/183790572">rdar://183790572</a>

Reviewed by Eric Carlson.

315668@main moved the pending seek target from MediaSource to MediaSourcePrivate.

It regressed two things:
- monitorSourceBuffer() which caused the ManagedMediaSource to monitor the buffered range
and appropriately handled the start/stop streaming event stop being called.
- It called the MediaSourcePrivate&apos;s currentTime rather than the player&apos;s one.
The MediaSourcePrivateAVFObjC::currentTime() implementation returned the renderer&apos;s currentTime.
The currentTime returned by the renderer will only be the same as the pending seek time once
the render seek as started. But the seek will only start if there&apos;s sufficient
buffered data to continue the seek.

Due to the latter, when the ManagedMediaSource&apos;s monitorSourceBuffer algoritm ran
it read the renderer&apos;s time before seek started which was always buffered
and so no startstreaming event needed firing.

HLS.js player is waiting for that event to be fired before appending data
and so seek never completed (it was never started).

MediaSourcePrivate::currentTime() is no longer virtual: it keeps the pending
seek target check and delegates to a new protected platformCurrentTime(), which
carries the thread-safety requirement the platform implementations need, so an
override can no longer drop the pending target. MediaSourcePrivateAVFObjC
overrides platformCurrentTime() and still reads the renderer, which is the only
source of time it can use off the main thread.
We also add in MediaSourcePrivate::waitForTarget() a call to monitorSourceBuffer
when data isn&apos;t buffered to ensure startstreaming is fired.

Added a new test.

* LayoutTests/media/media-source/media-managedmse-resume-after-seek-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-resume-after-seek.html: Added.
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSourceClientImpl::monitorSourceBuffers): Run the algorithm on the MediaSource&apos;s thread.
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::waitForTarget): Ask the client to monitor the source buffers when the target isn&apos;t buffered.
(WebCore::MediaSourcePrivate::currentTime const): Return the pending seek target, otherwise the platform&apos;s time.
(WebCore::MediaSourcePrivate::platformCurrentTime const): Moved from currentTime().
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::platformCurrentTime const): Renamed from currentTime().

Canonical link: <a href="https://commits.webkit.org/319330@main">https://commits.webkit.org/319330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15184ad08097889cc3ff3286319f380dfd2be7d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145367 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68f403b0-64d8-49f2-9d10-8ec528a5a213) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141264 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f63fbea-9542-4fa9-9955-172abf3275dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121716 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3adbe537-1b28-4b59-a19f-15f2301a45b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43604 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41881 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154008 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41539 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2418 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193193 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150649 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55343 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38158 "Too many flaky failures: http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/privateClickMeasurement/store-private-click-measurement-nested.html, http/tests/resourceLoadStatistics/downgraded-referrer-for-navigation-with-link-query-from-prevalent-resource.html, http/tests/security/cached-svg-image-with-css-cross-domain.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/image-blocked-alt-text.html, http/tests/security/mixedContent/redirect-http-to-https-script-in-iframe-UpgradeMixedContent.html, http/tests/site-isolation/edge-sampling-commit-root-frame-load.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html, http/tests/webshare/webshare-allow-attribute-share.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150366 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44960 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127609 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123139 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53860 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16535 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53242 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53479 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53307 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->