### PR TITLE
REGRESSION(317782@main) An audible video element that will not be allowed to play can interrupt play in another app

### DIFF
--- a/LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash.html
+++ b/LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash.html
@@ -24,6 +24,7 @@ const skippedInternalFunctions = [
   "setVP9ScreenSizeAndScaleForTesting",
   "storeRegistrationsOnDisk",
   "systemAudioSessionCategory", // Calls IPC method behind AllowTestOnlyIPC which this test doesn't set.
+  "systemAudioSessionActivationCount", // Calls IPC method behind AllowTestOnlyIPC which this test doesn't set.
   "terminateWebContentProcess",
 ];
 

--- a/LayoutTests/media/audio-session-not-activated-for-denied-audible-element-expected.txt
+++ b/LayoutTests/media/audio-session-not-activated-for-denied-audible-element-expected.txt
@@ -1,0 +1,15 @@
+
+RUN(internals.settings.setShouldManageAudioSessionCategory(true))
+RUN(video = document.querySelector("video"))
+RUN(video.src = findMediaFile("video", "content/test"))
+RUN(video.play())
+EVENT(loadedmetadata)
+EXPECTED (video.audioTracks.length == '1') OK
+EXPECTED (playOutcome == 'NotAllowedError') OK
+EXPECTED (video.paused == 'true') OK
+EXPECTED (activations == '0') OK
+RUN(video.play())
+EVENT(playing)
+EXPECTED (activations == '1') OK
+END OF TEST
+

--- a/LayoutTests/media/audio-session-not-activated-for-denied-audible-element.html
+++ b/LayoutTests/media/audio-session-not-activated-for-denied-audible-element.html
@@ -1,0 +1,67 @@
+<!-- webkit-test-runner [ RequiresUserGestureForAudioPlayback=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>audio-session-not-activated-for-denied-audible-element</title>
+    <script src="video-test.js"></script>
+    <script src="media-file.js"></script>
+    <script>
+    // An element is allowed to start playing while it is believed to be silent, and is denied once an
+    // audio track is discovered. Activating the audio session interrupts other applications and the
+    // request cannot be withdrawn once it reaches the platform, so no activation may be requested for
+    // an element that is about to be paused.
+    //
+    // The count is read from the GPU process, which owns the real audio session: a web process's own
+    // AudioSession reports the state it asked for, and reports it optimistically, so a short-lived
+    // activation is already gone from it by the time a test reads it.
+    async function activationsSince(baseline)
+    {
+        window.activations = (await internals.systemAudioSessionActivationCount()) - baseline;
+        return window.activations;
+    }
+
+    window.addEventListener('load', async event => {
+        if (!window.internals) {
+            failTest('This test requires internals.');
+            return;
+        }
+        failTestIn(20000);
+        run('internals.settings.setShouldManageAudioSessionCategory(true)');
+        run('video = document.querySelector("video")');
+
+        let baseline = await internals.systemAudioSessionActivationCount();
+
+        // hasAudio() is false until metadata arrives, so play() without a user gesture is permitted
+        // here, and denied once the audio track is known. The outcome is captured at the call site, as
+        // the rejection lands while this test is still waiting on metadata and a rejection left
+        // unhandled for a turn is reported to the console.
+        run('video.src = findMediaFile("video", "content/test")');
+        let playSettled = run('video.play()').then(() => window.playOutcome = 'resolved', error => window.playOutcome = error.name);
+        await waitFor(video, 'loadedmetadata');
+        await testExpectedEventually('video.audioTracks.length', 1);
+
+        await playSettled;
+        testExpected('playOutcome', 'NotAllowedError');
+        testExpected('video.paused', true);
+
+        // The count query travels the same connection as an activation request would, so it cannot be
+        // answered ahead of one already sent.
+        await activationsSince(baseline);
+        testExpected('activations', 0);
+
+        // A user gesture removes the restriction, so the same element is allowed to play and the audio
+        // session is activated for it.
+        runWithKeyDown('video.play()');
+        await waitFor(video, 'playing');
+        for (let tries = 0; tries < 200 && await activationsSince(baseline) < 1; ++tries)
+            await sleepFor(10);
+        testExpected('activations', 1);
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/media/audio-session-not-activated-when-unmuting-denied-element-expected.txt
+++ b/LayoutTests/media/audio-session-not-activated-when-unmuting-denied-element-expected.txt
@@ -1,0 +1,14 @@
+
+RUN(internals.settings.setShouldManageAudioSessionCategory(true))
+RUN(video = document.querySelector("video"))
+RUN(video.muted = true)
+RUN(video.src = findMediaFile("video", "content/test"))
+RUN(video.play())
+EVENT(playing)
+EXPECTED (video.paused == 'false') OK
+EXPECTED (activations == '0') OK
+RUN(video.muted = false)
+EXPECTED (video.paused == 'true') OK
+EXPECTED (activations == '0') OK
+END OF TEST
+

--- a/LayoutTests/media/audio-session-not-activated-when-unmuting-denied-element.html
+++ b/LayoutTests/media/audio-session-not-activated-when-unmuting-denied-element.html
@@ -1,0 +1,56 @@
+<!-- webkit-test-runner [ RequiresUserGestureForAudioPlayback=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>audio-session-not-activated-when-unmuting-denied-element</title>
+    <script src="video-test.js"></script>
+    <script src="media-file.js"></script>
+    <script>
+    // Unmuting a playing element makes it audible, and playback of an audible element is not permitted
+    // without a user gesture, so the element is paused. The audio session must not be activated on its
+    // behalf: activating it interrupts other applications and the request cannot be withdrawn once it
+    // reaches the platform.
+    //
+    // The count is read from the GPU process, which owns the real audio session: a web process's own
+    // AudioSession reports the state it asked for, and reports it optimistically, so a short-lived
+    // activation is already gone from it by the time a test reads it.
+    async function activationsSince(baseline)
+    {
+        window.activations = (await internals.systemAudioSessionActivationCount()) - baseline;
+        return window.activations;
+    }
+
+    window.addEventListener('load', async event => {
+        if (!window.internals) {
+            failTest('This test requires internals.');
+            return;
+        }
+        failTestIn(20000);
+        run('internals.settings.setShouldManageAudioSessionCategory(true)');
+        run('video = document.querySelector("video")');
+
+        let baseline = await internals.systemAudioSessionActivationCount();
+
+        // A muted element is not audible, so playback is permitted without a user gesture and the
+        // audio session is not needed for it.
+        run('video.muted = true');
+        run('video.src = findMediaFile("video", "content/test")');
+        run('video.play()');
+        await waitFor(video, 'playing');
+        testExpected('video.paused', false);
+        await activationsSince(baseline);
+        testExpected('activations', 0);
+
+        run('video.muted = false');
+        await testExpectedEventually('video.paused', true);
+        await activationsSince(baseline);
+        testExpected('activations', 0);
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4886,6 +4886,8 @@ webkit.org/b/303873 imported/w3c/web-platform-tests/trusted-types/navigate-to-ja
 
 # No USE(AUDIO_SESSION) support:
 media/volume-activate-audio-session.html [ Skip ]
+media/audio-session-not-activated-for-denied-audible-element.html [ Skip ]
+media/audio-session-not-activated-when-unmuting-denied-element.html [ Skip ]
 
 # Does not work on glib platforms
 http/tests/performance/performance-resource-timing-cross-origin-media-with-cors.html [ Skip ]

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -93,6 +93,10 @@ public:
     void inActiveDocumentChanged();
 
     Expected<void, MediaPlaybackDenialExplanation> playbackStateChangePermitted(MediaPlaybackState) const;
+    // playbackStateChangePermitted() only denies an audible element, so play() is permitted while
+    // the resource is believed to be silent (no audio track discovered yet, muted, or volume zero)
+    // and denied once it becomes audible.
+    bool playbackPermitted() const final { return playbackStateChangePermitted(MediaPlaybackState::Playing).has_value(); }
     bool autoplayPermitted() const;
     bool dataLoadingPermitted() const;
     WEBCORE_EXPORT MediaPlayer::BufferingPolicy preferredBufferingPolicy() const;

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -143,12 +143,24 @@ Ref<AudioSession::SetActivePromise> AudioSession::tryToSetActive(bool active)
             ALWAYS_LOG(logSiteIdentifier, "is active = ", active, ", previousIsActive = ", previousIsActive);
             bool hasActiveChanged = previousIsActive != active;
             m_active = active;
+            if (active && hasActiveChanged)
+                ++m_activationCountForTesting;
             if (m_isInterrupted && m_active && previousIsInterrupted)
                 endInterruption(MayResume::Yes);
             if (hasActiveChanged)
                 activeStateChanged();
             return SetActivePromise::createAndResolve();
         });
+}
+
+Ref<AudioSession::ActivationCountPromise> AudioSession::systemActivationCountForTesting()
+{
+    return ActivationCountPromise::createAndResolve(activationCountForTesting());
+}
+
+uint64_t AudioSession::activationCountForTesting() const
+{
+    return m_activationCountForTesting;
 }
 
 void AudioSession::setActive(bool active)

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -131,6 +131,12 @@ public:
     // The category applied to the real audio session.
     using CategoryPromise = NativePromise<AudioSessionCategory, void>;
     virtual Ref<CategoryPromise> systemCategoryForTesting() { return CategoryPromise::createAndResolve(category()); }
+
+    // How many times the audio session has been made active, counting only transitions from inactive to active.
+    using ActivationCountPromise = NativePromise<uint64_t, void>;
+    virtual Ref<ActivationCountPromise> systemActivationCountForTesting();
+    uint64_t activationCountForTesting() const;
+
     virtual void clearInterruptionFlagForTesting() { }
 
     static void addInterruptionObserver(AudioSessionInterruptionObserver&);
@@ -174,6 +180,7 @@ protected:
     AudioSession::CategoryType m_categoryOverride { AudioSession::CategoryType::None };
     bool m_active { false }; // Used only for testing.
     bool m_isInterrupted { false };
+    uint64_t m_activationCountForTesting { 0 };
 };
 
 class AudioSessionInterruptionObserver : public AbstractRefCountedAndCanMakeWeakPtr<AudioSessionInterruptionObserver> {

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -209,6 +209,25 @@ bool MediaSessionManagerInterface::activeAudioSessionRequired() const
 #endif
 }
 
+bool MediaSessionManagerInterface::audioSessionActivationRequired() const
+{
+    // Stricter than activeAudioSessionRequired(): activating the audio session interrupts other
+    // applications and cannot be withdrawn once the request reaches the platform, so a session whose
+    // client is not allowed to play must not cause it. Deactivation keys on
+    // activeAudioSessionRequired() instead (conservative about giving the session up, strict about
+    // taking it).
+#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
+    if (anyOfSessions([] (auto& session) { return session.activeAudioSessionRequired() && session.playbackPermitted(); }))
+        return true;
+
+    return std::ranges::any_of(m_audioCaptureSources, [](auto& source) {
+        return Ref { source }->isCapturingAudio();
+    });
+#else
+    return false;
+#endif
+}
+
 bool MediaSessionManagerInterface::hasActiveAudioSession(PlatformMediaSessionInterface&) const
 {
 #if USE(AUDIO_SESSION)
@@ -879,7 +898,7 @@ void MediaSessionManagerInterface::maybeDeactivateAudioSession(ShouldCheckRequir
 Ref<GenericPromise> MediaSessionManagerInterface::maybeActivateAudioSession()
 {
 #if USE(AUDIO_SESSION)
-    if (!activeAudioSessionRequired()) {
+    if (!audioSessionActivationRequired()) {
         MEDIASESSIONMANAGERINTERFACE_RELEASE_LOG(MaybeActivateAudioSessionActiveSessionNotRequired);
         // Do NOT deactivate here. This is an "activate or no-op" function, matching
         // the pre-async contract (7136b90d351d). Tearing the session down on any

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -72,6 +72,7 @@ public:
     virtual bool hasNoSession() const;
 
     virtual bool activeAudioSessionRequired() const;
+    bool audioSessionActivationRequired() const;
     virtual bool hasActiveAudioSession(PlatformMediaSessionInterface&) const;
     virtual bool canProduceAudio() const;
 

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
@@ -202,6 +202,11 @@ public:
 
     virtual bool blockedBySystemInterruption() const = 0;
     virtual bool activeAudioSessionRequired() const = 0;
+
+    // Whether the client is allowed to begin playing right now. A session can be Playing and audible
+    // while its client is no longer allowed to start.
+    virtual bool playbackPermitted() const;
+
     virtual bool canProduceAudio() const { return protect(client())->canProduceAudio(); }
     virtual bool hasMediaStreamSource() const { return protect(client())->hasMediaStreamSource(); }
     virtual void canProduceAudioChanged() = 0;
@@ -271,5 +276,6 @@ private:
 inline void PlatformMediaSessionInterface::setMediaSessionIdentifier(MediaSessionIdentifier identifier) { m_mediaSessionIdentifier = identifier; }
 inline PlatformMediaSessionClient& PlatformMediaSessionInterface::client() const { return m_client; }
 inline bool PlatformMediaSessionInterface::isRemoteSessionProxy() const { return false; }
+inline bool PlatformMediaSessionInterface::playbackPermitted() const { return true; }
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7045,6 +7045,22 @@ void Internals::systemAudioSessionCategory(DOMPromiseDeferred<IDLEnumeration<Aud
 #endif
 }
 
+void Internals::systemAudioSessionActivationCount(DOMPromiseDeferred<IDLUnsignedLongLong>&& promise)
+{
+#if USE(AUDIO_SESSION)
+    AudioSession::singleton().systemActivationCountForTesting()->whenSettled(RunLoop::mainSingleton(),
+        [promise = WTF::move(promise)](auto&& result) mutable {
+            if (!result) {
+                promise.reject(Exception { ExceptionCode::InvalidStateError, "Could not read the system audio session activation count"_s });
+                return;
+            }
+            promise.resolve(*result);
+        });
+#else
+    promise.resolve(0);
+#endif
+}
+
 auto Internals::audioSessionMode() const -> AudioSessionMode
 {
 #if USE(AUDIO_SESSION)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1152,6 +1152,7 @@ public:
     bool NODELETE supportsAudioSession() const;
     AudioSessionCategory audioSessionCategory() const;
     void systemAudioSessionCategory(DOMPromiseDeferred<IDLEnumeration<AudioSessionCategory>>&&);
+    void systemAudioSessionActivationCount(DOMPromiseDeferred<IDLUnsignedLongLong>&&);
     AudioSessionMode audioSessionMode() const;
     RouteSharingPolicy routeSharingPolicy() const;
 #if ENABLE(VIDEO)

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1316,6 +1316,7 @@ enum ContentsFormat {
     readonly attribute boolean supportsAudioSession;
     AudioSessionCategory audioSessionCategory();
     Promise<AudioSessionCategory> systemAudioSessionCategory();
+    Promise<unsigned long long> systemAudioSessionActivationCount();
     AudioSessionMode audioSessionMode();
     [Conditional=VIDEO] AudioSessionCategory categoryAtMostRecentPlayback(HTMLMediaElement element);
     [Conditional=VIDEO] AudioSessionMode modeAtMostRecentPlayback(HTMLMediaElement element);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -193,6 +193,12 @@ void RemoteAudioSessionProxy::systemCategoryForTesting(CompletionHandler<void(We
     completionHandler(AudioSession::singleton().category());
 }
 
+void RemoteAudioSessionProxy::systemActivationCountForTesting(CompletionHandler<void(uint64_t)>&& completionHandler)
+{
+    // How many times the GPU process made the real session active..
+    completionHandler(AudioSession::singleton().activationCountForTesting());
+}
+
 void RemoteAudioSessionProxy::triggerBeginInterruptionForTesting()
 {
     AudioSession::singleton().beginInterruptionForTesting();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -103,6 +103,7 @@ private:
     void tryToSetActiveSync(bool, SetActiveCompletion&&);
     void setIsPlayingToBluetoothOverride(std::optional<bool>&& value);
     void systemCategoryForTesting(CompletionHandler<void(WebCore::AudioSessionCategory)>&&);
+    void systemActivationCountForTesting(CompletionHandler<void(uint64_t)>&&);
     void triggerBeginInterruptionForTesting();
     void triggerEndInterruptionForTesting();
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
@@ -40,6 +40,7 @@ messages -> RemoteAudioSessionProxy {
     [EnabledBy=AllowTestOnlyIPC] TriggerBeginInterruptionForTesting()
     [EnabledBy=AllowTestOnlyIPC] TriggerEndInterruptionForTesting()
     [EnabledBy=AllowTestOnlyIPC] SystemCategoryForTesting() -> (enum:uint8_t WebCore::AudioSessionCategory category)
+    [EnabledBy=AllowTestOnlyIPC] SystemActivationCountForTesting() -> (uint64_t count)
 
     BeginInterruptionRemote()
     EndInterruptionRemote(enum:bool WebCore::AudioSessionMayResume flags)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -301,6 +301,16 @@ Ref<AudioSession::CategoryPromise> RemoteAudioSession::systemCategoryForTesting(
         });
 }
 
+Ref<AudioSession::ActivationCountPromise> RemoteAudioSession::systemActivationCountForTesting()
+{
+    return protect(ensureConnection())->sendWithPromisedReply(Messages::RemoteAudioSessionProxy::SystemActivationCountForTesting())->whenSettled(RunLoop::mainSingleton(),
+        [](auto&& result) {
+            if (!result)
+                return ActivationCountPromise::createAndReject();
+            return ActivationCountPromise::createAndResolve(*result);
+        });
+}
+
 void RemoteAudioSession::beginInterruptionForTesting()
 {
     m_isInterruptedForTesting = true;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -99,6 +99,7 @@ private:
     void beginInterruptionForTesting() final;
     void endInterruptionForTesting() final;
     Ref<CategoryPromise> systemCategoryForTesting() final;
+    Ref<ActivationCountPromise> systemActivationCountForTesting() final;
     void clearInterruptionFlagForTesting() final { m_isInterruptedForTesting = false; }
 
     void setSceneIdentifier(const String&) final;


### PR DESCRIPTION
#### 7fa5ab54bb881f1ea530ff0e36e1a35e1c55f6ad
<pre>
REGRESSION(317782@main) An audible video element that will not be allowed to play can interrupt play in another app
<a href="https://bugs.webkit.org/show_bug.cgi?id=322011">https://bugs.webkit.org/show_bug.cgi?id=322011</a>
<a href="https://rdar.apple.com/184545492">rdar://184545492</a>

Reviewed by Eric Carlson.

Playing a trailer in the TV app on visionOS and then opening a page carrying an
autoplaying video paused the trailer, and it did not resume.

Following 317782@main, void MediaSessionManagerInterface::sessionCanProduceAudioChanged() unconditionally called maybeActivateAudioSession() synchronously;
When the element was first loaded, and not yet known to have audible content,
it was allowed to play and the MediaSession state became Playing,
shortly after when the metadata was loaded and readyState moved to HAVE_METADATA
(having canProduceAudio() now returning true but not yet actually audible
having not loaded any content to render), maybeActivateAudioSession() activated
the AudioSession only to then immediately deny playback and pause the video.
This caused any other application currently playing audio on visionOS or iPadOS to be paused.

The audio session is now activated only for a session whose client would be
allowed to begin playing. PlatformMediaSessionInterface gains playbackPermitted(),
defaulting to true so that AudioContext, MediaSession and MediaStream sessions are
unaffected, and MediaElementSession answers it with
playbackStateChangePermitted(MediaPlaybackState::Playing).
MediaSessionManagerInterface::audioSessionActivationRequired() is
activeAudioSessionRequired() plus that condition and is consulted only by
maybeActivateAudioSession(). maybeDeactivateAudioSession() keeps using
activeAudioSessionRequired(): the permission is state-dependent and can be false
for a session that is legitimately playing, and deactivation must stay
conservative.

Asserting that no activation happened needs the GPU process&apos;s view, as a web
process&apos;s own AudioSession reports the state it asked for and reports it
optimistically. AudioSession counts transitions from inactive to active, and the
count is readable through internals.systemAudioSessionActivationCount(), plumbed
the way systemAudioSessionCategory() already is.

* LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash.html:
Skip the new internals function, which sends IPC behind AllowTestOnlyIPC that this test does not set.
* LayoutTests/media/audio-session-not-activated-for-denied-audible-element-expected.txt: Added.
* LayoutTests/media/audio-session-not-activated-for-denied-audible-element.html: Added.
* LayoutTests/media/audio-session-not-activated-when-unmuting-denied-element-expected.txt: Added.
* LayoutTests/media/audio-session-not-activated-when-unmuting-denied-element.html: Added.
* LayoutTests/platform/glib/TestExpectations: Skip both, no USE(AUDIO_SESSION) support.
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::tryToSetActive): Count activations.
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::audioSessionActivationRequired const): Added.
(WebCore::MediaSessionManagerInterface::maybeActivateAudioSession): Use it.
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::systemAudioSessionActivationCount): Added.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::systemActivationCountForTesting): Added.
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::systemActivationCountForTesting): Added.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:

Canonical link: <a href="https://commits.webkit.org/319413@main">https://commits.webkit.org/319413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/972f831a52e6382b51ab7edc32ccfee4b82c9872

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145613 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d6543ad-cfd5-4707-919c-102ff6c4a2d7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141481 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ba1e3ff-c1a1-4021-8a2d-a6aecc1aadd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121923 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7f0762b-5887-4624-aa90-6576570362dd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43845 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42114 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41770 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2664 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193438 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54903 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150876 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40438 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55590 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150584 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45176 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127871 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123450 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54106 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16768 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53488 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53726 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53553 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->