### PR TITLE
[GTK][WPE] StackTraceTest.StackTraceWorks fails when building with clang

### DIFF
--- a/Source/WTF/wtf/StackTrace.cpp
+++ b/Source/WTF/wtf/StackTrace.cpp
@@ -55,22 +55,31 @@ void WTFGetBacktrace(void** stack, int* size)
 namespace WTF {
 
 #if USE(LIBBACKTRACE)
+// libbacktrace invokes the error callback unconditionally, so it must not be null.
+static void backtraceErrorCallback(void*, const char*, int)
+{
+}
+
 static struct backtrace_state* backtraceState()
 {
-    static NeverDestroyed<struct backtrace_state*> backtraceState = backtrace_create_state(nullptr, 1, nullptr, nullptr);
+    static NeverDestroyed<struct backtrace_state*> backtraceState = backtrace_create_state(nullptr, 1, backtraceErrorCallback, nullptr);
     return backtraceState;
 }
 
 static void backtraceSyminfoCallback(void* data, uintptr_t, const char* symname, uintptr_t, uintptr_t)
 {
-    const char** symbol = static_cast<const char**>(data);
-    *symbol = symname;
+    if (symname) {
+        const char** symbol = static_cast<const char**>(data);
+        *symbol = symname;
+    }
 }
 
 static int backtraceFullCallback(void* data, uintptr_t, const char*, int, const char* function)
 {
-    const char** symbol = static_cast<const char**>(data);
-    *symbol = function;
+    if (function) {
+        const char** symbol = static_cast<const char**>(data);
+        *symbol = function;
+    }
     return 0;
 }
 
@@ -85,11 +94,16 @@ char** symbolize(void* const* addresses, int size)
 
     for (int i = 0; i < size; ++i) {
         uintptr_t pc = reinterpret_cast<uintptr_t>(addresses[i]);
-        char* symbol;
+        const char* symbol = nullptr;
 
-        backtrace_pcinfo(state, pc, backtraceFullCallback, nullptr, &symbol);
+        // The symbol table is consulted first because it stores mangled names, which
+        // demangle to fully qualified ones. The debug information only carries the
+        // mangled name when the compiler emitted DW_AT_linkage_name, and the
+        // -dwarf-linkage-names=Abstract option that we use to compile forces clang
+        // to omit it for out-of-line definitions, leaving just the unqualified DW_AT_name.
+        backtrace_syminfo(state, pc, backtraceSyminfoCallback, backtraceErrorCallback, &symbol);
         if (!symbol)
-            backtrace_syminfo(backtraceState(), pc, backtraceSyminfoCallback, nullptr, &symbol);
+            backtrace_pcinfo(state, pc, backtraceFullCallback, backtraceErrorCallback, &symbol);
 
         if (symbol) {
             char* demangled = abi::__cxa_demangle(symbol, nullptr, nullptr, nullptr);


### PR DESCRIPTION
#### 1f7ab2fec82cca3cf49b4688f5d47ccc5651c095
<pre>
[GTK][WPE] StackTraceTest.StackTraceWorks fails when building with clang
<a href="https://bugs.webkit.org/show_bug.cgi?id=322041">https://bugs.webkit.org/show_bug.cgi?id=322041</a>

Reviewed by Adrian Perez de Castro.

The test started failing when the bots switched to clang in 318539@main.

WebKitCompilerFlags.cmake passes &quot;-mllvm -dwarf-linkage-names=Abstract&quot;, which
GCC ignores but which makes clang drop the mangled name from the debug info of
regular function definitions. Only the plain name is left, so symbolize() named
the test frame &quot;TestBody&quot; instead of
&quot;TestWebKitAPI::StackTraceTest_StackTraceWorks_Test::TestBody()&quot;. Every frame of
a debug build backtrace lost its namespace and class this way. Release builds
were fine because they have no debug info to begin with.

Look the name up in the symbol table first, which always stores the mangled
name, and only ask the debug info when the symbol table has nothing.

Also fix two smaller problems in the same code: the symbol was read
uninitialized when neither lookup found anything, and libbacktrace always calls
the error callback, so passing null for it would crash on the first failed
lookup.

* Source/WTF/wtf/StackTrace.cpp:
(WTF::backtraceErrorCallback):
(WTF::backtraceState):
(WTF::backtraceSyminfoCallback):
(WTF::backtraceFullCallback):
(WTF::symbolize):

Canonical link: <a href="https://commits.webkit.org/319400@main">https://commits.webkit.org/319400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fad5f2e8631de794aeeab158577d45895c6d22b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191571 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141534 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45210 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121974 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43888 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42160 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3940 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10762 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154290 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/41816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2727 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42624 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193499 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54964 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/150930 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55651 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150636 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45220 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127932 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123527 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54167 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16815 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53549 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53787 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->