### PR TITLE
[scroll-animations] crash in `WebAnimation::bindingsRangeStart()`

### DIFF
--- a/LayoutTests/fast/animation/css-animation-range-calc-crash-expected.txt
+++ b/LayoutTests/fast/animation/css-animation-range-calc-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it doesn't crash.
+

--- a/LayoutTests/fast/animation/css-animation-range-calc-crash.html
+++ b/LayoutTests/fast/animation/css-animation-range-calc-crash.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html> 
+<html> 
+<head>
+<style> 
+@keyframes slide { 
+    from { transform: translateX(0); } 
+    to { transform: translateX(300px); } 
+}
+#test {
+  animation: slide 2s ease-in-out infinite alternate;
+  animation-range-start: calc(10% + 10px);
+}
+</style> 
+</head> 
+<body> 
+<div>This test passes if it doesn't crash.</div>
+<div id="test"></div> 
+<script> 
+  if (window.testRunner)
+      window.testRunner.dumpAsText(); 
+
+  const animation = document.getElementById("test").getAnimations()[0];
+  animation.rangeStart;
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
@@ -31,16 +31,25 @@
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+DeprecatedCSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 
 namespace WebCore {
 namespace Style {
 
 static RefPtr<CSSNumericValue> toCSSNumericValue(const SingleAnimationRangeEdgeOffset& offset, ZoomFactor zoom)
 {
-    // FIXME: This will fail for calc().
-    return offset.isPercentOrCalculated()
-        ? CSSNumericFactory::percent(offset.tryPercentage()->value)
-        : CSSNumericFactory::px(offset.tryFixed()->resolveZoom(zoom));
+    return WTF::switchOn(offset,
+        [&](const SingleAnimationRangeEdgeOffset::Fixed& fixed) -> RefPtr<CSSNumericValue> {
+            return CSSNumericFactory::px(Style::evaluate<double>(fixed, zoom));
+        },
+        [](const SingleAnimationRangeEdgeOffset::Percentage& percentage) -> RefPtr<CSSNumericValue> {
+            return CSSNumericFactory::percent(percentage.value);
+        },
+        [&](const SingleAnimationRangeEdgeOffset::Calc&) -> RefPtr<CSSNumericValue> {
+            // FIXME: This should try to construct a CSSMathValue.
+            return nullptr;
+        }
+    );
 }
 
 TimelineRangeValue SingleAnimationRangeStart::toTimelineRangeValue(ZoomFactor zoom) const


### PR DESCRIPTION
#### 55c608d2b1b46d1ac0b40d093a8c6b5a69c16907
<pre>
[scroll-animations] crash in `WebAnimation::bindingsRangeStart()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=322002">https://bugs.webkit.org/show_bug.cgi?id=322002</a>

Reviewed by Darin Adler.

Fixes crash that happens when a StyleSingleAnimationRange&apos;s offset is a
calc value and the Animation.rangeStart or Animation.rangeEnd getters are
called. The code was unconditionally accessing the result of tryPercentage()
which returns std::nullopt in the calc case. To fix this, we use the switchOn
form to ensure all alternatives are handled.

Test: fast/animation/css-animation-range-calc-crash.html
* LayoutTests/fast/animation/css-animation-range-calc-crash-expected.txt: Added.
* LayoutTests/fast/animation/css-animation-range-calc-crash.html: Added.
* Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp:

Canonical link: <a href="https://commits.webkit.org/319422@main">https://commits.webkit.org/319422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b60421b6f4af42eaaa8396e037f045fbab56f87d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145725 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141568 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122008 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43942 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42206 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154344 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41847 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2779 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193550 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150968 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40445 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55702 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150675 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45260 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127983 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123584 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54218 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16846 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53600 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->