### PR TITLE
[GTK][WPE] Skia compositor: use deferred display list to paint scrollbars

### DIFF
--- a/Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp
@@ -32,13 +32,18 @@
 #include "BitmapTexturePool.h"
 #include "CoordinatedPlatformLayer.h"
 #include "CoordinatedPlatformLayerBufferRGB.h"
+#include "CoordinatedPlatformLayerBufferSkiaDeferredImage.h"
+#include "FontRenderOptions.h"
 #include "GLContext.h"
 #include "GLFence.h"
 #include "GraphicsContextSkia.h"
 #include "PlatformDisplay.h"
 #include "ScrollerImpAdwaita.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkSurface.h>
+#include <skia/core/SkCanvas.h>
+#include <skia/private/chromium/GrDeferredDisplayList.h>
+#include <skia/private/chromium/GrDeferredDisplayListRecorder.h>
+#include <skia/private/chromium/GrSurfaceCharacterization.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/TZoneMallocInlines.h>
 
@@ -122,15 +127,6 @@ void ScrollerCoordinated::updateValues()
     state.thumbPosition = (values.visibleSize - state.thumbLength) * values.value;
     state.frameRect = rect;
 
-    auto& display = PlatformDisplay::sharedDisplay();
-    auto* glContext = display.skiaGLContext();
-    if (!glContext)
-        return;
-
-    auto* grContext = display.skiaGrContext();
-    RELEASE_ASSERT(grContext);
-    GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
-
     float contentsScale;
     {
         Locker layerLocker { hostLayer->lock() };
@@ -139,23 +135,59 @@ void ScrollerCoordinated::updateValues()
 
     auto frameRect = enclosingIntRect(FloatRect(state.frameRect.x() * contentsScale, state.frameRect.y() * contentsScale,
         state.frameRect.width() * contentsScale, state.frameRect.height() * contentsScale));
-    Ref texture = BitmapTexturePool::singleton().acquireTexture(frameRect.size(), { BitmapTexture::Flags::SupportsAlpha });
-    auto surface = texture->createSkiaSurface(grContext);
-    if (!surface)
-        return;
 
-    auto* canvas = surface->getCanvas();
-    if (!canvas)
-        return;
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> buffer;
 
-    canvas->clear(SK_ColorTRANSPARENT);
+    if (const auto& threadSafeGrContext = hostLayer->threadSafeGrContext()) {
+        auto imageInfo = SkImageInfo::Make(frameRect.size().width(), frameRect.size().height(), kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+        auto backendFormat = threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
+        ASSERT(backendFormat.isValid());
+        auto properties = FontRenderOptions::singleton().createSurfaceProps();
+        auto maxResourceCacheBytes = PlatformDisplay::sharedDisplay().maxSkiaResourceCacheBytes();
+        auto characterization = threadSafeGrContext->createCharacterization(maxResourceCacheBytes, imageInfo, backendFormat, 0, kTopLeft_GrSurfaceOrigin, properties, skgpu::Mipmapped::kNo);
+        GrDeferredDisplayListRecorder ddlRecorder(characterization);
+        auto* canvas = ddlRecorder.getCanvas();
+        if (!canvas)
+            return;
 
-    GraphicsContextSkia context(*canvas, RenderingMode::Accelerated, RenderingPurpose::DOM);
-    context.scale(contentsScale);
-    scrollerImp->paint(context, state.frameRect, state);
+        canvas->clear(SK_ColorTRANSPARENT);
 
-    grContext->flushAndSubmit(surface.get(), GLFence::isSupported(display.glDisplay()) ? GrSyncCpu::kNo : GrSyncCpu::kYes);
-    auto buffer = CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), { TextureMapperFlags::ShouldBlend }, GLFence::create(display.glDisplay()));
+        GraphicsContextSkia recordingContext(*canvas, RenderingMode::Accelerated, RenderingPurpose::LayerBacking);
+        recordingContext.beginRecording(GraphicsContextSkia::RecordingMode::Scrollbar, threadSafeGrContext);
+        recordingContext.scale(contentsScale);
+        scrollerImp->paint(recordingContext, state.frameRect, state);
+        recordingContext.endRecording();
+
+        buffer = CoordinatedPlatformLayerBufferSkiaDeferredImage::create(ddlRecorder.detach());
+    } else {
+        auto& display = PlatformDisplay::sharedDisplay();
+        auto* glContext = display.skiaGLContext();
+        if (!glContext)
+            return;
+
+        auto* grContext = display.skiaGrContext();
+        ASSERT(grContext);
+        GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
+
+        Ref texture = BitmapTexturePool::singleton().acquireTexture(frameRect.size(), { BitmapTexture::Flags::SupportsAlpha });
+        auto surface = texture->createSkiaSurface(grContext);
+        if (!surface)
+            return;
+
+        auto* canvas = surface->getCanvas();
+        if (!canvas)
+            return;
+
+        canvas->clear(SK_ColorTRANSPARENT);
+
+        GraphicsContextSkia context(*canvas, RenderingMode::Accelerated, RenderingPurpose::DOM);
+        context.scale(contentsScale);
+        scrollerImp->paint(context, state.frameRect, state);
+
+        grContext->flushAndSubmit(surface.get(), GLFence::isSupported(display.glDisplay()) ? GrSyncCpu::kNo : GrSyncCpu::kYes);
+        buffer = CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), { TextureMapperFlags::ShouldBlend }, GLFence::create(display.glDisplay()));
+    }
+
     if (!buffer)
         return;
 

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -78,6 +78,7 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
+        platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaDeferredImage.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
         platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -1229,6 +1229,11 @@ void GraphicsContextSkia::beginRecording(RecordingMode recordingMode, const sk_s
             pushSkiaState();
         }
         break;
+    case RecordingMode::Scrollbar:
+        ASSERT(threadSafeGrContext);
+        m_threadSafeGrContext = threadSafeGrContext;
+        m_contextMode = ContextMode::ScrollbarRecordingMode;
+        break;
     }
 }
 
@@ -1249,6 +1254,10 @@ SkiaRecordingData GraphicsContextSkia::endRecording()
     }
     case ContextMode::CanvasRecordingMode:
         ASSERT(!m_threadSafeGrContext);
+        return { };
+    case ContextMode::ScrollbarRecordingMode:
+        ASSERT(m_threadSafeGrContext);
+        m_threadSafeGrContext = nullptr;
         return { };
     case ContextMode::PaintingMode:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -58,7 +58,7 @@ public:
 
     const DestinationColorSpace& colorSpace() const final;
 
-    enum class RecordingMode : bool { Tile, Canvas };
+    enum class RecordingMode : uint8_t { Tile, Canvas, Scrollbar };
     void beginRecording(RecordingMode, const sk_sp<GrContextThreadSafeProxy>& = nullptr);
     SkiaRecordingData endRecording();
 
@@ -128,7 +128,8 @@ private:
     enum class ContextMode : uint8_t {
         PaintingMode,
         TileRecordingMode,
-        CanvasRecordingMode
+        CanvasRecordingMode,
+        ScrollbarRecordingMode
     };
 
     bool makeGLContextCurrentIfNeeded() const;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -61,6 +61,9 @@ Ref<CoordinatedPlatformLayer> CoordinatedPlatformLayer::create()
 CoordinatedPlatformLayer::CoordinatedPlatformLayer(Client* client)
     : m_client(client)
     , m_id(PlatformLayerIdentifier::generate())
+#if USE(SKIA)
+    , m_threadSafeGrContext(m_client ? m_client->paintingEngine().threadSafeGrContext() : nullptr)
+#endif
 {
     ASSERT(isMainThread());
 }
@@ -985,16 +988,6 @@ void CoordinatedPlatformLayer::didPaintTile()
     if (m_client)
         m_client->didPaintTile();
 }
-
-#if USE(SKIA)
-sk_sp<GrContextThreadSafeProxy> CoordinatedPlatformLayer::threadSafeGrContext() const
-{
-    if (!m_client)
-        return nullptr;
-
-    return m_client->paintingEngine().threadSafeGrContext();
-}
-#endif
 
 void CoordinatedPlatformLayer::waitUntilPaintingComplete()
 {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -106,7 +106,7 @@ public:
     TextureMapperLayer& ensureTarget();
 #if USE(SKIA)
     SkiaCompositingLayer& ensureSkiaTarget();
-    sk_sp<GrContextThreadSafeProxy> threadSafeGrContext() const;
+    sk_sp<GrContextThreadSafeProxy> threadSafeGrContext() const { return m_threadSafeGrContext; }
 #endif
     void invalidateTarget();
 
@@ -283,6 +283,7 @@ private:
     std::unique_ptr<TextureMapperLayer> m_target;
 #if USE(SKIA)
     RefPtr<SkiaCompositingLayer> m_skiaTarget;
+    sk_sp<GrContextThreadSafeProxy> m_threadSafeGrContext;
 #endif
 
     // Accessed only from the main thread.

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
@@ -52,7 +52,8 @@ public:
         DMABuf,
         NativeImage,
 #if USE(SKIA)
-        SkiaImage
+        SkiaImage,
+        SkiaDeferredImage
 #endif
     };
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaDeferredImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaDeferredImage.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CoordinatedPlatformLayerBufferSkiaDeferredImage.h"
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "PlatformDisplay.h"
+#include "SkiaUtilities.h"
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
+#include <skia/private/chromium/GrSurfaceCharacterization.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+namespace WebCore {
+
+std::unique_ptr<CoordinatedPlatformLayerBufferSkiaDeferredImage> CoordinatedPlatformLayerBufferSkiaDeferredImage::create(sk_sp<GrDeferredDisplayList>&& displayList)
+{
+    OptionSet<TextureMapperFlags> flags;
+    if (displayList->characterization().imageInfo().alphaType() != kOpaque_SkAlphaType)
+        flags.add(TextureMapperFlags::ShouldBlend);
+    return makeUnique<CoordinatedPlatformLayerBufferSkiaDeferredImage>(WTF::move(displayList), flags);
+}
+
+CoordinatedPlatformLayerBufferSkiaDeferredImage::CoordinatedPlatformLayerBufferSkiaDeferredImage(sk_sp<GrDeferredDisplayList>&& displayList, OptionSet<TextureMapperFlags> flags)
+    : CoordinatedPlatformLayerBuffer(Type::SkiaDeferredImage, { displayList->characterization().width(), displayList->characterization().height() }, flags, nullptr)
+    , m_displayList(WTF::move(displayList))
+{
+}
+
+sk_sp<SkImage> CoordinatedPlatformLayerBufferSkiaDeferredImage::skiaImage()
+{
+    if (!m_surface) {
+        auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+        const auto& characterization = m_displayList->characterization();
+        m_surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kYes, characterization.imageInfo(), characterization.sampleCount(), characterization.origin(), &characterization.surfaceProps());
+        if (!m_surface)
+            return nullptr;
+
+        skgpu::ganesh::DrawDDL(m_surface.get(), m_displayList);
+    }
+
+    return m_surface->makeImageSnapshot();
+}
+
+void CoordinatedPlatformLayerBufferSkiaDeferredImage::paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaDeferredImage.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaDeferredImage.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "CoordinatedPlatformLayerBuffer.h"
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkSurface.h>
+#include <skia/private/chromium/GrDeferredDisplayList.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+namespace WebCore {
+
+class CoordinatedPlatformLayerBufferSkiaDeferredImage final : public CoordinatedPlatformLayerBuffer {
+public:
+    static std::unique_ptr<CoordinatedPlatformLayerBufferSkiaDeferredImage> create(sk_sp<GrDeferredDisplayList>&&);
+    CoordinatedPlatformLayerBufferSkiaDeferredImage(sk_sp<GrDeferredDisplayList>&&, OptionSet<TextureMapperFlags>);
+    virtual ~CoordinatedPlatformLayerBufferSkiaDeferredImage() = default;
+
+private:
+    void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float) override;
+    sk_sp<SkImage> skiaImage() override;
+
+    sk_sp<GrDeferredDisplayList> m_displayList;
+    sk_sp<SkSurface> m_surface;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_COORDINATED_PLATFORM_LAYER_BUFFER_TYPE(CoordinatedPlatformLayerBufferSkiaDeferredImage, Type::SkiaDeferredImage)
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)


### PR DESCRIPTION
#### fb7b8624edc02b0d33e121fff1c41026d75b555a
<pre>
[GTK][WPE] Skia compositor: use deferred display list to paint scrollbars
<a href="https://bugs.webkit.org/show_bug.cgi?id=321930">https://bugs.webkit.org/show_bug.cgi?id=321930</a>

Reviewed by Nikolas Zimmermann.

This way we avoid creating a gl context for skia in the scrolling
thread. A new buffer type CoordinatedPlatformLayerBufferSkiaDeferredImage
receives the recorded display list that is replayed on the compositor
thread when painting the buffer for the first time.

* Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp:
(WebCore::ScrollerCoordinated::updateValues):
* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::beginRecording):
(WebCore::GraphicsContextSkia::endRecording):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::CoordinatedPlatformLayer):
(WebCore::CoordinatedPlatformLayer::threadSafeGrContext const): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
(WebCore::CoordinatedPlatformLayer::threadSafeGrContext const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaDeferredImage.cpp: Added.
(WebCore::CoordinatedPlatformLayerBufferSkiaDeferredImage::create):
(WebCore::CoordinatedPlatformLayerBufferSkiaDeferredImage::CoordinatedPlatformLayerBufferSkiaDeferredImage):
(WebCore::m_displayList):
(WebCore::CoordinatedPlatformLayerBufferSkiaDeferredImage::skiaImage):
(WebCore::CoordinatedPlatformLayerBufferSkiaDeferredImage::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaDeferredImage.h: Added.

Canonical link: <a href="https://commits.webkit.org/319437@main">https://commits.webkit.org/319437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdc80ea4a2c094582ad9ed510831c52ca755417a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141298 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97996 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121749 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43638 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41916 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41582 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2457 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193232 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54694 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55382 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38202 "Too many flaky failures: http/tests/media/text-served-as-text.html, http/tests/misc/refresh-meta-with-newline.html, http/tests/navigation/post-307-response.html, http/tests/resourceLoadStatistics/dont-count-third-party-image-as-third-party-script.html, http/tests/security/cached-cross-origin-shared-css-stylesheet.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/iframe-inside-csp.html, http/tests/security/mixedContent/secure-page-navigates-to-basic-auth-insecure-page.https.html, http/tests/site-isolation/frame-index.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150403 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27558 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44992 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127648 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123191 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53899 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16578 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53281 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->