### PR TITLE
[web-animations] An animation of width or height is incorrectly accelerated when only some keyframes have a size-dependent transform

### DIFF
--- a/LayoutTests/animations/transform-percent-in-single-keyframe-with-height-expected.html
+++ b/LayoutTests/animations/transform-percent-in-single-keyframe-with-height-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 10px;
+    height: 200px;
+    background-color: black;
+    transform: translateY(50%);
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/animations/transform-percent-in-single-keyframe-with-height.html
+++ b/LayoutTests/animations/transform-percent-in-single-keyframe-with-height.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animating the "transform" property with a percent value in a single keyframe while also animating "height"</title>
+<style>
+
+div {
+    width: 10px;
+    height: 10px;
+    background-color: black;
+    animation: anim 10s linear forwards;
+}
+
+/* The 0% keyframe is implicit so that the first frame of this animation, during which an accelerated
+   animation would be committed, uses the unanimated 10px height. From the second frame onwards the
+   animated values are constant, so this animation must render like the reference. The "to" keyframe
+   is the only one without a size-dependent transform. */
+@keyframes anim {
+    0.000000001%, 99.999999999% {
+        height: 200px;
+        transform: translateY(50%);
+    }
+    to {
+        height: 200px;
+        transform: translateY(0px);
+    }
+}
+
+</style>
+</head>
+<body>
+<div></div>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/animations/transform-percent-in-single-keyframe-with-width-expected.html
+++ b/LayoutTests/animations/transform-percent-in-single-keyframe-with-width-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 200px;
+    height: 10px;
+    background-color: black;
+    transform: translateX(50%);
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/animations/transform-percent-in-single-keyframe-with-width.html
+++ b/LayoutTests/animations/transform-percent-in-single-keyframe-with-width.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animating the "transform" property with a percent value in a single keyframe while also animating "width"</title>
+<style>
+
+div {
+    width: 10px;
+    height: 10px;
+    background-color: black;
+    animation: anim 10s linear forwards;
+}
+
+/* The 0% keyframe is implicit so that the first frame of this animation, during which an accelerated
+   animation would be committed, uses the unanimated 10px width. From the second frame onwards the
+   animated values are constant, so this animation must render like the reference. The "to" keyframe
+   is the only one without a size-dependent transform. */
+@keyframes anim {
+    0.000000001%, 99.999999999% {
+        width: 200px;
+        transform: translateX(50%);
+    }
+    to {
+        width: 200px;
+        transform: translateX(0px);
+    }
+}
+
+</style>
+</head>
+<body>
+<div></div>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/webanimations/size-dependent-transform-not-accelerated-expected.txt
+++ b/LayoutTests/webanimations/size-dependent-transform-not-accelerated-expected.txt
@@ -1,0 +1,7 @@
+
+PASS An animation of width and a width-dependent transform in all of its keyframes should not be accelerated.
+PASS An animation of width and a width-dependent transform in its first keyframe only should not be accelerated.
+PASS An animation of height and a height-dependent transform in its first keyframe only should not be accelerated.
+PASS An animation of width and a width-dependent transform in its first keyframe and a height-dependent transform in its last keyframe should not be accelerated.
+PASS An animation of width, a width-dependent transform and a size-independent translate should not be accelerated.
+

--- a/LayoutTests/webanimations/size-dependent-transform-not-accelerated.html
+++ b/LayoutTests/webanimations/size-dependent-transform-not-accelerated.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/rendering-frames.js"></script>
+<body>
+<script>
+
+const assertNotAccelerated = async keyframes => {
+    const target = document.body.appendChild(document.createElement("div"));
+    target.style.cssText = "position: absolute; top: 0; left: 0; width: 100px; height: 100px; background-color: black;";
+
+    const animation = target.animate(keyframes, 60 * 1000);
+    await animation.ready;
+
+    // We wait for two frames to ensure an accelerated animation would have been committed.
+    await renderingFrames(2);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0, "The animation's target has no accelerated animation.");
+};
+
+// A size-dependent transform must be resolved against the animated size on every frame, which an
+// accelerated animation cannot do since it resolves percentages once, when it is committed. Each of
+// the animations below specifies a size-dependent transform in at least one keyframe and must not be
+// accelerated, no matter which keyframe or which of the transform-related properties provides the
+// size dependency.
+
+promise_test(() => assertNotAccelerated([
+    { width: "100px", transform: "translateX(50%)" },
+    { width: "200px", transform: "translateX(50%)" }
+]), "An animation of width and a width-dependent transform in all of its keyframes should not be accelerated.");
+
+promise_test(() => assertNotAccelerated([
+    { width: "100px", transform: "translateX(50%)" },
+    { width: "200px", transform: "translateX(0px)" }
+]), "An animation of width and a width-dependent transform in its first keyframe only should not be accelerated.");
+
+promise_test(() => assertNotAccelerated([
+    { height: "100px", transform: "translateY(50%)" },
+    { height: "200px", transform: "translateY(0px)" }
+]), "An animation of height and a height-dependent transform in its first keyframe only should not be accelerated.");
+
+promise_test(() => assertNotAccelerated([
+    { width: "100px", transform: "translateX(50%)" },
+    { width: "200px", transform: "translateY(50%)" }
+]), "An animation of width and a width-dependent transform in its first keyframe and a height-dependent transform in its last keyframe should not be accelerated.");
+
+promise_test(() => assertNotAccelerated([
+    { width: "100px", transform: "translateX(50%)", translate: "10px" },
+    { width: "200px", transform: "translateX(50%)", translate: "20px" }
+]), "An animation of width, a width-dependent transform and a size-independent translate should not be accelerated.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -382,14 +382,14 @@ void BlendingKeyframes::analyzeKeyframe(const BlendingKeyframe& keyframe)
 
         if (keyframe.animatesProperty(CSSPropertyTransform)) {
             auto [isWidthDependent, isHeightDependent] = style->transform().computeSizeDependencies();
-            m_hasWidthDependentTransform = isWidthDependent;
-            m_hasHeightDependentTransform = isHeightDependent;
+            m_hasWidthDependentTransform |= isWidthDependent;
+            m_hasHeightDependentTransform |= isHeightDependent;
         }
 
         if (keyframe.animatesProperty(CSSPropertyTranslate)) {
             auto [isWidthDependent, isHeightDependent] = style->translate().computeSizeDependencies();
-            m_hasWidthDependentTransform = isWidthDependent;
-            m_hasHeightDependentTransform = isHeightDependent;
+            m_hasWidthDependentTransform |= isWidthDependent;
+            m_hasHeightDependentTransform |= isHeightDependent;
         }
     };
 


### PR DESCRIPTION
#### 26589117d86d3ca8f966b8d3efa3da5fb549c3f9
<pre>
[web-animations] An animation of width or height is incorrectly accelerated when only some keyframes have a size-dependent transform
<a href="https://bugs.webkit.org/show_bug.cgi?id=321975">https://bugs.webkit.org/show_bug.cgi?id=321975</a>
<a href="https://rdar.apple.com/185153675">rdar://185153675</a>

Reviewed by Antoine Quint.

BlendingKeyframes::analyzeKeyframe() runs once per keyframe and accumulates metadata about
the animation as a whole, but the size-dependent transform flags were assigned rather than
or-ed in, so they described only the last keyframe analyzed. A later size-independent
keyframe, a height-dependent keyframe following a width-dependent one, or the
CSSPropertyTranslate block following the CSSPropertyTransform block within a single
keyframe would each wipe a dependency.

The flags feed computedNeedsForcedLayout(), computeHasSizeDependentTransform() and the
RunningAccelerated::Prevented check in applyPendingAcceleratedActions(), so losing one
lets the animation be committed to the compositor with no forced layout, where
RenderLayerBacking::startAnimation() bakes translateX(50%) against the stale,
pre-animation width and never updates it.

Accumulate with |=, matching every other lambda in analyzeKeyframe().

Tests: animations/transform-percent-in-single-keyframe-with-height.html
       animations/transform-percent-in-single-keyframe-with-width.html
       webanimations/size-dependent-transform-not-accelerated.html

* LayoutTests/animations/transform-percent-in-single-keyframe-with-height-expected.html: Added.
* LayoutTests/animations/transform-percent-in-single-keyframe-with-height.html: Added.
* LayoutTests/animations/transform-percent-in-single-keyframe-with-width-expected.html: Added.
* LayoutTests/animations/transform-percent-in-single-keyframe-with-width.html: Added.
* LayoutTests/webanimations/size-dependent-transform-not-accelerated-expected.txt: Added.
* LayoutTests/webanimations/size-dependent-transform-not-accelerated.html: Added.
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::analyzeKeyframe):

Canonical link: <a href="https://commits.webkit.org/319363@main">https://commits.webkit.org/319363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1271e6b2a40859f0897f771f05ef836d816fb88e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191400 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145506 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141388 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121839 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43730 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42007 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41662 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2559 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193332 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150779 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40405 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55482 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38285 "Too many flaky failures: http/tests/media/now-playing-info-private-browsing.html, http/tests/misc/repeat-open-cancel.html, http/tests/navigation/post-308-response.html, http/tests/resourceLoadStatistics/dont-count-third-party-image-as-third-party-script.html, http/tests/security/cached-cross-origin-shared-css-stylesheet.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/form-action-src-redirect-allowed.html, http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https.html, http/tests/site-isolation/scrolling/scrolling-after-cross-origin-navigation.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150495 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45083 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127750 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123308 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53999 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16658 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53381 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53618 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53446 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->