### PR TITLE
[LBSE] Cache the SVG viewport size used for length resolution

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -243,9 +243,7 @@ void RenderSVGRoot::layout()
     StackStats::LayoutCheckPoint layoutCheckPoint;
     ASSERT(needsLayout());
 
-    // Drop the cached viewport size before any in-layout length/transform resolution reads it, so a
-    // resize-triggered relayout recomputes against the new content box rather than a stale value.
-    svgSVGElement().invalidateCachedViewportSizeExcludingZoom();
+    svgSVGElement().invalidateCachedViewportSizes();
 
     // Arbitrary affine transforms are incompatible with RenderLayoutState.
     LayoutStateDisabler layoutStateDisabler(view().frameView().layoutContext());
@@ -272,11 +270,7 @@ void RenderSVGRoot::layout()
     addVisualEffectOverflow();
 
     invalidateBackgroundObscurationStatus();
-
-    // The viewport size (content box) is finalized - flush the cached value now so post-layout
-    // transform/length resolution recomputes it once instead of repeating the same computation
-    // whenver the view port size is queried.
-    svgSVGElement().invalidateCachedViewportSizeExcludingZoom();
+    svgSVGElement().invalidateCachedViewportSizes();
 
     repainter.repaintAfterLayout();
     clearNeedsLayout();

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -90,7 +90,7 @@ bool RenderSVGViewportContainer::updateLayoutSizeIfNeeded()
     auto previousViewportSize = viewportSize();
     m_viewport = { computeViewportLocation(), computeViewportSize() };
     if (previousViewportSize != viewportSize()) {
-        svgSVGElement().invalidateCachedViewportSizeExcludingZoom();
+        svgSVGElement().invalidateCachedViewportSizes();
         return true;
     }
     return selfNeedsLayout();

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -414,11 +414,7 @@ std::optional<FloatSize> SVGLengthContext::computeViewportSize() const
     if (!svg)
         return std::nullopt;
 
-    auto viewportSize = svg->currentViewBoxRect().size();
-    if (viewportSize.isEmpty())
-        viewportSize = svg->currentViewportSizeExcludingZoom();
-
-    return viewportSize;
+    return svg->viewportSizeForLengthResolution();
 }
 
 }

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -671,6 +671,21 @@ FloatSize SVGSVGElement::currentViewportSizeExcludingZoom() const
     return *m_cachedViewportSizeExcludingZoom;
 }
 
+FloatSize SVGSVGElement::viewportSizeForLengthResolution() const
+{
+    auto compute = [&]() -> FloatSize {
+        auto viewBoxSize = currentViewBoxRect().size();
+        return viewBoxSize.isEmpty() ? currentViewportSizeExcludingZoom() : viewBoxSize;
+    };
+
+    if (!document().settings().layerBasedSVGEngineEnabled())
+        return compute();
+
+    if (!m_cachedViewportSizeForLengthResolution)
+        m_cachedViewportSizeForLengthResolution = compute();
+    return *m_cachedViewportSizeForLengthResolution;
+}
+
 FloatSize SVGSVGElement::computeCurrentViewportSizeExcludingZoom() const
 {
     FloatSize viewportSize;

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -108,7 +108,13 @@ public:
     bool hasIntrinsicDimensions() const;
 
     FloatSize currentViewportSizeExcludingZoom() const;
-    void invalidateCachedViewportSizeExcludingZoom() const { m_cachedViewportSizeExcludingZoom = std::nullopt; }
+    void invalidateCachedViewportSizes() const
+    {
+        m_cachedViewportSizeExcludingZoom = std::nullopt;
+        m_cachedViewportSizeForLengthResolution = std::nullopt;
+    }
+
+    FloatSize viewportSizeForLengthResolution() const;
 
     FloatRect currentViewBoxRect() const;
     bool hasSynthesizedViewBoxForSVGImage() const;
@@ -167,6 +173,7 @@ private:
     Ref<SVGPoint> m_currentTranslate { SVGPoint::create() };
 
     mutable std::optional<FloatSize> m_cachedViewportSizeExcludingZoom;
+    mutable std::optional<FloatSize> m_cachedViewportSizeForLengthResolution;
 
     float m_currentScale { 1 };
 


### PR DESCRIPTION
#### 48f0a2d2fe553bb66088d7158e509f6c01b44321
<pre>
[LBSE] Cache the SVG viewport size used for length resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=322055">https://bugs.webkit.org/show_bug.cgi?id=322055</a>

Reviewed by Said Abou-Hallawa.

SVGLengthContext::computeViewportSize() resolves a descendant&apos;s viewport
size from the nearest &lt;svg&gt; by recomputing currentViewBoxRect() on every
call. During a transform animation this runs once per shape per frame,
even though the viewport is invariant across the flush and identical for
all shapes under the same &lt;svg&gt;.

Cache the derived size - mirroring the existing logic used already for
m_cachedViewportSizeExcludingZoom.

Covered by existing tests.

* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::layout):
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::updateLayoutSizeIfNeeded):
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::computeViewportSize const):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::viewportSizeForLengthResolution const):
* Source/WebCore/svg/SVGSVGElement.h:

Canonical link: <a href="https://commits.webkit.org/319468@main">https://commits.webkit.org/319468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9648b02632715867d3dc1805f8a70dd08f479bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145819 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141652 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184448 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45336 "Found 1 new test failure: http/tests/app-privacy-report/app-attribution-post-request.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44014 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42286 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41928 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2877 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193644 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55109 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151058 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55796 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150765 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27573 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45341 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128079 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123712 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54312 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16926 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53694 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53932 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->