### PR TITLE
Git webkit conflict checks out the conflict branch for main, even though an SU branch Radar was passed

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py
@@ -23,6 +23,7 @@
 import sys
 
 from webkitbugspy import Tracker, radar
+from webkitcorepy import Terminal
 from .command import Command
 from .. import local
 from ..commit import Commit
@@ -42,11 +43,29 @@ class Conflict(Command):
         )
 
     @classmethod
+    def radar_ids_from_text(cls, text):
+        ids = set()
+        for word in (text or '').split():
+            issue = Tracker.from_string(word)
+            if issue:
+                ids.add(issue.id)
+        return ids
+
+    @classmethod
+    def related_radar_ids(cls, radar_obj):
+        # a PR may be titled with a clone/clone-parent's id instead of radar_obj's own id
+        ids = {radar_obj.id}
+        related = radar_obj.related or {}
+        for relationship in ('clone-of', 'cloned-to'):
+            for related_radar in related.get(relationship) or []:
+                ids.add(related_radar.id)
+        return ids
+
+    @classmethod
     def find_conflict_pr(cls, remote, radar_id):
         """
-        Because we don't know what the target branch was just given the radar id,
-        we need to search for PRs with branches that start with the integration prefix
-        and have the first and last sha.
+        We don't know the target branch just from a radar id, so we match PRs by sha prefix
+        alone, then disambiguate any resulting duplicates by the radar id in the PR title.
         """
         radar_obj = Tracker.from_string(f'rdar://{radar_id}')
         assert radar_obj, 'Could not fetch radar object for id {}'.format(radar_id)
@@ -66,10 +85,32 @@ class Conflict(Command):
         for prefix in ('ci', 'conflict'):
             integration_branches.append("{}/{}/{}_{}".format(cls.INTEGRATION_BRANCH_PREFIX, prefix, shas[0][:Commit.HASH_LABEL_SIZE], shas[-1][:Commit.HASH_LABEL_SIZE]))
 
+        candidates = []
         for pr in cls.get_open_integration_prs(remote):
             for branch in integration_branches:
                 if pr.head.startswith(branch):
-                    return pr
+                    candidates.append(pr)
+                    break
+
+        if len(candidates) <= 1:
+            return candidates[0] if candidates else None
+
+        # exact id wins outright; only widen to clone relatives if nothing matched exactly
+        exact = [pr for pr in candidates if radar_obj.id in cls.radar_ids_from_text(pr.title)]
+        if len(exact) == 1:
+            return exact[0]
+
+        related_ids = cls.related_radar_ids(radar_obj)
+        matched = exact or [pr for pr in candidates if cls.radar_ids_from_text(pr.title) & related_ids]
+        if len(matched) == 1:
+            return matched[0]
+        if matched:
+            candidates = matched
+
+        print(f'Found {len(candidates)} conflict pull requests matching rdar://{radar_id}; could not disambiguate by radar id in PR title.', file=sys.stderr)
+        options = ['{} ({})'.format(pr.head, pr.title) for pr in candidates]
+        choice = Terminal.choose('Which conflict pull request would you like to check out?', options=options, default=options[0], numbered=True)
+        return candidates[options.index(choice)]
 
     @classmethod
     def get_open_integration_prs(cls, remote):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import re
 import time
 from unittest.mock import Mock, patch
 
@@ -29,6 +30,7 @@ from webkitcorepy import OutputCapture, testing
 from webkitcorepy.mocks import Time as MockTime
 
 from webkitscmpy import Commit, Contributor, local, mocks, program
+from webkitscmpy.program.conflict import Conflict
 
 
 class TestConflict(testing.PathTestCase):
@@ -54,6 +56,83 @@ class TestConflict(testing.PathTestCase):
         rdar.source_changes = rdar.sourceChanges.splitlines()
         rdar.id = 1234
         return rdar
+
+    RDAR_LINK_RE = re.compile(r'rdar://(\d+)$')
+
+    @staticmethod
+    def _mock_radar(id, related=None):
+        rdar = bmocks.Radar()
+        rdar.sourceChanges = 'WebKit, merge, sha123'
+        rdar.source_changes = rdar.sourceChanges.splitlines()
+        rdar.id = id
+        rdar.related = related or {}
+        return rdar
+
+    @staticmethod
+    def _mock_tracker_from_string(primary):
+        # Stands in for `Tracker.from_string`: resolves `rdar://<id>` links the way the real
+        # tracker would, returning `primary` for its own id and a minimal stub (only `.id` is
+        # ever read by `radar_ids_from_text`) for any other radar referenced in PR titles.
+        def _response(string, *args, **kwargs):
+            match = TestConflict.RDAR_LINK_RE.match(string)
+            if not match:
+                return None
+            id = int(match.group(1))
+            return primary if id == primary.id else Mock(id=id)
+        return _response
+
+    @staticmethod
+    def _mock_remote():
+        remote = Mock()
+        remote.name = 'WebKit'
+        return remote
+
+    def test_find_conflict_pr_ambiguous_resolved_by_own_radar_id(self):
+        # Two candidate PRs share the same sha-prefix (as would happen when the same source
+        # change conflicts on two target branches), but only one references the radar we asked
+        # for in its title -- that one should be picked without prompting.
+        prs = [
+            Mock(head='integration/conflict/sha123_sha123_main', title='Cherry-pick sha123. rdar://184745333'),
+            Mock(head='integration/conflict/sha123_sha123_su-branch', title='Cherry-pick sha123. rdar://184747345'),
+        ]
+        radar_obj = TestConflict._mock_radar(184747345)
+        with (
+            patch('webkitscmpy.program.conflict.Tracker.from_string', TestConflict._mock_tracker_from_string(radar_obj)),
+            patch('webkitscmpy.program.conflict.Conflict.get_open_integration_prs', lambda remote: prs),
+        ):
+            self.assertIs(prs[1], Conflict.find_conflict_pr(TestConflict._mock_remote(), 184747345))
+
+    def test_find_conflict_pr_ambiguous_resolved_by_clone_relationship(self):
+        # rdar://184747345 is a clone of rdar://184745333; the correct conflict PR's title only
+        # references the clone-parent's id, so disambiguation must walk the clone relationship.
+        parent = Mock(id=184745333)
+        prs = [
+            Mock(head='integration/conflict/sha123_sha123_main', title='Cherry-pick sha123. rdar://999999'),
+            Mock(head='integration/conflict/sha123_sha123_su-branch', title='Cherry-pick sha123. rdar://184745333'),
+        ]
+        radar_obj = TestConflict._mock_radar(184747345, related={'clone-of': [parent], 'cloned-to': []})
+        with (
+            patch('webkitscmpy.program.conflict.Tracker.from_string', TestConflict._mock_tracker_from_string(radar_obj)),
+            patch('webkitscmpy.program.conflict.Conflict.get_open_integration_prs', lambda remote: prs),
+        ):
+            self.assertIs(prs[1], Conflict.find_conflict_pr(TestConflict._mock_remote(), 184747345))
+
+    def test_find_conflict_pr_ambiguous_prompts_user(self):
+        # Neither candidate's title references the radar (or a clone relative), so there's no way
+        # to disambiguate automatically -- the user should be prompted to pick.
+        prs = [
+            Mock(head='integration/conflict/sha123_sha123_main', title='Cherry-pick sha123.'),
+            Mock(head='integration/conflict/sha123_sha123_su-branch', title='Cherry-pick sha123.'),
+        ]
+        radar_obj = TestConflict._mock_radar(184747345)
+        with (
+            patch('webkitscmpy.program.conflict.Tracker.from_string', TestConflict._mock_tracker_from_string(radar_obj)),
+            patch('webkitscmpy.program.conflict.Conflict.get_open_integration_prs', lambda remote: prs),
+            patch('webkitscmpy.program.conflict.Terminal.choose') as choose,
+        ):
+            choose.return_value = '{} ({})'.format(prs[1].head, prs[1].title)
+            self.assertIs(prs[1], Conflict.find_conflict_pr(TestConflict._mock_remote(), 184747345))
+            self.assertTrue(choose.called)
 
     def test_conflict_not_found(self):
         with (


### PR DESCRIPTION
Git webkit conflict checks out the conflict branch for main, even though an SU branch Radar was passed
https://bugs.webkit.org/show_bug.cgi?id=321791
rdar://184785071

Reviewed by NOBODY (OOPS!).

When git-webkit conflict runs, it will first try to find an existing PR with the exact radar id match. if not, it will fall back to a search based on it's cloned to / from relationships and ask the user if multiple are found.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py: (Conflict):
(Conflict.radar_ids_from_text):
(Conflict.related_radar_ids):
(Conflict.find_conflict_pr):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py: (TestConflict):
(TestConflict._mock_radar):
(TestConflict._mock_tracker_from_string):
(TestConflict._mock_tracker_from_string._response): (TestConflict._mock_remote):
(TestConflict.test_find_conflict_pr_ambiguous_resolved_by_own_radar_id): (TestConflict.test_find_conflict_pr_ambiguous_resolved_by_clone_relationship): (TestConflict.test_find_conflict_pr_ambiguous_prompts_user):

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f95ca5a4b31a6e7dbc6e6b8c3ffc9410aa829dc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145396 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3bb94e28-d2ce-4035-874b-7045402ae896) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141290 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97985 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbbc93d2-5876-4197-9f9d-71bdef49d0c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121741 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c27c9158-a94d-4dc4-9a1f-c4684ea51fea) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180397 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43626 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41908 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41567 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2447 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193222 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/180474 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54684 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150677 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55372 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150393 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44982 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/123178 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53889 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16562 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53271 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53336 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->