### PR TITLE
Subgrid columns ignore the parent grid's content distribution

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgridded-axis-content-distribution-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgridded-axis-content-distribution-001-expected.txt
@@ -1,0 +1,10 @@
+
+PASS .grid 1: columns, parent space-between, subgrid sets nothing
+PASS .grid 2: columns, parent space-around
+PASS .grid 3: columns, parent space-evenly
+PASS .grid 4: columns, parent center, shift must not be applied twice
+PASS .grid 5: columns, parent space-between, subgrid spans 2 / -1
+PASS .grid 6: rows, parent align-content space-between
+PASS .grid 7: columns, nested subgrid inside a subgrid
+PASS .grid 8: columns, subgrid's own justify-content is ignored
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgridded-axis-content-distribution-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgridded-axis-content-distribution-001.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Test: content distribution is inherited by a subgrid in the subgridded axis</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#subgrid-grid-alignment">
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<!--
+  "Layoutwise, the subgrid's grid is always aligned with the corresponding section of the
+  parent grid; the 'align-content'/'justify-content' properties on it are also ignored in
+  the subgridded dimension."
+
+  Two requirements. When the parent distributes its leftover space between its tracks, the
+  subgrid's tracks have to move with them; and the subgrid's own content distribution never
+  applies. Every grid here is 3 tracks of 100px with a 10px gap, so tracks plus gaps come to
+  320px, and the container width sets how much is left to distribute.
+-->
+<style>
+.grid {
+  position: relative; /* Makes every offset below relative to this box. */
+  display: grid;
+  grid-template-columns: 100px 100px 100px;
+  grid-auto-rows: 20px;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+
+/* A subgrid does not set a gap of its own: it inherits the parent's. */
+.subgrid {
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+}
+
+.item { background: teal; }
+.subitem { background: orange; }
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<body onload="checkLayout('.grid')">
+
+<!-- 400 - 320 = 80 left over, shared between 2 gaps: 40 each. -->
+<div class="grid" style="width: 400px; justify-content: space-between"
+     title="columns, parent space-between, subgrid sets nothing">
+  <div class="item" data-offset-x="0" data-expected-width="100"></div>
+  <div class="item" data-offset-x="150" data-expected-width="100"></div>
+  <div class="item" data-offset-x="300" data-expected-width="100"></div>
+  <div class="subgrid" data-offset-x="0" data-expected-width="400">
+    <div class="subitem" data-offset-x="0" data-expected-width="100"></div>
+    <div class="subitem" data-offset-x="150" data-expected-width="100"></div>
+    <div class="subitem" data-offset-x="300" data-expected-width="100"></div>
+  </div>
+</div>
+
+<!-- 410 - 320 = 90 over 3 tracks: 30 between tracks, 15 at each edge. -->
+<div class="grid" style="width: 410px; justify-content: space-around"
+     title="columns, parent space-around">
+  <div class="item" data-offset-x="15" data-expected-width="100"></div>
+  <div class="item" data-offset-x="155" data-expected-width="100"></div>
+  <div class="item" data-offset-x="295" data-expected-width="100"></div>
+  <div class="subgrid" data-offset-x="15" data-expected-width="380">
+    <div class="subitem" data-offset-x="15" data-expected-width="100"></div>
+    <div class="subitem" data-offset-x="155" data-expected-width="100"></div>
+    <div class="subitem" data-offset-x="295" data-expected-width="100"></div>
+  </div>
+</div>
+
+<!-- 400 - 320 = 80 over 4 equal spaces: 20 each. -->
+<div class="grid" style="width: 400px; justify-content: space-evenly"
+     title="columns, parent space-evenly">
+  <div class="item" data-offset-x="20" data-expected-width="100"></div>
+  <div class="item" data-offset-x="150" data-expected-width="100"></div>
+  <div class="item" data-offset-x="280" data-expected-width="100"></div>
+  <div class="subgrid" data-offset-x="20" data-expected-width="360">
+    <div class="subitem" data-offset-x="20" data-expected-width="100"></div>
+    <div class="subitem" data-offset-x="150" data-expected-width="100"></div>
+    <div class="subitem" data-offset-x="280" data-expected-width="100"></div>
+  </div>
+</div>
+
+<!--
+  'center' shifts the whole grid and adds nothing between the tracks. The subgrid's box is
+  already placed at the parent's first grid line, so that shift must not be applied a second
+  time inside the subgrid: 40 / 150 / 260, not 80 / 190 / 300.
+-->
+<div class="grid" style="width: 400px; justify-content: center"
+     title="columns, parent center, shift must not be applied twice">
+  <div class="item" data-offset-x="40" data-expected-width="100"></div>
+  <div class="item" data-offset-x="150" data-expected-width="100"></div>
+  <div class="item" data-offset-x="260" data-expected-width="100"></div>
+  <div class="subgrid" data-offset-x="40" data-expected-width="320">
+    <div class="subitem" data-offset-x="40" data-expected-width="100"></div>
+    <div class="subitem" data-offset-x="150" data-expected-width="100"></div>
+    <div class="subitem" data-offset-x="260" data-expected-width="100"></div>
+  </div>
+</div>
+
+<!-- A subgrid over only part of the parent's tracks still lines up with them. -->
+<div class="grid" style="width: 400px; justify-content: space-between"
+     title="columns, parent space-between, subgrid spans 2 / -1">
+  <div class="item" data-offset-x="0" data-expected-width="100"></div>
+  <div class="item" data-offset-x="150" data-expected-width="100"></div>
+  <div class="item" data-offset-x="300" data-expected-width="100"></div>
+  <div class="subgrid" style="grid-column: 2 / -1" data-offset-x="150" data-expected-width="250">
+    <div class="subitem" data-offset-x="150" data-expected-width="100"></div>
+    <div class="subitem" data-offset-x="300" data-expected-width="100"></div>
+  </div>
+</div>
+
+<!-- The block axis works the same way, through align-content. -->
+<div class="grid" style="width: 210px; height: 400px; grid-template-columns: 100px 100px;
+                         grid-template-rows: 100px 100px 100px; align-content: space-between"
+     title="rows, parent align-content space-between">
+  <div class="item" style="grid-column: 1" data-offset-y="0" data-expected-height="100"></div>
+  <div class="item" style="grid-column: 1" data-offset-y="150" data-expected-height="100"></div>
+  <div class="item" style="grid-column: 1" data-offset-y="300" data-expected-height="100"></div>
+  <div style="display: grid; grid-template-rows: subgrid; grid-column: 2; grid-row: 1 / -1"
+       data-offset-y="0" data-expected-height="400">
+    <div class="subitem" data-offset-y="0" data-expected-height="100"></div>
+    <div class="subitem" data-offset-y="150" data-expected-height="100"></div>
+    <div class="subitem" data-offset-y="300" data-expected-height="100"></div>
+  </div>
+</div>
+
+<!-- A subgrid of a subgrid reaches all the way back to the outermost grid's tracks. -->
+<div class="grid" style="width: 400px; justify-content: space-between"
+     title="columns, nested subgrid inside a subgrid">
+  <div class="item" data-offset-x="0" data-expected-width="100"></div>
+  <div class="item" data-offset-x="150" data-expected-width="100"></div>
+  <div class="item" data-offset-x="300" data-expected-width="100"></div>
+  <div class="subgrid" data-offset-x="0" data-expected-width="400">
+    <div class="subgrid" data-offset-x="0" data-expected-width="400">
+      <div class="subitem" data-offset-x="0" data-expected-width="100"></div>
+      <div class="subitem" data-offset-x="150" data-expected-width="100"></div>
+      <div class="subitem" data-offset-x="300" data-expected-width="100"></div>
+    </div>
+  </div>
+</div>
+
+<!--
+  The subgrid asks for something different from its parent. It is ignored, so this has to
+  match the first case exactly. If it were honoured the items would sit at 40 / 190 / 340.
+-->
+<div class="grid" style="width: 400px; justify-content: space-between"
+     title="columns, subgrid's own justify-content is ignored">
+  <div class="item" data-offset-x="0" data-expected-width="100"></div>
+  <div class="item" data-offset-x="150" data-expected-width="100"></div>
+  <div class="item" data-offset-x="300" data-expected-width="100"></div>
+  <div class="subgrid" style="justify-content: center" data-offset-x="0" data-expected-width="400">
+    <div class="subitem" data-offset-x="0" data-expected-width="100"></div>
+    <div class="subitem" data-offset-x="150" data-expected-width="100"></div>
+    <div class="subitem" data-offset-x="300" data-expected-width="100"></div>
+  </div>
+</div>
+
+</body>

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2354,8 +2354,13 @@ StyleContentAlignmentData RenderGrid::contentAlignment(Style::GridTrackSizingDir
 
 ContentAlignmentData RenderGrid::computeContentPositionAndDistributionOffset(Style::GridTrackSizingDirection direction, const LayoutUnit& availableFreeSpace, unsigned numberOfGridTracks) const
 {
-    if (isSubgrid(direction))
-        return { };
+    // https://drafts.csswg.org/css-grid-2/#subgrid-grid-alignment
+    // The position offset is not inherited: our border box already sits at the parent's grid line, which included it.
+    if (isSubgrid(direction)) {
+        auto& parent = downcast<RenderGrid>(*this->parent());
+        auto parentDirection = GridLayoutFunctions::flowAwareDirectionForParent(*this, parent, direction);
+        return { 0_lu, parent.gridItemOffset(parentDirection) };
+    }
 
     auto contentAlignmentData = contentAlignment(direction);
     auto contentAlignmentDistribution = contentAlignmentData.distribution();


### PR DESCRIPTION
#### 767e62cbb34461364cbdf59df9af230a7e5893a8
<pre>
Subgrid columns ignore the parent grid&apos;s content distribution
<a href="https://bugs.webkit.org/show_bug.cgi?id=321024">https://bugs.webkit.org/show_bug.cgi?id=321024</a>
<a href="https://rdar.apple.com/184542148">rdar://184542148</a>

Reviewed by Darin Adler.

A subgrid in a grid that spreads its leftover space between its tracks laid
its own tracks out packed together instead of on the parent&apos;s grid lines.
Firefox and Chrome place them on the parent&apos;s lines.

A grid keeps its content distribution as two numbers: one shift before the
first track, one added after every track.
computeContentPositionAndDistributionOffset() returned both as zero for a
subgridded axis. Zero is right for the shift, already in our border box
position, and wrong for the per-track offset, which nothing else put back.

Fix by inheriting the parent&apos;s per-track offset, keeping the shift at zero.

A subgrid that declares its own gap is a separate defect, not fixed here.

Test: imported/w3c/web-platform-tests/css/css-grid/subgrid/subgridded-axis-content-distribution-001.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgridded-axis-content-distribution-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgridded-axis-content-distribution-001.html: Added.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::computeContentPositionAndDistributionOffset const):

Canonical link: <a href="https://commits.webkit.org/319353@main">https://commits.webkit.org/319353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf37abfb74d34c84f10c2b1b6824490816ec20ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145550 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15b84eaa-cc39-4bdb-9c49-73623de88309) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141421 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7248e29b-b4b9-410c-8aa8-68f7b678536e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121872 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d71ac208-cd25-41ff-9b23-36ead3f7a9bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43772 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42049 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41707 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2604 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193376 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150814 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40397 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55526 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150530 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45125 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127794 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123355 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54043 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16705 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53425 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53662 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53490 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->