### PR TITLE
REGRESSION(303972@main) [block-in-inline] Unexpected ellipsis shows up when line-clamp is applied

### DIFF
--- a/LayoutTests/fast/overflow/line-clamp-on-last-formatted-line.html
+++ b/LayoutTests/fast/overflow/line-clamp-on-last-formatted-line.html
@@ -15,7 +15,7 @@
 </div>
 
 <div class="clamp">
-  <div><div><div style="display: inline-block">PASS if trailing ellipsis shows</div></div></div>
+  <div><div><div style="display: inline-block">PASS if trailing ellipsis does NOT show</div></div></div>
 </div>
 
 <div class="clamp">

--- a/LayoutTests/fast/overflow/line-clamp-with-block-in-inline-expected.html
+++ b/LayoutTests/fast/overflow/line-clamp-with-block-in-inline-expected.html
@@ -7,9 +7,6 @@ div {
 </style>
 <div>PASS if trailing ellipsis does NOT show</div>
 <div>PASS if trailing ellipsis does NOT show</div>
-<div>PASS if trailing ellipsis shows&#x2026;</div>
-<div>PASS if trailing ellipsis shows (but it's scrolled off)</div>
-<div>PASS if trailing ellipsis shows&#x2026;</div>
-<div>PASS if trailing ellipsis shows&#x2026;</div>
+<div>PASS if trailing ellipsis does NOT show</div>
 <div>PASS if trailing ellipsis shows&#x2026;</div>
 <div>PASS if trailing ellipsis shows&#x2026;</div>

--- a/LayoutTests/fast/overflow/line-clamp-with-block-in-inline.html
+++ b/LayoutTests/fast/overflow/line-clamp-with-block-in-inline.html
@@ -1,0 +1,20 @@
+<style>
+.clamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  font-family: Monospace;
+  font-size: 12px;
+  overflow: hidden;
+  margin-bottom: 10px;
+}
+</style>
+<div class="clamp"><span><div>PASS if trailing ellipsis does NOT show</div></span></div>
+
+<div class="clamp"><span><span><div>PASS if trailing ellipsis does NOT show</div></span></span></div>
+
+<div class="clamp"><span><div>PASS if trailing ellipsis does NOT show</div><span></span></span></div>
+
+<div class="clamp"><span><div>PASS if trailing ellipsis shows</div></span><div>second line</div></div>
+
+<div class="clamp"><span><div>PASS if trailing ellipsis shows</div>second line</span></div>

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -89,6 +89,7 @@ public:
 
     bool hasBlockContent() const;
     LeafBoxIterator blockLevelBox() const;
+    inline bool hasContentfulInFlowBox() const;
 
     // Text-relative left/right
     LeafBoxIterator lineLeftmostLeafBox() const;
@@ -326,6 +327,13 @@ inline bool LineBox::hasBlockContent() const
 {
     return WTF::switchOn(m_pathVariant, [](const auto& path) {
         return path.hasBlockLevelBox();
+    });
+}
+
+inline bool LineBox::hasContentfulInFlowBox() const
+{
+    return WTF::switchOn(m_pathVariant, [](const auto& path) {
+        return path.hasContentfulInFlowBox();
     });
 }
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
@@ -74,6 +74,7 @@ public:
 
     bool isFirstAfterPageBreak() const { return false; }
     bool hasBlockLevelBox() const { return false; }
+    bool hasContentfulInFlowBox() const { return true; }
 
     inline size_t lineIndex() const; // Defined in InlineIteratorLineBoxLegacyPathInlines.h
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -99,6 +99,7 @@ public:
 
     bool isFirstAfterPageBreak() const { return line().isFirstAfterPageBreak(); }
     bool hasBlockLevelBox() const { return line().hasBlockLevelBox(); }
+    bool hasContentfulInFlowBox() const { return line().hasContentfulInFlowBox(); }
 
     size_t lineIndex() const { return m_lineIndex; }
 

--- a/Source/WebCore/rendering/LineClampUpdater.h
+++ b/Source/WebCore/rendering/LineClampUpdater.h
@@ -52,8 +52,7 @@ inline LineClampUpdater::LineClampUpdater(const RenderBlock& blockContainer)
         return;
 
     m_previousLineClamp = layoutState->lineClamp();
-    if (blockContainer.isFieldset() || blockContainer.isNonReplacedAtomicInlineLevelBox()) {
-        // Line clamp does not cross into the interior of an atomic inline-level box.
+    if (blockContainer.isFieldset() || blockContainer.isNonReplacedAtomicInlineLevelBox() || blockContainer.isFloatingOrOutOfFlowPositioned()) {
         layoutState->setLineClamp({ });
 
         m_skippedLegacyLineClampToRestore = layoutState->legacyLineClamp();

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -24,6 +24,7 @@
 #include "RenderDeprecatedFlexibleBox.h"
 
 #include "FontCascade.h"
+#include "InlineIteratorBox.h"
 #include "InlineIteratorLineBox.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "LayoutRepainter.h"
@@ -1049,16 +1050,36 @@ void RenderDeprecatedFlexibleBox::layoutVerticalBox(RelayoutChildren relayoutChi
         setBorderBoxHeight(oldHeight);
 }
 
-static RenderBlockFlow* blockContainerForLastFormattedLine(const RenderBlock& enclosingBlockContainer)
+static CheckedPtr<RenderBlockFlow> blockContainerForLastFormattedLine(RenderBlock& enclosingBlockContainer)
 {
+    if (CheckedPtr blockFlow = dynamicDowncast<RenderBlockFlow>(enclosingBlockContainer); blockFlow && blockFlow->childrenInline()) {
+        // The lines tell us where the last formatted line is: either it is one of this container's own lines, or it is inside the block level box sitting on the last line.
+        auto blockLevelBoxOnLastFormattedLine = [&]() -> CheckedPtr<RenderBlock> {
+            for (auto lineBox = InlineIterator::lastLineBoxFor(*blockFlow); lineBox; --lineBox) {
+                if (!lineBox->hasContentfulInFlowBox()) {
+                    // Out-of-flow content could initiate a line with no inline content.
+                    continue;
+                }
+                if (!lineBox->hasBlockContent()) {
+                    // The last formatted line is one of this inline formatting context's own lines.
+                    return { };
+                }
+                auto blockBox = lineBox->blockLevelBox();
+                return blockBox ? dynamicDowncast<RenderBlock>(const_cast<RenderObject&>(blockBox->renderer())) : nullptr;
+            }
+            return { };
+        };
+        if (CheckedPtr blockOnLastFormattedLine = blockLevelBoxOnLastFormattedLine())
+            return blockContainerForLastFormattedLine(*blockOnLastFormattedLine);
+        return blockFlow->hasContentfulInlineLine() ? blockFlow : nullptr;
+    }
+
     for (auto* child = enclosingBlockContainer.lastChild(); child; child = child->previousSibling()) {
         CheckedPtr blockContainer = dynamicDowncast<RenderBlock>(*child);
         if (!blockContainer)
             continue;
-        if (auto* descendantRoot = blockContainerForLastFormattedLine(*blockContainer))
+        if (CheckedPtr descendantRoot = blockContainerForLastFormattedLine(*blockContainer))
             return descendantRoot;
-        if (CheckedPtr blockFlow = dynamicDowncast<RenderBlockFlow>(*blockContainer); blockFlow && blockFlow->hasContentfulInlineLine())
-            return blockFlow.unsafeGet();
     }
     return { };
 }
@@ -1107,7 +1128,7 @@ RenderDeprecatedFlexibleBox::ClampedContent RenderDeprecatedFlexibleBox::applyLi
         child->markForPaginationRelayoutIfNeeded();
         child->layoutIfNeeded();
     }
-    if (auto* lastRoot = blockContainerForLastFormattedLine(*this)) {
+    if (CheckedPtr lastRoot = blockContainerForLastFormattedLine(*this)) {
         if (auto* inlineLayout = lastRoot->inlineLayout(); inlineLayout && inlineLayout->hasEllipsisInBlockDirectionOnLastFormattedLine()) {
             auto currentLineClamp = layoutState.legacyLineClamp();
 


### PR DESCRIPTION
#### 6d0037baf724076591471b689f2fe0636fa11aa9
<pre>
REGRESSION(303972@main) [block-in-inline] Unexpected ellipsis shows up when line-clamp is applied
<a href="https://bugs.webkit.org/show_bug.cgi?id=319285">https://bugs.webkit.org/show_bug.cgi?id=319285</a>
&lt;<a href="https://rdar.apple.com/problem/182123153">rdar://problem/182123153</a>&gt;

Reviewed by Antti Koivisto.

  &lt;div style=&quot;display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 1&quot;&gt;
    &lt;span&gt;&lt;div&gt;PASS if no ellipsis&lt;/div&gt;&lt;/span&gt;
  &lt;/div&gt;

There is one line and room for one line, so nothing is clamped and no ellipsis
should show. Instead it was &quot;PASS if no ellipsis...&quot;.

Inline layout puts the ellipsis on as soon as a line reaches the clamp limit,
because clamping is shared across sibling formatting contexts and none of them
can tell whether more content follows. The deprecated flexbox takes it back off
afterwards by relaying out the block container that holds the last formatted line
with no clamping, and blockContainerForLastFormattedLine looked for that container
by walking block level children. With block-in-inline the block sits inside the
inline box, so the walk stepped right past it and found nothing.

Ask the lines instead of the render tree. A block container with inline children
knows from its own display lines whether the last formatted line is one of its own
or belongs to a block level box sitting on one of them, and recursing into that box
asks the same question one level down.

Off the render tree the walk no longer reaches floats, which is what used to take the
ellipsis back off a float by accident. Floating and out-of-flow boxes never count
towards the clamp (see updateLineClampStateAndLogicalHeightAfterLayout), so neither
should be ellipsized by one, and LineClampUpdater now clears the clamp for them the
way it already does for atomic inline level boxes.

The second case in line-clamp-on-last-formatted-line.html expected an ellipsis on a
line holding an inline-block with nothing after it. There is no clamp point after the
last line box there, so no ellipsis is correct (css-overflow-4 max-lines) -WebKit now matches Blink here.

* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
(WebCore::InlineIterator::LineBox::hasContentfulInFlowBox const):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h:
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
* Source/WebCore/rendering/LineClampUpdater.h:
(WebCore::LineClampUpdater::LineClampUpdater):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::blockContainerForLastFormattedLine):
(WebCore::RenderDeprecatedFlexibleBox::applyLineClamp):
* LayoutTests/fast/overflow/line-clamp-on-last-formatted-line.html:
* LayoutTests/fast/overflow/line-clamp-on-last-formatted-line-expected.html:
* LayoutTests/fast/overflow/line-clamp-with-block-in-inline.html: Added.
* LayoutTests/fast/overflow/line-clamp-with-block-in-inline-expected.html: Added.

Canonical link: <a href="https://commits.webkit.org/319392@main">https://commits.webkit.org/319392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ea4fdf592942dbde996f5f78fc24753d44d73e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145636 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fdd947c0-699d-4bdd-9554-24dbdd8e2cfa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141500 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/852c0926-61c2-4e30-b8b1-9201d5e019ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121940 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/95e19602-77e6-4f06-869a-f8dc2b1253ea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43861 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42132 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154264 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41788 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2687 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193461 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150895 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40428 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55613 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150602 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45193 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127894 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123483 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54129 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16786 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53511 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53749 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53576 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->