### PR TITLE
[JSC][Wasm] Re-exported imported Tag should be the same object

### DIFF
--- a/JSTests/wasm/js-api/tag-import-export-identity.js
+++ b/JSTests/wasm/js-api/tag-import-export-identity.js
@@ -1,0 +1,54 @@
+import * as assert from '../assert.js';
+import Builder from '../Builder.js';
+
+function moduleImportingAndExportingTag() {
+    const builder = new Builder();
+    builder.Type().End()
+        .Import()
+            .Exception("imp", "tag", { params: ["i32"], ret: "void" })
+        .End()
+        .Export()
+            .Exception("tag", 0)
+        .End();
+    const bin = builder.WebAssembly();
+    bin.trim();
+    return new WebAssembly.Module(bin.get());
+}
+
+{
+    const module = moduleImportingAndExportingTag();
+    const imported = new WebAssembly.Tag({ parameters: ["i32"] });
+    const instance = new WebAssembly.Instance(module, { imp: { tag: imported } });
+    assert.eq(instance.exports.tag, imported);
+    const exception = new WebAssembly.Exception(imported, [1]);
+    assert.eq(exception.is(instance.exports.tag), true);
+}
+
+{
+    const producer = new Builder();
+    producer.Type().End()
+        .Exception().Signature({ params: ["i32"] }).End()
+        .Export()
+            .Exception("tag", 0)
+        .End();
+    const producedBin = producer.WebAssembly();
+    producedBin.trim();
+    const produced = new WebAssembly.Instance(new WebAssembly.Module(producedBin.get()));
+    const module = moduleImportingAndExportingTag();
+    const instance = new WebAssembly.Instance(module, { imp: { tag: produced.exports.tag } });
+    assert.eq(instance.exports.tag, produced.exports.tag);
+}
+
+{
+    const builder = new Builder();
+    builder.Type().End()
+        .Exception().Signature({ params: ["i32"] }).End()
+        .Export()
+            .Exception("a", 0)
+            .Exception("b", 0)
+        .End();
+    const bin = builder.WebAssembly();
+    bin.trim();
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(bin.get()));
+    assert.eq(instance.exports.a, instance.exports.b);
+}

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -38,6 +38,7 @@
 #include "JSWebAssemblyMemory.h"
 #include "JSWebAssemblyModule.h"
 #include "JSWebAssemblyStruct.h"
+#include "JSWebAssemblyTag.h"
 #include "Register.h"
 #include "VMTrapsInlines.h"
 #include "WasmBaselineData.h"
@@ -220,6 +221,8 @@ void JSWebAssemblyInstance::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     for (auto& wrapper : thisObject->functionWrappers())
         visitor.appendUnbarriered(wrapper.get());
     for (auto& entry : thisObject->m_constantExpressionValues)
+        visitor.append(entry.value);
+    for (auto& entry : thisObject->m_tagWrappers)
         visitor.append(entry.value);
 }
 
@@ -448,6 +451,23 @@ void JSWebAssemblyInstance::setFunctionWrapper(unsigned i, JSValue value)
     Locker locker { cellLock() };
     m_functionWrappers.set(i, WriteBarrier<Unknown>(vm(), this, value));
     ASSERT(getFunctionWrapper(i) == value);
+}
+
+void JSWebAssemblyInstance::setTagWrapper(VM& vm, unsigned index, JSWebAssemblyTag* tag)
+{
+    ASSERT(tag);
+    Locker locker { cellLock() };
+    ASSERT(!m_tagWrappers.contains(index));
+    m_tagWrappers.set(index, WriteBarrier<JSWebAssemblyTag>(vm, this, tag));
+}
+
+JSWebAssemblyTag* JSWebAssemblyInstance::tagWrapper(unsigned index) const
+{
+    Locker locker { cellLock() };
+    auto iterator = m_tagWrappers.find(index);
+    if (iterator == m_tagWrappers.end())
+        return nullptr;
+    return iterator->value.get();
 }
 
 JSValue JSWebAssemblyInstance::ensureFunctionWrapper(FunctionSpaceIndex functionIndexSpace)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -61,6 +61,7 @@ namespace JSC {
 class JSModuleNamespaceObject;
 class JSWebAssemblyArray;
 class JSWebAssemblyModule;
+class JSWebAssemblyTag;
 class WebAssemblyModuleRecord;
 
 namespace Wasm {
@@ -164,6 +165,9 @@ public:
         linkGlobal(index, *value->global());
         vm.writeBarrier(this, value);
     }
+
+    void setTagWrapper(VM&, unsigned index, JSWebAssemblyTag*);
+    JSWebAssemblyTag* tagWrapper(unsigned index) const;
 
     JSWebAssemblyModule* jsModule() const LIFETIME_BOUND { return m_jsModule.get(); }
     const Wasm::ModuleInformation& moduleInformation() const { return m_moduleInformation.get(); }
@@ -469,6 +473,8 @@ private:
     BitVector m_globalsToBinding;
     unsigned m_numImportFunctions { 0 };
     UncheckedKeyHashMap<uint32_t, Ref<Wasm::Global>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_linkedGlobals;
+    using TagWrapperMap = UncheckedKeyHashMap<uint32_t, WriteBarrier<JSWebAssemblyTag>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    TagWrapperMap m_tagWrappers;
     BitVector m_passiveElements;
     BitVector m_passiveDataSegments;
     FixedVector<RefPtr<const Wasm::Tag>> m_tags;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -479,6 +479,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported Tag"_s, "signature doesn't match the imported WebAssembly Tag's signature"_s)));
 
             m_instance->setTag(import.kindIndex, tag->tag());
+            m_instance->setTagWrapper(vm, import.kindIndex, tag);
             break;
         }
 
@@ -753,7 +754,13 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
             break;
         }
         case Wasm::ExternalKind::Exception: {
-            exportedValue = JSWebAssemblyTag::create(vm, globalObject, globalObject->m_webAssemblyTagStructure.get(globalObject), m_instance->tag(exp.kindIndex));
+            if (JSWebAssemblyTag* wrapper = m_instance->tagWrapper(exp.kindIndex))
+                exportedValue = wrapper;
+            else {
+                auto* created = JSWebAssemblyTag::create(vm, globalObject, globalObject->m_webAssemblyTagStructure.get(globalObject), m_instance->tag(exp.kindIndex));
+                m_instance->setTagWrapper(vm, exp.kindIndex, created);
+                exportedValue = created;
+            }
             break;
         }
         }


### PR DESCRIPTION
#### 39de2d4eea61f947ee9ea9d364fc54715a17de84
<pre>
[JSC][Wasm] Re-exported imported Tag should be the same object
<a href="https://bugs.webkit.org/show_bug.cgi?id=321931">https://bugs.webkit.org/show_bug.cgi?id=321931</a>

Reviewed by Yusuke Suzuki.

Importing a WebAssembly.Tag and re-exporting it should return the same
JS object. Export always created a new wrapper, so === failed.

Remember the imported wrapper and return it from the export object.
Local tags are cached on first export so two export names share one
object.

* JSTests/wasm/js-api/tag-import-export-identity.js: Added.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::visitChildrenImpl):
(JSC::JSWebAssemblyInstance::setTagWrapper):
(JSC::JSWebAssemblyInstance::tagWrapper):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):
(JSC::WebAssemblyModuleRecord::initializeExports):

Canonical link: <a href="https://commits.webkit.org/319294@main">https://commits.webkit.org/319294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b096b534bb1c82bd7c2a85e77dd437108cf7396

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191295 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145403 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141299 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121750 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43637 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41917 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3715 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10531 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41576 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2454 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42354 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193229 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54691 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150686 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55379 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38195 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150402 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27482 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44994 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127645 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/123187 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53896 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16574 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53278 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53515 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->