### PR TITLE
[Coordinated Graphics] Support background color of layer

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -699,6 +699,13 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
 
     if (m_backingStore)
         context.imageSetBatch.addImageSet(canvas, *m_backingStore, transform, context.opacity, enableAntialias, context.damageRegionOrNull(), setupPaint());
+    else if (m_backgroundColor.isValid() && m_backgroundColor.isVisible()) {
+        ScopedFlush autoFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBefore);
+        canvas.concat(transform);
+        SkPaint paint = setupPaint();
+        paint.setColor(SkColor(m_backgroundColor.colorWithAlphaMultipliedBy(context.opacity)));
+        drawRectRestricted(canvas, context.damageRegionOrNull(), SkRect(m_rect), paint);
+    }
 
     if (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()) {
         ScopedFlush autoFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBefore);

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -78,6 +78,7 @@ public:
     void setChildrenTransform(const TransformationMatrix& matrix) { m_childrenTransform = matrix; }
     void setPreserves3D(bool preserves3D) { m_preserves3D = preserves3D; }
     void setBackfaceVisibility(bool visible) { m_backfaceVisibility = visible; }
+    void setBackgroundColor(const Color& color) { m_backgroundColor = color; }
     void setContentsVisible(bool visible) { m_contentsVisible = visible; }
     void setContentsOpaque(bool opaque) { m_contentsOpaque = opaque; }
     void setMasksToBounds(bool masksToBounds) { m_masksToBounds = masksToBounds; }
@@ -134,7 +135,7 @@ private:
     bool isReplica() const { return !!m_replicatedLayer; }
     // Contents are painted into m_contentsRect, which the layer bounds do not have to contain.
     bool paintsContentsRect() const { return m_contentsBuffer || m_imageBackingStore || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()); }
-    bool hasVisualContent() const { return m_backingStore || paintsContentsRect(); }
+    bool hasVisualContent() const { return (m_backgroundColor.isValid() && m_backgroundColor.isVisible()) || m_backingStore || paintsContentsRect(); }
     bool hasVisiblePaintableContent() const { return !m_rect.isEmpty() && m_visible && m_contentsVisible && hasVisualContent(); }
 
     // A backdrop filter paints the layer without any content of its own, so it contributes damage too.
@@ -322,6 +323,7 @@ private:
     RefPtr<CoordinatedAnimatedBackingStoreClient> m_animatedBackingStoreClient;
     RefPtr<CoordinatedImageBackingStore> m_imageBackingStore;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_contentsBuffer;
+    Color m_backgroundColor;
     Color m_contentsSolidColor;
     std::optional<DebugBorder> m_debugBorder;
     std::optional<unsigned> m_repaintCount;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -380,6 +380,17 @@ void CoordinatedPlatformLayer::setBackfaceVisibility(bool backfaceVisibility)
     notifyCompositionRequired();
 }
 
+void CoordinatedPlatformLayer::setBackgroundColor(const Color& backgroundColor)
+{
+    assertIsHeld(m_lock);
+    if (m_backgroundColor == backgroundColor)
+        return;
+
+    m_backgroundColor = backgroundColor;
+    m_pendingChanges.add(Change::BackgroundColor);
+    notifyCompositionRequired();
+}
+
 void CoordinatedPlatformLayer::setOpacity(float opacity)
 {
     assertIsHeld(m_lock);
@@ -1140,6 +1151,11 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
             m_pendingChanges.remove(Change::BackfaceVisibility);
         }
 
+        if (m_pendingChanges.contains(Change::BackgroundColor)) {
+            layer.setBackgroundColor(m_backgroundColor);
+            m_pendingChanges.remove(Change::BackgroundColor);
+        }
+
         if (m_pendingChanges.contains(Change::Opacity)) {
             layer.setOpacity(m_opacity);
             m_pendingChanges.remove(Change::Opacity);
@@ -1150,6 +1166,7 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
                 if (!m_backingStore)
                     m_backingStore = CoordinatedBackingStore::create();
                 layer.setBackingStore(m_backingStore.get());
+                layer.setBackgroundColor({ });
 
                 if (auto* animatedBackingStoreClient = m_backingStoreProxy->animatedBackingStoreClient())
                     layer.setAnimatedBackingStoreClient(animatedBackingStoreClient);
@@ -1343,6 +1360,11 @@ void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet
         if (m_pendingChanges.contains(Change::BackfaceVisibility)) {
             layer.setBackfaceVisibility(m_backfaceVisibility);
             m_pendingChanges.remove(Change::BackfaceVisibility);
+        }
+
+        if (m_pendingChanges.contains(Change::BackgroundColor)) {
+            layer.setBackgroundColor(m_backgroundColor);
+            m_pendingChanges.remove(Change::BackgroundColor);
         }
 
         if (m_pendingChanges.contains(Change::Opacity)) {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -148,6 +148,7 @@ public:
     bool masksToBounds() const WTF_REQUIRES_LOCK(m_lock);
     void setPreserves3D(bool) WTF_REQUIRES_LOCK(m_lock);
     void setBackfaceVisibility(bool) WTF_REQUIRES_LOCK(m_lock);
+    void setBackgroundColor(const Color&) WTF_REQUIRES_LOCK(m_lock);
     void setOpacity(float) WTF_REQUIRES_LOCK(m_lock);
     void setBlendMode(BlendMode) WTF_REQUIRES_LOCK(m_lock);
 
@@ -241,6 +242,7 @@ private:
         BackdropRect,
         BackdropRoot,
         BackfaceVisibility,
+        BackgroundColor,
         BackingStore,
         BlendMode,
         BoundsOrigin,
@@ -315,6 +317,7 @@ private:
     bool m_contentsRectClipsDescendants WTF_GUARDED_BY_LOCK(m_lock) { false };
     FloatRoundedRect m_contentsClippingRect WTF_GUARDED_BY_LOCK(m_lock);
     Path m_contentsClipShapePath WTF_GUARDED_BY_LOCK(m_lock);
+    Color m_backgroundColor WTF_GUARDED_BY_LOCK(m_lock);
     Color m_contentsColor WTF_GUARDED_BY_LOCK(m_lock);
     FloatSize m_contentsTileSize WTF_GUARDED_BY_LOCK(m_lock);
     FloatSize m_contentsTilePhase WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -264,6 +264,15 @@ void GraphicsLayerCoordinated::setPreserves3D(bool preserves3D)
     setNeedsUpdateLayerTransform();
 }
 
+void GraphicsLayerCoordinated::setBackgroundColor(const Color& color)
+{
+    if (m_backgroundColor == color)
+        return;
+
+    GraphicsLayer::setBackgroundColor(color);
+    noteLayerPropertyChanged(Change::BackgroundColor, ScheduleFlush::Yes);
+}
+
 void GraphicsLayerCoordinated::setBackfaceVisibility(bool backfaceVisibility)
 {
     if (m_backfaceVisibility == backfaceVisibility)
@@ -1112,6 +1121,9 @@ void GraphicsLayerCoordinated::commitLayerChanges(CommitState& commitState, floa
 
     if (m_pendingChanges.contains(Change::BackfaceVisibility))
         m_platformLayer->setBackfaceVisibility(m_backfaceVisibility);
+
+    if (m_pendingChanges.contains(Change::BackgroundColor))
+        m_platformLayer->setBackgroundColor(m_backgroundColor);
 
     if (m_pendingChanges.contains(Change::Opacity))
         m_platformLayer->setOpacity(m_opacity);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -70,6 +70,7 @@ private:
     void setDrawsContent(bool) override;
     void setMasksToBounds(bool) override;
     void setPreserves3D(bool) override;
+    void setBackgroundColor(const Color&) override;
     void setBackfaceVisibility(bool) override;
     void setOpacity(float) override;
     void setBlendMode(BlendMode) override;
@@ -141,6 +142,7 @@ private:
         Backdrop,
         BackdropRect,
         BackdropRoot,
+        BackgroundColor,
         BackfaceVisibility,
         BlendMode,
         Children,


### PR DESCRIPTION
#### 9ff20369e3d7ddbd3d90fd7d798857ad7f03cdfa
<pre>
[Coordinated Graphics] Support background color of layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=321991">https://bugs.webkit.org/show_bug.cgi?id=321991</a>

Reviewed by Nikolas Zimmermann.

Added background color support to GraphicsLayerCoordinated,
CoordinatedPlatformLayer and SkiaCompositingLayer.

The &quot;paint flushing&quot; feature of WebInspector is using
GraphicsLayer::setBackgroundColor. For Skia compositor, there is one more bug
for the &quot;paint flushing&quot; feature. See &lt;<a href="https://webkit.org/b/321993">https://webkit.org/b/321993</a>&gt;.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setBackgroundColor):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnTarget):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::setBackgroundColor):
(WebCore::GraphicsLayerCoordinated::commitLayerChanges):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintContents):

Canonical link: <a href="https://commits.webkit.org/319403@main">https://commits.webkit.org/319403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac641307f10a38efc984973812c4a4d22b54412e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141422 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43771 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42043 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41705 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2601 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193373 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54836 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150810 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55523 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150526 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27535 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45124 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127791 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123352 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54040 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16703 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53422 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53659 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->