### PR TITLE
[Cleanup] Remove unused overloads that take CSSToLengthConversionData

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -477,7 +477,6 @@ style/Styleable.cpp
 style/Styleable.h
 style/computed/StyleComputedStyle.cpp
 style/computed/StyleComputedStyleBase.cpp
-style/values/color/StyleColor.cpp
 style/values/content/StyleContent.cpp
 style/values/grid/StyleGridPositionsResolver.cpp
 style/values/images/kinds/StyleGradientImage.cpp

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -375,22 +375,6 @@ Color toStyleColor(const CSS::Color& value, ColorResolutionState& state)
     return WTF::switchOn(value, [&](const auto& color) { return toStyleColor(color, state); });
 }
 
-Color toStyleColor(const CSS::Color& value, Ref<const Document> document, const ComputedStyle& style, const CSSToLengthConversionData& conversionData, ForVisitedLink forVisitedLink)
-{
-    auto resolutionState = ColorResolutionState {
-        .document = document,
-        .style = style,
-        .conversionData = conversionData,
-        .forVisitedLink = forVisitedLink
-    };
-    return toStyleColor(value, resolutionState);
-}
-
-Color toStyleColor(const CSS::Color& value, const BuilderState& builderState, ForVisitedLink forVisitedLink)
-{
-    return toStyleColor(value, builderState.document(), builderState.style(), builderState.cssToLengthConversionData(), forVisitedLink);
-}
-
 auto ToCSS<Color>::operator()(const Color& value, const Style::ComputedStyle& style) -> CSS::Color
 {
     ColorResolver colorResolver { style };
@@ -399,7 +383,13 @@ auto ToCSS<Color>::operator()(const Color& value, const Style::ComputedStyle& st
 
 auto ToStyle<CSS::Color>::operator()(const CSS::Color& value, const BuilderState& builderState, ForVisitedLink forVisitedLink) -> Color
 {
-    return toStyleColor(value, builderState.document(), builderState.style(), builderState.cssToLengthConversionData(), forVisitedLink);
+    auto resolutionState = ColorResolutionState {
+        .document = builderState.document(),
+        .style = builderState.style(),
+        .conversionData = builderState.cssToLengthConversionData(),
+        .forVisitedLink = forVisitedLink
+    };
+    return toStyleColor(value, resolutionState);
 }
 
 auto ToStyle<CSS::Color>::operator()(const CSS::Color& value, const BuilderState& builderState) -> Color

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -189,8 +189,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, const Color&);
 // MARK: - Conversion
 
 Color toStyleColor(const CSS::Color&, ColorResolutionState&);
-Color toStyleColor(const CSS::Color&, Ref<const Document>, const ComputedStyle&, const CSSToLengthConversionData&, ForVisitedLink);
-Color toStyleColor(const CSS::Color&, const BuilderState&, ForVisitedLink);
 
 template<> struct ToCSS<Color> {
     auto operator()(const Color&, const Style::ComputedStyle&) -> CSS::Color;

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -759,31 +759,14 @@ bool equalForLengthResolution(const ComputedStyle& styleA, const ComputedStyle& 
 
 // MARK: - em-to-px utility functions
 
-double emToPxDouble(double value, const CSSToLengthConversionData& conversionData)
-{
-    CSSToLengthConversionDataAdaptor adaptor {
-        .conversionData = conversionData,
-    };
-    return value * adaptor.applyTextZoom(resolveEm(adaptor.fontCascadeForFontUnits()));
-}
-
 double emToPxDouble(double value, const ComputedStyle& style)
 {
-    return emToPxDouble(value, CSSToLengthConversionData(style, nullptr, nullptr, nullptr, nullptr));
-}
-
-double emToPxDoubleZoomed(double value, const CSSToLengthConversionData& conversionData)
-{
-    // Text zoom is not applied here as it is already included in the FontDescription's computedSize().
-    CSSToLengthConversionDataAdaptor adaptor {
-        .conversionData = conversionData,
-    };
-    return value * adaptor.fontCascadeForFontUnits().fontDescription().computedSize();
+    return value * style.fontCascade().fontDescription().specifiedSize();
 }
 
 double emToPxDoubleZoomed(double value, const ComputedStyle& style)
 {
-    return emToPxDoubleZoomed(value, CSSToLengthConversionData(style, nullptr, nullptr, nullptr, nullptr));
+    return value * style.fontCascade().fontDescription().computedSize();
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.h
@@ -62,39 +62,19 @@ bool equalForLengthResolution(const ComputedStyle&, const ComputedStyle&);
 
 // Utilities for common conversions.
 
-double emToPxDouble(double value, const CSSToLengthConversionData&);
 double emToPxDouble(double value, const ComputedStyle&);
-double emToPxDoubleZoomed(double value, const CSSToLengthConversionData&);
 double emToPxDoubleZoomed(double value, const ComputedStyle&);
-
-template<typename T> inline T emToPx(double value, const CSSToLengthConversionData& conversionData)
-{
-    if constexpr (std::floating_point<T>)
-        return static_cast<T>(emToPxDouble(value, conversionData));
-    else if constexpr (std::integral<T>)
-        return roundForImpreciseConversion<T>(emToPxDouble(value, conversionData));
-}
 
 template<typename T> inline T emToPx(double value, const ComputedStyle& style)
 {
-    // For `em`, we only need the element's style, so we can overload this to take just a `ComputedStyle`.
     if constexpr (std::floating_point<T>)
         return static_cast<T>(emToPxDouble(value, style));
     else if constexpr (std::integral<T>)
         return roundForImpreciseConversion<T>(emToPxDouble(value, style));
 }
 
-template<typename T> inline T emToPxZoomed(double value, const CSSToLengthConversionData& conversionData)
-{
-    if constexpr (std::floating_point<T>)
-        return static_cast<T>(emToPxDoubleZoomed(value, conversionData));
-    else if constexpr (std::integral<T>)
-        return roundForImpreciseConversion<T>(emToPxDoubleZoomed(value, conversionData));
-}
-
 template<typename T> inline T emToPxZoomed(double value, const ComputedStyle& style)
 {
-    // For `em`, we only need the element's style, so we can overload this to take just a `ComputedStyle`.
     if constexpr (std::floating_point<T>)
         return static_cast<T>(emToPxDoubleZoomed(value, style));
     else if constexpr (std::integral<T>)


### PR DESCRIPTION
#### 7247fcb1ca9690c80edd9cba7cbe915418987484
<pre>
[Cleanup] Remove unused overloads that take CSSToLengthConversionData
<a href="https://bugs.webkit.org/show_bug.cgi?id=322039">https://bugs.webkit.org/show_bug.cgi?id=322039</a>

Reviewed by Darin Adler.

Remove a few unused overloads that take CSSToLengthConversionData.

* Source/WebCore/style/values/color/StyleColor.cpp:
* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.h:

Canonical link: <a href="https://commits.webkit.org/319426@main">https://commits.webkit.org/319426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/509bdf2e2d3743f227da672766e63d03d973ea43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191631 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145734 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141587 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122027 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43931 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42209 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41855 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2788 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193559 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55024 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150983 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40444 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55711 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150682 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45264 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127992 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123593 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54227 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16854 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53609 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->