### PR TITLE
[GTK] add support for window fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -85,6 +85,8 @@ void webkitWebViewRunFileChooserRequest(WebKitWebView*, WebKitFileChooserRequest
 void webKitWebViewDidReceiveSnapshot(WebKitWebView*, uint64_t callbackID, WebKit::WebImage*);
 #endif
 void webkitWebViewMaximizeWindow(WebKitWebView*, CompletionHandler<void()>&&);
+void webkitWebViewFullscreenWindow(WebKitWebView*, CompletionHandler<void()>&&);
+void webkitWebViewUnfullscreenWindow(WebKitWebView*, CompletionHandler<void()>&&);
 void webkitWebViewMinimizeWindow(WebKitWebView*, CompletionHandler<void()>&&);
 void webkitWebViewRestoreWindow(WebKitWebView*, CompletionHandler<void()>&&);
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -61,6 +61,7 @@
 #include "WebKitWebViewAccessible.h"
 #include "WebKitWebViewBaseInternal.h"
 #include "WebKitWebViewBasePrivate.h"
+#include "WebKitWebViewPrivate.h"
 #include "WebPageGroup.h"
 #include "WebPageProxy.h"
 #include "WebPopupMenuProxyGtk.h"
@@ -2647,6 +2648,14 @@ void webkitWebViewBaseEnterFullScreen(WebKitWebViewBase* webkitWebViewBase)
 
     priv->windowWasAlreadyInFullScreen = false;
 
+    if (WEBKIT_IS_WEB_VIEW(webkitWebViewBase)) {
+        webkitWebViewFullscreenWindow(WEBKIT_WEB_VIEW(webkitWebViewBase), [webViewBase = GRefPtr<WebKitWebViewBase>(webkitWebViewBase)] {
+            if (webViewBase->priv->fullScreenState == WebFullScreenManagerProxy::FullscreenState::EnteringFullscreen)
+                webkitWebViewBaseDidEnterFullScreen(webViewBase.get());
+        });
+        return;
+    }
+
     if (priv->toplevelOnScreenWindow)
         gtk_window_fullscreen(priv->toplevelOnScreenWindow->window());
 }
@@ -2673,7 +2682,20 @@ void webkitWebViewBaseExitFullScreen(WebKitWebViewBase* webkitWebViewBase)
     WebKitWebViewBasePrivate* priv = webkitWebViewBase->priv;
     ASSERT(priv->fullScreenState == WebFullScreenManagerProxy::FullscreenState::ExitingFullscreen);
 
-    if (!webkitWebViewBaseToplevelOnScreenWindowIsFullScreen(webkitWebViewBase) || priv->windowWasAlreadyInFullScreen) {
+    if (priv->windowWasAlreadyInFullScreen) {
+        webkitWebViewBaseDidExitFullScreen(webkitWebViewBase);
+        return;
+    }
+
+    if (WEBKIT_IS_WEB_VIEW(webkitWebViewBase)) {
+        webkitWebViewUnfullscreenWindow(WEBKIT_WEB_VIEW(webkitWebViewBase), [webViewBase = GRefPtr<WebKitWebViewBase>(webkitWebViewBase)] {
+            if (webViewBase->priv->fullScreenState == WebFullScreenManagerProxy::FullscreenState::ExitingFullscreen)
+                webkitWebViewBaseDidExitFullScreen(webViewBase.get());
+        });
+        return;
+    }
+
+    if (!webkitWebViewBaseToplevelOnScreenWindowIsFullScreen(webkitWebViewBase)) {
         webkitWebViewBaseDidExitFullScreen(webkitWebViewBase);
         return;
     }

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
@@ -136,7 +136,7 @@ gboolean webkitWebViewRunFileChooser(WebKitWebView* webView, WebKitFileChooserRe
 struct WindowStateEvent {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(WindowStateEvent);
 
-    enum class Type { Maximize, Minimize, Restore };
+    enum class Type { Fullscreen, Maximize, Minimize, Restore, Unfullscreen };
 
     WindowStateEvent(Type type, CompletionHandler<void()>&& completionHandler)
         : type(type)
@@ -165,6 +165,10 @@ struct WindowStateEvent {
 
 static const char* gWindowStateEventID = "wk-window-state-event";
 
+#if ENABLE(DEVELOPER_MODE)
+static const char* gXvfbFullscreenID = "wk-xvfb-fullscreen";
+#endif // ENABLE(DEVELOPER_MODE)
+
 #if USE(GTK4)
 static void surfaceStateChangedCallback(GdkSurface* surface, GParamSpec*, WebKitWebView* view)
 {
@@ -177,6 +181,10 @@ static void surfaceStateChangedCallback(GdkSurface* surface, GParamSpec*, WebKit
     auto surfaceState = gdk_toplevel_get_state(GDK_TOPLEVEL(surface));
     bool eventCompleted = false;
     switch (state->type) {
+    case WindowStateEvent::Type::Fullscreen:
+        if (surfaceState & GDK_TOPLEVEL_STATE_FULLSCREEN)
+            eventCompleted = true;
+        break;
     case WindowStateEvent::Type::Maximize:
         if (surfaceState & GDK_TOPLEVEL_STATE_MAXIMIZED)
             eventCompleted = true;
@@ -186,7 +194,11 @@ static void surfaceStateChangedCallback(GdkSurface* surface, GParamSpec*, WebKit
             eventCompleted = true;
         break;
     case WindowStateEvent::Type::Restore:
-        if (!(surfaceState & GDK_TOPLEVEL_STATE_MAXIMIZED) && !(surfaceState & GDK_TOPLEVEL_STATE_MINIMIZED))
+        if (!(surfaceState & GDK_TOPLEVEL_STATE_FULLSCREEN) && !(surfaceState & GDK_TOPLEVEL_STATE_MAXIMIZED) && !(surfaceState & GDK_TOPLEVEL_STATE_MINIMIZED))
+            eventCompleted = true;
+        break;
+    case WindowStateEvent::Type::Unfullscreen:
+        if (!(surfaceState & GDK_TOPLEVEL_STATE_FULLSCREEN))
             eventCompleted = true;
         break;
     }
@@ -207,6 +219,10 @@ static gboolean windowStateEventCallback(GtkWidget* window, GdkEventWindowState*
 
     bool eventCompleted = false;
     switch (state->type) {
+    case WindowStateEvent::Type::Fullscreen:
+        if (event->new_window_state & GDK_WINDOW_STATE_FULLSCREEN)
+            eventCompleted = true;
+        break;
     case WindowStateEvent::Type::Maximize:
         if (event->new_window_state & GDK_WINDOW_STATE_MAXIMIZED)
             eventCompleted = true;
@@ -216,7 +232,11 @@ static gboolean windowStateEventCallback(GtkWidget* window, GdkEventWindowState*
             eventCompleted = true;
         break;
     case WindowStateEvent::Type::Restore:
-        if (!(event->new_window_state & GDK_WINDOW_STATE_MAXIMIZED) && !(event->new_window_state & GDK_WINDOW_STATE_ICONIFIED))
+        if (!(event->new_window_state & GDK_WINDOW_STATE_FULLSCREEN) && !(event->new_window_state & GDK_WINDOW_STATE_MAXIMIZED) && !(event->new_window_state & GDK_WINDOW_STATE_ICONIFIED))
+            eventCompleted = true;
+        break;
+    case WindowStateEvent::Type::Unfullscreen:
+        if (!(event->new_window_state & GDK_WINDOW_STATE_FULLSCREEN))
             eventCompleted = true;
         break;
     }
@@ -233,12 +253,21 @@ static gboolean windowStateEventCallback(GtkWidget* window, GdkEventWindowState*
 static void
 webkitWebViewMonitorWindowState(WebKitWebView* view, GtkWindow* window, WindowStateEvent::Type type, CompletionHandler<void()>&& completionHandler)
 {
+#if USE(GTK4)
+    gtk_widget_realize(GTK_WIDGET(window));
+    auto* surface = gtk_native_get_surface(GTK_NATIVE(window));
+    if (!surface) {
+        completionHandler();
+        return;
+    }
+#endif // USE(GTK4)
+
     g_object_set_data_full(G_OBJECT(view), gWindowStateEventID, new WindowStateEvent(type, WTF::move(completionHandler)), [](gpointer userData) {
         delete static_cast<WindowStateEvent*>(userData);
     });
 
 #if USE(GTK4)
-    g_signal_connect_object(gtk_native_get_surface(GTK_NATIVE(window)), "notify::state", G_CALLBACK(surfaceStateChangedCallback), view, G_CONNECT_AFTER);
+    g_signal_connect_object(surface, "notify::state", G_CALLBACK(surfaceStateChangedCallback), view, G_CONNECT_AFTER);
 #else
     g_signal_connect_object(window, "window-state-event", G_CALLBACK(windowStateEventCallback), view, G_CONNECT_AFTER);
 #endif
@@ -269,10 +298,132 @@ void webkitWebViewMaximizeWindow(WebKitWebView* view, CompletionHandler<void()>&
             auto screenRect = WebCore::screenAvailableRect(nullptr);
             gtk_window_move(window, screenRect.x(), screenRect.y());
             gtk_window_resize(window, screenRect.width(), screenRect.height());
+            if (auto* state = static_cast<WindowStateEvent*>(g_object_get_data(G_OBJECT(view), gWindowStateEventID)))
+                state->complete();
+            g_object_set_data(G_OBJECT(view), gWindowStateEventID, nullptr);
         }
     }
 #endif
     gtk_widget_show(topLevel);
+}
+
+static bool webkitWebViewWindowIsFullscreen(GtkWidget* topLevel)
+{
+#if USE(GTK4)
+    auto* surface = gtk_native_get_surface(GTK_NATIVE(topLevel));
+    return surface && gdk_toplevel_get_state(GDK_TOPLEVEL(surface)) & GDK_TOPLEVEL_STATE_FULLSCREEN;
+#else // USE(GTK4)
+    auto* gdkWindow = gtk_widget_get_window(topLevel);
+    return gdkWindow && gdk_window_get_state(gdkWindow) & GDK_WINDOW_STATE_FULLSCREEN;
+#endif // !USE(GTK4)
+}
+
+enum class WindowFullscreenState {
+    Fullscreen,
+    Unfullscreen,
+};
+
+static void webkitWebViewSetWindowFullscreen(GtkWidget* topLevel, WindowFullscreenState state)
+{
+    if (G_IS_ACTION_GROUP(topLevel) && g_action_group_has_action(G_ACTION_GROUP(topLevel), "toggle-fullscreen")) {
+        g_action_group_activate_action(G_ACTION_GROUP(topLevel), "toggle-fullscreen", nullptr);
+        return;
+    }
+    if (state == WindowFullscreenState::Fullscreen)
+        gtk_window_fullscreen(GTK_WINDOW(topLevel));
+    else
+        gtk_window_unfullscreen(GTK_WINDOW(topLevel));
+}
+
+#if ENABLE(DEVELOPER_MODE)
+
+static bool webkitWebViewIsUnderXvfb()
+{
+    return WebKit::Display::singleton().isX11() && !g_strcmp0(g_getenv("UNDER_XVFB"), "yes");
+}
+
+static void webkitWebViewCompleteWindowStateEvent(WebKitWebView* view)
+{
+    g_object_set_data(G_OBJECT(view), gWindowStateEventID, nullptr);
+}
+
+#endif // ENABLE(DEVELOPER_MODE)
+
+void webkitWebViewFullscreenWindow(WebKitWebView* view, CompletionHandler<void()>&& completionHandler)
+{
+    auto* topLevel = gtk_widget_get_toplevel(GTK_WIDGET(view));
+    if (!gtk_widget_is_toplevel(topLevel)) {
+        completionHandler();
+        return;
+    }
+
+    auto* window = GTK_WINDOW(topLevel);
+    gtk_widget_realize(topLevel);
+
+#if ENABLE(DEVELOPER_MODE)
+    bool isUnderXvfb = webkitWebViewIsUnderXvfb();
+    bool isFullscreen = isUnderXvfb ? GPOINTER_TO_INT(g_object_get_data(G_OBJECT(view), gXvfbFullscreenID)) : webkitWebViewWindowIsFullscreen(topLevel);
+#else // ENABLE(DEVELOPER_MODE)
+    bool isFullscreen = webkitWebViewWindowIsFullscreen(topLevel);
+#endif // !ENABLE(DEVELOPER_MODE)
+    if (isFullscreen) {
+        completionHandler();
+        return;
+    }
+
+    webkitWebViewMonitorWindowState(view, window, WindowStateEvent::Type::Fullscreen, WTF::move(completionHandler));
+#if ENABLE(DEVELOPER_MODE)
+    if (isUnderXvfb)
+        g_object_set_data(G_OBJECT(view), gXvfbFullscreenID, GINT_TO_POINTER(true));
+#endif // ENABLE(DEVELOPER_MODE)
+    webkitWebViewSetWindowFullscreen(topLevel, WindowFullscreenState::Fullscreen);
+    gtk_widget_show(topLevel);
+
+#if ENABLE(DEVELOPER_MODE)
+    if (isUnderXvfb) {
+        auto screenRect = WebCore::screenRect(nullptr);
+        gtk_window_move(window, screenRect.x(), screenRect.y());
+        gtk_window_resize(window, screenRect.width(), screenRect.height());
+        webkitWebViewCompleteWindowStateEvent(view);
+    }
+#endif // ENABLE(DEVELOPER_MODE)
+}
+
+void webkitWebViewUnfullscreenWindow(WebKitWebView* view, CompletionHandler<void()>&& completionHandler)
+{
+    auto* topLevel = gtk_widget_get_toplevel(GTK_WIDGET(view));
+    if (!gtk_widget_is_toplevel(topLevel)) {
+        completionHandler();
+        return;
+    }
+
+    auto* window = GTK_WINDOW(topLevel);
+    gtk_widget_realize(topLevel);
+
+#if ENABLE(DEVELOPER_MODE)
+    bool isUnderXvfb = webkitWebViewIsUnderXvfb();
+    bool isFullscreen = isUnderXvfb ? GPOINTER_TO_INT(g_object_get_data(G_OBJECT(view), gXvfbFullscreenID)) : webkitWebViewWindowIsFullscreen(topLevel);
+#else // ENABLE(DEVELOPER_MODE)
+    bool isFullscreen = webkitWebViewWindowIsFullscreen(topLevel);
+#endif // !ENABLE(DEVELOPER_MODE)
+    if (!isFullscreen) {
+        completionHandler();
+        return;
+    }
+
+    webkitWebViewMonitorWindowState(view, window, WindowStateEvent::Type::Unfullscreen, WTF::move(completionHandler));
+    webkitWebViewSetWindowFullscreen(topLevel, WindowFullscreenState::Unfullscreen);
+    gtk_widget_show(topLevel);
+
+#if ENABLE(DEVELOPER_MODE)
+    if (isUnderXvfb) {
+        g_object_set_data(G_OBJECT(view), gXvfbFullscreenID, nullptr);
+        int width, height;
+        gtk_window_get_default_size(window, &width, &height);
+        gtk_window_resize(window, width, height);
+        webkitWebViewCompleteWindowStateEvent(view);
+    }
+#endif // ENABLE(DEVELOPER_MODE)
 }
 
 void webkitWebViewMinimizeWindow(WebKitWebView* view, CompletionHandler<void()>&& completionHandler)
@@ -298,7 +449,14 @@ void webkitWebViewRestoreWindow(WebKitWebView* view, CompletionHandler<void()>&&
     }
 
     auto* window = GTK_WINDOW(topLevel);
-    if (gtk_widget_get_mapped(topLevel) && !gtk_window_is_maximized(window)) {
+    gtk_widget_realize(topLevel);
+#if ENABLE(DEVELOPER_MODE)
+    bool isUnderXvfb = webkitWebViewIsUnderXvfb();
+    bool isFullscreen = isUnderXvfb ? GPOINTER_TO_INT(g_object_get_data(G_OBJECT(view), gXvfbFullscreenID)) : webkitWebViewWindowIsFullscreen(topLevel);
+#else // ENABLE(DEVELOPER_MODE)
+    bool isFullscreen = webkitWebViewWindowIsFullscreen(topLevel);
+#endif // !ENABLE(DEVELOPER_MODE)
+    if (gtk_widget_get_mapped(topLevel) && !isFullscreen && !gtk_window_is_maximized(window)) {
         completionHandler();
         return;
     }
@@ -306,18 +464,22 @@ void webkitWebViewRestoreWindow(WebKitWebView* view, CompletionHandler<void()>&&
     webkitWebViewMonitorWindowState(view, window, WindowStateEvent::Type::Restore, WTF::move(completionHandler));
     if (gtk_window_is_maximized(window))
         gtk_window_unmaximize(window);
+    if (isFullscreen) {
+        webkitWebViewSetWindowFullscreen(topLevel, WindowFullscreenState::Unfullscreen);
+#if ENABLE(DEVELOPER_MODE)
+        if (isUnderXvfb)
+            g_object_set_data(G_OBJECT(view), gXvfbFullscreenID, nullptr);
+#endif // ENABLE(DEVELOPER_MODE)
+    }
     if (!gtk_widget_get_mapped(topLevel))
         gtk_window_unminimize(window);
 
 #if ENABLE(DEVELOPER_MODE)
     // Xvfb doesn't support maximize, so we resize the window to the default size.
-    if (WebKit::Display::singleton().isX11()) {
-        const char* underXvfb = g_getenv("UNDER_XVFB");
-        if (!g_strcmp0(underXvfb, "yes")) {
-            int x, y;
-            gtk_window_get_default_size(window, &x, &y);
-            gtk_window_resize(window, x, y);
-        }
+    if (isUnderXvfb) {
+        int width, height;
+        gtk_window_get_default_size(window, &width, &height);
+        gtk_window_resize(window, width, height);
     }
 #endif
     gtk_widget_show(topLevel);

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -2765,21 +2765,19 @@
             "notes": "",
             "test_fullscreen_from_normal_window": {
                 "expected": {
-                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"},
-                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"}
                 }
             },
             "test_fullscreen_from_maximized_window": {
                 "expected": {
-                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"},
-                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279100"}
                 }
             },
             "test_fullscreen_twice_is_idempotent": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
             "test_response_payload": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             }
         }
     },
@@ -2788,7 +2786,6 @@
         "subtests": {
             "test_fullscreen_from_minimized_window": {
                 "expected": {
-                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"},
                     "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/277945"}
                 }
             }
@@ -2799,22 +2796,22 @@
         "subtests": {
             "notes": "Some WPE tests are skipped as they trigger failure or timeout regardless of the expectation if they are run. Also, some tests expect the browser to start in non fullscreen mode, which isn't happening in the headless backend.",
             "test_accept[alert-None]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
             "test_accept[confirm-True]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
             "test_accept[prompt-]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
             "test_dismiss[alert-None]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
             "test_dismiss[confirm-False]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             },
             "test_dismiss[prompt-None]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
+                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}}
             }
         }
     },
@@ -2823,32 +2820,27 @@
             "notes": "Some WPE tests are skipped as they trigger failure or timeout regardless of the expectation if they are run. Also, some tests expect the browser to start in non fullscreen mode, which isn't happening in the headless backend.",
             "test_stress[0]": {
                 "expected": {
-                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
-                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}
                 }
             },
             "test_stress[1]": {
                 "expected": {
-                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
-                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}
                 }
             },
             "test_stress[2]": {
                 "expected": {
-                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
-                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}
                 }
             },
             "test_stress[3]": {
                 "expected": {
-                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
-                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}
                 }
             },
             "test_stress[4]": {
                 "expected": {
-                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"},
-                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/320856"}
+                    "wpe": {"status": ["SKIP"], "bug": "webkit.org/b/212950"}
                 }
             }
         }


### PR DESCRIPTION
#### 2e315e0b71c194d6ce0c0f1bae617104fddcdaad
<pre>
[GTK] add support for window fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=322052">https://bugs.webkit.org/show_bug.cgi?id=322052</a>

Reviewed by NOBODY (OOPS!).

Add awaitable native fullscreen helpers for GTK 3 and GTK 4
Route DOM fullscreen through them so completion follows the native window state
Use the embedder fullscreen action for both entry and exit so its state remains synchronized
Keep an Xvfb fallback because it has no window manager to report fullscreen state

The existing WebKitWebView fullscreen API test covers DOM entry and exit
The W3C WebDriver tests cover normal, maximized, minimized, repeated, prompt, and stress paths

* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h:
(webkitWebViewFullscreenWindow): Added.
(webkitWebViewUnfullscreenWindow): Added.
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseEnterFullScreen):
(webkitWebViewBaseExitFullScreen):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp:
(WindowStateEvent::Type):
(surfaceStateChangedCallback):
(windowStateEventCallback):
(webkitWebViewMonitorWindowState):
(webkitWebViewMaximizeWindow):
(WindowFullscreenState): Added.
(webkitWebViewWindowIsFullscreen): Added.
(webkitWebViewSetWindowFullscreen): Added.
(webkitWebViewIsUnderXvfb): Added.
(webkitWebViewCompleteWindowStateEvent): Added.
(webkitWebViewFullscreenWindow): Added.
(webkitWebViewUnfullscreenWindow): Added.
(webkitWebViewRestoreWindow):
* WebDriverTests/TestExpectations.json:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e315e0b71c194d6ce0c0f1bae617104fddcdaad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147985 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143372 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99550 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45841 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44070 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43655 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5097 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195854 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57288 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152914 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57992 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152592 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47131 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130271 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126585 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56500 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18665 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55871 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->