### PR TITLE
Remove @newPromiseCapability

### DIFF
--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -92,7 +92,6 @@ namespace JSC {
     macro(promiseReturnUndefinedOnFulfilled) \
     macro(promiseResolve) \
     macro(promiseReject) \
-    macro(newPromiseCapability) \
     macro(performPromiseThen) \
     macro(push) \
     macro(repeatCharacter) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -68,7 +68,6 @@ class JSGlobalObject;
     v(promiseReturnUndefinedOnFulfilled, nullptr) \
     v(promiseResolve, nullptr) \
     v(promiseReject, nullptr) \
-    v(newPromiseCapability, nullptr) \
     v(performPromiseThen, nullptr) \
     v(makeTypeError, nullptr) \
     v(AggregateError, nullptr) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -381,7 +381,6 @@ static JSC_DECLARE_HOST_FUNCTION(newHandledRejectedPromise);
 static JSC_DECLARE_HOST_FUNCTION(promiseReturnUndefinedOnFulfilled);
 static JSC_DECLARE_HOST_FUNCTION(promiseResolve);
 static JSC_DECLARE_HOST_FUNCTION(promiseReject);
-static JSC_DECLARE_HOST_FUNCTION(newPromiseCapability);
 static JSC_DECLARE_HOST_FUNCTION(performPromiseThen);
 #if ASSERT_ENABLED
 static JSC_DECLARE_HOST_FUNCTION(assertCall);
@@ -867,12 +866,6 @@ JSC_DEFINE_HOST_FUNCTION(promiseReject, (JSGlobalObject* globalObject, CallFrame
     JSObject* constructor = uncheckedDowncast<JSObject>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
     return JSValue::encode(JSPromise::promiseReject(globalObject, constructor, argument));
-}
-
-JSC_DEFINE_HOST_FUNCTION(newPromiseCapability, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    ASSERT(callFrame->argumentCount() == 1);
-    return JSValue::encode(JSPromise::createNewPromiseCapability(globalObject, callFrame->uncheckedArgument(0)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(performPromiseThen, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -1997,9 +1990,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::promiseReject)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, init.owner, 2, "promiseReject"_s, promiseReject, ImplementationVisibility::Private, PromiseRejectIntrinsic));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::newPromiseCapability)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, init.owner, 1, "newPromiseCapability"_s, newPromiseCapability, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::performPromiseThen)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, init.owner, 4, "performPromiseThen"_s, performPromiseThen, ImplementationVisibility::Private));

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js
@@ -91,5 +91,5 @@ function closed()
     if (!@isReadableStreamDefaultReader(this))
         return @promiseReject(@Promise, @makeGetterTypeError("ReadableStreamDefaultReader", "closed"));
 
-    return @getByIdDirectPrivate(this, "closedPromiseCapability").promise;
+    return @getByIdDirectPrivate(this, "closedPromise");
 }

--- a/Source/WebCore/Modules/streams/ReadableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamInternals.js
@@ -112,7 +112,7 @@ function readableStreamDefaultReaderClosedForBindings(reader)
     if (!@isReadableStreamDefaultReader(reader))
         return @promiseReject(@Promise, @makeGetterTypeError("ReadableStreamDefaultReader", "closed"));
 
-    return @getByIdDirectPrivate(reader, "closedPromiseCapability").promise;
+    return @getByIdDirectPrivate(reader, "closedPromise");
 }
 
 function readableStreamDefaultReaderReadForBindings(reader)
@@ -156,7 +156,7 @@ function readableStreamDefaultReaderCancelForBindings(reader, reason)
 function readableStreamDefaultReaderClosedPromise(reader)
 {
     @assert(@isReadableStreamDefaultReader(reader));
-    return @getByIdDirectPrivate(reader, "closedPromiseCapability").promise;
+    return @getByIdDirectPrivate(reader, "closedPromise");
 }
 
 function readableStreamReaderGenericInitialize(reader, stream)
@@ -166,12 +166,12 @@ function readableStreamReaderGenericInitialize(reader, stream)
     @putByIdDirectPrivate(reader, "ownerReadableStream", stream);
     @putByIdDirectPrivate(stream, "reader", reader);
     if (@getByIdDirectPrivate(stream, "state") === @streamReadable)
-        @putByIdDirectPrivate(reader, "closedPromiseCapability", @newPromiseCapability(@Promise));
+        @putByIdDirectPrivate(reader, "closedPromise", @newPromise());
     else if (@getByIdDirectPrivate(stream, "state") === @streamClosed)
-        @putByIdDirectPrivate(reader, "closedPromiseCapability", { promise: @promiseResolve(@Promise, @undefined) });
+        @putByIdDirectPrivate(reader, "closedPromise", @promiseResolve(@Promise, @undefined));
     else {
         @assert(@getByIdDirectPrivate(stream, "state") === @streamErrored);
-        @putByIdDirectPrivate(reader, "closedPromiseCapability", { promise: @newHandledRejectedPromise(@getByIdDirectPrivate(stream, "storedError")) });
+        @putByIdDirectPrivate(reader, "closedPromise", @newHandledRejectedPromise(@getByIdDirectPrivate(stream, "storedError")));
     }
 }
 
@@ -259,7 +259,7 @@ function readableStreamTee(stream, shouldClone)
         readAgain: false,
     };
 
-    teeState.cancelPromiseCapability = @newPromiseCapability(@Promise);
+    teeState.cancelPromise = @newPromise();
 
     const pullFunction = @readableStreamTeePullFunction(teeState, reader, shouldClone);
 
@@ -274,11 +274,11 @@ function readableStreamTee(stream, shouldClone)
     const branch1 = @createInternalReadableStreamFromUnderlyingSource(branch1Source);
     const branch2 = @createInternalReadableStreamFromUnderlyingSource(branch2Source);
 
-    @getByIdDirectPrivate(reader, "closedPromiseCapability").promise.@then(@undefined, function(e) {
+    @getByIdDirectPrivate(reader, "closedPromise").@then(@undefined, function(e) {
         @readableStreamDefaultControllerError(branch1.@readableStreamController, e);
         @readableStreamDefaultControllerError(branch2.@readableStreamController, e);
         if (!teeState.canceled1 || !teeState.canceled2)
-            teeState.cancelPromiseCapability.resolve.@call();
+            @resolvePromiseWithFirstResolvingFunctionCallCheck(teeState.cancelPromise, @undefined);
     });
 
     // Additional fields compared to the spec, as they are needed within pull/cancel functions.
@@ -309,7 +309,7 @@ function readableStreamTeePullFunction(teeState, reader, shouldClone)
                 if (!teeState.canceled2)
                     @readableStreamDefaultControllerClose(teeState.branch2.@readableStreamController);
                 if (!teeState.canceled1 || !teeState.canceled2)
-                    teeState.cancelPromiseCapability.resolve.@call();
+                    @resolvePromiseWithFirstResolvingFunctionCallCheck(teeState.cancelPromise, @undefined);
                 return;
             }
             // chunk steps.
@@ -322,7 +322,9 @@ function readableStreamTeePullFunction(teeState, reader, shouldClone)
                 } catch (e) {
                     @readableStreamDefaultControllerError(teeState.branch1.@readableStreamController, e);
                     @readableStreamDefaultControllerError(teeState.branch2.@readableStreamController, e);
-                    @readableStreamCancel(teeState.stream, e).@then(teeState.cancelPromiseCapability.resolve, teeState.cancelPromiseCapability.reject);
+                    @readableStreamCancel(teeState.stream, e).@then(
+                        (value) => @resolvePromiseWithFirstResolvingFunctionCallCheck(teeState.cancelPromise, value),
+                        (reason) => @rejectPromiseWithFirstResolvingFunctionCallCheck(teeState.cancelPromise, reason));
                     return;
                 }
             }
@@ -354,10 +356,10 @@ function readableStreamTeeBranch1CancelFunction(teeState, stream)
         teeState.reason1 = r;
         if (teeState.canceled2) {
             @readableStreamCancel(stream, [teeState.reason1, teeState.reason2]).@then(
-                teeState.cancelPromiseCapability.resolve,
-                teeState.cancelPromiseCapability.reject);
+                (value) => @resolvePromiseWithFirstResolvingFunctionCallCheck(teeState.cancelPromise, value),
+                (reason) => @rejectPromiseWithFirstResolvingFunctionCallCheck(teeState.cancelPromise, reason));
         }
-        return teeState.cancelPromiseCapability.promise;
+        return teeState.cancelPromise;
     }
 }
 
@@ -370,10 +372,10 @@ function readableStreamTeeBranch2CancelFunction(teeState, stream)
         teeState.reason2 = r;
         if (teeState.canceled1) {
             @readableStreamCancel(stream, [teeState.reason1, teeState.reason2]).@then(
-                teeState.cancelPromiseCapability.resolve,
-                teeState.cancelPromiseCapability.reject);
+                (value) => @resolvePromiseWithFirstResolvingFunctionCallCheck(teeState.cancelPromise, value),
+                (reason) => @rejectPromiseWithFirstResolvingFunctionCallCheck(teeState.cancelPromise, reason));
         }
-        return teeState.cancelPromiseCapability.promise;
+        return teeState.cancelPromise;
     }
 }
 
@@ -423,8 +425,8 @@ function readableStreamError(stream, error)
     const reader = @getByIdDirectPrivate(stream, "reader");
     @assert(@isReadableStreamDefaultReader(reader));
 
-    @getByIdDirectPrivate(reader, "closedPromiseCapability").reject.@call(@undefined, error);
-    const promise = @getByIdDirectPrivate(reader, "closedPromiseCapability").promise;
+    const promise = @getByIdDirectPrivate(reader, "closedPromise");
+    @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, error);
     @markPromiseAsHandled(promise);
 
     @readableStreamDefaultReaderErrorReadRequests(reader, error);
@@ -580,7 +582,7 @@ function readableStreamClose(stream)
             @fulfillPromiseWithFirstResolvingFunctionCallCheck(requests[index], { value: @undefined, done: true });
     }
 
-    @getByIdDirectPrivate(reader, "closedPromiseCapability").resolve.@call();
+    @resolvePromiseWithFirstResolvingFunctionCallCheck(@getByIdDirectPrivate(reader, "closedPromise"), @undefined);
 }
 
 function readableStreamFulfillReadRequest(stream, chunk, done)
@@ -669,11 +671,11 @@ function readableStreamReaderGenericRelease(reader)
     @assert(@getByIdDirectPrivate(@getByIdDirectPrivate(reader, "ownerReadableStream"), "reader") === reader);
 
     if (@getByIdDirectPrivate(@getByIdDirectPrivate(reader, "ownerReadableStream"), "state") === @streamReadable)
-        @getByIdDirectPrivate(reader, "closedPromiseCapability").reject.@call(@undefined, @makeTypeError("releasing lock of reader whose stream is still in readable state"));
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(@getByIdDirectPrivate(reader, "closedPromise"), @makeTypeError("releasing lock of reader whose stream is still in readable state"));
     else
-        @putByIdDirectPrivate(reader, "closedPromiseCapability", { promise: @newHandledRejectedPromise(@makeTypeError("reader released lock")) });
+        @putByIdDirectPrivate(reader, "closedPromise", @newHandledRejectedPromise(@makeTypeError("reader released lock")));
 
-    const promise = @getByIdDirectPrivate(reader, "closedPromiseCapability").promise;
+    const promise = @getByIdDirectPrivate(reader, "closedPromise");
     @markPromiseAsHandled(promise);
     @putByIdDirectPrivate(@getByIdDirectPrivate(reader, "ownerReadableStream"), "reader", @undefined);
     @putByIdDirectPrivate(reader, "ownerReadableStream", @undefined);

--- a/Source/WebCore/Modules/streams/TransformStreamInternals.js
+++ b/Source/WebCore/Modules/streams/TransformStreamInternals.js
@@ -81,8 +81,8 @@ function createInternalTransformStreamFromTransformer(transformer, writableStrat
     const writableSizeAlgorithm = @extractSizeAlgorithm(writableStrategy);
 
     const internalTransformStream = {};
-    const startPromiseCapability = @newPromiseCapability(@Promise);
-    const [readable, writable] = @initializeTransformStream(internalTransformStream, startPromiseCapability.promise, writableHighWaterMark, writableSizeAlgorithm, readableHighWaterMark, readableSizeAlgorithm);
+    const startPromise = @newPromise();
+    const [readable, writable] = @initializeTransformStream(internalTransformStream, startPromise, writableHighWaterMark, writableSizeAlgorithm, readableHighWaterMark, readableSizeAlgorithm);
     @setUpTransformStreamDefaultControllerFromTransformer(internalTransformStream, transformer, transformerDict);
 
     if ("start" in transformerDict) {
@@ -90,12 +90,12 @@ function createInternalTransformStreamFromTransformer(transformer, writableStrat
         const startAlgorithm = () => @promiseInvokeOrNoopMethodNoCatch(transformer, transformerDict["start"], [controller]);
         startAlgorithm().@then(() => {
             // FIXME: We probably need to resolve start promise with the result of the start algorithm.
-            startPromiseCapability.resolve.@call();
+            @resolvePromiseWithFirstResolvingFunctionCallCheck(startPromise, @undefined);
         }, (error) => {
-            startPromiseCapability.reject.@call(@undefined, error);
+            @rejectPromiseWithFirstResolvingFunctionCallCheck(startPromise, error);
         });
     } else
-        startPromiseCapability.resolve.@call();
+        @resolvePromiseWithFirstResolvingFunctionCallCheck(startPromise, @undefined);
 
     return [internalTransformStream, readable, writable];
 }
@@ -114,16 +114,16 @@ function createTransformStream(startAlgorithm, transformAlgorithm, flushAlgorith
     @assert(readableHighWaterMark >= 0);
 
     const stream = {};
-    const startPromiseCapability = @newPromiseCapability(@Promise);
-    const [readable, writable] = @initializeTransformStream(stream, startPromiseCapability.promise, writableHighWaterMark, writableSizeAlgorithm, readableHighWaterMark, readableSizeAlgorithm);
+    const startPromise = @newPromise();
+    const [readable, writable] = @initializeTransformStream(stream, startPromise, writableHighWaterMark, writableSizeAlgorithm, readableHighWaterMark, readableSizeAlgorithm);
 
     const controller = new @TransformStreamDefaultController(@isTransformStream);
     @setUpTransformStreamDefaultController(stream, controller, transformAlgorithm, flushAlgorithm);
 
     startAlgorithm().@then(() => {
-        startPromiseCapability.resolve.@call();
+        @resolvePromiseWithFirstResolvingFunctionCallCheck(startPromise, @undefined);
     }, (error) => {
-        startPromiseCapability.reject.@call(@undefined, error);
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(startPromise, error);
     });
 
     return [stream, readable, writable];
@@ -201,9 +201,9 @@ function transformStreamSetBackpressure(stream, backpressure)
 
     const backpressureChangePromise = @getByIdDirectPrivate(stream, "backpressureChangePromise");
     if (backpressureChangePromise !== @undefined)
-        backpressureChangePromise.resolve.@call();
+        @resolvePromiseWithFirstResolvingFunctionCallCheck(backpressureChangePromise, @undefined);
 
-    @putByIdDirectPrivate(stream, "backpressureChangePromise", @newPromiseCapability(@Promise));
+    @putByIdDirectPrivate(stream, "backpressureChangePromise", @newPromise());
     @putByIdDirectPrivate(stream, "backpressure", backpressure);
 }
 
@@ -296,16 +296,16 @@ function transformStreamDefaultControllerPerformTransform(controller, chunk)
 {
     "use strict";
 
-    const promiseCapability = @newPromiseCapability(@Promise);
+    const promise = @newPromise();
 
     const transformPromise = @getByIdDirectPrivate(controller, "transformAlgorithm").@call(@undefined, chunk);
     transformPromise.@then(() => {
-        promiseCapability.resolve();
+        @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, @undefined);
     }, (r) => {
         @transformStreamError(@getByIdDirectPrivate(controller, "stream"), r);
-        promiseCapability.reject.@call(@undefined, r);
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, r);
     });
-    return promiseCapability.promise;
+    return promise;
 }
 
 function transformStreamDefaultControllerTerminate(controller)
@@ -335,28 +335,28 @@ function transformStreamDefaultSinkWriteAlgorithm(stream, chunk)
     const controller = @getByIdDirectPrivate(stream, "controller");
 
     if (@getByIdDirectPrivate(stream, "backpressure")) {
-        const promiseCapability = @newPromiseCapability(@Promise);
+        const promise = @newPromise();
 
         const backpressureChangePromise = @getByIdDirectPrivate(stream, "backpressureChangePromise");
         @assert(backpressureChangePromise !== @undefined);
-        backpressureChangePromise.promise.@then(() => {
+        backpressureChangePromise.@then(() => {
             const state = @getByIdDirectPrivate(writable, "state");
             if (state === "erroring") {
-                promiseCapability.reject.@call(@undefined, @getByIdDirectPrivate(writable, "storedError"));
+                @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, @getByIdDirectPrivate(writable, "storedError"));
                 return;
             }
 
             @assert(state === "writable");
             @transformStreamDefaultControllerPerformTransform(controller, chunk).@then(() => {
-                promiseCapability.resolve();
+                @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, @undefined);
             }, (e) => {
-                promiseCapability.reject.@call(@undefined, e);
+                @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, e);
             });
         }, (e) => {
-            promiseCapability.reject.@call(@undefined, e);
+            @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, e);
         });
 
-        return promiseCapability.promise;
+        return promise;
     }
     return @transformStreamDefaultControllerPerformTransform(controller, chunk);
 }
@@ -382,22 +382,22 @@ function transformStreamDefaultSinkCloseAlgorithm(stream)
     const flushPromise = @getByIdDirectPrivate(controller, "flushAlgorithm").@call();
     @transformStreamDefaultControllerClearAlgorithms(controller);
 
-    const promiseCapability = @newPromiseCapability(@Promise);
+    const promise = @newPromise();
     flushPromise.@then(() => {
         if (@getByIdDirectPrivate(readable, "state") === @streamErrored) {
-            promiseCapability.reject.@call(@undefined, @getByIdDirectPrivate(readable, "storedError"));
+            @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, @getByIdDirectPrivate(readable, "storedError"));
             return;
         }
 
         // FIXME: Update readableStreamDefaultControllerClose to make this check.
         if (@readableStreamDefaultControllerCanCloseOrEnqueue(readableController))
             @readableStreamDefaultControllerClose(readableController);
-        promiseCapability.resolve();
+        @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, @undefined);
     }, (r) => {
         @transformStreamError(@getByIdDirectPrivate(controller, "stream"), r);
-        promiseCapability.reject.@call(@undefined, @getByIdDirectPrivate(readable, "storedError"));
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, @getByIdDirectPrivate(readable, "storedError"));
     });
-    return promiseCapability.promise;
+    return promise;
 }
 
 function transformStreamDefaultSourcePullAlgorithm(stream)
@@ -409,5 +409,5 @@ function transformStreamDefaultSourcePullAlgorithm(stream)
 
     @transformStreamSetBackpressure(stream, false);
 
-    return @getByIdDirectPrivate(stream, "backpressureChangePromise").promise;
+    return @getByIdDirectPrivate(stream, "backpressureChangePromise");
 }

--- a/Source/WebCore/Modules/streams/WritableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/WritableStreamInternals.js
@@ -153,7 +153,7 @@ function writableStreamDefaultWriterClosedForBindings(writer)
     if (!@isWritableStreamDefaultWriter(writer))
         return @promiseReject(@Promise, @makeGetterTypeError("WritableStreamDefaultWriter", "closed"));
 
-    return @getByIdDirectPrivate(writer, "closedPromise").promise;
+    return @getByIdDirectPrivate(writer, "closedPromise");
 }
 
 function writableStreamDefaultWriterReadyForBindings(writer)
@@ -163,7 +163,7 @@ function writableStreamDefaultWriterReadyForBindings(writer)
     if (!@isWritableStreamDefaultWriter(writer))
         return @promiseReject(@Promise, @makeThisTypeError("WritableStreamDefaultWriter", "ready"));
 
-    return @getByIdDirectPrivate(writer, "readyPromise").promise;
+    return @getByIdDirectPrivate(writer, "readyPromise");
 }
 
 function writableStreamDefaultWriterDesiredSizeForBindings(writer)
@@ -250,28 +250,28 @@ function setUpWritableStreamDefaultWriter(writer, stream)
     @putByIdDirectPrivate(writer, "stream", stream);
     @putByIdDirectPrivate(stream, "writer", writer);
 
-    const readyPromiseCapability = @newPromiseCapability(@Promise);
-    const closedPromiseCapability = @newPromiseCapability(@Promise);
-    @putByIdDirectPrivate(writer, "readyPromise", readyPromiseCapability);
-    @putByIdDirectPrivate(writer, "closedPromise", closedPromiseCapability);
+    const readyPromise = @newPromise();
+    const closedPromise = @newPromise();
+    @putByIdDirectPrivate(writer, "readyPromise", readyPromise);
+    @putByIdDirectPrivate(writer, "closedPromise", closedPromise);
 
     const state = @getByIdDirectPrivate(stream, "state");
     if (state === "writable") {
         if (@writableStreamCloseQueuedOrInFlight(stream) || !@getByIdDirectPrivate(stream, "backpressure"))
-            readyPromiseCapability.resolve.@call();
+            @resolvePromiseWithFirstResolvingFunctionCallCheck(readyPromise, @undefined);
     } else if (state === "erroring") {
-        readyPromiseCapability.reject.@call(@undefined, @getByIdDirectPrivate(stream, "storedError"));
-        @markPromiseAsHandled(readyPromiseCapability.promise);
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(readyPromise, @getByIdDirectPrivate(stream, "storedError"));
+        @markPromiseAsHandled(readyPromise);
     } else if (state === "closed") {
-        readyPromiseCapability.resolve.@call();
-        closedPromiseCapability.resolve.@call();
+        @resolvePromiseWithFirstResolvingFunctionCallCheck(readyPromise, @undefined);
+        @resolvePromiseWithFirstResolvingFunctionCallCheck(closedPromise, @undefined);
     } else {
         @assert(state === "errored");
         const storedError = @getByIdDirectPrivate(stream, "storedError");
-        readyPromiseCapability.reject.@call(@undefined, storedError);
-        @markPromiseAsHandled(readyPromiseCapability.promise);
-        closedPromiseCapability.reject.@call(@undefined, storedError);
-        @markPromiseAsHandled(closedPromiseCapability.promise);
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(readyPromise, storedError);
+        @markPromiseAsHandled(readyPromise);
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(closedPromise, storedError);
+        @markPromiseAsHandled(closedPromise);
     }
 }
 
@@ -290,7 +290,7 @@ function writableStreamAbort(stream, reason)
 
     const pendingAbortRequest = @getByIdDirectPrivate(stream, "pendingAbortRequest");
     if (pendingAbortRequest !== @undefined)
-        return pendingAbortRequest.promise.promise;
+        return pendingAbortRequest.promise;
 
     @assert(state === "writable" || state === "erroring");
     let wasAlreadyErroring = false;
@@ -299,12 +299,12 @@ function writableStreamAbort(stream, reason)
         reason = @undefined;
     }
 
-    const abortPromiseCapability = @newPromiseCapability(@Promise);
-    @putByIdDirectPrivate(stream, "pendingAbortRequest", { promise : abortPromiseCapability, reason : reason, wasAlreadyErroring : wasAlreadyErroring });
+    const abortPromise = @newPromise();
+    @putByIdDirectPrivate(stream, "pendingAbortRequest", { promise : abortPromise, reason, wasAlreadyErroring });
 
     if (!wasAlreadyErroring)
         @writableStreamStartErroring(stream, reason);
-    return abortPromiseCapability.promise;
+    return abortPromise;
 }
 
 function writableStreamErrorIfPossible(stream, reason)
@@ -336,16 +336,16 @@ function writableStreamClose(stream)
     @assert(state === "writable" || state === "erroring");
     @assert(!@writableStreamCloseQueuedOrInFlight(stream));
 
-    const closePromiseCapability = @newPromiseCapability(@Promise);
-    @putByIdDirectPrivate(stream, "closeRequest", closePromiseCapability);
+    const closePromise = @newPromise();
+    @putByIdDirectPrivate(stream, "closeRequest", closePromise);
 
     const writer = @getByIdDirectPrivate(stream, "writer");
     if (writer !== @undefined && @getByIdDirectPrivate(stream, "backpressure") && state === "writable")
-        @getByIdDirectPrivate(writer, "readyPromise").resolve.@call();
-        
+        @resolvePromiseWithFirstResolvingFunctionCallCheck(@getByIdDirectPrivate(writer, "readyPromise"), @undefined);
+
     @writableStreamDefaultControllerClose(@getByIdDirectPrivate(stream, "controller"));
 
-    return closePromiseCapability.promise;
+    return closePromise;
 }
 
 function writableStreamAddWriteRequest(stream)
@@ -353,10 +353,10 @@ function writableStreamAddWriteRequest(stream)
     @assert(@isWritableStreamLocked(stream))
     @assert(@getByIdDirectPrivate(stream, "state") === "writable");
 
-    const writePromiseCapability = @newPromiseCapability(@Promise);
+    const writePromise = @newPromise();
     const writeRequests = @getByIdDirectPrivate(stream, "writeRequests");
-    @arrayPush(writeRequests, writePromiseCapability);
-    return writePromiseCapability.promise;
+    @arrayPush(writeRequests, writePromise);
+    return writePromise;
 }
 
 function writableStreamCloseQueuedOrInFlight(stream)
@@ -389,7 +389,7 @@ function writableStreamFinishErroring(stream)
     const storedError = @getByIdDirectPrivate(stream, "storedError");
     const requests = @getByIdDirectPrivate(stream, "writeRequests");
     for (let index = 0, length = requests.length; index < length; ++index)
-        requests[index].reject.@call(@undefined, storedError);
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(requests[index], storedError);
 
     @putByIdDirectPrivate(stream, "writeRequests", []);
 
@@ -401,16 +401,16 @@ function writableStreamFinishErroring(stream)
 
     @putByIdDirectPrivate(stream, "pendingAbortRequest", @undefined);
     if (abortRequest.wasAlreadyErroring) {
-        abortRequest.promise.reject.@call(@undefined, storedError);
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(abortRequest.promise, storedError);
         @writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
         return;
     }
 
     @getByIdDirectPrivate(controller, "abortSteps").@call(@undefined, abortRequest.reason).@then(() => {
-        abortRequest.promise.resolve.@call();
+        @resolvePromiseWithFirstResolvingFunctionCallCheck(abortRequest.promise, @undefined);
         @writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
     }, (reason) => {
-        abortRequest.promise.reject.@call(@undefined, reason);
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(abortRequest.promise, reason);
         @writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
     });
 }
@@ -418,7 +418,7 @@ function writableStreamFinishErroring(stream)
 function writableStreamFinishInFlightClose(stream)
 {
     const inFlightCloseRequest = @getByIdDirectPrivate(stream, "inFlightCloseRequest");
-    inFlightCloseRequest.resolve.@call();
+    @resolvePromiseWithFirstResolvingFunctionCallCheck(inFlightCloseRequest, @undefined);
 
     @putByIdDirectPrivate(stream, "inFlightCloseRequest", @undefined);
 
@@ -429,7 +429,7 @@ function writableStreamFinishInFlightClose(stream)
         @putByIdDirectPrivate(stream, "storedError", @undefined);
         const abortRequest = @getByIdDirectPrivate(stream, "pendingAbortRequest");
         if (abortRequest !== @undefined) {
-            abortRequest.promise.resolve.@call();
+            @resolvePromiseWithFirstResolvingFunctionCallCheck(abortRequest.promise, @undefined);
             @putByIdDirectPrivate(stream, "pendingAbortRequest", @undefined);
         }
     }
@@ -438,7 +438,7 @@ function writableStreamFinishInFlightClose(stream)
 
     const writer = @getByIdDirectPrivate(stream, "writer");
     if (writer !== @undefined)
-        @getByIdDirectPrivate(writer, "closedPromise").resolve.@call();
+        @resolvePromiseWithFirstResolvingFunctionCallCheck(@getByIdDirectPrivate(writer, "closedPromise"), @undefined);
 
     @assert(@getByIdDirectPrivate(stream, "pendingAbortRequest") === @undefined);
     @assert(@getByIdDirectPrivate(stream, "storedError") === @undefined);
@@ -448,7 +448,7 @@ function writableStreamFinishInFlightCloseWithError(stream, error)
 {
     const inFlightCloseRequest = @getByIdDirectPrivate(stream, "inFlightCloseRequest");
     @assert(inFlightCloseRequest !== @undefined);
-    inFlightCloseRequest.reject.@call(@undefined, error);
+    @rejectPromiseWithFirstResolvingFunctionCallCheck(inFlightCloseRequest, error);
 
     @putByIdDirectPrivate(stream, "inFlightCloseRequest", @undefined);
 
@@ -457,7 +457,7 @@ function writableStreamFinishInFlightCloseWithError(stream, error)
 
     const abortRequest = @getByIdDirectPrivate(stream, "pendingAbortRequest");
     if (abortRequest !== @undefined) {
-        abortRequest.promise.reject.@call(@undefined, error);
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(abortRequest.promise, error);
         @putByIdDirectPrivate(stream, "pendingAbortRequest", @undefined);
     }
 
@@ -468,7 +468,7 @@ function writableStreamFinishInFlightWrite(stream)
 {
     const inFlightWriteRequest = @getByIdDirectPrivate(stream, "inFlightWriteRequest");
     @assert(inFlightWriteRequest !== @undefined);
-    inFlightWriteRequest.resolve.@call();
+    @resolvePromiseWithFirstResolvingFunctionCallCheck(inFlightWriteRequest, @undefined);
 
     @putByIdDirectPrivate(stream, "inFlightWriteRequest", @undefined);
 }
@@ -477,7 +477,7 @@ function writableStreamFinishInFlightWriteWithError(stream, error)
 {
     const inFlightWriteRequest = @getByIdDirectPrivate(stream, "inFlightWriteRequest");
     @assert(inFlightWriteRequest !== @undefined);
-    inFlightWriteRequest.reject.@call(@undefined, error);
+    @rejectPromiseWithFirstResolvingFunctionCallCheck(inFlightWriteRequest, error);
 
     @putByIdDirectPrivate(stream, "inFlightWriteRequest", @undefined);
 
@@ -521,15 +521,15 @@ function writableStreamRejectCloseAndClosedPromiseIfNeeded(stream)
     const closeRequest = @getByIdDirectPrivate(stream, "closeRequest");
     if (closeRequest !== @undefined) {
         @assert(@getByIdDirectPrivate(stream, "inFlightCloseRequest") === @undefined);
-        closeRequest.reject.@call(@undefined, storedError);
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(closeRequest, storedError);
         @putByIdDirectPrivate(stream, "closeRequest", @undefined);
     }
 
     const writer = @getByIdDirectPrivate(stream, "writer");
     if (writer !== @undefined) {
         const closedPromise = @getByIdDirectPrivate(writer, "closedPromise");
-        closedPromise.reject.@call(@undefined, storedError);
-        @markPromiseAsHandled(closedPromise.promise);
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(closedPromise, storedError);
+        @markPromiseAsHandled(closedPromise);
     }
 }
 
@@ -560,9 +560,9 @@ function writableStreamUpdateBackpressure(stream, backpressure)
     const writer = @getByIdDirectPrivate(stream, "writer");
     if (writer !== @undefined && backpressure !== @getByIdDirectPrivate(stream, "backpressure")) {
         if (backpressure)
-           @putByIdDirectPrivate(writer, "readyPromise", @newPromiseCapability(@Promise));
+            @putByIdDirectPrivate(writer, "readyPromise", @newPromise());
         else
-            @getByIdDirectPrivate(writer, "readyPromise").resolve.@call();
+            @resolvePromiseWithFirstResolvingFunctionCallCheck(@getByIdDirectPrivate(writer, "readyPromise"), @undefined);
     }
     @putByIdDirectPrivate(stream, "backpressure", backpressure);
 }
@@ -600,31 +600,27 @@ function writableStreamDefaultWriterCloseWithErrorPropagation(writer)
 
 function writableStreamDefaultWriterEnsureClosedPromiseRejected(writer, error)
 {
-    let closedPromiseCapability = @getByIdDirectPrivate(writer, "closedPromise");
-    let closedPromise = closedPromiseCapability.promise;
+    let closedPromise = @getByIdDirectPrivate(writer, "closedPromise");
 
     if (!@isPromiseStatePending(closedPromise)) {
-        closedPromiseCapability = @newPromiseCapability(@Promise);
-        closedPromise = closedPromiseCapability.promise;
-        @putByIdDirectPrivate(writer, "closedPromise", closedPromiseCapability);
+        closedPromise = @newPromise();
+        @putByIdDirectPrivate(writer, "closedPromise", closedPromise);
     }
 
-    closedPromiseCapability.reject.@call(@undefined, error);
+    @rejectPromiseWithFirstResolvingFunctionCallCheck(closedPromise, error);
     @markPromiseAsHandled(closedPromise);
 }
 
 function writableStreamDefaultWriterEnsureReadyPromiseRejected(writer, error)
 {
-    let readyPromiseCapability = @getByIdDirectPrivate(writer, "readyPromise");
-    let readyPromise = readyPromiseCapability.promise;
+    let readyPromise = @getByIdDirectPrivate(writer, "readyPromise");
 
     if (!@isPromiseStatePending(readyPromise)) {
-        readyPromiseCapability = @newPromiseCapability(@Promise);
-        readyPromise = readyPromiseCapability.promise;
-        @putByIdDirectPrivate(writer, "readyPromise", readyPromiseCapability);
+        readyPromise = @newPromise();
+        @putByIdDirectPrivate(writer, "readyPromise", readyPromise);
     }
 
-    readyPromiseCapability.reject.@call(@undefined, error);
+    @rejectPromiseWithFirstResolvingFunctionCallCheck(readyPromise, error);
     @markPromiseAsHandled(readyPromise);
 }
 
@@ -918,11 +914,11 @@ function writableStreamStoredError(stream)
 function writableStreamDefaultWriterClosedPromise(writer)
 {
     @assert(@isWritableStreamDefaultWriter(writer));
-    return @getByIdDirectPrivate(writer, "closedPromise").promise;
+    return @getByIdDirectPrivate(writer, "closedPromise");
 }
 
 function writableStreamDefaultWriterReadyPromise(writer)
 {
     @assert(@isWritableStreamDefaultWriter(writer));
-    return @getByIdDirectPrivate(writer, "readyPromise").promise;
+    return @getByIdDirectPrivate(writer, "readyPromise");
 }


### PR DESCRIPTION
#### 38027ff0ecca7efe0e74a7f1d7ca71061083381a
<pre>
Remove @newPromiseCapability
<a href="https://bugs.webkit.org/show_bug.cgi?id=321999">https://bugs.webkit.org/show_bug.cgi?id=321999</a>
<a href="https://rdar.apple.com/185184613">rdar://185184613</a>

Reviewed by Yijia Huang.

Let&apos;s just use `@newPromise` and
@rejectPromiseWithFirstResolvingFunctionCallCheck etc. that is much more
efficient (not allocating an object for a tuple), not doing any property
lookup. As a result, nobody is using @newPromiseCapability anymore. So
this patch removes it from builtin JS.

* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js:
(getter.closed):
* Source/WebCore/Modules/streams/ReadableStreamInternals.js:
(readableStreamDefaultReaderClosedForBindings):
(readableStreamDefaultReaderClosedPromise):
(readableStreamReaderGenericInitialize):
(readableStreamTee):
(const.pullAlgorithm):
(readableStreamTeePullFunction):
(readableStreamTeeBranch1CancelFunction):
(readableStreamTeeBranch2CancelFunction):
(readableStreamError):
(readableStreamClose):
(readableStreamReaderGenericRelease):
* Source/WebCore/Modules/streams/TransformStreamInternals.js:
(createInternalTransformStreamFromTransformer):
(createTransformStream):
(transformStreamSetBackpressure):
(transformStreamDefaultControllerPerformTransform):
(transformStreamDefaultSinkWriteAlgorithm):
(transformStreamDefaultSinkCloseAlgorithm):
(transformStreamDefaultSourcePullAlgorithm):
* Source/WebCore/Modules/streams/WritableStreamInternals.js:
(writableStreamDefaultWriterClosedForBindings):
(writableStreamDefaultWriterReadyForBindings):
(setUpWritableStreamDefaultWriter):
(writableStreamAbort):
(writableStreamClose):
(writableStreamAddWriteRequest):
(writableStreamFinishErroring):
(writableStreamFinishInFlightWrite):
(writableStreamFinishInFlightWriteWithError):
(writableStreamRejectCloseAndClosedPromiseIfNeeded):
(writableStreamUpdateBackpressure):
(writableStreamDefaultWriterEnsureClosedPromiseRejected):
(writableStreamDefaultWriterEnsureReadyPromiseRejected):
(writableStreamDefaultWriterClosedPromise):
(writableStreamDefaultWriterReadyPromise):

Canonical link: <a href="https://commits.webkit.org/319396@main">https://commits.webkit.org/319396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a71e36ec032cd895a4a74a01cf2bb8238f07300b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191464 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145570 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/91b622be-b3bc-4f65-a575-e84aea4c9124) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141436 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16876c45-d308-4f41-a891-911e7f690cbd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121887 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb95a786-196f-40cd-8674-53ec6fbda704) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43796 "") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42063 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3852 "Passed tests") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10684 "") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154193 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41721 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2624 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42521 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193396 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54859 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150829 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55546 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38348 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150546 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27529 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45137 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127814 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123381 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54063 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16719 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53445 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53682 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53510 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->