### PR TITLE
[list-marker] List marker overlaps the list item content when the marker text is right-to-left

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5457,9 +5457,7 @@ imported/w3c/web-platform-tests/css/css-lists/list-style-type-decimal-vertical-l
 imported/w3c/web-platform-tests/css/css-lists/list-style-type-decimal-vertical-rl.html [ ImageOnlyFailure ]
 
 # list-style bidi support
-webkit.org/b/202849 imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-005a.html [ ImageOnlyFailure ]
 webkit.org/b/202849 imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-005b.html [ ImageOnlyFailure ]
-webkit.org/b/202849 imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-006.html [ ImageOnlyFailure ]
 webkit.org/b/249918 imported/w3c/web-platform-tests/css/css-lists/list-marker-symbol-bidi.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-lists/content-property/marker-text-matches-lower-greek.html [ ImageOnlyFailure ]
@@ -5659,7 +5657,6 @@ webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-conten
 webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-font-variant-numeric-default.html [ ImageOnlyFailure ]
 webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-font-variant-numeric-normal.html [ ImageOnlyFailure ]
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/marker-list-style-position.html [ ImageOnlyFailure ]
-webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/marker-unicode-bidi-default.html [ ImageOnlyFailure ]
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/marker-unicode-bidi-normal.html [ ImageOnlyFailure ]
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/spelling-error-001.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/hebrew/css3-counter-styles-016.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/hebrew/css3-counter-styles-016.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html  lang="en" >
 <head>
+<meta name="fuzzy" content="maxDifference=0-250; totalPixels=0-29">
 <meta charset="utf-8"/>
 <title>hebrew, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-fallback-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-fallback-rtl-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<style>
+ol {
+  list-style-position: inside;
+  list-style-type: hebrew;
+  margin: 0;
+  padding: 0;
+  font-size: 40px;
+}
+</style>
+<ol start="14">
+  <li>text</li>
+</ol>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-fallback-rtl-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-fallback-rtl-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<style>
+ol {
+  list-style-position: inside;
+  list-style-type: hebrew;
+  margin: 0;
+  padding: 0;
+  font-size: 40px;
+}
+</style>
+<ol start="14">
+  <li>text</li>
+</ol>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-fallback-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-fallback-rtl.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: marker reaching a right-to-left counter style through a fallback</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles-3/#counter-style-fallback">
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-type-property">
+<link rel="match" href="list-marker-counter-style-fallback-rtl-ref.html">
+<meta name="assert" content="A counter style that cannot represent a value draws its fallback's text, so a marker falling back to a right-to-left counter style is laid out like that counter style rather than in logical order.">
+<style>
+@counter-style ltr-with-rtl-fallback {
+  system: fixed;
+  symbols: "a";
+  fallback: hebrew;
+}
+ol {
+  list-style-position: inside;
+  list-style-type: ltr-with-rtl-fallback;
+  margin: 0;
+  padding: 0;
+  font-size: 40px;
+}
+</style>
+<!-- The fixed system covers value 1 only, so 14 comes from hebrew: yod followed by dalet in logical
+     order, which has to be reordered to paint dalet first. -->
+<ol start="14">
+  <li>text</li>
+</ol>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-mutation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-mutation-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<style>
+@counter-style mutated { system: cyclic; symbols: "x"; }
+</style>
+<ol style="list-style-type: mutated"><li>text</li></ol>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-mutation-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-mutation-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<style>
+@counter-style mutated { system: cyclic; symbols: "x"; }
+</style>
+<ol style="list-style-type: mutated"><li>text</li></ol>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-mutation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-mutation.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS Lists: marker follows a mutated @counter-style rule</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles-3/#the-counter-style-rule">
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-type-property">
+<link rel="match" href="list-marker-counter-style-mutation-ref.html">
+<meta name="assert" content="Changing an @counter-style rule's symbols descriptor updates the markers of the list items using that counter style, including when the new symbols no longer need bidi resolution.">
+<style id="counterStyleSheet">
+@counter-style mutated { system: cyclic; symbols: "\627"; }
+</style>
+<ol style="list-style-type: mutated"><li>text</li></ol>
+<script src="/common/reftest-wait.js"></script>
+<script>
+addEventListener("load", () => {
+  document.body.offsetLeft;
+  document.getElementById("counterStyleSheet").sheet.cssRules[0].symbols = '"x"';
+  takeScreenshot();
+}, { once: true });
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-rtl-string-width-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-rtl-string-width-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<style>
+div {
+  margin: 0;
+  padding: 0;
+}
+span {
+  unicode-bidi: isolate;
+  white-space: pre;
+}
+</style>
+<div><span>&#x627;&#x644;</span>a</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-rtl-string-width-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-rtl-string-width-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<style>
+div {
+  margin: 0;
+  padding: 0;
+}
+span {
+  unicode-bidi: isolate;
+  white-space: pre;
+}
+</style>
+<div><span>&#x627;&#x644;</span>a</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-rtl-string-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-rtl-string-width.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: marker box reserves the width of the glyphs it paints</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-type-property">
+<link rel="match" href="list-marker-rtl-string-width-ref.html">
+<meta name="assert" content="A list-style-type string of right-to-left text reserves the width of the glyphs actually painted, so the list item's content starts after the marker instead of overlapping it.">
+<style>
+ol {
+  list-style-position: inside;
+  list-style-type: "\627 \644 ";
+  margin: 0;
+  padding: 0;
+}
+</style>
+<!-- The marker text is two separate glyphs. Reversing it into lam-alef order would form a
+     narrower ligature; sizing the marker box from that would let "a" paint over the marker. -->
+<ol>
+  <li>a</li>
+</ol>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-003.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="fuzzy" content="maxDifference=0-86; totalPixels=0-428">
   <title>String value of list-style-type with RTL direction</title>
   <link rel="author" title="Oriol Brufau" href="mailto:obrufau@gmail.com">
   <link rel="help" href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-type-string">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-unicode-bidi-default.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-unicode-bidi-default.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-72">
 <meta charset="utf-8">
 <title>::marker has 'unicode-bidi: isolate' by default</title>
 <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com" />

--- a/LayoutTests/platform/glib/fast/html/details-writing-mode-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-writing-mode-expected.txt
@@ -97,11 +97,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (104,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,-1) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -110,11 +118,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (104,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,10) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -123,11 +139,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
                     RenderListMarker at (1,104) size 17x16: "\x{25B6}"
+                      RenderBlock (generated) at (10,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (1,46) size 17x58
                       text run at (1,46) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -136,11 +160,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
                     RenderListMarker at (1,104) size 17x16: "\x{25C0}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (1,46) size 17x58
                       text run at (1,46) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -240,11 +272,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (58,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,-1) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,1) size 58x17
                       text run at (0,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (58,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (0,0) size 58x18
                       text run at (0,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -253,11 +293,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (58,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,10) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,1) size 58x17
                       text run at (0,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (58,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 58x18
                       text run at (0,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -266,11 +314,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,58) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x58
                       text run at (0,0) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
                     RenderListMarker at (1,58) size 17x16: "\x{25B6}"
+                      RenderBlock (generated) at (10,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (1,0) size 17x58
                       text run at (1,0) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -279,11 +335,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,58) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x58
                       text run at (0,0) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
                     RenderListMarker at (1,58) size 17x16: "\x{25C0}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (1,0) size 17x58
                       text run at (1,0) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -383,11 +447,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (81,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,-1) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (23,1) size 58x17
                       text run at (23,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (79,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (21,0) size 58x18
                       text run at (21,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -396,11 +468,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (81,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,10) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (23,1) size 58x17
                       text run at (23,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (79,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (21,0) size 58x18
                       text run at (21,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -409,11 +489,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,79) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,21) size 18x58
                       text run at (0,21) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
                     RenderListMarker at (1,81) size 17x16: "\x{25B6}"
+                      RenderBlock (generated) at (10,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (1,23) size 17x58
                       text run at (1,23) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -422,11 +510,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,79) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,21) size 18x58
                       text run at (0,21) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
                     RenderListMarker at (1,81) size 17x16: "\x{25C0}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (1,23) size 17x58
                       text run at (1,23) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -526,11 +622,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (104,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,-1) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -539,11 +643,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (104,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,10) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -552,11 +664,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
                     RenderListMarker at (1,104) size 17x16: "\x{25B6}"
+                      RenderBlock (generated) at (10,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (1,46) size 17x58
                       text run at (1,46) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -565,11 +685,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
                     RenderListMarker at (1,104) size 17x16: "\x{25C0}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (1,46) size 17x58
                       text run at (1,46) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120

--- a/LayoutTests/platform/glib/fast/html/details-writing-mode-mixed-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-writing-mode-mixed-expected.txt
@@ -97,11 +97,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (104,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,-1) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -110,11 +118,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (104,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,10) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -123,11 +139,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,104) size 18x16: "\x{25B6}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (0,46) size 18x58
                       text run at (0,46) width 59: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -136,11 +160,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,104) size 18x16: "\x{25C0}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,46) size 18x58
                       text run at (0,46) width 59: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -240,11 +272,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (58,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,-1) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,1) size 58x17
                       text run at (0,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (58,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (0,0) size 58x18
                       text run at (0,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -253,11 +293,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (58,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,10) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,1) size 58x17
                       text run at (0,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (58,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 58x18
                       text run at (0,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -266,11 +314,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,58) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x58
                       text run at (0,0) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,58) size 18x16: "\x{25B6}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (0,0) size 18x58
                       text run at (0,0) width 59: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -279,11 +335,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,58) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x58
                       text run at (0,0) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,58) size 18x16: "\x{25C0}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 18x58
                       text run at (0,0) width 59: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -383,11 +447,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (81,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,-1) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (23,1) size 58x17
                       text run at (23,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (79,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (21,0) size 58x18
                       text run at (21,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -396,11 +468,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (81,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,10) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (23,1) size 58x17
                       text run at (23,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (79,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (21,0) size 58x18
                       text run at (21,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -409,11 +489,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,79) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,21) size 18x58
                       text run at (0,21) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,81) size 18x16: "\x{25B6}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (0,23) size 18x58
                       text run at (0,23) width 59: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -422,11 +510,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,79) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,21) size 18x58
                       text run at (0,21) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,81) size 18x16: "\x{25C0}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,23) size 18x58
                       text run at (0,23) width 59: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -526,11 +622,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (104,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,-1) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -539,11 +643,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
                     RenderListMarker at (104,1) size 16x17: "\x{25C0}"
+                      RenderBlock (generated) at (0,10) size 16x19
+                        RenderText at (0,1) size 16x17
+                          text run at (0,1) width 4 RTL: " "
+                          text run at (4,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
                     RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -552,11 +664,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,104) size 18x16: "\x{25B6}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (0,46) size 18x58
                       text run at (0,46) width 59: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -565,11 +685,19 @@ layer at (0,0) size 785x1478
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
                     RenderListMarker at (0,104) size 18x16: "\x{25C0}"
+                      RenderBlock (generated) at (-1,0) size 19x16
+                        RenderText at (1,0) size 17x16
+                          text run at (1,0) width 4 RTL: " "
+                          text run at (1,4) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,46) size 18x58
                       text run at (0,46) width 59: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120

--- a/LayoutTests/platform/ios/fast/html/details-writing-mode-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-writing-mode-expected.txt
@@ -96,53 +96,85 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (103,5) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,5) size 61x19
-                      text run at (43,5) width 61: "summary"
+                    RenderListMarker at (95,5) size 25x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-6) size 25x27
+                        RenderText at (0,5) size 25x19
+                          text run at (0,5) width 4 RTL: " "
+                          text run at (4,5) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (35,5) size 60x19
+                      text run at (35,5) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (103,3) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,2) size 61x19
-                      text run at (43,2) width 61: "summary"
+                    RenderListMarker at (95,3) size 25x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,8) size 25x27
+                        RenderText at (0,2) size 25x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (35,2) size 60x19
+                      text run at (35,2) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 26x120
                   RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,103) size 18x17: "\x{25B6}"
-                    RenderText {#text} at (2,43) size 19x61
-                      text run at (2,43) width 61: "summary"
+                    RenderListMarker at (3,95) size 18x25: "\x{25B6}"
+                      RenderBlock (generated) at (8,0) size 27x25
+                        RenderText at (2,0) size 19x25
+                          text run at (2,0) width 5 RTL: " "
+                          text run at (2,4) width 22 RTL: "\x{25B6}"
+                    RenderText {#text} at (2,35) size 19x60
+                      text run at (2,35) width 61: "summary"
                   RenderBlock {SLOT} at (26,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 26x120
                   RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,103) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (5,43) size 19x61
-                      text run at (5,43) width 61: "summary"
+                    RenderListMarker at (5,95) size 18x25: "\x{25C0}"
+                      RenderBlock (generated) at (-6,0) size 27x25
+                        RenderText at (5,0) size 19x25
+                          text run at (5,0) width 5 RTL: " "
+                          text run at (5,4) width 22 RTL: "\x{25C0}"
+                    RenderText {#text} at (5,35) size 19x60
+                      text run at (5,35) width 61: "summary"
                   RenderBlock {SLOT} at (26,0) size 0x120
       RenderBlock (anonymous) at (0,352) size 784x18
         RenderBR {BR} at (0,0) size 0x18
@@ -239,12 +271,20 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (59,5) size 18x18: "\x{25C0}"
+                    RenderListMarker at (59,5) size 26x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-6) size 25x27
+                        RenderText at (0,5) size 25x19
+                          text run at (0,5) width 4 RTL: " "
+                          text run at (4,5) width 21 RTL: "\x{25C0}"
                     RenderText {#text} at (0,5) size 60x19
                       text run at (0,5) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 17x18: "\x{25BC}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -252,12 +292,20 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (59,3) size 18x18: "\x{25C0}"
+                    RenderListMarker at (59,3) size 26x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,8) size 25x27
+                        RenderText at (0,2) size 25x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 21 RTL: "\x{25C0}"
                     RenderText {#text} at (0,2) size 60x19
                       text run at (0,2) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 17x18: "\x{25B2}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -265,12 +313,20 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
+                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 26x120
                   RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,59) size 18x18: "\x{25B6}"
+                    RenderListMarker at (3,59) size 18x26: "\x{25B6}"
+                      RenderBlock (generated) at (8,0) size 27x25
+                        RenderText at (2,0) size 19x25
+                          text run at (2,0) width 5 RTL: " "
+                          text run at (2,4) width 22 RTL: "\x{25B6}"
                     RenderText {#text} at (2,0) size 19x60
                       text run at (2,0) width 61: "summary"
                   RenderBlock {SLOT} at (26,0) size 0x120
@@ -278,12 +334,20 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
+                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 26x120
                   RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,59) size 18x18: "\x{25C0}"
+                    RenderListMarker at (5,59) size 18x26: "\x{25C0}"
+                      RenderBlock (generated) at (-6,0) size 27x25
+                        RenderText at (5,0) size 19x25
+                          text run at (5,0) width 5 RTL: " "
+                          text run at (5,4) width 22 RTL: "\x{25C0}"
                     RenderText {#text} at (5,0) size 19x60
                       text run at (5,0) width 61: "summary"
                   RenderBlock {SLOT} at (26,0) size 0x120
@@ -382,53 +446,85 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (81,5) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (21,5) size 61x19
-                      text run at (21,5) width 61: "summary"
+                    RenderListMarker at (77,5) size 26x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-6) size 25x27
+                        RenderText at (0,5) size 25x19
+                          text run at (0,5) width 4 RTL: " "
+                          text run at (4,5) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (17,5) size 61x19
+                      text run at (17,5) width 61: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (22,0) size 60x18
-                      text run at (22,0) width 60: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (81,3) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (21,2) size 61x19
-                      text run at (21,2) width 61: "summary"
+                    RenderListMarker at (77,3) size 26x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,8) size 25x27
+                        RenderText at (0,2) size 25x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (17,2) size 61x19
+                      text run at (17,2) width 61: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (22,0) size 60x18
-                      text run at (22,0) width 60: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,22) size 18x60
-                      text run at (0,22) width 60: "summary"
+                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,20) size 18x60
+                      text run at (0,20) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 26x120
                   RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,81) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (2,21) size 19x61
-                      text run at (2,21) width 61: "summary"
+                    RenderListMarker at (3,77) size 18x26: "\x{25B6}"
+                      RenderBlock (generated) at (8,0) size 27x25
+                        RenderText at (2,0) size 19x25
+                          text run at (2,0) width 5 RTL: " "
+                          text run at (2,4) width 22 RTL: "\x{25B6}"
+                    RenderText {#text} at (2,17) size 19x61
+                      text run at (2,17) width 61: "summary"
                   RenderBlock {SLOT} at (26,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,22) size 18x60
-                      text run at (0,22) width 60: "summary"
+                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,20) size 18x60
+                      text run at (0,20) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 26x120
                   RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,81) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (5,21) size 19x61
-                      text run at (5,21) width 61: "summary"
+                    RenderListMarker at (5,77) size 18x26: "\x{25C0}"
+                      RenderBlock (generated) at (-6,0) size 27x25
+                        RenderText at (5,0) size 19x25
+                          text run at (5,0) width 5 RTL: " "
+                          text run at (5,4) width 22 RTL: "\x{25C0}"
+                    RenderText {#text} at (5,17) size 19x61
+                      text run at (5,17) width 61: "summary"
                   RenderBlock {SLOT} at (26,0) size 0x120
       RenderBlock (anonymous) at (0,1092) size 784x18
         RenderBR {BR} at (0,0) size 0x18
@@ -525,51 +621,83 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (103,5) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,5) size 61x19
-                      text run at (43,5) width 61: "summary"
+                    RenderListMarker at (95,5) size 25x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-6) size 25x27
+                        RenderText at (0,5) size 25x19
+                          text run at (0,5) width 4 RTL: " "
+                          text run at (4,5) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (35,5) size 60x19
+                      text run at (35,5) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (103,3) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,2) size 61x19
-                      text run at (43,2) width 61: "summary"
+                    RenderListMarker at (95,3) size 25x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,8) size 25x27
+                        RenderText at (0,2) size 25x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (35,2) size 60x19
+                      text run at (35,2) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 26x120
                   RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (3,103) size 18x17: "\x{25B6}"
-                    RenderText {#text} at (2,43) size 19x61
-                      text run at (2,43) width 61: "summary"
+                    RenderListMarker at (3,95) size 18x25: "\x{25B6}"
+                      RenderBlock (generated) at (8,0) size 27x25
+                        RenderText at (2,0) size 19x25
+                          text run at (2,0) width 5 RTL: " "
+                          text run at (2,4) width 22 RTL: "\x{25B6}"
+                    RenderText {#text} at (2,35) size 19x60
+                      text run at (2,35) width 61: "summary"
                   RenderBlock {SLOT} at (26,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 26x120
                   RenderListItem {SUMMARY} at (0,0) size 26x120
-                    RenderListMarker at (5,103) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (5,43) size 19x61
-                      text run at (5,43) width 61: "summary"
+                    RenderListMarker at (5,95) size 18x25: "\x{25C0}"
+                      RenderBlock (generated) at (-6,0) size 27x25
+                        RenderText at (5,0) size 19x25
+                          text run at (5,0) width 5 RTL: " "
+                          text run at (5,4) width 22 RTL: "\x{25C0}"
+                    RenderText {#text} at (5,35) size 19x60
+                      text run at (5,35) width 61: "summary"
                   RenderBlock {SLOT} at (26,0) size 0x120

--- a/LayoutTests/platform/ios/fast/html/details-writing-mode-mixed-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-writing-mode-mixed-expected.txt
@@ -96,53 +96,85 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (103,5) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,5) size 61x19
-                      text run at (43,5) width 61: "summary"
+                    RenderListMarker at (95,5) size 25x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-6) size 25x27
+                        RenderText at (0,5) size 25x19
+                          text run at (0,5) width 4 RTL: " "
+                          text run at (4,5) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (35,5) size 60x19
+                      text run at (35,5) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (103,3) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,2) size 61x19
-                      text run at (43,2) width 61: "summary"
+                    RenderListMarker at (95,3) size 25x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,8) size 25x27
+                        RenderText at (0,2) size 25x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (35,2) size 60x19
+                      text run at (35,2) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B6}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,95) size 18x25: "\x{25B6}"
+                      RenderBlock (generated) at (-5,0) size 27x25
+                        RenderText at (4,0) size 18x25
+                          text run at (4,0) width 5 RTL: " "
+                          text run at (4,4) width 22 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,35) size 18x60
+                      text run at (0,35) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,95) size 18x25: "\x{25C0}"
+                      RenderBlock (generated) at (-5,0) size 27x25
+                        RenderText at (4,0) size 18x25
+                          text run at (4,0) width 5 RTL: " "
+                          text run at (4,4) width 22 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,35) size 18x60
+                      text run at (0,35) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
       RenderBlock (anonymous) at (0,352) size 784x18
         RenderBR {BR} at (0,0) size 0x18
@@ -239,12 +271,20 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (59,5) size 18x18: "\x{25C0}"
+                    RenderListMarker at (59,5) size 26x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-6) size 25x27
+                        RenderText at (0,5) size 25x19
+                          text run at (0,5) width 4 RTL: " "
+                          text run at (4,5) width 21 RTL: "\x{25C0}"
                     RenderText {#text} at (0,5) size 60x19
                       text run at (0,5) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 17x18: "\x{25BC}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -252,12 +292,20 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (59,3) size 18x18: "\x{25C0}"
+                    RenderListMarker at (59,3) size 26x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,8) size 25x27
+                        RenderText at (0,2) size 25x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 21 RTL: "\x{25C0}"
                     RenderText {#text} at (0,2) size 60x19
                       text run at (0,2) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 17x18: "\x{25B2}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -265,12 +313,20 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
+                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x18: "\x{25B6}"
+                    RenderListMarker at (0,59) size 18x26: "\x{25B6}"
+                      RenderBlock (generated) at (-5,0) size 27x25
+                        RenderText at (4,0) size 18x25
+                          text run at (4,0) width 5 RTL: " "
+                          text run at (4,4) width 22 RTL: "\x{25B6}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -278,12 +334,20 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
+                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x18: "\x{25C0}"
+                    RenderListMarker at (0,59) size 18x26: "\x{25C0}"
+                      RenderBlock (generated) at (-5,0) size 27x25
+                        RenderText at (4,0) size 18x25
+                          text run at (4,0) width 5 RTL: " "
+                          text run at (4,4) width 22 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -382,53 +446,85 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (81,5) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (21,5) size 61x19
-                      text run at (21,5) width 61: "summary"
+                    RenderListMarker at (77,5) size 26x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-6) size 25x27
+                        RenderText at (0,5) size 25x19
+                          text run at (0,5) width 4 RTL: " "
+                          text run at (4,5) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (17,5) size 61x19
+                      text run at (17,5) width 61: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (22,0) size 60x18
-                      text run at (22,0) width 60: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (81,3) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (21,2) size 61x19
-                      text run at (21,2) width 61: "summary"
+                    RenderListMarker at (77,3) size 26x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,8) size 25x27
+                        RenderText at (0,2) size 25x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (17,2) size 61x19
+                      text run at (17,2) width 61: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (22,0) size 60x18
-                      text run at (22,0) width 60: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,22) size 18x60
-                      text run at (0,22) width 60: "summary"
+                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,20) size 18x60
+                      text run at (0,20) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (0,21) size 18x61
-                      text run at (0,21) width 60: "summary"
+                    RenderListMarker at (0,77) size 18x26: "\x{25B6}"
+                      RenderBlock (generated) at (-5,0) size 27x25
+                        RenderText at (4,0) size 18x25
+                          text run at (4,0) width 5 RTL: " "
+                          text run at (4,4) width 22 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,17) size 18x61
+                      text run at (0,17) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,22) size 18x60
-                      text run at (0,22) width 60: "summary"
+                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,20) size 18x60
+                      text run at (0,20) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (0,21) size 18x61
-                      text run at (0,21) width 60: "summary"
+                    RenderListMarker at (0,77) size 18x26: "\x{25C0}"
+                      RenderBlock (generated) at (-5,0) size 27x25
+                        RenderText at (4,0) size 18x25
+                          text run at (4,0) width 5 RTL: " "
+                          text run at (4,4) width 22 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,17) size 18x61
+                      text run at (0,17) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
       RenderBlock (anonymous) at (0,1092) size 784x18
         RenderBR {BR} at (0,0) size 0x18
@@ -525,51 +621,83 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (103,5) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,5) size 61x19
-                      text run at (43,5) width 61: "summary"
+                    RenderListMarker at (95,5) size 25x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-6) size 25x27
+                        RenderText at (0,5) size 25x19
+                          text run at (0,5) width 4 RTL: " "
+                          text run at (4,5) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (35,5) size 60x19
+                      text run at (35,5) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x26
                   RenderListItem {SUMMARY} at (0,0) size 120x26
-                    RenderListMarker at (103,3) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,2) size 61x19
-                      text run at (43,2) width 61: "summary"
+                    RenderListMarker at (95,3) size 25x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,8) size 25x27
+                        RenderText at (0,2) size 25x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 21 RTL: "\x{25C0}"
+                    RenderText {#text} at (35,2) size 60x19
+                      text run at (35,2) width 60: "summary"
                 RenderBlock {DETAILS} at (0,26) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B6}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,95) size 18x25: "\x{25B6}"
+                      RenderBlock (generated) at (-5,0) size 27x25
+                        RenderText at (4,0) size 18x25
+                          text run at (4,0) width 5 RTL: " "
+                          text run at (4,4) width 22 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,35) size 18x60
+                      text run at (0,35) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,95) size 18x25: "\x{25C0}"
+                      RenderBlock (generated) at (-5,0) size 27x25
+                        RenderText at (4,0) size 18x25
+                          text run at (4,0) width 5 RTL: " "
+                          text run at (4,4) width 22 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,35) size 18x60
+                      text run at (0,35) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120

--- a/LayoutTests/platform/ios/fast/lists/008-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/008-expected.txt
@@ -134,15 +134,30 @@ layer at (0,0) size 800x1844
       RenderBlock {OL} at (0,1386) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "1"
+            RenderBlock (generated) at (0,-1) size 16x19
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "1"
           RenderText {#text} at (71,10) size 63x18
             text run at (71,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "2"
+            RenderBlock (generated) at (0,-1) size 16x19
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "2"
           RenderText {#text} at (26,10) size 108x36
             text run at (26,10) width 108: "Second and very"
             text run at (39,28) width 95: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "3"
+            RenderBlock (generated) at (0,-1) size 16x19
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "3"
           RenderText {#text} at (65,10) size 69x18
             text run at (65,10) width 69: "Third item"
       RenderBlock {OL} at (0,1536) size 186x134 [border: (1px solid #0000FF)]
@@ -162,14 +177,29 @@ layer at (0,0) size 800x1844
       RenderBlock {OL} at (0,1686) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (117,10) size 17x18: "1"
+            RenderBlock (generated) at (0,-1) size 16x19
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "1"
           RenderText {#text} at (55,10) size 63x18
             text run at (55,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
           RenderListMarker at (117,10) size 17x18: "2"
+            RenderBlock (generated) at (0,-1) size 16x19
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "2"
           RenderText {#text} at (10,10) size 124x36
             text run at (10,10) width 108: "Second and very"
             text run at (39,28) width 95: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (117,10) size 17x18: "3"
+            RenderBlock (generated) at (0,-1) size 16x19
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "3"
           RenderText {#text} at (49,10) size 69x18
             text run at (49,10) width 69: "Third item"

--- a/LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt
@@ -134,15 +134,30 @@ layer at (0,0) size 1844x600
       RenderBlock {OL} at (1386,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "1"
+            RenderBlock (generated) at (-1,0) size 19x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 5 RTL: " "
+                text run at (0,4) width 5 RTL: "."
+                text run at (0,8) width 9: "1"
           RenderText {#text} at (10,71) size 18x63
             text run at (10,71) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "2"
+            RenderBlock (generated) at (-1,0) size 19x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 5 RTL: " "
+                text run at (0,4) width 5 RTL: "."
+                text run at (0,8) width 9: "2"
           RenderText {#text} at (10,26) size 36x108
             text run at (10,26) width 107: "Second and very"
             text run at (28,39) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "3"
+            RenderBlock (generated) at (-1,0) size 19x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 5 RTL: " "
+                text run at (0,4) width 5 RTL: "."
+                text run at (0,8) width 9: "3"
           RenderText {#text} at (10,65) size 18x69
             text run at (10,65) width 69: "Third item"
       RenderBlock {OL} at (1536,0) size 134x186 [border: (1px solid #0000FF)]
@@ -162,14 +177,29 @@ layer at (0,0) size 1844x600
       RenderBlock {OL} at (1686,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,117) size 18x17: "1"
+            RenderBlock (generated) at (-1,0) size 19x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 5 RTL: " "
+                text run at (0,4) width 5 RTL: "."
+                text run at (0,8) width 9: "1"
           RenderText {#text} at (10,55) size 18x63
             text run at (10,55) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,117) size 18x17: "2"
+            RenderBlock (generated) at (-1,0) size 19x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 5 RTL: " "
+                text run at (0,4) width 5 RTL: "."
+                text run at (0,8) width 9: "2"
           RenderText {#text} at (10,10) size 36x124
             text run at (10,10) width 107: "Second and very"
             text run at (28,39) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,117) size 18x17: "3"
+            RenderBlock (generated) at (-1,0) size 19x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 5 RTL: " "
+                text run at (0,4) width 5 RTL: "."
+                text run at (0,8) width 9: "3"
           RenderText {#text} at (10,49) size 18x69
             text run at (10,49) width 69: "Third item"

--- a/LayoutTests/platform/ios/fast/lists/marker-image-error-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/marker-image-error-expected.txt
@@ -21,22 +21,22 @@ layer at (0,0) size 800x600
           text run at (0,0) width 407: "There should be a bullet next to each item on the following list:"
       RenderBlock {UL} at (0,86) size 784x90
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-17,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 162x18
             text run at (0,0) width 162: "Prospectuses and courses"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (-17,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 170x18
             text run at (0,0) width 170: "Undergraduate admissions"
         RenderListItem {LI} at (40,36) size 744x18
-          RenderListMarker at (-17,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 134x18
             text run at (0,0) width 134: "Graduate admissions"
         RenderListItem {LI} at (40,54) size 744x18
-          RenderListMarker at (-17,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 139x18
             text run at (0,0) width 139: "Continuing education"
         RenderListItem {LI} at (40,72) size 744x18
-          RenderListMarker at (-17,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 96x18
             text run at (0,0) width 96: "Online courses"

--- a/LayoutTests/platform/mac/fast/html/details-writing-mode-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-writing-mode-expected.txt
@@ -96,53 +96,85 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,0) size 61x18
-                      text run at (43,0) width 61: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-4) size 20x25
+                        RenderText at (0,3) size 20x19
+                          text run at (0,3) width 4 RTL: " "
+                          text run at (4,3) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (40,0) size 60x18
+                      text run at (40,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x19
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,0) size 61x18
-                      text run at (43,0) width 61: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,7) size 20x25
+                        RenderText at (0,2) size 20x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (40,0) size 60x18
+                      text run at (40,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B6}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,101) size 18x19: "\x{25B6}"
+                      RenderBlock (generated) at (10,0) size 20x19
+                        RenderText at (0,0) size 18x19
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 15 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,42) size 18x60
+                      text run at (0,42) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 19x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (-4,0) size 25x20
+                        RenderText at (3,0) size 19x20
+                          text run at (3,0) width 5 RTL: " "
+                          text run at (3,4) width 17 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,40) size 18x60
+                      text run at (0,40) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
       RenderBlock (anonymous) at (0,352) size 769x18
         RenderBR {BR} at (0,0) size 0x18
@@ -239,12 +271,20 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 18x18: "\x{25C0}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-4) size 20x25
+                        RenderText at (0,3) size 20x19
+                          text run at (0,3) width 4 RTL: " "
+                          text run at (4,3) width 16 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 17x18: "\x{25BC}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x19
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -252,12 +292,20 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 18x18: "\x{25C0}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,7) size 20x25
+                        RenderText at (0,2) size 20x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 16 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 17x18: "\x{25B2}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -265,12 +313,20 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
+                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,59) size 18x18: "\x{25B6}"
+                    RenderListMarker at (0,59) size 18x19: "\x{25B6}"
+                      RenderBlock (generated) at (10,0) size 20x19
+                        RenderText at (0,0) size 18x19
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 15 RTL: "\x{25B6}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -278,12 +334,20 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
+                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 19x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x18: "\x{25C0}"
+                    RenderListMarker at (0,59) size 18x21: "\x{25C0}"
+                      RenderBlock (generated) at (-4,0) size 25x20
+                        RenderText at (3,0) size 19x20
+                          text run at (3,0) width 5 RTL: " "
+                          text run at (3,4) width 17 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -382,53 +446,85 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (21,0) size 61x18
-                      text run at (21,0) width 61: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-4) size 20x25
+                        RenderText at (0,3) size 20x19
+                          text run at (0,3) width 4 RTL: " "
+                          text run at (4,3) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (22,0) size 60x18
-                      text run at (22,0) width 60: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x19
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (21,0) size 61x18
-                      text run at (21,0) width 61: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,7) size 20x25
+                        RenderText at (0,2) size 20x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (22,0) size 60x18
-                      text run at (22,0) width 60: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,22) size 18x60
-                      text run at (0,22) width 60: "summary"
+                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,20) size 18x60
+                      text run at (0,20) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,81) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (0,21) size 18x61
+                    RenderListMarker at (0,80) size 18x19: "\x{25B6}"
+                      RenderBlock (generated) at (10,0) size 20x19
+                        RenderText at (0,0) size 18x19
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 15 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,21) size 18x60
                       text run at (0,21) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,22) size 18x60
-                      text run at (0,22) width 60: "summary"
+                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 19x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,20) size 18x60
+                      text run at (0,20) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (0,21) size 18x61
-                      text run at (0,21) width 60: "summary"
+                    RenderListMarker at (0,79) size 18x21: "\x{25C0}"
+                      RenderBlock (generated) at (-4,0) size 25x20
+                        RenderText at (3,0) size 19x20
+                          text run at (3,0) width 5 RTL: " "
+                          text run at (3,4) width 17 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,20) size 18x60
+                      text run at (0,20) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
       RenderBlock (anonymous) at (0,1092) size 769x18
         RenderBR {BR} at (0,0) size 0x18
@@ -525,51 +621,83 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,0) size 61x18
-                      text run at (43,0) width 61: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-4) size 20x25
+                        RenderText at (0,3) size 20x19
+                          text run at (0,3) width 4 RTL: " "
+                          text run at (4,3) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (40,0) size 60x18
+                      text run at (40,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x19
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,0) size 61x18
-                      text run at (43,0) width 61: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,7) size 20x25
+                        RenderText at (0,2) size 20x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (40,0) size 60x18
+                      text run at (40,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (10,0) size 19x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B6}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,101) size 18x19: "\x{25B6}"
+                      RenderBlock (generated) at (10,0) size 20x19
+                        RenderText at (0,0) size 18x19
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 15 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,42) size 18x60
+                      text run at (0,42) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (-1,0) size 19x20
+                        RenderText at (0,0) size 19x20
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (-4,0) size 25x20
+                        RenderText at (3,0) size 19x20
+                          text run at (3,0) width 5 RTL: " "
+                          text run at (3,4) width 17 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,40) size 18x60
+                      text run at (0,40) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120

--- a/LayoutTests/platform/mac/fast/html/details-writing-mode-mixed-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-writing-mode-mixed-expected.txt
@@ -96,53 +96,85 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,0) size 61x18
-                      text run at (43,0) width 61: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-4) size 20x25
+                        RenderText at (0,3) size 20x19
+                          text run at (0,3) width 4 RTL: " "
+                          text run at (4,3) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (40,0) size 60x18
+                      text run at (40,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x19
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,0) size 61x18
-                      text run at (43,0) width 61: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,7) size 20x25
+                        RenderText at (0,2) size 20x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (40,0) size 60x18
+                      text run at (40,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 18x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B6}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,101) size 18x19: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 18x19
+                        RenderText at (0,0) size 18x19
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 15 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,42) size 18x60
+                      text run at (0,42) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 18x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (-3,0) size 24x20
+                        RenderText at (3,0) size 18x20
+                          text run at (3,0) width 4 RTL: " "
+                          text run at (3,4) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,40) size 18x60
+                      text run at (0,40) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
       RenderBlock (anonymous) at (0,352) size 769x18
         RenderBR {BR} at (0,0) size 0x18
@@ -239,12 +271,20 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 18x18: "\x{25C0}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-4) size 20x25
+                        RenderText at (0,3) size 20x19
+                          text run at (0,3) width 4 RTL: " "
+                          text run at (4,3) width 16 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 17x18: "\x{25BC}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x19
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -252,12 +292,20 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 18x18: "\x{25C0}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,7) size 20x25
+                        RenderText at (0,2) size 20x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 16 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (59,0) size 17x18: "\x{25B2}"
+                    RenderListMarker at (59,0) size 21x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -265,12 +313,20 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
+                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 18x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x18: "\x{25B6}"
+                    RenderListMarker at (0,59) size 18x19: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 18x19
+                        RenderText at (0,0) size 18x19
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 15 RTL: "\x{25B6}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -278,12 +334,20 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
+                    RenderListMarker at (0,59) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 18x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x18: "\x{25C0}"
+                    RenderListMarker at (0,59) size 18x21: "\x{25C0}"
+                      RenderBlock (generated) at (-3,0) size 24x20
+                        RenderText at (3,0) size 18x20
+                          text run at (3,0) width 4 RTL: " "
+                          text run at (3,4) width 16 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -382,53 +446,85 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (21,0) size 61x18
-                      text run at (21,0) width 61: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-4) size 20x25
+                        RenderText at (0,3) size 20x19
+                          text run at (0,3) width 4 RTL: " "
+                          text run at (4,3) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (22,0) size 60x18
-                      text run at (22,0) width 60: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x19
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (21,0) size 61x18
-                      text run at (21,0) width 61: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,7) size 20x25
+                        RenderText at (0,2) size 20x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (81,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (22,0) size 60x18
-                      text run at (22,0) width 60: "summary"
+                    RenderListMarker at (79,0) size 21x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (20,0) size 60x18
+                      text run at (20,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,22) size 18x60
-                      text run at (0,22) width 60: "summary"
+                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 18x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,20) size 18x60
+                      text run at (0,20) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x18: "\x{25B6}"
-                    RenderText {#text} at (0,21) size 18x61
+                    RenderListMarker at (0,80) size 18x19: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 18x19
+                        RenderText at (0,0) size 18x19
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 15 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,21) size 18x60
                       text run at (0,21) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,22) size 18x60
-                      text run at (0,22) width 60: "summary"
+                    RenderListMarker at (0,79) size 18x21: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 18x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,20) size 18x60
+                      text run at (0,20) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x18: "\x{25C0}"
-                    RenderText {#text} at (0,21) size 18x61
-                      text run at (0,21) width 60: "summary"
+                    RenderListMarker at (0,79) size 18x21: "\x{25C0}"
+                      RenderBlock (generated) at (-3,0) size 24x20
+                        RenderText at (3,0) size 18x20
+                          text run at (3,0) width 4 RTL: " "
+                          text run at (3,4) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,20) size 18x60
+                      text run at (0,20) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
       RenderBlock (anonymous) at (0,1092) size 769x18
         RenderBR {BR} at (0,0) size 0x18
@@ -525,51 +621,83 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,0) size 61x18
-                      text run at (43,0) width 61: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,-4) size 20x25
+                        RenderText at (0,3) size 20x19
+                          text run at (0,3) width 4 RTL: " "
+                          text run at (4,3) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (40,0) size 60x18
+                      text run at (40,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25BC}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
+                      RenderBlock (generated) at (0,-1) size 20x19
+                        RenderText at (0,0) size 20x19
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (233,224) size 125x124 [border: (1px solid #000000)] [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25C0}"
-                    RenderText {#text} at (43,0) size 61x18
-                      text run at (43,0) width 61: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25C0}"
+                      RenderBlock (generated) at (0,7) size 20x25
+                        RenderText at (0,2) size 20x19
+                          text run at (0,2) width 4 RTL: " "
+                          text run at (4,2) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (40,0) size 60x18
+                      text run at (40,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,18) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (103,0) size 17x18: "\x{25B2}"
-                    RenderText {#text} at (44,0) size 60x18
-                      text run at (44,0) width 60: "summary"
+                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
+                      RenderBlock (generated) at (0,10) size 20x19
+                        RenderText at (0,0) size 20x18
+                          text run at (0,0) width 5 RTL: " "
+                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (40,0) size 61x18
+                      text run at (40,0) width 61: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 18x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B6}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,101) size 18x19: "\x{25B6}"
+                      RenderBlock (generated) at (0,0) size 18x19
+                        RenderText at (0,0) size 18x19
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 15 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,42) size 18x60
+                      text run at (0,42) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
+                      RenderBlock (generated) at (0,0) size 18x20
+                        RenderText at (0,0) size 18x20
+                          text run at (0,0) width 4 RTL: " "
+                          text run at (0,4) width 16 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,40) size 18x61
+                      text run at (0,40) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25C0}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
+                    RenderListMarker at (0,100) size 18x20: "\x{25C0}"
+                      RenderBlock (generated) at (-3,0) size 24x20
+                        RenderText at (3,0) size 18x20
+                          text run at (3,0) width 4 RTL: " "
+                          text run at (3,4) width 16 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,40) size 18x60
+                      text run at (0,40) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120

--- a/LayoutTests/platform/mac/fast/lists/008-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/008-expected.txt
@@ -134,15 +134,30 @@ layer at (0,0) size 785x1844
       RenderBlock {OL} at (0,1386) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "1"
+            RenderBlock (generated) at (0,0) size 16x18
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "1"
           RenderText {#text} at (71,10) size 63x18
             text run at (71,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "2"
+            RenderBlock (generated) at (0,0) size 16x18
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "2"
           RenderText {#text} at (26,10) size 108x36
             text run at (26,10) width 108: "Second and very"
             text run at (40,28) width 94: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "3"
+            RenderBlock (generated) at (0,0) size 16x18
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "3"
           RenderText {#text} at (65,10) size 69x18
             text run at (65,10) width 69: "Third item"
       RenderBlock {OL} at (0,1536) size 186x134 [border: (1px solid #0000FF)]
@@ -162,14 +177,29 @@ layer at (0,0) size 785x1844
       RenderBlock {OL} at (0,1686) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (117,10) size 17x18: "1"
+            RenderBlock (generated) at (0,0) size 16x18
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "1"
           RenderText {#text} at (55,10) size 63x18
             text run at (55,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
           RenderListMarker at (117,10) size 17x18: "2"
+            RenderBlock (generated) at (0,0) size 16x18
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "2"
           RenderText {#text} at (10,10) size 124x36
             text run at (10,10) width 108: "Second and very"
             text run at (40,28) width 94: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (117,10) size 17x18: "3"
+            RenderBlock (generated) at (0,0) size 16x18
+              RenderText at (0,0) size 16x18
+                text run at (0,0) width 4 RTL: " "
+                text run at (4,0) width 4 RTL: "."
+                text run at (8,0) width 8: "3"
           RenderText {#text} at (49,10) size 69x18
             text run at (49,10) width 69: "Third item"

--- a/LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt
@@ -134,15 +134,30 @@ layer at (0,0) size 1844x585
       RenderBlock {OL} at (1386,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "1"
+            RenderBlock (generated) at (0,0) size 18x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 4 RTL: " "
+                text run at (0,4) width 4 RTL: "."
+                text run at (0,8) width 8: "1"
           RenderText {#text} at (10,71) size 18x63
             text run at (10,71) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "2"
+            RenderBlock (generated) at (0,0) size 18x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 4 RTL: " "
+                text run at (0,4) width 4 RTL: "."
+                text run at (0,8) width 8: "2"
           RenderText {#text} at (10,26) size 36x108
             text run at (10,26) width 107: "Second and very"
             text run at (28,40) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "3"
+            RenderBlock (generated) at (0,0) size 18x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 4 RTL: " "
+                text run at (0,4) width 4 RTL: "."
+                text run at (0,8) width 8: "3"
           RenderText {#text} at (10,65) size 18x69
             text run at (10,65) width 68: "Third item"
       RenderBlock {OL} at (1536,0) size 134x186 [border: (1px solid #0000FF)]
@@ -162,14 +177,29 @@ layer at (0,0) size 1844x585
       RenderBlock {OL} at (1686,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,117) size 18x17: "1"
+            RenderBlock (generated) at (0,0) size 18x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 4 RTL: " "
+                text run at (0,4) width 4 RTL: "."
+                text run at (0,8) width 8: "1"
           RenderText {#text} at (10,55) size 18x63
             text run at (10,55) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,117) size 18x17: "2"
+            RenderBlock (generated) at (0,0) size 18x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 4 RTL: " "
+                text run at (0,4) width 4 RTL: "."
+                text run at (0,8) width 8: "2"
           RenderText {#text} at (10,10) size 36x124
             text run at (10,10) width 107: "Second and very"
             text run at (28,40) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,117) size 18x17: "3"
+            RenderBlock (generated) at (0,0) size 18x16
+              RenderText at (0,0) size 18x16
+                text run at (0,0) width 4 RTL: " "
+                text run at (0,4) width 4 RTL: "."
+                text run at (0,8) width 8: "3"
           RenderText {#text} at (10,49) size 18x69
             text run at (10,49) width 68: "Third item"

--- a/Source/WebCore/css/CSSRegisteredCounterStyle.h
+++ b/Source/WebCore/css/CSSRegisteredCounterStyle.h
@@ -55,6 +55,7 @@ public:
     const CSSCounterStyleDescriptors::Ranges& ranges() const LIFETIME_BOUND { return m_descriptors.m_ranges; }
     const CSSCounterStyleDescriptors::Pad& pad() const LIFETIME_BOUND { return m_descriptors.m_pad; }
     const CSSCounterStyleDescriptors::Name& fallbackName() const LIFETIME_BOUND { return m_descriptors.m_fallbackName; }
+    RefPtr<const CSSRegisteredCounterStyle> fallbackStyle() const { return m_fallbackReference.get(); }
     const Vector<CSSCounterStyleDescriptors::Symbol>& symbols() const LIFETIME_BOUND { return m_descriptors.m_symbols; }
     const CSSCounterStyleDescriptors::AdditiveSymbols& additiveSymbols() const LIFETIME_BOUND { return m_descriptors.m_additiveSymbols; }
     CSSCounterStyleDescriptors::SpeakAs speakAs() const { return m_descriptors.m_speakAs; }

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "RenderListMarker.h"
 
+#include "BaselineAlignment.h"
 #include "CSSCounterStyleDescriptors.h"
 #include "CSSCounterStyleRegistry.h"
 #include "CSSFontSelector.h"
@@ -46,6 +47,7 @@
 #include "RenderMultiColumnSpannerPlaceholder.h"
 #include "RenderObjectInlines.h"
 #include "RenderTable.h"
+#include "RenderText.h"
 #include "RenderView.h"
 #include "Settings.h"
 #include "StyleComputedStyle+GettersInlines.h"
@@ -54,10 +56,10 @@
 #include "StyleListStyleType.h"
 #include "StyleScope.h"
 #include "TextUtil.h"
+#include <wtf/HashSet.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
-#include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
 
@@ -118,12 +120,77 @@ bool RenderListMarker::isImage() const
 {
     // `content` supersedes list-style-image (css-lists-3 §3.3), so a marker with generated content
     // is never treated as an image marker (affects inline margins, baseline, and layout attributes).
-    return m_image && !protect(m_image)->errorOccurred() && !hasContent();
+    return m_image && !protect(m_image)->errorOccurred() && !hasContentProperty();
 }
 
-bool RenderListMarker::hasContent() const
+bool RenderListMarker::hasContentProperty() const
 {
     return document().settings().cssMarkerContentEnabled() && style().content().isData();
+}
+
+static bool symbolsContainStrongDirectionalityText(const CSSRegisteredCounterStyle& counterStyle)
+{
+    auto isStrongDirectionalitySymbol = [](auto& symbol) {
+        return Layout::TextUtil::containsStrongDirectionalityText(symbol.text);
+    };
+    return isStrongDirectionalitySymbol(counterStyle.prefix())
+        || isStrongDirectionalitySymbol(counterStyle.suffix())
+        || isStrongDirectionalitySymbol(counterStyle.negative().m_prefix)
+        || isStrongDirectionalitySymbol(counterStyle.negative().m_suffix)
+        || isStrongDirectionalitySymbol(counterStyle.pad().m_padSymbol)
+        || std::ranges::any_of(counterStyle.symbols(), isStrongDirectionalitySymbol)
+        || std::ranges::any_of(counterStyle.additiveSymbols(), [&](auto& additiveSymbol) {
+            return isStrongDirectionalitySymbol(additiveSymbol.first);
+        });
+}
+
+static bool counterStyleChainHasStrongDirectionalitySymbols(const CSSRegisteredCounterStyle& counterStyle)
+{
+    // A counter style draws its fallback's text whenever a value is out of range or its own system cannot
+    // represent it (CSSRegisteredCounterStyle::text), so every style the chain can reach has to be
+    // left-to-right before the marker can go without content renderers. Measuring and painting the text
+    // directly follows memory order, so text this gets wrong is painted wrong.
+    HashSet<const CSSRegisteredCounterStyle*> visitedCounterStyles;
+    RefPtr currentCounterStyle = &counterStyle;
+    while (true) {
+        // A cycle draws decimal instead (see fallbackText), which never reorders.
+        if (!visitedCounterStyles.add(currentCounterStyle.get()).isNewEntry)
+            return false;
+
+        if (symbolsContainStrongDirectionalityText(*currentCounterStyle))
+            return true;
+
+        // No fallback to follow is the same condition fallbackText draws decimal on, whether the chain
+        // ends here or its reference was never resolved.
+        RefPtr fallbackCounterStyle = currentCounterStyle->fallbackStyle();
+        if (!fallbackCounterStyle)
+            return false;
+
+        currentCounterStyle = WTF::move(fallbackCounterStyle);
+    }
+}
+
+bool RenderListMarker::textNeedsBidiResolution() const
+{
+    if (hasContentProperty() || isImage() || drawsBulletShape() || style().listStyleType().isNone())
+        return false;
+
+    if (auto markerString = style().listStyleType().tryString())
+        return !style().writingMode().isBidiLTR() || Layout::TextUtil::containsStrongDirectionalityText(*markerString);
+
+    RefPtr counterStyle = this->counterStyle();
+    if (!counterStyle)
+        return false;
+
+    if (!style().writingMode().isBidiLTR())
+        return true;
+
+    return counterStyleChainHasStrongDirectionalitySymbols(*counterStyle);
+}
+
+bool RenderListMarker::needsContentContainer() const
+{
+    return hasContentProperty() || textNeedsBidiResolution();
 }
 
 RenderBlockFlow* RenderListMarker::contentContainer() const
@@ -136,18 +203,6 @@ RenderBlockFlow* RenderListMarker::contentContainer() const
 LayoutRect RenderListMarker::localSelectionRect()
 {
     return LayoutRect(LayoutPoint(), borderBoxSize());
-}
-
-static String reversed(StringView string)
-{
-    auto length = string.length();
-    if (length <= 1)
-        return string.toString();
-    std::span<char16_t> characters;
-    auto result = String::createUninitialized(length, characters);
-    for (unsigned i = 0; i < length; ++i)
-        characters[i] = string[length - i - 1];
-    return result;
 }
 
 struct TextRunWithUnderlyingString {
@@ -169,20 +224,7 @@ static auto textRunForContent(ListMarkerTextContent textContent, const Style::Co
 {
     ASSERT(!textContent.isEmpty());
 
-    // Since the bidi algorithm doesn't run on this text, we instead reorder the characters here.
-    // We use u_charDirection to figure out if the marker text is RTL and assume the suffix matches the surrounding direction.
-    String textForRun;
-    if (textContent.textDirection == TextDirection::LTR) {
-        if (style.writingMode().isBidiLTR())
-            textForRun = textContent.textWithSuffix;
-        else
-            textForRun = makeString(reversed(textContent.suffix()), textContent.textWithoutSuffix());
-    } else {
-        if (!style.writingMode().isBidiLTR())
-            textForRun = reversed(textContent.textWithSuffix);
-        else
-            textForRun = makeString(reversed(textContent.textWithoutSuffix()), textContent.suffix());
-    }
+    auto textForRun = textContent.textWithSuffix;
     auto textRun = RenderBlock::constructTextRun(textForRun, style);
     return { WTF::move(textRun), WTF::move(textForRun) };
 }
@@ -220,7 +262,7 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
 
         // Paint the generated-content subtree as an atomic inline: paintAsInlineBlock fans out all
         // sub-phases for Foreground and forwards Selection/EventRegion/TextClip to the child's paint().
-        container->paintAsInlineBlock(paintInfo, boxOrigin);
+        container->paintAsInlineBlock(paintInfo, flipForWritingModeForChild(*container, boxOrigin));
         return;
     }
 
@@ -266,17 +308,14 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
     context.setStrokeThickness(1.0f);
     context.setFillColor(color);
 
-    auto listStyleType = style().listStyleType();
-    if (listStyleType.isDisc()) {
-        context.fillEllipse(markerRect);
-        return;
-    }
-    if (listStyleType.isCircle()) {
-        context.strokeEllipse(markerRect);
-        return;
-    }
-    if (listStyleType.isSquare()) {
-        context.fillRect(markerRect);
+    if (drawsBulletShape()) {
+        auto listStyleType = style().listStyleType();
+        if (listStyleType.isDisc())
+            context.fillEllipse(markerRect);
+        else if (listStyleType.isCircle())
+            context.strokeEllipse(markerRect);
+        else
+            context.fillRect(markerRect);
         return;
     }
 
@@ -373,18 +412,23 @@ void RenderListMarker::layoutContentContainer(RenderBlockFlow& container)
     container.clearOverridingBorderBoxLogicalWidth();
 
     setLogicalWidth(container.logicalWidth());
-    setLogicalHeight(container.logicalHeight());
 
     // The inline formatting context aligns the marker box on the marker's primary-font baseline
     // (like a text marker; see InlineLineBoxBuilder), then we paint the content box at the marker
     // box origin. Offset the content box along the block axis so its own first-line baseline lands
     // on that font baseline — otherwise the content's line-box half-leading shifts it off the list
     // item's baseline. Logical setters keep this correct in vertical writing modes.
-    auto markerAscent = LayoutUnit { style().metricsOfPrimaryFont().ascent() };
+    auto markerAscent = LayoutUnit { style().metricsOfPrimaryFont().ascent(BaselineAlignment::dominantBaseline(writingMode())) };
     auto contentBaseline = container.firstLineBaseline().value_or(container.logicalHeight());
     container.setLogicalTop(markerAscent - contentBaseline);
 
-    m_layoutBounds = { contentBaseline, container.logicalHeight() - contentBaseline };
+    if (textNeedsBidiResolution()) {
+        setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
+        m_layoutBounds = layoutBoundForTextContent(textWithSuffix());
+    } else {
+        setLogicalHeight(container.logicalHeight());
+        m_layoutBounds = { contentBaseline, container.logicalHeight() - contentBaseline };
+    }
 
     // The content box can extend outside the marker's border box (its baseline offset may be
     // negative, or the content taller than the marker font), so record its overflow. The marker
@@ -401,6 +445,11 @@ void RenderListMarker::imageChanged(WrappedImagePtr o, const IntRect* rect)
     if (parent()) {
         RefPtr image = m_image;
         if (image && o == image->data()) {
+            if (image->errorOccurred()) {
+                // A failed image turns this into a text marker, and that text may need content subtree.
+                if (RefPtr element = m_listItem ? m_listItem->element() : nullptr)
+                    element->invalidateStyle();
+            }
             if (borderBoxWidth() != image->imageSize(this, style().usedZoom()).width() || borderBoxHeight() != image->imageSize(this, style().usedZoom()).height() || image->errorOccurred())
                 setNeedsLayoutAndInvalidateContentLogicalWidths();
             else
@@ -420,7 +469,7 @@ void RenderListMarker::updateInlineMarginsAndContent()
 
 void RenderListMarker::updateContent()
 {
-    if (hasContent()) {
+    if (hasContentProperty()) {
         // css-lists-3 §3.3: `content` (not normal) supersedes list-style-image/type. The generated
         // content lives in the anonymous inline-block contentContainer(); the marker has no text/image.
         m_textContent = { };
@@ -436,36 +485,21 @@ void RenderListMarker::updateContent()
         m_textContent = {
             .textWithSuffix = emptyString(),
             .textWithoutSuffixLength = 0,
-            .textDirection = TextDirection::LTR,
         };
         return;
     }
-
-    auto contentTextDirection = [&](auto content) {
-        if (!content.length())
-            return TextDirection::LTR;
-        // FIXME: Depending on the string value, we may need the real bidi algorithm. (rdar://106139180)
-        // Also we may need to start checking for the entire content for directionality (and whether we need to check for additional
-        // directionality characters like U_RIGHT_TO_LEFT_EMBEDDING).
-        auto bidiCategory = u_charDirection(content[0]);
-        if (bidiCategory != U_RIGHT_TO_LEFT && bidiCategory != U_RIGHT_TO_LEFT_ARABIC)
-            return TextDirection::LTR;
-        return TextDirection::RTL;
-    };
 
     WTF::switchOn(style().listStyleType(),
         [&](const CSS::Keyword::None&) {
             m_textContent = {
                 .textWithSuffix = " "_s,
                 .textWithoutSuffixLength = 0,
-                .textDirection = TextDirection::LTR,
             };
         },
         [&](const Style::String& identifier) {
             m_textContent = {
                 .textWithSuffix = identifier.value,
                 .textWithoutSuffixLength = identifier.value.length(),
-                .textDirection = contentTextDirection(StringView { identifier.value }),
             };
         },
         [&](const Style::CounterStyle&) {
@@ -476,10 +510,31 @@ void RenderListMarker::updateContent()
             m_textContent = {
                 .textWithSuffix = makeString(text, counter->suffix().text),
                 .textWithoutSuffixLength = text.length(),
-                .textDirection = contentTextDirection(text),
             };
         }
     );
+
+    // The marker text is only known here (counter values resolve at layout), while the renderers
+    // holding it were created from style. Push the text down so the inline formatting context has something to lay out.
+    if (textNeedsBidiResolution())
+        updateContentContainerText();
+}
+
+void RenderListMarker::updateContentContainerText()
+{
+    CheckedPtr container = contentContainer();
+    if (!container) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    CheckedPtr textRenderer = dynamicDowncast<RenderText>(container->firstChild());
+    if (!textRenderer) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    textRenderer->setText(m_textContent.textWithSuffix);
 }
 
 void RenderListMarker::computeIntrinsicLogicalWidthContributions()
@@ -515,7 +570,7 @@ void RenderListMarker::computeIntrinsicLogicalWidthContributions()
     auto& font = systemUIFontCascade ? *systemUIFontCascade : style().fontCascade();
 
     LayoutUnit logicalWidth;
-    if (widthUsesMetricsOfPrimaryFont())
+    if (drawsBulletShape())
         logicalWidth = (font.metricsOfPrimaryFont().intAscent() * 2 / 3 + 1) / 2 + 2;
     else if (!m_textContent.isEmpty())
         logicalWidth = font.width(textRunForContent(m_textContent, style()));
@@ -537,7 +592,7 @@ void RenderListMarker::updateInlineMargins()
         if (isImage())
             return { 0, markerPadding };
 
-        if (widthUsesMetricsOfPrimaryFont())
+        if (drawsBulletShape())
             return { -1, fontMetrics.intAscent() - minContentLogicalWidthContribution() + 1 };
 
         return { };
@@ -548,7 +603,7 @@ void RenderListMarker::updateInlineMargins()
             return { -minContentLogicalWidthContribution() - markerPadding, markerPadding };
 
         int offset = fontMetrics.intAscent() * 2 / 3;
-        if (widthUsesMetricsOfPrimaryFont())
+        if (drawsBulletShape())
             return { -offset - markerPadding - 1, offset + markerPadding + 1 - minContentLogicalWidthContribution() };
 
         if (m_textContent.isEmpty() && !contentContainer())
@@ -632,7 +687,7 @@ FloatRect RenderListMarker::relativeMarkerRect()
         return { 0.f, 0.f, protect(m_image)->imageSize(this, style().usedZoom()).width(), protect(m_image)->imageSize(this, style().usedZoom()).height() };
 
     FloatRect relativeRect;
-    if (widthUsesMetricsOfPrimaryFont()) {
+    if (drawsBulletShape()) {
         auto& fontMetrics = style().metricsOfPrimaryFont();
         auto ascent = fontMetrics.ascent();
         auto bulletWidth = (ascent * 2 / 3 + 1) / 2;
@@ -679,10 +734,10 @@ RefPtr<CSSRegisteredCounterStyle> RenderListMarker::counterStyle() const
     return document().counterStyleRegistry().resolvedCounterStyle(*counterStyle);
 }
 
-bool RenderListMarker::widthUsesMetricsOfPrimaryFont() const
+bool RenderListMarker::drawsBulletShape() const
 {
     // `content` supersedes list-style-type, so a content marker never draws a bullet glyph.
-    if (hasContent())
+    if (hasContentProperty())
         return false;
     auto& listType = style().listStyleType();
     return listType.isCircle() || listType.isDisc() || listType.isSquare();

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -34,7 +34,6 @@ class StyleRuleCounterStyle;
 struct ListMarkerTextContent {
     String textWithSuffix;
     uint32_t textWithoutSuffixLength { 0 };
-    TextDirection textDirection { TextDirection::LTR };
     bool isEmpty() const
     {
         return textWithSuffix.isEmpty();
@@ -43,11 +42,6 @@ struct ListMarkerTextContent {
     StringView textWithoutSuffix() const LIFETIME_BOUND
     {
         return StringView { textWithSuffix }.left(textWithoutSuffixLength);
-    }
-
-    StringView suffix() const LIFETIME_BOUND
-    {
-        return StringView { textWithSuffix }.substring(textWithoutSuffixLength);
     }
 };
 
@@ -73,7 +67,9 @@ public:
     // True when the ::marker's `content` property generates the marker box contents
     // (css-lists-3 §3.3). In that case the contents live in an anonymous inline-block
     // child (contentContainer()) that this marker lays out and paints itself.
-    bool hasContent() const;
+    bool hasContentProperty() const;
+    bool needsContentContainer() const;
+
     RenderBlockFlow* contentContainer() const;
 
     LayoutUnit lineLogicalOffsetForListItem() const { return m_lineLogicalOffsetForListItem; }
@@ -106,7 +102,8 @@ private:
     void willBeDestroyed() final;
     ASCIILiteral renderName() const final { return "RenderListMarker"_s; }
     void computeIntrinsicLogicalWidthContributions() final;
-    bool canHaveChildren() const final { return hasContent(); }
+    bool canHaveChildren() const final { return needsContentContainer(); }
+    bool canHaveGeneratedChildren() const final { return true; }
     void paint(PaintInfo&, const LayoutPoint&) final;
     void layout() final;
     void imageChanged(WrappedImagePtr, const IntRect*) final;
@@ -122,6 +119,7 @@ private:
 
     void updateInlineMargins();
     void updateContent();
+    void updateContentContainerText();
     RenderBox* parentBox(RenderBox&);
     void layoutContentContainer(RenderBlockFlow&);
 
@@ -130,7 +128,8 @@ private:
     void paintDisclosureMarker(GraphicsContext&, const FloatRect& markerRect);
 
     RefPtr<CSSRegisteredCounterStyle> counterStyle() const;
-    bool widthUsesMetricsOfPrimaryFont() const;
+    bool drawsBulletShape() const;
+    bool textNeedsBidiResolution() const;
 
 private:
     ListMarkerTextContent m_textContent;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -135,17 +135,20 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
         m_builder.destroyAndCleanUpAnonymousWrappers(*markerRenderer, { });
 
     if (auto* markerRenderer = listItemRenderer.markerRenderer()) {
-        auto contentChanged = markerRenderer->style().content() != newStyle.content();
-        // Tear down any existing generated content while the current style still permits children:
-        // setStyle below may flip canHaveChildren() to false (content: normal/none), and destroying
-        // the container afterwards would trip the detach assertion.
-        if (contentChanged) {
+        // Whether the marker box holds inline content depends on `content` and on list-style-type
+        // (only text markers with right-to-left content need it). The container also inherits
+        // unicode-bidi, so rebuild on that too, to carry the new value into it.
+        auto contentChanged = markerRenderer->style().content() != newStyle.content() || markerRenderer->style().unicodeBidi() != newStyle.unicodeBidi() || markerRenderer->style().listStyleType() != newStyle.listStyleType();
+        markerRenderer->setStyle(WTF::move(newStyle));
+
+        // Recomputing this here rather than diffing the style properties it is made of also picks up
+        // what is not the marker's own style: its direction, and what the document's counter style
+        // registry currently resolves list-style-type to.
+        auto needsContentContainer = markerRenderer->needsContentContainer();
+        if (contentChanged || needsContentContainer != !!markerRenderer->contentContainer()) {
             if (auto* existingContainer = markerRenderer->contentContainer())
                 m_builder.destroy(*existingContainer);
-        }
-        markerRenderer->setStyle(WTF::move(newStyle));
-        if (contentChanged) {
-            if (markerHasContent)
+            if (needsContentContainer)
                 buildMarkerContentRenderers(*markerRenderer);
         } else if (auto* container = markerRenderer->contentContainer()) {
             // Content unchanged but other style changed: refresh the generated image/quote children
@@ -203,13 +206,13 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
     // child (e.g., <img>), we should collapse the anonymous block's height so it doesn't inflate the list item.
     listItemRenderer.markerRenderer()->setShouldCollapseAnonymousBlockParent(shouldCollapseAnonymousBlockParent);
 
-    if (markerHasContent)
+    if (listItemRenderer.markerRenderer()->needsContentContainer())
         buildMarkerContentRenderers(*listItemRenderer.markerRenderer());
 }
 
 void RenderTreeBuilder::List::buildMarkerContentRenderers(RenderListMarker& marker)
 {
-    ASSERT(marker.style().content().isData());
+    ASSERT(marker.needsContentContainer());
     ASSERT(!marker.contentContainer());
 
     // css-lists-3 §3.3 generates the marker contents "exactly as for ::before": an anonymous
@@ -220,6 +223,15 @@ void RenderTreeBuilder::List::buildMarkerContentRenderers(RenderListMarker& mark
     newContainer->initializeStyle();
     CheckedRef container = *newContainer;
     m_builder.attach(marker, WTF::move(newContainer));
+
+    if (!marker.hasContentProperty()) {
+        // list-style-type text that needs renderers of its own, so inline layout can bidi-resolve it.
+        // The text itself is only known once counter values resolve, so start empty and let
+        // RenderListMarker::updateContent() fill it in at layout time.
+        auto textRenderer = WebCore::createRenderer<RenderText>(RenderObject::Type::Text, marker.document(), emptyString());
+        m_builder.attach(container.get(), WTF::move(textRenderer));
+        return;
+    }
 
     RenderTreeUpdater::GeneratedContent::createContentRenderers(m_builder, container.get(), marker.style(), PseudoElementType::Marker);
 }


### PR DESCRIPTION
#### 924a6596c2f80d8e923ba220dadf364430d9789b
<pre>
[list-marker] List marker overlaps the list item content when the marker text is right-to-left
<a href="https://bugs.webkit.org/show_bug.cgi?id=321396">https://bugs.webkit.org/show_bug.cgi?id=321396</a>
&lt;<a href="https://rdar.apple.com/problem/185048387">rdar://problem/185048387</a>&gt;

Reviewed by Antti Koivisto.

  &lt;style&gt;
  li { list-style-type: &quot;\627 \644 &quot; }
  &lt;/style&gt;
  &lt;ol&gt;&lt;li&gt;a

The marker should reserve the 12px its two glyphs occupy. Instead it reserved 9px, so the list item&apos;s content painted on top of the marker.

The marker had no renderers for its text, so nothing ever ran the bidi algorithm over it and
textRunForContent reversed the characters itself. Painting needs that reversal: drawText forces the
embedding level, so it draws in memory order and pre-reversed text lands in the right visual order.
Measuring does not, because FontCascade::width lets CoreText resolve the run instead. Reversing
right-to-left text also changes its Arabic joining forms, here forming a lam-alef ligature, so the box
was sized for 8.41px of ligature while 12.28px of two separate glyphs was painted. Reordering by hand
got text of mixed direction wrong outright.

Give the marker&apos;s text renderers of its own when it needs bidi resolution, reusing the anonymous
inline-block child that `content` markers already have, so inline layout measures and paints the same
resolved runs. A counter style draws its fallback&apos;s text whenever it cannot represent a value, so that
decision walks the whole fallback chain and sends anything it cannot prove is left-to-right through
inline layout. A disclosure triangle is no longer excluded from it either: its glyph and suffix are
both direction-neutral, so a right-to-left box reorders them and the suffix space used to end up on
the wrong side of the triangle.

* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::isImage const):
(WebCore::RenderListMarker::hasContentProperty const):
(WebCore::symbolsContainStrongDirectionalityText):
(WebCore::counterStyleChainHasStrongDirectionalitySymbols):
(WebCore::RenderListMarker::textNeedsBidiResolution const):
(WebCore::RenderListMarker::usesInlineLayout const):
(WebCore::textRunForContent):
(WebCore::RenderListMarker::paint):
(WebCore::RenderListMarker::updateContent):
(WebCore::RenderListMarker::updateTextRendererForInlineLayout):
(WebCore::RenderListMarker::layoutContentContainer):
(WebCore::RenderListMarker::computeIntrinsicLogicalWidthContributions):
(WebCore::RenderListMarker::updateInlineMargins):
(WebCore::RenderListMarker::relativeMarkerRect):
(WebCore::RenderListMarker::drawsBulletShape const):
(WebCore::RenderListMarker::hasContent const): Deleted.
(WebCore::reversed): Deleted.
(WebCore::RenderListMarker::widthUsesMetricsOfPrimaryFont const): Deleted.
(WebCore::RenderListMarker::imageChanged):
(WebCore::RenderListMarker::needsContentContainer const):
(WebCore::RenderListMarker::updateContentContainerText):
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/css/CSSRegisteredCounterStyle.h:
(WebCore::CSSRegisteredCounterStyle::fallbackStyle const):
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::RenderTreeBuilder::List::updateItemMarker):
(WebCore::RenderTreeBuilder::List::buildMarkerContentRenderers):
(WebCore::RenderTreeBuilder::List::wrapInsideMarkerInAnonymousInline):
* LayoutTests/TestExpectations: list-style-type-string-005a, -006 and disclosure-styles pass now.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-rtl-string-width.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-rtl-string-width-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-rtl-string-width-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-unicode-bidi-default.html:
* LayoutTests/platform/ios/fast/lists/008-expected.txt:
* LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt:
* LayoutTests/platform/mac/fast/lists/008-expected.txt:
* LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/hebrew/css3-counter-styles-016.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-mutation-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-mutation-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-mutation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-fallback-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-fallback-rtl-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-counter-style-fallback-rtl-expected.html: Added.
* LayoutTests/platform/ios/fast/lists/marker-image-error-expected.txt:
* LayoutTests/platform/glib/fast/html/details-writing-mode-expected.txt:
* LayoutTests/platform/glib/fast/html/details-writing-mode-mixed-expected.txt:
* LayoutTests/platform/ios/fast/html/details-writing-mode-expected.txt:
* LayoutTests/platform/ios/fast/html/details-writing-mode-mixed-expected.txt:
* LayoutTests/platform/mac/fast/html/details-writing-mode-expected.txt:
* LayoutTests/platform/mac/fast/html/details-writing-mode-mixed-expected.txt:

Canonical link: <a href="https://commits.webkit.org/319314@main">https://commits.webkit.org/319314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1cb8e573fdeb2559f5e9f30b92b2385d62f4795

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191304 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145410 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe1af60d-7df6-4d46-8c4e-02b788ad2f37) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182949 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54748 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141305 "Found 3 new test failures: fast/lists/008-vertical.html fast/lists/008.html fast/lists/marker-image-error.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/691cfc5e-f183-4e44-818e-8cb29133f307) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121756 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9daef6c1-0d04-4cf1-a03f-3937fd4670fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43642 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41922 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41583 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2461 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193236 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161571 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150691 "Found 3 new test failures: fast/lists/008-vertical.html fast/lists/008.html fast/lists/marker-image-error.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40338 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55386 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150407 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44999 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127652 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123196 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53903 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16579 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53285 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53522 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53350 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->