### PR TITLE
[JSC][Wasm] Re-exported imported immutable Global should be the same object

### DIFF
--- a/JSTests/wasm/js-api/global-import-export-identity.js
+++ b/JSTests/wasm/js-api/global-import-export-identity.js
@@ -1,0 +1,46 @@
+import * as assert from '../assert.js';
+import Builder from '../Builder.js';
+
+function moduleImportingAndExportingI32() {
+    const builder = new Builder();
+    builder.Type().End()
+        .Import()
+            .Global().I32("imp", "global", "immutable").End()
+        .End()
+        .Export()
+            .Global("global", 0)
+        .End();
+    const bin = builder.WebAssembly();
+    bin.trim();
+    return new WebAssembly.Module(bin.get());
+}
+
+{
+    const module = moduleImportingAndExportingI32();
+    const imported = new WebAssembly.Global({ value: "i32", mutable: false }, 7);
+    const instance = new WebAssembly.Instance(module, { imp: { global: imported } });
+    assert.eq(instance.exports.global, imported);
+    assert.eq(instance.exports.global.value, 7);
+}
+
+{
+    const module = moduleImportingAndExportingI32();
+    const instance = new WebAssembly.Instance(module, { imp: { global: 11 } });
+    assert.eq(instance.exports.global.value, 11);
+}
+
+{
+    const producer = new Builder();
+    producer.Type().End()
+        .Global().I32(13, "immutable").End()
+        .Export()
+            .Global("global", 0)
+        .End();
+    const producedBin = producer.WebAssembly();
+    producedBin.trim();
+    const produced = new WebAssembly.Instance(new WebAssembly.Module(producedBin.get()));
+    const module = moduleImportingAndExportingI32();
+    const instance = new WebAssembly.Instance(module, { imp: { global: produced.exports.global } });
+    assert.eq(instance.exports.global, produced.exports.global);
+    assert.eq(instance.exports.global.value, 13);
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-caching.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-caching.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL constructor-caching assert_equals: expected object "[object WebAssembly.Global]" but got object "[object WebAssembly.Global]"
+PASS constructor-caching
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-caching.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-caching.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL constructor-caching assert_equals: expected object "[object WebAssembly.Global]" but got object "[object WebAssembly.Global]"
+PASS constructor-caching
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -229,6 +229,8 @@ void JSWebAssemblyInstance::visitChildrenImpl(JSCell* cell, Visitor& visitor)
         visitor.append(entry.value);
     for (auto& entry : thisObject->m_tagWrappers)
         visitor.append(entry.value);
+    for (auto& entry : thisObject->m_importedGlobalWrappers)
+        visitor.append(entry.value);
 }
 
 DEFINE_VISIT_CHILDREN(JSWebAssemblyInstance);
@@ -471,6 +473,22 @@ JSWebAssemblyTag* JSWebAssemblyInstance::tagWrapper(unsigned index) const
     Locker locker { cellLock() };
     auto iterator = m_tagWrappers.find(index);
     if (iterator == m_tagWrappers.end())
+        return nullptr;
+    return iterator->value.get();
+}
+
+void JSWebAssemblyInstance::setImportedGlobalWrapper(VM& vm, unsigned index, JSWebAssemblyGlobal* global)
+{
+    ASSERT(global);
+    Locker locker { cellLock() };
+    m_importedGlobalWrappers.set(index, WriteBarrier<JSWebAssemblyGlobal>(vm, this, global));
+}
+
+JSWebAssemblyGlobal* JSWebAssemblyInstance::importedGlobalWrapper(unsigned index) const
+{
+    Locker locker { cellLock() };
+    auto iterator = m_importedGlobalWrappers.find(index);
+    if (iterator == m_importedGlobalWrappers.end())
         return nullptr;
     return iterator->value.get();
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -169,6 +169,8 @@ public:
 
     void setTagWrapper(VM&, unsigned index, JSWebAssemblyTag*);
     JSWebAssemblyTag* tagWrapper(unsigned index) const;
+    void setImportedGlobalWrapper(VM&, unsigned index, JSWebAssemblyGlobal*);
+    JSWebAssemblyGlobal* importedGlobalWrapper(unsigned index) const;
 
     JSWebAssemblyModule* jsModule() const LIFETIME_BOUND { return m_jsModule.get(); }
     const Wasm::ModuleInformation& moduleInformation() const { return m_moduleInformation.get(); }
@@ -479,6 +481,8 @@ private:
     UncheckedKeyHashMap<uint32_t, Ref<Wasm::Global>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_linkedGlobals;
     using TagWrapperMap = UncheckedKeyHashMap<uint32_t, WriteBarrier<JSWebAssemblyTag>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
     TagWrapperMap m_tagWrappers;
+    using GlobalWrapperMap = UncheckedKeyHashMap<uint32_t, WriteBarrier<JSWebAssemblyGlobal>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    GlobalWrapperMap m_importedGlobalWrappers;
     BitVector m_passiveElements;
     BitVector m_passiveDataSegments;
     FixedVector<RefPtr<const Wasm::Tag>> m_tags;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -307,6 +307,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                         return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "must be a same type"_s)));
                     if (globalValue->global()->mutability() != Wasm::Immutable)
                         return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "must be a same mutability"_s)));
+                    m_instance->setImportedGlobalWrapper(vm, import.kindIndex, globalValue);
                     const auto& declaredGlobalType = moduleInformation.globals[import.kindIndex].type;
                     switch (declaredGlobalType.kind()) {
                     case Wasm::TypeKind::I32:
@@ -727,6 +728,10 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
                 // If global is immutable, we are not creating a binding internally.
                 // But we need to create a binding just to export it. This binding is not actually connected. But this is OK since it is immutable.
                 if (global.bindingMode == Wasm::GlobalInformation::BindingMode::EmbeddedInInstance) {
+                    if (JSWebAssemblyGlobal* wrapper = m_instance->importedGlobalWrapper(exp.kindIndex)) {
+                        exportedValue = wrapper;
+                        break;
+                    }
                     RefPtr<Wasm::Global> globalRef;
                     if (global.type.kind() == Wasm::TypeKind::V128) {
                         v128_t initialValue = m_instance->loadV128Global(exp.kindIndex);


### PR DESCRIPTION
#### 20c0bd7d62f4eaef2e9d82e34875ba340b016b0f
<pre>
[JSC][Wasm] Re-exported imported immutable Global should be the same object
<a href="https://bugs.webkit.org/show_bug.cgi?id=321924">https://bugs.webkit.org/show_bug.cgi?id=321924</a>

Reviewed by Yusuke Suzuki.

Immutable imported globals copy their value into the instance. Export
then built a new JS wrapper, so re-exporting an imported
WebAssembly.Global produced a different object. Mutable imports already
go through linkGlobal and keep identity.

Remember the imported wrapper and return it from the export object.
Number imports still get a fresh wrapper.

* JSTests/wasm/js-api/global-import-export-identity.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-caching.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-caching.any.worker-expected.txt:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::visitChildrenImpl):
(JSC::JSWebAssemblyInstance::setImportedGlobalWrapper):
(JSC::JSWebAssemblyInstance::importedGlobalWrapper):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):
(JSC::WebAssemblyModuleRecord::initializeExports):

Canonical link: <a href="https://commits.webkit.org/319351@main">https://commits.webkit.org/319351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40f9f292500c5428a8ee070898dee4f06c5e905a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145447 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141335 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121786 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43673 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41953 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3751 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10569 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154077 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41614 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2498 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42398 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47681 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193273 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54735 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150725 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55423 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150441 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27512 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45029 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127689 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/123238 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53940 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16610 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53559 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->