### PR TITLE
[GTK][WPE] Skia compositor: use promise images for WebGL DMABuf buffers

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -232,10 +232,17 @@ void GraphicsContextGLTextureMapperGBM::prepareForDisplay()
     if (contextAttributes().alpha)
         flags.add(TextureMapperFlags::ShouldBlend);
     std::unique_ptr<CoordinatedPlatformLayerBuffer> buffer;
+#if USE(SKIA)
+    if (fenceFD)
+        buffer = CoordinatedPlatformLayerBufferDMABuf::create(protect(*m_displayBuffer.dmabuf), flags, WTF::move(fenceFD), m_layerContentsDisplayDelegate->threadSafeGrContext());
+    else
+        buffer = CoordinatedPlatformLayerBufferDMABuf::create(protect(*m_displayBuffer.dmabuf), flags, WTF::move(fence), m_layerContentsDisplayDelegate->threadSafeGrContext());
+#else
     if (fenceFD)
         buffer = CoordinatedPlatformLayerBufferDMABuf::create(protect(*m_displayBuffer.dmabuf), flags, WTF::move(fenceFD));
     else
         buffer = CoordinatedPlatformLayerBufferDMABuf::create(protect(*m_displayBuffer.dmabuf), flags, WTF::move(fence));
+#endif
     m_layerContentsDisplayDelegate->setDisplayBuffer(WTF::move(buffer));
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -31,6 +31,7 @@
 #include "CoordinatedPlatformLayerBufferRGB.h"
 #include "CoordinatedPlatformLayerBufferYUV.h"
 #include "DMABufBuffer.h"
+#include "GLContext.h"
 #include "PlatformDisplay.h"
 #include "TextureMapper.h"
 #include <drm_fourcc.h>
@@ -38,6 +39,16 @@
 #include <epoxy/gl.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+#include <skia/private/chromium/GrPromiseImageTexture.h>
+#include <skia/private/chromium/SkImageChromium.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
 
 namespace WebCore {
 
@@ -63,6 +74,33 @@ CoordinatedPlatformLayerBufferDMABuf::CoordinatedPlatformLayerBufferDMABuf(Ref<D
     , m_fenceFD(WTF::move(fenceFD))
 {
 }
+
+#if USE(SKIA)
+std::unique_ptr<CoordinatedPlatformLayerBufferDMABuf> CoordinatedPlatformLayerBufferDMABuf::create(Ref<DMABufBuffer>&& dmabuf, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+{
+    return makeUnique<CoordinatedPlatformLayerBufferDMABuf>(WTF::move(dmabuf), flags, WTF::move(fence), threadSafeGrContext);
+}
+
+std::unique_ptr<CoordinatedPlatformLayerBufferDMABuf> CoordinatedPlatformLayerBufferDMABuf::create(Ref<DMABufBuffer>&& dmabuf, OptionSet<TextureMapperFlags> flags, UnixFileDescriptor&& fenceFD, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+{
+    return makeUnique<CoordinatedPlatformLayerBufferDMABuf>(WTF::move(dmabuf), flags, WTF::move(fenceFD), threadSafeGrContext);
+}
+
+CoordinatedPlatformLayerBufferDMABuf::CoordinatedPlatformLayerBufferDMABuf(Ref<DMABufBuffer>&& dmabuf, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+    : CoordinatedPlatformLayerBuffer(Type::DMABuf, dmabuf->attributes().size, flags, WTF::move(fence))
+    , m_dmabuf(WTF::move(dmabuf))
+{
+    createSkiaImageIfNeeded(threadSafeGrContext);
+}
+
+CoordinatedPlatformLayerBufferDMABuf::CoordinatedPlatformLayerBufferDMABuf(Ref<DMABufBuffer>&& dmabuf, OptionSet<TextureMapperFlags> flags, UnixFileDescriptor&& fenceFD, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+    : CoordinatedPlatformLayerBuffer(Type::DMABuf, dmabuf->attributes().size, flags, nullptr)
+    , m_dmabuf(WTF::move(dmabuf))
+    , m_fenceFD(WTF::move(fenceFD))
+{
+    createSkiaImageIfNeeded(threadSafeGrContext);
+}
+#endif
 
 CoordinatedPlatformLayerBufferDMABuf::~CoordinatedPlatformLayerBufferDMABuf() = default;
 
@@ -274,8 +312,86 @@ void CoordinatedPlatformLayerBufferDMABuf::paintToTextureMapper(TextureMapper& t
 }
 
 #if USE(SKIA)
+struct PromiseDMABufImageContext {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(PromiseDMABufImageContext);
+
+    PromiseDMABufImageContext(Ref<DMABufBuffer>&& buffer, std::unique_ptr<GLFence>&& glFence, WTF::UnixFileDescriptor&& fd)
+        : dmabuf(WTF::move(buffer))
+        , fence(WTF::move(glFence))
+        , fenceFD(WTF::move(fd))
+    {
+    }
+
+    sk_sp<GrPromiseImageTexture> promiseImageTexture()
+    {
+        auto& display = PlatformDisplay::sharedDisplay();
+        auto* glContext = display.skiaGLContext();
+        if (!glContext || !glContext->makeContextCurrent())
+            return nullptr;
+
+        if (auto glFence = WTF::move(fence))
+            glFence->serverWait();
+        else if (fenceFD) {
+            if (auto glFence = GLFence::importFD(display.glDisplay(), WTF::move(fenceFD)))
+                glFence->serverWait();
+        }
+
+        const auto& attributes = dmabuf->attributes();
+        if (!dmabuf->buffer()) {
+            std::unique_ptr<CoordinatedPlatformLayerBuffer> buffer;
+            if (auto texture = importToTexture(attributes.size, attributes, { }))
+                buffer = CoordinatedPlatformLayerBufferRGB::create(texture.releaseNonNull(), { }, nullptr);
+            dmabuf->setBuffer(WTF::move(buffer));
+        }
+
+        auto* buffer = dmabuf->buffer();
+        if (is<CoordinatedPlatformLayerBufferRGB>(buffer)) {
+            GrGLTextureInfo externalTexture;
+            externalTexture.fTarget = GL_TEXTURE_2D;
+            externalTexture.fID = downcast<CoordinatedPlatformLayerBufferRGB>(*buffer).textureID();
+            externalTexture.fFormat = GL_RGBA8;
+            auto backendTexture = GrBackendTextures::MakeGL(attributes.size.width(), attributes.size.height(), skgpu::Mipmapped::kNo, externalTexture);
+            return GrPromiseImageTexture::Make(backendTexture);
+        }
+
+        return nullptr;
+    }
+
+    const Ref<DMABufBuffer> dmabuf;
+    std::unique_ptr<GLFence> fence;
+    WTF::UnixFileDescriptor fenceFD;
+};
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(PromiseDMABufImageContext);
+
+void CoordinatedPlatformLayerBufferDMABuf::createSkiaImageIfNeeded(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+{
+    const auto& attributes = m_dmabuf->attributes();
+    RELEASE_ASSERT(!formatIsYUV(attributes.fourcc.value));
+
+    auto backendFormat = threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
+    ASSERT(backendFormat.isValid());
+
+    auto context = makeUnique<PromiseDMABufImageContext>(m_dmabuf.copyRef(), WTF::move(m_fence), WTF::move(m_fenceFD));
+
+    auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
+    auto alphaType = m_flags.contains(TextureMapperFlags::ShouldBlend) ? kPremul_SkAlphaType : kOpaque_SkAlphaType;
+    m_image = SkImages::PromiseTextureFrom(threadSafeGrContext, backendFormat, SkISize::Make(attributes.size.width(), attributes.size.height()), skgpu::Mipmapped::kNo,
+        origin, kRGBA_8888_SkColorType, alphaType, SkColorSpace::MakeSRGB(),
+        +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
+            auto& context = *static_cast<PromiseDMABufImageContext*>(userData);
+            return context.promiseImageTexture();
+        },
+        +[](void* userData) {
+            std::unique_ptr<PromiseDMABufImageContext> context(static_cast<PromiseDMABufImageContext*>(userData));
+        }, context.release());
+}
+
 sk_sp<SkImage> CoordinatedPlatformLayerBufferDMABuf::skiaImage()
 {
+    if (m_image)
+        return m_image;
+
     waitForContentsIfNeeded();
 
     if (m_fenceFD) {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
@@ -29,6 +29,12 @@
 #include "CoordinatedPlatformLayerBuffer.h"
 #include <wtf/unix/UnixFileDescriptor.h>
 
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
+
 namespace WebCore {
 
 class DMABufBuffer;
@@ -38,6 +44,12 @@ class CoordinatedPlatformLayerBufferDMABuf final : public CoordinatedPlatformLay
 public:
     static std::unique_ptr<CoordinatedPlatformLayerBufferDMABuf> create(Ref<DMABufBuffer>&&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     static std::unique_ptr<CoordinatedPlatformLayerBufferDMABuf> create(Ref<DMABufBuffer>&&, OptionSet<TextureMapperFlags>, WTF::UnixFileDescriptor&&);
+#if USE(SKIA)
+    static std::unique_ptr<CoordinatedPlatformLayerBufferDMABuf> create(Ref<DMABufBuffer>&&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&, const sk_sp<GrContextThreadSafeProxy>&);
+    static std::unique_ptr<CoordinatedPlatformLayerBufferDMABuf> create(Ref<DMABufBuffer>&&, OptionSet<TextureMapperFlags>, WTF::UnixFileDescriptor&&, const sk_sp<GrContextThreadSafeProxy>&);
+    CoordinatedPlatformLayerBufferDMABuf(Ref<DMABufBuffer>&&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&, const sk_sp<GrContextThreadSafeProxy>&);
+    CoordinatedPlatformLayerBufferDMABuf(Ref<DMABufBuffer>&&, OptionSet<TextureMapperFlags>, WTF::UnixFileDescriptor&&, const sk_sp<GrContextThreadSafeProxy>&);
+#endif
     CoordinatedPlatformLayerBufferDMABuf(Ref<DMABufBuffer>&&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     CoordinatedPlatformLayerBufferDMABuf(Ref<DMABufBuffer>&&, OptionSet<TextureMapperFlags>, WTF::UnixFileDescriptor&&);
     virtual ~CoordinatedPlatformLayerBufferDMABuf();
@@ -46,6 +58,7 @@ private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
 #if USE(SKIA)
+    void createSkiaImageIfNeeded(const sk_sp<GrContextThreadSafeProxy>&);
     sk_sp<SkImage> skiaImage() override;
 #endif
 
@@ -54,6 +67,9 @@ private:
 
     const Ref<DMABufBuffer> m_dmabuf;
     WTF::UnixFileDescriptor m_fenceFD;
+#if USE(SKIA)
+    sk_sp<SkImage> m_image;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
@@ -70,6 +70,11 @@ CoordinatedPlatformLayerBufferRGB::CoordinatedPlatformLayerBufferRGB(unsigned te
 
 CoordinatedPlatformLayerBufferRGB::~CoordinatedPlatformLayerBufferRGB() = default;
 
+unsigned CoordinatedPlatformLayerBufferRGB::textureID() const
+{
+    return m_texture ? m_texture->id() : m_textureID;
+}
+
 void CoordinatedPlatformLayerBufferRGB::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity)
 {
     waitForContentsIfNeeded();
@@ -91,7 +96,7 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferRGB::skiaImage()
     ASSERT(grContext);
     GrGLTextureInfo externalTexture;
     externalTexture.fTarget = GL_TEXTURE_2D;
-    externalTexture.fID = m_texture ? m_texture->id() : m_textureID;
+    externalTexture.fID = textureID();
     externalTexture.fFormat = GL_RGBA8;
     auto backendTexture = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
     auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h
@@ -40,7 +40,7 @@ public:
     CoordinatedPlatformLayerBufferRGB(unsigned textureID, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     virtual ~CoordinatedPlatformLayerBufferRGB();
 
-    unsigned textureID() const { return m_textureID; }
+    unsigned textureID() const;
 
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;

--- a/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
@@ -83,7 +83,11 @@ void RemoteGraphicsContextGLProxyGBM::prepareForDisplay()
     OptionSet<TextureMapperFlags> flags = TextureMapperFlags::ShouldFlipTexture;
     if (contextAttributes().alpha)
         flags.add(TextureMapperFlags::ShouldBlend);
+#if USE(SKIA)
+    m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferDMABuf::create(protect(*m_displayBuffer), flags, WTF::move(fenceFD), m_layerContentsDisplayDelegate->threadSafeGrContext()));
+#else
     m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferDMABuf::create(protect(*m_displayBuffer), flags, WTF::move(fenceFD)));
+#endif
 }
 
 Ref<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::platformCreate(const GraphicsContextGLAttributes& attributes, RemoteRenderingBackendProxy& renderingBackend)


### PR DESCRIPTION
#### 29b0c50957f19a3849848a7d08f46b888000ff9d
<pre>
[GTK][WPE] Skia compositor: use promise images for WebGL DMABuf buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=321923">https://bugs.webkit.org/show_bug.cgi?id=321923</a>

Reviewed by Nikolas Zimmermann.

Create a promise image that imports the DMABuf from the compositing thread when needed.

* Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp:
(WebCore::GraphicsContextGLTextureMapperGBM::prepareForDisplay):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp:
(WebCore::CoordinatedPlatformLayerBufferDMABuf::create):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::CoordinatedPlatformLayerBufferDMABuf):
(WebCore::PromiseDMABufImageContext::PromiseDMABufImageContext):
(WebCore::PromiseDMABufImageContext::promiseImageTexture):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::createSkiaImageIfNeeded):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::skiaImage):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp:
(WebCore::CoordinatedPlatformLayerBufferRGB::textureID const):
(WebCore::CoordinatedPlatformLayerBufferRGB::skiaImage):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h:
* Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp:
(WebKit::RemoteGraphicsContextGLProxyGBM::prepareForDisplay):

Canonical link: <a href="https://commits.webkit.org/319519@main">https://commits.webkit.org/319519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad5ae446462a223de9e5468c76d6d1f12faff29a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146035 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141833 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122269 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44215 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42113 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3092 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193857 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55323 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151245 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56012 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150950 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27602 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45533 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128295 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124004 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54525 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17109 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53907 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54146 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53972 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->