### PR TITLE
A zero-length animation attachment range produces infinite computed keyframe offsets

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-zero-length-attachment-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-zero-length-attachment-range-expected.txt
@@ -1,0 +1,4 @@
+
+PASS A zero-length attachment range yields unresolved computed keyframe offsets, not infinite ones
+PASS A non-degenerate attachment range still maps timeline range offsets outside [0,1]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-zero-length-attachment-range.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-zero-length-attachment-range.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Computed keyframe offsets for a zero-length animation attachment range</title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#named-timeline-range">
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#animation-range">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+</head>
+<style>
+  @keyframes anim {
+    cover 0% { margin-left: 0px; }
+    cover 100% { margin-right: 0px; }
+  }
+
+  #scroller {
+    overflow-y: scroll;
+    overflow-x: hidden;
+    width: 300px;
+    height: 200px;
+    timeline-scope: --t1;
+  }
+  #block {
+    margin-top: 800px;
+    width: 100px;
+    height: 50px;
+    view-timeline: --t1;
+  }
+  .target {
+    margin-bottom: 800px;
+    width: 100px;
+    height: 100px;
+    animation: anim auto both linear;
+    animation-timeline: --t1;
+  }
+  /* A zero-length attachment range: start and end resolve to the same offset. */
+  #degenerate {
+    animation-range-start: contain 50%;
+    animation-range-end: contain 50%;
+  }
+  /* A normal, non-degenerate attachment range, for contrast. */
+  #ordinary {
+    animation-range-start: contain 0%;
+    animation-range-end: contain 100%;
+  }
+</style>
+<body>
+  <div id="scroller">
+    <div id="block"></div>
+    <div id="degenerate" class="target"></div>
+    <div id="ordinary" class="target"></div>
+  </div>
+</body>
+<script>
+function animationForTarget(id) {
+  return document.getAnimations().find(animation => animation.effect.target.id === id);
+}
+
+async function activeAnimationFor(id) {
+  await waitForNextFrame();
+  const animation = animationForTarget(id);
+  assert_true(!!animation, `an animation is attached to #${id}`);
+  await animation.ready;
+  await waitForNextFrame();
+  return animation;
+}
+
+// getKeyframes() also reports the implicit offset-0 and offset-1 keyframes synthesized for
+// the "both" fill, so pick out just the ones written with a timeline range offset. Those
+// report their offset as a { rangeName, offset } object rather than a number.
+function computedOffsetsByRange(animation) {
+  const offsets = new Map();
+  for (const frame of animation.effect.getKeyframes()) {
+    if (!frame.offset || typeof frame.offset !== 'object')
+      continue;
+    offsets.set(`${frame.offset.rangeName} ${frame.offset.offset.value}%`, frame.computedOffset);
+  }
+  return offsets;
+}
+
+// The subject is 50px tall inside a 200px scrollport, so the cover range spans 250px and the
+// contain range spans the middle 150px of it. "contain 50%" therefore resolves to timeline
+// offset 0.5, and both edges of #degenerate's attachment range land on that single point.
+promise_test(async t => {
+  const animation = await activeAnimationFor('degenerate');
+  const offsets = computedOffsetsByRange(animation);
+  assert_array_equals([...offsets.keys()].sort(), ['cover 0%', 'cover 100%'].sort(),
+                      'both timeline range offsets are reported');
+
+  for (const [range, offset] of offsets) {
+    assert_false(offset === Infinity || offset === -Infinity,
+                 `computedOffset for "${range}" is not infinite`);
+    assert_true(Number.isNaN(offset),
+                `computedOffset for "${range}" is unresolved`);
+  }
+}, 'A zero-length attachment range yields unresolved computed keyframe offsets, not infinite ones');
+
+// Guards against the zero-length check above swallowing ranges that are merely narrow.
+promise_test(async t => {
+  const animation = await activeAnimationFor('ordinary');
+  const offsets = computedOffsetsByRange(animation);
+  assert_array_equals([...offsets.keys()].sort(), ['cover 0%', 'cover 100%'].sort(),
+                      'both timeline range offsets are reported');
+
+  assert_approx_equals(offsets.get('cover 0%'), -1 / 3, 1e-6, 'computedOffset for "cover 0%"');
+  assert_approx_equals(offsets.get('cover 100%'), 4 / 3, 1e-6, 'computedOffset for "cover 100%"');
+}, 'A non-degenerate attachment range still maps timeline range offsets outside [0,1]');
+</script>
+</html>

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -440,7 +440,13 @@ void BlendingKeyframes::updatedComputedOffsets(NOESCAPE const Function<double(co
     for (auto& keyframe : m_keyframes)
         keyframe.setComputedOffset(callback(keyframe.specifiedOffset()));
 
-    std::ranges::stable_sort(m_keyframes, { }, &BlendingKeyframe::offset);
+    std::ranges::stable_sort(m_keyframes, [](double a, double b) {
+        if (std::isnan(a))
+            return false;
+        if (std::isnan(b))
+            return true;
+        return a < b;
+    }, &BlendingKeyframe::offset);
 }
 
 bool BlendingKeyframes::hasKeyframeWithUnresolvedComputedOffset() const

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -264,6 +264,9 @@ static double computedOffset(Style::SingleAnimationRangeName rangeName, Style::P
 
     auto [attachmentRangeStartOffset, attachmentRangeEndOffset] = viewTimeline->offsetIntervalForAttachmentRange(attachmentRange);
     auto attachmentRangeOffsetDelta = attachmentRangeEndOffset - attachmentRangeStartOffset;
+    if (!attachmentRangeOffsetDelta)
+        return std::numeric_limits<double>::quiet_NaN();
+
     return (computedOffsetWithinNamedRange - attachmentRangeStartOffset) / attachmentRangeOffsetDelta;
 }
 


### PR DESCRIPTION
#### e9521780a83da546fd1cea021caf29306de8af8d
<pre>
A zero-length animation attachment range produces infinite computed keyframe offsets
<a href="https://bugs.webkit.org/show_bug.cgi?id=322009">https://bugs.webkit.org/show_bug.cgi?id=322009</a>
<a href="https://rdar.apple.com/185204758">rdar://185204758</a>

Reviewed by Antoine Quint.

computedOffset() maps a keyframe&apos;s timeline range offset into the progress space of the
animation&apos;s attachment range by dividing by that range&apos;s length. It skipped the division
only when the attachment range isDefault(), which tests start.isNormal() &amp;&amp; end.isNormal()
and so does not catch a range that is non-default but degenerate. With a range such as
&quot;contain 50% contain 50%&quot; both edges resolve to the same timeline offset, the length is
zero, and the division yielded +/-Infinity (or NaN when the numerator happened to be zero
as well).

The guard in updateComputedKeyframeOffsetsIfNeeded() does not help here: it bails out when
the timeline&apos;s currentTime is unresolved, but in this case the timeline range is perfectly
ordinary and only the attachment range is degenerate.

A zero-length attachment range gives the animation no interval to progress over, so there
is no offset to map onto. Return quiet_NaN() instead, which is how this code already
represents an unresolved computed offset -- see the named-range-without-a-timeline case
above it, and hasKeyframeWithUnresolvedComputedOffset(), which disables acceleration.
Computed offsets legitimately fall outside [0,1], so clamping would be wrong.

This matches Chrome, which already reports an unresolved computed offset here. Firefox
reports +/-Infinity, as WebKit did before this change.

While here, make BlendingKeyframes::updatedComputedOffsets() sort with an explicit
comparator. It sorted on BlendingKeyframe::offset() using std::less, which is not a strict
weak ordering over NaN: every NaN compares equivalent to every other offset, while those
offsets are not equivalent to each other. That is undefined behavior and trips hardened
libc++ comparator checks. It is reachable independently of the above, via range-offset
keyframes on an element with no scroll timeline at all. Order unresolved offsets last.

Test: imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-zero-length-attachment-range.html

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-zero-length-attachment-range-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-zero-length-attachment-range.html: Added.
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::updatedComputedOffsets):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::computedOffset):

Canonical link: <a href="https://commits.webkit.org/319443@main">https://commits.webkit.org/319443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9025d9018cf8df3a249abef2cac9fb29e8324536

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145607 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bfa46e8b-8b1a-4d25-ab89-3499f9d4680a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141478 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98145 "4 flakes 12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3364d41-1d66-4dfe-9464-835c383b2a9e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121920 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ca036c0-6d05-41f6-906a-782880fea787) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43837 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42107 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154240 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41762 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2658 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193432 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150871 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40454 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55584 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150579 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45168 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127865 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123436 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54100 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16759 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53482 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53720 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53547 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->