### PR TITLE
[JSC][Wasm] Don't assert NativeCallee on JS frames in wasm exception paths

### DIFF
--- a/JSTests/wasm/stress/js-callee-stack-overflow.js
+++ b/JSTests/wasm/stress/js-callee-stack-overflow.js
@@ -1,0 +1,56 @@
+//@ requireOptions("--maxPerThreadStackUsage=524288")
+
+import Builder from "../Builder.js";
+
+const builder = (new Builder())
+    .Type().End()
+    .Import().Function("env", "reenter", { params: [], ret: "void" }).End()
+    .Function().End()
+    .Export()
+        .Function("run")
+    .End()
+    .Code()
+        .Function("run", { params: [], ret: "void" })
+            .Call(0)
+        .End()
+    .End();
+
+let instance;
+function reenter()
+{
+    instance.exports.run();
+}
+
+instance = new WebAssembly.Instance(new WebAssembly.Module(builder.WebAssembly().get()), { env: { reenter } });
+
+try {
+    instance.exports.run();
+} catch (e) {
+    if (!(e instanceof RangeError))
+        throw e;
+}
+
+const identity = (new Builder())
+    .Type().End()
+    .Function().End()
+    .Export()
+        .Function("f")
+    .End()
+    .Code()
+        .Function("f", { params: ["f64"], ret: "f64" })
+            .GetLocal(0)
+        .End()
+    .End();
+
+const numberInstance = new WebAssembly.Instance(new WebAssembly.Module(identity.WebAssembly().get()));
+const rec = {
+    valueOf() {
+        return numberInstance.exports.f(rec);
+    }
+};
+try {
+    numberInstance.exports.f(rec);
+} catch (e) {
+    if (!(e instanceof RangeError))
+        throw e;
+}

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -423,6 +423,8 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, void, (void* sp,
 ALWAYS_INLINE void assertCalleeIsReferenced(CallFrame* frame, JSWebAssemblyInstance* instance)
 {
 #if ASSERT_ENABLED
+    if (!frame->callee().isNativeCallee())
+        return;
     CalleeGroup& calleeGroup = *instance->calleeGroup();
     Wasm::Callee* callee = uncheckedDowncast<Wasm::Callee>(frame->callee().asNativeCallee());
     TriState status;


### PR DESCRIPTION
#### 4cc12fa76b1f68595032ab541295f237462665e6
<pre>
[JSC][Wasm] Don&apos;t assert NativeCallee on JS frames in wasm exception paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=296371">https://bugs.webkit.org/show_bug.cgi?id=296371</a>

Reviewed by Yusuke Suzuki.

Stack overflow during JS-to-Wasm or Wasm-to-JS can invoke
operationWasmToJSException while DECLARE_WASM_CALL_FRAME still points at
a JS callee. Debug then called asNativeCallee() and crashed.

Skip the callee-group check unless the frame is a NativeCallee.

* JSTests/wasm/stress/js-callee-stack-overflow.js: Added.
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::assertCalleeIsReferenced):

Canonical link: <a href="https://commits.webkit.org/319429@main">https://commits.webkit.org/319429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/719c1aa50c9a71b4f9d8ce2e41a0c6abbd13283d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145459 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141347 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98039 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121798 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43686 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41966 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3763 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10581 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154090 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41626 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2512 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42410 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193285 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54747 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150735 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55435 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150452 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27551 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45042 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127702 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/123255 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53952 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16622 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53334 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53571 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->