### PR TITLE
[WebGPU] drawIndirect/drawIndexedIndirect clamp into a single per-Buffer scratch slot, racing every other indirect draw in the same render pass

### DIFF
--- a/LayoutTests/fast/webgpu/draw-indirect-repeated-shared-args-buffer-expected.txt
+++ b/LayoutTests/fast/webgpu/draw-indirect-repeated-shared-args-buffer-expected.txt
@@ -1,0 +1,11 @@
+Two drawIndirect calls in one render pass, reading two different argument records out of one GPUBuffer, with a pipeline that declares a required vertex buffer layout so both draws take the min-count clamp path. The clamped arguments must land in per-draw scratch: a single per-Buffer scratch slot is written by the second draw's clamp dispatch at the same address the first draw fetches its arguments from, and no barrier can order a vertex-stage write against an indirect argument fetch. Each draw selects a differently coloured triangle via firstVertex and is scissored to its own pixel, so a clobbered record shows up as the wrong colour.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS leftPixel.join() is "0,255,0,255"
+PASS rightPixel.join() is "0,0,255,255"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/webgpu/draw-indirect-repeated-shared-args-buffer.html
+++ b/LayoutTests/fast/webgpu/draw-indirect-repeated-shared-args-buffer.html
@@ -1,0 +1,107 @@
+<script src="../../resources/js-test.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+description("Two drawIndirect calls in one render pass, reading two different argument records out of one " +
+           "GPUBuffer, with a pipeline that declares a required vertex buffer layout so both draws take the " +
+           "min-count clamp path. The clamped arguments must land in per-draw scratch: a single per-Buffer " +
+           "scratch slot is written by the second draw's clamp dispatch at the same address the first draw " +
+           "fetches its arguments from, and no barrier can order a vertex-stage write against an indirect " +
+           "argument fetch. Each draw selects a differently coloured triangle via firstVertex and is scissored " +
+           "to its own pixel, so a clobbered record shows up as the wrong colour.");
+
+async function main() {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+
+    const format = 'rgba8unorm';
+    // A real @location vertex-step-mode buffer, so computeMininumVertexInstanceCount lowers minVertexCount off
+    // the invalid sentinel and clampIndirectBufferToValidValues does not early-out to the app's own buffer.
+    let module = device.createShaderModule({ code: `
+        struct VSOut {
+            @builtin(position) position: vec4f,
+            @location(0) color: vec4f,
+        };
+        @vertex fn vs(@location(0) p: vec2f, @location(1) c: vec4f) -> VSOut {
+            return VSOut(vec4f(p, 0, 1), c);
+        }
+        @fragment fn fs(in: VSOut) -> @location(0) vec4f { return in.color; }
+    ` });
+    let pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module,
+            entryPoint: 'vs',
+            buffers: [{
+                arrayStride: 24,
+                attributes: [
+                    { shaderLocation: 0, offset: 0, format: 'float32x2' },
+                    { shaderLocation: 1, offset: 8, format: 'float32x4' },
+                ],
+            }],
+        },
+        fragment: { module, entryPoint: 'fs', targets: [{ format }] },
+        primitive: { topology: 'triangle-list' },
+    });
+
+    // Six vertices, two full-target triangles: 0..2 green, 3..5 blue. 6 * 24 == 144 bytes, so minVertexCount
+    // is exactly 6 and neither draw's (firstVertex + vertexCount) is clamped down.
+    let v = [];
+    for (const color of [[0, 1, 0, 1], [0, 0, 1, 1]]) {
+        for (const p of [[-1, -3], [-1, 1], [3, 1]])
+            v.push(p[0], p[1], ...color);
+    }
+    let vertexData = new Float32Array(v);
+    let vertexBuffer = device.createBuffer({ size: vertexData.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(vertexBuffer, 0, vertexData);
+
+    // Two MTLDrawPrimitivesIndirectArguments records in one buffer: vertexCount, instanceCount, firstVertex,
+    // firstInstance. The second is read at offset 16, which also misses the one-entry recomputation cache the
+    // old shared-slot path kept, so both draws really do run a clamp dispatch.
+    let args = new Uint32Array([3, 1, 0, 0, 3, 1, 3, 0]);
+    let argsBuffer = device.createBuffer({ size: args.byteLength, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(argsBuffer, 0, args);
+
+    let texture = device.createTexture({ size: [2, 1], format, usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
+    let readback = device.createBuffer({ size: 256, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+
+    let commandEncoder = device.createCommandEncoder();
+    let pass = commandEncoder.beginRenderPass({
+        colorAttachments: [{ view: texture.createView(), loadOp: 'clear', storeOp: 'store', clearValue: { r: 1, g: 0, b: 0, a: 1 } }],
+    });
+    pass.setPipeline(pipeline);
+    pass.setVertexBuffer(0, vertexBuffer);
+    // Left pixel from the record at offset 0 (firstVertex 0, green).
+    pass.setScissorRect(0, 0, 1, 1);
+    pass.drawIndirect(argsBuffer, 0);
+    // Right pixel from the record at offset 16 (firstVertex 3, blue).
+    pass.setScissorRect(1, 0, 1, 1);
+    pass.drawIndirect(argsBuffer, 16);
+    pass.end();
+    commandEncoder.copyTextureToBuffer({ texture }, { buffer: readback, bytesPerRow: 256 }, [2, 1]);
+    device.queue.submit([commandEncoder.finish()]);
+
+    await device.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    let pixels = new Uint8Array(readback.getMappedRange(0, 8));
+    window.leftPixel = [...pixels.subarray(0, 4)];
+    window.rightPixel = [...pixels.subarray(4, 8)];
+    readback.unmap();
+
+    shouldBeEqualToString('leftPixel.join()', '0,255,0,255');
+    shouldBeEqualToString('rightPixel.join()', '0,0,255,255');
+
+    let error = await device.popErrorScope();
+    if (error)
+        testFailed(error.message);
+}
+
+main().catch(e => {
+    testFailed("Exception: " + e);
+}).finally(() => {
+    finishJSTest();
+});
+
+</script>

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -96,8 +96,6 @@ public:
     };
 
     id<MTLBuffer> buffer() const { return m_buffer; }
-    id<MTLBuffer> NODELETE indirectBuffer() const;
-    id<MTLBuffer> indirectIndexedBuffer() const { return m_indirectIndexedBuffer; }
 
     uint64_t NODELETE initialSize() const;
     uint64_t currentSize() const;
@@ -110,17 +108,9 @@ public:
     void setCommandEncoder(CommandEncoder&, bool mayModifyBuffer = false) const;
     std::span<uint8_t> getBufferContents();
 
-    bool NODELETE indirectIndexedBufferRequiresRecomputation(MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount) const;
-    bool NODELETE indirectBufferRequiresRecomputation(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount) const;
-
-    void NODELETE indirectBufferRecomputed(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
-    void NODELETE indirectIndexedBufferRecomputed(MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
-
     std::optional<DrawIndexCacheContainerIterator> canSkipDrawIndexedValidation(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t primitiveOffset, id<MTLIndirectCommandBuffer> = nil) const;
     void drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t primitiveOffset, uint64_t validationGeneration, id<MTLIndirectCommandBuffer> = nil);
     void skippedDrawIndexedValidation(CommandEncoder&, DrawIndexCacheContainerIterator);
-    void skippedDrawIndirectIndexedValidation(CommandEncoder&, Buffer*, MTLIndexType, uint32_t indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType);
-    void skippedDrawIndirectValidation(CommandEncoder&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
 
     bool didReadOOB(id<MTLIndirectCommandBuffer> = nil) const;
     void didReadOOB(uint32_t v, id<MTLIndirectCommandBuffer> = nil);
@@ -156,12 +146,8 @@ private:
     void NODELETE setState(State);
     void incrementBufferMapCount();
     void decrementBufferMapCount();
-    void takeSlowIndirectIndexValidationPath(CommandBuffer&, Buffer&, MTLIndexType, uint32_t indexBufferOffsetInBytes, uint32_t indirectOffset, uint32_t minVertexCount, MTLPrimitiveType);
-    void takeSlowIndirectValidationPath(CommandBuffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
 
     id<MTLBuffer> m_buffer { nil };
-    id<MTLBuffer> _Nullable m_indirectBuffer { nil };
-    id<MTLBuffer> _Nullable m_indirectIndexedBuffer { nil };
 
     // https://gpuweb.github.io/gpuweb/#buffer-interface
 
@@ -175,19 +161,6 @@ private:
     WGPUMapModeFlags m_mapMode { WGPUMapMode_None };
     uint32_t m_maxUnsignedIndex { 0 };
     uint16_t m_maxUshortIndex { 0 };
-
-    struct IndirectArgsCache {
-        uint64_t indirectOffset { UINT64_MAX };
-        uint64_t indexBufferOffsetInBytes { UINT64_MAX };
-        uint32_t minVertexCount { 0 };
-        uint32_t minInstanceCount { 0 };
-        MTLIndexType indexType { MTLIndexTypeUInt16 };
-        enum {
-            NoDraw,
-            IndirectDraw,
-            IndirectIndexedDraw
-        } drawType { NoDraw };
-    } m_indirectCache;
 
     DrawIndexCacheContainer m_drawIndexedCache;
 

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -194,10 +194,6 @@ Buffer::Buffer(id<MTLBuffer> buffer, uint64_t initialSize, WGPUBufferUsageFlags 
     , m_mappedAtCreation(m_state == State::MappedAtCreation)
 #endif
 {
-    if (m_usage & WGPUBufferUsage_Indirect) {
-        m_indirectBuffer = device.safeCreateBuffer(sizeof(WebKitMTLDrawPrimitivesIndirectArguments), MTLStorageModeShared);
-        m_indirectIndexedBuffer = device.safeCreateBuffer(sizeof(WebKitMTLDrawIndexedPrimitivesIndirectArguments), MTLStorageModeShared);
-    }
 }
 
 Buffer::Buffer(Device& device)
@@ -483,11 +479,6 @@ bool Buffer::isValid() const
     return isDestroyed() || m_buffer;
 }
 
-id<MTLBuffer> Buffer::indirectBuffer() const
-{
-    return m_indirectBuffer;
-}
-
 static DrawIndexCacheContainerKey makeKey(uint32_t firstIndex, uint32_t indexCount, MTLIndexType indexType, uint32_t primitiveOffset, id<MTLIndirectCommandBuffer> icb)
 {
     return { firstIndex, indexCount, primitiveOffset | static_cast<uint32_t>(indexType << 1), static_cast<uint32_t>(icb.gpuResourceID._impl & 0xffffffff), static_cast<uint32_t>((icb.gpuResourceID._impl >> 32) & 0xffffffff) };
@@ -556,137 +547,10 @@ void Buffer::takeSlowIndexValidationPath(CommandBuffer& commandBuffer, uint32_t 
     }
 }
 
-void Buffer::takeSlowIndirectIndexValidationPath(CommandBuffer& commandBuffer, Buffer& apiIndexBuffer, MTLIndexType indexType, uint32_t indexBufferOffsetInBytes, uint32_t indirectOffset, uint32_t minVertexCount, MTLPrimitiveType primitiveType)
-{
-    WTFLogAlways("WARNING: Severe performance penalty due to encoding drawIndexedIndirect calls out of order with submission"); // NOLINT
-    Ref queue = m_device->getQueue();
-    queue->waitForAllCommitedWorkToComplete();
-    queue->synchronizeResourceAndWait(m_buffer);
-    if (m_buffer.length < indexBufferOffsetInBytes + sizeof(MTLDrawIndexedPrimitivesIndirectArguments))
-        return;
-    auto bufferSubData = span<MTLDrawIndexedPrimitivesIndirectArguments>(m_buffer, indexBufferOffsetInBytes);
-    if (!bufferSubData.data() || !bufferSubData.size())
-        return;
-
-    auto& args = *bufferSubData.data();
-    bool verified = false;
-    auto primitiveOffset = primitiveType == MTLPrimitiveTypeLineStrip || primitiveType == MTLPrimitiveTypeTriangleStrip ? 1u : 0u;
-    if (indexType == MTLIndexTypeUInt16)
-        verified = verifyIndexBufferData<uint16_t>(apiIndexBuffer.buffer(), args.indexStart, args.indexCount, minVertexCount > static_cast<int64_t>(args.baseVertex) ? minVertexCount - args.baseVertex : 0, primitiveOffset);
-    else
-        verified = verifyIndexBufferData<uint32_t>(apiIndexBuffer.buffer(), args.indexStart, args.indexCount, minVertexCount > static_cast<int64_t>(args.baseVertex) ? minVertexCount - args.baseVertex : 0, primitiveOffset);
-
-    if (!verified) {
-        SUPPRESS_UNCOUNTED_ARG Vector<uint8_t> priorData = borrow(*this)->getBufferContents();
-
-        queue->clearBuffer(m_buffer, indirectOffset, sizeof(MTLDrawPrimitivesIndirectArguments));
-        queue->finalizeBlitCommandEncoder();
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        if (m_buffer.storageMode == MTLStorageModeManaged)
-            [m_buffer didModifyRange:NSMakeRange(0, m_buffer.length)];
-        ALLOW_DEPRECATED_DECLARATIONS_END
-#endif
-        commandBuffer.addPostCommitHandler([queue, priorData = WTF::move(priorData), protectedThis = protect(*this)](id<MTLCommandBuffer> mtlCommandBuffer) mutable {
-            [mtlCommandBuffer waitUntilCompleted];
-
-            queue->writeBuffer(*protectedThis.ptr(), 0, priorData.mutableSpan());
-        });
-    }
-}
-
-static bool NODELETE verifyIndirectBufferData(MTLDrawPrimitivesIndirectArguments& input, uint32_t minVertexCount, uint32_t minInstanceCount)
-{
-    bool vertexCondition = input.vertexCount + input.vertexStart > minVertexCount || input.vertexStart >= minVertexCount;
-    bool instanceCondition = input.baseInstance + input.instanceCount > minInstanceCount || input.baseInstance >= minInstanceCount;
-    return !vertexCondition && !instanceCondition;
-}
-
-void Buffer::takeSlowIndirectValidationPath(CommandBuffer& commandBuffer, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount)
-{
-    WTFLogAlways("WARNING: Severe performance penalty due to encoding drawIndirect calls out of order with submission"); // NOLINT
-    Ref queue = m_device->getQueue();
-    queue->waitForAllCommitedWorkToComplete();
-    queue->synchronizeResourceAndWait(m_buffer);
-    auto bufferSubData = span<MTLDrawPrimitivesIndirectArguments>(m_buffer, indirectOffset);
-    if (!bufferSubData.data() || !bufferSubData.size())
-        return;
-
-    auto& args = *bufferSubData.data();
-    bool verified = verifyIndirectBufferData(args, minVertexCount, minInstanceCount);
-
-    if (!verified) {
-        SUPPRESS_UNCOUNTED_ARG Vector<uint8_t> priorData = borrow(*this)->getBufferContents();
-
-        MTLDrawPrimitivesIndirectArguments data = {
-            .vertexCount = std::min(args.vertexCount, minVertexCount),
-            .instanceCount = std::min(args.instanceCount, minInstanceCount),
-            .vertexStart = args.vertexStart,
-            .baseInstance = args.baseInstance
-        };
-        auto newDataSpan = asMutableByteSpan(data);
-        queue->writeBuffer(m_buffer, indirectOffset, newDataSpan);
-        queue->finalizeBlitCommandEncoder();
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        if (m_buffer.storageMode == MTLStorageModeManaged)
-            [m_buffer didModifyRange:NSMakeRange(0, m_buffer.length)];
-        ALLOW_DEPRECATED_DECLARATIONS_END
-#endif
-        commandBuffer.addPostCommitHandler([queue, priorData = WTF::move(priorData), protectedThis = protect(*this)](id<MTLCommandBuffer> mtlCommandBuffer) mutable {
-            [mtlCommandBuffer waitUntilCompleted];
-
-            queue->writeBuffer(*protectedThis.ptr(), 0, priorData.mutableSpan());
-        });
-    }
-}
-
 void Buffer::skippedDrawIndexedValidation(CommandEncoder& commandEncoder, DrawIndexCacheContainerIterator it)
 {
     CommandEncoder::trackEncoder(commandEncoder, m_skippedValidationCommandEncoders);
     commandEncoder.skippedDrawIndexedValidation(m_buffer.gpuAddress, it);
-}
-
-void Buffer::skippedDrawIndirectIndexedValidation(CommandEncoder& commandEncoder, Buffer* apiIndexBuffer, MTLIndexType indexType, uint32_t indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType primitiveType)
-{
-    UNUSED_PARAM(minInstanceCount);
-    if (!apiIndexBuffer)
-        return;
-
-    CommandEncoder::trackEncoder(commandEncoder, m_skippedValidationCommandEncoders);
-    commandEncoder.addOnCommitHandler([weakThis = ThreadSafeWeakPtr { *this }, apiIndexBuffer = protect(apiIndexBuffer), indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, primitiveType](CommandBuffer& commandBuffer, CommandEncoder& commandEncoder) {
-        if (!weakThis.get())
-            return true;
-
-        RefPtr protectedThis = weakThis.get();
-        protectedThis->m_skippedValidationCommandEncoders.remove(commandEncoder.uniqueId());
-        if (protectedThis->m_mustTakeSlowIndexValidationPath) {
-            protectedThis->takeSlowIndirectIndexValidationPath(commandBuffer, *apiIndexBuffer.get(), indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, primitiveType);
-            commandBuffer.addPostCommitHandler([protectedThis = WTF::move(protectedThis)](id<MTLCommandBuffer>) {
-                protectedThis->clearMustTakeSlowIndexValidationPath();
-            });
-        }
-        return true;
-    });
-}
-
-void Buffer::skippedDrawIndirectValidation(CommandEncoder& commandEncoder, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount)
-{
-    CommandEncoder::trackEncoder(commandEncoder, m_skippedValidationCommandEncoders);
-    commandEncoder.addOnCommitHandler([weakThis = ThreadSafeWeakPtr { *this }, indirectOffset, minVertexCount, minInstanceCount](CommandBuffer& commandBuffer, CommandEncoder& commandEncoder) {
-        if (!weakThis.get())
-            return true;
-
-        RefPtr protectedThis = weakThis.get();
-        protectedThis->m_skippedValidationCommandEncoders.remove(commandEncoder.uniqueId());
-        if (protectedThis->m_mustTakeSlowIndexValidationPath) {
-            protectedThis->takeSlowIndirectValidationPath(commandBuffer, indirectOffset, minVertexCount, minInstanceCount);
-            commandBuffer.addPostCommitHandler([protectedThis = WTF::move(protectedThis)](id<MTLCommandBuffer>) {
-                protectedThis->clearMustTakeSlowIndexValidationPath();
-            });
-        }
-        return true;
-    });
 }
 
 bool Buffer::didReadOOB(id<MTLIndirectCommandBuffer> icb) const
@@ -698,34 +562,6 @@ bool Buffer::didReadOOB(id<MTLIndirectCommandBuffer> icb) const
 void Buffer::didReadOOB(uint32_t v, id<MTLIndirectCommandBuffer> icb)
 {
     m_didReadOOB.set(icb.gpuResourceID._impl, !!v || didReadOOB(icb));
-}
-
-bool Buffer::indirectBufferRequiresRecomputation(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount) const
-{
-    return m_indirectCache.indirectOffset != indirectOffset || m_indirectCache.minVertexCount != minVertexCount || m_indirectCache.minInstanceCount != minInstanceCount || m_indirectCache.drawType != IndirectArgsCache::IndirectDraw;
-}
-
-bool Buffer::indirectIndexedBufferRequiresRecomputation(MTLIndexType indexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount) const
-{
-    return Buffer::indirectBufferRequiresRecomputation(indirectOffset, minVertexCount, minInstanceCount) || m_indirectCache.indexType != indexType || m_indirectCache.indexBufferOffsetInBytes != indexBufferOffsetInBytes || m_indirectCache.drawType != IndirectArgsCache::IndirectIndexedDraw;
-}
-
-void Buffer::indirectBufferRecomputed(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount)
-{
-    m_indirectCache.indirectOffset = indirectOffset;
-    m_indirectCache.minVertexCount = minVertexCount;
-    m_indirectCache.minInstanceCount = minInstanceCount;
-    m_indirectCache.drawType = IndirectArgsCache::IndirectDraw;
-}
-
-void Buffer::indirectIndexedBufferRecomputed(MTLIndexType indexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount)
-{
-    m_indirectCache.indexType = indexType;
-    m_indirectCache.indexBufferOffsetInBytes = indexBufferOffsetInBytes;
-    m_indirectCache.indirectOffset = indirectOffset;
-    m_indirectCache.minVertexCount = minVertexCount;
-    m_indirectCache.minInstanceCount = minInstanceCount;
-    m_indirectCache.drawType = IndirectArgsCache::IndirectIndexedDraw;
 }
 
 void Buffer::indirectBufferInvalidated(CommandEncoder& commandEncoder)
@@ -779,13 +615,6 @@ void Buffer::indirectBufferInvalidated(CommandEncoder* commandEncoder)
     ++m_indexContentsGeneration;
     m_indexValueUpperBoundUint = UINT32_MAX;
     m_indexValueUpperBoundUshort = UINT16_MAX;
-    m_indirectCache = {
-        .indirectOffset = UINT64_MAX,
-        .indexBufferOffsetInBytes = UINT64_MAX,
-        .minVertexCount = 0,
-        .minInstanceCount = 0,
-        .indexType = MTLIndexTypeUInt16
-    };
 }
 
 void Buffer::removeSkippedValidationCommandEncoder(uint64_t uniqueId)

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -34,8 +34,10 @@
 #import <wtf/HashTraits.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
+#import <wtf/RetainPtr.h>
 #import <wtf/SwiftBridging.h>
 #import <wtf/TZoneMalloc.h>
+#import <wtf/ThreadSafeRefCounted.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakPtr.h>
 
@@ -122,6 +124,7 @@ public:
     static DrawIndexResult clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes, Buffer*, uint32_t minVertexCount, uint32_t minInstanceCount, RenderPassEncoder&, Device&, uint32_t rasterSampleCount, MTLPrimitiveType);
     [[nodiscard]] bool splitRenderPass();
     static std::pair<uint32_t, uint32_t> computeMininumVertexInstanceCount(const RenderPipeline*, bool& needsValidationLayerWorkaround, uint64_t (^)(uint32_t));
+    void trackIndirectDeviceLostCheck(id<MTLBuffer> scratch, uint64_t scratchOffset, id<MTLBuffer> alsoRetain);
 
 private:
     RenderPassEncoder(id<MTLRenderCommandEncoder>, const WGPURenderPassDescriptor&, NSUInteger, bool depthReadOnly, bool stencilReadOnly, CommandEncoder&, id<MTLBuffer>, uint64_t maxDrawCount, Device&, MTLRenderPassDescriptor*);
@@ -229,6 +232,18 @@ private:
     bool m_passEnded { false };
     bool m_ignoreBufferCache { false };
     Vector<bool> m_bindGroupDynamicOffsetsChanged;
+
+    // Scratch records whose lostOrOOBRead flag the pass checks once, from a single completion handler,
+    // rather than one handler per clamping indirect draw. Shared with that handler, hence thread-safe.
+    struct IndirectDeviceLostChecks : public ThreadSafeRefCounted<IndirectDeviceLostChecks> {
+        struct Entry {
+            RetainPtr<id<MTLBuffer>> scratch;
+            uint64_t offset { 0 };
+            RetainPtr<id<MTLBuffer>> alsoRetain;
+        };
+        Vector<Entry> entries;
+    };
+    RefPtr<IndirectDeviceLostChecks> m_indirectDeviceLostChecks;
 } SWIFT_SHARED_REFERENCE(refRenderPassEncoder, derefRenderPassEncoder) SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -861,28 +861,49 @@ RenderPassEncoder::DrawIndexResult RenderPassEncoder::clampIndexBufferToValidVal
     return clampIndexBufferToValidValues(indexCount, instanceCount, baseVertex, firstInstance, indexType, indexBufferOffsetInBytes, m_indexBuffer.get(), minVertexCount, minInstanceCount, *this, m_device.get(), m_rasterSampleCount, m_primitiveType);
 }
 
-static void checkForIndirectDrawDeviceLost(Device &device, RenderPassEncoder &encoder, id<MTLBuffer> indirectBuffer, uint64_t indirectBufferOffset = 0, id<MTLBuffer> alsoRetain = nil)
+// Records one clamp's scratch for a deferred lostOrOOBRead check. The first call in a pass installs the
+// completion handler; later calls only append, so N clamping draws cost one handler, not N.
+void RenderPassEncoder::trackIndirectDeviceLostCheck(id<MTLBuffer> scratch, uint64_t scratchOffset, id<MTLBuffer> alsoRetain)
 {
-    auto encoderHandle = device.getQueue()->retainCounterSampleBuffer(encoder.parentEncoder());
-    [encoder.parentEncoder().commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = protect(device), indirectBuffer, indirectBufferOffset, alsoRetain](id<MTLCommandBuffer> completedCommandBuffer) {
-        if (completedCommandBuffer.status != MTLCommandBufferStatusCompleted) {
-            protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
-            return;
-        }
-        protectedDevice->getQueue()->scheduleWork([encoderHandle, indirectBuffer, indirectBufferOffset, alsoRetain, protectedDevice]() mutable {
-            protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
-            (void)alsoRetain; // Held only to keep a companion scratch buffer alive until GPU completion.
-            // The clamped args live at indirectBufferOffset (0 for a per-Buffer slot, non-zero for per-draw scratch).
-            auto checkedEnd = checkedSum<uint64_t>(indirectBufferOffset, sizeof(WebKitMTLDrawPrimitivesIndirectArguments));
-            if (!indirectBuffer.contents || checkedEnd.hasOverflowed() || checkedEnd.value() > indirectBuffer.length)
+    if (!m_indirectDeviceLostChecks) {
+        m_indirectDeviceLostChecks = adoptRef(*new IndirectDeviceLostChecks);
+        auto encoderHandle = m_device->getQueue()->retainCounterSampleBuffer(m_parentEncoder);
+        [m_parentEncoder->commandBuffer() addCompletedHandler:[encoderHandle, protectedDevice = protect(m_device.get()), checks = m_indirectDeviceLostChecks](id<MTLCommandBuffer> completedCommandBuffer) {
+            if (completedCommandBuffer.status != MTLCommandBufferStatusCompleted) {
+                protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
                 return;
+            }
+            protectedDevice->getQueue()->scheduleWork([encoderHandle, checks, protectedDevice]() mutable {
+                protectedDevice->getQueue()->releaseCounterSampleBuffer(encoderHandle);
+                for (auto& entry : checks->entries) {
+                    id<MTLBuffer> buffer = entry.scratch.get();
+                    auto checkedEnd = checkedSum<uint64_t>(entry.offset, sizeof(WebKitMTLDrawPrimitivesIndirectArguments));
+                    if (!buffer.contents || checkedEnd.hasOverflowed() || checkedEnd.value() > buffer.length)
+                        continue;
 
-            auto* contents = static_cast<uint8_t*>(indirectBuffer.contents) + indirectBufferOffset;
-            auto& args = *static_cast<WebKitMTLDrawPrimitivesIndirectArguments*>(static_cast<void*>(contents));
-            if (args.lostOrOOBRead)
-                protectedDevice->loseTheDevice(WGPUDeviceLostReason_Undefined);
-        });
-    }];
+                    auto* contents = static_cast<uint8_t*>(buffer.contents) + entry.offset;
+                    auto& args = *static_cast<WebKitMTLDrawPrimitivesIndirectArguments*>(static_cast<void*>(contents));
+                    if (args.lostOrOOBRead) {
+                        protectedDevice->loseTheDevice(WGPUDeviceLostReason_Undefined);
+                        break;
+                    }
+                }
+                checks->entries.clear();
+            });
+        }];
+    }
+
+    // alsoRetain has no flag of its own; it is held so a companion scratch outlives the GPU work.
+    m_indirectDeviceLostChecks->entries.append(IndirectDeviceLostChecks::Entry { scratch, scratchOffset, alsoRetain });
+}
+
+// The clamp shaders store lostOrOOBRead only on failure, so scratch must arrive zeroed or a stale 1 loses the
+// device. Vector does not initialize POD, hence zeroSpan; the inline capacity fits either argument struct.
+std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::newZeroedIndirectScratch(Device& device, size_t size)
+{
+    Vector<uint8_t, 32> zero(size);
+    zeroSpan(zero.mutableSpan());
+    return device.getQueue()->newTemporaryBufferWithBytes(zero.mutableSpan(), false);
 }
 
 std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectIndexBufferToValidValues(Buffer* apiIndexBuffer, Buffer& indexedIndirectBuffer, MTLIndexType indexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType primitiveType, Device& device, uint32_t rasterSampleCount, RenderPassEncoder& encoder, bool& splitEncoder)
@@ -894,24 +915,24 @@ std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectIndexBufferTo
     if (!indexBuffer || apiIndexBuffer->isDestroyed() || indexedIndirectBuffer.isDestroyed())
         return std::make_pair(nil, 0ull);
 
-    id<MTLBuffer> indirectBuffer = indexedIndirectBuffer.indirectBuffer();
     auto indexSize = indexType == MTLIndexTypeUInt16 ? sizeof(uint16_t) : sizeof(uint32_t);
     auto checkedOffsetPlusSize = checkedSum<uint32_t>(indexBufferOffsetInBytes, indexSize);
     // '>' not '>=': offset + indexSize == length is a valid single-element index buffer
-    if (!indirectBuffer || !minVertexCount || !minInstanceCount || checkedOffsetPlusSize.hasOverflowed() || checkedOffsetPlusSize.value() > indexBuffer.length)
+    if (!minVertexCount || !minInstanceCount || checkedOffsetPlusSize.hasOverflowed() || checkedOffsetPlusSize.value() > indexBuffer.length)
         return std::make_pair(nil, 0ull);
 
-    if (!indexedIndirectBuffer.indirectIndexedBufferRequiresRecomputation(indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, minInstanceCount)) {
-        indexedIndirectBuffer.skippedDrawIndirectIndexedValidation(encoder.parentEncoder(), apiIndexBuffer, indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, minInstanceCount, primitiveType);
-        return std::make_pair(indexedIndirectBuffer.indirectIndexedBuffer(), 0ull);
-    }
+    // Per-draw for the reason in clampIndirectBufferToValidValues; both records are fetched as arguments.
+    auto [finalScratch, finalScratchOffset] = newZeroedIndirectScratch(device, sizeof(WebKitMTLDrawIndexedPrimitivesIndirectArguments));
+    auto [intermediateScratch, intermediateScratchOffset] = newZeroedIndirectScratch(device, sizeof(WebKitMTLDrawPrimitivesIndirectArguments));
+    if (!finalScratch || !intermediateScratch)
+        return std::make_pair(nil, 0ull);
 
     id<MTLRenderCommandEncoder> renderCommandEncoder = encoder.renderCommandEncoder();
     CHECKED_SET_PSO(renderCommandEncoder, device, device.indexedIndirectBufferClampPipeline(rasterSampleCount), std::make_pair(nil, 0ull));
     uint32_t indexBufferCount = static_cast<uint32_t>((indexBuffer.length - indexBufferOffsetInBytes) / indexSize);
     encoder.setVertexBuffer(renderCommandEncoder, indexedIndirectBuffer.buffer(), indirectOffset, 0);
-    encoder.setVertexBuffer(renderCommandEncoder, indexedIndirectBuffer.indirectIndexedBuffer(), 0, 1);
-    encoder.setVertexBuffer(renderCommandEncoder, indirectBuffer, 0, 2);
+    encoder.setVertexBuffer(renderCommandEncoder, finalScratch, finalScratchOffset, 1);
+    encoder.setVertexBuffer(renderCommandEncoder, intermediateScratch, intermediateScratchOffset, 2);
     uint32_t indirectData[] = { indexBufferCount, minInstanceCount };
     encoder.setVertexBytes(renderCommandEncoder, asByteSpan(indirectData), 3);
     [renderCommandEncoder drawPrimitives:MTLPrimitiveTypePoint vertexStart:0 vertexCount:1];
@@ -921,18 +942,20 @@ std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectIndexBufferTo
         renderCommandEncoder = encoder.renderCommandEncoder();
     CHECKED_SET_PSO(renderCommandEncoder, device, device.indexBufferClampPipeline(indexType, rasterSampleCount), std::make_pair(nil, 0ull));
     encoder.setVertexBuffer(renderCommandEncoder, indexBuffer, indexBufferOffsetInBytes, 0);
-    encoder.setVertexBuffer(renderCommandEncoder, indexedIndirectBuffer.indirectIndexedBuffer(), 0, 1);
+    encoder.setVertexBuffer(renderCommandEncoder, finalScratch, finalScratchOffset, 1);
     auto primitiveOffset = primitiveType == MTLPrimitiveTypeLineStrip || primitiveType == MTLPrimitiveTypeTriangleStrip ? 1u : 0u;
     uint32_t data[] = { minVertexCount == RenderBundleEncoder::invalidVertexInstanceCount ? minVertexCount - primitiveOffset : minVertexCount, primitiveOffset, indexBufferCount - 1 };
     encoder.setVertexBytes(renderCommandEncoder, asByteSpan(data), 2);
-    [renderCommandEncoder drawPrimitives:MTLPrimitiveTypePoint indirectBuffer:indirectBuffer indirectBufferOffset:0];
+    [renderCommandEncoder drawPrimitives:MTLPrimitiveTypePoint indirectBuffer:intermediateScratch indirectBufferOffset:intermediateScratchOffset];
     encoder.emitMemoryBarrier(renderCommandEncoder);
 
     splitEncoder = true;
-    indexedIndirectBuffer.indirectIndexedBufferRecomputed(indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, minInstanceCount);
-    checkForIndirectDrawDeviceLost(device, encoder, indirectBuffer);
+    encoder.parentEncoder().addBuffer(finalScratch);
+    encoder.parentEncoder().addBuffer(intermediateScratch);
+    // Device-loss flag lives in intermediateScratch; also retain finalScratch until GPU completion.
+    encoder.trackIndirectDeviceLostCheck(intermediateScratch, intermediateScratchOffset, finalScratch);
 
-    return std::make_pair(indexedIndirectBuffer.indirectIndexedBuffer(), 0ull);
+    return std::make_pair(finalScratch, finalScratchOffset);
 }
 
 std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectIndexBufferToValidValues(Buffer& indexedIndirectBuffer, MTLIndexType indexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, bool& splitEncoder)
@@ -948,26 +971,28 @@ std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectBufferToValid
     if (minVertexCount == RenderBundleEncoder::invalidVertexInstanceCount && minInstanceCount == RenderBundleEncoder::invalidVertexInstanceCount)
         return std::make_pair(indirectBuffer.buffer(), indirectOffset);
 
-    if (!indirectBuffer.indirectBufferRequiresRecomputation(indirectOffset, minVertexCount, minInstanceCount)) {
-        indirectBuffer.skippedDrawIndirectValidation(encoder.parentEncoder(), indirectOffset, minVertexCount, minInstanceCount);
-        return std::make_pair(indirectBuffer.indirectBuffer(), 0ull);
-    }
+    // Scratch must be per-draw, not one slot shared by every draw against this Buffer. emitMemoryBarrier()
+    // below orders the clamp against its own draw, but MTLRenderStages cannot name an indirect argument fetch,
+    // so nothing can order draw N's fetch against draw N+1's clamp store into the same slot.
+    auto [scratch, scratchOffset] = newZeroedIndirectScratch(device, sizeof(WebKitMTLDrawPrimitivesIndirectArguments));
+    if (!scratch)
+        return std::make_pair(nil, 0ull);
 
     id<MTLRenderCommandEncoder> renderCommandEncoder = encoder.renderCommandEncoder();
     id<MTLRenderPipelineState> renderPipelineState = device.indirectBufferClampPipeline(rasterSampleCount);
     CHECKED_SET_PSO(renderCommandEncoder, device, renderPipelineState, std::make_pair(nil, 0ull));
     encoder.setVertexBuffer(renderCommandEncoder, indirectBuffer.buffer(), indirectOffset, 0);
-    encoder.setVertexBuffer(renderCommandEncoder, indirectBuffer.indirectBuffer(), 0, 1);
+    encoder.setVertexBuffer(renderCommandEncoder, scratch, scratchOffset, 1);
     uint32_t data[] = { minVertexCount, minInstanceCount };
     encoder.setVertexBytes(renderCommandEncoder, asByteSpan(data), 2);
     [renderCommandEncoder drawPrimitives:MTLPrimitiveTypePoint vertexStart:0 vertexCount:1];
     encoder.emitMemoryBarrier(renderCommandEncoder);
 
     splitEncoder = true;
-    indirectBuffer.indirectBufferRecomputed(indirectOffset, minVertexCount, minInstanceCount);
-    checkForIndirectDrawDeviceLost(device, encoder, indirectBuffer.indirectBuffer());
+    encoder.parentEncoder().addBuffer(scratch);
+    encoder.trackIndirectDeviceLostCheck(scratch, scratchOffset, nil);
 
-    return std::make_pair(indirectBuffer.indirectBuffer(), 0ull);
+    return std::make_pair(scratch, scratchOffset);
 }
 
 std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectBufferToValidValues(Buffer& indirectBuffer, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, bool& splitEncoder)
@@ -978,14 +1003,6 @@ std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::clampIndirectBufferToValid
 // --- Batched indirect clamp (executeBundles only) ------------------------------------------------
 // These mirror clampIndirect*ToValidValues but write caller-supplied per-draw scratch and emit no
 // internal memory barrier, so executeBundles can batch one barrier around all draws instead of per draw.
-
-// Zeroed scratch is required because the clamp shaders write lostOrOOBRead only on failure.
-std::pair<id<MTLBuffer>, uint64_t> RenderPassEncoder::newZeroedIndirectScratch(Device& device, size_t size)
-{
-    Vector<uint8_t> zero(size);
-    zeroSpan(zero.mutableSpan());
-    return device.getQueue()->newTemporaryBufferWithBytes(zero.mutableSpan(), false);
-}
 
 // One dispatch; writes the clamped MTLDrawPrimitivesIndirectArguments (+lostOrOOBRead) into finalScratch.
 bool RenderPassEncoder::clampIndirectBufferDispatchBatched(Buffer& indirectBuffer, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, Device& device, uint32_t rasterSampleCount, RenderPassEncoder& encoder, id<MTLBuffer> finalScratch, uint64_t finalScratchOffset)
@@ -1000,7 +1017,7 @@ bool RenderPassEncoder::clampIndirectBufferDispatchBatched(Buffer& indirectBuffe
     uint32_t data[] = { minVertexCount, minInstanceCount };
     encoder.setVertexBytes(renderCommandEncoder, asByteSpan(data), 2);
     [renderCommandEncoder drawPrimitives:MTLPrimitiveTypePoint vertexStart:0 vertexCount:1];
-    checkForIndirectDrawDeviceLost(device, encoder, finalScratch, finalScratchOffset);
+    encoder.trackIndirectDeviceLostCheck(finalScratch, finalScratchOffset, nil);
     return true;
 }
 
@@ -1029,7 +1046,7 @@ bool RenderPassEncoder::clampIndirectIndexBufferDispatch1Batched(Buffer* apiInde
     encoder.setVertexBytes(renderCommandEncoder, asByteSpan(indirectData), 3);
     [renderCommandEncoder drawPrimitives:MTLPrimitiveTypePoint vertexStart:0 vertexCount:1];
     // Device-loss flag lives in intermediateScratch; also retain finalScratch until GPU completion.
-    checkForIndirectDrawDeviceLost(device, encoder, intermediateScratch, intermediateScratchOffset, finalScratch);
+    encoder.trackIndirectDeviceLostCheck(intermediateScratch, intermediateScratchOffset, finalScratch);
     return true;
 }
 
@@ -1166,7 +1183,10 @@ void RenderPassEncoder::drawIndexedIndirect(Buffer& indirectBuffer, uint64_t ind
     if (splitEncoder)
         splitEncoder = splitRenderPass();
 
-    if (!executePreDrawCommands(0, 0, splitEncoder, &indirectBuffer, needsValidationLayerWorkaround) || m_indexBuffer->isDestroyed() || mtlIndirectBuffer.length < sizeof(MTLDrawIndexedPrimitivesIndirectArguments))
+    // Range-check offset + size, not size alone: the args now sit at a non-zero offset in pooled scratch.
+    // Also rejects a nil buffer from a failed clamp, whose length is 0.
+    auto checkedIndirectEnd = checkedSum<uint64_t>(modifiedIndirectOffset, sizeof(MTLDrawIndexedPrimitivesIndirectArguments));
+    if (!executePreDrawCommands(0, 0, splitEncoder, &indirectBuffer, needsValidationLayerWorkaround) || m_indexBuffer->isDestroyed() || checkedIndirectEnd.hasOverflowed() || checkedIndirectEnd.value() > mtlIndirectBuffer.length)
         return;
 
     uint32_t indexSizeInBytes = m_indexType == MTLIndexTypeUInt16 ? sizeof(uint16_t) : sizeof(uint32_t);
@@ -1247,7 +1267,9 @@ void RenderPassEncoder::drawIndirect(Buffer& indirectBuffer, uint64_t indirectOf
     if (splitEncoder)
         splitEncoder = splitRenderPass();
 
-    if (!executePreDrawCommands(0, 0, splitEncoder, &indirectBuffer, needsValidationLayerWorkaround) || mtlIndirectBuffer.length < sizeof(MTLDrawPrimitivesIndirectArguments) || indirectBuffer.isDestroyed())
+    // See drawIndexedIndirect.
+    auto checkedIndirectEnd = checkedSum<uint64_t>(adjustedIndirectBufferOffset, sizeof(MTLDrawPrimitivesIndirectArguments));
+    if (!executePreDrawCommands(0, 0, splitEncoder, &indirectBuffer, needsValidationLayerWorkaround) || checkedIndirectEnd.hasOverflowed() || checkedIndirectEnd.value() > mtlIndirectBuffer.length || indirectBuffer.isDestroyed())
         return;
 
     [renderCommandEncoder() drawPrimitives:m_primitiveType indirectBuffer:mtlIndirectBuffer indirectBufferOffset:adjustedIndirectBufferOffset];


### PR DESCRIPTION
#### 6dca6330dba27ff589985db50e5e259f71a44f61
<pre>
[WebGPU] drawIndirect/drawIndexedIndirect clamp into a single per-Buffer scratch slot, racing every other indirect draw in the same render pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=321876">https://bugs.webkit.org/show_bug.cgi?id=321876</a>
<a href="https://rdar.apple.com/185057290">rdar://185057290</a>

Reviewed by Mike Wyrzykowski.

Repeated drawIndirect/drawIndexedIndirect in one render pass could hang the GPU
unrecoverably, because every clamping draw against a given arguments buffer wrote
its clamped arguments into the same scratch slot and then fetched them from it
with no ordering against the neighbouring draws doing the same.

RenderPassEncoder::clampIndirectBufferToValidValues and
clampIndirectIndexBufferToValidValues wrote into Buffer::indirectBuffer() /
Buffer::indirectIndexedBuffer(): one scratch slot per Buffer, sized for exactly
one arguments struct, returned at offset 0. Every clamping draw was therefore
issued as

drawPrimitives:indirectBuffer:&lt;sameSlot&gt; indirectBufferOffset:0

The clamp path is entered whenever computeMininumVertexInstanceCount can lower
either minimum, i.e. whenever the pipeline declares a required vertex buffer
layout with a positive stride and at least one attribute -- whether or not the
shader ever reads it. Zero-attribute and undefined-stride layouts are dropped in
createVertexDescriptor before requiredBufferIndices is populated and cannot lower
a minimum, so they take the early-out that returns the application&apos;s own buffer
and offset.

emitMemoryBarrier() emits a vertex-&gt;vertex MTLBarrierScopeBuffers barrier between
a draw&apos;s clamp dispatch and that same draw&apos;s indirect draw, which covers the
read-after-write within one draw. Nothing is emitted between draw N&apos;s indirect
argument fetch and draw N+1&apos;s clamp dispatch, and on Apple8 and later
memoryBarrierLimit is UINT32_MAX unless shader validation is enabled
(HardwareCapabilities.mm:264), so splitRenderPass() never fires and never
separates them either. Draw N+1&apos;s clamp vertex shader therefore stores to the
same bytes draw N is fetching its arguments from, with no ordering between them,
and MTLRenderStages has no way to name the argument fetch so no barrier can
express the constraint. Draw N can observe draw N+1&apos;s counts, or a torn mixture
of the two, since the clamp shader stores vertexCount, instanceCount, vertexStart
and baseInstance as four separate stores. A large-instance-count draw issued with
arguments its own bounds no longer describe is consistent with the reported AGX
tiler progress timeout. Apple7 gets a memoryBarrierLimit of 512 from mac2() and
capabilities merge with std::min, so splitRenderPass() does eventually fire
there, which bounds the window rather than closing it: the slot is still shared
by every draw between two splits.

Buffer::m_indirectCache was a single struct, not a map, keyed on (indirectOffset,
minVertexCount, minInstanceCount, drawType), so consecutive draws at different
offsets out of one arguments buffer missed it on every draw and every one of them
re-ran the clamp into the shared slot.

The fix is to allocate per-draw scratch, which is what the two other clamp sites
in this file already do: clampIndexBufferToValidValues (the non-indirect indexed
path) uses Queue::newTemporaryBufferWithBytes directly, and the batched
executeBundles helpers added in 59b6d9a2d027 use newZeroedIndirectScratch.
newTemporaryBufferWithBytes bump-allocates a distinct 64-byte-aligned offset out
of a pooled buffer. Both direct-path clamps now do the same and return
(scratch, offset); the per-Buffer m_indirectBuffer / m_indirectIndexedBuffer
slots are removed. Metal requires indirectBufferOffset to be a multiple of 4, so
64-byte-aligned offsets satisfy it with headroom.

m_indirectCache is removed with them. A cache hit would have to return the same
scratch it validated, and the pooled allocator recycles, so the skip cannot be
kept as-is; every clamping indirect draw now runs one point dispatch, which is
the cost the batched path already accepts. Removing the skip also makes
Buffer::skippedDrawIndirectValidation, skippedDrawIndirectIndexedValidation,
takeSlowIndirectValidationPath and takeSlowIndirectIndexValidationPath dead:
they existed only to re-verify on the CPU at commit time when a skipped clamp
might have gone stale. The GPU clamp now always runs in the same command buffer
as the draw and always reads the current arguments. The non-indirect index
validation cache and takeSlowIndexValidationPath are untouched, and
m_mustTakeSlowIndexValidationPath still has a live reader in CommandEncoder.mm.

Because the recomputation cache no longer suppresses most of them, the
device-loss readback would otherwise run once per clamping indirect draw, each
time installing an addCompletedHandler plus two Queue::scheduleWork main-thread
hops (releaseCounterSampleBuffer schedules its own). The encoderHandle is
CommandEncoder::uniqueId(), identical for every draw in the pass, so the
per-draw retain/release of the counter sample buffer was redundant as well.
RenderPassEncoder::trackIndirectDeviceLostCheck now accumulates the scratch
records in a ThreadSafeRefCounted holder and installs a single completion handler
on the first clamp of the pass, so N clamping draws cost one handler and one
scheduleWork pair instead of N and 2N. Appends can never race that handler:
RETURN_IF_FINISHED() rejects every draw once the parent encoder is finished, and
CommandEncoder::finish is the only commit path, so all appends precede commit.
Entries hold RetainPtr, keeping scratch alive independently of
CommandEncoder::addBuffer (which is a no-op unless shader validation is on,
since m_retainedBuffers is only allocated in that case).

drawIndirect and drawIndexedIndirect bounded the arguments struct against the
whole buffer length, which is no longer sufficient once the arguments live at a
non-zero offset in a pooled buffer; both now bound offset + sizeof(args) against
the length. A nil buffer from a failed clamp has length 0 and is still rejected,
which also replaces the removed !indirectBuffer early-out.

drawIndexedIndirect was not covered by the original report but shares the same
defect, and consumed both scratch slots.

The new layout test is a correctness test for the shape in question -- two
drawIndirect calls in one pass out of one arguments buffer, each selecting a
differently coloured triangle via firstVertex and scissored to its own pixel, so
a clobbered record renders the wrong colour. It is not a deterministic pre-patch
failure, because the underlying defect is a race; the reproduction attached to
the bug is the stronger signal.

* Source/WebGPU/WebGPU/Buffer.h:
(WebGPU::Buffer::buffer const):
(WebGPU::Buffer::indirectIndexedBuffer const): Deleted.
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::Buffer):
(WebGPU::Buffer::indirectBufferInvalidated):
(WebGPU::Buffer::indirectBuffer const): Deleted.
(WebGPU::Buffer::takeSlowIndirectIndexValidationPath): Deleted.
(WebGPU::verifyIndirectBufferData): Deleted.
(WebGPU::Buffer::takeSlowIndirectValidationPath): Deleted.
(WebGPU::Buffer::skippedDrawIndirectIndexedValidation): Deleted.
(WebGPU::Buffer::skippedDrawIndirectValidation): Deleted.
(WebGPU::Buffer::indirectBufferRequiresRecomputation const): Deleted.
(WebGPU::Buffer::indirectIndexedBufferRequiresRecomputation const): Deleted.
(WebGPU::Buffer::indirectBufferRecomputed): Deleted.
(WebGPU::Buffer::indirectIndexedBufferRecomputed): Deleted.
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::trackIndirectDeviceLostCheck):
(WebGPU::RenderPassEncoder::newZeroedIndirectScratch):
(WebGPU::RenderPassEncoder::clampIndirectIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::clampIndirectBufferToValidValues):
(WebGPU::RenderPassEncoder::clampIndirectBufferDispatchBatched):
(WebGPU::RenderPassEncoder::clampIndirectIndexBufferDispatch1Batched):
(WebGPU::RenderPassEncoder::drawIndexedIndirect):
(WebGPU::RenderPassEncoder::drawIndirect):
(WebGPU::checkForIndirectDrawDeviceLost): Deleted.

Canonical link: <a href="https://commits.webkit.org/319317@main">https://commits.webkit.org/319317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/108d2112666d53b66d8ef122d03d27a4d8a65d90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145454 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54792 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141338 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed layout tests; 6 flakes 3 failures; Uploaded test results; 1 flakes 1 failures; Compiled WebKit (warnings); 1 failures; Passed layout tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45005 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162093 "Found 1 new API test failure: TestWebKitAPI.IsolatedSiteStore.PersistsAcrossSessions (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121789 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43678 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41959 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41620 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2507 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193280 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54742 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150729 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40361 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55430 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150445 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45035 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127697 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123245 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53947 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16616 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53329 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53566 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53394 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->