### PR TITLE
[GLIB][a11y] WTR: Add missing implementation of dismiss

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1181,9 +1181,6 @@ accessibility/textarea-line-for-index.html [ Skip ]
 # AX support for datetime input elements needs to be completed in glib platforms.
 accessibility/datetime [ Skip ]
 
-# Requires AccessibilityUIElement::dismiss to return whether or not it was handled.
-accessibility/dismiss-action-returns-whether-keyevent-handled.html [ Skip ]
-
 # Different roles
 accessibility/contenteditable-values.html [ Skip ]
 
@@ -1192,9 +1189,6 @@ accessibility/aria-table-indextext.html [ Failure ]
 
 # Started failing on [313982@main..313983@main].
 webkit.org/b/315858 [ Release ] accessibility/aria-owns-deep-chain-no-timeout.html [ Timeout Pass ]
-
-# Requires implementation of 'dismiss' in 'AccessibilityObjectAtspi.h'.
-accessibility/keyevents-posted-for-dismiss-action.html [ Skip ]
 
 webkit.org/b/199860 accessibility/button-with-aria-haspopup-role.html [ Failure ]
 webkit.org/b/199860 accessibility/datalist.html [ Failure ]

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -135,6 +135,7 @@ public:
     WEBCORE_EXPORT double minimumIncrement() const;
     WEBCORE_EXPORT void increment();
     WEBCORE_EXPORT void decrement();
+    WEBCORE_EXPORT bool dismiss();
     void valueChanged(double);
 
     WEBCORE_EXPORT URL url() const;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectValueAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectValueAtspi.cpp
@@ -124,6 +124,11 @@ void AccessibilityObjectAtspi::decrement()
         m_coreObject->decrement();
 }
 
+bool AccessibilityObjectAtspi::dismiss()
+{
+    return m_coreObject && m_coreObject->performDismissAction();
+}
+
 } // namespace WebCore
 
 #endif // USE(ATSPI)

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -1506,6 +1506,12 @@ void AccessibilityUIElementAtspi::press()
     m_element->doAction();
 }
 
+bool AccessibilityUIElementAtspi::dismiss()
+{
+    m_element->updateBackingStore();
+    return m_element->dismiss();
+}
+
 void AccessibilityUIElementAtspi::setSelectedChild(AccessibilityUIElement* element) const
 {
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h
@@ -74,6 +74,7 @@ public:
     void decrement() override;
     void showMenu() override;
     void press() override;
+    bool dismiss() override;
 
     JSRetainPtr<JSStringRef> stringDescriptionOfAttributeValue(JSStringRef attribute) override;
     JSRetainPtr<JSStringRef> stringAttributeValue(JSStringRef attribute) override;


### PR DESCRIPTION
#### 511f726506ff83b7b6ad99cb42989dda307659c1
<pre>
[GLIB][a11y] WTR: Add missing implementation of dismiss
<a href="https://bugs.webkit.org/show_bug.cgi?id=322007">https://bugs.webkit.org/show_bug.cgi?id=322007</a>

Reviewed by Carlos Garcia Campos.

Similar to 319432@main.

ATSPI lacks an implementation of operation
&apos;dismiss&apos; which causes GLIB tests relying on this operation to time out.

The &apos;dismiss&apos; operation can be implemented via
&apos;performDismissAction&apos;, reaching the same entry point that macOS/iOS
ports eventually reach through their native a11y APIS (&apos;AXDismissAction&apos;
and &apos;accessibilityPerformEscape&apos;, respectively).

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectValueAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::dismiss):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::AccessibilityUIElementAtspi::dismiss):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h:

Canonical link: <a href="https://commits.webkit.org/319441@main">https://commits.webkit.org/319441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f64eface2e65fc5380aa7e4a3330d489e219942c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141633 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45316 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122073 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43995 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41908 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2855 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193622 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55087 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151037 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55774 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150744 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27560 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45322 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128055 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123671 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54290 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16907 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53672 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53910 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53737 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->