### PR TITLE
Add API tests for user agent override quirks

### DIFF
--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 // When editing the quirks in this file, be sure to update
-// Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp.
+// Tools/TestWebKitAPI/Tests/WebCore/glib/UserAgentQuirks.cpp.
 //
 // When testing changes, be sure to test with application branding enabled.
 // Otherwise, we will not notice when urlRequiresUnbrandedUserAgent is needed.

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -349,6 +349,8 @@ if (ENABLE_WEBKIT)
     set(TestWebKit_SOURCES
         Helpers/Utilities.cpp
 
+        Tests/WebCore/Quirks.cpp
+
         Tests/WebKit/WKPage/AboutBlankLoad.cpp
         Tests/WebKit/WKPage/CanHandleRequest.cpp
         Tests/WebKit/WKPage/DOMWindowExtensionBasic.cpp

--- a/Tools/TestWebKitAPI/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/PlatformGTK.cmake
@@ -41,12 +41,11 @@ list(APPEND TestJavaScriptCore_LIBRARIES
 
 # TestWebCore
 list(APPEND TestWebCore_SOURCES
-    Tests/WebCore/UserAgentQuirks.cpp
-
     Tests/WebCore/glib/Damage.cpp
     Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
     Tests/WebCore/glib/RunLoopObserver.cpp
     Tests/WebCore/glib/SkiaCompositingLayerDamage.cpp
+    Tests/WebCore/glib/UserAgentQuirks.cpp
 
     Tests/WebCore/gstreamer/GStreamerTest.cpp
     Tests/WebCore/gstreamer/GstElementHarness.cpp

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -37,12 +37,11 @@ list(APPEND TestJavaScriptCore_SOURCES
 list(APPEND TestWebCore_SOURCES
     ${test_main_SOURCES}
 
-    Tests/WebCore/UserAgentQuirks.cpp
-
     Tests/WebCore/glib/Damage.cpp
     Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
     Tests/WebCore/glib/RunLoopObserver.cpp
     Tests/WebCore/glib/SkiaCompositingLayerDamage.cpp
+    Tests/WebCore/glib/UserAgentQuirks.cpp
 
     Tests/WebCore/gstreamer/GStreamerTest.cpp
     Tests/WebCore/gstreamer/GstElementHarness.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -799,6 +799,7 @@
 				WebCore/PublicSuffix.cpp,
 				WebCore/PushDatabase.cpp,
 				WebCore/PushMessageCrypto.cpp,
+				WebCore/Quirks.cpp,
 				WebCore/RegionTests.cpp,
 				WebCore/RegistrableDomain.cpp,
 				WebCore/RenderStyleChange.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/Quirks.h>
+#include <wtf/MainThread.h>
+#include <wtf/URL.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+class QuirksTest : public testing::Test {
+public:
+    virtual void SetUp()
+    {
+        WTF::initializeMainThread();
+    }
+};
+
+static std::optional<String> customUserAgentFor(ASCIILiteral urlString)
+{
+    return WebCore::Quirks::needsCustomUserAgentOverride(URL { urlString }, "TestApp"_s, "TestBase/1.0 (KHTML, like Gecko) Trailer/1.0"_s);
+}
+
+TEST_F(QuirksTest, NeedsIPadMiniUserAgent)
+{
+    EXPECT_TRUE(WebCore::Quirks::needsIPadMiniUserAgent(URL { "https://roblox.com/"_s }));
+    EXPECT_TRUE(WebCore::Quirks::needsIPadMiniUserAgent(URL { "https://www.roblox.com/games"_s }));
+    EXPECT_TRUE(WebCore::Quirks::needsIPadMiniUserAgent(URL { "https://web.roblox.com/home"_s }));
+
+    EXPECT_FALSE(WebCore::Quirks::needsIPadMiniUserAgent(URL { "https://notroblox.com/"_s }));
+    EXPECT_FALSE(WebCore::Quirks::needsIPadMiniUserAgent(URL { "https://roblox.com.example.com/"_s }));
+
+    EXPECT_TRUE(WebCore::Quirks::needsIPadMiniUserAgent(URL { "https://www.indiatimes.com/"_s }));
+    EXPECT_FALSE(WebCore::Quirks::needsIPadMiniUserAgent(URL { "https://indiatimes.com/"_s }));
+    EXPECT_FALSE(WebCore::Quirks::needsIPadMiniUserAgent(URL { "https://timesofindia.indiatimes.com/"_s }));
+
+    EXPECT_FALSE(WebCore::Quirks::needsIPadMiniUserAgent(URL { "https://www.example.com/"_s }));
+}
+
+TEST_F(QuirksTest, NeedsIPhoneUserAgent)
+{
+    auto shopeeLandingURL = URL { "https://shopee.sg/payment/account-linking/landing"_s };
+
+#if PLATFORM(IOS_FAMILY)
+    EXPECT_TRUE(WebCore::Quirks::needsIPhoneUserAgent(shopeeLandingURL));
+
+    EXPECT_FALSE(WebCore::Quirks::needsIPhoneUserAgent(URL { "https://shopee.sg/"_s }));
+    EXPECT_FALSE(WebCore::Quirks::needsIPhoneUserAgent(URL { "https://shopee.sg/payment/account-linking/landing/"_s }));
+    EXPECT_FALSE(WebCore::Quirks::needsIPhoneUserAgent(URL { "https://shopee.sg/payment/account-linking/landing/step2"_s }));
+    EXPECT_FALSE(WebCore::Quirks::needsIPhoneUserAgent(URL { "https://shopee.sg/payment/account-linking"_s }));
+
+    EXPECT_FALSE(WebCore::Quirks::needsIPhoneUserAgent(URL { "https://www.shopee.sg/payment/account-linking/landing"_s }));
+    EXPECT_FALSE(WebCore::Quirks::needsIPhoneUserAgent(URL { "https://shopee.com/payment/account-linking/landing"_s }));
+#else
+    EXPECT_FALSE(WebCore::Quirks::needsIPhoneUserAgent(shopeeLandingURL));
+#endif
+
+    EXPECT_FALSE(WebCore::Quirks::needsIPhoneUserAgent(URL { "https://www.example.com/"_s }));
+}
+
+TEST_F(QuirksTest, NeedsCustomUserAgentOverrideNotAffected)
+{
+    EXPECT_FALSE(customUserAgentFor("https://www.example.com/"_s).has_value());
+    EXPECT_FALSE(customUserAgentFor("https://webkit.org/"_s).has_value());
+}
+
+TEST_F(QuirksTest, NeedsCustomUserAgentOverrideOutlook)
+{
+    auto agent = customUserAgentFor("https://outlook.live.com/mail/0/"_s);
+    ASSERT_TRUE(agent.has_value());
+    EXPECT_TRUE(agent->contains("Chrome/"_s));
+
+    EXPECT_FALSE(customUserAgentFor("https://live.com/"_s).has_value());
+    EXPECT_FALSE(customUserAgentFor("https://onedrive.live.com/"_s).has_value());
+}
+
+TEST_F(QuirksTest, NeedsCustomUserAgentOverrideGroupCall)
+{
+    for (auto url : { "https://www.messenger.com/groupcall/ROOM:12345"_s, "https://www.facebook.com/groupcall/ROOM:12345"_s }) {
+        auto agent = WebCore::Quirks::needsCustomUserAgentOverride(URL { url }, "TestApp"_s, "TestBase/1.0 (KHTML, like Gecko) Trailer/1.0"_s);
+        ASSERT_TRUE(agent.has_value());
+        EXPECT_TRUE(agent->contains("Chrome/"_s));
+    }
+
+    EXPECT_FALSE(customUserAgentFor("https://www.facebook.com/"_s).has_value());
+    EXPECT_FALSE(customUserAgentFor("https://www.messenger.com/t/12345"_s).has_value());
+    EXPECT_FALSE(customUserAgentFor("https://www.facebook.com/groupcall/"_s).has_value());
+}
+
+TEST_F(QuirksTest, NeedsCustomUserAgentOverrideIsRegistrableDomainGranularity)
+{
+    EXPECT_EQ(customUserAgentFor("https://app.101edu.co/"_s).has_value(), customUserAgentFor("https://101edu.co/"_s).has_value());
+    EXPECT_EQ(customUserAgentFor("https://app.aktiv.com/"_s).has_value(), customUserAgentFor("https://aktiv.com/"_s).has_value());
+    EXPECT_FALSE(customUserAgentFor("https://app.101edu.co/"_s).has_value());
+    EXPECT_FALSE(customUserAgentFor("https://app.aktiv.com/"_s).has_value());
+}
+
+#if PLATFORM(COCOA)
+TEST_F(QuirksTest, NeedsCustomUserAgentOverrideRewritesBaseAgent)
+{
+    struct Case {
+        ASCIILiteral url;
+        ASCIILiteral marker;
+    };
+
+    Case cases[] = {
+        { "https://www.tiktok.com/"_s, "like Chrome/136."_s },
+        { "https://mms.pinduoduo.com/"_s, "like Chrome/149."_s },
+        { "https://github.com/WebKit/WebKit"_s, "like Chrome/151."_s },
+    };
+
+    for (auto testCase : cases) {
+        auto agent = customUserAgentFor(testCase.url);
+        ASSERT_TRUE(agent.has_value());
+        EXPECT_TRUE(agent->contains(testCase.marker));
+        EXPECT_TRUE(agent->startsWith("TestBase/1.0"_s));
+        EXPECT_TRUE(agent->contains("Trailer/1.0"_s));
+    }
+
+    EXPECT_FALSE(customUserAgentFor("https://www.pinduoduo.com/"_s).has_value());
+
+    EXPECT_TRUE(customUserAgentFor("https://gist.github.com/"_s).has_value());
+    EXPECT_TRUE(customUserAgentFor("https://ads.tiktok.com/"_s).has_value());
+}
+#endif // PLATFORM(COCOA)
+
+#if PLATFORM(IOS)
+TEST_F(QuirksTest, NeedsCustomUserAgentOverrideAmazonPrimeVideo)
+{
+    auto agent = customUserAgentFor("https://www.amazon.com/gp/video/"_s);
+    ASSERT_TRUE(agent.has_value());
+    EXPECT_TRUE(agent->contains("Chrome/"_s));
+
+    EXPECT_TRUE(customUserAgentFor("https://www.amazon.co.uk/gp/video/"_s).has_value());
+
+    EXPECT_FALSE(customUserAgentFor("https://www.amazon.com/"_s).has_value());
+    EXPECT_FALSE(customUserAgentFor("https://www.amazon.com/gp/video/storefront"_s).has_value());
+}
+#endif // PLATFORM(IOS)
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/UserAgentQuirks.cpp
@@ -28,13 +28,11 @@
 #include <WebCore/UserAgent.h>
 #include <wtf/URL.h>
 
-using namespace WebCore;
-
 namespace TestWebKitAPI {
 
 static void assertUserAgentForURLHasChromeBrowserQuirk(const char* url)
 {
-    String uaString = standardUserAgentForURL(URL(String::fromLatin1(url)));
+    String uaString = WebCore::standardUserAgentForURL(URL(String::fromLatin1(url)));
 
     EXPECT_TRUE(uaString.contains("Chrome"_s));
     EXPECT_TRUE(uaString.contains("Safari"_s));
@@ -45,7 +43,7 @@ static void assertUserAgentForURLHasChromeBrowserQuirk(const char* url)
 
 static void assertUserAgentForURLHasFirefoxBrowserQuirk(const char* url)
 {
-    String uaString = standardUserAgentForURL(URL(String::fromLatin1(url)));
+    String uaString = WebCore::standardUserAgentForURL(URL(String::fromLatin1(url)));
 
     EXPECT_FALSE(uaString.contains("Chrome"_s));
     EXPECT_FALSE(uaString.contains("Safari"_s));
@@ -56,7 +54,7 @@ static void assertUserAgentForURLHasFirefoxBrowserQuirk(const char* url)
 
 static void assertUserAgentForURLHasMacPlatformQuirk(const char* url)
 {
-    String uaString = standardUserAgentForURL(URL(String::fromLatin1(url)));
+    String uaString = WebCore::standardUserAgentForURL(URL(String::fromLatin1(url)));
 
     EXPECT_TRUE(uaString.contains("Macintosh"_s));
     EXPECT_TRUE(uaString.contains("Mac OS X"_s));
@@ -69,7 +67,7 @@ static void assertUserAgentForURLHasMacPlatformQuirk(const char* url)
 #if ENABLE(WEBXR) && PLATFORM(WPE)
 static void assertUserAgentForURLHasAndroidQuirk(const char* url)
 {
-    String uaString = standardUserAgentForURL(URL(String::fromLatin1(url)));
+    String uaString = WebCore::standardUserAgentForURL(URL(String::fromLatin1(url)));
 
     EXPECT_FALSE(uaString.contains("Macintosh"_s));
     EXPECT_FALSE(uaString.contains("Mac OS X"_s));
@@ -87,14 +85,14 @@ static void assertUserAgentForURLHasAndroidQuirk(const char* url)
 // that the standard user agent should be used.)
 static void assertUserAgentForURLHasEmptyQuirk(const char* url)
 {
-    String uaString = standardUserAgentForURL(URL(String::fromLatin1(url)));
+    String uaString = WebCore::standardUserAgentForURL(URL(String::fromLatin1(url)));
     EXPECT_FALSE(uaString.isNull());
 }
 
 static void assertUserAgentForURLHasNoQuirk(const char* url)
 {
     // A site with no quirks should return a null String.
-    String uaString = standardUserAgentForURL(URL(String::fromLatin1(url)));
+    String uaString = WebCore::standardUserAgentForURL(URL(String::fromLatin1(url)));
     EXPECT_TRUE(uaString.isNull());
 }
 


### PR DESCRIPTION
#### 5d77774e94782f6e2feb16c78cc1555c416816b3
<pre>
Add API tests for user agent override quirks
<a href="https://bugs.webkit.org/show_bug.cgi?id=321973">https://bugs.webkit.org/show_bug.cgi?id=321973</a>
<a href="https://rdar.apple.com/185153208">rdar://185153208</a>

Reviewed by Zak Ridouh.

I am going to start making large changes to the quirking system. I want to be sure
that my changes do not affect what quirks are active for which websites.

This patch adds API tests for the following static user agent quirks:
needsIPadMiniUserAgent, needsIPhoneUserAgent, and needsCustomUserAgentOverride.

I also moved Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp to
Tools/TestWebKitAPI/Tests/WebCore/glib/UserAgentQuirks.cpp.

Tests: Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp
       Tools/TestWebKitAPI/Tests/WebCore/glib/UserAgentQuirks.cpp

* Source/WebCore/platform/glib/UserAgentQuirks.cpp:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/PlatformGTK.cmake:
* Tools/TestWebKitAPI/PlatformWPE.cmake:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/Quirks.cpp: Added.
(TestWebKitAPI::QuirksTest::SetUp):
(TestWebKitAPI::customUserAgentFor):
(TestWebKitAPI::TEST_F(QuirksTest, NeedsIPadMiniUserAgent)):
(TestWebKitAPI::TEST_F(QuirksTest, NeedsIPhoneUserAgent)):
(TestWebKitAPI::TEST_F(QuirksTest, NeedsCustomUserAgentOverrideNotAffected)):
(TestWebKitAPI::TEST_F(QuirksTest, NeedsCustomUserAgentOverrideOutlook)):
(TestWebKitAPI::TEST_F(QuirksTest, NeedsCustomUserAgentOverrideGroupCall)):
(TestWebKitAPI::TEST_F(QuirksTest, NeedsCustomUserAgentOverrideIsRegistrableDomainGranularity)):
(TestWebKitAPI::TEST_F(QuirksTest, NeedsCustomUserAgentOverrideRewritesBaseAgent)):
(TestWebKitAPI::TEST_F(QuirksTest, NeedsCustomUserAgentOverrideAmazonPrimeVideo)):
* Tools/TestWebKitAPI/Tests/WebCore/glib/UserAgentQuirks.cpp: Renamed from Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp.
(TestWebKitAPI::assertUserAgentForURLHasChromeBrowserQuirk):
(TestWebKitAPI::assertUserAgentForURLHasFirefoxBrowserQuirk):
(TestWebKitAPI::assertUserAgentForURLHasMacPlatformQuirk):
(TestWebKitAPI::assertUserAgentForURLHasAndroidQuirk):
(TestWebKitAPI::assertUserAgentForURLHasEmptyQuirk):
(TestWebKitAPI::assertUserAgentForURLHasNoQuirk):
(TestWebKitAPI::TEST(UserAgentTest, Quirks)):

Canonical link: <a href="https://commits.webkit.org/319391@main">https://commits.webkit.org/319391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/264fca1f900986415a3770a10bd86a3565cc8df1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145509 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141387 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98074 "4 flakes 11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/93255879-ba06-4d36-947c-1ee20dd3d302) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121838 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c0455d4-c4e1-4e49-9481-9c786ff025c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43733 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42008 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41666 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2562 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193335 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54797 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150780 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40427 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55485 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150496 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45084 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127753 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123311 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54002 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16662 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53384 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53621 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53449 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->