### PR TITLE
[EvaluationTimeZoom] px values in calc() expressions that survive through computed style are being serialized incorrectly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/calc-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/calc-computed-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Property text-indent value 'calc(10% + 10px)' calc value no zoom
+PASS Property text-indent value 'calc(10% + 10px)' calc value with zoom: 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/calc-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/calc-computed.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom doesn't effect px values in computed style</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+const target = document.getElementById("target");
+test_computed_value("text-indent", "calc(10% + 10px)", "calc(10% + 10px)", "calc value no zoom");
+target.style.zoom = "2";
+test_computed_value("text-indent", "calc(10% + 10px)", "calc(10% + 10px)", "calc value with zoom: 2");
+</script>
+</body>
+</html>

--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -77,7 +77,5 @@ style/StyleResolver.h
 style/StyleScope.h
 style/StyleTreeResolver.h
 style/Styleable.h
-style/calc/StyleCalculationTree+Conversion.cpp
-style/calc/StyleCalculationTree+Conversion.h
 style/values/primitives/StyleLengthResolution.cpp
 svg/properties/SVGPropertyOwnerRegistry.h

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -82,12 +82,11 @@ RefPtr<Value> Value::parse(CSSParserTokenRange& tokens, CSS::PropertyParserState
     return result;
 }
 
-Ref<Value> Value::create(CSS::Category category, CSS::Range range, const Style::Calculation::Value& value, const Style::ComputedStyle& style)
+Ref<Value> Value::create(CSS::Category category, CSS::Range range, const Style::Calculation::Value& value)
 {
     auto toCSSOptions = Style::Calculation::ToCSSOptions {
         .category = category,
         .range = range,
-        .style = style,
     };
     return Value::create(category, range, Style::Calculation::toCSS(value.tree(), toCSSOptions));
 }

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -38,7 +38,6 @@
 namespace WebCore {
 
 namespace Style {
-class ComputedStyle;
 namespace Calculation {
 class Value;
 }
@@ -70,7 +69,7 @@ class Value final : public RefCounted<Value> {
 public:
     static RefPtr<Value> parse(CSSParserTokenRange&, CSS::PropertyParserState&, CSS::Category, CSS::Range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 
-    static Ref<Value> create(CSS::Category, CSS::Range, const Style::Calculation::Value&, const Style::ComputedStyle&);
+    static Ref<Value> create(CSS::Category, CSS::Range, const Style::Calculation::Value&);
     static Ref<Value> create(CSS::Category, CSS::Range, CSSCalc::Tree&&);
 
     ~Value();

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
@@ -59,8 +59,8 @@ UnevaluatedCalcBase::UnevaluatedCalcBase(Ref<CSSCalc::Value>&& value)
 {
 }
 
-UnevaluatedCalcBase::UnevaluatedCalcBase(Category category, Range range, const Style::UnevaluatedCalculationBase& value, const Style::ComputedStyle& style)
-    : m_calc { CSSCalc::Value::create(category, range, protect(value.calculation()), style) }
+UnevaluatedCalcBase::UnevaluatedCalcBase(Category category, Range range, const Style::UnevaluatedCalculationBase& value)
+    : m_calc { CSSCalc::Value::create(category, range, protect(value.calculation())) }
 {
 }
 

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -45,7 +45,6 @@ struct CSSPropertyParserOptions;
 
 namespace Style {
 class BuilderState;
-class ComputedStyle;
 class UnevaluatedCalculationBase;
 }
 
@@ -72,7 +71,7 @@ class UnevaluatedCalcBase {
 public:
     WEBCORE_EXPORT UnevaluatedCalcBase(CSSCalc::Value&);
     UnevaluatedCalcBase(Ref<CSSCalc::Value>&&);
-    UnevaluatedCalcBase(Category, Range, const Style::UnevaluatedCalculationBase&, const Style::ComputedStyle&);
+    UnevaluatedCalcBase(Category, Range, const Style::UnevaluatedCalculationBase&);
 
     UnevaluatedCalcBase(const UnevaluatedCalcBase&);
     UnevaluatedCalcBase(UnevaluatedCalcBase&&);
@@ -131,8 +130,8 @@ template<NumericRaw RawType> struct UnevaluatedCalc : UnevaluatedCalcBase {
     static constexpr auto range = Raw::range;
     static constexpr auto category = Raw::category;
 
-    explicit UnevaluatedCalc(const Style::UnevaluatedCalculationBase& value, const Style::ComputedStyle& style)
-        : UnevaluatedCalcBase(category, range, value, style)
+    explicit UnevaluatedCalc(const Style::UnevaluatedCalculationBase& value)
+        : UnevaluatedCalcBase(category, range, value)
     {
     }
 

--- a/Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp
@@ -37,10 +37,8 @@
 #include "CSSUnevaluatedCalc.h"
 #include "StyleBuilderState.h"
 #include "StyleCalculationTree.h"
-#include "StyleComputedStyle+GettersInlines.h"
 #include "StyleLengthResolution.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
-#include "StyleZoomPrimitivesInlines.h"
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 
@@ -51,7 +49,6 @@ namespace Calculation {
 struct ToCSSConversionOptions {
     CSSCalc::CanonicalDimension::Dimension canonicalDimension;
     CSSCalc::SimplificationOptions simplification;
-    const Style::ComputedStyle& style;
 };
 
 struct ToStyleConversionOptions {
@@ -173,18 +170,6 @@ CSSCalc::Child toCSS(const Percentage& percentage, const ToCSSConversionOptions&
 
 CSSCalc::Child toCSS(const Dimension& root, const ToCSSConversionOptions& options)
 {
-    switch (options.canonicalDimension) {
-    case CSSCalc::CanonicalDimension::Dimension::Length:
-        return CSSCalc::makeChild(CSSCalc::CanonicalDimension { .value = Style::adjustFloatForAbsoluteZoom(root.value, options.style), .dimension = options.canonicalDimension });
-
-    case CSSCalc::CanonicalDimension::Dimension::Angle:
-    case CSSCalc::CanonicalDimension::Dimension::Time:
-    case CSSCalc::CanonicalDimension::Dimension::Frequency:
-    case CSSCalc::CanonicalDimension::Dimension::Resolution:
-    case CSSCalc::CanonicalDimension::Dimension::Flex:
-        break;
-    }
-
     return CSSCalc::makeChild(CSSCalc::CanonicalDimension { .value = root.value, .dimension = options.canonicalDimension });
 }
 
@@ -391,7 +376,6 @@ CSSCalc::Tree toCSS(const Tree& tree, const ToCSSOptions& toCSSOptions)
             .symbolTable = { },
             .allowZeroValueLengthRemovalFromSum = true,
         },
-        .style = toCSSOptions.style,
     };
 
     auto root = toCSS(tree.root, conversionOptions);

--- a/Source/WebCore/style/calc/StyleCalculationTree+Conversion.h
+++ b/Source/WebCore/style/calc/StyleCalculationTree+Conversion.h
@@ -27,7 +27,6 @@
 #include "CSSCalcSymbolTable.h"
 #include "CSSPrimitiveNumericRange.h"
 #include "CSSToLengthConversionData.h"
-#include "StyleComputedStyle.h"
 
 namespace WebCore {
 
@@ -50,9 +49,6 @@ struct ToCSSOptions {
 
     // `range` represents the allowed numeric range for the calculated result.
     CSS::Range range;
-
-    // `style` represents the ComputedStyle the Tree is from for zoom calculations.
-    const ComputedStyle& style;
 };
 
 struct ToStyleOptions {

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -141,58 +141,44 @@ template<auto R, typename V, typename... Rest> LengthPercentage<R, V> canonicali
 
 // MARK: - Conversion from "Style to "CSS"
 
-// Length requires a specialized implementation due to unresolvedValue() usage.
-template<auto R, typename V> struct ToCSS<Length<R, V>> {
-    auto operator()(const Length<R, V>& value, const ComputedStyle&) -> CSS::Length<R, V>
-    {
-        return CSS::LengthRaw<R, V> { value.unit, value.unresolvedValue() };
-    }
-};
-
 template<auto R, typename V> struct ToCSS<UnevaluatedCalculation<CSS::AnglePercentage<R, V>>> {
-    auto operator()(const UnevaluatedCalculation<CSS::AnglePercentage<R, V>>& value, const ComputedStyle& style) -> typename CSS::AnglePercentage<R, V>::Calc
+    auto operator()(const UnevaluatedCalculation<CSS::AnglePercentage<R, V>>& value, const ComputedStyle&) -> typename CSS::AnglePercentage<R, V>::Calc
     {
-        return typename CSS::AnglePercentage<R, V>::Calc { value, style };
+        return typename CSS::AnglePercentage<R, V>::Calc { value };
     }
 };
 
 template<auto R, typename V> struct ToCSS<UnevaluatedCalculation<CSS::LengthPercentage<R, V>>> {
-    auto operator()(const UnevaluatedCalculation<CSS::LengthPercentage<R, V>>& value, const ComputedStyle& style) -> typename CSS::LengthPercentage<R, V>::Calc
+    auto operator()(const UnevaluatedCalculation<CSS::LengthPercentage<R, V>>& value, const ComputedStyle&) -> typename CSS::LengthPercentage<R, V>::Calc
     {
-        return typename CSS::LengthPercentage<R, V>::Calc { value, style };
+        return typename CSS::LengthPercentage<R, V>::Calc { value };
     }
 };
 
 // AnglePercentage / LengthPercentage require specialized implementations due to additional `calc` field.
 template<auto R, typename V> struct ToCSS<AnglePercentage<R, V>> {
-    auto operator()(const AnglePercentage<R, V>& value, const ComputedStyle& style) -> CSS::AnglePercentage<R, V>
+    auto operator()(const AnglePercentage<R, V>& value, const ComputedStyle&) -> CSS::AnglePercentage<R, V>
     {
         return WTF::switchOn(value,
-            [&](const Angle<R, V>& angle) -> CSS::AnglePercentage<R, V> {
-                return typename CSS::AnglePercentage<R, V>::Raw { angle.unit, angle.value };
-            },
-            [&](const Percentage<R, V>& percentage) -> CSS::AnglePercentage<R, V> {
-                return typename CSS::AnglePercentage<R, V>::Raw { percentage.unit, percentage.value };
+            [&](Numeric auto const& angleOrPercentage) -> CSS::AnglePercentage<R, V> {
+                return typename CSS::AnglePercentage<R, V>::Raw { angleOrPercentage.unit, angleOrPercentage.unresolvedValue() };
             },
             [&](const typename AnglePercentage<R, V>::Calc& calculation) -> CSS::AnglePercentage<R> {
-                return typename CSS::AnglePercentage<R, V>::Calc { calculation, style };
+                return typename CSS::AnglePercentage<R, V>::Calc { calculation };
             }
         );
     }
 };
 
 template<auto R, typename V> struct ToCSS<LengthPercentage<R, V>> {
-    auto operator()(const LengthPercentage<R, V>& value, const ComputedStyle& style) -> CSS::LengthPercentage<R, V>
+    auto operator()(const LengthPercentage<R, V>& value, const ComputedStyle&) -> CSS::LengthPercentage<R, V>
     {
         return WTF::switchOn(value,
-            [&](const typename LengthPercentage<R, V>::Dimension& length) -> CSS::LengthPercentage<R, V> {
-                return typename CSS::LengthPercentage<R, V>::Raw { length.unit, length.unresolvedValue() };
-            },
-            [&](const typename LengthPercentage<R, V>::Percentage& percentage) -> CSS::LengthPercentage<R, V> {
-                return typename CSS::LengthPercentage<R, V>::Raw { percentage.unit, percentage.value };
+            [&](Numeric auto const& lengthOrPercentage) -> CSS::LengthPercentage<R, V> {
+                return typename CSS::LengthPercentage<R, V>::Raw { lengthOrPercentage.unit, lengthOrPercentage.unresolvedValue() };
             },
             [&](const typename LengthPercentage<R, V>::Calc& calculation) -> CSS::LengthPercentage<R> {
-                return typename CSS::LengthPercentage<R, V>::Calc { calculation, style };
+                return typename CSS::LengthPercentage<R, V>::Calc { calculation };
             }
         );
     }
@@ -202,7 +188,7 @@ template<auto R, typename V> struct ToCSS<LengthPercentage<R, V>> {
 template<Numeric StyleType> struct ToCSS<StyleType> {
     auto operator()(const StyleType& value, const ComputedStyle&) -> typename StyleType::CSS
     {
-        return { value.unit, value.value };
+        return { value.unit, value.unresolvedValue() };
     }
 };
 


### PR DESCRIPTION
#### 17e6d00a19246a5c1a9fc4d1e94f3b0ce26835ca
<pre>
[EvaluationTimeZoom] px values in calc() expressions that survive through computed style are being serialized incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=321939">https://bugs.webkit.org/show_bug.cgi?id=321939</a>

Reviewed by Sammy Gill.

Removes incorrect zoom unscaling of px values in computed value calc() expressions
that was left over from build time zoom.

Now that no zoom unscaling is needed, the Style::ComputedStyle passed during conversion
from Style::UnevaluatedCalculation to CSS::UnevalutatedCalc can be removed. Also simplified
toCSS conversion for numeric types a bit by using unresolvedValue() for all numeric types
instead of specializing for Length&lt;&gt;.

Test: imported/w3c/web-platform-tests/css/css-viewport/zoom/calc-computed.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/calc-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/calc-computed.html: Added.
* Source/WebCore/css/calc/CSSCalcValue.cpp:
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
* Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp:
* Source/WebCore/style/calc/StyleCalculationTree+Conversion.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:

Canonical link: <a href="https://commits.webkit.org/319320@main">https://commits.webkit.org/319320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa3db12ba740a6e5c3763f9306079b049cb04cc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191361 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141362 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121813 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43701 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41974 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41635 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2520 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193293 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150747 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40358 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55443 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150463 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45050 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127710 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123266 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53960 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16631 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53342 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53579 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->