### PR TITLE
[SVG] Emoji in <text> is not rendered when a positioning list is used

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/positioning-list-typographic-character-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/positioning-list-typographic-character-expected.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:title>A text positioning list must not split a typographic character (reference)</h:title>
+  </metadata>
+  <text x="0" y="40" style="font-size: 20px">&#x1F1FA;&#x1F1F8;</text>
+  <text x="80" y="40" style="font-size: 20px">a</text>
+  <text x="0" y="80" style="font-size: 20px">e&#x0301;</text>
+  <text x="80" y="80" style="font-size: 20px">a</text>
+  <text x="0" y="120" style="font-size: 20px">&#x1F1FA;&#x1F1F8;</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/positioning-list-typographic-character-ref.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/positioning-list-typographic-character-ref.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:title>A text positioning list must not split a typographic character (reference)</h:title>
+  </metadata>
+  <text x="0" y="40" style="font-size: 20px">&#x1F1FA;&#x1F1F8;</text>
+  <text x="80" y="40" style="font-size: 20px">a</text>
+  <text x="0" y="80" style="font-size: 20px">e&#x0301;</text>
+  <text x="80" y="80" style="font-size: 20px">a</text>
+  <text x="0" y="120" style="font-size: 20px">&#x1F1FA;&#x1F1F8;</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/positioning-list-typographic-character.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/positioning-list-typographic-character.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:title>A text positioning list must not split a typographic character</h:title>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextLayoutAlgorithm"/>
+    <h:link rel="match" href="positioning-list-typographic-character-ref.svg"/>
+  </metadata>
+  <!-- The 'x' value belonging to the second character of a typographic character is skipped, but it
+       still consumes an entry in the list, so "a" is placed at x=80. The flag (a regional indicator
+       pair) and the "e" followed by U+0301 must each stay a single typographic character. -->
+  <text x="0 40 80" y="40" style="font-size: 20px">&#x1F1FA;&#x1F1F8;a</text>
+  <text x="0 40 80" y="80" style="font-size: 20px">e&#x0301;a</text>
+  <text x="0 40 80 120 160" y="120" style="font-size: 20px">&#x1F1FA;&#x1F1F8;</text>
+</svg>

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -29,7 +29,9 @@
 #include "RenderSVGText.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "WidthIterator.h"
+#include <unicode/ubrk.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/text/TextBreakIterator.h>
 
 namespace WebCore {
 
@@ -229,6 +231,12 @@ std::tuple<unsigned, char16_t> SVGTextMetricsBuilder::measureTextRendererWithIte
     auto& textMetricsValues = attributes->textMetricsValues();
     int surrogatePairCharacters = 0;
     unsigned skippedCharacters = 0;
+
+    // Grapheme-cluster boundaries, keyed by the same code-unit offset as m_textPosition. A character
+    // that is not at a boundary is a "middle" character per SVG 2 §11.5: the second or later
+    // character of a typographic character.
+    NonSharedCharacterBreakIterator clusterIterator(m_run.text());
+
     while (advance(iterator)) {
         char16_t currentCharacter = m_run[m_textPosition];
         if (currentCharacter == space && !preserveWhiteSpace && (!lastCharacter || lastCharacter == space)) {
@@ -241,8 +249,22 @@ std::tuple<unsigned, char16_t> SVGTextMetricsBuilder::measureTextRendererWithIte
         if (data.processRenderer) {
             if (data.allCharactersMap) {
                 auto it = data.allCharactersMap->find(valueListPosition + m_textPosition - skippedCharacters - surrogatePairCharacters + 1);
-                if (it != data.allCharactersMap->end())
-                    attributes->characterDataMap().set(m_textPosition + 1, it->value);
+                if (it != data.allCharactersMap->end()) {
+                    auto characterData = it->value;
+
+                    // Repositioning applies to whole typographic characters, so a middle character's
+                    // x/y/rotate are skipped -- honoring them would split the typographic character
+                    // into independently shaped pieces. The value list index is still consumed.
+                    // FIXME: dx/dy are left alone here, and are then dropped rather than accumulated
+                    // onto the next typographic character as SVG 2 requires.
+                    if (!ubrk_isBoundary(clusterIterator, m_textPosition)) {
+                        characterData.x = SVGTextLayoutAttributes::emptyValue();
+                        characterData.y = SVGTextLayoutAttributes::emptyValue();
+                        characterData.rotate = SVGTextLayoutAttributes::emptyValue();
+                    }
+
+                    attributes->characterDataMap().set(m_textPosition + 1, characterData);
+                }
             }
             textMetricsValues.append(m_currentMetrics);
         }


### PR DESCRIPTION
#### 39bb03746589e5822e58fe492d75425234091f02
<pre>
[SVG] Emoji in &lt;text&gt; is not rendered when a positioning list is used
<a href="https://bugs.webkit.org/show_bug.cgi?id=73354">https://bugs.webkit.org/show_bug.cgi?id=73354</a>
<a href="https://rdar.apple.com/10505691">rdar://10505691</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox.

&lt;svg:text x=&quot;0 40 80 120 160&quot;&gt;&amp;#x1F1FA;&amp;#x1F1F8;&lt;/svg:text&gt; rendered nothing.
The flag is one grapheme cluster of two code points, and the positioning list
cut it in half: each regional indicator was shaped alone, and a lone regional
indicator has no glyph. The same flag renders fine with a single x value.

measureTextRendererWithIterator() stored the value list entry for the second
regional indicator in the renderer&apos;s characterDataMap(), so
RenderSVGInlineText::characterStartsNewTextChunk() reported a new chunk in
the middle of the cluster. SVG text runs on legacy line layout, where
BreakingContext::handleText then calls ensureCharacterGetsLineBox() -- giving
two inline boxes, shaped independently. The isClusterStart guard in
SVGTextLayoutEngine (bug 266832) only suppresses fragment breaks.

Per the SVG 2 text layout algorithm [1], the second or later character of a
typographic character is &quot;middle&quot;, and &quot;array values corresponding to other
characters in the typographic character are skipped (for x and y)&quot;. Clear
x/y for those characters, keyed off a grapheme-cluster break iterator on the
same code-unit basis as m_textPosition. The value list index is still
consumed, since addressable characters count code points, not clusters:
x=&quot;0 40 80&quot; on {flag}a places &quot;a&quot; at 80. rotate is cleared as well, so a
divergent angle on a middle character does not start a new fragment at the
next cluster; the &quot;last value carries forward&quot; rule is unaffected because
fillCharacterDataMap() applies it against the value list.

Also fixes &quot;e&quot; followed by U+0301 with a positioning list, which was split
into the base character and a lone combining mark.

dx/dy are left alone, and are still dropped rather than accumulated onto the
next typographic character as the specification requires; noted as a FIXME.

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextLayoutAlgorithm">https://w3c.github.io/svgwg/svg2-draft/text.html#TextLayoutAlgorithm</a>

Tests: imported/w3c/web-platform-tests/svg/text/reftests/positioning-list-typographic-character.svg

* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/positioning-list-typographic-character-expected.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/positioning-list-typographic-character-ref.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/positioning-list-typographic-character.svg: Added.
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::measureTextRendererWithIterator):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39bb03746589e5822e58fe492d75425234091f02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145412 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8bbc749f-d3e2-46b9-859d-997693b13a8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141306 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98001 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c42dee02-3481-4355-8217-007b7ed776b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121757 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7617ea6-ebef-454b-ac07-3afc65249e18) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43645 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41923 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41584 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2463 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193238 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150692 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55388 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150408 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45000 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127654 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123198 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53905 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16580 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53287 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53524 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53352 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->