### PR TITLE
FrameRateAligner aligns a newly-encountered frame rate with the lowest compatible frame rate instead of the highest

### DIFF
--- a/LayoutTests/webanimations/frame-rate/animation-frame-rate-alignment-highest-compatible-frame-rate-expected.txt
+++ b/LayoutTests/webanimations/frame-rate/animation-frame-rate-alignment-highest-compatible-frame-rate-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A frame rate encountered for the first time aligns with the highest compatible frame rate
+

--- a/LayoutTests/webanimations/frame-rate/animation-frame-rate-alignment-highest-compatible-frame-rate.html
+++ b/LayoutTests/webanimations/frame-rate/animation-frame-rate-alignment-highest-compatible-frame-rate.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Animation.frameRate</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<body>
+<script>
+'use strict';
+
+promise_test(async t => {
+    // A newly-encountered frame rate must align with the highest frame rate it is
+    // compatible with. Here, 10fps and 15fps are not compatible with each other and
+    // are started one frame apart, so they update in different frames. A 30fps
+    // animation started later is compatible with both and must align with 15fps,
+    // the highest of the two, meaning it updates in the frames in which the 15fps
+    // animation updates rather than in those of the 10fps animation.
+
+    const timing = { duration: 10_000, iterations: Infinity };
+
+    // The lists of timeline times at which each frame rate was sampled.
+    const ticksAt10 = [];
+    const ticksAt15 = [];
+    const ticksAt30 = [];
+    const ticks = new Map([[10, ticksAt10], [15, ticksAt15], [30, ticksAt30]]);
+
+    // The samples of the 15fps animation that can be compared against the 30fps
+    // animation, ie. those taken once the 30fps animation had been sampled.
+    const comparableSamples = () => ticksAt30.length ? ticksAt15.filter(value => value > ticksAt30[0]) : [];
+    const numberOfSamplesToCompare = 10;
+
+    await new Promise(resolve => {
+        const addAnimation = frameRate => {
+            const animation = document.timeline.animate(() => {
+                ticks.get(frameRate).push(document.timeline.currentTime);
+                if (comparableSamples().length >= numberOfSamplesToCompare)
+                    resolve();
+            }, timing);
+            animation.frameRate = frameRate;
+            t.add_cleanup(() => animation.cancel());
+        };
+
+        // Start an animation that updates at 10fps.
+        addAnimation(10);
+
+        // Wait one frame before we start another animation running at 15fps. Since
+        // 15fps and 10fps cannot be aligned, this animation updates in frames of its
+        // own, out of phase with the 10fps animation.
+        requestAnimationFrame(() => {
+            addAnimation(15);
+
+            // Wait one more frame before we start an animation running at 30fps,
+            // which is compatible with both of the animations above.
+            requestAnimationFrame(() => addAnimation(30));
+        });
+    });
+
+    assert_greater_than(ticksAt10.length, 1, "the 10fps animation was sampled repeatedly");
+    assert_greater_than(ticksAt30.length, 2, "the 30fps animation was sampled repeatedly");
+
+    // The two frame rates the 30fps animation may align with must be out of phase for
+    // this test to tell them apart, ie. the delay between their first samples must be
+    // far enough from a multiple of the 30fps interval that aligning with either one
+    // yields a different set of frames. A dropped frame can make that delay longer than
+    // the single frame we waited for and bring the two frame rates in phase, in which
+    // case there is nothing this test can observe.
+    const intervalFor30fps = 1000 / 30;
+    const phaseDifference = (ticksAt15[0] - ticksAt10[0]) % intervalFor30fps;
+    if (Math.min(phaseDifference, intervalFor30fps - phaseDifference) < intervalFor30fps / 4)
+        return;
+
+    // Since the 30fps animation aligned with the 15fps animation, it is sampled in the
+    // frames in which the 15fps animation is sampled. This does not hold for every
+    // single frame: a frame rate may be sampled up to 1ms before its ideal sample time,
+    // and since the ideal sample times for 15fps and 30fps are each computed from the
+    // time of their own previous sample, a frame falling within that tolerance can be
+    // attributed to one frame rate and not to the other. A frame taking longer than
+    // expected can likewise shift a sample to a later frame. Both are one-off
+    // deviations, so we allow a couple of them: had the 30fps animation aligned with the
+    // 10fps animation, it would share close to none of the samples.
+    const minimumRatioOfSharedSamples = 0.75;
+    const framesAt30 = new Set(ticksAt30);
+    const samplesAt15 = comparableSamples();
+    const sharedSamples = samplesAt15.filter(value => framesAt30.has(value));
+    assert_greater_than(sharedSamples.length / samplesAt15.length, minimumRatioOfSharedSamples,
+        `the 30fps animation was sampled along with the 15fps animation in ${sharedSamples.length} of the ${samplesAt15.length} frames in which the 15fps animation was sampled`);
+}, "A frame rate encountered for the first time aligns with the highest compatible frame rate");
+
+</script>
+</body>

--- a/Source/WebCore/animation/FrameRateAligner.cpp
+++ b/Source/WebCore/animation/FrameRateAligner.cpp
@@ -111,7 +111,7 @@ void FrameRateAligner::finishUpdate()
                 continue;
 
             if (frameRatesCanBeAligned(frameRate, potentiallyCompatibleFrameRate)) {
-                if (!highestCompatibleFrameRate || *highestCompatibleFrameRate > potentiallyCompatibleFrameRate)
+                if (!highestCompatibleFrameRate || *highestCompatibleFrameRate < potentiallyCompatibleFrameRate)
                     highestCompatibleFrameRate = potentiallyCompatibleFrameRate;
             }
         }


### PR DESCRIPTION
#### 662686d7e7b2cb7fd3a8d5df6ff7d036e4038af1
<pre>
FrameRateAligner aligns a newly-encountered frame rate with the lowest compatible frame rate instead of the highest
<a href="https://bugs.webkit.org/show_bug.cgi?id=321971">https://bugs.webkit.org/show_bug.cgi?id=321971</a>
<a href="https://rdar.apple.com/185152473">rdar://185152473</a>

Reviewed by Antoine Quint.

FrameRateAligner::finishUpdate() looks for &quot;the compatible frame rate with the
highest value&quot; to align a newly-encountered frame rate with, but the comparison
was inverted, so it picked the lowest one instead.

This only matters when the new frame rate is compatible with two existing frame
rates that are incompatible with each other, and therefore may have different
first update times. With animations running at 10fps and 15fps started one frame
apart, a new 30fps animation aligned with the 10fps animation and so was never
sampled in the same frame as the 15fps animation, which is exactly what this
code exists to avoid.

Test: webanimations/frame-rate/animation-frame-rate-alignment-highest-compatible-frame-rate.html

* LayoutTests/webanimations/frame-rate/animation-frame-rate-alignment-highest-compatible-frame-rate-expected.txt: Added.
* LayoutTests/webanimations/frame-rate/animation-frame-rate-alignment-highest-compatible-frame-rate.html: Added.
* Source/WebCore/animation/FrameRateAligner.cpp:
(WebCore::FrameRateAligner::finishUpdate):

Canonical link: <a href="https://commits.webkit.org/319362@main">https://commits.webkit.org/319362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de52fc6f61b2504cd35f09f3208e2d6ac5b15183

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145518 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9b177c8-75cc-4941-9aad-03bdb6759963) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141399 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b25be694-3466-409e-bd3a-8f2784c05f85) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121850 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6da7f162-cbeb-4255-b33e-2f9b4496cb8a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43742 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42020 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41675 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2571 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193344 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150790 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40404 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55494 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150506 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45094 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127762 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123320 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54011 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16671 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53393 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53630 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53458 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->