### PR TITLE
Speed up lunisolar calendar month walk in JS Temporal

### DIFF
--- a/JSTests/microbenchmarks/temporal-plain-month-day-lunisolar-month-code.js
+++ b/JSTests/microbenchmarks/temporal-plain-month-day-lunisolar-month-code.js
@@ -1,0 +1,59 @@
+// Regression benchmark for the chinese/dangi monthCode path in nonISOCalendarDateToISO
+// (CalendarICUBridge.cpp). ICU4C cannot say which ordinal a month code occupies, so the bridge
+// anchors on the start of the reference year and walks month by month; each advance jumps to
+// day 29 and then steps, since a lunar month is 29 or 30 days. The walk is memoized per
+// (calendar, year, monthCode), and the month length per month start.
+//
+// One phase per thing to protect:
+//   steady - a single input, so both memos hit every time
+//   warm   - four distinct keys over both calendars, still inside the walk memo
+//   cold   - every month code for both calendars, more keys than either memo holds
+//
+// The resolved day is checked once per case up front rather than in the loops: the day getter
+// is a second ICU round trip that touches neither memo, so accumulating it would dilute what
+// the loops measure.
+
+const steadyCase = { calendar: "chinese", monthCode: "M07", day: 15 };
+
+const warmCases = [
+    { calendar: "chinese", monthCode: "M03", day: 15 },
+    { calendar: "chinese", monthCode: "M05L", day: 15 },
+    { calendar: "dangi", monthCode: "M07", day: 15 },
+    { calendar: "dangi", monthCode: "M11", day: 15 },
+];
+
+const coldCases = [];
+for (const calendar of ["chinese", "dangi"]) {
+    for (let month = 1; month <= 12; ++month) {
+        const monthCode = "M" + (month < 10 ? "0" : "") + month;
+        coldCases.push({ calendar, monthCode, day: 15 });
+        coldCases.push({ calendar, monthCode: monthCode + "L", day: 15 });
+    }
+}
+
+if (coldCases.length !== 48)
+    throw "Bad case count: " + coldCases.length;
+
+// Day 15 is inside every lunar month, and under the default constrain overflow a leap month
+// absent from the reference year falls back to the non-leap month, so every case resolves to
+// day 15 rather than throwing.
+for (const fields of [steadyCase, ...warmCases, ...coldCases]) {
+    const day = Temporal.PlainMonthDay.from(fields).day;
+    if (day !== 15)
+        throw "Bad day for " + fields.calendar + " " + fields.monthCode + ": " + day;
+}
+
+let sink = null;
+for (var i = 0; i < 10000; ++i)
+    sink = Temporal.PlainMonthDay.from(steadyCase);
+for (var i = 0; i < 2000; ++i) {
+    for (var j = 0; j < warmCases.length; ++j)
+        sink = Temporal.PlainMonthDay.from(warmCases[j]);
+}
+for (var i = 0; i < 5; ++i) {
+    for (var j = 0; j < coldCases.length; ++j)
+        sink = Temporal.PlainMonthDay.from(coldCases[j]);
+}
+
+if (!sink)
+    throw "Bad result: " + sink;

--- a/JSTests/stress/temporal-lunisolar-memo-aliasing.js
+++ b/JSTests/stress/temporal-lunisolar-memo-aliasing.js
@@ -1,0 +1,181 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: expected ${expected}, got ${actual}`);
+}
+
+// CalendarICUBridge.cpp memoizes two lunisolar results in small direct-mapped tables shared by
+// chinese and dangi: the month-code walk (16 slots) and the month length (4 slots). One entry per
+// slot, so every store can evict an unrelated key, and a broken tag check answers a lookup with a
+// neighbour's value. Asserting a single expected field cannot see that, so everything below
+// compares a value against the same value read at another time, or against an independent oracle.
+
+// A CalendarID is the index of the identifier in intlAvailableCalendars(), which is the same
+// sorted table Intl.supportedValuesOf("calendar") exposes.
+const availableCalendars = Intl.supportedValuesOf("calendar");
+const calendarId = { chinese: availableCalendars.indexOf("chinese"), dangi: availableCalendars.indexOf("dangi") };
+shouldBe(calendarId.chinese >= 0 && calendarId.dangi >= 0, true, "chinese and dangi are available");
+
+// Mirrors nonISOCalendarDateToISO:
+//   packedMonthCode = (monthNumber << 1) | isLeapMonth
+//   walkSlot = ((year * 31) ^ packedMonthCode ^ (calendarId * 7)) & (lunisolarWalkMemoCount - 1)
+// lunisolarWalkMemoCount is 16. No slot number is written down below: the colliding pairs are
+// searched for at run time, so this keeps testing real collisions if the mixing or size changes.
+const walkMemoCount = 16;
+function walkSlot({ calendar, year, monthCode }) {
+    const monthNumber = Number(monthCode.substring(1, 3));
+    const packedMonthCode = (monthNumber << 1) | (monthCode.length > 3 ? 1 : 0);
+    return ((year * 31) ^ packedMonthCode ^ (calendarId[calendar] * 7)) & (walkMemoCount - 1);
+}
+
+const searchSpace = [];
+for (const calendar of ["chinese", "dangi"]) {
+    for (let year = 2019; year <= 2026; ++year) {
+        for (let monthNumber = 1; monthNumber <= 12; ++monthNumber) {
+            const monthCode = `M${monthNumber < 10 ? "0" : ""}${monthNumber}`;
+            searchSpace.push({ calendar, year, monthCode });
+            // A leap code missing from its year constrains to a neighbouring month; that answer is
+            // memoized too, and it is the only way to vary the packed leap bit.
+            searchSpace.push({ calendar, year, monthCode: `${monthCode}L` });
+        }
+    }
+}
+
+const bySlot = new Map();
+for (const entry of searchSpace) {
+    const slot = walkSlot(entry);
+    if (!bySlot.has(slot))
+        bySlot.set(slot, []);
+    bySlot.get(slot).push(entry);
+}
+
+// Same calendar plus same year plus same slot implies the same packed month code, so a pair must
+// differ in the calendar or the year; both kinds are picked, plus one that flips the leap bit.
+// Already-chosen pairs are excluded, since one pair can satisfy several of the predicates and
+// would otherwise be selected repeatedly instead of widening what is covered.
+const chosen = new Set();
+function findCollidingPair(name, predicate) {
+    for (const [slot, entries] of bySlot) {
+        for (let i = 0; i < entries.length; ++i) {
+            for (let j = i + 1; j < entries.length; ++j) {
+                const pairKey = `${keyOf(entries[i])} | ${keyOf(entries[j])}`;
+                if (chosen.has(pairKey) || !predicate(entries[i], entries[j]))
+                    continue;
+                chosen.add(pairKey);
+                return { name, slot, entries: [entries[i], entries[j]] };
+            }
+        }
+    }
+    throw new Error(`no unused same-slot collision found for ${name}`);
+}
+
+const collisions = [
+    findCollidingPair("different calendar", (a, b) => a.calendar !== b.calendar),
+    findCollidingPair("different year", (a, b) => a.calendar === b.calendar && a.year !== b.year),
+    findCollidingPair("different leap bit", (a, b) => (a.monthCode.length > 3) !== (b.monthCode.length > 3)),
+];
+
+function keyOf({ calendar, year, monthCode }) {
+    return `${calendar} ${year} ${monthCode}`;
+}
+
+// Everything the walk memo decides: the ISO date it lands on, the ordinal month it counted, and
+// the month it settled on. An aliased hit changes at least one of them.
+function walkSignature({ calendar, year, monthCode }) {
+    const date = Temporal.PlainDate.from({ calendar, year, monthCode, day: 1 });
+    return `${date.toString()} m=${date.month} mc=${date.monthCode} d=${date.day} dim=${date.daysInMonth}`;
+}
+
+// Record each answer exactly once, before any of the re-reads below.
+const recorded = new Map();
+for (const collision of collisions) {
+    for (const entry of collision.entries) {
+        if (!recorded.has(keyOf(entry)))
+            recorded.set(keyOf(entry), walkSignature(entry));
+    }
+}
+
+// If a colliding pair agreed, swapping the two answers would be invisible and the re-reads would
+// pass for the wrong reason.
+for (const { name, slot, entries } of collisions) {
+    shouldBe(recorded.get(keyOf(entries[0])) !== recorded.get(keyOf(entries[1])), true,
+        `slot ${slot} pair (${name}) is distinguishable: ${keyOf(entries[0])} vs ${keyOf(entries[1])}`);
+}
+
+// Re-read interleaved, so each lookup is preceded by a store into its own slot from another key.
+for (const { name, slot, entries } of collisions) {
+    for (let round = 0; round < 4; ++round) {
+        for (const entry of entries)
+            shouldBe(walkSignature(entry), recorded.get(keyOf(entry)), `slot ${slot} (${name}) aliasing for ${keyOf(entry)}`);
+    }
+}
+
+// Month-length memo: 4 slots keyed by the month the cursor sits in, so consecutive days hit one
+// slot repeatedly while the other calendar and the neighbouring months evict it.
+const walkCalendars = ["chinese", "dangi"];
+const walkLength = 400;
+const observations = new Map(walkCalendars.map(calendar => [calendar, []]));
+let isoDate = Temporal.PlainDate.from("2023-11-05");
+for (let i = 0; i < walkLength; ++i) {
+    // Alternate which calendar reads first so the eviction order varies.
+    for (const calendar of (i % 2) ? walkCalendars.slice().reverse() : walkCalendars) {
+        const date = isoDate.withCalendar(calendar);
+        observations.get(calendar).push({ iso: isoDate.toString(), monthCode: date.monthCode, day: date.day, daysInMonth: date.daysInMonth });
+    }
+    isoDate = isoDate.add({ days: 1 });
+}
+
+for (const calendar of walkCalendars) {
+    const days = observations.get(calendar);
+    for (let i = days.length - 1; i >= 0; --i) {
+        const expected = days[i];
+        const date = Temporal.PlainDate.from(expected.iso).withCalendar(calendar);
+        shouldBe(date.monthCode, expected.monthCode, `${calendar} ${expected.iso} monthCode re-read in reverse`);
+        shouldBe(date.day, expected.day, `${calendar} ${expected.iso} day re-read in reverse`);
+        shouldBe(date.daysInMonth, expected.daysInMonth, `${calendar} ${expected.iso} daysInMonth re-read in reverse`);
+    }
+
+    // Independent of any memo: consecutive days carrying one month code must agree on the length,
+    // number their days consecutively, and -- when the whole month is inside the walk -- span
+    // exactly that many days starting at day 1.
+    let runStart = 0;
+    for (let i = 1; i <= days.length; ++i) {
+        if (i < days.length && days[i].monthCode === days[runStart].monthCode)
+            continue;
+        const daysInMonth = days[runStart].daysInMonth;
+        shouldBe(daysInMonth === 29 || daysInMonth === 30, true, `${calendar} ${days[runStart].monthCode} length is 29 or 30`);
+        for (let j = runStart; j < i; ++j) {
+            shouldBe(days[j].daysInMonth, daysInMonth, `${calendar} ${days[j].iso} daysInMonth inside ${days[runStart].monthCode}`);
+            shouldBe(days[j].day, days[runStart].day + (j - runStart), `${calendar} ${days[j].iso} day inside ${days[runStart].monthCode}`);
+        }
+        if (runStart > 0 && i < days.length) {
+            shouldBe(days[runStart].day, 1, `${calendar} ${days[runStart].monthCode} run starts on day 1`);
+            shouldBe(i - runStart, daysInMonth, `${calendar} ${days[runStart].monthCode} run length matches daysInMonth`);
+        }
+        runStart = i;
+    }
+}
+
+// Oracle reached through the ordinal-month path instead of the walk above: a year's months must
+// tile it exactly, each be a real lunation, and carry distinct codes.
+for (const calendar of walkCalendars) {
+    for (const year of [2022, 2023, 2024, 2026]) {
+        const yearStart = Temporal.PlainDate.from({ calendar, year, month: 1, day: 1 });
+        const monthsInYear = yearStart.monthsInYear;
+        shouldBe(monthsInYear === 12 || monthsInYear === 13, true, `${calendar} ${year} monthsInYear is 12 or 13`);
+        const monthCodes = new Set();
+        let total = 0;
+        for (let month = 1; month <= monthsInYear; ++month) {
+            const date = Temporal.PlainDate.from({ calendar, year, month, day: 1 });
+            shouldBe(date.month, month, `${calendar} ${year} ordinal month ${month} round-trips`);
+            shouldBe(date.day, 1, `${calendar} ${year} ordinal month ${month} starts on day 1`);
+            const daysInMonth = date.daysInMonth;
+            shouldBe(daysInMonth === 29 || daysInMonth === 30, true, `${calendar} ${year} ordinal month ${month} length is 29 or 30`);
+            monthCodes.add(date.monthCode);
+            total += daysInMonth;
+        }
+        shouldBe(monthCodes.size, monthsInYear, `${calendar} ${year} month codes are distinct`);
+        shouldBe(total, yearStart.daysInYear, `${calendar} ${year} months sum to daysInYear`);
+    }
+}

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -33,6 +33,7 @@
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DateMath.h>
 #include <wtf/Lock.h>
+#include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -42,6 +43,8 @@
 
 namespace JSC {
 namespace TemporalCore {
+
+static constexpr double millisecondsPerDay = 86'400'000.0;
 
 CalendarID calendarIDFromString(StringView identifier)
 {
@@ -469,7 +472,6 @@ static std::optional<String> getMonthCode(UCalendar* cal, CalendarID calendarId)
 
 static bool addUTCCalendarDays(UCalendar* cal, int32_t days, UErrorCode& status)
 {
-    static constexpr double millisecondsPerDay = 86'400'000.0;
     double epochMs = ucal_getMillis(cal, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return false;
@@ -547,7 +549,33 @@ static LunisolarMonthAdvanceResult advanceToNextLunisolarMonth(UCalendar* cal, C
     auto currentMonthCode = getMonthCode(cal, calendarId, status);
     if (!currentMonthCode) [[unlikely]]
         return LunisolarMonthAdvanceResult::Error;
-    for (int i = 0; i < 32; ++i) {
+
+    // A lunar month is 29 or 30 days, so day 29 exists and is at most two single-day steps from
+    // day 1 of the next month. Jump there instead of resolving fields once per day.
+    int32_t day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return LunisolarMonthAdvanceResult::Error;
+    // From day 29 or later the next month is within three steps. Undoing the jump puts the cursor
+    // back on a day that may still have most of a month ahead of it.
+    int walkLimit = 3;
+    if (day < 29) {
+        double beforeJumpMs = ucal_getMillis(cal, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return LunisolarMonthAdvanceResult::Error;
+        if (!addUTCCalendarDays(cal, 29 - day, status)) [[unlikely]]
+            return LunisolarMonthAdvanceResult::Error;
+        auto jumpedMonthCode = getMonthCode(cal, calendarId, status);
+        if (!jumpedMonthCode) [[unlikely]]
+            return LunisolarMonthAdvanceResult::Error;
+        if (*jumpedMonthCode != *currentMonthCode) {
+            // Unreachable while ICU reports 29- or 30-day months; keeps the walk correct if not.
+            ucal_setMillis(cal, beforeJumpMs, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return LunisolarMonthAdvanceResult::Error;
+            walkLimit = 32;
+        }
+    }
+    for (int i = 0; i < walkLimit; ++i) {
         if (!addUTCCalendarDays(cal, 1, status)) [[unlikely]]
             return LunisolarMonthAdvanceResult::Error;
         auto adjacentMonthCode = getMonthCode(cal, calendarId, status);
@@ -616,6 +644,34 @@ static std::optional<MonthCodeSearchResult> searchYearForMonthCode(UCalendar* ca
     return std::nullopt;
 }
 
+struct LunisolarWalkMemo {
+    bool valid { false };
+    CalendarID calendarId { 0 };
+    int32_t year { 0 };
+    uint8_t packedMonthCode { 0 };
+    MonthCodeSearchResult result;
+};
+
+struct LunisolarMonthLengthMemo {
+    bool valid { false };
+    CalendarID calendarId { 0 };
+    double startMs { 0 };
+    int32_t length { 0 };
+};
+
+// These tables need their own lock because useLock is per-calendar and chinese/dangi share them.
+// It is taken inside useLock and nothing else is taken while holding it.
+// Entries never go stale: ICU's calendar data is fixed for the process, and a CalendarID keeps its
+// meaning because intlAvailableCalendars() is built once and never reordered.
+static constexpr size_t lunisolarWalkMemoCount = 16;
+static constexpr size_t lunisolarMonthLengthMemoCount = 4;
+static_assert(hasOneBitSet(lunisolarWalkMemoCount), "slot masks below require a power of two");
+static_assert(hasOneBitSet(lunisolarMonthLengthMemoCount), "slot masks below require a power of two");
+
+static Lock lunisolarMemoLock;
+static std::array<LunisolarWalkMemo, lunisolarWalkMemoCount> lunisolarWalkMemos WTF_GUARDED_BY_LOCK(lunisolarMemoLock) { };
+static std::array<LunisolarMonthLengthMemo, lunisolarMonthLengthMemoCount> lunisolarMonthLengthMemos WTF_GUARDED_BY_LOCK(lunisolarMemoLock) { };
+
 static std::optional<int32_t> stableLunisolarYear(UCalendar* cal, CalendarID calendarId, UErrorCode& status)
 {
     auto anchor = lunisolarYearAnchor(cal, calendarId, status);
@@ -643,6 +699,17 @@ static std::optional<int32_t> actualLunisolarMonthLength(UCalendar* cal, Calenda
     double savedMs = ucal_getMillis(cal, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
+
+    // Keyed on the cursor rather than the month start: reading UCAL_DAY_OF_MONTH to normalize would
+    // force a field resolution on every hit, which costs more than the misses it would turn into
+    // hits for calendarDaysInMonth.
+    size_t slot = static_cast<size_t>(static_cast<int64_t>(savedMs / millisecondsPerDay) ^ static_cast<int64_t>(calendarId)) & (lunisolarMonthLengthMemoCount - 1);
+    {
+        Locker locker { lunisolarMemoLock };
+        const auto& memo = lunisolarMonthLengthMemos.at(slot);
+        if (memo.valid && memo.calendarId == calendarId && memo.startMs == savedMs)
+            return memo.length;
+    }
 
     auto restoreCalendar = [&] {
         UErrorCode operationStatus = status;
@@ -676,8 +743,14 @@ static std::optional<int32_t> actualLunisolarMonthLength(UCalendar* cal, Calenda
         return std::nullopt;
     if (!operationSucceeded) [[unlikely]]
         return std::nullopt;
-    int32_t length = day - 1 + static_cast<int32_t>((nextMonthStartMs - savedMs) / 86'400'000.0);
-    return length >= 29 && length <= 30 ? std::optional<int32_t> { length } : std::nullopt;
+    int32_t length = day - 1 + static_cast<int32_t>((nextMonthStartMs - savedMs) / millisecondsPerDay);
+    if (length < 29 || length > 30) [[unlikely]]
+        return std::nullopt;
+    {
+        Locker locker { lunisolarMemoLock };
+        lunisolarMonthLengthMemos.at(slot) = { true, calendarId, savedMs, length };
+    }
+    return length;
 }
 
 static bool addLunisolarCalendarDays(UCalendar* cal, CalendarID calendarId, int32_t days, UErrorCode& status)
@@ -2218,11 +2291,10 @@ static TemporalResult<ISO8601::Duration> nonISODateUntil(CalendarID calendarId, 
             return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
 
         // Days: derived from epoch-ms delta between cal (source + years + months) and target.
-        const double msPerDay = 86'400'000.0;
         double finalMs1 = ucal_getMillis(cal, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-        double daysDiff = std::trunc((target.epochMs - finalMs1) / msPerDay);
+        double daysDiff = std::trunc((target.epochMs - finalMs1) / millisecondsPerDay);
 
         // If largestUnit is Month, clear years (months were counted from one + years=0).
         int32_t resultYears = (largestUnit == TemporalUnit::Month) ? 0 : years;
@@ -2650,12 +2722,34 @@ TemporalResult<ISO8601::PlainDate> nonISOCalendarDateToISO(CalendarID calendarId
                 // doesn't expose this data, so we walk. The walk is correct and safe.
                 if (!isValidMonthCodeForCalendar(calendarId, *monthCode)) [[unlikely]]
                     return makeUnexpected(rangeError("monthCode is not valid for this calendar"_s));
-                if (!setCalendarToLunisolarYearStart(cal, calendarId, year, status)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
 
-                String targetCode = makeString("M"_s, monthCode->monthNumber < 10 ? "0"_s : ""_s,
-                    monthCode->monthNumber, monthCode->isLeapMonth ? "L"_s : ""_s);
-                auto found = searchYearForMonthCode(cal, calendarId, targetCode);
+                bool memoUsable = year && (calendarId == chineseCalendarID() || calendarId == dangiCalendarID());
+                uint8_t packedMonthCode = static_cast<uint8_t>((monthCode->monthNumber << 1) | (monthCode->isLeapMonth ? 1 : 0));
+                size_t walkSlot = memoUsable ? ((static_cast<size_t>(*year) * 31u) ^ packedMonthCode ^ (calendarId * 7u)) & (lunisolarWalkMemoCount - 1) : 0;
+                std::optional<MonthCodeSearchResult> found;
+                if (memoUsable) {
+                    Locker locker { lunisolarMemoLock };
+                    const auto& walkMemo = lunisolarWalkMemos.at(walkSlot);
+                    if (walkMemo.valid && walkMemo.calendarId == calendarId
+                        && walkMemo.year == *year && walkMemo.packedMonthCode == packedMonthCode)
+                        found = walkMemo.result;
+                }
+                if (found) {
+                    ucal_setMillis(cal, found->stoppedMonthMs, &status);
+                    if (U_FAILURE(status)) [[unlikely]]
+                        return makeUnexpected(rangeError(icuSetCalendarFailed));
+                } else {
+                    if (!setCalendarToLunisolarYearStart(cal, calendarId, year, status)) [[unlikely]]
+                        return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+
+                    String targetCode = makeString("M"_s, monthCode->monthNumber < 10 ? "0"_s : ""_s,
+                        monthCode->monthNumber, monthCode->isLeapMonth ? "L"_s : ""_s);
+                    found = searchYearForMonthCode(cal, calendarId, targetCode);
+                    if (found && memoUsable) {
+                        Locker locker { lunisolarMemoLock };
+                        lunisolarWalkMemos.at(walkSlot) = { true, calendarId, *year, packedMonthCode, *found };
+                    }
+                }
                 if (!found) [[unlikely]]
                     return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
                 auto rewindToPreviousMonth = [&]() -> bool {


### PR DESCRIPTION
#### 2ca559226b1bdd624bc8c4224662a5794227c048
<pre>
Speed up lunisolar calendar month walk in JS Temporal
<a href="https://bugs.webkit.org/show_bug.cgi?id=322044">https://bugs.webkit.org/show_bug.cgi?id=322044</a>
<a href="https://rdar.apple.com/185152703">rdar://185152703</a>

Reviewed by Yijia Huang.

Optimize chinese/dangi month code resolution in CalendarICUBridge.cpp by
caching results and no longer single stepping forward day by day.

                                                  TipOfTree                  Changes
temporal-plain-month-day-lunisolar-month-code
                                            14785.2729+-102.0720   ^    223.6251+-4.9208        ^ definitely 66.1163x faster
&lt;geometric&gt;                                 14785.2729+-102.0720   ^    223.6251+-4.9208        ^ definitely 66.1163x faster

Tests: JSTests/microbenchmarks/temporal-plain-month-day-lunisolar-month-code.js
       JSTests/stress/temporal-lunisolar-memo-aliasing.js

* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
(JSC::TemporalCore::advanceToNextLunisolarMonth):
(JSC::TemporalCore::actualLunisolarMonthLength):
(JSC::TemporalCore::nonISOCalendarDateToISO):
(JSC::TemporalCore::WTF_GUARDED_BY_LOCK):
(JSC::TemporalCore::addUTCCalendarDays):
(JSC::TemporalCore::nonISODateUntil):
* JSTests/microbenchmarks/temporal-plain-month-day-lunisolar-month-code.js: Added.
* JSTests/stress/temporal-lunisolar-memo-aliasing.js: Added.
(shouldBe):
(walkSlot):

Canonical link: <a href="https://commits.webkit.org/319834@main">https://commits.webkit.org/319834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/896dd8aaefa00d0d726ed5a04f970460ac926d22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193105 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a849837-df21-4306-8bfe-a64d8550fe68) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56546 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/628a0322-0e89-44d1-a67b-8d7964d37f20) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46466 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123177 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9344f69-565a-4f11-9e2b-4eba697f4fa6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45158 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5147 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11977 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155554 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43037 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4278 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44158 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49458 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195046 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56480 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40778 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57185 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151903 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46466 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125540 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55693 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/18047 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55064 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55301 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->