### PR TITLE
<input type=checkbox switch>: pointer tracking uses the wrong axis and coordinate space

### DIFF
--- a/LayoutTests/fast/forms/switch/pointer-tracking-transform-expected.txt
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-transform-expected.txt
@@ -1,0 +1,10 @@
+A transformed switch tracks the pointer along its track. A drag to the far end of the track and back leaves the thumb where it was, so releasing it does not flip the switch.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.checked is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/switch/pointer-tracking-transform.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-transform.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<script src="../../../resources/js-test.js"></script>
+<input type=checkbox switch style="margin: 20px; transform: scale(5); transform-origin: top left">
+<script>
+description("A transformed switch tracks the pointer along its track. A drag to the far end of the track and back leaves the thumb where it was, so releasing it does not flip the switch.");
+jsTestIsAsync = true;
+
+const input = document.querySelector("input");
+
+(async () => {
+    if (!window.eventSender) {
+        testFailed("This test requires eventSender.");
+        finishJSTest();
+        return;
+    }
+
+    const rect = input.getBoundingClientRect();
+    const y = Math.round(rect.top + rect.height / 2);
+    const start = Math.round(rect.left + rect.width * 0.15);
+    const far = Math.round(rect.left + rect.width * 0.85);
+
+    const clicked = new Promise(resolve => input.addEventListener("click", resolve, { once: true }));
+    await eventSender.asyncMouseMoveTo(start, y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(far, y);
+    await eventSender.asyncMouseMoveTo(start, y);
+    await eventSender.asyncMouseUp();
+    await Promise.race([clicked, new Promise(resolve => setTimeout(resolve, 1000))]);
+
+    shouldBeFalse("input.checked");
+    finishJSTest();
+})();
+</script>
+</html>

--- a/LayoutTests/fast/forms/switch/pointer-tracking-vertical-lr-expected.txt
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-vertical-lr-expected.txt
@@ -1,0 +1,10 @@
+A vertical switch tracks the pointer along its inline axis, which runs down the track. A drag that stays short of the middle of the track and comes back leaves the thumb where it was, so releasing it is an ordinary click and flips the switch.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.checked is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/switch/pointer-tracking-vertical-lr.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-vertical-lr.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<script src="../../../resources/js-test.js"></script>
+<input type=checkbox switch style="zoom: 5; writing-mode: vertical-lr">
+<script>
+description("A vertical switch tracks the pointer along its inline axis, which runs down the track. A drag that stays short of the middle of the track and comes back leaves the thumb where it was, so releasing it is an ordinary click and flips the switch.");
+jsTestIsAsync = true;
+
+const input = document.querySelector("input");
+
+(async () => {
+    if (!window.eventSender) {
+        testFailed("This test requires eventSender.");
+        finishJSTest();
+        return;
+    }
+
+    const rect = input.getBoundingClientRect();
+    const x = Math.round(rect.left + rect.width / 2);
+    const start = Math.round(rect.top + rect.height * 0.15);
+    const partway = Math.round(rect.top + rect.height * 0.4);
+
+    const clicked = new Promise(resolve => input.addEventListener("click", resolve, { once: true }));
+    await eventSender.asyncMouseMoveTo(x, start);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(x, partway);
+    await eventSender.asyncMouseMoveTo(x, start);
+    await eventSender.asyncMouseUp();
+    await Promise.race([clicked, new Promise(resolve => setTimeout(resolve, 1000))]);
+
+    shouldBeTrue("input.checked");
+    finishJSTest();
+})();
+</script>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -49,6 +49,8 @@ fast/snapshot [ Skip ]
 fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html [ Skip ]
 fast/forms/switch/pointer-tracking-there-and-back-again.html [ Skip ]
 fast/forms/switch/pointer-tracking.html [ Skip ]
+fast/forms/switch/pointer-tracking-vertical-lr.html [ Skip ]
+fast/forms/switch/pointer-tracking-transform.html [ Skip ]
 
 # Shadow of Liquid Glass switches is different between transform and zoom.
 fast/forms/switch/zoom-approximates-transform.html [ Skip ]

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -50,7 +50,9 @@
 #include "LocalizedStrings.h"
 #include "MouseEvent.h"
 #include "NodeDocument.h"
+#include "NodeInlines.h"
 #include "PlatformRenderTheme.h"
+#include "RenderBoxInlines.h"
 #include "RenderElement.h"
 #include "RenderTheme.h"
 #include "ScopedEventQueue.h"
@@ -471,21 +473,23 @@ bool CheckboxInputType::isSwitchHeld() const
 void CheckboxInputType::updateIsSwitchVisuallyOnFromAbsoluteLocation(LayoutPoint absoluteLocation)
 {
     Ref element = *this->element();
+    CheckedPtr renderer = element->renderBox();
+    if (!renderer)
+        return;
     auto logicalLeftPosition = switchPointerTrackingLogicalLeftPosition(element.get(), absoluteLocation);
     auto isSwitchVisuallyOn = m_isSwitchVisuallyOn;
-    auto isRTL = element->computedStyle()->writingMode().isBidiRTL();
+    auto isRTL = renderer->writingMode().isBidiRTL();
     auto switchThumbIsLogicallyLeft = (!isRTL && !isSwitchVisuallyOn) || (isRTL && isSwitchVisuallyOn);
-    auto switchTrackRect = protect(element->renderer())->absoluteBoundingBoxRect();
-    auto switchThumbLength = switchTrackRect.height();
-    auto switchTrackWidth = switchTrackRect.width();
+    auto switchThumbLogicalLength = renderer->logicalHeight();
+    auto switchTrackLogicalWidth = renderer->logicalWidth();
 
-    auto changePosition = switchTrackWidth / 2;
+    auto changePosition = switchTrackLogicalWidth / 2;
     if (!m_hasSwitchVisuallyOnChanged) {
-        auto switchTrackNoThumbWidth = switchTrackWidth - switchThumbLength;
-        auto changeOffset = switchTrackWidth * RenderTheme::singleton().switchPointerTrackingMagnitudeProportion();
-        if (switchThumbIsLogicallyLeft && *m_switchPointerTrackingLogicalLeftPositionStart > switchTrackNoThumbWidth)
+        auto switchTrackNoThumbLogicalWidth = switchTrackLogicalWidth - switchThumbLogicalLength;
+        auto changeOffset = switchTrackLogicalWidth * RenderTheme::singleton().switchPointerTrackingMagnitudeProportion();
+        if (switchThumbIsLogicallyLeft && *m_switchPointerTrackingLogicalLeftPositionStart > switchTrackNoThumbLogicalWidth)
             changePosition = *m_switchPointerTrackingLogicalLeftPositionStart + changeOffset;
-        else if (!switchThumbIsLogicallyLeft && *m_switchPointerTrackingLogicalLeftPositionStart < switchTrackNoThumbWidth)
+        else if (!switchThumbIsLogicallyLeft && *m_switchPointerTrackingLogicalLeftPositionStart < switchTrackNoThumbLogicalWidth)
             changePosition = *m_switchPointerTrackingLogicalLeftPositionStart - changeOffset;
     }
 


### PR DESCRIPTION
#### cce7cffe955e012a6d428cda6dbab5098b841bad
<pre>
&lt;input type=checkbox switch&gt;: pointer tracking uses the wrong axis and coordinate space
<a href="https://bugs.webkit.org/show_bug.cgi?id=321929">https://bugs.webkit.org/show_bug.cgi?id=321929</a>

Reviewed by Aditya Keerthi.

updateIsSwitchVisuallyOnFromAbsoluteLocation took the track width and the thumb length
from absoluteBoundingBoxRect, which is wrong twice over.

Width and height are the wrong way around for a vertical switch, so the thumb moved once
the pointer passed roughly 29% of the track rather than the middle of it.

And the rect is in absolute coordinates while switchPointerTrackingLogicalLeftPosition
returns a local one, so a transformed switch compared a local position against
transform-inflated lengths. Under transform: scale(5) the change position sits five times
past the end of the track, so the thumb never moves and every drag ends up as an ordinary
click.

Tests: fast/forms/switch/pointer-tracking-transform.html
       fast/forms/switch/pointer-tracking-vertical-lr.html

Canonical link: <a href="https://commits.webkit.org/319434@main">https://commits.webkit.org/319434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a90bb1aa960bab96707ac75a407cc52aa8c4a243

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145577 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4902119-f2f7-4e7c-be1a-c1d591b87bc3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141494 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98122 "4 flakes 14 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e8d54c2c-a1b0-41d9-ac3c-1be625068f3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121894 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aab31bce-b5be-4600-ab12-510ec089fe8d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43815 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42121 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154218 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41776 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2631 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193403 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161715 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40447 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55553 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150596 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45145 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127840 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123392 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54070 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16774 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53452 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53689 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53517 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->