### PR TITLE
[css-conditional-3] Support CSSMediaRule.matches

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-001-expected.txt
@@ -1,0 +1,4 @@
+
+PASS "@media all" always matches
+PASS "@media not all" never matches
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+
+<title>CSSMediaRule.matches</title>
+
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-conditional-3/#dom-cssmediarule-matches">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style id="sheet">
+  @media all { }
+  @media not all { }
+</style>
+
+<script>
+  test(() => {
+    assert_true(sheet.sheet.cssRules[0].matches);
+  }, '"@media all" always matches');
+
+  test(() => {
+    assert_false(sheet.sheet.cssRules[1].matches);
+  }, '"@media not all" never matches');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-002-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Initially, @media (max-height: 100px) doesn't match in an iframe with 200px height
+PASS Change iframe height to 90px, @media (max-height: 100px) now matches
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-002.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+
+<title>CSSMediaRule.matches changes when viewport changes</title>
+
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-conditional-3/#dom-cssmediarule-matches">
+
+<script src="/common/rendering-utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 200px;
+    height: 200px;
+  }
+</style>
+
+<iframe id=iframe src="support/at-media-matches-002-iframe.html"></iframe>
+
+<script>
+  function getMediaMatches() {
+    return new Promise(resolve => {
+      window.addEventListener("message", (event) => {
+        resolve(event.data);
+      }, { "once": true });
+
+      iframe.contentWindow.postMessage("getMediaMatches");
+    });
+  }
+
+  // Wait for the frame to fully load.
+  promise_setup(() => {
+    return new Promise(resolve => {
+      window.addEventListener("message", (event) => {
+        if (event.data === "ready")
+          resolve();
+      }, { "once": true });
+    });
+  });
+
+  promise_test(async () => {
+    const matches = await getMediaMatches();
+    assert_false(matches);
+  }, "Initially, @media (max-height: 100px) doesn't match in an iframe with 200px height");
+
+  promise_test(async () => {
+    iframe.style.height = "90px";
+
+    // Wait a few frames for style resolution.
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    const matches = await getMediaMatches();
+    assert_true(matches);
+  }, "Change iframe height to 90px, @media (max-height: 100px) now matches");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/idlharness-expected.txt
@@ -19,11 +19,11 @@ PASS CSSMediaRule interface: existence and properties of interface prototype obj
 PASS CSSMediaRule interface: existence and properties of interface prototype object's "constructor" property
 PASS CSSMediaRule interface: existence and properties of interface prototype object's @@unscopables property
 PASS CSSMediaRule interface: attribute media
-FAIL CSSMediaRule interface: attribute matches assert_true: The prototype object must have a property "matches" expected true got false
+PASS CSSMediaRule interface: attribute matches
 PASS CSSMediaRule must be primary interface of cssMediaRule
 PASS Stringification of cssMediaRule
 PASS CSSMediaRule interface: cssMediaRule must inherit property "media" with the proper type
-FAIL CSSMediaRule interface: cssMediaRule must inherit property "matches" with the proper type assert_inherits: property "matches" not found in prototype chain
+PASS CSSMediaRule interface: cssMediaRule must inherit property "matches" with the proper type
 PASS CSSConditionRule interface: cssMediaRule must inherit property "conditionText" with the proper type
 PASS CSSRule interface: cssMediaRule must inherit property "SUPPORTS_RULE" with the proper type
 PASS CSSSupportsRule interface: existence and properties of interface object

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/support/at-media-matches-002-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/support/at-media-matches-002-iframe.html
@@ -1,0 +1,13 @@
+<style id="sheet">
+  @media (max-height: 100px) { }
+</style>
+
+<script>
+  onload = () => window.top.postMessage("ready");
+
+  window.addEventListener("message", event => {
+    if (event.data === "getMediaMatches") {
+      window.top.postMessage(sheet.sheet.cssRules[0].matches);
+    }
+  });
+</script>

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -24,7 +24,9 @@
 #include "CSSMediaRule.h"
 
 #include "CSSStyleSheet.h"
+#include "Document.h"
 #include "MediaList.h"
+#include "MediaQueryEvaluator.h"
 #include "MediaQueryParser.h"
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
@@ -80,6 +82,17 @@ MediaList& CSSMediaRule::media() const
     if (!m_mediaCSSOMWrapper)
         m_mediaCSSOMWrapper = MediaList::create(const_cast<CSSMediaRule*>(this));
     return *m_mediaCSSOMWrapper;
+}
+
+bool CSSMediaRule::matches(const Document& document) const
+{
+    const auto mediaQueries = this->mediaQueries();
+
+    MQ::MediaQueryEvaluator evaluator { document.printing() ? printAtom() : screenAtom(), document };
+
+    // FIXME: maybe cache this so we don't have to re-evaluate
+    // (have to invalidate when viewport changes)
+    return evaluator.evaluate(mediaQueries);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSMediaRule.h
+++ b/Source/WebCore/css/CSSMediaRule.h
@@ -26,6 +26,7 @@
 
 namespace WebCore {
 
+class Document;
 class MediaList;
 class StyleRuleMedia;
 
@@ -40,6 +41,7 @@ public:
     virtual ~CSSMediaRule();
 
     WEBCORE_EXPORT MediaList& media() const;
+    bool matches(const Document&) const;
 
 private:
     friend class MediaList;

--- a/Source/WebCore/css/CSSMediaRule.idl
+++ b/Source/WebCore/css/CSSMediaRule.idl
@@ -24,6 +24,5 @@
     Exposed=Window
 ] interface CSSMediaRule : CSSConditionRule {
     [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
-    // FIXME: Add support for `matches`.
-    // readonly attribute boolean matches;
+    [CallWith=CurrentDocument] readonly attribute boolean matches;
 };


### PR DESCRIPTION
#### 965fa913bdf7df5567909e4d438ffad3d9610e63
<pre>
[css-conditional-3] Support CSSMediaRule.matches
<a href="https://rdar.apple.com/185154835">rdar://185154835</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=321977">https://bugs.webkit.org/show_bug.cgi?id=321977</a>

Reviewed by Antti Koivisto.

CSSWG resolves in 2022 [1] to add CSSMediaRule.matches, which returns
whether the query in @media matches or not.

Supposedly, .matches should evaluate the media query against the current media,
including when the page is being printed. This implementation has that, but
it&apos;s not possible to write a test for this, as run-webkit-tests doesn&apos;t support
WPT print reftests.

[1]: <a href="https://github.com/w3c/csswg-drafts/issues/4240#issuecomment-1196983719">https://github.com/w3c/csswg-drafts/issues/4240#issuecomment-1196983719</a>

Tests: imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-001.html
       imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-002.html
       imported/w3c/web-platform-tests/css/css-conditional/idlharness.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-002-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-media-matches-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/support/at-media-matches-002-iframe.html: Added.
* Source/WebCore/css/CSSMediaRule.cpp:
(WebCore::CSSMediaRule::matches const):
* Source/WebCore/css/CSSMediaRule.h:
* Source/WebCore/css/CSSMediaRule.idl:

Canonical link: <a href="https://commits.webkit.org/319988@main">https://commits.webkit.org/319988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82e497365a3ef9aa0a2ad1b726c0d76b77c30ce5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147544 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd0108b4-5d7c-42b0-842d-e730c937f128) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143036 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/23dc5320-cd4a-4a27-8f7e-b614748e5427) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123462 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26c124e7-54b4-41ad-b222-7b3718b57e28) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182582 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45465 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43721 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5432 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12265 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43325 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4648 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44525 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195414 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182659 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163290 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152522 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40903 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57552 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152218 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46774 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129822 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56060 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18337 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55431 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55498 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->