### PR TITLE
[dialog] show() should invalidate style so the focusing steps see the dialog as rendered

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -865,7 +865,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-eleme
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/natural-size-orientation.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-submit-remove-children.html [ Skip ]
 webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-nested-display.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints.html [ Pass Failure ]
 imported/w3c/web-platform-tests/inert/inert-with-fullscreen-element.html [ Pass Failure ]
 imported/w3c/web-platform-tests/screen-orientation/active-lock.html [ Pass Failure ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-2.html [ Skip ]

--- a/LayoutTests/fast/html/dialog-focus-after-modal-close-expected.txt
+++ b/LayoutTests/fast/html/dialog-focus-after-modal-close-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS show() runs the dialog focusing steps after a showModal()/close() cycle
+PASS dialog contents are focusable after a showModal()/close() cycle
+PASS repeated showModal()/close() cycles keep the dialog contents focusable
+

--- a/LayoutTests/fast/html/dialog-focus-after-modal-close.html
+++ b/LayoutTests/fast/html/dialog-focus-after-modal-close.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Dialog contents are focusable after a modal dialog is closed and shown again</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-focusing-steps">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<input id="outside">
+<dialog id="dialog">
+  <button id="button">button</button>
+</dialog>
+
+<script>
+// After a modal dialog is closed, its cached computed style says display:none. show() must mark
+// that style invalid, otherwise resolveComputedStyle() treats the dialog as an unrendered subtree
+// and nothing inside it is focusable, so the dialog focusing steps have no candidate to focus.
+// showModal() gets the same invalidation from addToTopLayer(), which is why only show() was affected.
+test(t => {
+    t.add_cleanup(() => { if (dialog.open) dialog.close(); });
+    outside.focus();
+    dialog.showModal();
+    assert_equals(document.activeElement, button, 'showModal() should focus the button');
+    dialog.close();
+    assert_equals(document.activeElement, outside, 'close() should restore focus');
+
+    outside.focus();
+    dialog.show();
+    assert_equals(document.activeElement, button, 'show() after a modal cycle should focus the button');
+    dialog.close();
+}, 'show() runs the dialog focusing steps after a showModal()/close() cycle');
+
+test(t => {
+    t.add_cleanup(() => { if (dialog.open) dialog.close(); });
+    outside.focus();
+    dialog.showModal();
+    dialog.close();
+
+    // Focusability must also be correct for a direct focus() call, not just the focusing steps.
+    outside.focus();
+    dialog.show();
+    button.blur();
+    button.focus();
+    assert_equals(document.activeElement, button, 'the button should be focusable via focus()');
+    dialog.close();
+}, 'dialog contents are focusable after a showModal()/close() cycle');
+
+test(t => {
+    t.add_cleanup(() => { if (dialog.open) dialog.close(); });
+    // Two modal cycles, to confirm the state is cleaned up each time rather than once.
+    for (let i = 0; i < 2; ++i) {
+        outside.focus();
+        dialog.showModal();
+        assert_equals(document.activeElement, button, `showModal() should focus the button (cycle ${i})`);
+        dialog.close();
+    }
+}, 'repeated showModal()/close() cycles keep the dialog contents focusable');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt
@@ -1,5 +1,4 @@
 button 1 button 2
-hello world
 
 FAIL Focus should not be restored if the currently focused element is not inside the dialog. assert_equals: expected Element node <button id="b2">button 2</button> but got Element node <button id="b1">button 1</button>
 FAIL Focus restore should not occur when the focused element is in a shadowroot outside of the dialog. assert_equals: document.activeElement should point at the shadow host. expected Element node <div id="host">
@@ -8,5 +7,5 @@ FAIL Focus restore should not occur when the focused element is in a shadowroot 
 PASS Focus restore should occur when the focused element is in a shadowroot inside the dialog.
 PASS Focus restore should occur when the focused element is slotted into a dialog.
 PASS Focus restore should always occur for modal dialogs.
-FAIL Focus restore should work when the dialog itself is focused. assert_equals: The dialog should be focused after show() because it has no interactive descendants. expected Element node <dialog id="mydialog2" open="">hello world</dialog> but got Element node <button id="b1">button 1</button>
+PASS Focus restore should work when the dialog itself is focused.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints-expected.txt
@@ -12,16 +12,16 @@ PASS Nested auto/hint ancestors with dialog
 PASS Nested auto/hint ancestors with dialog, top layer element *is* a popover
 PASS Nested auto/hint ancestors with fullscreen
 PASS Nested auto/hint ancestors with fullscreen, top layer element *is* a popover
-FAIL Nested auto/hint ancestors, target is auto with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Nested auto/hint ancestors, target is auto with dialog
 PASS Nested auto/hint ancestors, target is auto with dialog, top layer element *is* a popover
-FAIL Nested auto/hint ancestors, target is auto with fullscreen assert_equals: Incorrect behavior expected true but got false
+PASS Nested auto/hint ancestors, target is auto with fullscreen
 PASS Nested auto/hint ancestors, target is auto with fullscreen, top layer element *is* a popover
 PASS Unrelated hint, target=hint with dialog
 PASS Unrelated hint, target=hint with dialog, top layer element *is* a popover
 PASS Unrelated hint, target=hint with fullscreen
 PASS Unrelated hint, target=hint with fullscreen, top layer element *is* a popover
-FAIL Unrelated hint, target=auto with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Unrelated hint, target=auto with dialog
 PASS Unrelated hint, target=auto with dialog, top layer element *is* a popover
-FAIL Unrelated hint, target=auto with fullscreen assert_equals: Incorrect behavior expected true but got false
+PASS Unrelated hint, target=auto with fullscreen
 PASS Unrelated hint, target=auto with fullscreen, top layer element *is* a popover
 

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -147,6 +147,13 @@ ExceptionOr<void> HTMLDialogElement::show()
 
     setAttributeWithoutSynchronization(openAttr, emptyAtom());
 
+    // The dialog's cached computed style still says display:none at this point. The focusing steps
+    // below determine focusability from it, and Element::resolveComputedStyle() treats a cached
+    // display:none ancestor as an unrendered subtree unless the ancestor is marked as having an
+    // invalid computed style, so nothing in the dialog would look focusable. showModal() gets this
+    // invalidation from addToTopLayer(). See rdar://185153996 for the underlying issue.
+    invalidateStyle();
+
     Ref document = this->document();
     m_previouslyFocusedElement = document->focusedElement();
 


### PR DESCRIPTION
#### 4e2ff065567a0291ed0c7af24052a56e8c54a2a2
<pre>
[dialog] show() should invalidate style so the focusing steps see the dialog as rendered
<a href="https://bugs.webkit.org/show_bug.cgi?id=321980">https://bugs.webkit.org/show_bug.cgi?id=321980</a>
<a href="https://rdar.apple.com/185156091">rdar://185156091</a>

Reviewed by Tim Nguyen.

After a modal dialog is closed its cached computed style says display:none. show() set the
open attribute but did not mark that style invalid, and
Element::resolveComputedStyle(ResolveComputedStyleMode::RenderedOnly) treats a cached
display:none ancestor as an unrendered subtree unless the ancestor is flagged as having an
invalid computed style. Every focus candidate inside the dialog therefore looked
unfocusable, so the dialog focusing steps had nothing to focus and focus did not move. An
explicit focus() on the dialog&apos;s contents failed at the same point.

showModal() was unaffected only because addToTopLayer() ends with an explicit
invalidateStyle(). Invalidating style here rather than updating it means nothing is
computed at call time, so this does not determine content-visibility proximity early the
way a forced style update would.

The underlying resolveComputedStyle() behavior is tracked separately by <a href="https://rdar.apple.com/185153996">rdar://185153996</a>;
addToTopLayer() and show() are now both compensating for it at their call sites.

This also folds in unrelated popover gardening. popover-top-layer-nesting-hints.html has
been passing all 20 subtests, but its baseline recorded four failures and a
[ Pass Failure ] expectation accepted either outcome, so the test provided no signal.
Verified over 50 iterations with num_flaky 0.

* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::show):
* LayoutTests/fast/html/dialog-focus-after-modal-close.html: Added.
* LayoutTests/fast/html/dialog-focus-after-modal-close-expected.txt: Added.
* LayoutTests/TestExpectations: Remove the obsolete [ Pass Failure ] expectation.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints-expected.txt:

Canonical link: <a href="https://commits.webkit.org/319387@main">https://commits.webkit.org/319387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0854b6a477b2b47a501b160c6f457d82b602233

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145515 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/554ac76e-8225-4134-8669-8cdc7f9a906a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141395 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98079 "2 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6707a3e7-1771-40ab-b448-4c4494075580) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121846 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d200e07d-949d-469a-b2c8-e9732ce03839) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43741 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42018 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154146 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41677 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2568 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193341 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150787 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40425 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55491 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150503 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45095 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127759 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123317 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54008 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16684 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53390 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53627 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53455 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->