### PR TITLE
[macOS]REGRESSION(318934@main): 5x TestWebKitAPI.UnifiedPDF.*/TestWebKitAPI.WebKit.* (api-tests) are constant crashes.

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView+Testing.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView+Testing.swift
@@ -31,21 +31,15 @@ extension WKAlternatePDFHUDView {
     // For testing only, via `NSSelectorFromString`.
     @objc(_performActionForControl:)
     private func performAction(controlName: String) {
-        guard let hostingView = subviews.first as? NSHostingView<PDFHUDControls> else {
-            fatalError()
-        }
-
-        let action = hostingView.rootView.action
-
         switch controlName {
         case "minus.magnifyingglass":
-            action(.zoomOut)
+            actionHandlerForTesting(.zoomOut)
         case "plus.magnifyingglass":
-            action(.zoomIn)
+            actionHandlerForTesting(.zoomIn)
         case "preview":
-            action(.openInPreview)
+            actionHandlerForTesting(.openInPreview)
         case "arrow.down.circle":
-            action(.savePDF)
+            actionHandlerForTesting(.savePDF)
         default:
             fatalError()
         }

--- a/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
+++ b/Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift
@@ -134,6 +134,9 @@ extension WKAlternatePDFHUDView {
     let frameIdentifier: UInt64
 
     @nonobjc
+    final let actionHandlerForTesting: @MainActor @Sendable (WKPDFHUDViewControlAction) -> Void
+
+    @nonobjc
     final let model = PDFHUDControlsModel()
 
     init(
@@ -143,6 +146,7 @@ extension WKAlternatePDFHUDView {
         actionHandler: @MainActor @Sendable @escaping (WKPDFHUDViewControlAction) -> Void
     ) {
         self.frameIdentifier = frameIdentifier
+        self.actionHandlerForTesting = actionHandler
 
         super.init(frame: frame)
 


### PR DESCRIPTION
#### 0032bf6cdfb079d8888cabd2e81a120ba6953685
<pre>
[macOS]REGRESSION(318934@main): 5x TestWebKitAPI.UnifiedPDF.*/TestWebKitAPI.WebKit.* (api-tests) are constant crashes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=321995">https://bugs.webkit.org/show_bug.cgi?id=321995</a>
<a href="https://rdar.apple.com/185147060">rdar://185147060</a>

Reviewed by Abrar Rahman Protyasha.

The tests depended on introspecting the root view of the NSHostingView, which is not
actually a `PDFHUDControls` (but rather, a `SwiftUI.NSHostingView&lt;SwiftUI.ModifiedContent&lt;WebKit.PDFHUDControls, SwiftUI._EnvironmentKeyWritingModifier&lt;WebKit.PDFHUDControlsModel?&gt;&gt;&gt;`).

Fix by just storing the action handler directly and calling that.

* Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView+Testing.swift:
(WKAlternatePDFHUDView.performAction(_:)):
* Source/WebKit/UIProcess/PDF/WKAlternatePDFHUDView.swift:

Canonical link: <a href="https://commits.webkit.org/319348@main">https://commits.webkit.org/319348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7fc024e0b8815b3fba8978118b3a98a5a1940f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145548 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35a1a59d-aa27-4140-bae9-1b1523a3388c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54886 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d24e8100-416d-43f0-8ee7-400fc4e5e8c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121871 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a60d753-8289-4d96-82ff-c5941414487e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43768 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42046 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41702 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2602 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47782 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193374 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54837 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150813 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40393 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55524 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150529 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27511 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45119 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127792 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123353 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54041 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16700 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53423 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53660 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53488 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->