### PR TITLE
[Text Extraction] Limit `replacementStrings` substitutions to word boundaries (to reduce false positives when redacting PII)

### DIFF
--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -507,16 +507,52 @@ String foldTextForReplacement(const String& source)
     return foldForReplacement(source).text;
 }
 
+static bool isWordCharacter(char32_t codePoint)
+{
+    return !!u_isalnum(codePoint);
+}
+
+static bool anchorsToWordBoundary(char32_t codePoint)
+{
+    if (!isWordCharacter(codePoint))
+        return false;
+
+    switch (u_getIntPropertyValue(codePoint, UCHAR_LINE_BREAK)) {
+    case U_LB_IDEOGRAPHIC:
+    case U_LB_COMPLEX_CONTEXT:
+    case U_LB_CONDITIONAL_JAPANESE_STARTER:
+    case U_LB_NONSTARTER:
+    case U_LB_H2:
+    case U_LB_H3:
+    case U_LB_JL:
+    case U_LB_JV:
+    case U_LB_JT:
+        return false;
+    default:
+        return true;
+    }
+}
+
+static bool matchIsWordBounded(StringView text, StringView key, unsigned start)
+{
+    if (start && anchorsToWordBoundary(key.codePointAt(0)) && isWordCharacter(text.codePointBefore(start)))
+        return false;
+
+    auto end = start + key.length();
+    return end >= text.length() || !anchorsToWordBoundary(key.codePointBefore(key.length())) || !isWordCharacter(text.codePointAt(end));
+}
+
 String applyReplacements(const String& text, const Vector<std::pair<String, String>>& replacementStrings)
 {
     if (replacementStrings.isEmpty())
         return text;
 
     auto folded = foldForReplacement(text);
+    auto foldedView = StringView { folded.text };
     StringBuilder result;
     result.reserveCapacity(text.length());
     unsigned cursor = 0;
-    while (cursor < folded.text.length()) {
+    while (cursor < foldedView.length()) {
         bool matched = false;
         for (auto& [foldedKey, replacement] : replacementStrings) {
             if (foldedKey.isEmpty()) {
@@ -524,10 +560,13 @@ String applyReplacements(const String& text, const Vector<std::pair<String, Stri
                 break;
             }
 
-            if (foldedKey.length() > folded.text.length() - cursor)
+            if (foldedKey.length() > foldedView.length() - cursor)
                 continue;
 
-            if (StringView { folded.text }.substring(cursor, foldedKey.length()) != foldedKey)
+            if (foldedView.substring(cursor, foldedKey.length()) != foldedKey)
+                continue;
+
+            if (!matchIsWordBounded(foldedView, foldedKey, cursor))
                 continue;
 
             result.append(replacement);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -1108,6 +1108,66 @@ TEST(TextExtractionTests, ReplacementStringsDiacriticInsensitive)
     EXPECT_FALSE([debugText containsString:@"Zurich"]);
 }
 
+TEST(TextExtractionTests, ReplacementStringsWordBoundaries)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    auto textAfterReplacing = [&](NSString *markup, NSDictionary<NSString *, NSString *> *replacementStrings) -> RetainPtr<NSString> {
+        [webView synchronouslyLoadHTMLString:markup];
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setReplacementStrings:replacementStrings];
+        return [webView synchronouslyGetDebugText:configuration];
+    };
+
+    {
+        // A key matching only part of a longer word is not the user's data, and replacing it would both
+        // corrupt the surrounding text and reveal the key to anyone diffing against the unredacted page.
+        RetainPtr text = textAfterReplacing(@"<p>Two-factor authentication</p><p>Location customization</p><p>Cat pictures</p>", @{
+            @"Cat": @"Jane",
+        });
+        EXPECT_TRUE([text containsString:@"Two-factor authentication"]);
+        EXPECT_TRUE([text containsString:@"Location customization"]);
+        EXPECT_TRUE([text containsString:@"Jane pictures"]);
+        EXPECT_FALSE([text containsString:@"authentiJaneion"]);
+        EXPECT_FALSE([text containsString:@"LoJaneion"]);
+    }
+    {
+        RetainPtr text = textAfterReplacing(@"<p>At least 8 characters</p><button>Cancel</button><p>L is an initial</p>", @{
+            @"L": @"Marie",
+        });
+        EXPECT_TRUE([text containsString:@"At least 8 characters"]);
+        EXPECT_TRUE([text containsString:@"Cancel"]);
+        EXPECT_TRUE([text containsString:@"Marie is an initial"]);
+        EXPECT_FALSE([text containsString:@"Marieeast"]);
+        EXPECT_FALSE([text containsString:@"CanceMarie"]);
+    }
+    {
+        // Only alphanumeric characters are part of a word, so punctuation and symbols bound a match.
+        RetainPtr text = textAfterReplacing(@"<p>wenson@me.com</p><p>wenson.hsieh@me.com</p><p>wenson-hsieh</p><p>wensonhsieh</p>", @{
+            @"Wenson": @"jane",
+        });
+        EXPECT_TRUE([text containsString:@"jane@me.com"]);
+        EXPECT_TRUE([text containsString:@"jane.hsieh@me.com"]);
+        EXPECT_TRUE([text containsString:@"jane-hsieh"]);
+        EXPECT_TRUE([text containsString:@"wensonhsieh"]);
+        EXPECT_FALSE([text containsString:@"janehsieh"]);
+    }
+    {
+        // Scripts written without interword spacing have no boundary to anchor to, so requiring one
+        // would keep replacements from ever applying within them.
+        RetainPtr text = textAfterReplacing(@"<p>王謝李明</p><p>서울특별시</p>", @{
+            @"謝李": @"<redacted-name>",
+            @"울특": @"<redacted-place>",
+        });
+        EXPECT_TRUE([text containsString:@"王<redacted-name>明"]);
+        EXPECT_TRUE([text containsString:@"서<redacted-place>별시"]);
+    }
+}
+
 TEST(TextExtractionTests, ReplacementStringsAppliedToInteractionDescription)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 9d44026b876f9914a02c641007b9ebbe75999ce6
<pre>
[Text Extraction] Limit `replacementStrings` substitutions to word boundaries (to reduce false positives when redacting PII)
<a href="https://bugs.webkit.org/show_bug.cgi?id=322061">https://bugs.webkit.org/show_bug.cgi?id=322061</a>
<a href="https://rdar.apple.com/185254024">rdar://185254024</a>

Reviewed by Abrar Rahman Protyasha.

Adjust the string replacement heuristics for text extractions, such that it only redacts text if it
spans word boundaries, in order to limit false positives (which may actually cause us to indirectly
and unintentionally leak information, which the agent would not have otherwise observed).

Test: TextExtractionTests.ReplacementStringsWordBoundaries

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::isWordCharacter):
(WebKit::anchorsToWordBoundary):
(WebKit::matchIsWordBounded):
(WebKit::applyReplacements):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, ReplacementStringsWordBoundaries)):

Canonical link: <a href="https://commits.webkit.org/319423@main">https://commits.webkit.org/319423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41ab6f7d5da23d500356eee51a44c6f68adb8f79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145724 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8d3dd7c9-8c36-4395-b75a-97735ccda840) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141572 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c8465c4-676a-4a5f-80e9-ca9171dc4607) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122012 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5874269-289d-478e-b6fc-12772e9c9890) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43930 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42204 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41845 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2778 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193549 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55014 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150967 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40443 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55701 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38468 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150674 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45259 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127982 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123583 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54217 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16844 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53599 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53664 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->