### PR TITLE
[Part 1 of 4] Self-painted outlines should expand their clips when needed to paint auto styled focus rings

### DIFF
--- a/LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor-expected-mismatch.html
+++ b/LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor-expected-mismatch.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Not-reference: full author outline (must differ from the clipped test)</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: visible;             /* full outline drawn -> the test must NOT look like this */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        overflow: hidden;
+        outline: 10px solid green;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the green outline's right edge is clipped by the container.</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor.html
+++ b/LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>An author (non-auto) outline on a self-painting layer is still clipped by an ancestor's overflow:hidden</title>
+<!-- A regular author outline on a self-painting-layer element must remain clipped by an ancestor's overflow:hidden -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: hidden; /* must clip the author outline on the flush edge */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        overflow: hidden;
+        outline: 10px solid green;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the green outline's right edge is clipped by the container.</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-expected.html
+++ b/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reference: platform focus ring fully painted</title>
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: visible;         /* reference: nothing clips the focus ring */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        overflow: hidden;
+        outline: auto;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides.</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor.html
+++ b/LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Platform focus ring (outline-style:auto) is not clipped by an ancestor's overflow:hidden</title>
+<link rel="match" href="focus-ring-not-clipped-by-overflow-hidden-ancestor-expected.html">
+<!-- The outline-style:auto platform focus ring must not be clipped when a self-painting-layer element is flush to the right edge of an overflow:hidden ancestor. -->
+<style>
+    body { margin: 0; }
+    #ancestor {
+        position: absolute; left: 50px; top: 50px;
+        width: 200px; height: 200px;
+        overflow: hidden; /* folds into the child layer's clip; must not clip the focus ring */
+        background: #ddd;
+    }
+    #child {
+        position: absolute;
+        left: 90px; top: 40px;
+        right: 0;
+        height: 100px;
+        overflow: hidden;
+        outline: auto;
+        background: #eee;
+    }
+</style>
+</head>
+<body>
+    <p>Test passes if the inner box shows a complete focus ring on all four sides.</p>
+    <div id="ancestor"><div id="child"></div></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/LayerFragment.h
+++ b/Source/WebCore/rendering/LayerFragment.h
@@ -51,6 +51,8 @@ public:
 
         LayoutRect layerBounds() const { return m_layerBounds; }
 
+        LayoutRect paintDirtyRect() const { return m_paintDirtyRect; }
+
         ClipRect backgroundRect() const { return m_backgroundRect; }
         ClipRect dirtyBackgroundRect() const { return intersection(m_paintDirtyRect, m_backgroundRect); }
         ClipRect dirtyForegroundRect() const { return intersection(m_paintDirtyRect, m_foregroundRect); }
@@ -93,6 +95,8 @@ public:
     LayerFragment(Rects&& rects) { this->rects = WTF::move(rects); }
 
     LayoutRect layerBounds() const { return rects.layerBounds(); }
+
+    LayoutRect paintDirtyRect() const { return rects.paintDirtyRect(); }
 
     ClipRect backgroundRect() const { return rects.backgroundRect(); }
     ClipRect dirtyBackgroundRect() const { return rects.dirtyBackgroundRect(); }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4358,20 +4358,38 @@ void RenderLayer::paintForegroundForFragmentsWithPhase(PaintPhase phase, const L
     }
 }
 
+// Extent an outline-style:auto platform focus ring paints outside the border box, or std::nullopt when there is
+// no auto outline and so no clip needs expanding.
+static std::optional<LayoutUnit> autoFocusRingExtent(const RenderElement& renderer)
+{
+    CheckedRef outlineStyle = renderer.outlineStyleForRepaint();
+    if (outlineStyle->outlineStyle() != OutlineStyle::Auto)
+        return std::nullopt;
+    return LayoutUnit { std::ceil(outlineStyle->usedOutlineSize(outlineStyle->usedZoomForLength(), outlineStyle->deviceScaleFactor())) };
+}
+
 void RenderLayer::paintOutlineForFragments(const LayerFragments& layerFragments, GraphicsContext& context, const LayerPaintingInfo& localPaintingInfo,
     OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRootForRenderer)
 {
+    auto focusRingExtent = autoFocusRingExtent(renderer());
+
     for (const auto& fragment : layerFragments) {
         if (fragment.dirtyBackgroundRect().isEmpty())
             continue;
 
+        auto outlineClipRect = fragment.dirtyBackgroundRect();
+        if (focusRingExtent) {
+            outlineClipRect.inflate(*focusRingExtent);
+            outlineClipRect.intersect(fragment.paintDirtyRect());
+        }
+
         // Paint our own outline
-        PaintInfo paintInfo(context, fragment.dirtyBackgroundRect().rect(), PaintPhase::SelfOutline, paintBehavior, subtreePaintRootForRenderer, nullptr, nullptr, &localPaintingInfo.rootLayer->renderer(), this);
+        PaintInfo paintInfo(context, outlineClipRect.rect(), PaintPhase::SelfOutline, paintBehavior, subtreePaintRootForRenderer, nullptr, nullptr, &localPaintingInfo.rootLayer->renderer(), this);
 
         GraphicsContextStateSaver stateSaver(context, false);
         RegionContextStateSaver regionContextStateSaver(localPaintingInfo.regionContext);
 
-        clipToRect(context, stateSaver, regionContextStateSaver, localPaintingInfo, paintBehavior, fragment.dirtyBackgroundRect(), DoNotIncludeSelfForBorderRadius);
+        clipToRect(context, stateSaver, regionContextStateSaver, localPaintingInfo, paintBehavior, outlineClipRect, DoNotIncludeSelfForBorderRadius);
         renderer().paint(paintInfo, paintOffsetForRenderer(fragment, localPaintingInfo));
     }
 }


### PR DESCRIPTION
#### e5b19f91733aaff5edcaf735bf5692616bbed70c
<pre>
[Part 1 of 4] Self-painted outlines should expand their clips when needed to paint auto styled focus rings
<a href="https://bugs.webkit.org/show_bug.cgi?id=321963">https://bugs.webkit.org/show_bug.cgi?id=321963</a>
<a href="https://rdar.apple.com/185149528">rdar://185149528</a>

Reviewed by NOBODY (OOPS!).

This patch teaches `RenderLayer::paintOutlineForFragments()` to handle `PaintPhase::SelfOutline`
properly for the case of auto style focus rings. It is the first piece of work to resolve
Bug 319283.

Previously that paint was clipped to fragment.dirtyBackgroundRect(), which is computed as
`intersection(m_paintDirtyRect, m_backgroundRect)` (i.e. the layer&apos;s border box narrowed by
any ancestor clip). An outline-style:auto ring is drawn outside the border box, so at any
edge where an ancestor clip sits flush with that box, the ring had nowhere to go and was
cut off.

This patch modifies the code so that the clip gets inflated by the ring&apos;s own extent. We
do so by inflating the clip used for PaintPhase::SelfOutline by the ring&apos;s own extent,
bounded by the fragment&apos;s paint dirty rect so it can never exceed the region being painted.
The inflation is gated on OutlineStyle::Auto, so an author outline keeps its existing
clipping.

This covers the case where the box painting the ring has a self-painting layer of its own.
A box without one paints through an ancestor&apos;s shared clip, which is handled in a future
patch.

Two new test cases are added to confirm proper behavior.

Tests: fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor.html
       fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor.html

* LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor-expected-mismatch.html: Added.
* LayoutTests/fast/clip/author-outline-still-clipped-by-overflow-hidden-ancestor.html: Added.
* LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor-expected.html: Added.
* LayoutTests/fast/clip/focus-ring-not-clipped-by-overflow-hidden-ancestor.html: Added.
* Source/WebCore/rendering/LayerFragment.h:
(WebCore::LayerFragment::Rects::paintDirtyRect const):
(WebCore::LayerFragment::paintDirtyRect const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintOutlineForFragments):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5b19f91733aaff5edcaf735bf5692616bbed70c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145514 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141396 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98080 "2 flakes 10 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121847 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15349c55-d892-477d-bf43-8bbb8efc2ccc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43870 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42016 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41673 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2567 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193340 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150786 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55490 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150502 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45092 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127758 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123316 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54007 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16669 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53389 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53626 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53454 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->