### PR TITLE
Remove the unused trimmed-margin rare data bits from RenderBox

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2844,8 +2844,6 @@ void RenderBlock::setTrimmedMarginForChild(RenderBox& child, Style::MarginTrimSi
         ASSERT_NOT_REACHED();
         break;
     }
-
-    child.markMarginAsTrimmed(side);
 }
 
 LayoutUnit RenderBlock::collapsedMarginBeforeForChild(const RenderBox& child) const

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1679,21 +1679,6 @@ void RenderBox::clearOverridingLogicalWidthForFlexBasisComputation()
         gOverridingLogicalWidthMapForFlexBasisComputation->remove(*this);
 }
 
-void RenderBox::markMarginAsTrimmed(Style::MarginTrimSide newTrimmedMargin)
-{
-    auto& rareData = ensureRareData();
-    rareData.trimmedMargins = rareData.trimmedMargins | newTrimmedMargin;
-}
-
-bool RenderBox::hasTrimmedMargin(Style::MarginTrimSide marginTrimSide) const
-{
-    if (!isInFlow())
-        return false;
-    if (!hasRareData())
-        return false;
-    return rareData().trimmedMargins.contains(marginTrimSide);
-}
-
 LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(const Style::Length<CSS::NonnegativeLayoutUnitClamped, float>& logicalWidth) const
 {
     auto width = LayoutUnit { logicalWidth.resolveZoom(style().usedZoomForLength()) };

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -190,9 +190,6 @@ public:
     void computeBlockDirectionMargins(const RenderBlock& containingBlock, LayoutUnit& marginBefore, LayoutUnit& marginAfter) const;
     void computeAndSetBlockDirectionMargins(const RenderBlock& containingBlock);
 
-    void markMarginAsTrimmed(Style::MarginTrimSide);
-    bool NODELETE hasTrimmedMargin(Style::MarginTrimSide) const;
-
     enum class VisualEffectOverflowOption : uint8_t {
         ExcludeFilterOutsets,
     };

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1297,7 +1297,6 @@ private:
         // Dirty bit was set with MarkingBehavior::MarkOnlyThis
         bool contentLogicalWidthsInvalidationIsMarkOnlyThis { false };
         bool isYouTubeReplacement { false };
-        EnumSet<Style::MarginTrimSide> trimmedMargins;
 
         // From RenderElement
         std::unique_ptr<ReferencedSVGResources> referencedSVGResources;

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -411,74 +411,6 @@ template<CSSPropertyID propertyID> struct InsetEdgeSharedAdaptor {
 template<CSSPropertyID propertyID> struct MarginEdgeSharedAdaptor {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, const MarginEdge& value, F&& functor) const
     {
-        auto rendererCanHaveTrimmedMargin = [](const RenderBox& renderer) {
-            auto marginTrimSide = [] -> MarginTrimSide {
-                if constexpr (propertyID == CSSPropertyMarginTop)
-                    return MarginTrimSide::BlockStart;
-                else if constexpr (propertyID == CSSPropertyMarginRight)
-                    return MarginTrimSide::InlineEnd;
-                else if constexpr (propertyID == CSSPropertyMarginBottom)
-                    return MarginTrimSide::BlockEnd;
-                else if constexpr (propertyID == CSSPropertyMarginLeft)
-                    return MarginTrimSide::InlineStart;
-            };
-
-            // A renderer will have a specific margin marked as trimmed by setting its rare data bit if:
-            // 1.) The layout system the box is in has this logic (setting the rare data bit for this
-            // specific margin) implemented
-            // 2.) The block container/grid has this margin specified in its margin-trim style
-            // If marginTrimSide is empty we will check if any of the supported margins are in the style
-            if (renderer.isGridItem())
-                return renderer.parent()->style().marginTrim().contains(marginTrimSide());
-
-            // Even though margin-trim is not inherited, it is possible for nested block level boxes
-            // to get placed at the block-start of an containing block ancestor which does have margin-trim.
-            // In this case it is not enough to simply check the immediate containing block of the child. It is
-            // also probably too expensive to perform an arbitrary walk up the tree to check for the existence
-            // of an ancestor containing block with the property, so we will just return true and let
-            // the rest of the logic in RenderBox::hasTrimmedMargin to determine if the rare data bit
-            // were set at some point during layout
-            if (renderer.isBlockLevelBox()) {
-                auto containingBlock = renderer.containingBlock();
-                return containingBlock && containingBlock->isHorizontalWritingMode();
-            }
-            return false;
-        };
-
-        auto toMarginTrimSide = [](const RenderBox& renderer) -> MarginTrimSide {
-            auto formattingContextRootStyle = [](const RenderBox& renderer) -> const ComputedStyle& {
-                if (auto* ancestorToUse = renderer.isGridItem() ? renderer.parent() : renderer.containingBlock())
-                    return ancestorToUse->style();
-                ASSERT_NOT_REACHED();
-                return renderer.style();
-            };
-
-            auto boxSide = [] -> BoxSide {
-                if constexpr (propertyID == CSSPropertyMarginTop)
-                    return BoxSide::Top;
-                else if constexpr (propertyID == CSSPropertyMarginRight)
-                    return BoxSide::Right;
-                else if constexpr (propertyID == CSSPropertyMarginBottom)
-                    return BoxSide::Bottom;
-                else if constexpr (propertyID == CSSPropertyMarginLeft)
-                    return BoxSide::Left;
-            };
-
-            switch (mapSidePhysicalToLogical(formattingContextRootStyle(renderer).writingMode(), boxSide())) {
-            case LogicalBoxSide::BlockStart:
-                return MarginTrimSide::BlockStart;
-            case LogicalBoxSide::BlockEnd:
-                return MarginTrimSide::BlockEnd;
-            case LogicalBoxSide::InlineStart:
-                return MarginTrimSide::InlineStart;
-            case LogicalBoxSide::InlineEnd:
-                return MarginTrimSide::InlineEnd;
-            default:
-                ASSERT_NOT_REACHED();
-                return MarginTrimSide::BlockStart;
-            }
-        };
-
         auto usedValue = [](auto& box) {
             if constexpr (propertyID == CSSPropertyMarginTop)
                 return box.marginTop();
@@ -495,9 +427,6 @@ template<CSSPropertyID propertyID> struct MarginEdgeSharedAdaptor {
             return functor(value);
 
         if constexpr (propertyID == CSSPropertyMarginRight) {
-            if (rendererCanHaveTrimmedMargin(*box) && box->hasTrimmedMargin(toMarginTrimSide(*box)))
-                return functor(unzoomed<Length<>>(state, usedValue(*box)));
-
             if (value.isFixed())
                 return functor(value);
 


### PR DESCRIPTION
#### 75f22acf41f4639f3487a5954712331b579c91a7
<pre>
Remove the unused trimmed-margin rare data bits from RenderBox
<a href="https://bugs.webkit.org/show_bug.cgi?id=321967">https://bugs.webkit.org/show_bug.cgi?id=321967</a>
<a href="https://rdar.apple.com/185151625">rdar://185151625</a>

Reviewed by Alan Baradlay.

RenderBox tracked which of a box&apos;s margins had been trimmed by margin-trim in
a RenderObjectRareData EnumSet, but nothing observable ever consulted it.

The only writer was RenderBlock::setTrimmedMarginForChild(), which asserts on
the inline sides, so the set only ever held BlockStart / BlockEnd. Its callers
are all in RenderBlockFlow; grid never populated the bits, and inline-axis
trimming in RenderBox::computeOrTrimInlineMargin() returns 0 without recording
anything.

The only reader was the margin-right branch of MarginEdgeSharedAdaptor in
StyleExtractorCustom.h. That check is unreachable for block-level boxes:
rendererCanHaveTrimmedMargin() requires a horizontal-writing-mode containing
block, and in a horizontal writing mode physical right always maps to an inline
side, which the set never contains. The grid-item path required the grid to
specify margin-trim, which grid does not implement. Even where it did fire, the
other three margin properties already fall through to the used value, so
computed style reports the trimmed 0px without needing the bits.

The bits were also never cleared on relayout or style change, so any future
reader would have observed stale trim state.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::setTrimmedMarginForChild): Drop the markMarginAsTrimmed() call.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::markMarginAsTrimmed): Deleted.
(WebCore::RenderBox::hasTrimmedMargin): Deleted.
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderObject.h: Remove RenderObjectRareData::trimmedMargins.
* Source/WebCore/style/StyleExtractorCustom.h: Remove rendererCanHaveTrimmedMargin()
and toMarginTrimSide() along with the margin-right early return that used them.

Canonical link: <a href="https://commits.webkit.org/319341@main">https://commits.webkit.org/319341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1457e28f0767a7502ed6edded39e2fa74e3eb46f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145494 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a29fd67-717e-48d7-9000-ffafc7c8c9b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141389 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/376a207c-385c-4bac-b695-375b22286d90) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121840 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a78f25f3-3572-46ce-8606-dd566d19d955) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43722 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42002 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41665 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2547 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193320 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54782 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150771 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40387 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55470 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150487 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45080 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127738 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123296 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53987 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16661 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53369 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53606 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53434 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->