### PR TITLE
[GLIB] accessibility/keyevents-posted-for-increment-actions.html times out

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1193,10 +1193,8 @@ accessibility/aria-table-indextext.html [ Failure ]
 # Started failing on [313982@main..313983@main].
 webkit.org/b/315858 [ Release ] accessibility/aria-owns-deep-chain-no-timeout.html [ Timeout Pass ]
 
-# Added in r263823. Both tests are timing out.
-webkit.org/b/213874 accessibility/keyevents-for-increment-actions-with-node-removal.html [ Skip ]
-webkit.org/b/213874 accessibility/keyevents-posted-for-increment-actions.html [ Skip ]
-webkit.org/b/213874 accessibility/keyevents-posted-for-dismiss-action.html [ Skip ]
+# Requires implementation of 'dismiss' in 'AccessibilityObjectAtspi.h'.
+accessibility/keyevents-posted-for-dismiss-action.html [ Skip ]
 
 webkit.org/b/199860 accessibility/button-with-aria-haspopup-role.html [ Failure ]
 webkit.org/b/199860 accessibility/datalist.html [ Failure ]

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -133,6 +133,8 @@ public:
     WEBCORE_EXPORT double minimumValue() const;
     WEBCORE_EXPORT double maximumValue() const;
     WEBCORE_EXPORT double minimumIncrement() const;
+    WEBCORE_EXPORT void increment();
+    WEBCORE_EXPORT void decrement();
     void valueChanged(double);
 
     WEBCORE_EXPORT URL url() const;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectValueAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectValueAtspi.cpp
@@ -112,6 +112,18 @@ void AccessibilityObjectAtspi::valueChanged(double value)
     AccessibilityAtspi::singleton().valueChanged(*this, value);
 }
 
+void AccessibilityObjectAtspi::increment()
+{
+    if (m_coreObject)
+        m_coreObject->increment();
+}
+
+void AccessibilityObjectAtspi::decrement()
+{
+    if (m_coreObject)
+        m_coreObject->decrement();
+}
+
 } // namespace WebCore
 
 #endif // USE(ATSPI)

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -1484,7 +1484,7 @@ void AccessibilityUIElementAtspi::increment()
         return;
 
     m_element->updateBackingStore();
-    m_element->setCurrentValue(intValue() + m_element->minimumIncrement());
+    m_element->increment();
 }
 
 void AccessibilityUIElementAtspi::decrement()
@@ -1493,7 +1493,7 @@ void AccessibilityUIElementAtspi::decrement()
         return;
 
     m_element->updateBackingStore();
-    m_element->setCurrentValue(intValue() - m_element->minimumIncrement());
+    m_element->decrement();
 }
 
 void AccessibilityUIElementAtspi::showMenu()


### PR DESCRIPTION
#### 8ea696080a81725a5ec108c4982bca863824a40f
<pre>
[GLIB] accessibility/keyevents-posted-for-increment-actions.html times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=213874">https://bugs.webkit.org/show_bug.cgi?id=213874</a>

Reviewed by Patrick Griffis.

GLIB ports have a custom implementation for increment/decrement actions,
which directly sets a value on the underlying backing object.

On the other hand, macOS and iOS ports use the increment/decrement methods
provided by &apos;AccessibilityNodeObject&apos;. These operations are more complex than
simply updating the value of the backing object (for instance, in the case of
a slider, a keyboard event is emitted instead).

The test hangs on GLIB ports because their current implementation never emits
this keyboard event.

Since increment/decrement live in &apos;AccessibilityNodeObject&apos;, this patch modifies
the GLIB implementation to reuse the same general implementation used by the
macOS and iOS ports, which fixes the timeout in the targetting tests.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectValueAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::increment):
(WebCore::AccessibilityObjectAtspi::decrement):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::AccessibilityUIElementAtspi::increment):
(WTR::AccessibilityUIElementAtspi::decrement):

Canonical link: <a href="https://commits.webkit.org/319432@main">https://commits.webkit.org/319432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a77b71667ec238f7b4c98aeab4d2bc6518ab61b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145581 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141460 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98124 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45143 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162217 "Found 1 new API test failure: TestWebKitAPI.IsolatedSiteStore.PersistsAcrossSessions (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121903 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43821 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42090 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154224 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41743 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2634 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193423 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54870 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150862 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55557 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150570 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27554 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45147 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127843 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123404 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54074 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16740 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53456 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->