### PR TITLE
[JSC] Use std::array for fixed-sized ArgList

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4390,10 +4390,10 @@ JSC_DEFINE_JIT_OPERATION(operationStringSplitRegExp, EncodedJSValue, (JSGlobalOb
             throwTypeError(globalObject, scope, "@@split method is not callable"_s);
             OPERATION_RETURN(scope, encodedJSValue());
         }
-        std::array<EncodedJSValue, 2> args { {
+        auto args = WTF::toArray<EncodedJSValue>({
             JSValue::encode(thisString),
             JSValue::encode(limitValue),
-        } };
+        });
         JSValue result = call(globalObject, splitter, callData, separator, ArgList { args.data(), args.size() });
         OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
         OPERATION_RETURN(scope, JSValue::encode(result));
@@ -4437,9 +4437,9 @@ JSC_DEFINE_JIT_OPERATION(operationStringMatchRegExp, EncodedJSValue, (JSGlobalOb
             throwTypeError(globalObject, scope, "@@match method is not callable"_s);
             OPERATION_RETURN(scope, encodedJSValue());
         }
-        std::array<EncodedJSValue, 1> args { {
+        auto args = WTF::toArray<EncodedJSValue>({
             JSValue::encode(thisString),
-        } };
+        });
         JSValue result = call(globalObject, matcher, callData, regexp, ArgList { args.data(), args.size() });
         OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
         OPERATION_RETURN(scope, JSValue::encode(result));
@@ -4475,9 +4475,9 @@ JSC_DEFINE_JIT_OPERATION(operationStringSearchRegExp, EncodedJSValue, (JSGlobalO
             throwTypeError(globalObject, scope, "@@search method is not callable"_s);
             OPERATION_RETURN(scope, encodedJSValue());
         }
-        std::array<EncodedJSValue, 1> args { {
+        auto args = WTF::toArray<EncodedJSValue>({
             JSValue::encode(thisString),
-        } };
+        });
         JSValue result = call(globalObject, searcher, callData, regexp, ArgList { args.data(), args.size() });
         OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
         OPERATION_RETURN(scope, JSValue::encode(result));
@@ -5813,10 +5813,10 @@ JSC_DEFINE_JIT_OPERATION(operationSpreadGeneric, JSCell*, (JSGlobalObject* globa
         auto callData = JSC::getCallData(iterationFunction);
         ASSERT(callData.type != CallData::Type::None);
 
-        MarkedArgumentBuffer arguments;
-        arguments.append(iterable);
-        ASSERT(!arguments.hasOverflowed());
-        JSValue arrayResult = call(globalObject, iterationFunction, callData, jsNull(), arguments);
+        auto arguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(iterable),
+        });
+        JSValue arrayResult = call(globalObject, iterationFunction, callData, jsNull(), ArgList { arguments.data(), arguments.size() });
         OPERATION_RETURN_IF_EXCEPTION(scope, nullptr);
         array = uncheckedDowncast<JSArray>(arrayResult);
     }
@@ -5838,10 +5838,10 @@ JSC_DEFINE_JIT_OPERATION(operationSpreadSet, JSCell*, (JSGlobalObject* globalObj
         JSFunction* iterationFunction = globalObject->iteratorProtocolFunction();
         auto callData = JSC::getCallData(iterationFunction);
         ASSERT(callData.type != CallData::Type::None);
-        MarkedArgumentBuffer arguments;
-        arguments.append(set);
-        ASSERT(!arguments.hasOverflowed());
-        JSValue arrayResult = call(globalObject, iterationFunction, callData, jsNull(), arguments);
+        auto arguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(set),
+        });
+        JSValue arrayResult = call(globalObject, iterationFunction, callData, jsNull(), ArgList { arguments.data(), arguments.size() });
         OPERATION_RETURN_IF_EXCEPTION(scope, nullptr);
         JSArray* array = uncheckedDowncast<JSArray>(arrayResult);
         OPERATION_RETURN(scope, JSCellButterfly::createFromArray(globalObject, vm, array));

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
@@ -153,13 +153,13 @@ Expected<JSObject*, NakedPtr<Exception>> InjectedScriptManager::createInjectedSc
     if (callData.type == CallData::Type::None)
         return nullptr;
 
-    MarkedArgumentBuffer args;
-    args.append(m_injectedScriptHost->wrapper(globalObject));
-    args.append(globalThisValue);
-    args.append(jsNumber(id));
-    ASSERT(!args.hasOverflowed());
+    std::array<JSC::EncodedJSValue, 3> args { {
+        JSC::JSValue::encode(m_injectedScriptHost->wrapper(globalObject)),
+        JSC::JSValue::encode(globalThisValue),
+        JSC::JSValue::encode(jsNumber(id)),
+    } };
 
-    JSValue result = JSC::call(globalObject, functionValue, callData, globalThisValue, args);
+    JSValue result = JSC::call(globalObject, functionValue, callData, globalThisValue, JSC::ArgList { args.data(), args.size() });
     RETURN_IF_EXCEPTION(scope, makeUnexpected(scope.exception()));
     return result.getObject();
 }

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1167,11 +1167,11 @@ JSValue Interpreter::executeProgram(const SourceCode& source, JSGlobalObject*, J
                 auto callData = JSC::getCallDataInline(function);
                 if (callData.type == CallData::Type::None)
                     return throwException(globalObject, throwScope, createNotAFunctionError(globalObject, function));
-                MarkedArgumentBuffer jsonArg;
-                jsonArg.append(JSONPValue);
-                ASSERT(!jsonArg.hasOverflowed());
+                auto jsonArg = WTF::toArray<EncodedJSValue>({
+                    JSValue::encode(JSONPValue),
+                });
                 JSValue thisValue = JSONPPath.size() == 1 ? jsUndefined() : baseObject;
-                JSONPValue = JSC::call(globalObject, function, callData, thisValue, jsonArg);
+                JSONPValue = JSC::call(globalObject, function, callData, thisValue, ArgList { jsonArg.data(), jsonArg.size() });
                 RETURN_IF_EXCEPTION(throwScope, JSValue());
                 break;
             }

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2662,12 +2662,11 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentReceiveBroadcast, (JSGlobalObject* g
         return jsUndefined();
     })();
 
-    MarkedArgumentBuffer args;
-    args.append(result);
-    args.append(jsNumber(message->index()));
-    if (args.hasOverflowed()) [[unlikely]]
-        return JSValue::encode(throwOutOfMemoryError(globalObject, scope));
-    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, callback, callData, jsNull(), args)));
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(result),
+        JSValue::encode(jsNumber(message->index())),
+    });
+    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, callback, callData, jsNull(), ArgList { args.data(), args.size() })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionDollarAgentReport, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -3004,8 +3003,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeout, (JSGlobalObject* globalObject, Call
         vmPtr->deferredWorkTimer->scheduleWorkSoonIfActive(weakTicket, [](DeferredWorkTimer::Ticket& ticket) {
             auto* callback = uncheckedDowncast<JSFunction>(ticket.target());
             JSGlobalObject* globalObject = callback->realm();
-            MarkedArgumentBuffer args;
-            call(globalObject, callback, jsUndefined(), args, "You shouldn't see this..."_s);
+            call(globalObject, callback, jsUndefined(), ArgList { }, "You shouldn't see this..."_s);
         });
     };
 

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -227,9 +227,10 @@ JSC_DEFINE_HOST_FUNCTION(arrayConstructorOf, (JSGlobalObject* globalObject, Call
 
     JSObject* result = nullptr;
     if (thisValue.isConstructor()) {
-        MarkedArgumentBuffer args;
-        args.append(jsNumber(length));
-        result = construct(globalObject, thisValue, args, "Array.of did not get a valid constructor");
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(jsNumber(length)),
+        });
+        result = construct(globalObject, thisValue, ArgList { args.data(), args.size() }, "Array.of did not get a valid constructor");
         RETURN_IF_EXCEPTION(scope, { });
     } else {
         result = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), length);

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -299,12 +299,12 @@ static JSString* toLocaleString(JSGlobalObject* globalObject, JSValue value, JSV
         return { };
     }
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(locales);
-    arguments.append(options);
-    ASSERT(!arguments.hasOverflowed());
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(locales),
+        JSValue::encode(options),
+    });
 
-    JSValue result = call(globalObject, toLocaleStringMethod, callData, value, arguments);
+    JSValue result = call(globalObject, toLocaleStringMethod, callData, value, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, result.toString(globalObject));
@@ -1000,20 +1000,12 @@ static ALWAYS_INLINE std::span<EncodedJSValue> sortStableSort(JSGlobalObject* gl
         })));
     }
 
-    MarkedArgumentBuffer args;
     RELEASE_AND_RETURN(scope, (arrayStableSort<MergeStrategy::Galloping>(vm, compacted, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        args.clear();
+        auto args = WTF::toArray<EncodedJSValue>({ left, right });
 
-        args.append(JSValue::decode(left));
-        args.append(JSValue::decode(right));
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return false;
-        }
-
-        JSValue jsResult = call(globalObject, comparator, callData, jsUndefined(), args);
+        JSValue jsResult = call(globalObject, comparator, callData, jsUndefined(), ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION(scope, false);
 
         RELEASE_AND_RETURN(scope, coerceComparatorResultToBoolean(globalObject, jsResult));

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -132,10 +132,10 @@ ALWAYS_INLINE std::pair<SpeciesConstructResult, JSObject*> speciesConstructArray
     if (constructor.isUndefined())
         return std::pair { SpeciesConstructResult::FastPath, nullptr };
 
-    MarkedArgumentBuffer args;
-    args.append(jsNumber(length));
-    ASSERT(!args.hasOverflowed());
-    JSObject* newObject = construct(globalObject, constructor, args, "Species construction did not get a valid constructor"_s);
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(jsNumber(length)),
+    });
+    JSObject* newObject = construct(globalObject, constructor, ArgList { args.data(), args.size() }, "Species construction did not get a valid constructor"_s);
     RETURN_IF_EXCEPTION(scope, exceptionResult);
     return std::pair { SpeciesConstructResult::CreatedObject, newObject };
 }

--- a/Source/JavaScriptCore/runtime/AsyncFromSyncIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/AsyncFromSyncIteratorPrototype.cpp
@@ -87,11 +87,10 @@ static bool callSyncIteratorMethodAndExtract(JSGlobalObject* globalObject, JSVal
         return { };
     }
 
-    MarkedArgumentBuffer args;
-    if (!argument.isEmpty())
-        args.append(argument);
-    ASSERT(!args.hasOverflowed());
-    JSValue result = call(globalObject, method, callData, syncIterator, args);
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(argument),
+    });
+    JSValue result = call(globalObject, method, callData, syncIterator, ArgList { args.data(), argument.isEmpty() ? 0u : 1u });
     RETURN_IF_EXCEPTION(scope, { });
 
     if (!result.isObject()) [[unlikely]] {

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -1710,10 +1710,10 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_spread)
         auto callData = JSC::getCallData(iterationFunction);
         ASSERT(callData.type != CallData::Type::None);
 
-        MarkedArgumentBuffer arguments;
-        arguments.append(iterableValue);
-        ASSERT(!arguments.hasOverflowed());
-        JSValue arrayResult = call(globalObject, iterationFunction, callData, jsNull(), arguments);
+        auto arguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(iterableValue),
+        });
+        JSValue arrayResult = call(globalObject, iterationFunction, callData, jsNull(), ArgList { arguments.data(), arguments.size() });
         CHECK_EXCEPTION();
         array = uncheckedDowncast<JSArray>(arrayResult);
     }

--- a/Source/JavaScriptCore/runtime/GetterSetter.cpp
+++ b/Source/JavaScriptCore/runtime/GetterSetter.cpp
@@ -70,13 +70,13 @@ bool GetterSetter::callSetter(JSGlobalObject* globalObject, JSValue thisValue, J
     if (setter->type() == NullSetterFunctionType)
         return typeError(globalObject, scope, shouldThrow, ReadonlyPropertyWriteError);
 
-    MarkedArgumentBuffer args;
-    args.append(value);
-    ASSERT(!args.hasOverflowed());
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(value),
+    });
 
     auto callData = JSC::getCallDataInline(setter);
     scope.release();
-    call(globalObject, setter, callData, thisValue, args);
+    call(globalObject, setter, callData, thisValue, ArgList { args.data(), args.size() });
     return true;
 }
 

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -54,11 +54,10 @@ static JSValue iteratorNextImpl(JSGlobalObject* globalObject, IterationRecord it
     if (nextFunctionCallData.type == CallData::Type::None)
         return throwTypeError(globalObject, scope);
 
-    MarkedArgumentBuffer nextFunctionArguments;
-    if (!argument.isEmpty())
-        nextFunctionArguments.append(argument);
-    ASSERT(!nextFunctionArguments.hasOverflowed());
-    JSValue result = call(globalObject, nextFunction, nextFunctionCallData, iterator, nextFunctionArguments);
+    auto nextFunctionArguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(argument),
+    });
+    JSValue result = call(globalObject, nextFunction, nextFunctionCallData, iterator, ArgList { nextFunctionArguments.data(), argument.isEmpty() ? 0u : 1u });
     RETURN_IF_EXCEPTION(scope, JSValue());
 
     if (!result.isObject())
@@ -181,9 +180,7 @@ void iteratorClose(JSGlobalObject* globalObject, JSValue iterator)
         return;
     }
 
-    MarkedArgumentBuffer returnFunctionArguments;
-    ASSERT(!returnFunctionArguments.hasOverflowed());
-    JSValue innerResult = call(globalObject, returnFunction, returnFunctionCallData, iterator, returnFunctionArguments);
+    JSValue innerResult = call(globalObject, returnFunction, returnFunctionCallData, iterator, ArgList { });
 
     if (exception) {
         throwException(globalObject, scope, exception);

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -107,10 +107,10 @@ static ALWAYS_INLINE std::pair<SpeciesConstructResult, JSArrayBuffer*> speciesCo
         return fastPathResult;
 
     // 16. Let new be ? Construct(ctor, « 𝔽(newLen) »).
-    MarkedArgumentBuffer args;
-    args.append(jsNumber(length));
-    ASSERT(!args.hasOverflowed());
-    JSObject* newObject = construct(globalObject, species.value(), args, "Species construction did not get a valid constructor"_s);
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(jsNumber(length)),
+    });
+    JSObject* newObject = construct(globalObject, species.value(), ArgList { args.data(), args.size() }, "Species construction did not get a valid constructor"_s);
     RETURN_IF_EXCEPTION(scope, errorResult);
 
     // 17. Perform ? RequireInternalSlot(new, [[ArrayBufferData]]).

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
@@ -168,9 +168,10 @@ void JSFinalizationRegistry::runFinalizationCleanup(JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     while (JSValue value = takeDeadHoldingsValue()) {
-        MarkedArgumentBuffer args;
-        args.append(value);
-        call(globalObject, callback(), args, "This should not be visible: please report a bug to bugs.webkit.org"_s);
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(value),
+        });
+        call(globalObject, callback(), ArgList { args.data(), args.size() }, "This should not be visible: please report a bug to bugs.webkit.org"_s);
         RETURN_IF_EXCEPTION(scope, void());
     }
 }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -96,6 +96,9 @@ ALWAYS_INLINE bool speciesWatchpointIsValid(JSGlobalObject* globalObject, ViewCl
 // This implements 22.2.4.7 TypedArraySpeciesCreate
 // Note, that this function throws.
 // https://tc39.es/ecma262/#typedarray-species-create
+// constructArgs fills the caller's buffer and returns how many entries it used.
+static constexpr size_t maximumSpeciesConstructArguments = 3;
+
 template<typename ViewClass, typename Functor, typename SlowPathArgsConstructor>
 inline JSArrayBufferView* speciesConstruct(JSGlobalObject* globalObject, ViewClass* exemplar, const Functor& defaultConstructor, const SlowPathArgsConstructor& constructArgs, std::optional<size_t> length)
 {
@@ -139,11 +142,11 @@ inline JSArrayBufferView* speciesConstruct(JSGlobalObject* globalObject, ViewCla
     if (species == viewClassConstructor)
         RELEASE_AND_RETURN(scope, defaultConstructor());
 
-    MarkedArgumentBuffer args;
-    constructArgs(args);
+    std::array<EncodedJSValue, maximumSpeciesConstructArguments> args { };
+    unsigned argCount = constructArgs(args);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    JSValue result = construct(globalObject, species, args, "species is not a constructor"_s);
+    JSValue result = construct(globalObject, species, ArgList { args.data(), argCount }, "species is not a constructor"_s);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     if (JSArrayBufferView* view = dynamicDowncast<JSArrayBufferView>(result); view) [[likely]] {
@@ -842,24 +845,14 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncForEach(VM& vm, JSGlo
         return JSValue::encode(jsUndefined());
     }
 
-    MarkedArgumentBuffer args;
-
     scope.release();
     typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) ALWAYS_INLINE_LAMBDA {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-
-        args.clear();
-
-        args.append(element);
-        args.append(jsNumber(index));
-        args.append(thisObject);
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return IterationStatus::Continue;
-        }
-
-        scope.release();
-        call(globalObject, functorValue, callData, thisArg, args);
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(element),
+            JSValue::encode(jsNumber(index)),
+            JSValue::encode(thisObject),
+        });
+        call(globalObject, functorValue, callData, thisArg, ArgList { args.data(), args.size() });
         return IterationStatus::Continue;
     });
     return JSValue::encode(jsUndefined());
@@ -894,9 +887,9 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncMap(VM& vm, JSGlobalO
         bool isResizableOrGrowableShared = false;
         Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType, isResizableOrGrowableShared);
         return ViewClass::createUninitialized(globalObject, structure, length);
-    }, [&](MarkedArgumentBuffer& args) {
-        args.append(jsNumber(length));
-        ASSERT(!args.hasOverflowed());
+    }, [&](auto& args) {
+        args[0] = JSValue::encode(jsNumber(length));
+        return 1;
     }, length);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -924,23 +917,17 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncMap(VM& vm, JSGlobalO
         return JSValue::encode(result);
     }
 
-    MarkedArgumentBuffer args;
-
     scope.release();
     typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) ALWAYS_INLINE_LAMBDA {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        args.clear();
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(element),
+            JSValue::encode(jsNumber(index)),
+            JSValue::encode(thisObject),
+        });
 
-        args.append(element);
-        args.append(jsNumber(index));
-        args.append(thisObject);
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return IterationStatus::Continue;
-        }
-
-        JSValue mapped = call(globalObject, functorValue, callData, thisArg, args);
+        JSValue mapped = call(globalObject, functorValue, callData, thisArg, ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, IterationStatus::Done);
 
         scope.release();
@@ -1019,22 +1006,16 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFilter(VM& vm, JSGlob
         });
         RETURN_IF_EXCEPTION(scope, { });
     } else {
-        MarkedArgumentBuffer args;
-
         typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto nativeValue) ALWAYS_INLINE_LAMBDA {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
-            args.clear();
+            auto args = WTF::toArray<EncodedJSValue>({
+                JSValue::encode(element),
+                JSValue::encode(jsNumber(index)),
+                JSValue::encode(thisObject),
+            });
 
-            args.append(element);
-            args.append(jsNumber(index));
-            args.append(thisObject);
-            if (args.hasOverflowed()) [[unlikely]] {
-                throwOutOfMemoryError(globalObject, scope);
-                return IterationStatus::Continue;
-            }
-
-            JSValue result = call(globalObject, functorValue, callData, thisArg, args);
+            JSValue result = call(globalObject, functorValue, callData, thisArg, ArgList { args.data(), args.size() });
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, IterationStatus::Done);
 
             scope.release();
@@ -1050,9 +1031,9 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFilter(VM& vm, JSGlob
         bool isResizableOrGrowableShared = false;
         Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType, isResizableOrGrowableShared);
         return ViewClass::createUninitialized(globalObject, structure, length);
-    }, [&](MarkedArgumentBuffer& args) {
-        args.append(jsNumber(length));
-        ASSERT(!args.hasOverflowed());
+    }, [&](auto& args) {
+        args[0] = JSValue::encode(jsNumber(length));
+        return 1;
     }, length);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1113,25 +1094,19 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFind(VM& vm, JSGlobal
         return JSValue::encode(found);
     }
 
-    MarkedArgumentBuffer args;
-
     scope.release();
 
     JSValue found = jsUndefined();
     typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) ALWAYS_INLINE_LAMBDA -> IterationStatus {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        args.clear();
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(element),
+            JSValue::encode(jsNumber(index)),
+            JSValue::encode(thisObject),
+        });
 
-        args.append(element);
-        args.append(jsNumber(index));
-        args.append(thisObject);
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return IterationStatus::Continue;
-        }
-
-        JSValue result = call(globalObject, functorValue, callData, thisArg, args);
+        JSValue result = call(globalObject, functorValue, callData, thisArg, ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, { });
 
         scope.release();
@@ -1186,25 +1161,19 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindIndex(VM& vm, JSG
         return JSValue::encode(found);
     }
 
-    MarkedArgumentBuffer args;
-
     scope.release();
 
     JSValue found = jsNumber(-1);
     typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) ALWAYS_INLINE_LAMBDA -> IterationStatus {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        args.clear();
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(element),
+            JSValue::encode(jsNumber(index)),
+            JSValue::encode(thisObject),
+        });
 
-        args.append(element);
-        args.append(jsNumber(index));
-        args.append(thisObject);
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return IterationStatus::Continue;
-        }
-
-        JSValue result = call(globalObject, functorValue, callData, thisArg, args);
+        JSValue result = call(globalObject, functorValue, callData, thisArg, ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, { });
 
         scope.release();
@@ -1259,25 +1228,19 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindLast(VM& vm, JSGl
         return JSValue::encode(found);
     }
 
-    MarkedArgumentBuffer args;
-
     scope.release();
 
     JSValue found = jsUndefined();
     typedArrayViewForEachImpl<ForEachDirection::Backward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) ALWAYS_INLINE_LAMBDA -> IterationStatus {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        args.clear();
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(element),
+            JSValue::encode(jsNumber(index)),
+            JSValue::encode(thisObject),
+        });
 
-        args.append(element);
-        args.append(jsNumber(index));
-        args.append(thisObject);
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return IterationStatus::Continue;
-        }
-
-        JSValue result = call(globalObject, functorValue, callData, thisArg, args);
+        JSValue result = call(globalObject, functorValue, callData, thisArg, ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, { });
 
         scope.release();
@@ -1332,25 +1295,19 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindLastIndex(VM& vm,
         return JSValue::encode(found);
     }
 
-    MarkedArgumentBuffer args;
-
     scope.release();
 
     JSValue found = jsNumber(-1);
     typedArrayViewForEachImpl<ForEachDirection::Backward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) ALWAYS_INLINE_LAMBDA -> IterationStatus {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        args.clear();
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(element),
+            JSValue::encode(jsNumber(index)),
+            JSValue::encode(thisObject),
+        });
 
-        args.append(element);
-        args.append(jsNumber(index));
-        args.append(thisObject);
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return IterationStatus::Continue;
-        }
-
-        JSValue result = call(globalObject, functorValue, callData, thisArg, args);
+        JSValue result = call(globalObject, functorValue, callData, thisArg, ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, { });
 
         scope.release();
@@ -1405,25 +1362,19 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncEvery(VM& vm, JSGloba
         return JSValue::encode(condition);
     }
 
-    MarkedArgumentBuffer args;
-
     scope.release();
 
     JSValue condition = jsBoolean(true);
     typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) ALWAYS_INLINE_LAMBDA -> IterationStatus {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        args.clear();
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(element),
+            JSValue::encode(jsNumber(index)),
+            JSValue::encode(thisObject),
+        });
 
-        args.append(element);
-        args.append(jsNumber(index));
-        args.append(thisObject);
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return IterationStatus::Continue;
-        }
-
-        JSValue result = call(globalObject, functorValue, callData, thisArg, args);
+        JSValue result = call(globalObject, functorValue, callData, thisArg, ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, { });
 
         scope.release();
@@ -1478,25 +1429,19 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSome(VM& vm, JSGlobal
         return JSValue::encode(condition);
     }
 
-    MarkedArgumentBuffer args;
-
     scope.release();
 
     JSValue condition = jsBoolean(false);
     typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) ALWAYS_INLINE_LAMBDA -> IterationStatus {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        args.clear();
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(element),
+            JSValue::encode(jsNumber(index)),
+            JSValue::encode(thisObject),
+        });
 
-        args.append(element);
-        args.append(jsNumber(index));
-        args.append(thisObject);
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return IterationStatus::Continue;
-        }
-
-        JSValue result = call(globalObject, functorValue, callData, thisArg, args);
+        JSValue result = call(globalObject, functorValue, callData, thisArg, ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, { });
 
         scope.release();
@@ -1552,8 +1497,6 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduce(VM& vm, JSGlob
         return JSValue::encode(accumulator);
     }
 
-    MarkedArgumentBuffer args;
-
     scope.release();
 
     typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) -> IterationStatus {
@@ -1565,19 +1508,15 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduce(VM& vm, JSGlob
             return IterationStatus::Continue;
         }
 
-        args.clear();
-
-        args.append(accumulator);
-        args.append(element);
-        args.append(jsNumber(index));
-        args.append(thisObject);
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return IterationStatus::Continue;
-        }
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(accumulator),
+            JSValue::encode(element),
+            JSValue::encode(jsNumber(index)),
+            JSValue::encode(thisObject),
+        });
 
         scope.release();
-        accumulator = call(globalObject, callback, callData, jsUndefined(), args);
+        accumulator = call(globalObject, callback, callData, jsUndefined(), ArgList { args.data(), args.size() });
         return IterationStatus::Continue;
     });
 
@@ -1628,8 +1567,6 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduceRight(VM& vm, J
         return JSValue::encode(accumulator);
     }
 
-    MarkedArgumentBuffer args;
-
     scope.release();
 
     typedArrayViewForEachImpl<ForEachDirection::Backward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) -> IterationStatus {
@@ -1641,19 +1578,15 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduceRight(VM& vm, J
             return IterationStatus::Continue;
         }
 
-        args.clear();
-
-        args.append(accumulator);
-        args.append(element);
-        args.append(jsNumber(index));
-        args.append(thisObject);
-        if (args.hasOverflowed()) [[unlikely]] {
-            throwOutOfMemoryError(globalObject, scope);
-            return IterationStatus::Continue;
-        }
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(accumulator),
+            JSValue::encode(element),
+            JSValue::encode(jsNumber(index)),
+            JSValue::encode(thisObject),
+        });
 
         scope.release();
-        accumulator = call(globalObject, callback, callData, jsUndefined(), args);
+        accumulator = call(globalObject, callback, callData, jsUndefined(), ArgList { args.data(), args.size() });
         return IterationStatus::Continue;
     });
 
@@ -1765,25 +1698,20 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
         });
         RETURN_IF_EXCEPTION(scope, { });
     } else {
-        MarkedArgumentBuffer args;
         result = arrayStableSort<MergeStrategy::Simple>(vm, src, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
             auto scope = DECLARE_THROW_SCOPE(vm);
-
-            args.clear();
 
             JSValue leftValue = ViewClass::Adaptor::toJSValue(globalObject, left);
             RETURN_IF_EXCEPTION(scope, false);
             JSValue rightValue = ViewClass::Adaptor::toJSValue(globalObject, right);
             RETURN_IF_EXCEPTION(scope, false);
 
-            args.append(leftValue);
-            args.append(rightValue);
-            if (args.hasOverflowed()) [[unlikely]] {
-                throwOutOfMemoryError(globalObject, scope);
-                return false;
-            }
+            auto args = WTF::toArray<EncodedJSValue>({
+                JSValue::encode(leftValue),
+                JSValue::encode(rightValue),
+            });
 
-            JSValue jsResult = call(globalObject, comparatorValue, callData, jsUndefined(), args);
+            JSValue jsResult = call(globalObject, comparatorValue, callData, jsUndefined(), ArgList { args.data(), args.size() });
             RETURN_IF_EXCEPTION(scope, false);
             RELEASE_AND_RETURN(scope, coerceComparatorResultToBoolean(globalObject, jsResult));
         });
@@ -1955,9 +1883,9 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSlice(VM& vm, JSGloba
             return ViewClass::create(globalObject, structure, length);
 
         return ViewClass::createUninitialized(globalObject, structure, length);
-    }, [&](MarkedArgumentBuffer& args) {
-        args.append(jsNumber(length));
-        ASSERT(!args.hasOverflowed());
+    }, [&](auto& args) {
+        args[0] = JSValue::encode(jsNumber(length));
+        return 1;
     }, length);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -2091,12 +2019,13 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSubarray(VM& vm, JSGl
     return JSValue::encode(speciesConstruct(globalObject, thisObject, [&]() {
         Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType, arrayBuffer->isResizableOrGrowableShared());
         return ViewClass::create(globalObject, structure, WTF::move(arrayBuffer), newByteOffset, count);
-    }, [&](MarkedArgumentBuffer& args) {
-        args.append(vm.m_typedArrayController->toJS(globalObject, thisObject->realm(), *arrayBuffer));
-        args.append(jsNumber(newByteOffset));
-        if (count)
-            args.append(jsNumber(count.value()));
-        ASSERT(!args.hasOverflowed());
+    }, [&](auto& args) {
+        args[0] = JSValue::encode(vm.m_typedArrayController->toJS(globalObject, thisObject->realm(), *arrayBuffer));
+        args[1] = JSValue::encode(jsNumber(newByteOffset));
+        if (!count)
+            return 2;
+        args[2] = JSValue::encode(jsNumber(count.value()));
+        return 3;
     }, std::nullopt));
 }
 

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -204,12 +204,12 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncForEach, (JSGlobalObject* globalObject
 
     scope.release();
     forEachInIteratorProtocol(globalObject, thisValue, [&](VM&, JSGlobalObject*, JSValue nextItem) ALWAYS_INLINE_LAMBDA {
-        MarkedArgumentBuffer args;
-        args.append(nextItem);
-        args.append(jsNumber(counter++));
-        ASSERT(!args.hasOverflowed());
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(nextItem),
+            JSValue::encode(jsNumber(counter++)),
+        });
 
-        call(globalObject, callbackArg, callData, jsUndefined(), args);
+        call(globalObject, callbackArg, callData, jsUndefined(), ArgList { args.data(), args.size() });
     });
 
     return JSValue::encode(jsUndefined());

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -234,11 +234,11 @@ static void promiseResolveThenableJobFastSlow(JSGlobalObject* globalObject, JSPr
     if (!scope.clearExceptionExceptTermination()) [[unlikely]]
         return;
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(error);
-    ASSERT(!arguments.hasOverflowed());
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(error),
+    });
     auto callData = JSC::getCallDataInline(reject);
-    call(globalObject, reject, callData, jsUndefined(), arguments);
+    call(globalObject, reject, callData, jsUndefined(), ArgList { arguments.data(), arguments.size() });
     EXCEPTION_ASSERT(scope.exception() || true);
 }
 
@@ -262,11 +262,11 @@ static void promiseResolveThenableJobWithInternalMicrotaskFastSlow(JSGlobalObjec
     if (!scope.clearExceptionExceptTermination()) [[unlikely]]
         return;
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(error);
-    ASSERT(!arguments.hasOverflowed());
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(error),
+    });
     auto callData = JSC::getCallDataInline(reject);
-    call(globalObject, reject, callData, jsUndefined(), arguments);
+    call(globalObject, reject, callData, jsUndefined(), ArgList { arguments.data(), arguments.size() });
     EXCEPTION_ASSERT(scope.exception() || true);
 }
 
@@ -285,10 +285,10 @@ static void promiseResolveThenableJob(JSGlobalObject* globalObject, JSValue prom
     if (!scope.clearExceptionExceptTermination()) [[unlikely]]
         return;
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(error);
-    ASSERT(!arguments.hasOverflowed());
-    call(globalObject, reject, jsUndefined(), arguments, "|reject| is not a function"_s);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(error),
+    });
+    call(globalObject, reject, jsUndefined(), ArgList { arguments.data(), arguments.size() }, "|reject| is not a function"_s);
     EXCEPTION_ASSERT(scope.exception() || true);
 }
 
@@ -1593,22 +1593,22 @@ static void promiseResolveWithoutHandlerJobSlow(JSGlobalObject* globalObject, VM
         JSValue reject = capability.get(globalObject, vm.propertyNames->reject);
         RETURN_IF_EXCEPTION(scope, void());
 
-        MarkedArgumentBuffer arguments;
-        arguments.append(resolution);
-        ASSERT(!arguments.hasOverflowed());
+        auto arguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(resolution),
+        });
         scope.release();
-        call(globalObject, reject, jsUndefined(), arguments, "reject is not a function"_s);
+        call(globalObject, reject, jsUndefined(), ArgList { arguments.data(), arguments.size() }, "reject is not a function"_s);
         return;
     }
 
     JSValue resolve = capability.get(globalObject, vm.propertyNames->resolve);
     RETURN_IF_EXCEPTION(scope, void());
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(resolution);
-    ASSERT(!arguments.hasOverflowed());
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(resolution),
+    });
     scope.release();
-    call(globalObject, resolve, jsUndefined(), arguments, "resolve is not a function"_s);
+    call(globalObject, resolve, jsUndefined(), ArgList { arguments.data(), arguments.size() }, "resolve is not a function"_s);
 }
 
 static void promiseResolveWithoutHandlerJob(JSGlobalObject* globalObject, VM& vm, JSValue promiseOrCapability, JSValue resolution, JSPromise::Status status)
@@ -1879,11 +1879,11 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
             JSValue reject = promiseOrCapability.get(globalObject, vm.propertyNames->reject);
             RETURN_IF_EXCEPTION(scope, void());
 
-            MarkedArgumentBuffer arguments;
-            arguments.append(error);
-            ASSERT(!arguments.hasOverflowed());
+            auto arguments = WTF::toArray<EncodedJSValue>({
+                JSValue::encode(error),
+            });
             scope.release();
-            call(globalObject, reject, jsUndefined(), arguments, "reject is not a function"_s);
+            call(globalObject, reject, jsUndefined(), ArgList { arguments.data(), arguments.size() }, "reject is not a function"_s);
             return;
         }
 
@@ -1893,11 +1893,11 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         JSValue resolve = promiseOrCapability.get(globalObject, vm.propertyNames->resolve);
         RETURN_IF_EXCEPTION(scope, void());
 
-        MarkedArgumentBuffer arguments;
-        arguments.append(result);
-        ASSERT(!arguments.hasOverflowed());
+        auto arguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(result),
+        });
         scope.release();
-        call(globalObject, resolve, jsUndefined(), arguments, "resolve is not a function"_s);
+        call(globalObject, resolve, jsUndefined(), ArgList { arguments.data(), arguments.size() }, "resolve is not a function"_s);
         return;
     }
 

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -333,10 +333,10 @@ ALWAYS_INLINE JSValue Stringifier::toJSON(JSValue baseValue, const PropertyNameF
     if (callData.type == CallData::Type::None)
         return baseValue;
 
-    MarkedArgumentBuffer args;
-    args.append(propertyName.value(vm));
-    ASSERT(!args.hasOverflowed());
-    RELEASE_AND_RETURN(scope, call(m_globalObject, asObject(toJSONFunction), callData, baseValue, args));
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(propertyName.value(vm)),
+    });
+    RELEASE_AND_RETURN(scope, call(m_globalObject, asObject(toJSONFunction), callData, baseValue, ArgList { args.data(), args.size() }));
 }
 
 // We clamp recursion well beyond anything reasonable.
@@ -362,12 +362,12 @@ Stringifier::StringifyResult Stringifier::appendStringifiedValue(StringBuilder& 
 
     // Call the replacer function.
     if (isCallableReplacer()) {
-        MarkedArgumentBuffer args;
-        args.append(propertyName.value(vm));
-        args.append(value);
-        ASSERT(!args.hasOverflowed());
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(propertyName.value(vm)),
+            JSValue::encode(value),
+        });
         ASSERT(holder.object());
-        value = call(m_globalObject, m_replacer, m_replacerCallData, holder.object(), args);
+        value = call(m_globalObject, m_replacer, m_replacerCallData, holder.object(), ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION(scope, StringifyFailed);
     }
 
@@ -1918,13 +1918,12 @@ private:
             }
         }
 
-        MarkedArgumentBuffer args;
-        args.append(property);
-        args.append(unfiltered);
-        if (context)
-            args.append(context);
-        ASSERT(!args.hasOverflowed());
-        RELEASE_AND_RETURN(scope, call(m_globalObject, m_function, m_callData, thisObj, args));
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(property),
+            JSValue::encode(unfiltered),
+            JSValue::encode(context),
+        });
+        RELEASE_AND_RETURN(scope, call(m_globalObject, m_function, m_callData, thisObj, ArgList { args.data(), context ? 3u : 2u }));
     }
 
     friend class Holder;

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -787,13 +787,13 @@ bool ordinarySetWithOwnDescriptor(JSGlobalObject* globalObject, JSObject* object
 
     // 9.1.9.1-8 Perform ? Call(setter, Receiver, << V >>).
     JSObject* setterObject = asObject(setter);
-    MarkedArgumentBuffer args;
-    args.append(value);
-    ASSERT(!args.hasOverflowed());
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(value),
+    });
 
     auto callData = JSC::getCallData(setterObject);
     scope.release();
-    call(globalObject, setterObject, callData, receiver, args);
+    call(globalObject, setterObject, callData, receiver, ArgList { args.data(), args.size() });
 
     // 9.1.9.1-9 Return true.
     return true;
@@ -2534,7 +2534,8 @@ static ALWAYS_INLINE JSValue callToPrimitiveFunction(JSGlobalObject* globalObjec
         return scope.exception();
     }
 
-    MarkedArgumentBuffer callArgs;
+    constexpr size_t argCount = key == CachedSpecialPropertyKey::ToPrimitive ? 1 : 0;
+    std::array<EncodedJSValue, argCount> callArgs { };
     if constexpr (key == CachedSpecialPropertyKey::ToPrimitive) {
         JSString* hintString = nullptr;
         switch (hint) {
@@ -2548,13 +2549,12 @@ static ALWAYS_INLINE JSValue callToPrimitiveFunction(JSGlobalObject* globalObjec
             hintString = vm.smallStrings.stringString();
             break;
         }
-        callArgs.append(hintString);
+        callArgs[0] = JSValue::encode(hintString);
     } else {
         UNUSED_PARAM(hint);
     }
-    ASSERT(!callArgs.hasOverflowed());
 
-    JSValue result = call(globalObject, function, callData, const_cast<JSObject*>(object), callArgs);
+    JSValue result = call(globalObject, function, callData, const_cast<JSObject*>(object), ArgList { callArgs.data(), callArgs.size() });
     RETURN_IF_EXCEPTION(scope, scope.exception());
     ASSERT(!result.isGetterSetter());
     if (result.isObject()) {
@@ -2654,10 +2654,10 @@ bool JSObject::hasInstance(JSGlobalObject* globalObject, JSValue value, JSValue 
             return false;
         }
 
-        MarkedArgumentBuffer args;
-        args.append(value);
-        ASSERT(!args.hasOverflowed());
-        JSValue result = call(globalObject, hasInstanceValue, callData, this, args);
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(value),
+        });
+        JSValue result = call(globalObject, hasInstanceValue, callData, this, ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION(scope, false);
         return result.toBoolean(globalObject);
     }

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -117,10 +117,10 @@ std::tuple<JSObject*, JSObject*, JSObject*> JSPromise::newPromiseCapability(JSGl
     executor->setField(vm, JSFunctionWithFields::Field::ExecutorResolve, jsUndefined());
     executor->setField(vm, JSFunctionWithFields::Field::ExecutorReject, jsUndefined());
 
-    MarkedArgumentBuffer args;
-    args.append(executor);
-    ASSERT(!args.hasOverflowed());
-    JSObject* newObject = construct(globalObject, constructor, args, "argument is not a constructor"_s);
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(executor),
+    });
+    JSObject* newObject = construct(globalObject, constructor, ArgList { args.data(), args.size() }, "argument is not a constructor"_s);
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue resolve = executor->getField(JSFunctionWithFields::Field::ExecutorResolve);
@@ -1023,11 +1023,11 @@ JSObject* JSPromise::promiseResolve(JSGlobalObject* globalObject, JSObject* cons
     auto [promise, resolve, reject] = newPromiseCapability(globalObject, constructor);
     RETURN_IF_EXCEPTION(scope, { });
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(argument);
-    ASSERT(!arguments.hasOverflowed());
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(argument),
+    });
     scope.release();
-    call(globalObject, resolve, jsUndefined(), arguments, "resolve is not a function"_s);
+    call(globalObject, resolve, jsUndefined(), ArgList { arguments.data(), arguments.size() }, "resolve is not a function"_s);
     return promise;
 }
 
@@ -1045,11 +1045,11 @@ JSObject* JSPromise::promiseReject(JSGlobalObject* globalObject, JSObject* const
     auto [promise, resolve, reject] = newPromiseCapability(globalObject, constructor);
     RETURN_IF_EXCEPTION(scope, { });
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(argument);
-    ASSERT(!arguments.hasOverflowed());
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(argument),
+    });
     scope.release();
-    call(globalObject, reject, jsUndefined(), arguments, "reject is not a function"_s);
+    call(globalObject, reject, jsUndefined(), ArgList { arguments.data(), arguments.size() }, "reject is not a function"_s);
     return promise;
 }
 

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -185,12 +185,12 @@ static JSObject* promiseRaceSlow(JSGlobalObject* globalObject, CallFrame* callFr
     RETURN_IF_EXCEPTION(scope, { });
 
     auto callReject = [&](JSValue exception) -> void {
-        MarkedArgumentBuffer rejectArguments;
-        rejectArguments.append(exception);
-        ASSERT(!rejectArguments.hasOverflowed());
+        auto rejectArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(exception),
+        });
         auto rejectCallData = getCallDataInline(reject);
         scope.release();
-        call(globalObject, reject, rejectCallData, jsUndefined(), rejectArguments);
+        call(globalObject, reject, rejectCallData, jsUndefined(), ArgList { rejectArguments.data(), rejectArguments.size() });
     };
     auto callRejectWithScopeException = [&]() -> void {
         Exception* exception = scope.exception();
@@ -232,10 +232,10 @@ static JSObject* promiseRaceSlow(JSGlobalObject* globalObject, CallFrame* callFr
             nextPromise = cachedCall->callWithArguments(globalObject, thisValue, value);
             RETURN_IF_EXCEPTION(scope, void());
         } else {
-            MarkedArgumentBuffer arguments;
-            arguments.append(value);
-            ASSERT(!arguments.hasOverflowed());
-            nextPromise = call(globalObject, promiseResolveValue, promiseResolveCallData, thisValue, arguments);
+            auto arguments = WTF::toArray<EncodedJSValue>({
+                JSValue::encode(value),
+            });
+            nextPromise = call(globalObject, promiseResolveValue, promiseResolveCallData, thisValue, ArgList { arguments.data(), arguments.size() });
             RETURN_IF_EXCEPTION(scope, void());
         }
         ASSERT(nextPromise);
@@ -247,12 +247,12 @@ static JSObject* promiseRaceSlow(JSGlobalObject* globalObject, CallFrame* callFr
             throwTypeError(globalObject, scope, "then is not a function"_s);
             return;
         }
-        MarkedArgumentBuffer thenArguments;
-        thenArguments.append(resolve);
-        thenArguments.append(reject);
-        ASSERT(!thenArguments.hasOverflowed());
+        auto thenArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(resolve),
+            JSValue::encode(reject),
+        });
         scope.release();
-        call(globalObject, then, thenCallData, nextPromise, thenArguments);
+        call(globalObject, then, thenCallData, nextPromise, ArgList { thenArguments.data(), thenArguments.size() });
     });
 
     if (scope.exception()) [[unlikely]]
@@ -317,12 +317,12 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncRace, (JSGlobalObject* globalObje
             throwTypeError(globalObject, scope, "then is not a function"_s);
             return;
         }
-        MarkedArgumentBuffer thenArguments;
-        thenArguments.append(resolve);
-        thenArguments.append(reject);
-        ASSERT(!thenArguments.hasOverflowed());
+        auto thenArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(resolve),
+            JSValue::encode(reject),
+        });
         scope.release();
-        call(globalObject, then, thenCallData, nextPromise, thenArguments);
+        call(globalObject, then, thenCallData, nextPromise, ArgList { thenArguments.data(), thenArguments.size() });
     });
 
     if (scope.exception()) [[unlikely]]
@@ -340,12 +340,12 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
     RETURN_IF_EXCEPTION(scope, { });
 
     auto callReject = [&](JSValue exception) -> void {
-        MarkedArgumentBuffer rejectArguments;
-        rejectArguments.append(exception);
-        ASSERT(!rejectArguments.hasOverflowed());
+        auto rejectArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(exception),
+        });
         auto rejectCallData = getCallDataInline(reject);
         scope.release();
-        call(globalObject, reject, rejectCallData, jsUndefined(), rejectArguments);
+        call(globalObject, reject, rejectCallData, jsUndefined(), ArgList { rejectArguments.data(), rejectArguments.size() });
     };
     auto callRejectWithScopeException = [&]() -> void {
         Exception* exception = scope.exception();
@@ -400,10 +400,10 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
             nextPromise = cachedCall->callWithArguments(globalObject, thisValue, value);
             RETURN_IF_EXCEPTION(scope, void());
         } else {
-            MarkedArgumentBuffer arguments;
-            arguments.append(value);
-            ASSERT(!arguments.hasOverflowed());
-            nextPromise = call(globalObject, promiseResolveValue, promiseResolveCallData, thisValue, arguments);
+            auto arguments = WTF::toArray<EncodedJSValue>({
+                JSValue::encode(value),
+            });
+            nextPromise = call(globalObject, promiseResolveValue, promiseResolveCallData, thisValue, ArgList { arguments.data(), arguments.size() });
             RETURN_IF_EXCEPTION(scope, void());
         }
         ASSERT(nextPromise);
@@ -426,12 +426,12 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
             return;
         }
 
-        MarkedArgumentBuffer thenArguments;
-        thenArguments.append(onFulfilled);
-        thenArguments.append(reject);
-        ASSERT(!thenArguments.hasOverflowed());
+        auto thenArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(onFulfilled),
+            JSValue::encode(reject),
+        });
         scope.release();
-        call(globalObject, then, thenCallData, nextPromise, thenArguments);
+        call(globalObject, then, thenCallData, nextPromise, ArgList { thenArguments.data(), thenArguments.size() });
     });
 
     if (scope.exception()) [[unlikely]] {
@@ -442,12 +442,12 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
     uint64_t count = globalContext->remainingElementsCount() - 1;
     globalContext->setRemainingElementsCount(count);
     if (!count) {
-        MarkedArgumentBuffer resolveArguments;
-        resolveArguments.append(values);
-        ASSERT(!resolveArguments.hasOverflowed());
+        auto resolveArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(values),
+        });
         auto resolveCallData = getCallDataInline(resolve);
         scope.release();
-        call(globalObject, resolve, resolveCallData, jsUndefined(), resolveArguments);
+        call(globalObject, resolve, resolveCallData, jsUndefined(), ArgList { resolveArguments.data(), resolveArguments.size() });
         if (scope.exception()) [[unlikely]] {
             callRejectWithScopeException();
             return promise;
@@ -537,12 +537,12 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
         auto* onFulfilled = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllFulfillFunctionExecutable());
         onFulfilled->setField(vm, JSFunctionWithFields::Field::PromiseAllContext, context);
 
-        MarkedArgumentBuffer thenArguments;
-        thenArguments.append(onFulfilled);
-        thenArguments.append(onRejected);
-        ASSERT(!thenArguments.hasOverflowed());
+        auto thenArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(onFulfilled),
+            JSValue::encode(onRejected),
+        });
         scope.release();
-        call(globalObject, then, thenCallData, nextPromise, thenArguments);
+        call(globalObject, then, thenCallData, nextPromise, ArgList { thenArguments.data(), thenArguments.size() });
         ++index;
     });
 
@@ -624,12 +624,12 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSlowFulfillFunction, (JSGlobalObject* globalO
     uint64_t count = globalContext->remainingElementsCount() - 1;
     globalContext->setRemainingElementsCount(count);
     if (!count) {
-        MarkedArgumentBuffer resolveArguments;
-        resolveArguments.append(values);
-        ASSERT(!resolveArguments.hasOverflowed());
+        auto resolveArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(values),
+        });
         auto resolveCallData = getCallDataInline(resolve);
         scope.release();
-        call(globalObject, resolve, resolveCallData, jsUndefined(), resolveArguments);
+        call(globalObject, resolve, resolveCallData, jsUndefined(), ArgList { resolveArguments.data(), resolveArguments.size() });
     }
 
     return JSValue::encode(jsUndefined());
@@ -644,12 +644,12 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
     RETURN_IF_EXCEPTION(scope, { });
 
     auto callReject = [&](JSValue exception) -> void {
-        MarkedArgumentBuffer rejectArguments;
-        rejectArguments.append(exception);
-        ASSERT(!rejectArguments.hasOverflowed());
+        auto rejectArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(exception),
+        });
         auto rejectCallData = getCallDataInline(reject);
         scope.release();
-        call(globalObject, reject, rejectCallData, jsUndefined(), rejectArguments);
+        call(globalObject, reject, rejectCallData, jsUndefined(), ArgList { rejectArguments.data(), rejectArguments.size() });
     };
     auto callRejectWithScopeException = [&]() -> void {
         Exception* exception = scope.exception();
@@ -704,10 +704,10 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
             nextPromise = cachedCall->callWithArguments(globalObject, thisValue, value);
             RETURN_IF_EXCEPTION(scope, void());
         } else {
-            MarkedArgumentBuffer arguments;
-            arguments.append(value);
-            ASSERT(!arguments.hasOverflowed());
-            nextPromise = call(globalObject, promiseResolveValue, promiseResolveCallData, thisValue, arguments);
+            auto arguments = WTF::toArray<EncodedJSValue>({
+                JSValue::encode(value),
+            });
+            nextPromise = call(globalObject, promiseResolveValue, promiseResolveCallData, thisValue, ArgList { arguments.data(), arguments.size() });
             RETURN_IF_EXCEPTION(scope, void());
         }
         ASSERT(nextPromise);
@@ -735,12 +735,12 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
             return;
         }
 
-        MarkedArgumentBuffer thenArguments;
-        thenArguments.append(onFulfilled);
-        thenArguments.append(onRejected);
-        ASSERT(!thenArguments.hasOverflowed());
+        auto thenArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(onFulfilled),
+            JSValue::encode(onRejected),
+        });
         scope.release();
-        call(globalObject, then, thenCallData, nextPromise, thenArguments);
+        call(globalObject, then, thenCallData, nextPromise, ArgList { thenArguments.data(), thenArguments.size() });
     });
 
     if (scope.exception()) [[unlikely]] {
@@ -751,12 +751,12 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
     uint64_t count = globalContext->remainingElementsCount() - 1;
     globalContext->setRemainingElementsCount(count);
     if (!count) {
-        MarkedArgumentBuffer resolveArguments;
-        resolveArguments.append(values);
-        ASSERT(!resolveArguments.hasOverflowed());
+        auto resolveArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(values),
+        });
         auto resolveCallData = getCallDataInline(resolve);
         scope.release();
-        call(globalObject, resolve, resolveCallData, jsUndefined(), resolveArguments);
+        call(globalObject, resolve, resolveCallData, jsUndefined(), ArgList { resolveArguments.data(), resolveArguments.size() });
         if (scope.exception()) [[unlikely]] {
             callRejectWithScopeException();
             return promise;
@@ -849,12 +849,12 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
             return;
         }
 
-        MarkedArgumentBuffer thenArguments;
-        thenArguments.append(onFulfilled);
-        thenArguments.append(onRejected);
-        ASSERT(!thenArguments.hasOverflowed());
+        auto thenArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(onFulfilled),
+            JSValue::encode(onRejected),
+        });
         scope.release();
-        call(globalObject, then, thenCallData, nextPromise, thenArguments);
+        call(globalObject, then, thenCallData, nextPromise, ArgList { thenArguments.data(), thenArguments.size() });
         ++index;
     });
 
@@ -993,12 +993,12 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledSlowFulfillFunction, (JSGlobalObject* 
     uint64_t count = globalContext->remainingElementsCount() - 1;
     globalContext->setRemainingElementsCount(count);
     if (!count) {
-        MarkedArgumentBuffer resolveArguments;
-        resolveArguments.append(values);
-        ASSERT(!resolveArguments.hasOverflowed());
+        auto resolveArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(values),
+        });
         auto resolveCallData = getCallDataInline(resolve);
         scope.release();
-        call(globalObject, resolve, resolveCallData, jsUndefined(), resolveArguments);
+        call(globalObject, resolve, resolveCallData, jsUndefined(), ArgList { resolveArguments.data(), resolveArguments.size() });
     }
 
     return JSValue::encode(jsUndefined());
@@ -1039,12 +1039,12 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledSlowRejectFunction, (JSGlobalObject* g
     uint64_t count = globalContext->remainingElementsCount() - 1;
     globalContext->setRemainingElementsCount(count);
     if (!count) {
-        MarkedArgumentBuffer resolveArguments;
-        resolveArguments.append(values);
-        ASSERT(!resolveArguments.hasOverflowed());
+        auto resolveArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(values),
+        });
         auto resolveCallData = getCallDataInline(resolve);
         scope.release();
-        call(globalObject, resolve, resolveCallData, jsUndefined(), resolveArguments);
+        call(globalObject, resolve, resolveCallData, jsUndefined(), ArgList { resolveArguments.data(), resolveArguments.size() });
     }
 
     return JSValue::encode(jsUndefined());
@@ -1106,12 +1106,12 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
     RETURN_IF_EXCEPTION(scope, { });
 
     auto callReject = [&](JSValue exception) -> void {
-        MarkedArgumentBuffer rejectArguments;
-        rejectArguments.append(exception);
-        ASSERT(!rejectArguments.hasOverflowed());
+        auto rejectArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(exception),
+        });
         auto rejectCallData = getCallDataInline(reject);
         scope.release();
-        call(globalObject, reject, rejectCallData, jsUndefined(), rejectArguments);
+        call(globalObject, reject, rejectCallData, jsUndefined(), ArgList { rejectArguments.data(), rejectArguments.size() });
     };
     auto callRejectWithScopeException = [&]() -> void {
         Exception* exception = scope.exception();
@@ -1166,10 +1166,10 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
             nextPromise = cachedCall->callWithArguments(globalObject, thisValue, value);
             RETURN_IF_EXCEPTION(scope, void());
         } else {
-            MarkedArgumentBuffer arguments;
-            arguments.append(value);
-            ASSERT(!arguments.hasOverflowed());
-            nextPromise = call(globalObject, promiseResolveValue, promiseResolveCallData, thisValue, arguments);
+            auto arguments = WTF::toArray<EncodedJSValue>({
+                JSValue::encode(value),
+            });
+            nextPromise = call(globalObject, promiseResolveValue, promiseResolveCallData, thisValue, ArgList { arguments.data(), arguments.size() });
             RETURN_IF_EXCEPTION(scope, void());
         }
 
@@ -1190,12 +1190,12 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
             return;
         }
 
-        MarkedArgumentBuffer thenArguments;
-        thenArguments.append(resolve);
-        thenArguments.append(onRejected);
-        ASSERT(!thenArguments.hasOverflowed());
+        auto thenArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(resolve),
+            JSValue::encode(onRejected),
+        });
         scope.release();
-        call(globalObject, then, thenCallData, nextPromise, thenArguments);
+        call(globalObject, then, thenCallData, nextPromise, ArgList { thenArguments.data(), thenArguments.size() });
         ++index;
     });
 
@@ -1300,12 +1300,12 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
             return;
         }
 
-        MarkedArgumentBuffer thenArguments;
-        thenArguments.append(resolve);
-        thenArguments.append(onRejected);
-        ASSERT(!thenArguments.hasOverflowed());
+        auto thenArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(resolve),
+            JSValue::encode(onRejected),
+        });
         scope.release();
-        call(globalObject, then, thenCallData, nextPromise, thenArguments);
+        call(globalObject, then, thenCallData, nextPromise, ArgList { thenArguments.data(), thenArguments.size() });
         ++index;
     });
 
@@ -1390,12 +1390,12 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnySlowRejectFunction, (JSGlobalObject* globalOb
     globalContext->setRemainingElementsCount(count);
     if (!count) {
         auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
-        MarkedArgumentBuffer rejectArguments;
-        rejectArguments.append(aggregateError);
-        ASSERT(!rejectArguments.hasOverflowed());
+        auto rejectArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(aggregateError),
+        });
         auto rejectCallData = getCallDataInline(reject);
         scope.release();
-        call(globalObject, reject, rejectCallData, jsUndefined(), rejectArguments);
+        call(globalObject, reject, rejectCallData, jsUndefined(), ArgList { rejectArguments.data(), rejectArguments.size() });
     }
 
     return JSValue::encode(jsUndefined());

--- a/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
@@ -145,11 +145,11 @@ JSC_DEFINE_HOST_FUNCTION(promiseProtoFuncCatch, (JSGlobalObject* globalObject, C
     auto thenCallData = getCallDataInline(then);
     if (thenCallData.type == CallData::Type::None) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "|this|.then is not a function"_s);
-    MarkedArgumentBuffer thenArguments;
-    thenArguments.append(jsUndefined());
-    thenArguments.append(onRejected);
-    ASSERT(!thenArguments.hasOverflowed());
-    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, thisValue, thenArguments)));
+    auto thenArguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(jsUndefined()),
+        JSValue::encode(onRejected),
+    });
+    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, thisValue, ArgList { thenArguments.data(), thenArguments.size() })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(promiseFinallyValueThunkFunc, (JSGlobalObject*, CallFrame* callFrame))
@@ -193,11 +193,11 @@ JSC_DEFINE_HOST_FUNCTION(promiseFinallyThenFinallyFunc, (JSGlobalObject* globalO
     auto thenCallData = getCallDataInline(then);
     if (thenCallData.type == CallData::Type::None)
         return throwVMTypeError(globalObject, scope, "|this|.then is not a function"_s);
-    MarkedArgumentBuffer thenArgs;
-    thenArgs.append(valueThunk);
-    thenArgs.append(jsUndefined());
-    ASSERT(!thenArgs.hasOverflowed());
-    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, resolvedPromise, thenArgs)));
+    auto thenArgs = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(valueThunk),
+        JSValue::encode(jsUndefined()),
+    });
+    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, resolvedPromise, ArgList { thenArgs.data(), thenArgs.size() })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(promiseFinallyCatchFinallyFunc, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -225,11 +225,11 @@ JSC_DEFINE_HOST_FUNCTION(promiseFinallyCatchFinallyFunc, (JSGlobalObject* global
     auto thenCallData = getCallDataInline(then);
     if (thenCallData.type == CallData::Type::None)
         return throwVMTypeError(globalObject, scope, "|this|.then is not a function"_s);
-    MarkedArgumentBuffer thenArgs;
-    thenArgs.append(thrower);
-    thenArgs.append(jsUndefined());
-    ASSERT(!thenArgs.hasOverflowed());
-    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, resolvedPromise, thenArgs)));
+    auto thenArgs = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(thrower),
+        JSValue::encode(jsUndefined()),
+    });
+    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, resolvedPromise, ArgList { thenArgs.data(), thenArgs.size() })));
 }
 
 static EncodedJSValue promiseProtoFuncFinallySlow(JSGlobalObject* globalObject, JSValue thisValue, JSValue onFinally)
@@ -248,11 +248,11 @@ static EncodedJSValue promiseProtoFuncFinallySlow(JSGlobalObject* globalObject, 
         return throwVMTypeError(globalObject, scope, "|this|.then is not a function"_s);
 
     if (!onFinally.isCallable()) {
-        MarkedArgumentBuffer thenArguments;
-        thenArguments.append(onFinally);
-        thenArguments.append(onFinally);
-        ASSERT(!thenArguments.hasOverflowed());
-        RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, thisValue, thenArguments)));
+        auto thenArguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(onFinally),
+            JSValue::encode(onFinally),
+        });
+        RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, thisValue, ArgList { thenArguments.data(), thenArguments.size() })));
     }
 
     NativeExecutable* thenFinallyExecutable = vm.getHostFunction(promiseFinallyThenFinallyFunc, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, nullString());
@@ -265,11 +265,11 @@ static EncodedJSValue promiseProtoFuncFinallySlow(JSGlobalObject* globalObject, 
     catchFinally->setField(vm, JSFunctionWithFields::Field::ResolvingPromise, onFinally);
     catchFinally->setField(vm, JSFunctionWithFields::Field::ResolvingOther, constructor);
 
-    MarkedArgumentBuffer thenArguments;
-    thenArguments.append(thenFinally);
-    thenArguments.append(catchFinally);
-    ASSERT(!thenArguments.hasOverflowed());
-    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, thisValue, thenArguments)));
+    auto thenArguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(thenFinally),
+        JSValue::encode(catchFinally),
+    });
+    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, thisValue, ArgList { thenArguments.data(), thenArguments.size() })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(promiseProtoFuncFinally, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp
@@ -115,10 +115,10 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayConstructorOf, (JSGlobalObject* globalObject,
     FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(JSC_TYPED_ARRAY_OF_FAST)
 #undef JSC_TYPED_ARRAY_OF_FAST
 
-    MarkedArgumentBuffer args;
-    args.append(jsNumber(length));
-    ASSERT(!args.hasOverflowed());
-    JSObject* constructed = construct(globalObject, thisValue, args, "TypedArray.of requires |this| to be a constructor"_s);
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(jsNumber(length)),
+    });
+    JSObject* constructed = construct(globalObject, thisValue, ArgList { args.data(), args.size() }, "TypedArray.of requires |this| to be a constructor"_s);
     RETURN_IF_EXCEPTION(scope, { });
 
     JSArrayBufferView* view = validateTypedArray(globalObject, constructed);

--- a/Source/JavaScriptCore/runtime/MapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/MapConstructor.cpp
@@ -119,11 +119,11 @@ JSC_DEFINE_HOST_FUNCTION(constructMap, (JSGlobalObject* globalObject, CallFrame*
             return;
         }
 
-        MarkedArgumentBuffer arguments;
-        arguments.append(key);
-        arguments.append(value);
-        ASSERT(!arguments.hasOverflowed());
-        call(globalObject, adderFunction, adderFunctionCallData, map, arguments);
+        auto arguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(key),
+            JSValue::encode(value),
+        });
+        call(globalObject, adderFunction, adderFunctionCallData, map, ArgList { arguments.data(), arguments.size() });
     });
 
     return JSValue::encode(map);

--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -227,11 +227,11 @@ JSC_DEFINE_HOST_FUNCTION(mapProtoFuncGetOrInsertComputed, (JSGlobalObject* globa
             return cachedCall.callWithArguments(globalObject, jsUndefined(), key);
         }
 
-        MarkedArgumentBuffer args;
-        args.append(key);
-        ASSERT(!args.hasOverflowed());
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(key),
+        });
 
-        return call(globalObject, valueCallback, callData, jsUndefined(), args);
+        return call(globalObject, valueCallback, callData, jsUndefined(), ArgList { args.data(), args.size() });
     })));
 }
 

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -188,12 +188,12 @@ static JSValue performProxyGet(JSGlobalObject* globalObject, ProxyObject* proxyO
     if (!getHandler)
         return performDefaultGet();
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    arguments.append(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid())));
-    arguments.append(receiver.toThis(globalObject, ECMAMode::strict()));
-    ASSERT(!arguments.hasOverflowed());
-    JSValue trapResult = call(globalObject, getHandler, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+        JSValue::encode(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid()))),
+        JSValue::encode(receiver.toThis(globalObject, ECMAMode::strict())),
+    });
+    JSValue trapResult = call(globalObject, getHandler, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, { });
 
     if (target->structure()->hasNonConfigurableReadOnlyOrGetterSetterProperties()) {
@@ -294,11 +294,11 @@ bool ProxyObject::performInternalMethodGetOwnProperty(JSGlobalObject* globalObje
     if (!getOwnPropertyDescriptorMethod)
         RELEASE_AND_RETURN(scope, performDefaultGetOwnProperty());
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    arguments.append(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid())));
-    ASSERT(!arguments.hasOverflowed());
-    JSValue trapResult = call(globalObject, getOwnPropertyDescriptorMethod, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+        JSValue::encode(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid()))),
+    });
+    JSValue trapResult = call(globalObject, getOwnPropertyDescriptorMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, false);
 
     if (trapResult.isUndefined() && !target->structure()->isNonExtensibleOrHasNonConfigurableProperties())
@@ -401,11 +401,11 @@ bool ProxyObject::performHasProperty(JSGlobalObject* globalObject, PropertyName 
     if (!hasMethod)
         RELEASE_AND_RETURN(scope, performDefaultHasProperty());
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    arguments.append(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid())));
-    ASSERT(!arguments.hasOverflowed());
-    JSValue trapResult = call(globalObject, hasMethod, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+        JSValue::encode(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid()))),
+    });
+    JSValue trapResult = call(globalObject, hasMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, false);
 
     bool trapResultAsBool = trapResult.toBoolean(globalObject);
@@ -517,13 +517,13 @@ bool ProxyObject::performPut(JSGlobalObject* globalObject, JSValue putValue, JSV
     if (!setMethod)
         RELEASE_AND_RETURN(scope, performDefaultPut());
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    arguments.append(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid())));
-    arguments.append(putValue);
-    arguments.append(thisValue.toThis(globalObject, ECMAMode::strict()));
-    ASSERT(!arguments.hasOverflowed());
-    JSValue trapResult = call(globalObject, setMethod, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+        JSValue::encode(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid()))),
+        JSValue::encode(putValue),
+        JSValue::encode(thisValue.toThis(globalObject, ECMAMode::strict())),
+    });
+    JSValue trapResult = call(globalObject, setMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, false);
 
     bool trapResultAsBool = trapResult.toBoolean(globalObject);
@@ -627,12 +627,12 @@ JSC_DEFINE_HOST_FUNCTION(performProxyCall, (JSGlobalObject* globalObject, CallFr
 
     JSArray* argArray = constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), ArgList(callFrame));
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    arguments.append(callFrame->thisValue().toThis(globalObject, ECMAMode::strict()));
-    arguments.append(argArray);
-    ASSERT(!arguments.hasOverflowed());
-    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, applyMethod, callData, handler, arguments)));
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+        JSValue::encode(callFrame->thisValue().toThis(globalObject, ECMAMode::strict())),
+        JSValue::encode(argArray),
+    });
+    RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, applyMethod, callData, handler, ArgList { arguments.data(), arguments.size() })));
 }
 
 CallData ProxyObject::getCallData(JSCell* cell)
@@ -679,12 +679,12 @@ JSC_DEFINE_HOST_FUNCTION(performProxyConstruct, (JSGlobalObject* globalObject, C
 
     JSArray* argArray = constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), ArgList(callFrame));
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    arguments.append(argArray);
-    arguments.append(callFrame->newTarget());
-    ASSERT(!arguments.hasOverflowed());
-    JSValue result = call(globalObject, constructMethod, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+        JSValue::encode(argArray),
+        JSValue::encode(callFrame->newTarget()),
+    });
+    JSValue result = call(globalObject, constructMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     if (!result.isObject())
         // Proxies, unlike other spec provided callable/constructable objects,
@@ -736,11 +736,11 @@ bool ProxyObject::performDelete(JSGlobalObject* globalObject, PropertyName prope
     if (deletePropertyMethod.isUndefined())
         RELEASE_AND_RETURN(scope, performDefaultDelete());
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    arguments.append(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid())));
-    ASSERT(!arguments.hasOverflowed());
-    JSValue trapResult = call(globalObject, deletePropertyMethod, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+        JSValue::encode(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid()))),
+    });
+    JSValue trapResult = call(globalObject, deletePropertyMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, false);
 
     bool trapResultAsBool = trapResult.toBoolean(globalObject);
@@ -820,10 +820,10 @@ bool ProxyObject::performPreventExtensions(JSGlobalObject* globalObject)
     if (preventExtensionsMethod.isUndefined())
         RELEASE_AND_RETURN(scope, target->methodTable()->preventExtensions(target, globalObject));
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    ASSERT(!arguments.hasOverflowed());
-    JSValue trapResult = call(globalObject, preventExtensionsMethod, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+    });
+    JSValue trapResult = call(globalObject, preventExtensionsMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, false);
 
     bool trapResultAsBool = trapResult.toBoolean(globalObject);
@@ -872,10 +872,10 @@ bool ProxyObject::performIsExtensible(JSGlobalObject* globalObject)
     if (isExtensibleMethod.isUndefined())
         RELEASE_AND_RETURN(scope, target->isExtensible(globalObject));
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    ASSERT(!arguments.hasOverflowed());
-    JSValue trapResult = call(globalObject, isExtensibleMethod, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+    });
+    JSValue trapResult = call(globalObject, isExtensibleMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, false);
 
     bool trapResultAsBool = trapResult.toBoolean(globalObject);
@@ -940,12 +940,12 @@ bool ProxyObject::performDefineOwnProperty(JSGlobalObject* globalObject, Propert
     scope.assertNoException();
     ASSERT(descriptorObject);
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    arguments.append(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid())));
-    arguments.append(descriptorObject);
-    ASSERT(!arguments.hasOverflowed());
-    JSValue trapResult = call(globalObject, definePropertyMethod, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+        JSValue::encode(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid()))),
+        JSValue::encode(descriptorObject),
+    });
+    JSValue trapResult = call(globalObject, definePropertyMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, false);
 
     bool trapResultAsBool = trapResult.toBoolean(globalObject);
@@ -1058,10 +1058,10 @@ void ProxyObject::performGetOwnPropertyNames(JSGlobalObject* globalObject, Prope
         return;
     }
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    ASSERT(!arguments.hasOverflowed());
-    JSValue trapResult = call(globalObject, ownKeysMethod, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+    });
+    JSValue trapResult = call(globalObject, ownKeysMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, void());
 
     if (!trapResult.isObject()) {
@@ -1190,11 +1190,11 @@ bool ProxyObject::performSetPrototype(JSGlobalObject* globalObject, JSValue prot
     if (setPrototypeOfMethod.isUndefined())
         RELEASE_AND_RETURN(scope, target->setPrototype(vm, globalObject, prototype, shouldThrowIfCantSet));
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    arguments.append(prototype);
-    ASSERT(!arguments.hasOverflowed());
-    JSValue trapResult = call(globalObject, setPrototypeOfMethod, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+        JSValue::encode(prototype),
+    });
+    JSValue trapResult = call(globalObject, setPrototypeOfMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, false);
 
     bool trapResultAsBool = trapResult.toBoolean(globalObject);
@@ -1254,10 +1254,10 @@ JSValue ProxyObject::performGetPrototype(JSGlobalObject* globalObject)
     if (getPrototypeOfMethod.isUndefined()) 
         RELEASE_AND_RETURN(scope, target->getPrototype(globalObject));
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(target);
-    ASSERT(!arguments.hasOverflowed());
-    JSValue trapResult = call(globalObject, getPrototypeOfMethod, callData, handler, arguments);
+    auto arguments = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(target),
+    });
+    JSValue trapResult = call(globalObject, getPrototypeOfMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, { });
 
     if (!trapResult.isObject() && !trapResult.isNull()) {

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -127,10 +127,10 @@ JSValue regExpExec(JSGlobalObject* globalObject, JSValue thisValue, JSString* st
             match = cachedCall.callWithArguments(globalObject, thisValue, str);
             RETURN_IF_EXCEPTION(scope, { });
         } else {
-            MarkedArgumentBuffer args;
-            args.append(str);
-            ASSERT(!args.hasOverflowed());
-            match = call(globalObject, regExpExec, callData, thisValue, args);
+            auto args = WTF::toArray<EncodedJSValue>({
+                JSValue::encode(str),
+            });
+            match = call(globalObject, regExpExec, callData, thisValue, ArgList { args.data(), args.size() });
             RETURN_IF_EXCEPTION(scope, { });
         }
         if (!match.isNull() && !match.isObject()) {
@@ -139,10 +139,10 @@ JSValue regExpExec(JSGlobalObject* globalObject, JSValue thisValue, JSString* st
         }
     } else {
         auto callData = JSC::getCallDataInline(regExpBuiltinExec);
-        MarkedArgumentBuffer args;
-        args.append(str);
-        ASSERT(!args.hasOverflowed());
-        match = call(globalObject, regExpBuiltinExec, callData, thisValue, args);
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(str),
+        });
+        match = call(globalObject, regExpBuiltinExec, callData, thisValue, ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION(scope, { });
     }
 
@@ -1169,12 +1169,12 @@ JSValue regExpSplitSlow(JSGlobalObject* globalObject, JSObject* thisObject, JSSt
     }
 
     // 10. Let splitter be ? Construct(speciesCtor, « regexp, newFlags »).
-    MarkedArgumentBuffer constructorArgs;
-    constructorArgs.append(thisValue);
-    constructorArgs.append(jsString(vm, newFlags));
-    ASSERT(!constructorArgs.hasOverflowed());
+    auto constructorArgs = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(thisValue),
+        JSValue::encode(jsString(vm, newFlags)),
+    });
     auto constructData = JSC::getConstructDataInline(speciesConstructor);
-    JSObject* splitter = construct(globalObject, speciesConstructor, constructData, constructorArgs);
+    JSObject* splitter = construct(globalObject, speciesConstructor, constructData, ArgList { constructorArgs.data(), constructorArgs.size() });
     RETURN_IF_EXCEPTION(scope, { });
 
     // After Construct, re-check whether the splitter is a primordial RegExpObject with non-observable
@@ -1771,13 +1771,13 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncMatchAll, (JSGlobalObject* globalObject,
     String flags = flagsValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    MarkedArgumentBuffer constructorArgs;
-    constructorArgs.append(thisValue);
-    constructorArgs.append(jsString(vm, flags));
-    ASSERT(!constructorArgs.hasOverflowed());
+    auto constructorArgs = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(thisValue),
+        JSValue::encode(jsString(vm, flags)),
+    });
 
     auto constructData = JSC::getConstructDataInline(constructor);
-    JSObject* matcher = construct(globalObject, constructor, constructData, constructorArgs);
+    JSObject* matcher = construct(globalObject, constructor, constructData, ArgList { constructorArgs.data(), constructorArgs.size() });
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue lastIndexValue = thisObject->get(globalObject, vm.propertyNames->lastIndex);

--- a/Source/JavaScriptCore/runtime/SetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SetConstructor.cpp
@@ -99,10 +99,10 @@ JSC_DEFINE_HOST_FUNCTION(constructSet, (JSGlobalObject* globalObject, CallFrame*
             return;
         }
 
-        MarkedArgumentBuffer arguments;
-        arguments.append(nextValue);
-        ASSERT(!arguments.hasOverflowed());
-        call(globalObject, adderFunction, adderFunctionCallData, set, arguments);
+        auto arguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(nextValue),
+        });
+        call(globalObject, adderFunction, adderFunctionCallData, set, ArgList { arguments.data(), arguments.size() });
     });
 
     return JSValue::encode(set);

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -299,10 +299,10 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
                 hasResult = cachedHasCall->callWithArguments(globalObject, otherValue, entryKey);
                 RETURN_IF_EXCEPTION(scope, void());
             } else {
-                MarkedArgumentBuffer args;
-                args.append(entryKey);
-                ASSERT(!args.hasOverflowed());
-                hasResult = call(globalObject, has, hasCallData, otherValue, args);
+                auto args = WTF::toArray<EncodedJSValue>({
+                    JSValue::encode(entryKey),
+                });
+                hasResult = call(globalObject, has, hasCallData, otherValue, ArgList { args.data(), args.size() });
                 RETURN_IF_EXCEPTION(scope, void());
             }
 
@@ -317,9 +317,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
     }
 
     CallData keysCallData = JSC::getCallDataInline(keys);
-    MarkedArgumentBuffer args;
-    ASSERT(!args.hasOverflowed());
-    JSValue iterator = call(globalObject, keys, keysCallData, otherValue, args);
+    JSValue iterator = call(globalObject, keys, keysCallData, otherValue, ArgList { });
     RETURN_IF_EXCEPTION(scope, { });
 
     scope.release();
@@ -390,9 +388,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncUnion, (JSGlobalObject* globalObject, CallF
         return throwVMTypeError(globalObject, scope, "Set.prototype.union expects other.keys to be callable"_s);
 
     CallData keysCallData = JSC::getCallDataInline(keys);
-    MarkedArgumentBuffer args;
-    ASSERT(!args.hasOverflowed());
-    JSValue iterator = call(globalObject, keys, keysCallData, otherValue, args);
+    JSValue iterator = call(globalObject, keys, keysCallData, otherValue, ArgList { });
     RETURN_IF_EXCEPTION(scope, { });
 
     IterationRecord iterationRecord = iteratorDirect(globalObject, iterator);
@@ -515,10 +511,10 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
                 hasResult = cachedHasCall->callWithArguments(globalObject, otherValue, entryKey);
                 RETURN_IF_EXCEPTION(scope, void());
             } else {
-                MarkedArgumentBuffer hasArgs;
-                hasArgs.append(entryKey);
-                ASSERT(!hasArgs.hasOverflowed());
-                hasResult = call(globalObject, has, hasCallData, otherValue, hasArgs);
+                auto hasArgs = WTF::toArray<EncodedJSValue>({
+                    JSValue::encode(entryKey),
+                });
+                hasResult = call(globalObject, has, hasCallData, otherValue, ArgList { hasArgs.data(), hasArgs.size() });
                 RETURN_IF_EXCEPTION(scope, void());
             }
 
@@ -533,9 +529,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
     }
 
     CallData keysCallData = JSC::getCallDataInline(keys);
-    MarkedArgumentBuffer keysArgs;
-    ASSERT(!keysArgs.hasOverflowed());
-    JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, keysArgs);
+    JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, ArgList { });
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue nextMethod = keysResult.get(globalObject, vm.propertyNames->next);
@@ -557,9 +551,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
             nextResult = cachedNextCall->callWithArguments(globalObject, keysResult);
             RETURN_IF_EXCEPTION(scope, { });
         } else {
-            MarkedArgumentBuffer nextArgs;
-            ASSERT(!nextArgs.hasOverflowed());
-            nextResult = call(globalObject, nextMethod, nextCallData, keysResult, nextArgs);
+            nextResult = call(globalObject, nextMethod, nextCallData, keysResult, ArgList { });
             RETURN_IF_EXCEPTION(scope, { });
         }
 
@@ -652,9 +644,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncSymmetricDifference, (JSGlobalObject* globa
         return throwVMTypeError(globalObject, scope, "Set.prototype.symmetricDifference expects other.keys to be callable"_s);
 
     CallData keysCallData = JSC::getCallDataInline(keys);
-    MarkedArgumentBuffer keysArgs;
-    ASSERT(!keysArgs.hasOverflowed());
-    JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, keysArgs);
+    JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, ArgList { });
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue nextMethod = keysResult.get(globalObject, vm.propertyNames->next);
@@ -679,9 +669,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncSymmetricDifference, (JSGlobalObject* globa
             nextResult = cachedNextCall->callWithArguments(globalObject, keysResult);
             RETURN_IF_EXCEPTION(scope, { });
         } else {
-            MarkedArgumentBuffer nextArgs;
-            ASSERT(!nextArgs.hasOverflowed());
-            nextResult = call(globalObject, nextMethod, nextCallData, keysResult, nextArgs);
+            nextResult = call(globalObject, nextMethod, nextCallData, keysResult, ArgList { });
             RETURN_IF_EXCEPTION(scope, { });
         }
 
@@ -771,10 +759,10 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSubsetOf, (JSGlobalObject* globalObject, 
             hasResult = cachedHasCall->callWithArguments(globalObject, otherValue, entryKey);
             RETURN_IF_EXCEPTION(scope, IterationStatus::Done);
         } else {
-            MarkedArgumentBuffer args;
-            args.append(entryKey);
-            ASSERT(!args.hasOverflowed());
-            hasResult = call(globalObject, has, hasCallData, otherValue, args);
+            auto args = WTF::toArray<EncodedJSValue>({
+                JSValue::encode(entryKey),
+            });
+            hasResult = call(globalObject, has, hasCallData, otherValue, ArgList { args.data(), args.size() });
             RETURN_IF_EXCEPTION(scope, IterationStatus::Done);
         }
 
@@ -852,9 +840,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSupersetOf, (JSGlobalObject* globalObject
         return JSValue::encode(jsBoolean(false));
 
     CallData keysCallData = JSC::getCallDataInline(keys);
-    MarkedArgumentBuffer keysArgs;
-    ASSERT(!keysArgs.hasOverflowed());
-    JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, keysArgs);
+    JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, ArgList { });
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue nextMethod = keysResult.get(globalObject, vm.propertyNames->next);
@@ -876,9 +862,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSupersetOf, (JSGlobalObject* globalObject
             nextResult = cachedNextCall->callWithArguments(globalObject, keysResult);
             RETURN_IF_EXCEPTION(scope, { });
         } else {
-            MarkedArgumentBuffer nextArgs;
-            ASSERT(!nextArgs.hasOverflowed());
-            nextResult = call(globalObject, nextMethod, nextCallData, keysResult, nextArgs);
+            nextResult = call(globalObject, nextMethod, nextCallData, keysResult, ArgList { });
             RETURN_IF_EXCEPTION(scope, { });
         }
 
@@ -993,10 +977,10 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
                 hasResult = cachedHasCall->callWithArguments(globalObject, otherValue, entryKey);
                 RETURN_IF_EXCEPTION(scope, IterationStatus::Done);
             } else {
-                MarkedArgumentBuffer hasArgs;
-                hasArgs.append(entryKey);
-                ASSERT(!hasArgs.hasOverflowed());
-                hasResult = call(globalObject, has, hasCallData, otherValue, hasArgs);
+                auto hasArgs = WTF::toArray<EncodedJSValue>({
+                    JSValue::encode(entryKey),
+                });
+                hasResult = call(globalObject, has, hasCallData, otherValue, ArgList { hasArgs.data(), hasArgs.size() });
                 RETURN_IF_EXCEPTION(scope, IterationStatus::Done);
             }
 
@@ -1012,9 +996,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
     }
 
     CallData keysCallData = JSC::getCallDataInline(keys);
-    MarkedArgumentBuffer keysArgs;
-    ASSERT(!keysArgs.hasOverflowed());
-    JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, keysArgs);
+    JSValue keysResult = call(globalObject, keys, keysCallData, otherValue, ArgList { });
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue nextMethod = keysResult.get(globalObject, vm.propertyNames->next);
@@ -1036,9 +1018,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
             nextResult = cachedNextCall->callWithArguments(globalObject, keysResult);
             RETURN_IF_EXCEPTION(scope, { });
         } else {
-            MarkedArgumentBuffer nextArgs;
-            ASSERT(!nextArgs.hasOverflowed());
-            nextResult = call(globalObject, nextMethod, nextCallData, keysResult, nextArgs);
+            nextResult = call(globalObject, nextMethod, nextCallData, keysResult, ArgList { });
             RETURN_IF_EXCEPTION(scope, { });
         }
 

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -627,10 +627,10 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncReplace, (JSGlobalObject* globalObject, 
             auto callData = JSC::getCallData(replacer);
             if (callData.type == CallData::Type::None) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "@@replace method is not callable"_s);
-            std::array<EncodedJSValue, 2> args { {
+            auto args = WTF::toArray<EncodedJSValue>({
                 JSValue::encode(thisValue),
                 JSValue::encode(callFrame->argument(1)),
-            } };
+            });
             RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, replacer, callData, searchValue, ArgList { args.data(), args.size() })));
         }
     }
@@ -703,10 +703,10 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncReplaceAll, (JSGlobalObject* globalObjec
             auto callData = JSC::getCallData(replacer);
             if (callData.type == CallData::Type::None) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "@@replace method is not callable"_s);
-            std::array<EncodedJSValue, 2> args { {
+            auto args = WTF::toArray<EncodedJSValue>({
                 JSValue::encode(thisValue),
                 JSValue::encode(callFrame->argument(1)),
-            } };
+            });
             RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, replacer, callData, searchValue, ArgList { args.data(), args.size() })));
         }
     }
@@ -1269,10 +1269,10 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplit, (JSGlobalObject* globalObject, Ca
             auto callData = JSC::getCallData(splitter);
             if (callData.type == CallData::Type::None) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "@@split method is not callable"_s);
-            std::array<EncodedJSValue, 2> args { {
+            auto args = WTF::toArray<EncodedJSValue>({
                 JSValue::encode(thisValue),
                 JSValue::encode(limitValue),
-            } };
+            });
             JSValue result = call(globalObject, splitter, callData, separatorValue, ArgList { args.data(), args.size() });
             RETURN_IF_EXCEPTION(scope, { });
             return JSValue::encode(result);
@@ -1295,9 +1295,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplit, (JSGlobalObject* globalObject, Ca
             RELEASE_AND_RETURN(scope, JSValue::encode(constructEmptyArray(globalObject, nullptr)));
         auto input = thisString->value(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        std::array<EncodedJSValue, 1> args { {
+        auto args = WTF::toArray<EncodedJSValue>({
             JSValue::encode(jsStringWithReuse(globalObject, thisString, input))
-        } };
+        });
         RETURN_IF_EXCEPTION(scope, { });
         RELEASE_AND_RETURN(scope, JSValue::encode(constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), ArgList { args.data(), args.size() })));
     }
@@ -1329,9 +1329,9 @@ JSValue stringMatchSlow(JSGlobalObject* globalObject, JSString* thisString, JSVa
         throwTypeError(globalObject, scope, makeString(description, " is not a function"_s));
         return { };
     }
-    std::array<EncodedJSValue, 1> args { {
+    auto args = WTF::toArray<EncodedJSValue>({
         JSValue::encode(thisString),
-    } };
+    });
     RELEASE_AND_RETURN(scope, call(globalObject, matcher, callData, regExpObject, ArgList { args.data(), args.size() }));
 }
 
@@ -1355,9 +1355,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncMatch, (JSGlobalObject* globalObject, Ca
             JSValue matcher = globalObject->linkTimeConstant(LinkTimeConstant::regExpPrototypeSymbolMatch);
             auto callData = JSC::getCallData(matcher);
             ASSERT(callData.type != CallData::Type::None);
-            std::array<EncodedJSValue, 1> args { {
+            auto args = WTF::toArray<EncodedJSValue>({
                 JSValue::encode(thisString),
-            } };
+            });
             RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, matcher, callData, regExpObject, ArgList { args.data(), args.size() })));
         }
 
@@ -1371,9 +1371,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncMatch, (JSGlobalObject* globalObject, Ca
                 RETURN_IF_EXCEPTION(scope, { });
                 return throwVMTypeError(globalObject, scope, makeString(description, " is not a function"_s));
             }
-            std::array<EncodedJSValue, 1> args { {
+            auto args = WTF::toArray<EncodedJSValue>({
                 JSValue::encode(thisValue),
-            } };
+            });
             RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, matcher, callData, regexpValue, ArgList { args.data(), args.size() })));
         }
     }
@@ -1404,9 +1404,9 @@ JSValue stringSearchSlow(JSGlobalObject* globalObject, JSString* thisString, JSV
         throwTypeError(globalObject, scope, makeString(description, " is not a function"_s));
         return { };
     }
-    std::array<EncodedJSValue, 1> args { {
+    auto args = WTF::toArray<EncodedJSValue>({
         JSValue::encode(thisString),
-    } };
+    });
     RELEASE_AND_RETURN(scope, call(globalObject, searcher, callData, createdRegExp, ArgList { args.data(), args.size() }));
 }
 
@@ -1454,9 +1454,9 @@ JSValue stringMatchAllSlow(JSGlobalObject* globalObject, JSString* thisString, J
         throwTypeError(globalObject, scope, makeString(description, " is not a function"_s));
         return { };
     }
-    std::array<EncodedJSValue, 1> args { {
+    auto args = WTF::toArray<EncodedJSValue>({
         JSValue::encode(thisString),
-    } };
+    });
     RELEASE_AND_RETURN(scope, call(globalObject, matchAllMethod, callData, regExpObject, ArgList { args.data(), args.size() }));
 }
 
@@ -1493,9 +1493,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSearch, (JSGlobalObject* globalObject, C
                 RETURN_IF_EXCEPTION(scope, { });
                 return throwVMTypeError(globalObject, scope, makeString(description, " is not a function"_s));
             }
-            std::array<EncodedJSValue, 1> args { {
+            auto args = WTF::toArray<EncodedJSValue>({
                 JSValue::encode(thisValue),
-            } };
+            });
             RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, searcher, callData, regexpValue, ArgList { args.data(), args.size() })));
         }
     }
@@ -1547,9 +1547,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncMatchAll, (JSGlobalObject* globalObject,
             JSValue matcher = globalObject->linkTimeConstant(LinkTimeConstant::regExpPrototypeSymbolMatchAll);
             auto callData = JSC::getCallData(matcher);
             ASSERT(callData.type != CallData::Type::None);
-            std::array<EncodedJSValue, 1> args { {
+            auto args = WTF::toArray<EncodedJSValue>({
                 JSValue::encode(thisString),
-            } };
+            });
             RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, matcher, callData, regExpObject, ArgList { args.data(), args.size() })));
         }
 
@@ -1574,9 +1574,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncMatchAll, (JSGlobalObject* globalObject,
                 RETURN_IF_EXCEPTION(scope, { });
                 return throwVMTypeError(globalObject, scope, makeString(description, " is not a function"_s));
             }
-            std::array<EncodedJSValue, 1> args { {
+            auto args = WTF::toArray<EncodedJSValue>({
                 JSValue::encode(thisValue),
-            } };
+            });
             RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, matcher, callData, regexpValue, ArgList { args.data(), args.size() })));
         }
     }

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -545,14 +545,14 @@ inline JSString* replaceUsingStringSearch(VM& vm, JSGlobalObject* globalObject, 
             replacement = cachedCall->callWithArguments(globalObject, jsUndefined(), substring, jsNumber(matchStart), jsString);
             RETURN_IF_EXCEPTION(scope, nullptr);
         } else {
-            MarkedArgumentBuffer args;
             auto* substring = jsSubstring(globalObject, vm, jsString, matchStart, searchString.impl()->length());
             RETURN_IF_EXCEPTION(scope, nullptr);
-            args.append(substring);
-            args.append(jsNumber(matchStart));
-            args.append(jsString);
-            ASSERT(!args.hasOverflowed());
-            replacement = call(globalObject, replaceValue, callData, jsUndefined(), args);
+            auto args = WTF::toArray<EncodedJSValue>({
+                JSValue::encode(substring),
+                JSValue::encode(jsNumber(matchStart)),
+                JSValue::encode(jsString),
+            });
+            replacement = call(globalObject, replaceValue, callData, jsUndefined(), ArgList { args.data(), args.size() });
             RETURN_IF_EXCEPTION(scope, nullptr);
         }
         replaceString = replacement.toWTFString(globalObject);

--- a/Source/JavaScriptCore/runtime/SyntheticModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/SyntheticModuleRecord.cpp
@@ -88,7 +88,7 @@ JSValue SyntheticModuleRecord::evaluate(JSGlobalObject*)
 }
 
 
-SyntheticModuleRecord* SyntheticModuleRecord::tryCreateWithExportNamesAndValues(JSGlobalObject* globalObject, const Identifier& moduleKey, const Vector<Identifier, 4>& exportNames, const MarkedArgumentBuffer& exportValues, SourceProviderSourceType sourceType)
+SyntheticModuleRecord* SyntheticModuleRecord::tryCreateWithExportNamesAndValues(JSGlobalObject* globalObject, const Identifier& moduleKey, const Vector<Identifier, 4>& exportNames, ArgList exportValues, SourceProviderSourceType sourceType)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -132,12 +132,11 @@ SyntheticModuleRecord* SyntheticModuleRecord::tryCreateDefaultExportSyntheticMod
     VM& vm = globalObject->vm();
 
     Vector<Identifier, 4> exportNames;
-    MarkedArgumentBuffer exportValues;
-
+    auto exportValues = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(defaultExport),
+    });
     exportNames.append(vm.propertyNames->defaultKeyword);
-    exportValues.appendWithCrashOnOverflow(defaultExport);
-
-    return tryCreateWithExportNamesAndValues(globalObject, moduleKey, exportNames, exportValues, sourceType);
+    return tryCreateWithExportNamesAndValues(globalObject, moduleKey, exportNames, ArgList { exportValues.data(), exportValues.size() }, sourceType);
 }
 
 SyntheticModuleRecord* SyntheticModuleRecord::parseJSONModule(JSGlobalObject* globalObject, const Identifier& moduleKey, SourceCode&& sourceCode)

--- a/Source/JavaScriptCore/runtime/SyntheticModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/SyntheticModuleRecord.h
@@ -65,7 +65,7 @@ private:
     SyntheticModuleRecord(VM&, Structure*, const Identifier& moduleKey, SourceProviderSourceType);
 
     static SyntheticModuleRecord* tryCreateDefaultExportSyntheticModule(JSGlobalObject*, const Identifier& moduleKey, JSValue, SourceProviderSourceType);
-    static SyntheticModuleRecord* tryCreateWithExportNamesAndValues(JSGlobalObject*, const Identifier& moduleKey, const Vector<Identifier, 4>& exportNames, const MarkedArgumentBuffer& exportValues, SourceProviderSourceType);
+    static SyntheticModuleRecord* tryCreateWithExportNamesAndValues(JSGlobalObject*, const Identifier& moduleKey, const Vector<Identifier, 4>& exportNames, ArgList exportValues, SourceProviderSourceType);
 
     void finishCreation(JSGlobalObject*, VM&);
 };

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1446,11 +1446,11 @@ void VM::callPromiseRejectionCallback(Strong<JSPromise>& promise)
     auto callData = JSC::getCallDataInline(callback);
     ASSERT(callData.type != CallData::Type::None);
 
-    MarkedArgumentBuffer args;
-    args.append(promise.get());
-    args.append(promise->result());
-    ASSERT(!args.hasOverflowed());
-    call(promise->realm(), callback, callData, jsNull(), args);
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(promise.get()),
+        JSValue::encode(promise->result()),
+    });
+    call(promise->realm(), callback, callData, jsNull(), ArgList { args.data(), args.size() });
     scope.clearException();
 }
 

--- a/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
@@ -104,12 +104,12 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakMap, (JSGlobalObject* globalObject, CallFr
             return;
         }
 
-        MarkedArgumentBuffer arguments;
-        arguments.append(key);
-        arguments.append(value);
-        ASSERT(!arguments.hasOverflowed());
+        auto arguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(key),
+            JSValue::encode(value),
+        });
         scope.release();
-        call(globalObject, adderFunction, adderFunctionCallData, weakMap, arguments);
+        call(globalObject, adderFunction, adderFunctionCallData, weakMap, ArgList { arguments.data(), arguments.size() });
     });
 
     return JSValue::encode(weakMap);

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
@@ -194,11 +194,11 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapGetOrInsertComputed, (JSGlobalObject* g
         value = cachedCall.callWithArguments(globalObject, jsUndefined(), key);
         RETURN_IF_EXCEPTION(scope, { });
     } else {
-        MarkedArgumentBuffer args;
-        args.append(key);
-        ASSERT(!args.hasOverflowed());
+        auto args = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(key),
+        });
 
-        value = call(globalObject, valueCallback, callData, jsUndefined(), args);
+        value = call(globalObject, valueCallback, callData, jsUndefined(), ArgList { args.data(), args.size() });
         RETURN_IF_EXCEPTION(scope, { });
     }
 

--- a/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
@@ -91,10 +91,10 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakSet, (JSGlobalObject* globalObject, CallFr
             return;
         }
 
-        MarkedArgumentBuffer arguments;
-        arguments.append(nextValue);
-        ASSERT(!arguments.hasOverflowed());
-        call(globalObject, adderFunction, adderFunctionCallData, weakSet, arguments);
+        auto arguments = WTF::toArray<EncodedJSValue>({
+            JSValue::encode(nextValue),
+        });
+        call(globalObject, adderFunction, adderFunctionCallData, weakSet, ArgList { arguments.data(), arguments.size() });
     });
 
     return JSValue::encode(weakSet);

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -1842,8 +1842,7 @@ JSC_DEFINE_CUSTOM_SETTER(customFunctionSetter, (JSGlobalObject* globalObject, En
         return false;
 
     auto callData = JSC::getCallData(function);
-    MarkedArgumentBuffer args;
-    call(globalObject, function, callData, jsUndefined(), args);
+    call(globalObject, function, callData, jsUndefined(), ArgList { });
 
     return true;
 }
@@ -3051,8 +3050,7 @@ static void callWithStackSizeProbeFunction(Probe::State* state)
     DollarVMAssertScope assertScope;
 
     auto callData = JSC::getCallData(function);
-    MarkedArgumentBuffer args;
-    call(globalObject, function, callData, jsUndefined(), args);
+    call(globalObject, function, callData, jsUndefined(), ArgList { });
 }
 #endif // ENABLE(ASSEMBLER) && OS(DARWIN) && CPU(X86_64)
 
@@ -3301,10 +3299,10 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForCompile, (JSGloba
         return throwVMTypeError(globalObject, scope, "First argument is not a JS function"_s);
 
     auto compiler = WasmStreamingCompiler::create(vm, globalObject, Wasm::CompilerMode::Validation, nullptr, source);
-    MarkedArgumentBuffer args;
-    args.append(compiler);
-    ASSERT(!args.hasOverflowed());
-    call(globalObject, callback, jsUndefined(), args, "You shouldn't see this..."_s);
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(compiler),
+    });
+    call(globalObject, callback, jsUndefined(), ArgList { args.data(), args.size() }, "You shouldn't see this..."_s);
     TRY_CLEAR_EXCEPTION(scope, { });
     compiler->streamingCompiler().finalize(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -3331,10 +3329,10 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiate, (JSG
         return throwVMTypeError(globalObject, scope);
 
     auto compiler = WasmStreamingCompiler::create(vm, globalObject, Wasm::CompilerMode::FullCompile, importObject, source);
-    MarkedArgumentBuffer args;
-    args.append(compiler);
-    ASSERT(!args.hasOverflowed());
-    call(globalObject, callback, jsUndefined(), args, "You shouldn't see this..."_s);
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(compiler),
+    });
+    call(globalObject, callback, jsUndefined(), ArgList { args.data(), args.size() }, "You shouldn't see this..."_s);
     TRY_CLEAR_EXCEPTION(scope, { });
     compiler->streamingCompiler().finalize(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -3369,10 +3367,10 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiateWithUR
     auto source = makeSource("[wasm code]"_s, SourceOrigin(url), taintedness);
 
     auto compiler = WasmStreamingCompiler::create(vm, globalObject, Wasm::CompilerMode::FullCompile, importObject, source, WTF::move(wasmSourceURL));
-    MarkedArgumentBuffer args;
-    args.append(compiler);
-    ASSERT(!args.hasOverflowed());
-    call(globalObject, callback, jsUndefined(), args, "You shouldn't see this..."_s);
+    auto args = WTF::toArray<EncodedJSValue>({
+        JSValue::encode(compiler),
+    });
+    call(globalObject, callback, jsUndefined(), ArgList { args.data(), args.size() }, "You shouldn't see this..."_s);
     TRY_CLEAR_EXCEPTION(scope, { });
     compiler->streamingCompiler().finalize(globalObject);
     RETURN_IF_EXCEPTION(scope, { });


### PR DESCRIPTION
#### db2d849cbee5ea5c6779bcb34525979cffc791c2
<pre>
[JSC] Use std::array for fixed-sized ArgList
<a href="https://bugs.webkit.org/show_bug.cgi?id=321955">https://bugs.webkit.org/show_bug.cgi?id=321955</a>
<a href="https://rdar.apple.com/185140117">rdar://185140117</a>

Reviewed by Yijia Huang.

Instead of using MarkedArgumentBuffer, let&apos;s just use std::array and
ArgList when we know the # of arguments statically.

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/inspector/InjectedScriptManager.cpp:
(Inspector::InjectedScriptManager::createInjectedScript):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeProgram):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::toLocaleString):
(JSC::sortStableSort):
* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
* Source/JavaScriptCore/runtime/AsyncFromSyncIteratorPrototype.cpp:
(JSC::callSyncIteratorMethodAndExtract):
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::JSC_DEFINE_COMMON_SLOW_PATH):
* Source/JavaScriptCore/runtime/GetterSetter.cpp:
(JSC::GetterSetter::callSetter):
* Source/JavaScriptCore/runtime/IteratorOperations.cpp:
(JSC::iteratorNextImpl):
(JSC::iteratorClose):
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
* Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp:
(JSC::JSFinalizationRegistry::runFinalizationCleanup):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::speciesConstruct):
(JSC::genericTypedArrayViewProtoFuncForEach):
(JSC::genericTypedArrayViewProtoFuncMap):
(JSC::genericTypedArrayViewProtoFuncFilter):
(JSC::genericTypedArrayViewProtoFuncFind):
(JSC::genericTypedArrayViewProtoFuncFindIndex):
(JSC::genericTypedArrayViewProtoFuncFindLast):
(JSC::genericTypedArrayViewProtoFuncFindLastIndex):
(JSC::genericTypedArrayViewProtoFuncEvery):
(JSC::genericTypedArrayViewProtoFuncSome):
(JSC::genericTypedArrayViewProtoFuncReduce):
(JSC::genericTypedArrayViewProtoFuncReduceRight):
(JSC::genericTypedArrayViewProtoFuncSortImpl):
(JSC::genericTypedArrayViewProtoFuncSlice):
(JSC::genericTypedArrayViewProtoFuncSubarray):
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::promiseResolveThenableJobFastSlow):
(JSC::promiseResolveThenableJobWithInternalMicrotaskFastSlow):
(JSC::promiseResolveThenableJob):
(JSC::promiseResolveWithoutHandlerJobSlow):
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::Stringifier::toJSON):
(JSC::Stringifier::appendStringifiedValue):
(JSC::Walker::callReviver):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::ordinarySetWithOwnDescriptor):
(JSC::callToPrimitiveFunction):
(JSC::JSObject::hasInstance):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::promiseResolve):
(JSC::JSPromise::promiseReject):
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::promiseRaceSlow):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::promiseAllSlow):
(JSC::promiseAllSettledSlow):
(JSC::promiseAnySlow):
* Source/JavaScriptCore/runtime/JSPromisePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::promiseProtoFuncFinallySlow):
* Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/MapConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/MapPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::performProxyGet):
(JSC::ProxyObject::performInternalMethodGetOwnProperty):
(JSC::ProxyObject::performHasProperty):
(JSC::ProxyObject::performPut):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::ProxyObject::performDelete):
(JSC::ProxyObject::performPreventExtensions):
(JSC::ProxyObject::performIsExtensible):
(JSC::ProxyObject::performDefineOwnProperty):
(JSC::ProxyObject::performGetOwnPropertyNames):
(JSC::ProxyObject::performSetPrototype):
(JSC::ProxyObject::performGetPrototype):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::regExpExec):
(JSC::regExpSplitSlow):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::stringMatchSlow):
(JSC::stringSearchSlow):
(JSC::stringMatchAllSlow):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::replaceUsingStringSearch):
* Source/JavaScriptCore/runtime/SyntheticModuleRecord.cpp:
(JSC::SyntheticModuleRecord::tryCreateWithExportNamesAndValues):
(JSC::SyntheticModuleRecord::tryCreateDefaultExportSyntheticModule):
* Source/JavaScriptCore/runtime/SyntheticModuleRecord.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::callPromiseRejectionCallback):
* Source/JavaScriptCore/runtime/WeakMapConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakMapPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakSetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::callWithStackSizeProbeFunction):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/319337@main">https://commits.webkit.org/319337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b080a4fb3a21fed8a78e82393902ad7dbbbedb8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55159 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/48957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191431 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b41c01f-1bd1-46bb-b173-d1fad6484f95) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54875 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/81355e52-c30e-45b2-a300-1bfce995d229) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184169 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/121864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ebb869f-c238-4d48-bbec-5e191b301d6c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/3829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/10652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/41697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2591 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42488 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47771 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193363 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54826 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/161685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55513 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/150521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27508 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/45115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127781 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123340 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54030 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/16694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53412 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53649 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->