### PR TITLE
REGRESSION (306560@main?): <select multiple> on iOS does not update the button text when the selection is changed

### DIFF
--- a/LayoutTests/fast/forms/ios/select-multiple-button-text-updates-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-multiple-button-text-updates-expected.txt
@@ -1,0 +1,16 @@
+This test verifies that the in-page text of a <select multiple> updates to reflect the number of selected options as options are chosen in the picker.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectButtonText is "0 Items"
+PASS selectButtonText is "A"
+PASS selectButtonText is "2 Items"
+PASS selectButtonText is "3 Items"
+PASS selectButtonText is "2 Items"
+PASS selectButtonText is "C"
+PASS selectButtonText is "0 Items"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-multiple-button-text-updates.html
+++ b/LayoutTests/fast/forms/ios/select-multiple-button-text-updates.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+    </head>
+<body>
+<select multiple id="select">
+    <option>A</option>
+    <option>B</option>
+    <option>C</option>
+</select>
+</body>
+<script>
+jsTestIsAsync = true;
+
+function buttonText()
+{
+    const shadow = internals.shadowRoot(select);
+    return shadow.querySelector("slot[name=buttonSlot]").firstElementChild.textContent.trim();
+}
+
+async function selectRowAndAssertButtonText(row, text)
+{
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.selectFormAccessoryPickerRow(row);
+    await UIHelper.ensurePresentationUpdate();
+
+    selectButtonText = buttonText();
+    shouldBeEqualToString("selectButtonText", text);
+}
+
+addEventListener("load", async () => {
+    description("This test verifies that the in-page text of a &lt;select multiple&gt; updates to reflect the number of selected options as options are chosen in the picker.");
+
+    selectButtonText = buttonText();
+    shouldBeEqualToString("selectButtonText", "0 Items");
+
+    await UIHelper.activateElement(select);
+    await selectRowAndAssertButtonText(0, "A");
+    await selectRowAndAssertButtonText(1, "2 Items");
+    await selectRowAndAssertButtonText(2, "3 Items");
+
+    // Deselecting brings the count back down.
+    await selectRowAndAssertButtonText(0, "2 Items");
+    await selectRowAndAssertButtonText(1, "C");
+    await selectRowAndAssertButtonText(2, "0 Items");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1143,6 +1143,7 @@ void HTMLSelectElement::updateListBoxSelection(bool deselectOtherOptions)
     }
 
     invalidateSelectedItems();
+    invalidateButtonText();
     scrollToSelection();
     updateValidity();
 }


### PR DESCRIPTION
#### 9e646aebfee7892e256aac4802e2ddbc4a713627
<pre>
REGRESSION (306560@main?): &lt;select multiple&gt; on iOS does not update the button text when the selection is changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=321964">https://bugs.webkit.org/show_bug.cgi?id=321964</a>
<a href="https://rdar.apple.com/185150121">rdar://185150121</a>

Reviewed by Aditya Keerthi, Abrar Rahman Protyasha, and Wenson Hsieh.

Test: fast/forms/ios/select-multiple-button-text-updates.html

* LayoutTests/fast/forms/ios/select-multiple-button-text-updates-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-multiple-button-text-updates.html: Added.
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::updateListBoxSelection):
Invalidate the button text when the selection changes; this path is used by the
iOS picker and needs to update the button text, or it gets stuck with &quot;0 items&quot;.

Canonical link: <a href="https://commits.webkit.org/319325@main">https://commits.webkit.org/319325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fc4d626e696987a882535b5b7e9806603da1dcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145500 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4138a07-600c-4efa-9162-1fd3160acce7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141383 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e21bdb33-7f16-4c95-9e88-a4104e299d84) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45053 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121834 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c40f859a-d16c-44dc-8f63-53c76727466e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43726 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154130 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41659 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2553 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47734 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193326 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161647 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40360 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55476 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150491 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45077 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127744 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123302 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53993 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16655 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53375 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53612 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53440 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->