### PR TITLE
[check-webkit-style] Add 'computed-style-getter-nodelete' to jsonchecker.py

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -400,6 +400,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'computed-style-getter-custom': self.validate_boolean,
             'computed-style-getter-exported': self.validate_boolean,
             'computed-style-getter-inline': self.validate_boolean,
+            'computed-style-getter-nodelete': self.validate_boolean,
             'computed-style-getter': self.validate_string,
             'computed-style-has-explicitly-set-getter-custom': self.validate_boolean,
             'computed-style-has-explicitly-set-policy': self.validate_string,


### PR DESCRIPTION
#### 4a9b52b842ed6e0bf4a522655d20107253d6370d
<pre>
[check-webkit-style] Add &apos;computed-style-getter-nodelete&apos; to jsonchecker.py
<a href="https://bugs.webkit.org/show_bug.cgi?id=321953">https://bugs.webkit.org/show_bug.cgi?id=321953</a>
<a href="https://rdar.apple.com/185132938">rdar://185132938</a>

Reviewed by Sam Weinig.

Tell jsonchecker.py about `computed-style-getter-nodelete`, which was
introduced in 319253@main. Without this, we get bogus errors when
touching CSSProperties.json:

check-webkit-style Source/WebCore/css/CSSProperties.json
Source/WebCore/css/CSSProperties.json:0: error: [json/syntax] codegen-properties for property &quot;font-feature-settings&quot; has unexpected key &quot;computed-style-getter-nodelete&quot;.
Source/WebCore/css/CSSProperties.json:0: error: [json/syntax] codegen-properties for property &quot;font-variation-settings&quot; has unexpected key &quot;computed-style-getter-nodelete&quot;.
Source/WebCore/css/CSSProperties.json:0: error: [json/syntax] codegen-properties for property &quot;font-variant-alternates&quot; has unexpected key &quot;computed-style-getter-nodelete&quot;.
Total errors found: 3 in 1 files

* Tools/Scripts/webkitpy/style/checkers/jsonchecker.py:
(JSONCSSPropertiesChecker.check_codegen_properties):

Canonical link: <a href="https://commits.webkit.org/319333@main">https://commits.webkit.org/319333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b82e918a1fc94f21e26efa8012068e0b96b107b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191345 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145451 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff158b43-af02-4025-950c-e85eba39d933) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141336 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8679a2e9-0082-4705-be89-988eb1bcd443) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45003 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162088 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121787 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6f4363b-1ee6-499b-a623-34133b2e29b9) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180452 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43676 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41958 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154080 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41616 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2504 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193277 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54739 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150726 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40384 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55427 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150442 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45032 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123242 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53944 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16612 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53326 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53563 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53391 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->