### PR TITLE
Page freezes with CSS transition duration calc(infinity * 1s)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-duration-infinite-cancelation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-duration-infinite-cancelation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Canceling a transition with transition-duration set to infinite value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-duration-infinite-cancelation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-duration-infinite-cancelation.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Canceling a transition with transition-duration set to infinite value</title>
+<link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=321274">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/helper.js"></script>
+<style>
+
+#target {
+  width: 100px;
+  height: 100px;
+  background-color: black;
+
+  transition: background-color calc(infinity * 1s) ease;
+}
+
+#target.transition {
+  background-color: blue;
+  transition-duration: .2s;
+}
+
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+promise_test(async t => {
+  const div = document.querySelector("div");
+
+  // Start the transition.
+  await new Promise(requestAnimationFrame);
+  div.classList.toggle("transition");
+
+  // End the transition.
+  await new Promise(requestAnimationFrame);
+  div.classList.toggle("transition");
+
+  // Ensure we wait a frame to make sure the page is responsive.
+  await new Promise(requestAnimationFrame);
+}, 'Canceling a transition with transition-duration set to infinite value');
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/UnitBezier.h
+++ b/Source/WebCore/platform/graphics/UnitBezier.h
@@ -37,6 +37,7 @@ namespace WebCore {
 #define CUBIC_BEZIER_SPLINE_SAMPLES 11
 
         static constexpr double kBezierEpsilon = 1e-7;
+        static constexpr double kBisectionEpsilon = 1e-10;
         static constexpr int kMaxNewtonIterations = 4;
 
         UnitBezier(double p1x, double p1y, double p2x, double p2y)
@@ -144,9 +145,10 @@ namespace WebCore {
                 return t2;
 
             // Fall back to the bisection method for reliability.
+            double bisectionEpsilon = std::max(kBisectionEpsilon, epsilon);
             while (t0 < t1) {
                 x2 = sampleCurveX(t2);
-                if (std::abs(x2 - x) < epsilon)
+                if (std::abs(x2 - x) < bisectionEpsilon)
                     return t2;
                 if (x > x2)
                     t0 = t2;


### PR DESCRIPTION
#### 029da7d3d074a75a24c2413e98b183a8bbfcfb62
<pre>
Page freezes with CSS transition duration calc(infinity * 1s)
<a href="https://bugs.webkit.org/show_bug.cgi?id=321274">https://bugs.webkit.org/show_bug.cgi?id=321274</a>
<a href="https://rdar.apple.com/184322389">rdar://184322389</a>

Reviewed by Sam Weinig.

Ensure we don&apos;t enter an infinite loop under `UnitBezier::solveCurveX()` by
enforcing a minimal value for `epsilon` larger than 0.

Test: imported/w3c/web-platform-tests/css/css-transitions/transition-duration-infinite-cancelation.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-duration-infinite-cancelation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-duration-infinite-cancelation.html: Added.
* Source/WebCore/platform/graphics/UnitBezier.h:
(WebCore::UnitBezier::solveCurveX):

Canonical link: <a href="https://commits.webkit.org/320034@main">https://commits.webkit.org/320034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4768ff5c089714c583c9cf04318fdae3395ba00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183586 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/57510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/51327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193808 "Failed to checkout and rebase branch from PR 71783") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57245 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/193808 "Failed to checkout and rebase branch from PR 71783") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186541 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/47049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/193808 "Failed to checkout and rebase branch from PR 71783") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/45751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/193808 "Failed to checkout and rebase branch from PR 71783") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/43571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/4986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/50165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/48251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/195746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57180 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/163533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/195746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57884 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/40197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/195746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27857 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/47043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/130163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56392 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/18581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55763 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56002 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55830 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->