### PR TITLE
[WPE] Add WPESettings API to unset application values and lookup platform values

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -46,13 +46,27 @@ struct SettingEntry {
 
     GRefPtr<GVariant> value() const
     {
-        return setValue ? setValue : defaultValue;
+        return valueForSource(WPE_SETTINGS_SOURCE_APPLICATION);
     }
 
-    GRefPtr<GVariant> setValue;
+    GRefPtr<GVariant> valueForSource(WPESettingsSource source) const
+    {
+        if (source == WPE_SETTINGS_SOURCE_APPLICATION && applicationValue)
+            return applicationValue;
+        if (platformValue)
+            return platformValue;
+        return defaultValue;
+    }
+
+    GRefPtr<GVariant>& valueSlot(WPESettingsSource source)
+    {
+        return source == WPE_SETTINGS_SOURCE_APPLICATION ? applicationValue : platformValue;
+    }
+
+    GRefPtr<GVariant> applicationValue;
+    GRefPtr<GVariant> platformValue;
     GRefPtr<GVariant> defaultValue;
     GUniquePtr<GVariantType> type;
-    bool setByApplication { false };
 };
 
 /**
@@ -219,7 +233,7 @@ gboolean wpe_settings_load_from_keyfile(WPESettings* settingsObject, GKeyFile* k
     for (unsigned i = 0; groups.get()[i]; i++) {
         const char* group = groups.get()[i];
 
-        if (!g_str_has_prefix(group, "wpe-platform/") && strcmp(group, "wpe-platform"))
+        if (!g_str_has_prefix(group, "wpe-platform/") && g_strcmp0(group, "wpe-platform"))
             continue;
 
         GUniquePtr<char*> keys(g_key_file_get_keys(keyFile, group, nullptr, nullptr));
@@ -244,11 +258,12 @@ gboolean wpe_settings_load_from_keyfile(WPESettings* settingsObject, GKeyFile* k
                 return FALSE;
             }
 
-            if (iter->value.setValue && !g_variant_compare(iter->value.setValue.get(), parsedValue.get()))
+            auto& applicationValue = iter->value.valueSlot(WPE_SETTINGS_SOURCE_APPLICATION);
+            if (applicationValue && g_variant_equal(applicationValue.get(), parsedValue.get()))
                 continue;
 
-            iter->value.setValue = WTF::move(parsedValue);
-            g_signal_emit(settingsObject, signals[CHANGED], g_quark_from_string(path.data()), path.data(), iter->value.setValue.get());
+            applicationValue = WTF::move(parsedValue);
+            g_signal_emit(settingsObject, signals[CHANGED], g_quark_from_string(path.data()), path.data(), iter->value.value().get());
         }
     }
 
@@ -263,6 +278,9 @@ gboolean wpe_settings_load_from_keyfile(WPESettings* settingsObject, GKeyFile* k
  * Adds settings to a keyfile. Keys are transformed into group names, for example:
  * `/wpe-platform/fonts/hinting` will be saved as `hinting` in the group `wpe-platform/fonts`.
  *
+ * Only the values set by [enum@WPEPlatform.SettingsSource.APPLICATION] are saved: what the
+ * platform reports is the system's to answer again on the next run.
+ *
  * Any existing values in the keyfile will be overwritten.
  */
 void wpe_settings_save_to_keyfile(WPESettings* settingsObject, GKeyFile* keyFile)
@@ -271,7 +289,7 @@ void wpe_settings_save_to_keyfile(WPESettings* settingsObject, GKeyFile* keyFile
     g_return_if_fail(keyFile);
 
     for (auto& [key, entry] : settingsObject->priv->settings) {
-        if (!entry.setValue)
+        if (!entry.applicationValue)
             continue;
 
         // Transform "/foo/bar/baz" into "foo/bar" and "baz".
@@ -284,7 +302,7 @@ void wpe_settings_save_to_keyfile(WPESettings* settingsObject, GKeyFile* keyFile
         const char* group = keyString.get() + 1;
         // FIXME: Handle empty?
 
-        GUniquePtr<char> variantString(g_variant_print(entry.setValue.get(), FALSE));
+        GUniquePtr<char> variantString(g_variant_print(entry.applicationValue.get(), FALSE));
         g_key_file_set_value(keyFile, group, keyStart, variantString.get());
     }
 }
@@ -297,17 +315,21 @@ void wpe_settings_save_to_keyfile(WPESettings* settingsObject, GKeyFile* keyFile
  * @source: the source of the settings change
  * @error: return location for a #GError, or %NULL
  *
- * If @source is %WPE_SETTINGS_SOURCE_APPLICATION, then the value will not be overwritten by the platform.
- * This value should always be %WPE_SETTINGS_SOURCE_PLATFORM for platforms themselves. This can cause this
- * method to return %TRUE even though no setting changes.
+ * Each source holds a value of its own, and the one set by
+ * [enum@WPEPlatform.SettingsSource.APPLICATION] is the one in use while it is set. This
+ * value should always be [enum@WPEPlatform.SettingsSource.PLATFORM] for platforms
+ * themselves, which may keep their value up to date whether or not an
+ * application value is hiding it. This can cause this method to return %TRUE
+ * even though no setting changes.
  *
  * To set a value @key must have been registered and @value must be of the correct type.
  *
  * Any floating reference of @value will be consumed.
  *
- * Setting @value to %NULL will reset it to the default.
+ * Setting @value to %NULL unsets the value for @source, as
+ * [method@WPESettings.unset] does.
  *
- * On a value being changed it will emit [signal@WPESettings::changed].
+ * On the value in use being changed it will emit [signal@WPESettings::changed].
  *
  * Returns: %FALSE if @error was set, %TRUE otherwise
  */
@@ -323,32 +345,77 @@ gboolean wpe_settings_set_value(WPESettings* settingsObject, const char* key, GV
         return FALSE;
     }
 
-    if (iter->value.setByApplication && source != WPE_SETTINGS_SOURCE_APPLICATION)
-        return TRUE;
-
-    if (!value) {
-        auto previousValue = iter->value.setValue;
-        iter->value.setValue = nullptr;
-        iter->value.setByApplication = source == WPE_SETTINGS_SOURCE_APPLICATION;
-        if (previousValue && g_variant_compare(previousValue.get(), iter->value.defaultValue.get()))
-            g_signal_emit(settingsObject, signals[CHANGED], g_quark_from_string(key), key, iter->value.value().get());
-        return TRUE;
-    }
-
-    if (!g_variant_type_equal(g_variant_get_type(value), iter->value.type.get())) {
+    if (value && !g_variant_type_equal(g_variant_get_type(value), iter->value.type.get())) {
         g_set_error(error, WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_INCORRECT_TYPE,
             "Incorrect type (%s) for key %s", g_variant_get_type_string(value), key);
         return FALSE;
     }
 
     auto previousValue = iter->value.value();
-    iter->value.setValue = value;
-    iter->value.setByApplication = source == WPE_SETTINGS_SOURCE_APPLICATION;
+    iter->value.valueSlot(source) = value;
+    auto newValue = iter->value.value();
 
-    if (g_variant_compare(previousValue.get(), value))
-        g_signal_emit(settingsObject, signals[CHANGED], g_quark_from_string(key), key, iter->value.value().get());
+    if (!g_variant_equal(previousValue.get(), newValue.get()))
+        g_signal_emit(settingsObject, signals[CHANGED], g_quark_from_string(key), key, newValue.get());
 
     return TRUE;
+}
+
+/**
+ * wpe_settings_unset:
+ * @settings: a #WPESettings
+ * @key: the key to unset
+ * @source: the source whose value is to be dropped
+ * @error: return location for a #GError, or %NULL
+ *
+ * Drops the value @source set for @key, leaving the key with whatever a lower
+ * source has to say about it: an application unsetting a key it had set gives
+ * the key back to the platform, and to the default when the platform has not
+ * set one either.
+ *
+ * On the value in use being changed it will emit [signal@WPESettings::changed].
+ *
+ * Returns: %FALSE if @error was set, %TRUE otherwise
+ * Since: 2.56
+ */
+gboolean wpe_settings_unset(WPESettings* settingsObject, const char* key, WPESettingsSource source, GError** error)
+{
+    return wpe_settings_set_value(settingsObject, key, nullptr, source, error);
+}
+
+/**
+ * wpe_settings_get_value_for_source:
+ * @settings: a #WPESettings
+ * @key: the key to look up
+ * @source: the source to look the key up in
+ * @error: return location for a #GError, or %NULL
+ *
+ * Gets the value @key would have if no source above @source had set it, which
+ * is what makes it possible to show what following the platform would amount to
+ * while an application value is in place.
+ *
+ * Asking [enum@WPEPlatform.SettingsSource.PLATFORM] gives the platform's value, or the
+ * default when the platform has not set one; asking
+ * [enum@WPEPlatform.SettingsSource.APPLICATION] gives the value in use, as
+ * [method@WPESettings.get_value] does.
+ *
+ * If the key is not registered it will return %NULL and set @error.
+ *
+ * Returns: (transfer none): the value @key has in @source.
+ * Since: 2.56
+ */
+GVariant* wpe_settings_get_value_for_source(WPESettings* settingsObject, const char* key, WPESettingsSource source, GError** error)
+{
+    g_return_val_if_fail(WPE_IS_SETTINGS(settingsObject), NULL);
+    g_return_val_if_fail(key && *key == '/', NULL);
+
+    const auto iter = settingsObject->priv->settings.find(key);
+    if (iter == settingsObject->priv->settings.end()) {
+        g_set_error(error, WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_NOT_REGISTERED, "Key %s not registered", key);
+        return nullptr;
+    }
+
+    return iter->value.valueForSource(source).getUncheckedLifetime();
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.h
@@ -307,6 +307,12 @@ typedef enum {
  * @WPE_SETTINGS_SOURCE_APPLICATION: Set by the application
  *
  * Indicates the source of a settings change.
+ *
+ * Each source holds a value of its own for a key. The application's is the one
+ * in use while it is set, the platform's stands in when it is not, and the
+ * default when neither has set one. An application can therefore let the
+ * platform have a key back with [method@WPESettings.unset], and ask what the
+ * platform would say meanwhile with [method@WPESettings.get_value_for_source].
  */
 typedef enum {
     WPE_SETTINGS_SOURCE_PLATFORM,
@@ -336,8 +342,18 @@ WPE_API gboolean     wpe_settings_set_value                       (WPESettings  
                                                                    WPESettingsSource   source,
                                                                    GError            **error);
 
+WPE_API gboolean     wpe_settings_unset                           (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   WPESettingsSource   source,
+                                                                   GError            **error);
+
 WPE_API GVariant    *wpe_settings_get_value                       (WPESettings        *settings,
                                                                    const char         *key,
+                                                                   GError            **error);
+
+WPE_API GVariant    *wpe_settings_get_value_for_source            (WPESettings        *settings,
+                                                                   const char         *key,
+                                                                   WPESettingsSource   source,
                                                                    GError            **error);
 
 WPE_API gint32       wpe_settings_get_int32                       (WPESettings        *settings,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/wpe-platform/TestSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/wpe-platform/TestSettings.cpp
@@ -88,9 +88,30 @@ static void testSettingsRegistration(WPEMockPlatformTest* test, gconstpointer)
     ret = wpe_settings_set_value(settings, "/wpe-platform/a-new-key", applicationValue, WPE_SETTINGS_SOURCE_APPLICATION, nullptr);
     g_assert_true(ret);
     g_assert_cmpvariant(wpe_settings_get_value(settings, "/wpe-platform/a-new-key", nullptr), applicationValue);
-    ret = wpe_settings_set_value(settings, "/wpe-platform/a-new-key", someValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    ret = wpe_settings_set_value(settings, "/wpe-platform/a-new-key", anotherValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
     g_assert_true(ret);
     g_assert_cmpvariant(wpe_settings_get_value(settings, "/wpe-platform/a-new-key", nullptr), applicationValue);
+
+    // The platform keeps a value of its own while the application's is in use,
+    // and it can still be asked what that value is.
+    g_assert_cmpvariant(wpe_settings_get_value_for_source(settings, "/wpe-platform/a-new-key", WPE_SETTINGS_SOURCE_PLATFORM, nullptr), anotherValue.get());
+    g_assert_cmpvariant(wpe_settings_get_value_for_source(settings, "/wpe-platform/a-new-key", WPE_SETTINGS_SOURCE_APPLICATION, nullptr), applicationValue);
+
+    // Unsetting the application value gives the key back to the platform.
+    ret = wpe_settings_unset(settings, "/wpe-platform/a-new-key", WPE_SETTINGS_SOURCE_APPLICATION, &error.outPtr());
+    g_assert_no_error(error.get());
+    g_assert_true(ret);
+    g_assert_cmpvariant(wpe_settings_get_value(settings, "/wpe-platform/a-new-key", nullptr), anotherValue.get());
+
+    // Unsetting the platform value leaves the default.
+    ret = wpe_settings_unset(settings, "/wpe-platform/a-new-key", WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    g_assert_true(ret);
+    g_assert_cmpvariant(wpe_settings_get_value(settings, "/wpe-platform/a-new-key", nullptr), someValue.get());
+
+    // Unsetting a key that was never registered.
+    ret = wpe_settings_unset(settings, "/wpe-platform/non-existing-key", WPE_SETTINGS_SOURCE_APPLICATION, &error.outPtr());
+    g_assert_error(error.get(), WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_NOT_REGISTERED);
+    g_assert_false(ret);
 }
 
 static void testSettingsSaveKeyFiles(WPEMockPlatformTest* test, gconstpointer)
@@ -109,8 +130,14 @@ static void testSettingsSaveKeyFiles(WPEMockPlatformTest* test, gconstpointer)
     wpe_settings_save_to_keyfile(settings, keyFile.get());
     g_assert_false(g_key_file_has_key(keyFile.get(), "wpe-platform", "a-new-key", nullptr));
 
-    // Non-default is written.
+    // What the platform reports is the system's to answer again next time, so
+    // it is not written.
     wpe_settings_set_value(settings, "/wpe-platform/a-new-key", anotherValue.get(), WPE_SETTINGS_SOURCE_PLATFORM, nullptr);
+    wpe_settings_save_to_keyfile(settings, keyFile.get());
+    g_assert_false(g_key_file_has_key(keyFile.get(), "wpe-platform", "a-new-key", nullptr));
+
+    // What the application chose is written.
+    wpe_settings_set_value(settings, "/wpe-platform/a-new-key", anotherValue.get(), WPE_SETTINGS_SOURCE_APPLICATION, nullptr);
     wpe_settings_save_to_keyfile(settings, keyFile.get());
     g_assert_true(g_key_file_has_key(keyFile.get(), "wpe-platform", "a-new-key", nullptr));
 }


### PR DESCRIPTION
#### 54d043f9c2e263ade31c13fb3a5bf58434c3b55b
<pre>
[WPE] Add WPESettings API to unset application values and lookup platform values
<a href="https://bugs.webkit.org/show_bug.cgi?id=321945">https://bugs.webkit.org/show_bug.cgi?id=321945</a>

Reviewed by NOBODY (OOPS!).

This is useful for an application as it allows exposing default and non-default
choices for the user to set.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/wpe-platform/TestSettings.cpp

* Source/WebKit/WPEPlatform/wpe/WPESettings.cpp:
(SettingEntry::value const):
(SettingEntry::valueForSource const):
(SettingEntry::valueSlot):
(wpe_settings_load_from_keyfile):
(wpe_settings_save_to_keyfile):
(wpe_settings_set_value):
(wpe_settings_unset):
(wpe_settings_get_value_for_source):
(): Deleted.
* Source/WebKit/WPEPlatform/wpe/WPESettings.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/wpe/wpe-platform/TestSettings.cpp:
(TestWebKitAPI::testSettingsRegistration):
(TestWebKitAPI::testSettingsSaveKeyFiles):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54d043f9c2e263ade31c13fb3a5bf58434c3b55b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145424 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141317 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98013 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121768 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43653 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41935 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154057 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41594 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2475 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193250 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54712 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150704 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55400 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150419 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45010 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127666 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123213 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53917 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16590 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->