### PR TITLE
[JSC] Bytecode cache should generate `CodeForConstruct` for class constructors

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.mm
+++ b/Source/JavaScriptCore/API/tests/testapi.mm
@@ -2250,6 +2250,34 @@ static void testBytecodeCachedFunctionsDontJITImmediately()
     }
 }
 
+static void testBytecodeCachedClassConstructorsDontReparse()
+{
+    @autoreleasepool {
+        NSString *fooSource = @"class Base { constructor(x) { this.x = x; } }; class Derived extends Base { constructor(x) { super(x); this.y = x + 1; } }; class Implicit extends Base { }; var before = $vm.parseCount(); var result = new Derived(20).y + new Implicit(21).x; [$vm.parseCount() - before, result];";
+        NSURL *fooCachePath = cacheFileInDataVault(@"foo.js.cache");
+        JSC::Options::useDollarVM() = true;
+        JSC::Options::countParseTimes() = true;
+        JSContext *context = [[JSContext alloc] init];
+        JSScript *script = [JSScript scriptOfType:kJSScriptTypeProgram withSource:fooSource andSourceURL:[NSURL URLWithString:@"my-path"] andBytecodeCache:fooCachePath inVirtualMachine:context.virtualMachine error:nil];
+        RELEASE_ASSERT(script);
+        if (![script cacheBytecodeWithError:nil])
+            CRASH();
+
+        JSC::Options::forceDiskCache() = true;
+        JSValue *result = [context evaluateJSScript:script];
+        RELEASE_ASSERT(result);
+        RELEASE_ASSERT([result isArray]);
+        checkResult(@"constructing cached classes does not parse", ![[result[0] toNumber] intValue]);
+        checkResult(@"result of cached class constructors is 21+21", [[result[1] toNumber] intValue] == 21 + 21);
+        JSC::Options::forceDiskCache() = false;
+        JSC::Options::countParseTimes() = false;
+
+        NSFileManager* fileManager = [NSFileManager defaultManager];
+        BOOL removedAll = [fileManager removeItemAtURL:fooCachePath error:nil];
+        checkResult(@"Removed all temp files created", removedAll);
+    }
+}
+
 static void testBytecodeCacheWithSyntaxError(JSScriptType type)
 {
     @autoreleasepool {
@@ -3016,6 +3044,7 @@ void testObjectiveCAPI(const char* filter)
         RUN(testModuleBytecodeCache());
         RUN(testProgramBytecodeCache());
         RUN(testBytecodeCachedFunctionsDontJITImmediately());
+        RUN(testBytecodeCachedClassConstructorsDontReparse());
         RUN(testBytecodeCacheWithSyntaxError(kJSScriptTypeProgram));
         RUN(testBytecodeCacheWithSyntaxError(kJSScriptTypeModule));
         RUN(testBytecodeCacheWithSameCacheFileAndDifferentScript(false));

--- a/Source/JavaScriptCore/runtime/CodeCache.cpp
+++ b/Source/JavaScriptCore/runtime/CodeCache.cpp
@@ -59,22 +59,20 @@ void CodeCacheMap::pruneSlowCase()
 
 static void generateUnlinkedCodeBlockForFunctions(VM& vm, UnlinkedCodeBlock* unlinkedCodeBlock, const SourceCode& parentSource, OptionSet<CodeGenerationMode> codeGenerationMode, ParserError& error)
 {
-    auto generate = [&](UnlinkedFunctionExecutable* unlinkedExecutable, CodeSpecializationKind constructorKind) {
-        if (constructorKind == CodeSpecializationKind::CodeForConstruct && SourceParseModeSet(SourceParseMode::AsyncArrowFunctionMode, SourceParseMode::AsyncMethodMode, SourceParseMode::AsyncFunctionMode).contains(unlinkedExecutable->parseMode()))
-            return;
-
+    auto generate = [&](UnlinkedFunctionExecutable* unlinkedExecutable) {
+        // FIXME: We should also generate CodeBlocks for CodeForConstruct of ordinary functions.
+        // https://bugs.webkit.org/show_bug.cgi?id=193823
+        CodeSpecializationKind kind = unlinkedExecutable->isClassConstructorFunction() ? CodeSpecializationKind::CodeForConstruct : CodeSpecializationKind::CodeForCall;
         SourceCode source = unlinkedExecutable->linkedSourceCode(parentSource);
-        UnlinkedFunctionCodeBlock* unlinkedFunctionCodeBlock = unlinkedExecutable->unlinkedCodeBlockFor(vm, source, constructorKind, codeGenerationMode, error, unlinkedExecutable->parseMode());
+        UnlinkedFunctionCodeBlock* unlinkedFunctionCodeBlock = unlinkedExecutable->unlinkedCodeBlockFor(vm, source, kind, codeGenerationMode, error, unlinkedExecutable->parseMode());
         if (unlinkedFunctionCodeBlock)
             generateUnlinkedCodeBlockForFunctions(vm, unlinkedFunctionCodeBlock, source, codeGenerationMode, error);
     };
 
-    // FIXME: We should also generate CodeBlocks for CodeForConstruct
-    // https://bugs.webkit.org/show_bug.cgi?id=193823
     for (unsigned i = 0; i < unlinkedCodeBlock->numberOfFunctionDecls(); i++)
-        generate(unlinkedCodeBlock->functionDecl(i), CodeSpecializationKind::CodeForCall);
+        generate(unlinkedCodeBlock->functionDecl(i));
     for (unsigned i = 0; i < unlinkedCodeBlock->numberOfFunctionExprs(); i++)
-        generate(unlinkedCodeBlock->functionExpr(i), CodeSpecializationKind::CodeForCall);
+        generate(unlinkedCodeBlock->functionExpr(i));
 }
 
 template <class UnlinkedCodeBlockType, class ExecutableType = ScriptExecutable>


### PR DESCRIPTION
#### c823243598c5b0ada8561918280e9a1d0649000d
<pre>
[JSC] Bytecode cache should generate `CodeForConstruct` for class constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=193823">https://bugs.webkit.org/show_bug.cgi?id=193823</a>

Reviewed by Yusuke Suzuki.

generateUnlinkedCodeBlockForFunctions only generates the CodeForCall variant of every function.
For a class constructor that variant is just the &quot;Cannot call a class constructor&quot; throw, emitted
before the body, so the cache holds neither the construct code nor the functions nested in the
constructor body. Every `new C()` from a bytecode-cached program misses the cache and reparses
the constructor from source; the implicit default constructor is reparsed from the builtin source too.

Generate CodeForConstruct instead when the executable is a class constructor. Calling a class
constructor throws, so nothing is lost. The async-function early return becomes unreachable and is
removed. Ordinary functions still get CodeForCall only, since whether they are constructed is not
known at cache time.

Constructing 182 three.js classes from a cached program: 253 -&gt; 4 parses, 14.5 ms -&gt; 10.3 ms.
babylon.js ES6 startup: 133 -&gt; 9 parses, 30.7 ms -&gt; 27.8 ms. Cache size grows by the previously
missing constructor bodies (three.js +10.8%, a 50 MB application bundle +0.5%).

Test: Source/JavaScriptCore/API/tests/testapi.mm

* Source/JavaScriptCore/API/tests/testapi.mm:
(testBytecodeCachedClassConstructorsDontReparse):
(testObjectiveCAPI):
* Source/JavaScriptCore/runtime/CodeCache.cpp:
(JSC::generateUnlinkedCodeBlockForFunctions):

Canonical link: <a href="https://commits.webkit.org/319439@main">https://commits.webkit.org/319439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4be0b1b78d4d5c516e97f49f11c1d857e420763b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145639 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141504 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121944 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43866 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42134 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3910 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10736 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41790 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2690 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42589 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193464 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54929 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150899 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40451 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55616 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150606 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45199 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127897 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123487 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54132 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16788 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53752 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->