### PR TITLE
Summary: TURN URLs with query-string parameters rejected after commit r316873, breaking WebRTC connectivity

### DIFF
--- a/LayoutTests/webrtc/stun-server-filtering-expected.txt
+++ b/LayoutTests/webrtc/stun-server-filtering-expected.txt
@@ -2,4 +2,5 @@
 PASS RTCPeerConnection and local STUN server
 PASS RTCPeerConnection and local TURN server
 PASS RTCPeerConnection and big TURN username/credential
+PASS RTCPeerConnection and TURN query string
 

--- a/LayoutTests/webrtc/stun-server-filtering.html
+++ b/LayoutTests/webrtc/stun-server-filtering.html
@@ -42,4 +42,14 @@ test(() => {
     assert_throws_dom("InvalidAccessError", () => new RTCPeerConnection({iceServers:[{username: 'test', credential: string510, urls:['turn:foo.com']}]}));
     assert_throws_dom("InvalidAccessError", () => new RTCPeerConnection({iceServers:[{username: string510, credential: 'test', urls:['turn:foo.com']}]}));
  }, "RTCPeerConnection and big TURN username/credential");
+
+test(() => {
+    new RTCPeerConnection({iceServers:[{username: 'test', credential: 'test', urls:['turn:foo.com?transport=udp']}]});
+    new RTCPeerConnection({iceServers:[{username: 'test', credential: 'test', urls:['turn:foo.com?transport=tcp']}]});
+    new RTCPeerConnection({iceServers:[{username: 'test', credential: 'test', urls:['turn:foo.com?transport=udp ']}]});
+    new RTCPeerConnection({iceServers:[{username: 'test', credential: 'test', urls:['turn:foo.com?transport=tcp ']}]});
+    assert_throws_dom("SyntaxError", () => new RTCPeerConnection({iceServers:[{username: 'test', credential: 'test', urls:['turn:foo.com?']}]}));
+    assert_throws_dom("SyntaxError", () => new RTCPeerConnection({iceServers:[{username: 'test', credential: 'test', urls:['turn:foo.com? transport=tcp']}]}));
+    assert_throws_dom("SyntaxError", () => new RTCPeerConnection({iceServers:[{username: 'test', credential: 'test', urls:['turn:foo.com?transport=udp&transport=tcp']}]}));
+ }, "RTCPeerConnection and TURN query string");
 </script>

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -75,6 +75,7 @@
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/URLParser.h>
 #include <wtf/UUID.h>
 #include <wtf/text/Base64.h>
 
@@ -556,8 +557,11 @@ ExceptionOr<Vector<MediaEndpointConfiguration::IceServerInfo>> RTCPeerConnection
             if (!serverURL.hasOpaquePath())
                 return Exception { ExceptionCode::SyntaxError, "STUN/TURN URL should be opaque-path"_s };
             if (serverURL.protocolIs("turn"_s) || serverURL.protocolIs("turns"_s)) {
-                if (serverURL.hasQuery() && !!serverURL.query().findIgnoringASCIICase("?transport="_s))
-                    return Exception { ExceptionCode::SyntaxError, "Invalid TURN URL query string"_s };
+                if (serverURL.hasQuery()) {
+                    auto parameters = WTF::URLParser::parseURLEncodedForm(serverURL.query());
+                    if (parameters.size() != 1 || !equalIgnoringASCIICase(parameters[0].key, "transport"_s))
+                        return Exception { ExceptionCode::SyntaxError, "Invalid TURN URL query string"_s };
+                }
                 if (server.credential.isNull() || server.username.isNull())
                     return Exception { ExceptionCode::InvalidAccessError, "TURN/TURNS server requires both username and credential"_s };
                 // https://tools.ietf.org/html/rfc8489#section-14.3


### PR DESCRIPTION
#### d1dca194fe699fe19361e216e2d5f29a2e5eec51
<pre>
Summary: TURN URLs with query-string parameters rejected after commit r316873, breaking WebRTC connectivity
<a href="https://rdar.apple.com/184556197">rdar://184556197</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=320931">https://bugs.webkit.org/show_bug.cgi?id=320931</a>

Reviewed by Jean-Yves Avenard.

We align with RFC 7065 by reusing the URLParser to parse the query string.
We validate that there is only one query string parameter and that the parameter name is transport.
We do not validate the parameter value as RFC 7065 allows extension names.
Libwebrtc underneath will still validate the the parameter value is either udp or tcp anyway.

* LayoutTests/webrtc/stun-server-filtering-expected.txt:
* LayoutTests/webrtc/stun-server-filtering.html:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::iceServersFromConfiguration):

Canonical link: <a href="https://commits.webkit.org/319365@main">https://commits.webkit.org/319365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6120ce8cb1fc7a25f1d3f0b4805866de626b5fc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191472 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145578 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9f67220-2301-4048-aa34-8860a128024d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141468 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34adc201-1a84-49d8-b1dc-f4b809b8a46c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121895 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e865afff-abe4-48c2-88cf-f900a04b92f5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43816 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42097 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154219 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41752 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2632 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193404 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150858 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40408 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55554 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150556 "") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45146 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127841 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123390 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54071 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16729 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53453 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53690 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53518 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->