### PR TITLE
BlendingKeyframe copy constructor drops m_hasPropertiesWithRevertRuleOrLayer, so keyframes using revert-layer/revert-rule stop being recomputed after KeyframeEffect is copied

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/copy-constructor-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/copy-constructor-revert-layer-expected.txt
@@ -1,0 +1,4 @@
+
+PASS revert-layer in a keyframe follows the author value as it changes
+PASS revert-layer in a keyframe stays dynamic through the KeyframeEffect copy constructor
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/copy-constructor-revert-layer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/copy-constructor-revert-layer.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>KeyframeEffect copy constructor: revert-layer in keyframes stays dynamic</title>
+<link rel="help"
+      href="https://drafts.csswg.org/web-animations/#dom-keyframeeffect-keyframeeffect-source">
+<link rel="help"
+      href="https://drafts.csswg.org/css-cascade-5/#revert-layer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+const KEYFRAMES = [ { width: 'revert-layer' }, { width: '200px' } ];
+
+const TIMING = { duration: 3600 * MS_PER_SEC,
+                 easing: 'steps(2, start)',
+                 fill: 'both' };
+
+function pausedAtStart(effect) {
+  const animation = new Animation(effect, document.timeline);
+  animation.pause();
+  animation.currentTime = 0;
+  return animation;
+}
+
+test(t => {
+  const target = createDiv(t);
+  target.style.width = '100px';
+
+  const effect = new KeyframeEffect(target, KEYFRAMES, TIMING);
+  assert_equals(effect.getKeyframes()[0].width, 'revert-layer',
+                'revert-layer is retained as the first keyframe value');
+
+  pausedAtStart(effect);
+  assert_equals(getComputedStyle(target).width, '150px',
+                'revert-layer resolves to the author value (100px)');
+
+  target.style.width = '120px';
+  assert_equals(getComputedStyle(target).width, '160px',
+                'revert-layer resolves to the new author value (120px)');
+}, 'revert-layer in a keyframe follows the author value as it changes');
+
+test(t => {
+  const target = createDiv(t);
+  target.style.width = '100px';
+
+  const source = new KeyframeEffect(target, KEYFRAMES, TIMING);
+  const sourceAnimation = pausedAtStart(source);
+
+  assert_equals(getComputedStyle(target).width, '150px',
+                'source effect resolves revert-layer to the author value');
+
+  const copy = new KeyframeEffect(source);
+  assert_equals(copy.getKeyframes()[0].width, 'revert-layer',
+                'the copy retains revert-layer as the first keyframe value');
+
+  sourceAnimation.cancel();
+  pausedAtStart(copy);
+  assert_equals(getComputedStyle(target).width, '150px',
+                'copied effect resolves revert-layer to the author value');
+
+  target.style.width = '120px';
+  assert_equals(getComputedStyle(target).width, '160px',
+                'copied effect resolves revert-layer to the new author value');
+}, 'revert-layer in a keyframe stays dynamic through the KeyframeEffect copy constructor');
+
+</script>
+</body>

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -475,6 +475,7 @@ BlendingKeyframe::BlendingKeyframe(const BlendingKeyframe& source)
     , m_timingFunction(source.m_timingFunction)
     , m_compositeOperation(source.m_compositeOperation)
     , m_containsDirectionAwareProperty(source.m_containsDirectionAwareProperty)
+    , m_hasPropertiesWithRevertRuleOrLayer(source.m_hasPropertiesWithRevertRuleOrLayer)
 {
 }
 


### PR DESCRIPTION
#### 6718717d10e990b85cababf273e22be911cffa72
<pre>
BlendingKeyframe copy constructor drops m_hasPropertiesWithRevertRuleOrLayer, so keyframes using revert-layer/revert-rule stop being recomputed after KeyframeEffect is copied
<a href="https://bugs.webkit.org/show_bug.cgi?id=321988">https://bugs.webkit.org/show_bug.cgi?id=321988</a>
<a href="https://rdar.apple.com/185164643">rdar://185164643</a>

Reviewed by Antoine Quint.

This patch aligns WebKit with Blink / Chromium.

BlendingKeyframe&apos;s copy constructor initializes every member except
m_hasPropertiesWithRevertRuleOrLayer. BlendingKeyframes::copyKeyframes()
copies each keyframe through that constructor and re-derives the container
flag in analyzeKeyframe(), so the copy always reports
hasPropertiesWithRevertRuleOrLayer() == false.

In the animation origin &apos;revert-layer&apos; and &apos;revert-rule&apos; roll the cascade
back to the author level, which WebKit implements by leaving the property
unapplied so the keyframe keeps the base style&apos;s value. That makes the
keyframe style depend on the author-level value, and
KeyframeEffect::recomputeKeyframesIfNecessary() relies on the flag to
re-resolve it when that value changes. Losing the flag leaves such an
effect permanently pinned to the value the keyframes were first computed
with.

This is web-observable through the KeyframeEffect copy constructor: the
copy carries already-computed keyframes, so updateBlendingKeyframes() will
not rebuild them from the parsed keyframes, and setAnimation() only clears
them for CSSAnimation-typed effects.

Test: imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/copy-constructor-revert-layer.html

* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/copy-constructor-revert-layer-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/copy-constructor-revert-layer.html: Added.
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframe::BlendingKeyframe):

Canonical link: <a href="https://commits.webkit.org/319368@main">https://commits.webkit.org/319368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d79cda119b6168ae58c488f726d31d5b9b39489

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145603 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141474 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121916 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43833 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42104 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154236 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41758 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2654 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193428 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150867 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40406 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55580 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150575 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45165 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127861 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123429 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54096 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16755 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53478 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53716 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->