### PR TITLE
new Blob() crashes when a blob part is too large to buffer

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -260,6 +260,7 @@ http/tests/security/clipboard/drag-drop-html-cross-origin-iframe-in-same-origin.
 fast/shapes/shape-outside-floats/shape-outside-imagedata-overflow.html [ Skip ]
 
 [ Debug ] fast/files/blob-stream-chunks.html [ Skip ]
+[ Debug ] fast/files/blob-constructor-part-too-large.html [ Skip ]
 [ Debug ] security/decode-buffer-size.html [ Skip ]
 [ Debug ] security/text-decode-long-strings.html [ Skip ]
 

--- a/LayoutTests/fast/files/blob-constructor-part-too-large-expected.txt
+++ b/LayoutTests/fast/files/blob-constructor-part-too-large-expected.txt
@@ -1,0 +1,11 @@
+Constructing a Blob or File from parts that are too large to buffer should throw instead of crashing the process.
+
+PASS new Blob([ArrayBuffer]) threw RangeError
+PASS new Blob([Uint8Array]) threw RangeError
+PASS new Blob([string]) threw RangeError
+PASS new File([ArrayBuffer]) threw RangeError
+PASS new Blob([string, ArrayBuffer]) threw RangeError
+PASS new Blob([ArrayBuffer]).size is 2147483647
+PASS new Blob(['abc', ArrayBuffer(1)]).size is 4
+PASS new Blob([Blob, 'de']).size is 5
+

--- a/LayoutTests/fast/files/blob-constructor-part-too-large.html
+++ b/LayoutTests/fast/files/blob-constructor-part-too-large.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Constructing a Blob or File from parts that are too large to buffer should throw
+instead of crashing the process.</p>
+<pre id="console"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function log(message)
+{
+    document.getElementById('console').appendChild(document.createTextNode(message + '\n'));
+}
+
+// A Vector<uint8_t> cannot hold more than 0x7fffffff bytes, so parts totalling at
+// least this much cannot be buffered for the blob's data.
+const vectorLimit = 0x7fffffff;
+
+// Allocating a part is not what is under test. Do it outside the try block below, so
+// that failing to allocate a part cannot look like a passing test.
+function allocate(description, allocatePart)
+{
+    try {
+        return allocatePart();
+    } catch (e) {
+        log('SKIP ' + description + ' - could not allocate the part: ' + e.name);
+        return null;
+    }
+}
+
+function shouldThrow(description, constructBlob)
+{
+    let blob;
+    try {
+        blob = constructBlob();
+    } catch (e) {
+        if (e.name === 'RangeError')
+            log('PASS ' + description + ' threw RangeError');
+        else
+            log('FAIL ' + description + ' threw ' + e.name + ', expected RangeError');
+        return;
+    }
+    log('FAIL ' + description + ' did not throw, size is ' + blob.size);
+}
+
+function shouldHaveSize(description, constructBlob, expectedSize)
+{
+    let size;
+    try {
+        size = constructBlob().size;
+    } catch (e) {
+        log('FAIL ' + description + ' threw ' + e.name);
+        return;
+    }
+    if (size === expectedSize)
+        log('PASS ' + description + '.size is ' + size);
+    else
+        log('FAIL ' + description + '.size is ' + size + ', expected ' + expectedSize);
+}
+
+// One part over the limit, reached through each of the part types that the Blob
+// constructor buffers. The string is Latin-1, so it is an 8-bit string, which is
+// sized at 2 UTF-8 bytes per character.
+const buffer = allocate('new Blob([ArrayBuffer])', () => new ArrayBuffer(vectorLimit + 1));
+if (buffer)
+    shouldThrow('new Blob([ArrayBuffer])', () => new Blob([buffer]));
+
+const view = allocate('new Blob([Uint8Array])', () => new Uint8Array(vectorLimit + 1));
+if (view)
+    shouldThrow('new Blob([Uint8Array])', () => new Blob([view]));
+
+const string = allocate('new Blob([string])', () => '\xe9'.repeat((vectorLimit + 1) / 2));
+if (string)
+    shouldThrow('new Blob([string])', () => new Blob([string]));
+
+const fileBuffer = allocate('new File([ArrayBuffer])', () => new ArrayBuffer(vectorLimit + 1));
+if (fileBuffer)
+    shouldThrow('new File([ArrayBuffer])', () => new File([fileBuffer], 'file.txt'));
+
+// Parts that each fit, but that together do not. Every part here is within what a
+// Vector can hold, so this case cannot pass merely because a part failed to allocate.
+const almostTooLarge = allocate('new Blob([string, ArrayBuffer])', () => new ArrayBuffer(vectorLimit));
+if (almostTooLarge)
+    shouldThrow('new Blob([string, ArrayBuffer])', () => new Blob(['x', almostTooLarge]));
+
+// Parts that do fit must still work, including one part right at the limit and a
+// nested Blob part, which becomes its own item instead of being buffered.
+if (almostTooLarge)
+    shouldHaveSize('new Blob([ArrayBuffer])', () => new Blob([almostTooLarge]), vectorLimit);
+
+shouldHaveSize('new Blob([\'abc\', ArrayBuffer(1)])', () => new Blob(['abc', new ArrayBuffer(1)]), 4);
+shouldHaveSize('new Blob([Blob, \'de\'])', () => new Blob([new Blob(['abc']), 'de']), 5);
+</script>
+</body>
+</html>

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -480,13 +480,24 @@ upConvertTo16Bit:
 
 Vector<uint8_t> TextCodecUTF8::encodeUTF8(StringView string)
 {
+    auto bytes = tryEncodeUTF8(string);
+    RELEASE_ASSERT(bytes);
+    return WTF::move(*bytes);
+}
+
+std::optional<Vector<uint8_t>> TextCodecUTF8::tryEncodeUTF8(StringView string)
+{
     // The buffer size is string.length() * maxBytesPerUnit, where maxBytesPerUnit is the
     // worst-case UTF-8 bytes per input code unit.
     // - 8-bit (Latin1) strings: max 2 UTF-8 bytes per character (for 0x80-0xFF).
     // - 16-bit strings: max 3 UTF-8 bytes per code unit (BMP characters use 1 code unit
     //   and up to 3 bytes; non-BMP use 2 code units and 4 bytes, i.e. only 2 per unit).
+    // A long enough string needs a buffer larger than a Vector can hold, so report the
+    // failure rather than crashing.
     size_t maxBytesPerUnit = string.is8Bit() ? 2 : 3;
-    Vector<uint8_t> bytes(WTF::checkedProduct<size_t>(string.length(), maxBytesPerUnit));
+    Vector<uint8_t> bytes;
+    if (!bytes.tryGrow(WTF::checkedProduct<size_t>(string.length(), maxBytesPerUnit)))
+        return std::nullopt;
     size_t bytesWritten = 0;
     for (auto character : string.codePoints())
         U8_APPEND_UNSAFE(bytes, bytesWritten, character);

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
@@ -39,6 +39,8 @@ public:
     static void registerCodecs(TextCodecRegistrar);
 
     static Vector<uint8_t> encodeUTF8(StringView);
+    // Returns std::nullopt if a buffer large enough to hold the encoded bytes cannot be allocated.
+    static std::optional<Vector<uint8_t>> tryEncodeUTF8(StringView);
     static std::unique_ptr<TextCodecUTF8> codec();
 
 private:

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -139,7 +139,7 @@ Blob::Blob(ScriptExecutionContext* context)
     ThreadableBlobRegistry::registerInternalBlobURL(m_internalURL, { }, { });
 }
 
-static size_t computeMemoryCost(const std::optional<Vector<BlobPartVariant>>& blobPartVariants)
+size_t Blob::memoryCostForParts(const std::optional<Vector<BlobPartVariant>>& blobPartVariants)
 {
     size_t memoryCost = 0;
     if (blobPartVariants) {
@@ -163,28 +163,55 @@ static size_t computeMemoryCost(const std::optional<Vector<BlobPartVariant>>& bl
     return memoryCost;
 }
 
-static Vector<BlobPart> buildBlobData(std::optional<Vector<BlobPartVariant>>&& blobPartVariants, const BlobPropertyBag& propertyBag)
+static std::optional<Vector<BlobPart>> buildBlobData(std::optional<Vector<BlobPartVariant>>&& blobPartVariants, const BlobPropertyBag& propertyBag)
 {
     BlobBuilder builder(propertyBag.endings);
     if (blobPartVariants) {
         for (auto& blobPartVariant : *blobPartVariants) {
+            bool success = true;
             WTF::switchOn(WTF::move(blobPartVariant),
-                [&](auto&& part) {
+                [&](Ref<Blob>&& part) {
                     builder.append(WTF::move(part));
+                },
+                [&](auto&& part) {
+                    success = builder.append(WTF::move(part));
                 }
             );
+            // A blob part can be larger than the buffer we are able to allocate for it.
+            if (!success)
+                return std::nullopt;
         }
     }
     return builder.finalize();
 }
 
-Blob::Blob(ScriptExecutionContext& context, std::optional<Vector<BlobPartVariant>>&& blobPartVariants, const BlobPropertyBag& propertyBag)
+ExceptionOr<Vector<BlobPart>> Blob::blobDataForParts(std::optional<Vector<BlobPartVariant>>&& blobPartVariants, const BlobPropertyBag& propertyBag)
+{
+    auto blobData = buildBlobData(WTF::move(blobPartVariants), propertyBag);
+    if (!blobData)
+        return Exception { ExceptionCode::OutOfMemoryError, "Blob parts are too large"_s };
+    return WTF::move(*blobData);
+}
+
+ExceptionOr<Ref<Blob>> Blob::create(ScriptExecutionContext& context, std::optional<Vector<BlobPartVariant>>&& blobPartVariants, const BlobPropertyBag& propertyBag)
+{
+    auto memoryCost = memoryCostForParts(blobPartVariants);
+    auto blobData = blobDataForParts(WTF::move(blobPartVariants), propertyBag);
+    if (blobData.hasException())
+        return blobData.releaseException();
+
+    Ref blob = adoptRef(*new Blob(context, blobData.releaseReturnValue(), memoryCost, propertyBag));
+    blob->suspendIfNeeded();
+    return blob;
+}
+
+Blob::Blob(ScriptExecutionContext& context, Vector<BlobPart>&& blobData, size_t memoryCost, const BlobPropertyBag& propertyBag)
     : ActiveDOMObject(&context)
     , m_type(normalizedContentType(propertyBag.type))
-    , m_memoryCost(computeMemoryCost(blobPartVariants))
+    , m_memoryCost(memoryCost)
     , m_internalURL(BlobURL::createInternalURL())
 {
-    ThreadableBlobRegistry::registerInternalBlobURL(m_internalURL, buildBlobData(WTF::move(blobPartVariants), propertyBag), m_type);
+    ThreadableBlobRegistry::registerInternalBlobURL(m_internalURL, WTF::move(blobData), m_type);
 }
 
 Blob::Blob(ScriptExecutionContext* context, Vector<uint8_t>&& data, const String& contentType)

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -52,6 +52,7 @@ namespace WebCore {
 
 class Blob;
 class BlobLoader;
+class BlobPart;
 class DeferredPromise;
 class FragmentedSharedBuffer;
 class ReadableStream;
@@ -79,12 +80,7 @@ public:
         return blob;
     }
 
-    static Ref<Blob> create(ScriptExecutionContext& context, std::optional<Vector<BlobPartVariant>>&& blobPartVariants, const BlobPropertyBag& propertyBag)
-    {
-        Ref blob = adoptRef(*new Blob(context, WTF::move(blobPartVariants), propertyBag));
-        blob->suspendIfNeeded();
-        return blob;
-    }
+    static ExceptionOr<Ref<Blob>> create(ScriptExecutionContext&, std::optional<Vector<BlobPartVariant>>&&, const BlobPropertyBag&);
 
     static Ref<Blob> create(ScriptExecutionContext* context, Vector<uint8_t>&& data, const String& contentType)
     {
@@ -144,9 +140,13 @@ public:
 
 protected:
     WEBCORE_EXPORT explicit Blob(ScriptExecutionContext*);
-    Blob(ScriptExecutionContext&, std::optional<Vector<BlobPartVariant>>&&, const BlobPropertyBag&);
+    Blob(ScriptExecutionContext&, Vector<BlobPart>&&, size_t memoryCost, const BlobPropertyBag&);
     Blob(ScriptExecutionContext*, Vector<uint8_t>&&, const String& contentType);
     Blob(ScriptExecutionContext*, Ref<FragmentedSharedBuffer>&&, const String& contentType);
+
+    // Buffers the blob parts, or returns an exception if they are too large to buffer.
+    static ExceptionOr<Vector<BlobPart>> blobDataForParts(std::optional<Vector<BlobPartVariant>>&&, const BlobPropertyBag&);
+    static size_t memoryCostForParts(const std::optional<Vector<BlobPartVariant>>&);
 
     enum ReferencingExistingBlobConstructor { referencingExistingBlobConstructor };
     Blob(ReferencingExistingBlobConstructor, ScriptExecutionContext*, const Blob&);

--- a/Source/WebCore/fileapi/BlobBuilder.cpp
+++ b/Source/WebCore/fileapi/BlobBuilder.cpp
@@ -46,14 +46,14 @@ BlobBuilder::BlobBuilder(EndingType endings)
 {
 }
 
-void BlobBuilder::append(Ref<ArrayBuffer>&& arrayBuffer)
+bool BlobBuilder::append(Ref<ArrayBuffer>&& arrayBuffer)
 {
-    m_appendableData.append(arrayBuffer->span());
+    return m_appendableData.tryAppend(arrayBuffer->span());
 }
 
-void BlobBuilder::append(Ref<ArrayBufferView>&& arrayBufferView)
+bool BlobBuilder::append(Ref<ArrayBufferView>&& arrayBufferView)
 {
-    m_appendableData.append(arrayBufferView->span());
+    return m_appendableData.tryAppend(arrayBufferView->span());
 }
 
 void BlobBuilder::append(Ref<Blob>&& blob)
@@ -63,19 +63,22 @@ void BlobBuilder::append(Ref<Blob>&& blob)
     m_items.append(blob->url());
 }
 
-void BlobBuilder::append(const String& text)
+bool BlobBuilder::append(const String& text)
 {
-    auto bytes = PAL::TextCodecUTF8::encodeUTF8(text);
+    auto bytes = PAL::TextCodecUTF8::tryEncodeUTF8(text);
+    if (!bytes)
+        return false;
 
     if (m_endings == EndingType::Native)
-        bytes = normalizeLineEndingsToNative(WTF::move(bytes));
+        bytes = normalizeLineEndingsToNative(WTF::move(*bytes));
 
-    if (m_appendableData.isEmpty())
-        m_appendableData = WTF::move(bytes);
-    else {
-        // FIXME: Would it be better to move multiple vectors into m_items instead of merging them into one?
-        m_appendableData.appendVector(bytes);
+    if (m_appendableData.isEmpty()) {
+        m_appendableData = WTF::move(*bytes);
+        return true;
     }
+
+    // FIXME: Would it be better to move multiple vectors into m_items instead of merging them into one?
+    return m_appendableData.tryAppend(bytes->span());
 }
 
 void BlobBuilder::append(Ref<FragmentedSharedBuffer>&& buffer)

--- a/Source/WebCore/fileapi/BlobBuilder.h
+++ b/Source/WebCore/fileapi/BlobBuilder.h
@@ -47,11 +47,14 @@ class BlobBuilder {
 public:
     BlobBuilder(EndingType);
 
-    void append(Ref<JSC::ArrayBuffer>&&);
-    void append(Ref<JSC::ArrayBufferView>&&);
-    void append(Ref<Blob>&&);
-    void append(const String& text);
+    // These buffer the data into a single Vector, and return false if it is too large to hold.
+    bool append(Ref<JSC::ArrayBuffer>&&);
+    bool append(Ref<JSC::ArrayBufferView>&&);
+    bool append(const String& text);
+
+    // These append an item instead of buffering, so there is nothing to fail to allocate.
     void append(Ref<FragmentedSharedBuffer>&&);
+    void append(Ref<Blob>&&);
 
     Vector<BlobPart> finalize();
 

--- a/Source/WebCore/fileapi/File.cpp
+++ b/Source/WebCore/fileapi/File.cpp
@@ -26,7 +26,9 @@
 #include "config.h"
 #include "File.h"
 
+#include "BlobPart.h"
 #include "BlobURL.h"
+#include "ExceptionOr.h"
 #include "MIMETypeRegistry.h"
 #include <JavaScriptCore/ArrayBufferView.h>
 #include "ThreadableBlobRegistry.h"
@@ -84,8 +86,21 @@ File::File(DeserializationContructor, ScriptExecutionContext* context, const Str
 {
 }
 
-File::File(ScriptExecutionContext& context, Vector<BlobPartVariant>&& blobPartVariants, const String& filename, const PropertyBag& propertyBag)
-    : Blob(context, WTF::move(blobPartVariants), propertyBag)
+ExceptionOr<Ref<File>> File::create(ScriptExecutionContext& context, Vector<BlobPartVariant>&& blobPartVariants, const String& filename, const PropertyBag& propertyBag)
+{
+    std::optional<Vector<BlobPartVariant>> optionalBlobPartVariants { WTF::move(blobPartVariants) };
+    auto memoryCost = memoryCostForParts(optionalBlobPartVariants);
+    auto blobData = blobDataForParts(WTF::move(optionalBlobPartVariants), propertyBag);
+    if (blobData.hasException())
+        return blobData.releaseException();
+
+    Ref file = adoptRef(*new File(context, blobData.releaseReturnValue(), memoryCost, filename, propertyBag));
+    file->suspendIfNeeded();
+    return file;
+}
+
+File::File(ScriptExecutionContext& context, Vector<BlobPart>&& blobData, size_t memoryCost, const String& filename, const PropertyBag& propertyBag)
+    : Blob(context, WTF::move(blobData), memoryCost, propertyBag)
     , m_name(filename)
     , m_lastModifiedDateOverride(propertyBag.lastModified.value_or(WallTime::now().secondsSinceEpoch().milliseconds()))
 {

--- a/Source/WebCore/fileapi/File.h
+++ b/Source/WebCore/fileapi/File.h
@@ -45,12 +45,7 @@ public:
     WEBCORE_EXPORT static Ref<File> create(ScriptExecutionContext*, const String& path, const String& replacementPath = { }, const String& nameOverride = { }, const std::optional<FileSystem::PlatformFileID>& fileID = { });
 
     // Create a File using the 'new File' constructor.
-    static Ref<File> create(ScriptExecutionContext& context, Vector<BlobPartVariant>&& blobPartVariants, const String& filename, const PropertyBag& propertyBag)
-    {
-        auto file = adoptRef(*new File(context, WTF::move(blobPartVariants), filename, propertyBag));
-        file->suspendIfNeeded();
-        return file;
-    }
+    static ExceptionOr<Ref<File>> create(ScriptExecutionContext&, Vector<BlobPartVariant>&&, const String& filename, const PropertyBag&);
 
     static Ref<File> deserialize(ScriptExecutionContext* context, const String& path, const URL& srcURL, const String& type, const String& name, const std::optional<int64_t>& lastModified = std::nullopt)
     {
@@ -94,7 +89,7 @@ public:
 private:
     WEBCORE_EXPORT File(ScriptExecutionContext*, const String& path);
     File(ScriptExecutionContext*, URL&&, String&& type, String&& path, String&& name);
-    File(ScriptExecutionContext&, Vector<BlobPartVariant>&& blobPartVariants, const String& filename, const PropertyBag&);
+    File(ScriptExecutionContext&, Vector<BlobPart>&&, size_t memoryCost, const String& filename, const PropertyBag&);
     File(ScriptExecutionContext*, URL&&, String&& type, String&& path, String&& name, const std::optional<FileSystem::PlatformFileID>&);
     File(ScriptExecutionContext*, const Blob&, const String& name);
     File(ScriptExecutionContext*, const File&, const String& name);


### PR DESCRIPTION
#### 5e33ad4952e2d07139a3dfef17d13d402927acfc
<pre>
new Blob() crashes when a blob part is too large to buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=321985">https://bugs.webkit.org/show_bug.cgi?id=321985</a>
<a href="https://rdar.apple.com/181485531">rdar://181485531</a>

Reviewed by NOBODY (OOPS!).

The Blob constructor buffers every part into one Vector&lt;uint8_t&gt;, which cannot
hold more than 0x7fffffff bytes. Appending a larger part called CRASH(), so
new Blob([new ArrayBuffer(0x80000000)]) killed the WebContent process from any
page. A long string part died the same way inside encodeUTF8(), which sizes its
buffer at up to 3 UTF-8 bytes per code unit.

Make buffering fallible. BlobBuilder::append() now returns false when the data
does not fit, using Vector::tryAppend() and a new TextCodecUTF8::tryEncodeUTF8().
A constructor cannot report failure, so Blob::create() and File::create() build
the blob data themselves, return ExceptionOr&lt;Ref&lt;...&gt;&gt;, and throw
OutOfMemoryError. Parts that fit take the same path as before.

Test: fast/files/blob-constructor-part-too-large.html

* LayoutTests/TestExpectations:
* LayoutTests/fast/files/blob-constructor-part-too-large-expected.txt: Added.
* LayoutTests/fast/files/blob-constructor-part-too-large.html: Added.
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::TextCodecUTF8::encodeUTF8):
(PAL::TextCodecUTF8::tryEncodeUTF8):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.h:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::memoryCostForParts):
(WebCore::buildBlobData):
(WebCore::Blob::blobDataForParts):
(WebCore::Blob::create):
(WebCore::Blob::Blob):
(WebCore::computeMemoryCost): Deleted.
* Source/WebCore/fileapi/Blob.h:
* Source/WebCore/fileapi/BlobBuilder.cpp:
(WebCore::BlobBuilder::append):
* Source/WebCore/fileapi/BlobBuilder.h:
* Source/WebCore/fileapi/File.cpp:
(WebCore::File::create):
(WebCore::File::File):
* Source/WebCore/fileapi/File.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e33ad4952e2d07139a3dfef17d13d402927acfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191421 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145527 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6d8184b-3119-4474-adb6-566fa0702905) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141406 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98088 "2 flakes 12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69adb97e-4f97-4c01-addd-1cb41f9b332f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121857 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d22e53a-2a2e-46bd-aae5-99e5e0351898) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43753 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42029 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154158 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41686 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2583 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193353 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150796 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55503 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150512 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45105 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127771 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123329 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54020 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16682 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53402 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53639 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53467 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->