### PR TITLE
[scroll-animations] View timeline range boundaries discard subpixel sticky adjustments

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-subpixel-adjustment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-subpixel-adjustment-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Subpixel sticky room is preserved at the end of the cover range.
+PASS Subpixel sticky room is preserved at the start of the cover range.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-subpixel-adjustment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-subpixel-adjustment.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>View timeline cover range preserves subpixel sticky adjustments</title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+<style>
+
+.scroller {
+  height: 500px;
+  overflow-y: scroll;
+}
+.space {
+  height: 550px;
+}
+.containing-block {
+  height: 550px;
+}
+.sticky {
+  position: sticky;
+  height: 200px;
+  background: yellow;
+}
+.subject {
+  position: relative;
+  top: 50px;
+  height: 100px;
+  background: orange;
+}
+
+/* 200.5px of room below the sticky box: 550.5px - (150px + 200px). */
+#containing-block-1 {
+  height: 550.5px;
+}
+#sticky-1 {
+  top: 400px;
+}
+#leading-space-1 {
+  height: 150px;
+}
+
+/* 150.5px of room above the sticky box. */
+#sticky-2 {
+  bottom: -100px;
+}
+#leading-space-2 {
+  height: 150.5px;
+}
+
+</style>
+</head>
+<body>
+<div class="scroller" id="scroller-1">
+  <div class="space"></div>
+  <div class="containing-block" id="containing-block-1">
+    <div id="leading-space-1"></div>
+    <div class="sticky" id="sticky-1">
+      <div class="subject" id="subject-1"></div>
+    </div>
+  </div>
+  <div class="space"></div>
+</div>
+<div class="scroller" id="scroller-2">
+  <div class="space"></div>
+  <div class="containing-block" id="containing-block-2">
+    <div id="leading-space-2"></div>
+    <div class="sticky" id="sticky-2">
+      <div class="subject" id="subject-2"></div>
+    </div>
+  </div>
+  <div class="space"></div>
+</div>
+<script type="text/javascript">
+
+// Sticky room ending in a half pixel must survive into the cover range.
+
+const EPSILON = 0.05;
+
+// Solves the linear scroll-offset-to-progress map for the cover range
+// boundaries, in px. The middle sample checks that linearity, which holds only
+// if sticky offsets are ignored when locating the subject.
+async function measureCoverRange(t, scroller, subject, samples) {
+  assert_equals(scroller.clientHeight, 500, 'scrollport height');
+  assert_greater_than(scroller.scrollHeight, scroller.clientHeight,
+                      'scroller overflows');
+
+  const timeline = new ViewTimeline({ subject: subject, axis: 'block' });
+  // Keeps the timeline sampled every frame.
+  const animation = subject.animate({ opacity: [0.3, 0.7] },
+                                    { timeline: timeline, fill: 'both' });
+  t.add_cleanup(() => animation.cancel());
+  await animation.ready;
+
+  const progressAt = async scrollOffset => {
+    scroller.scrollTop = scrollOffset;
+    await waitForNextFrame();
+    assert_equals(scroller.scrollTop, scrollOffset,
+                  `scrolled to ${scrollOffset}`);
+    const currentTime = timeline.currentTime;
+    assert_not_equals(currentTime, null, 'timeline is active');
+    assert_equals(currentTime.unit, 'percent', 'progress is a percentage');
+    return currentTime.value / 100;
+  };
+
+  const progress1 = await progressAt(samples[0]);
+  const progressMiddle = await progressAt(samples[1]);
+  const progress2 = await progressAt(samples[2]);
+
+  const length = (samples[2] - samples[0]) / (progress2 - progress1);
+  const start = samples[0] - progress1 * length;
+  assert_approx_equals(start + progressMiddle * length, samples[1], EPSILON,
+                       'progress is linear in the scroll offset');
+  return { start: start, end: start + length };
+}
+
+promise_test(async t => {
+  const range = await measureCoverRange(t, document.getElementById('scroller-1'),
+                                        document.getElementById('subject-1'),
+                                        [400, 600, 800]);
+  // Static range [250, 850]; top-stuck during entry pushes the end out by the
+  // 200.5px of room below.
+  assert_approx_equals(range.start, 250, EPSILON, 'cover range start');
+  assert_approx_equals(range.end, 1050.5, EPSILON, 'cover range end');
+}, 'Subpixel sticky room is preserved at the end of the cover range.');
+
+promise_test(async t => {
+  const range = await measureCoverRange(t, document.getElementById('scroller-2'),
+                                        document.getElementById('subject-2'),
+                                        [300, 500, 700]);
+  // Static range [250.5, 850.5]; bottom-stuck during entry pulls the start in
+  // by the 150.5px of room above.
+  assert_approx_equals(range.start, 100, EPSILON, 'cover range start');
+  assert_approx_equals(range.end, 850.5, EPSILON, 'cover range end');
+}, 'Subpixel sticky room is preserved at the start of the cover range.');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -186,7 +186,7 @@ float StickinessAdjustmentData::exitDistanceAdjustment() const
 
 float StickinessAdjustmentData::rangeStartAdjustment() const
 {
-    auto rangeStartAdjustment = 0;
+    float rangeStartAdjustment = 0;
     if (topOrLeftAdjustmentLocation == StickinessLocation::BeforeEntry)
         rangeStartAdjustment += stickyTopOrLeftAdjustment;
     if (bottomOrRightAdjustmentLocation != StickinessLocation::BeforeEntry)
@@ -196,7 +196,7 @@ float StickinessAdjustmentData::rangeStartAdjustment() const
 
 float StickinessAdjustmentData::rangeEndAdjustment() const
 {
-    auto rangeEndAdjustment = 0;
+    float rangeEndAdjustment = 0;
     if (topOrLeftAdjustmentLocation != StickinessLocation::AfterExit)
         rangeEndAdjustment += stickyTopOrLeftAdjustment;
     if (bottomOrRightAdjustmentLocation == StickinessLocation::AfterExit)


### PR DESCRIPTION
#### 5aea254b4c026383ea8087f076499506f50b0963
<pre>
[scroll-animations] View timeline range boundaries discard subpixel sticky adjustments
<a href="https://bugs.webkit.org/show_bug.cgi?id=321986">https://bugs.webkit.org/show_bug.cgi?id=321986</a>
<a href="https://rdar.apple.com/185162728">rdar://185162728</a>

Reviewed by Antoine Quint.

This patch aligns WebKit with Blink / Chromium.

StickinessAdjustmentData::rangeStartAdjustment() and rangeEndAdjustment()
accumulated into `auto x = 0`, which deduces int, so each `+=` of a float
sticky adjustment was truncated toward zero. The room a sticky box has to
move within its containing block is a float, so a fractional adjustment was
either discarded entirely or lost its fraction, shifting the start and end of
the view timeline&apos;s cover range by up to a pixel. The sibling
entryDistanceAdjustment() and exitDistanceAdjustment() already used float and
were unaffected.

Spell both accumulators float, matching the siblings.

Test: imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-subpixel-adjustment.html

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-subpixel-adjustment-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-subpixel-adjustment.html: Added.
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::StickinessAdjustmentData::rangeStartAdjustment const):
(WebCore::StickinessAdjustmentData::rangeEndAdjustment const):

Canonical link: <a href="https://commits.webkit.org/319369@main">https://commits.webkit.org/319369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebdb2af424ecbab1d2c6d868c07ac1eeae9029f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145605 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0043379-19cc-4847-a6b8-837a1ce1f422) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54947 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b439125-7f94-4586-a8ba-e344d7aa5559) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121918 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a549f070-32dd-4bcb-ab49-0ba9bd0486f5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42105 "Passed tests") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154238 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41760 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2656 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193430 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161739 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40407 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55582 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150577 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45166 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127863 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123431 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54098 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16757 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53480 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53718 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53545 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->