### PR TITLE
[Web Animations] Hang in an iteration composite operation of accumulate with an infinite current iteration

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-unbounded-current-iteration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-unbounded-current-iteration-expected.txt
@@ -1,0 +1,5 @@
+
+PASS iteration composition with an infinite current iteration
+PASS iteration composition with a current iteration too large to be applied one accumulation at a time
+PASS iteration composition with a current iteration small enough to be applied one accumulation at a time
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-unbounded-current-iteration.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-unbounded-current-iteration.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>The effect value of a keyframe effect: Applying the iteration composite
+  operation with an unbounded current iteration</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations/#calculating-the-current-iteration">
+<link rel="help" href="https://drafts.csswg.org/web-animations/#the-effect-value-of-a-keyframe-animation-effect">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="../../testcommon.js"></script>
+<div id="log"></div>
+<script>
+'use strict';
+
+test(t => {
+  const div = createDiv(t);
+  const anim =
+    div.animate({ color: ['rgb(0, 0, 0)', 'rgb(255, 0, 0)'] },
+                { duration: 0,
+                  iterations: Infinity,
+                  fill: 'forwards',
+                  iterationComposite: 'accumulate' });
+  anim.currentTime = 1;
+
+  assert_equals(anim.effect.getComputedTiming().currentIteration, Infinity,
+    'The current iteration is infinite');
+  assert_equals(getComputedStyle(div).color, 'rgb(255, 0, 0)',
+    'Animated color style in the after phase');
+}, 'iteration composition with an infinite current iteration');
+
+test(t => {
+  const div = createDiv(t);
+  const anim =
+    div.animate({ color: ['rgb(0, 0, 0)', 'rgb(255, 0, 0)'] },
+                { duration: 100 * MS_PER_SEC,
+                  easing: 'linear',
+                  iterationStart: 3e9,
+                  iterationComposite: 'accumulate' });
+  anim.pause();
+  anim.currentTime = 50 * MS_PER_SEC;
+
+  assert_equals(anim.effect.getComputedTiming().currentIteration, 3e9,
+    'The current iteration exceeds the range of a 32-bit signed integer');
+  assert_equals(getComputedStyle(div).color, 'rgb(255, 0, 0)',
+    'Animated color style at 50s of the 3000000001st iteration');
+}, 'iteration composition with a current iteration too large to be applied one '
+   + 'accumulation at a time');
+
+test(t => {
+  const div = createDiv(t);
+  const anim =
+    div.animate({ transform: ['translateX(0px)', 'translateX(1px)'] },
+                { duration: 100 * MS_PER_SEC,
+                  easing: 'linear',
+                  iterationStart: 5,
+                  iterationComposite: 'accumulate' });
+  anim.pause();
+  anim.currentTime = 50 * MS_PER_SEC;
+
+  assert_matrix_equals(getComputedStyle(div).transform,
+    'matrix(1, 0, 0, 1, 5.5, 0)',
+    'Animated transform style at 50s of the sixth iteration');
+}, 'iteration composition with a current iteration small enough to be applied '
+   + 'one accumulation at a time');
+
+</script>

--- a/Source/WebCore/animation/KeyframeInterpolation.cpp
+++ b/Source/WebCore/animation/KeyframeInterpolation.cpp
@@ -26,7 +26,11 @@
 #include "config.h"
 #include "KeyframeInterpolation.h"
 
+#include <wtf/MathExtras.h>
+
 namespace WebCore {
+
+static constexpr auto maximumAccumulativeIterationCount = 1000000;
 
 const KeyframeInterpolation::KeyframeInterval KeyframeInterpolation::interpolationKeyframes(Property property, double iterationProgress, const Keyframe& defaultStartKeyframe, const Keyframe& defaultEndKeyframe) const
 {
@@ -170,14 +174,24 @@ void KeyframeInterpolation::interpolateKeyframes(Property property, const Keyfra
         // If this keyframe effect has an iteration composite operation of accumulate,
         if (iterationCompositeOperation() == IterationCompositeOperation::Accumulate && currentIteration && requiresInterpolationForAccumulativeIterationCallback()) {
             usedInterpolationForAccumulativeIteration = true;
+
+            auto accumulateOntoStartKeyframe = !startKeyframe.offset() && !interval.hasImplicitZeroKeyframe;
+            auto accumulateOntoEndKeyframe = endKeyframe.offset() == 1 && !interval.hasImplicitOneKeyframe;
+
+            auto accumulativeIterationCount = [&] {
+                if (!accumulateOntoStartKeyframe && !accumulateOntoEndKeyframe)
+                    return 0;
+                return clampTo<int>(currentIteration, 0, maximumAccumulativeIterationCount);
+            }();
+
             // apply the following step current iteration times:
-            for (auto i = 0; i < currentIteration; ++i) {
+            for (auto i = 0; i < accumulativeIterationCount; ++i) {
                 // replace the property value of target property on keyframe with the result of combining the
                 // property value on the final keyframe in property-specific keyframes (Va) with the property
                 // value on keyframe (Vb) using the accumulation procedure defined for target property.
-                if (!startKeyframe.offset() && !interval.hasImplicitZeroKeyframe)
+                if (accumulateOntoStartKeyframe)
                     accumulationCallback(startKeyframe);
-                if (endKeyframe.offset() == 1 && !interval.hasImplicitOneKeyframe)
+                if (accumulateOntoEndKeyframe)
                     accumulationCallback(endKeyframe);
             }
         }


### PR DESCRIPTION
#### 2c675e3b607f9ca67e8f860ad180f9ce1143598d
<pre>
[Web Animations] Hang in an iteration composite operation of accumulate with an infinite current iteration
<a href="https://bugs.webkit.org/show_bug.cgi?id=321989">https://bugs.webkit.org/show_bug.cgi?id=321989</a>
<a href="https://rdar.apple.com/185167839">rdar://185167839</a>

Reviewed by NOBODY (OOPS!).

The effect value of a keyframe effect with an iteration composite operation of
accumulate applies the accumulation procedure &quot;current iteration times&quot;, which we
implemented as `for (auto i = 0; i &lt; currentIteration; ++i)`. The current iteration is
a double and need not be a small whole number: it is infinite for an effect with an
infinite iteration count in its after phase, and floor(overall progress) otherwise,
which an iterationStart of any size inflates without bound. It was also compared
against an int, so a count beyond INT_MAX was signed overflow rather than merely slow.

A zero iteration duration gives a zero active duration, so an infinite iteration count
reaches the after phase, the loop never terminates and the web process is wedged:

      element.animate([{ color: &quot;black&quot;, offset: 0 }, { color: &quot;red&quot;, offset: 1 }],
          { duration: 0, iterations: Infinity, fill: &quot;forwards&quot;,
            iterationComposite: &quot;accumulate&quot; });

Bound how many times the accumulation procedure is applied by clamping the current
iteration, which puts an infinite, NaN or negative current iteration in range too.
Accumulation costs roughly 100ns per iteration, so the bound is high enough not to
change any count we can already apply in reasonable time. Making larger counts exact
would require applying accumulation in closed form; left as a follow-up.

Also hoist the two loop-invariant keyframe offset conditions out of the loop so no
iterations run when there is nothing to accumulate.

Test: imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-unbounded-current-iteration.html

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-unbounded-current-iteration-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-unbounded-current-iteration.html: Added.
* Source/WebCore/animation/KeyframeInterpolation.cpp:
(WebCore::KeyframeInterpolation::interpolateKeyframes const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c675e3b607f9ca67e8f860ad180f9ce1143598d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191708 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145811 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9494bf3a-4bb3-4f5b-b1e5-bd242e433761) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183347 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141645 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98296 "1 flakes 12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d47732fb-5349-48ae-8242-4f34a08d868c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122085 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4947d9f8-0014-4e81-a0d4-4b98362375ee) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44006 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42278 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154407 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41921 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2869 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193636 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151050 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55788 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150757 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45333 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128071 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123697 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54304 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16919 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53686 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53924 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53751 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->