### PR TITLE
Append CompressionDictionary to FetchOptionsDestination instead of inserting it

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchRequestDestination.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequestDestination.idl
@@ -33,7 +33,6 @@
     "",
     "audio",
     "audioworklet",
-    "compression-dictionary",
     "document",
     "embed",
     "environmentmap",
@@ -55,5 +54,6 @@
     "video",
     "worker",
     "xslt",
-    "text"
+    "text",
+    "compression-dictionary"
 };

--- a/Source/WebCore/loader/FetchOptions.h
+++ b/Source/WebCore/loader/FetchOptions.h
@@ -133,7 +133,6 @@ template<> struct EnumTraitsForPersistence<WebCore::FetchOptions::Destination> {
         WebCore::FetchOptions::Destination::EmptyString,
         WebCore::FetchOptions::Destination::Audio,
         WebCore::FetchOptions::Destination::Audioworklet,
-        WebCore::FetchOptions::Destination::CompressionDictionary,
         WebCore::FetchOptions::Destination::Document,
         WebCore::FetchOptions::Destination::Embed,
         WebCore::FetchOptions::Destination::Environmentmap,
@@ -155,7 +154,8 @@ template<> struct EnumTraitsForPersistence<WebCore::FetchOptions::Destination> {
         WebCore::FetchOptions::Destination::Video,
         WebCore::FetchOptions::Destination::Worker,
         WebCore::FetchOptions::Destination::Xslt,
-        WebCore::FetchOptions::Destination::Text
+        WebCore::FetchOptions::Destination::Text,
+        WebCore::FetchOptions::Destination::CompressionDictionary
     >;
 };
 

--- a/Source/WebCore/loader/FetchOptionsDestination.h
+++ b/Source/WebCore/loader/FetchOptionsDestination.h
@@ -31,7 +31,6 @@ enum class FetchOptionsDestination : uint8_t {
     EmptyString,
     Audio,
     Audioworklet,
-    CompressionDictionary,
     Document,
     Embed,
     Environmentmap,
@@ -54,7 +53,8 @@ enum class FetchOptionsDestination : uint8_t {
     Video,
     Worker,
     Xslt,
-    Text
+    Text,
+    CompressionDictionary
 };
     
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2140,7 +2140,6 @@ enum class WebCore::FetchOptionsDestination : uint8_t {
     EmptyString,
     Audio,
     Audioworklet,
-    CompressionDictionary,
     Document,
     Embed,
     Environmentmap,
@@ -2162,7 +2161,8 @@ enum class WebCore::FetchOptionsDestination : uint8_t {
     Video,
     Worker,
     Xslt,
-    Text
+    Text,
+    CompressionDictionary
 };
 
 enum class WebCore::FetchOptionsMode : uint8_t {


### PR DESCRIPTION
#### 3c7f0230afde14d2b886fd4236851a66580853d9
<pre>
Append CompressionDictionary to FetchOptionsDestination instead of inserting it
<a href="https://bugs.webkit.org/show_bug.cgi?id=322030">https://bugs.webkit.org/show_bug.cgi?id=322030</a>

Reviewed by Alex Christensen.

FetchOptions::encodePersistent() writes destination as its raw value, and says
that changes to its encoding should bump the NetworkCache Storage format
version. We can just avoid the change in order.

* Source/WebCore/Modules/fetch/FetchRequestDestination.idl:
* Source/WebCore/loader/FetchOptions.h:
* Source/WebCore/loader/FetchOptionsDestination.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/319409@main">https://commits.webkit.org/319409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ee14c597c482ee736b1bbad6248b99fbdc968ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191545 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145648 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141520 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43871 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42142 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154273 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41797 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2700 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193473 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54938 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150909 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55625 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150615 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27539 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45203 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127906 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123500 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54141 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16795 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53523 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53761 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->