### PR TITLE
[scroll-animations] RemoteProgressBasedTimeline divides by an empty timeline range instead of leaving its current time unresolved

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/view-timeline-empty-range-unresolved-current-time-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/view-timeline-empty-range-unresolved-current-time-expected.txt
@@ -1,0 +1,3 @@
+
+PASS An empty view timeline range leaves the remote progress-based timeline's current time unresolved
+

--- a/LayoutTests/webanimations/threaded-animations/view-timeline-empty-range-unresolved-current-time.html
+++ b/LayoutTests/webanimations/threaded-animations/view-timeline-empty-range-unresolved-current-time.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<body>
+<style>
+
+#scroller {
+    position: absolute;
+    width: 200px;
+    height: 200px;
+    overflow-y: scroll;
+}
+
+#subject {
+    position: absolute;
+    top: 50px;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+#spacer {
+    height: 1000px;
+}
+
+#target {
+    width: 25px;
+    height: 25px;
+    opacity: 0;
+    background-color: green;
+}
+
+</style>
+
+<div id="scroller">
+    <div id="subject"><div id="target"></div></div>
+    <div id="spacer"></div>
+</div>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+promise_test(async t => {
+    const timeline = new ViewTimeline({ subject });
+    const animation = target.animate({ opacity: 1 }, { timeline });
+
+    await animationAcceleration(animation);
+
+    const initialStack = await UIHelper.remoteAnimationStackForElement(target);
+    assert_equals(initialStack.animations.length, 1, "The animation is accelerated");
+    assert_not_equals(initialStack.animations[0].timeline.currentTime, null,
+        "The remote timeline has a resolved current time while its range is not empty");
+
+    // A view timeline's range is its subject's size plus its scroll container's size.
+    scroller.style.height = "0px";
+    subject.style.height = "0px";
+    await threadedAnimationsCommit();
+
+    const updatedStack = await UIHelper.remoteAnimationStackForElement(target);
+    assert_equals(updatedStack.animations.length, 1, "The animation is still accelerated");
+    const remoteAnimation = updatedStack.animations[0];
+    assert_equals(remoteAnimation.timeline.currentTime, null,
+        "An empty range leaves the remote timeline's current time unresolved");
+    assert_false("progress" in remoteAnimation,
+        "The effect does not apply while the timeline's current time is unresolved");
+}, "An empty view timeline range leaves the remote progress-based timeline's current time unresolved");
+
+</script>
+</body>

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -416,20 +416,22 @@ static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& o
     }
 }
 
-ResolvedEffectTiming AcceleratedEffect::resolvedTimingForTesting(WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const
+ResolvedEffectTiming AcceleratedEffect::resolvedTimingForTesting(std::optional<WebAnimationTime> timelineTime, std::optional<WebAnimationTime> timelineDuration) const
 {
     return resolvedTiming(timelineTime, timelineDuration);
 }
 
-ResolvedEffectTiming AcceleratedEffect::resolvedTiming(WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const
+ResolvedEffectTiming AcceleratedEffect::resolvedTiming(std::optional<WebAnimationTime> timelineTime, std::optional<WebAnimationTime> timelineDuration) const
 {
     ASSERT_IMPLIES(m_paused, m_holdTime);
     ASSERT_IMPLIES(!m_paused, m_startTime);
 
-    auto localTime = [&] {
+    auto localTime = [&]() -> std::optional<WebAnimationTime> {
         if (m_paused)
             return *m_holdTime;
-        return (timelineTime - *m_startTime) * m_playbackRate;
+        if (!timelineTime)
+            return m_holdTime;
+        return (*timelineTime - *m_startTime) * m_playbackRate;
     }();
 
     return m_timing.resolve({
@@ -442,7 +444,7 @@ ResolvedEffectTiming AcceleratedEffect::resolvedTiming(WebAnimationTime timeline
     });
 }
 
-void AcceleratedEffect::apply(AcceleratedEffectValues& values, WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const
+void AcceleratedEffect::apply(AcceleratedEffectValues& values, std::optional<WebAnimationTime> timelineTime, std::optional<WebAnimationTime> timelineDuration) const
 {
     auto resolvedTiming = this->resolvedTiming(timelineTime, timelineDuration);
     if (!resolvedTiming.transformedProgress)

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -82,8 +82,8 @@ public:
     WEBCORE_EXPORT Ref<AcceleratedEffect> clone() const;
     WEBCORE_EXPORT Ref<AcceleratedEffect> copyWithProperties(OptionSet<AcceleratedEffectProperty>&) const;
 
-    WEBCORE_EXPORT void apply(AcceleratedEffectValues&, WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
-    WEBCORE_EXPORT ResolvedEffectTiming resolvedTimingForTesting(WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
+    WEBCORE_EXPORT void apply(AcceleratedEffectValues&, std::optional<WebAnimationTime> timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
+    WEBCORE_EXPORT ResolvedEffectTiming resolvedTimingForTesting(std::optional<WebAnimationTime> timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
 
     void clearProperty(AcceleratedEffectProperty);
     void makeForwardsFilling();
@@ -115,7 +115,7 @@ private:
     explicit AcceleratedEffect(const AcceleratedEffect&, OptionSet<AcceleratedEffectProperty>&);
 
     void validateFilters(const AcceleratedEffectValues& baseValues, OptionSet<AcceleratedEffectProperty>&);
-    ResolvedEffectTiming resolvedTiming(WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
+    ResolvedEffectTiming resolvedTiming(std::optional<WebAnimationTime> timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
 
     // KeyframeInterpolation
     bool isPropertyAdditiveOrCumulative(KeyframeInterpolation::Property) const final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
@@ -46,7 +46,7 @@ public:
     bool isMonotonic() const { return !m_duration; }
     bool isProgressBased() const { return !!m_duration; }
 
-    const WebCore::WebAnimationTime& currentTime() const LIFETIME_BOUND { return m_currentTime; }
+    const std::optional<WebCore::WebAnimationTime>& currentTime() const LIFETIME_BOUND { return m_currentTime; }
     const std::optional<WebCore::WebAnimationTime>& duration() const LIFETIME_BOUND { return m_duration; }
     const TimelineID& identifier() const LIFETIME_BOUND { return m_identifier; }
 
@@ -55,7 +55,7 @@ public:
 protected:
     RemoteAnimationTimeline(TimelineID, std::optional<WebCore::WebAnimationTime> duration);
 
-    WebCore::WebAnimationTime m_currentTime;
+    std::optional<WebCore::WebAnimationTime> m_currentTime;
 
 private:
     TimelineID m_identifier;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.cpp
@@ -67,7 +67,10 @@ void RemoteProgressBasedTimeline::updateCurrentTime(const WebCore::ScrollingTree
 void RemoteProgressBasedTimeline::updateCurrentTime()
 {
     auto range = m_resolutionData.rangeEnd - m_resolutionData.rangeStart;
-    ASSERT(range);
+    if (!range) {
+        m_currentTime = std::nullopt;
+        return;
+    }
 
     auto distance = m_resolutionData.isReversed ? m_resolutionData.rangeEnd - m_resolutionData.scrollOffset : m_resolutionData.scrollOffset - m_resolutionData.rangeStart;
     auto progress = distance / range;


### PR DESCRIPTION
#### 91ca88150fec2bd1c1c2b1c2b90148112e0fedf8
<pre>
[scroll-animations] RemoteProgressBasedTimeline divides by an empty timeline range instead of leaving its current time unresolved
<a href="https://bugs.webkit.org/show_bug.cgi?id=322046">https://bugs.webkit.org/show_bug.cgi?id=322046</a>
<a href="https://rdar.apple.com/185242468">rdar://185242468</a>

Reviewed by NOBODY (OOPS!).

Progress for a progress-based timeline is scroll offset ÷ range, so an empty range leaves the
timeline&apos;s current time unresolved, as ScrollTimeline::currentTime() does. Its UI process
mirror, RemoteProgressBasedTimeline::updateCurrentTime(), instead asserted the range was
non-zero and divided by it.

A view timeline&apos;s range is its subject&apos;s size plus its scroll container&apos;s size, so collapsing
both reaches that code: debug fails the assertion, release stores fromPercentage(NaN) and
resolves every accelerated animation on the timeline against a NaN timeline time. The empty
range had nowhere to go because RemoteAnimationTimeline::m_currentTime was a plain
WebAnimationTime, so make it optional and pass the optional to AcceleratedEffect::apply(),
whose ResolutionData already models timelineTime and localTime as optional.

The local time still falls back to the hold time so a filling animation keeps applying. Only
an animation with neither a hold time nor a resolved timeline time is left unresolved, putting
it in its idle phase so that it does not apply.

Test: webanimations/threaded-animations/view-timeline-empty-range-unresolved-current-time.html

* LayoutTests/webanimations/threaded-animations/view-timeline-empty-range-unresolved-current-time-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/view-timeline-empty-range-unresolved-current-time.html: Added.
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::resolvedTimingForTesting const):
(WebCore::AcceleratedEffect::resolvedTiming const):
(WebCore::AcceleratedEffect::apply const):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.cpp:
(WebKit::RemoteProgressBasedTimeline::updateCurrentTime):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91ca88150fec2bd1c1c2b1c2b90148112e0fedf8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191583 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145686 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141542 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98208 "6 flakes 32 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121982 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43903 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42175 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41822 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2739 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193511 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150940 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55663 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150646 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45237 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127944 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123545 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54179 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16821 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53561 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53799 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53626 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->