### PR TITLE
[ews-build] Remove Bugzilla patch workflow support from ews-build.webkit.org - Part 2

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -600,7 +600,7 @@ class ResultsDBReportMixin(abc.ABC):
 
     def results_db_details(self):
         """Extra build metadata folded into each row's `details` blob, non-queryable."""
-        authors = self.getProperty('owners', []) or [self.getProperty('patch_author', None)]
+        authors = self.getProperty('owners', [])
         return {
             'worker': self.getProperty('workername', None),
             'remote': self.getProperty('remote', None),
@@ -3097,9 +3097,6 @@ class CompileWebKit(shell.Compile, AddToLogMixin, ShellMixin):
         self.cancelled_due_to_huge_logs = False
         super().__init__(timeout=60 * 60, logEnviron=False, **kwargs)
 
-    def doStepIf(self, step):
-        return not (self.getProperty('fast_commit_queue') and self.getProperty('buildername', '').lower() == 'commit-queue')
-
     @defer.inlineCallbacks
     def run(self):
         platform = self.getProperty('platform')
@@ -3232,8 +3229,6 @@ class CompileWebKit(shell.Compile, AddToLogMixin, ShellMixin):
         if self.results == FAILURE:
             return {'step': 'Failed to compile WebKit'}
         if self.results == SKIPPED:
-            if self.getProperty('fast_commit_queue'):
-                return {'step': 'Skipped compiling WebKit in fast-cq mode'}
             return {'step': 'Skipped compiling WebKit'}
         if self.results == CANCELLED and self.cancelled_due_to_huge_logs:
             return {'step': 'Cancelled step due to huge logs', 'build': 'Cancelled build due to huge logs'}
@@ -3922,8 +3917,7 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
         self.layout_test_driver = None
 
     def doStepIf(self, step):
-        return not ((self.getProperty('buildername', '').lower() in ['commit-queue', 'merge-queue']) and
-                    (self.getProperty('fast_commit_queue') or self.getProperty('passed_mac_wk2')))
+        return not (self.getProperty('buildername', '').lower() == 'merge-queue' and self.getProperty('passed_mac_wk2'))
 
     def setLayoutTestCommand(self):
         platform = self.getProperty('platform')
@@ -4177,8 +4171,6 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
                 status = ' '.join(self.incorrectLayoutLines)
                 return {'step': status}
         if self.results == SKIPPED:
-            if self.getProperty('fast_commit_queue'):
-                return {'step': 'Skipped layout-tests in fast-cq mode'}
             return {'step': 'Skipped layout-tests'}
 
         return super().getResultSummary()

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -1383,14 +1383,6 @@ class TestCompileWebKit(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_outcome(result=FAILURE, state_string='Failed to compile WebKit')
         return self.run_step()
 
-    def test_skip_for_revert_patches_on_commit_queue(self):
-        self.setup_step(CompileWebKit())
-        self.setProperty('buildername', 'Commit-Queue')
-        self.setProperty('configuration', 'debug')
-        self.setProperty('fast_commit_queue', True)
-        self.expect_outcome(result=SKIPPED, state_string='Skipped compiling WebKit in fast-cq mode')
-        return self.run_step()
-
 
 class TestCompileWebKitWithoutChange(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
@@ -1456,7 +1448,6 @@ class TestAnalyzeCompileWebKitResults(BuildStepMixinAdditions, unittest.TestCase
         rc = self.run_step()
         self.expect_property('build_finish_summary', 'Hash 7496f8ec for PR 1234 does not build')
         return rc
-
 
 
     @expectedFailure
@@ -2000,16 +1991,6 @@ ts","version":4,"num_passes":42158,"pixel_tests_enabled":false,"date":"11:28AM o
         )
         self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
         return self.run_step()
-
-    def test_skip_for_revert_patches_on_commit_queue(self):
-        self.configureStep()
-        self.setProperty('buildername', 'Commit-Queue')
-        self.setProperty('fullPlatform', 'mac')
-        self.setProperty('configuration', 'debug')
-        self.setProperty('fast_commit_queue', True)
-        self.expect_outcome(result=SKIPPED, state_string='Skipped layout-tests in fast-cq mode')
-        return self.run_step()
-
 
     def test_skip_for_mac_wk2_passed_change_on_merge_queue(self):
         self.configureStep()
@@ -2826,15 +2807,6 @@ class TestRunWebKit1Tests(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
         return self.run_step()
 
-    def test_skip_for_revert_patches_on_commit_queue(self):
-        self.setup_step(RunWebKit1Tests())
-        self.setProperty('buildername', 'Commit-Queue')
-        self.setProperty('fullPlatform', 'mac')
-        self.setProperty('configuration', 'debug')
-        self.setProperty('fast_commit_queue', True)
-        self.expect_outcome(result=SKIPPED, state_string='Skipped layout-tests in fast-cq mode')
-        return self.run_step()
-
 
 class TestAnalyzeLayoutTestsResults(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
@@ -3363,15 +3335,6 @@ class TestReportToResultsDB(BuildStepMixinAdditions, unittest.TestCase):
         self.assertEqual(details['pr_number'], 12345)
         self.assertEqual(details['commit_hash'], 'abc123')
         self.assertEqual(details['build_url'], 'http://localhost:8080/#/builders/1/builds/13')
-
-    @defer.inlineCallbacks
-    def test_authors_fall_back_to_the_patch_author(self):
-        step = self.configureStep()
-        self.setProperty('owners', [])
-        self.setProperty('patch_author', 'jdoe@apple.com')
-        yield step.report_to_results_db(self.FLAKE)
-
-        self.assertEqual(self.results_db_reports[0]['details']['authors'], ['jdoe@apple.com'])
 
     @defer.inlineCallbacks
     def test_reports_the_commit_ews_tested(self):
@@ -7356,7 +7319,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
         self.expect_outcome(result=SUCCESS, state_string='Validated change')
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
     def test_success_pr_blocked(self):
@@ -7367,7 +7329,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
         self.expect_outcome(result=SUCCESS, state_string='Validated change')
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
 
@@ -7379,7 +7340,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.head.sha', '1ad60d45a112301f7b9f93dac06134524dae8480')
         self.expect_outcome(result=FAILURE, state_string='Hash 1ad60d45 on PR 1234 is outdated')
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
     def test_deleted_pr(self):
@@ -7390,7 +7350,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.head.sha', '1ad60d45a112301f7b9f93dac06134524dae8480')
         self.expect_outcome(result=FAILURE, state_string='Pull request 1234 is already closed')
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
 
@@ -7402,7 +7361,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
         self.expect_outcome(result=SUCCESS, state_string='Validated change')
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
     def test_merge_queue_blocked(self):
@@ -7413,7 +7371,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
         self.expect_outcome(result=FAILURE, state_string="PR 1234 has been marked as 'merging-blocked'")
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
     def test_no_merge_queue(self):
@@ -7424,7 +7381,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
         self.expect_outcome(result=FAILURE, state_string='PR 1234 does not have a merge queue label')
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
     def test_draft(self):
@@ -7435,7 +7391,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
         self.expect_outcome(result=FAILURE, state_string='PR 1234 is a draft pull request')
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
     def test_no_draft(self):
@@ -7446,7 +7401,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
         self.expect_outcome(result=SUCCESS, state_string='Validated change')
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
 
@@ -7460,7 +7414,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
 
         self.expect_outcome(result=FAILURE, state_string="Changes to 'safari-123-branch' are not tested")
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
     def test_excluded_branch(self):
@@ -7473,7 +7426,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
 
         self.expect_outcome(result=FAILURE, state_string="Skipping as PR 1234 targets 'webkitglib/2.46' branch")
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
     def test_allowed_branch_not_in_excluded(self):
@@ -7486,7 +7438,6 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
 
         self.expect_outcome(result=SUCCESS, state_string='Validated change')
         rc = self.run_step()
-        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
 
@@ -8408,8 +8359,6 @@ class TestDetermineLandedIdentifier(BuildStepMixinAdditions, unittest.TestCase):
 
         self.expect_property('comment_text', 'Committed ? (5dc27962b4c5): <https://commits.webkit.org/5dc27962b4c5>\n\nReviewed commits have been landed. Closing PR #1234 and removing active labels.')
         self.expect_property('build_summary', 'Committed 5dc27962b4c5')
-
-
 
 
 class TestCheckOutSource(BuildStepMixinAdditions, unittest.TestCase):
@@ -9462,7 +9411,6 @@ class TestValidateSquashed(BuildStepMixinAdditions, unittest.TestCase):
 
     def tearDown(self):
         return self.tear_down_test_build_step()
-
 
 
     def test_success(self):


### PR DESCRIPTION
#### b804ff8bde3f850005b3a90701bf071f5f3a136e
<pre>
[ews-build] Remove Bugzilla patch workflow support from ews-build.webkit.org - Part 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=322003">https://bugs.webkit.org/show_bug.cgi?id=322003</a>
&lt;<a href="https://rdar.apple.com/problem/185192934">rdar://problem/185192934</a>&gt;

Reviewed by Ryan Haddad.

The fast-cq mode skipped compiling and running layout tests for a revert submitted to
the commit-queue. Its property was only ever set while reading a Bugzilla attachment, so
it can no longer be set, and the same is true of the patch author which the results
database reported when a change had no pull request owners.

The merge-queue keeps skipping layout tests for a change which already passed mac-wk2.

* Tools/CISupport/ews-build/steps.py:
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/319389@main">https://commits.webkit.org/319389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2f91ca76b805db457288e726ace07526a2d6142

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191491 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145594 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d4a2cff-22fc-47bd-b443-ab0b244ee24a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54936 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141465 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0a05d19-a547-4b7d-b228-fc5ed4b83b05) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121908 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d31f6371-5381-4855-9bac-e5c58eac6387) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43824 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42091 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154227 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41746 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2645 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193418 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/180669 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54884 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150854 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55571 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150566 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27525 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45155 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123413 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54087 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16743 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53469 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53534 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->