### PR TITLE
[JSC] Defer Array materialization in JSON.parse

### DIFF
--- a/JSTests/stress/json-parse-array-materialization.js
+++ b/JSTests/stress/json-parse-array-materialization.js
@@ -1,0 +1,129 @@
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected))
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function shouldThrow(source) {
+    var threw = false;
+    try {
+        JSON.parse(source);
+    } catch (error) {
+        threw = true;
+    }
+    shouldBe(threw, true);
+}
+
+// An array is allocated at its final length and indexing type, so every element type combination
+// has to land in the same indexing shape a growing butterfly would have reached, and the values
+// have to survive a garbage collection that happens while the elements are still being collected.
+var cases = [
+    ["[]", []],
+    ["[0]", [0]],
+    ["[1,2,3]", [1, 2, 3]],
+    ["[-2147483648,2147483647]", [-2147483648, 2147483647]],
+    ["[1.5,2.5]", [1.5, 2.5]],
+    ["[1,2.5]", [1, 2.5]],
+    ["[2.5,1]", [2.5, 1]],
+    ["[1e400,1]", [Infinity, 1]],
+    ["[null]", [null]],
+    ["[true,false]", [true, false]],
+    ["[\"a\",\"b\"]", ["a", "b"]],
+    ["[1,\"a\"]", [1, "a"]],
+    ["[\"a\",1]", ["a", 1]],
+    ["[[1],[2]]", [[1], [2]]],
+    ["[{\"a\":1},{\"a\":2}]", [{ a: 1 }, { a: 2 }]],
+    ["[1,[2,[3,[4]]]]", [1, [2, [3, [4]]]]],
+];
+
+for (var i = 0; i < 1e3; ++i) {
+    for (var [source, expected] of cases) {
+        var parsed = JSON.parse(source);
+        shouldBe(JSON.stringify(parsed), JSON.stringify(expected));
+        shouldBe(parsed.length, expected.length);
+        shouldBe(Array.isArray(parsed), true);
+    }
+}
+
+// -0 must stay -0 rather than being flattened to 0 by the double indexing shape.
+shouldBe(JSON.parse("[-0]")[0], -0);
+shouldBe(JSON.parse("[-0,1.5]")[0], -0);
+shouldBe(JSON.parse("[1.5,-0]")[1], -0);
+
+// Lengths that cross the growth thresholds of the butterfly the old path grew element by element.
+for (var length of [1, 2, 3, 4, 5, 8, 9, 16, 17, 100, 1024, 100000]) {
+    var ints = JSON.parse("[" + Array.from({ length }, (_, i) => i).join(",") + "]");
+    shouldBe(ints.length, length);
+    shouldBe(ints[0], 0);
+    shouldBe(ints[length - 1], length - 1);
+
+    var doubles = JSON.parse("[" + Array.from({ length }, (_, i) => i + 0.5).join(",") + "]");
+    shouldBe(doubles.length, length);
+    shouldBe(doubles[length - 1], length - 1 + 0.5);
+
+    var strings = JSON.parse("[" + Array.from({ length }, (_, i) => '"' + i + '"').join(",") + "]");
+    shouldBe(strings.length, length);
+    shouldBe(strings[length - 1], String(length - 1));
+}
+
+// A malformed array must still report the same error, and must not leave collected elements behind.
+shouldThrow("[1,]");
+shouldThrow("[,1]");
+shouldThrow("[1 2]");
+shouldThrow("[");
+shouldThrow("[1");
+shouldThrow("[}");
+shouldThrow("[[1],]");
+shouldThrow("[1,[2,]]");
+shouldThrow('[{"a":1},]');
+for (var i = 0; i < 1e3; ++i)
+    shouldThrow("[1,2,3,]");
+shouldBe(JSON.stringify(JSON.parse("[1,2,3]")), "[1,2,3]");
+
+// Nesting past the recursive parser's stack limit hands the value to the iterative parser.
+var depth = 20000;
+var deep = JSON.parse("[".repeat(depth) + "1" + "]".repeat(depth));
+var levels = 0;
+while (Array.isArray(deep)) {
+    shouldBe(deep.length, 1);
+    deep = deep[0];
+    ++levels;
+}
+shouldBe(levels, depth);
+shouldBe(deep, 1);
+
+// An array index as an object key stays an indexed property, and a duplicate key keeps the last
+// value, both of which the fast property path has to decline.
+var indexed = JSON.parse('{"0":1,"b":2}');
+shouldBe(JSON.stringify(Object.keys(indexed)), '["0","b"]');
+shouldBe(indexed[0], 1);
+shouldBe(indexed.b, 2);
+
+var duplicate = JSON.parse('{"a":1,"a":2}');
+shouldBe(JSON.stringify(Object.keys(duplicate)), '["a"]');
+shouldBe(duplicate.a, 2);
+
+// Objects wide enough to need out-of-line storage exercise the butterfly growth check.
+for (var count of [1, 5, 6, 7, 8, 20, 64, 65, 200]) {
+    var source = "{" + Array.from({ length: count }, (_, i) => '"p' + i + '":' + i).join(",") + "}";
+    var wide = JSON.parse(source);
+    shouldBe(Object.keys(wide).length, count);
+    shouldBe(wide["p0"], 0);
+    shouldBe(wide["p" + (count - 1)], count - 1);
+}
+
+// A reviver goes through the general parser, which must agree with the fast one.
+shouldBe(JSON.stringify(JSON.parse("[1,2,3]", (key, value) => typeof value === "number" ? value * 2 : value)), "[2,4,6]");
+shouldBe(JSON.stringify(JSON.parse('{"a":[1,2]}', (key, value) => value)), '{"a":[1,2]}');
+
+// An indexed accessor on Array.prototype makes the global object have a bad time, after which arrays
+// are allocated with array storage instead of a contiguous vector.
+Object.defineProperty(Array.prototype, "1", { get() { return "bad"; }, configurable: true });
+for (var [source, expected] of cases) {
+    var parsed = JSON.parse(source);
+    shouldBe(JSON.stringify(parsed), JSON.stringify(expected));
+    shouldBe(parsed.length, expected.length);
+}
+var afterBadTime = JSON.parse("[" + Array.from({ length: 1000 }, (_, i) => i).join(",") + "]");
+shouldBe(afterBadTime.length, 1000);
+shouldBe(afterBadTime[999], 999);
+shouldBe(JSON.parse("[7,8]")[1], 8);

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -1377,6 +1377,50 @@ JSValue LiteralParser<CharType, reviverMode>::evalRecursivelyEntry(VM& vm)
 }
 
 template<typename CharType, JSONReviverMode reviverMode>
+JSArray* LiteralParser<CharType, reviverMode>::materializeArray(VM& vm, unsigned stackBase)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned length = m_elementStack.size() - stackBase;
+    JSValue* values = m_elementStack.begin() + stackBase;
+    ASSERT(length);
+
+    // putDirectIndex would have discovered this while growing the butterfly one element at a time.
+    IndexingType indexingType = ArrayWithInt32;
+    for (unsigned i = 0; i < length; ++i) {
+        JSValue value = values[i];
+        if (value.isInt32())
+            continue;
+        if (value.isDouble()) {
+            indexingType = ArrayWithDouble;
+            continue;
+        }
+        indexingType = ArrayWithContiguous;
+        break;
+    }
+
+    {
+        ObjectInitializationScope initializationScope(vm);
+        Structure* structure = m_globalObject->arrayStructureForIndexingTypeDuringAllocation(indexingType);
+        if (JSArray* array = JSArray::tryCreateUninitializedRestricted(initializationScope, structure, length)) [[likely]] {
+            for (unsigned i = 0; i < length; ++i)
+                array->initializeIndex(initializationScope, i, values[i]);
+            return array;
+        }
+    }
+
+    // Lengths beyond what a contiguous vector can hold, and allocation failures, grow an empty array
+    // instead so that they report out of memory rather than crashing.
+    JSArray* array = constructEmptyArray(m_globalObject, nullptr);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    for (unsigned i = 0; i < length; ++i) {
+        array->putDirectIndex(m_globalObject, i, values[i]);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+    }
+    return array;
+}
+
+template<typename CharType, JSONReviverMode reviverMode>
 template<ParserMode parserMode>
 JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* stackLimit)
     requires (reviverMode == JSONReviverMode::Disabled)
@@ -1387,14 +1431,15 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
     auto scope = DECLARE_THROW_SCOPE(vm);
     TokenType type = m_lexer.currentToken()->type;
     if (type == TokLBracket) {
-        JSArray* array = constructEmptyArray(m_globalObject, nullptr);
-        RETURN_IF_EXCEPTION(scope, { });
         TokenType type = m_lexer.next();
         if (type == TokRBracket) {
             m_lexer.next();
-            return array;
+            RELEASE_AND_RETURN(scope, constructEmptyArray(m_globalObject, nullptr));
         }
-        unsigned index = 0;
+
+        // Elements are collected first so that the array is allocated once at its final length and
+        // indexing type, rather than growing a butterfly once per element.
+        unsigned stackBase = m_elementStack.size();
         while (true) {
             JSValue value;
             if (type == TokLBrace || type == TokLBracket)
@@ -1402,17 +1447,23 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
             else
                 value = parsePrimitiveValue(vm);
             EXCEPTION_ASSERT((!!scope.exception() || !m_parseErrorMessage.isNull()) == !value);
-            if (!value) [[unlikely]]
+            if (!value) [[unlikely]] {
+                m_elementStack.shrink(stackBase);
                 return { };
-
-            array->putDirectIndex(m_globalObject, index++, value);
-            RETURN_IF_EXCEPTION(scope, { });
+            }
+            m_elementStack.append(value);
+            if (m_elementStack.hasOverflowed()) [[unlikely]] {
+                m_elementStack.shrink(stackBase);
+                throwOutOfMemoryError(m_globalObject, scope);
+                return { };
+            }
 
             type = m_lexer.currentToken()->type;
             if (type == TokComma) {
                 type = m_lexer.next();
                 if (type == TokRBracket) [[unlikely]] {
                     m_parseErrorMessage = "Unexpected comma at the end of array expression"_s;
+                    m_elementStack.shrink(stackBase);
                     return { };
                 }
                 continue;
@@ -1420,12 +1471,18 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
 
             if (type != TokRBracket) [[unlikely]] {
                 setErrorMessageForToken(TokRBracket);
+                m_elementStack.shrink(stackBase);
                 return { };
             }
 
             m_lexer.next();
-            return array;
+            break;
         }
+
+        JSArray* array = materializeArray(vm, stackBase);
+        m_elementStack.shrink(stackBase);
+        RETURN_IF_EXCEPTION(scope, { });
+        return array;
     }
 
     ASSERT(type == TokLBrace);
@@ -1513,7 +1570,9 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
                 auto& [newStructure, offset] = std::get<ExistingProperty>(property);
 
                 Butterfly* newButterfly = object->butterfly();
-                if (originalStructure->outOfLineCapacity() != newStructure->outOfLineCapacity()) {
+                // Both capacities are zero while the properties still fit in inline storage, which
+                // is the common case, and reading them means touching two Structures.
+                if (offset >= firstOutOfLineOffset && originalStructure->outOfLineCapacity() != newStructure->outOfLineCapacity()) [[unlikely]] {
                     ASSERT(newStructure != originalStructure);
                     newButterfly = object->allocateMoreOutOfLineStorage(vm, originalStructure->outOfLineCapacity(), newStructure->outOfLineCapacity());
                     object->nukeStructureAndSetButterfly(vm, originalStructure->id(), newButterfly);

--- a/Source/JavaScriptCore/runtime/LiteralParser.h
+++ b/Source/JavaScriptCore/runtime/LiteralParser.h
@@ -40,6 +40,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+class JSArray;
+
 enum ParserMode : uint8_t { StrictJSON, SloppyJSON, JSONP };
 enum class JSONReviverMode : uint8_t { Disabled, Enabled };
 
@@ -294,6 +296,8 @@ private:
 
     JSValue parsePrimitiveValue(VM&);
 
+    JSArray* materializeArray(VM&, unsigned stackBase);
+
     static ALWAYS_INLINE bool equalIdentifier(UniquedStringImpl*, typename Lexer::LiteralParserTokenPtr);
     static ALWAYS_INLINE AtomStringImpl* existingIdentifier(VM&, typename Lexer::LiteralParserTokenPtr);
     static ALWAYS_INLINE Identifier makeIdentifier(VM&, typename Lexer::LiteralParserTokenPtr);
@@ -308,6 +312,7 @@ private:
     String m_parseErrorMessage;
     UncheckedKeyHashSet<JSObject*> m_visitedUnderscoreProto;
     MarkedArgumentBuffer m_objectStack;
+    MarkedArgumentBuffer m_elementStack;
     Vector<ParserState, 16, UnsafeVectorOverflow> m_stateStack;
     Vector<Identifier, 16, UnsafeVectorOverflow> m_identifierStack;
     Vector<JSONRanges::Entry, 8> m_rangesStack;

--- a/Source/JavaScriptCore/runtime/MarkedVector.h
+++ b/Source/JavaScriptCore/runtime/MarkedVector.h
@@ -95,6 +95,12 @@ public:
         m_size--;
     }
 
+    void shrink(size_t newSize)
+    {
+        ASSERT(newSize <= m_size);
+        m_size = newSize;
+    }
+
     template<typename Visitor> static void markLists(Visitor&, ListSet&);
 
     void overflowCheckNotNeeded() { clearNeedsOverflowCheck(); }
@@ -375,7 +381,7 @@ public:
     void append(T v)
     {
         ASSERT(m_size <= m_capacity);
-        if (m_size == m_capacity || mallocBase()) {
+        if (m_size == m_capacity || (mallocBase() && !m_markSet)) {
             if (slowAppend<T>(v) == Status::Overflowed)
                 this->overflowed();
             return;


### PR DESCRIPTION
#### 218421554bbbf1b029d2cd2a0484fce36a46d5dd
<pre>
[JSC] Defer Array materialization in JSON.parse
<a href="https://bugs.webkit.org/show_bug.cgi?id=322048">https://bugs.webkit.org/show_bug.cgi?id=322048</a>
<a href="https://rdar.apple.com/185243612">rdar://185243612</a>

Reviewed by Sosuke Suzuki.

This patch introduces deferred Array materialization mechanism in JSON.parse.
Instead of placing an element each time, we push it to the stack, and we
materialize Array at the end of Array literal. This stack is used for
arrays nested way, so when materializing, we use the slice between
[stackBase, end). This avoids growing and reallocating butterflies,
which reduces wasted allocation during JSON.parse.

Also we do drive-by fixes,

1. MarkedVector::append ends up calling slowAppend after it gets
   mallocBase(). This is inefficient and not correct. We should do it
   only when (1) expanding capacity or (2) newly registering a
   m_markSet.
2. Accessing outOfLineCapacity requires some additional loads. But we do
   not need to care about it when offset is not reaching to
   firstOutOfLineOffset. Let&apos;s avoid loading them.

Test: JSTests/stress/json-parse-array-materialization.js

* JSTests/stress/json-parse-array-materialization.js: Added.
(shouldBe):
(shouldThrow):
(Array.isArray):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::reviverMode&gt;::materializeArray):
(JSC::requires):
* Source/JavaScriptCore/runtime/LiteralParser.h:
* Source/JavaScriptCore/runtime/MarkedVector.h:
(JSC::MarkedVector::append):

Canonical link: <a href="https://commits.webkit.org/319420@main">https://commits.webkit.org/319420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8416bfd4a916d19b910b7044842f1b6e2332ead9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181440 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/55387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56691 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/191663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184395 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/49189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/49189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/2823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42716 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/48013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/55108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193591 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/55056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/49189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/55743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/150714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27547 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/55743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/123625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54259 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/49189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/53641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->