### PR TITLE
Implement new MathMLAnchorElement Web IDL support.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/lists/DOMTokenList-coverage-for-attributes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/lists/DOMTokenList-coverage-for-attributes.html
@@ -29,7 +29,8 @@ var elements = ["a", "area", "link", "iframe", "output", "td", "th"];
 function testAttr(pair, new_el){
   return (pair.attr === "classList" ||
           (pair.attr === "relList" && new_el.localName === "a" &&
-           new_el.namespaceURI === "http://www.w3.org/2000/svg") ||
+           (new_el.namespaceURI === "http://www.w3.org/2000/svg" ||
+            new_el.namespaceURI === "http://www.w3.org/1998/Math/MathML")) ||
           (new_el.namespaceURI === "http://www.w3.org/1999/xhtml" &&
            pair.sup.indexOf(new_el.localName) != -1));
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-hreflang-getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-hreflang-getter-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test anchor's hreflang getter assert_equals: expected (string) "en" but got (undefined) undefined
+PASS Test anchor's hreflang getter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-hreflang-setter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-hreflang-setter-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test anchor's hreflang setter assert_equals: expected (string) "fr" but got (object) null
+PASS Test anchor's hreflang setter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-ping-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-ping-expected.txt
@@ -1,7 +1,7 @@
 Test Link
 Multiple Ping Link
 
-FAIL MathML anchor with ping attribute should send ping on click promise_test: Unhandled rejection with value: object "Error: observe_entry: timeout"
-FAIL MathML anchor with multiple ping URLs should send multiple pings promise_test: Unhandled rejection with value: object "Error: observe_entry: timeout"
-FAIL MathML anchor ping attribute should be settable via ping IDL attribute assert_equals: expected (string) "https://example.com/ping1 https://example.com/ping2" but got (undefined) undefined
+PASS MathML anchor with ping attribute should send ping on click
+PASS MathML anchor with multiple ping URLs should send multiple pings
+PASS MathML anchor ping attribute should be settable via ping IDL attribute
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-rel-getter-setter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-rel-getter-setter-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL MathMLAnchorElement rel and relList should reflect each other and support standard tokens assert_equals: Attribute should reflect IDL setter expected (string) "noopener noreferrer" but got (object) null
+PASS MathMLAnchorElement rel and relList should reflect each other and support standard tokens
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-type-getter-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-type-getter-001-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test anchor's type getter when empty assert_equals: expected (string) "" but got (undefined) undefined
+PASS Test anchor's type getter when empty
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-type-getter-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-type-getter-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test anchor's type getter assert_equals: expected (string) "text/plain" but got (undefined) undefined
+PASS Test anchor's type getter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-type-setter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-type-setter-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test anchor's type setter assert_equals: expected (string) "text/plain" but got (object) null
+PASS Test anchor's type setter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/anchor-hyperlinkutils-getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/anchor-hyperlinkutils-getter-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL Getter for attribute of anchor element(0): search assert_equals: expected (string) "?hi" but got (undefined) undefined
-FAIL Getter for attribute of anchor element(1): hash assert_equals: expected (string) "#somehash" but got (undefined) undefined
-FAIL Getter for attribute of anchor element(2): host assert_equals: expected (string) "google.com:1234" but got (undefined) undefined
-FAIL Getter for attribute of anchor element(3): hostname assert_equals: expected (string) "google.com" but got (undefined) undefined
-FAIL Getter for attribute of anchor element(4): href assert_equals: expected (string) "http://google.com:1234/somedir" but got (undefined) undefined
-FAIL Getter for attribute of anchor element(5): password assert_equals: expected (string) "flabada" but got (undefined) undefined
-FAIL Getter for attribute of anchor element(6): pathname assert_equals: expected (string) "/somedir/someotherdir/index.html" but got (undefined) undefined
-FAIL Getter for attribute of anchor element(7): port assert_equals: expected (string) "1234" but got (undefined) undefined
-FAIL Getter for attribute of anchor element(8): protocol assert_equals: expected (string) "http:" but got (undefined) undefined
-FAIL Getter for attribute of anchor element(9): username assert_equals: expected (string) "anonymous" but got (undefined) undefined
+PASS Getter for attribute of anchor element(0): search
+PASS Getter for attribute of anchor element(1): hash
+PASS Getter for attribute of anchor element(2): host
+PASS Getter for attribute of anchor element(3): hostname
+PASS Getter for attribute of anchor element(4): href
+PASS Getter for attribute of anchor element(5): password
+PASS Getter for attribute of anchor element(6): pathname
+PASS Getter for attribute of anchor element(7): port
+PASS Getter for attribute of anchor element(8): protocol
+PASS Getter for attribute of anchor element(9): username
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/anchor-hyperlinkutils-getter-setter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/anchor-hyperlinkutils-getter-setter-expected.txt
@@ -1,17 +1,17 @@
 
-FAIL Getter and setter for attribute of anchor element(0): hash assert_equals: expected (string) "#somehash" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(1): hash assert_equals: expected (string) "#somehash" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(2): host assert_equals: expected (string) "google.com:1234" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(3): hostname assert_equals: expected (string) "google.com" but got (undefined) undefined
+PASS Getter and setter for attribute of anchor element(0): hash
+PASS Getter and setter for attribute of anchor element(1): hash
+PASS Getter and setter for attribute of anchor element(2): host
+PASS Getter and setter for attribute of anchor element(3): hostname
 PASS Getter and setter for attribute of anchor element(4): href
-FAIL Getter and setter for attribute of anchor element(5): password assert_equals: expected (string) "flabada" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(6): pathname assert_equals: expected (string) "/somedir/someotherdir/index.html" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(7): port assert_equals: expected (string) "1234" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(8): protocol assert_equals: expected (string) "http:" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(9): protocol assert_equals: expected (string) "http:" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(10): search assert_equals: expected (string) "?ho" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(11): search assert_equals: expected (string) "?ho" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(12): search assert_equals: expected (string) "?ho" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(13): search assert_equals: expected (string) "?ho" but got (undefined) undefined
-FAIL Getter and setter for attribute of anchor element(14): username assert_equals: expected (string) "anonymous" but got (undefined) undefined
+PASS Getter and setter for attribute of anchor element(5): password
+PASS Getter and setter for attribute of anchor element(6): pathname
+PASS Getter and setter for attribute of anchor element(7): port
+PASS Getter and setter for attribute of anchor element(8): protocol
+PASS Getter and setter for attribute of anchor element(9): protocol
+PASS Getter and setter for attribute of anchor element(10): search
+PASS Getter and setter for attribute of anchor element(11): search
+PASS Getter and setter for attribute of anchor element(12): search
+PASS Getter and setter for attribute of anchor element(13): search
+PASS Getter and setter for attribute of anchor element(14): username
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-navigation-expected.txt
@@ -1,3 +1,4 @@
-FAIL: Timed out waiting for notifyDone to be called
+Click Me
 
+PASS Test MathMLAnchorElement _blank navigation via BroadcastChannel
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-target-base-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-target-base-expected.txt
@@ -1,3 +1,5 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+Link Empty Target
+
+PASS MathML <a> with target='' falls back to <base target>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/ping-rt-entries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/ping-rt-entries-expected.txt
@@ -1,4 +1,4 @@
 Link
 
-FAIL Hyperlink auditing (<a ping>) should have a resource timing entry assert_equals: expected "ping" but got "other"
+PASS Hyperlink auditing (<a ping>) should have a resource timing entry
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1441,7 +1441,7 @@ CSSMathDepthEnabled:
       default: true
     WebCore:
       default: true
-      
+
 CSSObjectViewBoxEnabled:
   type: bool
   status: stable
@@ -5531,6 +5531,20 @@ MathFontFamily:
       default: '""_str'
     WebCore:
       default: '""_str'
+
+MathMLAnchorElementEnabled:
+  type: bool
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  status: internal
+  category: dom
+  humanReadableName: "MathML <a> element"
+  humanReadableDescription: "Enable support for the MathML <a> element and href attribute."
 
 MathMLDisableHrefOnNonAnchorElement:
   type: bool

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1414,6 +1414,7 @@ set(WebCore_NON_SVG_IDL_FILES
     loader/COEPInheritenceViolationReportBody.idl
     loader/CORPViolationReportBody.idl
 
+    mathml/MathMLAnchorElement.idl
     mathml/MathMLElement.idl
     mathml/MathMLMathElement.idl
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1889,6 +1889,7 @@ $(PROJECT_DIR)/inspector/RTCLogsCallback.idl
 $(PROJECT_DIR)/loader/COEPInheritenceViolationReportBody.idl
 $(PROJECT_DIR)/loader/CORPViolationReportBody.idl
 $(PROJECT_DIR)/make-hash-tools.pl
+$(PROJECT_DIR)/mathml/MathMLAnchorElement.idl
 $(PROJECT_DIR)/mathml/MathMLElement.idl
 $(PROJECT_DIR)/mathml/MathMLMathElement.idl
 $(PROJECT_DIR)/mathml/mathattrs.in

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1552,6 +1552,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/track/VideoTrack.idl \
     $(WebCore)/html/track/VideoTrackConfiguration.idl \
     $(WebCore)/html/track/VideoTrackList.idl \
+    $(WebCore)/mathml/MathMLAnchorElement.idl \
     $(WebCore)/mathml/MathMLElement.idl \
     $(WebCore)/mathml/MathMLMathElement.idl \
     $(WebCore)/inspector/CommandLineAPIHost.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1550,6 +1550,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     history/ProcessSwapDisposition.h
 
     html/Allowlist.h
+    html/AnchorElementUtils.h
     html/AttachmentAssociatedElement.h
     html/Autocapitalize.h
     html/AutocapitalizeTypes.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1630,6 +1630,7 @@ history/BackForwardController.cpp
 history/CachedFrame.cpp @header:RenderStyleGetters
 history/CachedPage.cpp
 history/HistoryItem.cpp
+html/AnchorElementUtils.cpp
 html/AttachmentAssociatedElement.cpp
 html/Autocapitalize.cpp
 html/Autofill.cpp
@@ -2242,6 +2243,7 @@ loader/cache/KeepaliveRequestTracker.cpp
 loader/cache/MemoryCache.cpp
 loader/cache/TrustedFonts.cpp
 loader/icon/IconLoader.cpp
+mathml/MathMLAnchorElement.cpp @header:RenderStyleGetters
 mathml/MathMLAnnotationElement.cpp @header:RenderStyleGetters
 mathml/MathMLElement.cpp @header:RenderStyleGetters
 mathml/MathMLFractionElement.cpp @header:RenderStyleGetters
@@ -4660,6 +4662,7 @@ JSLongRange.cpp
 JSManagedMediaSource.cpp
 JSManagedSourceBuffer.cpp
 JSMapperCallback.cpp
+JSMathMLAnchorElement.cpp
 JSMathMLElement.cpp
 JSMathMLMathElement.cpp
 JSMediaCapabilities.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -7351,6 +7351,8 @@
 		FA9B50212BCA438500CDAB22 /* JSDOMWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = FA9B50202BCA438500CDAB22 /* JSDOMWindow.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FA9CD6322A01A78000EA5CAC /* OriginAccessPatterns.h in Headers */ = {isa = PBXBuildFile; fileRef = FA9CD6312A0186BC00EA5CAC /* OriginAccessPatterns.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FAA4E2FD2A156D57003F5E50 /* FrameLoaderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA4E2FC2A156D57003F5E50 /* FrameLoaderClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FABE72F51059C1EB00D889A1 /* MathMLAnchorElement.h in Headers */ = {isa = PBXBuildFile; fileRef = FABE72EE1059C1EB00D889A1 /* MathMLAnchorElement.h */; };
+		FABE72F51059C1EB00D889A6 /* AnchorElementUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = FABE72EE1059C1EB00D889A6 /* AnchorElementUtils.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FABE72F51059C1EB00D888CC /* MathMLAnnotationElement.h in Headers */ = {isa = PBXBuildFile; fileRef = FABE72EE1059C1EB00D888CC /* MathMLAnnotationElement.h */; };
 		FABE72F51059C1EB00D999DD /* MathMLElement.h in Headers */ = {isa = PBXBuildFile; fileRef = FABE72EE1059C1EB00D999DD /* MathMLElement.h */; };
 		FABE72F71059C1EB00D999DD /* MathMLPresentationElement.h in Headers */ = {isa = PBXBuildFile; fileRef = FABE72F01059C1EB00D999DD /* MathMLPresentationElement.h */; };
@@ -23664,6 +23666,13 @@
 		FA9CD6302A0186BC00EA5CAC /* OriginAccessPatterns.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = OriginAccessPatterns.cpp; sourceTree = "<group>"; };
 		FA9CD6312A0186BC00EA5CAC /* OriginAccessPatterns.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OriginAccessPatterns.h; sourceTree = "<group>"; };
 		FAA4E2FC2A156D57003F5E50 /* FrameLoaderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FrameLoaderClient.h; sourceTree = "<group>"; };
+		FABE72EE1059C1EB00D889A1 /* MathMLAnchorElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MathMLAnchorElement.h; sourceTree = "<group>"; };
+		FABE72EE1059C1EB00D889A2 /* MathMLAnchorElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MathMLAnchorElement.cpp; sourceTree = "<group>"; };
+		FABE72EE1059C1EB00D889A3 /* JSMathMLAnchorElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSMathMLAnchorElement.h; sourceTree = "<group>"; };
+		FABE72EE1059C1EB00D889A4 /* JSMathMLAnchorElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSMathMLAnchorElement.cpp; sourceTree = "<group>"; };
+		FABE72EE1059C1EB00D889A5 /* MathMLAnchorElement.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MathMLAnchorElement.idl; sourceTree = "<group>"; };
+		FABE72EE1059C1EB00D889A6 /* AnchorElementUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnchorElementUtils.h; sourceTree = "<group>"; };
+		FABE72EE1059C1EB00D889A7 /* AnchorElementUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AnchorElementUtils.cpp; sourceTree = "<group>"; };
 		FABE72ED1059C1EB00D888CC /* MathMLAnnotationElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MathMLAnnotationElement.cpp; sourceTree = "<group>"; };
 		FABE72ED1059C1EB00D999DD /* MathMLElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MathMLElement.cpp; sourceTree = "<group>"; };
 		FABE72EE1059C1EB00D888CC /* MathMLAnnotationElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MathMLAnnotationElement.h; sourceTree = "<group>"; };
@@ -33300,6 +33309,8 @@
 				4150F9ED12B6E0990008C860 /* shadow */,
 				B1AD4E7713A12A7200846B27 /* track */,
 				3AD4AB8B2C3CADF700A3E7F3 /* Allowlist.h */,
+				FABE72EE1059C1EB00D889A7 /* AnchorElementUtils.cpp */,
+				FABE72EE1059C1EB00D889A6 /* AnchorElementUtils.h */,
 				E5F67D942B65CC8F00CC30DE /* AttachmentAssociatedElement.cpp */,
 				E5F67D932B65CC2400CC30DE /* AttachmentAssociatedElement.h */,
 				A5F6E16C132ED46E008EDAE3 /* Autocapitalize.cpp */,
@@ -36098,6 +36109,8 @@
 		AACC83D92316578600EB6BF5 /* MATHML */ = {
 			isa = PBXGroup;
 			children = (
+				FABE72EE1059C1EB00D889A4 /* JSMathMLAnchorElement.cpp */,
+				FABE72EE1059C1EB00D889A3 /* JSMathMLAnchorElement.h */,
 				AA11C04D2316973D009D9831 /* JSMathMLMathElement.cpp */,
 				AA11C04E23169782009D9831 /* JSMathMLMathElement.h */,
 			);
@@ -43490,6 +43503,9 @@
 			isa = PBXGroup;
 			children = (
 				FA654A671108ABE2002615E0 /* mathattrs.in */,
+				FABE72EE1059C1EB00D889A2 /* MathMLAnchorElement.cpp */,
+				FABE72EE1059C1EB00D889A1 /* MathMLAnchorElement.h */,
+				FABE72EE1059C1EB00D889A5 /* MathMLAnchorElement.idl */,
 				FABE72ED1059C1EB00D888CC /* MathMLAnnotationElement.cpp */,
 				FABE72EE1059C1EB00D888CC /* MathMLAnnotationElement.h */,
 				FABE72ED1059C1EB00D999DD /* MathMLElement.cpp */,
@@ -44167,6 +44183,7 @@
 				5C53DCE124465DFC00A93124 /* ApplePaySetupFeatureWebCore.h in Headers */,
 				5C53DCEA24468FB400A93124 /* ApplePaySetupWebCore.h in Headers */,
 				5C53DCE724468AD200A93124 /* PaymentInstallmentConfigurationWebCore.h in Headers */,
+				FABE72F51059C1EB00D889A6 /* AnchorElementUtils.h */,
 				7CD0E2B81F80A4820016A4CE /* AbortController.h in Headers */,
 				7CD0E2BF1F80A56E0016A4CE /* AbortSignal.h in Headers */,
 				DD308A2D2A82F684000A2687 /* AbstractLineBuilder.h in Headers */,
@@ -47501,6 +47518,7 @@
 				E45BA6AA2374926C004DFC07 /* MatchedDeclarationsCache.h in Headers */,
 				E44A0256273AE0C000993A56 /* MatchResult.h in Headers */,
 				E4EF455E2D9D3E0500120306 /* MatchResultCache.h in Headers */,
+				FABE72F51059C1EB00D889A1 /* MathMLAnchorElement.h in Headers */,
 				FABE72F51059C1EB00D888CC /* MathMLAnnotationElement.h in Headers */,
 				FABE72F51059C1EB00D999DD /* MathMLElement.h in Headers */,
 				44A28AAC12DFB8AC00AE923B /* MathMLElementFactory.h in Headers */,

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -309,6 +309,7 @@ namespace WebCore {
     macro(LockManager) \
     macro(ManagedMediaSource) \
     macro(ManagedSourceBuffer) \
+    macro(MathMLAnchorElement) \
     macro(MathMLElement) \
     macro(MathMLMathElement) \
     macro(MediaCapabilities) \

--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -74,6 +74,14 @@ static inline int NODELETE windowsVirtualKeyCodeWithoutLocation(int keycode)
     }
 }
 
+bool KeyboardEvent::isEnterKeyKeydownEvent(Event& event)
+{
+    if (event.type() != eventNames().keydownEvent)
+        return false;
+    auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(event);
+    return keyboardEvent && keyboardEvent->keyIdentifier() == "Enter"_s;
+}
+
 static inline KeyboardEvent::KeyLocationCode NODELETE keyLocationCode(const PlatformKeyboardEvent& key)
 {
     if (key.isKeypad())

--- a/Source/WebCore/dom/KeyboardEvent.h
+++ b/Source/WebCore/dom/KeyboardEvent.h
@@ -69,11 +69,13 @@ public:
     static Ref<KeyboardEvent> create(const AtomString& type, const Init&, IsTrusted = IsTrusted::No);
 
     virtual ~KeyboardEvent();
-    
+
     WEBCORE_EXPORT void initKeyboardEvent(const AtomString& type, bool canBubble, bool cancelable, RefPtr<WindowProxy>&&,
         const AtomString& keyIdentifier, unsigned location,
         bool ctrlKey, bool altKey, bool shiftKey, bool metaKey);
-    
+
+    static bool isEnterKeyKeydownEvent(Event&);
+
     const String& key() const LIFETIME_BOUND { return m_key; }
     const String& code() const LIFETIME_BOUND { return m_code; }
     const AtomString& keyIdentifier() const LIFETIME_BOUND { return m_keyIdentifier; }

--- a/Source/WebCore/html/AnchorElementUtils.cpp
+++ b/Source/WebCore/html/AnchorElementUtils.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must reproduce the above copyright
+ *    notice, this list of conditions and the following conditions
+ *    the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following conditions and the
+ *    following disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES SUBSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF LIABILITY, WHETHER
+ * IN OUT OF THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * ASSOCIATED WITH THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AnchorElementUtils.h"
+
+#include "Document.h"
+#include "Event.h"
+#include "FrameLoader.h"
+#include "LocalFrame.h"
+#include "FrameDestructionObserverInlines.h"
+#include "ElementInlines.h"
+#include "OriginAccessPatterns.h"
+#include "PingLoader.h"
+#include "ResourceResponse.h"
+#include "SecurityOrigin.h"
+#include "Settings.h"
+#include "SpaceSplitString.h"
+
+#include <JavaScriptCore/ConsoleTypes.h>
+
+namespace WebCore {
+
+OptionSet<Relation> AnchorElementUtils::relationsForRelAttribute(const AtomString& relValue)
+{
+    // Update AnchorElementUtils::isSupportedRelToken() if more rel attributes values are supported.
+    static MainThreadNeverDestroyed<const AtomString> noReferrer("noreferrer"_s);
+    static MainThreadNeverDestroyed<const AtomString> noOpener("noopener"_s);
+    static MainThreadNeverDestroyed<const AtomString> opener("opener"_s);
+
+    OptionSet<Relation> relations;
+    SpaceSplitString values(relValue, SpaceSplitString::ShouldFoldCase::Yes);
+    if (values.contains(noReferrer))
+        relations.add(Relation::NoReferrer);
+    if (values.contains(noOpener))
+        relations.add(Relation::NoOpener);
+    if (values.contains(opener))
+        relations.add(Relation::Opener);
+    return relations;
+}
+
+bool AnchorElementUtils::isSupportedRelToken(Document& document, StringView token)
+{
+#if USE(SYSTEM_PREVIEW)
+    if (equalLettersIgnoringASCIICase(token, "ar"_s))
+        return document.settings().systemPreviewEnabled();
+#else
+    UNUSED_PARAM(document);
+#endif
+    return equalLettersIgnoringASCIICase(token, "noreferrer"_s)
+        || equalLettersIgnoringASCIICase(token, "noopener"_s)
+        || equalLettersIgnoringASCIICase(token, "opener"_s);
+}
+
+bool AnchorElementUtils::hasRel(OptionSet<Relation> linkRelations, Relation relation)
+{
+    return linkRelations.contains(relation);
+}
+
+AtomString AnchorElementUtils::parseDownloadAttribute(const Element& element, const URL& completedURL, const QualifiedName& downloadAttr)
+{
+    Ref document = element.document();
+    if (!document->settings().downloadAttributeEnabled())
+        return nullAtom();
+
+    bool isSameOrigin = completedURL.protocolIsData() || protect(document->securityOrigin())->canRequest(completedURL, OriginAccessPatternsForWebProcess::singleton());
+    if (isSameOrigin)
+        return AtomString { ResourceResponse::sanitizeSuggestedFilename(element.attributeWithoutSynchronization(downloadAttr)) };
+
+    if (element.hasAttributeWithoutSynchronization(downloadAttr))
+        document->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, "The download attribute on anchor was ignored because its href URL has a different security origin."_s);
+
+    return nullAtom();
+}
+
+void AnchorElementUtils::sendPings(const Element& element, const QualifiedName& pingAttr, const URL& destinationURL)
+{
+    const auto& pingValue = element.attributeWithoutSynchronization(pingAttr);
+    if (pingValue.isNull())
+        return;
+
+    Ref document = element.document();
+    RefPtr frame = document->frame();
+    if (!frame)
+        return;
+
+    SpaceSplitString pingURLs(pingValue, SpaceSplitString::ShouldFoldCase::No);
+    for (auto& pingURL : pingURLs)
+        PingLoader::sendPing(*frame, document->encodingParseURL(pingURL), destinationURL);
+}
+
+ReferrerPolicy AnchorElementUtils::effectiveReferrerPolicy(OptionSet<Relation> relations, ReferrerPolicy explicitPolicy)
+{
+    if (relations.contains(Relation::NoReferrer))
+        return ReferrerPolicy::NoReferrer;
+    return explicitPolicy;
+}
+
+void AnchorElementUtils::navigateHyperlink(
+    Element& sourceElement,
+    Event& event,
+    const URL& completedURL,
+    const AtomString& target,
+    OptionSet<Relation> relations,
+    ReferrerPolicy referrerPolicy,
+    const AtomString& downloadAttribute,
+    std::optional<PrivateClickMeasurement>&& privateClickMeasurement)
+{
+    Ref document = sourceElement.document();
+    RefPtr frame = document->frame();
+    if (!frame)
+        return;
+
+    NewFrameOpenerPolicy newFrameOpenerPolicy = NewFrameOpenerPolicy::Allow;
+    if (relations.contains(Relation::NoOpener)
+        || relations.contains(Relation::NoReferrer)
+        || (!relations.contains(Relation::Opener) && isBlankTargetFrameName(target) && !completedURL.protocolIsJavaScript())) {
+        newFrameOpenerPolicy = NewFrameOpenerPolicy::Suppress;
+    }
+
+    frame->loader().changeLocation(
+        completedURL,
+        target,
+        &event,
+        referrerPolicy,
+        document->shouldOpenExternalURLsPolicyToPropagate(),
+        newFrameOpenerPolicy,
+        downloadAttribute,
+        WTF::move(privateClickMeasurement),
+        NavigationHistoryBehavior::Auto,
+        &sourceElement);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/AnchorElementUtils.h
+++ b/Source/WebCore/html/AnchorElementUtils.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must reproduce the above copyright
+ *    notice, this list of conditions and the following conditions
+ *    the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following conditions and the
+ *    following disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES SUBSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF LIABILITY, WHETHER
+ * IN OUT OF THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * ASSOCIATED WITH THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/PrivateClickMeasurement.h>
+#include <WebCore/QualifiedName.h>
+#include <WebCore/ReferrerPolicy.h>
+
+#include <wtf/OptionSet.h>
+#include <wtf/URL.h>
+#include <wtf/text/AtomString.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class Document;
+class Element;
+class Event;
+
+// Link relation bitmask values.
+enum class Relation : uint8_t {
+    NoReferrer = 1 << 0,
+    NoOpener = 1 << 1,
+    Opener = 1 << 2,
+};
+
+// This class might migrate to what currently called `URLDecomposition`.
+// Since the goal of the recent HTML/SVG/MathML hyperlink elements alignment work is to move
+// most of the hyper links attributes (download, ping, rel, relList, referrerpolicy etc)
+// to new `HyperlinkElementUtils` which is implemented by `URLDecomposition` in WebKit.
+class AnchorElementUtils {
+    WTF_MAKE_NONCOPYABLE(AnchorElementUtils);
+
+public:
+    AnchorElementUtils() = delete;
+
+    static OptionSet<Relation> relationsForRelAttribute(const AtomString& relValue);
+    static bool isSupportedRelToken(Document&, StringView token);
+    static bool hasRel(OptionSet<Relation> linkRelations, Relation);
+
+    static AtomString parseDownloadAttribute(const Element&, const URL& completedURL, const QualifiedName& downloadAttr);
+
+    static void sendPings(const Element&, const QualifiedName& pingAttr, const URL& destinationURL);
+
+    static ReferrerPolicy effectiveReferrerPolicy(OptionSet<Relation>, ReferrerPolicy explicitPolicy);
+
+    static void navigateHyperlink(
+        Element& sourceElement,
+        Event&,
+        const URL& completedURL,
+        const AtomString& target,
+        OptionSet<Relation> relations,
+        ReferrerPolicy,
+        const AtomString& downloadAttribute = { },
+        std::optional<PrivateClickMeasurement>&& = std::nullopt);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "HTMLAnchorElement.h"
 
+#include "AnchorElementUtils.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "ContainerNodeInlines.h"
@@ -180,7 +181,7 @@ void HTMLAnchorElement::defaultEventHandler(Event& event)
     }
 
     if (isLink()) {
-        if (focused() && isEnterKeyKeydownEvent(event) && treatLinkAsLiveForEventType(NonMouseEvent)) {
+        if (focused() && KeyboardEvent::isEnterKeyKeydownEvent(event) && treatLinkAsLiveForEventType(NonMouseEvent)) {
             event.setDefaultHandled();
             dispatchSimulatedClick(&event);
             return;
@@ -223,14 +224,14 @@ void HTMLAnchorElement::setActive(bool down, Style::InvalidationScope invalidati
             if (down && document().frame() && document().frame()->selection().selection().rootEditableElement() == rootEditableElement())
                 return;
             break;
-        
+
         case EditableLinkBehavior::NeverLive:
         case EditableLinkBehavior::OnlyLiveWithShiftKey:
             return;
 
         }
     }
-    
+
     HTMLElement::setActive(down, invalidationScope);
 }
 
@@ -241,18 +242,7 @@ void HTMLAnchorElement::attributeChanged(const QualifiedName& name, const AtomSt
     if (name == hrefAttr)
         setIsLink(!newValue.isNull() && !shouldProhibitLinks(this));
     else if (name == relAttr) {
-        // Update HTMLAnchorElement::relList() if more rel attributes values are supported.
-        static MainThreadNeverDestroyed<const AtomString> noReferrer("noreferrer"_s);
-        static MainThreadNeverDestroyed<const AtomString> noOpener("noopener"_s);
-        static MainThreadNeverDestroyed<const AtomString> opener("opener"_s);
-        m_linkRelations = { };
-        SpaceSplitString relValue(newValue, SpaceSplitString::ShouldFoldCase::Yes);
-        if (relValue.contains(noReferrer))
-            m_linkRelations.add(Relation::NoReferrer);
-        if (relValue.contains(noOpener))
-            m_linkRelations.add(Relation::NoOpener);
-        if (relValue.contains(opener))
-            m_linkRelations.add(Relation::Opener);
+        m_linkRelations = AnchorElementUtils::relationsForRelAttribute(newValue);
         if (m_relList)
             m_relList->associatedAttributeValueChanged();
     } else if (name == nameAttr)
@@ -299,15 +289,7 @@ bool HTMLAnchorElement::hasRel(Relation relation) const
 DOMTokenList& HTMLAnchorElement::relList()
 {
     if (!m_relList) {
-        lazyInitialize(m_relList, makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::relAttr, [](Document& document, StringView token) {
-#if USE(SYSTEM_PREVIEW)
-            if (equalLettersIgnoringASCIICase(token, "ar"_s))
-                return document.settings().systemPreviewEnabled();
-#else
-            UNUSED_PARAM(document);
-#endif
-            return equalLettersIgnoringASCIICase(token, "noreferrer"_s) || equalLettersIgnoringASCIICase(token, "noopener"_s) || equalLettersIgnoringASCIICase(token, "opener"_s);
-        }));
+        lazyInitialize(m_relList, makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::relAttr, AnchorElementUtils::isSupportedRelToken));
     }
     return *m_relList;
 }
@@ -355,21 +337,6 @@ void HTMLAnchorElement::setText(String&& text)
 bool HTMLAnchorElement::isLiveLink() const
 {
     return isLink() && treatLinkAsLiveForEventType(m_wasShiftKeyDownOnMouseDown ? MouseEventWithShiftKey : MouseEventWithoutShiftKey);
-}
-
-void HTMLAnchorElement::sendPings(const URL& destinationURL)
-{
-    if (!document().frame())
-        return;
-
-    const auto& pingValue = attributeWithoutSynchronization(pingAttr);
-    if (pingValue.isNull())
-        return;
-
-    Ref document = this->document();
-    SpaceSplitString pingURLs(pingValue, SpaceSplitString::ShouldFoldCase::No);
-    for (auto& pingURL : pingURLs)
-        PingLoader::sendPing(*protect(document->frame()), document->encodingParseURL(pingURL), destinationURL);
 }
 
 #if USE(SYSTEM_PREVIEW)
@@ -511,7 +478,7 @@ std::optional<PrivateClickMeasurement> HTMLAnchorElement::parsePrivateClickMeasu
         protect(document())->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, "attributionsourceid is not a non-negative integer which is required for Private Click Measurement."_s);
         return std::nullopt;
     }
-    
+
     if (attributionSourceID.value() > std::numeric_limits<uint8_t>::max()) {
         protect(document())->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("attributionsourceid must have a non-negative value less than or equal to "_s, std::numeric_limits<uint8_t>::max(), " for Private Click Measurement."_s));
         return std::nullopt;
@@ -582,15 +549,7 @@ void HTMLAnchorElement::handleClick(Event& event)
     }
 #endif
 
-    AtomString downloadAttribute;
-    if (document->settings().downloadAttributeEnabled()) {
-        // Ignore the download attribute completely if the href URL is cross origin.
-        bool isSameOrigin = completedURL.protocolIsData() || protect(document->securityOrigin())->canRequest(completedURL, OriginAccessPatternsForWebProcess::singleton());
-        if (isSameOrigin)
-            downloadAttribute = AtomString { ResourceResponse::sanitizeSuggestedFilename(attributeWithoutSynchronization(downloadAttr)) };
-        else if (hasAttributeWithoutSynchronization(downloadAttr))
-            document->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, "The download attribute on anchor was ignored because its href URL has a different security origin."_s);
-    }
+    AtomString downloadAttribute = AnchorElementUtils::parseDownloadAttribute(*this, completedURL, downloadAttr);
 
     SystemPreviewInfo systemPreviewInfo;
 #if USE(SYSTEM_PREVIEW)
@@ -609,21 +568,18 @@ void HTMLAnchorElement::handleClick(Event& event)
     }
 #endif
 
-    auto referrerPolicy = hasRel(Relation::NoReferrer) ? ReferrerPolicy::NoReferrer : this->referrerPolicy();
+    auto referrerPolicy = AnchorElementUtils::effectiveReferrerPolicy(m_linkRelations, this->referrerPolicy());
 
     auto effectiveTarget = this->effectiveTarget();
-    NewFrameOpenerPolicy newFrameOpenerPolicy = NewFrameOpenerPolicy::Allow;
-    if (hasRel(Relation::NoOpener) || hasRel(Relation::NoReferrer) || (!hasRel(Relation::Opener) && isBlankTargetFrameName(effectiveTarget) && !completedURL.protocolIsJavaScript()))
-        newFrameOpenerPolicy = NewFrameOpenerPolicy::Suppress;
 
     auto privateClickMeasurement = parsePrivateClickMeasurement(completedURL);
     // A matching triggering event needs to happen before an attribution report can be sent.
     // Thus, URLs should be empty for now.
     ASSERT(!privateClickMeasurement || (privateClickMeasurement->attributionReportClickSourceURL().isNull() && privateClickMeasurement->attributionReportClickDestinationURL().isNull()));
-    
-    frame->loader().changeLocation(completedURL, effectiveTarget, &event, referrerPolicy, document->shouldOpenExternalURLsPolicyToPropagate(), newFrameOpenerPolicy, downloadAttribute, WTF::move(privateClickMeasurement), NavigationHistoryBehavior::Auto, this);
 
-    sendPings(completedURL);
+    AnchorElementUtils::navigateHyperlink(*this, event, completedURL, effectiveTarget, m_linkRelations, referrerPolicy, downloadAttribute, WTF::move(privateClickMeasurement));
+
+    AnchorElementUtils::sendPings(*this, pingAttr, completedURL);
 
     // Preconnect to the link's target for improved page load time.
     if (completedURL.protocolIsInHTTPFamily() && document->settings().linkPreconnectEnabled() && ((frame->isMainFrame() && isSelfTargetFrameName(effectiveTarget)) || isBlankTargetFrameName(effectiveTarget))) {
@@ -672,14 +628,6 @@ bool HTMLAnchorElement::treatLinkAsLiveForEventType(EventType eventType) const
 
     ASSERT_NOT_REACHED();
     return false;
-}
-
-bool isEnterKeyKeydownEvent(Event& event)
-{
-    if (event.type() != eventNames().keydownEvent)
-        return false;
-    auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(event);
-    return keyboardEvent && keyboardEvent->keyIdentifier() == "Enter"_s;
 }
 
 bool shouldProhibitLinks(Element* element)

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <WebCore/AnchorElementUtils.h>
 #include <WebCore/Document.h>
 #include <WebCore/HTMLElement.h>
 #include <WebCore/HTMLNames.h>
@@ -37,14 +38,6 @@ namespace WebCore {
 class DOMTokenList;
 
 enum class ReferrerPolicy : uint8_t;
-
-// Link relation bitmask values.
-enum class Relation : uint8_t {
-    NoReferrer = 1 << 0,
-    NoOpener = 1 << 1,
-    Opener = 1 << 2,
-};
-
 class HTMLAnchorElement : public HTMLElement, public URLDecomposition {
     WTF_MAKE_TZONE_ALLOCATED(HTMLAnchorElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLAnchorElement);
@@ -71,7 +64,7 @@ public:
     bool hasActivationBehavior() const final;
 
     bool NODELETE hasRel(Relation) const;
-    
+
     inline SharedStringHash visitedLinkHash() const;
 
     WEBCORE_EXPORT DOMTokenList& relList();
@@ -110,8 +103,6 @@ private:
     bool isInteractiveContent() const final;
 
     AtomString effectiveTarget() const;
-
-    void sendPings(const URL& destinationURL);
 
     std::optional<URL> attributionDestinationURLForPCM() const;
     std::optional<RegistrableDomain> mainDocumentRegistrableDomainForPCM() const;
@@ -159,8 +150,6 @@ private:
 };
 
 // Functions shared with the other anchor elements (i.e., SVG).
-
-bool isEnterKeyKeydownEvent(Event&);
 bool shouldProhibitLinks(Element*);
 
 } // namespace WebCore

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -265,6 +265,7 @@ void PingLoader::startPingLoad(LocalFrame& frame, ResourceRequest& request, HTTP
     }
 
     CachedResourceRequest cachedResourceRequest { ResourceRequest { request }, options };
+    cachedResourceRequest.setInitiatorType("ping"_s);
     std::ignore = protect(protect(frame.document())->cachedResourceLoader())->requestPingResource(WTF::move(cachedResourceRequest));
 }
 

--- a/Source/WebCore/mathml/MathMLAnchorElement.cpp
+++ b/Source/WebCore/mathml/MathMLAnchorElement.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MathMLAnchorElement.h"
+
+#include "AnchorElementUtils.h"
+#include "DOMTokenList.h"
+#include "ElementInlines.h"
+#include "Event.h"
+#include "EventNames.h"
+#include "KeyboardEvent.h"
+#include "MathMLNames.h"
+#include "MouseEvent.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MathMLAnchorElement);
+
+MathMLAnchorElement::MathMLAnchorElement(const QualifiedName& tagName, Document& document)
+    : MathMLElement(tagName, document)
+{
+    ASSERT(hasTagName(MathMLNames::aTag));
+}
+
+MathMLAnchorElement::~MathMLAnchorElement() = default;
+
+Ref<MathMLAnchorElement> MathMLAnchorElement::create(const QualifiedName& tagName, Document& document)
+{
+    return adoptRef(*new MathMLAnchorElement(tagName, document));
+}
+
+URL MathMLAnchorElement::href() const
+{
+    return protect(document())->encodingParseURL(attributeWithoutSynchronization(MathMLNames::hrefAttr));
+}
+
+URL MathMLAnchorElement::hrefURL() const
+{
+    return href();
+}
+
+AtomString MathMLAnchorElement::target() const
+{
+    return attributeWithoutSynchronization(MathMLNames::targetAttr);
+}
+
+void MathMLAnchorElement::setFullURL(const URL& fullURL)
+{
+    setAttributeWithoutSynchronization(MathMLNames::hrefAttr, AtomString { fullURL.string() });
+}
+
+void MathMLAnchorElement::defaultEventHandler(Event& event)
+{
+    if (isLink()) {
+        if (focused() && KeyboardEvent::isEnterKeyKeydownEvent(event)) {
+            event.setDefaultHandled();
+            dispatchSimulatedClick(&event);
+            return;
+        }
+
+        if (MouseEvent::canTriggerActivationBehavior(event)) {
+            event.setDefaultHandled();
+            URL completedURL = hrefURL();
+
+            AtomString downloadAttr = AnchorElementUtils::parseDownloadAttribute(*this, completedURL, MathMLNames::downloadAttr);
+            auto referrerPolicy = AnchorElementUtils::effectiveReferrerPolicy(m_linkRelations, this->referrerPolicy());
+
+            AnchorElementUtils::sendPings(*this, MathMLNames::pingAttr, completedURL);
+
+            AnchorElementUtils::navigateHyperlink(
+                *this,
+                event,
+                completedURL,
+                effectiveTarget(),
+                m_linkRelations,
+                referrerPolicy,
+                downloadAttr);
+            return;
+        }
+    }
+
+    MathMLElement::defaultEventHandler(event);
+}
+
+void MathMLAnchorElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
+{
+    MathMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
+
+    if (name == MathMLNames::relAttr) {
+        m_linkRelations = AnchorElementUtils::relationsForRelAttribute(newValue);
+        if (m_relList)
+            m_relList->associatedAttributeValueChanged();
+    }
+}
+
+// Falls back to using <base> element's target if the anchor does not have one.
+AtomString MathMLAnchorElement::effectiveTarget() const
+{
+    auto effectiveTarget = target();
+    if (effectiveTarget.isEmpty())
+        effectiveTarget = document().baseTarget();
+    return makeTargetBlankIfHasDanglingMarkup(effectiveTarget);
+}
+
+DOMTokenList& MathMLAnchorElement::relList()
+{
+    if (!m_relList)
+        lazyInitialize(m_relList, makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, MathMLNames::relAttr, AnchorElementUtils::isSupportedRelToken));
+
+    return *m_relList;
+}
+
+String MathMLAnchorElement::referrerPolicyForBindings() const
+{
+    return referrerPolicyToString(referrerPolicy());
+}
+
+ReferrerPolicy MathMLAnchorElement::referrerPolicy() const
+{
+    return parseReferrerPolicy(attributeWithoutSynchronization(MathMLNames::referrerpolicyAttr), ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/mathml/MathMLAnchorElement.h
+++ b/Source/WebCore/mathml/MathMLAnchorElement.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MathMLElement.h"
+#include "URLDecomposition.h"
+#include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class DOMTokenList;
+
+enum class ReferrerPolicy : uint8_t;
+enum class Relation : uint8_t;
+
+// TODO(tannal): We need to move all code for links from MathMLElement to MathMLAnchorElement
+// Once the legacy href attribute on all MathML elements is removed
+class MathMLAnchorElement final : public MathMLElement, public URLDecomposition {
+    WTF_MAKE_TZONE_ALLOCATED(MathMLAnchorElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLAnchorElement);
+
+public:
+    static Ref<MathMLAnchorElement> create(const QualifiedName&, Document&);
+    virtual ~MathMLAnchorElement();
+
+    WEBCORE_EXPORT URL href() const;
+
+    URL hrefURL() const;
+    AtomString target() const final;
+
+    URL fullURL() const final { return href(); }
+    void setFullURL(const URL&) final;
+
+    void defaultEventHandler(Event&);
+
+    bool hasRel(Relation) const;
+    DOMTokenList& relList();
+
+    String referrerPolicyForBindings() const;
+    ReferrerPolicy referrerPolicy() const;
+
+private:
+    MathMLAnchorElement(const QualifiedName&, Document&);
+
+    AtomString effectiveTarget() const;
+
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
+
+    OptionSet<Relation> m_linkRelations;
+    const std::unique_ptr<DOMTokenList> m_relList;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/mathml/MathMLAnchorElement.idl
+++ b/Source/WebCore/mathml/MathMLAnchorElement.idl
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://w3c.github.io/mathml-core/#dom-mathmlanchorelement
+[
+    EnabledBySetting=MathMLAnchorElementEnabled,
+    Exposed=Window,
+] interface MathMLAnchorElement : MathMLElement {
+    [CEReactions=NotNeeded, ReflectURL] stringifier attribute USVString href;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString target;
+
+    [CEReactions=NotNeeded, Reflect] attribute DOMString type;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString hreflang;
+
+    [CEReactions=NotNeeded, Reflect] attribute DOMString download;
+    [CEReactions=NotNeeded, Reflect] attribute USVString ping;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString rel;
+    [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings, ReflectSetter] attribute [AtomString] DOMString referrerPolicy;
+};
+
+MathMLAnchorElement includes HyperlinkElementUtils;

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -41,6 +41,7 @@
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLTableCellElement.h"
+#include "KeyboardEvent.h"
 #include "LocalFrame.h"
 #include "MathMLNames.h"
 #include "MouseEvent.h"
@@ -298,7 +299,7 @@ bool MathMLElement::willRespondToMouseClickEventsWithEditability(Editability edi
 void MathMLElement::defaultEventHandler(Event& event)
 {
     if (isLink()) {
-        if (focused() && isEnterKeyKeydownEvent(event)) {
+        if (focused() && KeyboardEvent::isEnterKeyKeydownEvent(event)) {
             event.setDefaultHandled();
             dispatchSimulatedClick(&event);
             return;

--- a/Source/WebCore/mathml/MathMLElement.h
+++ b/Source/WebCore/mathml/MathMLElement.h
@@ -76,16 +76,17 @@ protected:
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
 
     bool willRespondToMouseClickEventsWithEditability(Editability) const override;
+
     void defaultEventHandler(Event&) override;
+    bool supportsFocus() const override;
+    bool isMouseFocusable() const override;
+    bool isKeyboardFocusable(const FocusEventData&) const override;
+    bool NODELETE isURLAttribute(const Attribute&) const override;
+    bool canStartSelection() const override;
 
 private:
-    bool canStartSelection() const final;
-    bool isKeyboardFocusable(const FocusEventData&) const final;
-    bool isMouseFocusable() const final;
-    bool NODELETE isURLAttribute(const Attribute&) const final;
     bool NODELETE allowsHref() const;
-    bool supportsFocus() const final;
-    int defaultTabIndex() const final;
+    int defaultTabIndex() const override;
     Node::NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode& parentOfInsertedTree) final;
 };
 

--- a/Source/WebCore/mathml/mathattrs.in
+++ b/Source/WebCore/mathml/mathattrs.in
@@ -11,6 +11,7 @@ close
 color
 columnspan
 definitionURL
+download
 denomalign
 depth
 dir
@@ -24,6 +25,7 @@ fontstyle
 fontweight
 form
 height
+hreflang
 href
 largeop
 linethickness
@@ -38,6 +40,9 @@ movablelimits
 notation
 numalign
 open
+ping
+referrerpolicy
+rel
 rowspan
 rspace
 scriptlevel
@@ -48,6 +53,8 @@ src
 stretchy
 symmetric
 subscriptshift
+type
 superscriptshift
+target
 voffset
 width

--- a/Source/WebCore/mathml/mathtags.in
+++ b/Source/WebCore/mathml/mathtags.in
@@ -4,6 +4,7 @@ guardFactoryWith="ENABLE(MATHML)"
 fallbackInterfaceName="MathMLUnknownElement"
 fallbackJSInterfaceName="MathMLElement"
 
+a interfaceName=MathMLAnchorElement, JSInterfaceName=MathMLAnchorElement
 annotation interfaceName=MathMLAnnotationElement, JSInterfaceName=MathMLElement
 annotation-xml interfaceName=MathMLAnnotationElement, JSInterfaceName=MathMLElement
 maction interfaceName=MathMLSelectElement, JSInterfaceName=MathMLElement

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -87,18 +87,7 @@ void SVGAElement::attributeChanged(const QualifiedName& name, const AtomString& 
         Ref { m_target }->setBaseValInternal(newValue);
         return;
     } else if (name == SVGNames::relAttr) {
-        // Update SVGAElement::relList() if more rel attributes values are supported.
-        static MainThreadNeverDestroyed<const AtomString> noReferrer("noreferrer"_s);
-        static MainThreadNeverDestroyed<const AtomString> noOpener("noopener"_s);
-        static MainThreadNeverDestroyed<const AtomString> opener("opener"_s);
-        m_linkRelations = { };
-        SpaceSplitString relValue(newValue, SpaceSplitString::ShouldFoldCase::Yes);
-        if (relValue.contains(noReferrer))
-            m_linkRelations.add(Relation::NoReferrer);
-        if (relValue.contains(noOpener))
-            m_linkRelations.add(Relation::NoOpener);
-        if (relValue.contains(opener))
-            m_linkRelations.add(Relation::Opener);
+        m_linkRelations = AnchorElementUtils::relationsForRelAttribute(newValue);
         if (m_relList)
             m_relList->associatedAttributeValueChanged();
     }
@@ -133,7 +122,7 @@ RenderPtr<RenderElement> SVGAElement::createElementRenderer(Style::ComputedStyle
 void SVGAElement::defaultEventHandler(Event& event)
 {
     if (isLink()) {
-        if (focused() && isEnterKeyKeydownEvent(event)) {
+        if (focused() && KeyboardEvent::isEnterKeyKeydownEvent(event)) {
             event.setDefaultHandled();
             dispatchSimulatedClick(&event);
             return;
@@ -159,12 +148,7 @@ void SVGAElement::defaultEventHandler(Event& event)
             event.setDefaultHandled();
 
             auto referrerPolicy = hasRel(Relation::NoReferrer) ? ReferrerPolicy::NoReferrer : ReferrerPolicy::EmptyString;
-            NewFrameOpenerPolicy newFrameOpenerPolicy = NewFrameOpenerPolicy::Allow;
-            if (hasRel(Relation::NoOpener) || hasRel(Relation::NoReferrer) || (!hasRel(Relation::Opener) && isBlankTargetFrameName(target) && !completedURL.protocolIsJavaScript()))
-                newFrameOpenerPolicy = NewFrameOpenerPolicy::Suppress;
-
-            if (RefPtr frame = document->frame())
-                frame->loader().changeLocation(completedURL, target, &event, referrerPolicy, document->shouldOpenExternalURLsPolicyToPropagate(), newFrameOpenerPolicy);
+            AnchorElementUtils::navigateHyperlink(*this, event, completedURL, target, m_linkRelations, referrerPolicy);
             return;
         }
     }
@@ -196,7 +180,7 @@ bool SVGAElement::isMouseFocusable() const
     // https://bugs.webkit.org/show_bug.cgi?id=26856
     if (isLink())
         return Element::supportsFocus();
-    
+
     return SVGElement::isMouseFocusable();
 }
 
@@ -237,8 +221,8 @@ bool SVGAElement::childShouldCreateRenderer(const Node& child) const
 }
 
 bool SVGAElement::willRespondToMouseClickEventsWithEditability(Editability editability) const
-{ 
-    return isLink() || SVGGraphicsElement::willRespondToMouseClickEventsWithEditability(editability); 
+{
+    return isLink() || SVGGraphicsElement::willRespondToMouseClickEventsWithEditability(editability);
 }
 
 SharedStringHash SVGAElement::visitedLinkHash() const
@@ -257,13 +241,7 @@ URL SVGAElement::hrefURL() const
 DOMTokenList& SVGAElement::relList()
 {
     if (!m_relList) {
-        lazyInitialize(m_relList, makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, SVGNames::relAttr, [](Document&, StringView token) {
-#if USE(SYSTEM_PREVIEW)
-            if (equalLettersIgnoringASCIICase(token, "ar"_s))
-                return true;
-#endif
-            return equalLettersIgnoringASCIICase(token, "noreferrer"_s) || equalLettersIgnoringASCIICase(token, "noopener"_s) || equalLettersIgnoringASCIICase(token, "opener"_s);
-        }));
+        lazyInitialize(m_relList, makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, SVGNames::relAttr, AnchorElementUtils::isSupportedRelToken));
     }
     return *m_relList;
 }


### PR DESCRIPTION
#### 4ff7586b171f34d33094514e9e9d488144e91453
<pre>
Implement new MathMLAnchorElement Web IDL support.

<a href="https://bugs.webkit.org/show_bug.cgi?id=321990">https://bugs.webkit.org/show_bug.cgi?id=321990</a>

Reviewed by NOBODY (OOPS!).

This align the MathMLAnchorElement with the HTMLAnchorElement and SVGAElement.

Extracted common attributes handling code to a new class `AnchorElementUtils`.

Imported upstream WPTs and most of tests passed.

* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-hreflang-getter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-hreflang-setter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-ping-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-type-getter-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-type-getter-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-type-setter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/anchor-hyperlinkutils-getter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/anchor-hyperlinkutils-getter-setter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-navigation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-target-base-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/KeyboardEvent.cpp:
(WebCore::KeyboardEvent::isEnterKeyKeydownEvent):
* Source/WebCore/dom/KeyboardEvent.h:
* Source/WebCore/html/AnchorElementUtils.cpp: Added.
(WebCore::AnchorElementUtils::relationsForRelAttribute):
(WebCore::AnchorElementUtils::isSupportedRelToken):
(WebCore::AnchorElementUtils::hasRel):
(WebCore::AnchorElementUtils::parseDownloadAttribute):
(WebCore::AnchorElementUtils::sendPings):
(WebCore::AnchorElementUtils::effectiveReferrerPolicy):
(WebCore::AnchorElementUtils::navigateHyperlink):
* Source/WebCore/html/AnchorElementUtils.h: Added.
(WebCore::AnchorElementUtils::navigateHyperlink):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::defaultEventHandler):
(WebCore::HTMLAnchorElement::setActive):
(WebCore::HTMLAnchorElement::attributeChanged):
(WebCore::HTMLAnchorElement::relList):
(WebCore::HTMLAnchorElement::isSystemPreviewLink):
(WebCore::HTMLAnchorElement::sendPings): Deleted.
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::startPingLoad):
* Source/WebCore/mathml/MathMLAnchorElement.cpp: Added.
(WebCore::MathMLAnchorElement::MathMLAnchorElement):
(WebCore::MathMLAnchorElement::create):
(WebCore::MathMLAnchorElement::href const):
(WebCore::MathMLAnchorElement::hrefURL const):
(WebCore::MathMLAnchorElement::target const):
(WebCore::MathMLAnchorElement::setFullURL):
(WebCore::MathMLAnchorElement::defaultEventHandler):
(WebCore::MathMLAnchorElement::attributeChanged):
(WebCore::MathMLAnchorElement::effectiveTarget const):
(WebCore::MathMLAnchorElement::relList):
(WebCore::MathMLAnchorElement::referrerPolicyForBindings const):
(WebCore::MathMLAnchorElement::referrerPolicy const):
* Source/WebCore/mathml/MathMLAnchorElement.h: Added.
* Source/WebCore/mathml/MathMLAnchorElement.idl: Added.
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::defaultEventHandler):
* Source/WebCore/mathml/MathMLElement.h:
* Source/WebCore/mathml/mathattrs.in:
* Source/WebCore/mathml/mathtags.in:
* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::attributeChanged):
(WebCore::SVGAElement::defaultEventHandler):
(WebCore::SVGAElement::isMouseFocusable const):
(WebCore::SVGAElement::willRespondToMouseClickEventsWithEditability const):
(WebCore::SVGAElement::relList):
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* LayoutTests/imported/w3c/web-platform-tests/dom/lists/DOMTokenList-coverage-for-attributes.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/a-rel-getter-setter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/ping-rt-entries-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ff7586b171f34d33094514e9e9d488144e91453

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147551 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56920 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143039 "Found 5 new test failures: imported/w3c/web-platform-tests/dom/lists/DOMTokenList-coverage-for-attributes.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/floats/not-floating-001.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99337 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123465 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182589 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45477 "Found 4 new test failures: imported/w3c/web-platform-tests/dom/lists/DOMTokenList-coverage-for-attributes.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/floats/not-floating-001.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43724 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5435 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12272 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155874 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43332 "Found 5 new test failures: imported/w3c/web-platform-tests/dom/lists/DOMTokenList-coverage-for-attributes.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/floats/not-floating-001.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4655 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44532 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50531 "Found 1 new failure in html/HTMLFormElement.cpp") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48568 "Found 5 new test failures: imported/w3c/web-platform-tests/dom/lists/DOMTokenList-coverage-for-attributes.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/floats/not-floating-001.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195421 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/182666 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/163297 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153138 "Found 4 new test failures: imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/floats/not-floating-001.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57559 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39952 "Found 6 new test failures: imported/w3c/web-platform-tests/dom/lists/DOMTokenList-coverage-for-attributes.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/floats/not-floating-001.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152230 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46783 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130546 "Found 1 new failure in html/HTMLFormElement.cpp") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126138 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56067 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18344 "Found 5 new test failures: imported/w3c/web-platform-tests/dom/lists/DOMTokenList-coverage-for-attributes.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/floats/not-floating-001.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->