### PR TITLE
git-webkit install-hooks is failing - AttributeError: 'IdentifierTrailer' object has no attribute 'split'

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
@@ -205,7 +205,10 @@ class InstallHooks(Command):
             sorted(security_levels.items(), key=lambda x: (x[1], x[0]))
         )
 
-        trailers_to_strip = ['Identifier'] + ([identifier_template.split(':', 1)[0]] if identifier_template else [])
+        trailers_to_strip = ['Identifier'] + (
+            [identifier_template.name] + list(identifier_template.aliases)
+            if identifier_template else []
+        )
         source_remotes = repository.source_remotes() or ['origin']
         perl = 'perl'
         perl = shutil.which('perl')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py
@@ -28,19 +28,22 @@ from webkitcorepy import OutputCapture, Version, run, testing
 from webkitcorepy.mocks import Terminal as MockTerminal
 
 from webkitscmpy import local, mocks, program
+from webkitscmpy.program.canonicalize import IdentifierTrailer
 
 
 class TestInstallHooks(testing.PathTestCase):
     basepath = 'mock/repository'
 
     @classmethod
-    def write_hook(cls, path, version=None, security_levels=False):
+    def write_hook(cls, path, version=None, security_levels=False, trailers_to_strip=False):
         with open(path, 'w') as f:
             f.write('#!/usr/bin/env {{ python }}\n')
             if version:
                 f.write("VERSION = '{}'\n".format(version))
             if security_levels:
                 f.write('SECURITY_LEVELS = {{ security_levels }}\n')
+            if trailers_to_strip:
+                f.write('TRAILERS_TO_STRIP = {{ trailers_to_strip }}\n')
             f.write("print('Hello, world!\\n')\n")
 
     def write_config(self, **kwargs):
@@ -225,6 +228,39 @@ class TestInstallHooks(testing.PathTestCase):
         ))
         self.assertEqual(captured.stderr.getvalue(), 'No hooks installed because user canceled hook installation\n')
         self.assertEqual(captured.root.log.getvalue(), '')
+
+    def test_install_hook_with_identifier_trailer(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, remote='git@example.org:WebKit/project.git'), mocks.local.Svn():
+            self.write_hook(os.path.join(self.path, 'hooks', 'pre-push'), trailers_to_strip=True)
+
+            trailer = IdentifierTrailer(
+                name='Canonical-link',
+                value_template='https://commits.webkit.org/{}',
+                aliases=('Canonical link',),
+            )
+            result = program.main(
+                args=('install-hooks', '-v'),
+                path=self.path,
+                hooks=os.path.join(self.path, 'hooks'),
+                identifier_template=trailer,
+            )
+
+        self.assertEqual(0, result)
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Successfully installed 1 of 1 repository hooks\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.root.log.getvalue(),
+            "Configuring and copying hook 'pre-push' for this repository\n",
+        )
+
+        resolved_hook = os.path.join(self.path, '.git', 'hooks', 'pre-push')
+        self.assertTrue(os.path.isfile(resolved_hook))
+        with open(resolved_hook, 'r') as f:
+            hook_contents = f.read()
+            self.assertIn("TRAILERS_TO_STRIP = ['Identifier', 'Canonical-link', 'Canonical link']", hook_contents)
 
     def test_security_level_in_hook(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, remote='git@example.org:WebKit/project.git'), mocks.local.Svn():


### PR DESCRIPTION
#### 86793e595cda5bc3a921e0e68a2d3e135f294d5b
<pre>
git-webkit install-hooks is failing - AttributeError: &apos;IdentifierTrailer&apos; object has no attribute &apos;split&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=321968">https://bugs.webkit.org/show_bug.cgi?id=321968</a>
<a href="https://rdar.apple.com/185152046">rdar://185152046</a>

Unreviewed infrastructure fix.

This regressed in 319313@main (761e61f4ad96), from bug 316952.

We didn&apos;t udpate webkitscmpy.program.install_hooks for the change of
API, and we don&apos;t have Python type checking to have caught this.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py:
(InstallHooks.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py:
(TestInstallHooks.write_hook):
(TestInstallHooks.test_install_hook_with_identifier_trailer):

Canonical link: <a href="https://commits.webkit.org/319316@main">https://commits.webkit.org/319316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/447e34e84eea76aca74603f94ae17d988d9b38ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181184 "Failed to checkout and rebase branch from PR 71813") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55129 "Failed to checkout and rebase branch from PR 71813") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48927 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183046 "Failed to checkout and rebase branch from PR 71813") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56427 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54845 "Failed to checkout and rebase branch from PR 71813") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184139 "Failed to checkout and rebase branch from PR 71813") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/121835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180508 "Failed to checkout and rebase branch from PR 71813") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/54845 "Failed to checkout and rebase branch from PR 71813") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/41664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2560 "Failed to checkout and rebase branch from PR 71813") | | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/54845 "Failed to checkout and rebase branch from PR 71813") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/193333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/180585 "Failed to checkout and rebase branch from PR 71813") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54795 "Failed to checkout and rebase branch from PR 71813") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/161652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55483 "Failed to checkout and rebase branch from PR 71813") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/150490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27499 "Failed to push commit to Webkit repository") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/45079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123309 "Failed to checkout and rebase branch from PR 71813") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54000 "Failed to checkout and rebase branch from PR 71813") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/16660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/53382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53619 "Failed to checkout and rebase branch from PR 71813") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53447 "Failed to checkout and rebase branch from PR 71813") | | | | 
<!--EWS-Status-Bubble-End-->