### PR TITLE
[JSC] Inline `Map#forEach` / `Set#forEach` iteration in DFG and FTL

### DIFF
--- a/JSTests/microbenchmarks/map-for-each-deleted-entries.js
+++ b/JSTests/microbenchmarks/map-for-each-deleted-entries.js
@@ -1,0 +1,17 @@
+function sumEntries(map) {
+    var sum = 0;
+    map.forEach(function (value, key) {
+        sum += value - key;
+    });
+    return sum;
+}
+noInline(sumEntries);
+
+var map = new Map;
+for (var i = 0; i < 1500; ++i)
+    map.set(i, i * 2);
+for (var i = 0; i < 1500; i += 3)
+    map.delete(i);
+
+for (var i = 0; i < 1e4; ++i)
+    sumEntries(map);

--- a/JSTests/microbenchmarks/map-for-each-key-value.js
+++ b/JSTests/microbenchmarks/map-for-each-key-value.js
@@ -1,0 +1,15 @@
+function sumEntries(map) {
+    var sum = 0;
+    map.forEach(function (value, key) {
+        sum += value + key;
+    });
+    return sum;
+}
+noInline(sumEntries);
+
+var map = new Map;
+for (var i = 0; i < 1000; ++i)
+    map.set(i, i * 2);
+
+for (var i = 0; i < 1e4; ++i)
+    sumEntries(map);

--- a/JSTests/microbenchmarks/set-for-each-value.js
+++ b/JSTests/microbenchmarks/set-for-each-value.js
@@ -1,0 +1,15 @@
+function sumValues(set) {
+    var sum = 0;
+    set.forEach(function (value) {
+        sum += value;
+    });
+    return sum;
+}
+noInline(sumValues);
+
+var set = new Set;
+for (var i = 0; i < 1000; ++i)
+    set.add(i);
+
+for (var i = 0; i < 1e4; ++i)
+    sumValues(set);

--- a/JSTests/stress/map-for-each-mutation-during-iteration.js
+++ b/JSTests/stress/map-for-each-mutation-during-iteration.js
@@ -1,0 +1,95 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function makeMap(count) {
+    var map = new Map;
+    for (var i = 0; i < count; ++i)
+        map.set(i, i * 10);
+    return map;
+}
+
+function keys(map) {
+    var result = [];
+    map.forEach(function (value, key) { result.push(key + ':' + value); });
+    return result.join(',');
+}
+noInline(keys);
+
+function deleteAhead(map) {
+    var result = [];
+    map.forEach(function (value, key) {
+        result.push(key);
+        if (key % 2 == 0)
+            map.delete(key + 1);
+    });
+    return result.join(',');
+}
+noInline(deleteAhead);
+
+function deleteAllAhead(map) {
+    var result = [];
+    map.forEach(function (value, key) {
+        result.push(key);
+        if (key == 2) {
+            for (var i = 3; i < 10; ++i)
+                map.delete(i);
+        }
+    });
+    return result.join(',');
+}
+noInline(deleteAllAhead);
+
+function addDuring(map) {
+    var result = [];
+    var added = 0;
+    map.forEach(function (value, key) {
+        result.push(key);
+        if (added < 40)
+            map.set('x' + added++, added);
+    });
+    return result.length;
+}
+noInline(addDuring);
+
+function clearDuring(map) {
+    var result = [];
+    map.forEach(function (value, key) {
+        result.push(key);
+        if (key == 3)
+            map.clear();
+    });
+    return result.join(',');
+}
+noInline(clearDuring);
+
+function clearAndReadd(map) {
+    var result = [];
+    map.forEach(function (value, key) {
+        result.push(key);
+        if (key == 3) {
+            map.clear();
+            map.set('a', 1);
+            map.set('b', 2);
+        }
+    });
+    return result.join(',');
+}
+noInline(clearAndReadd);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(keys(new Map), '');
+    var map = makeMap(5);
+    map.delete(0);
+    map.delete(4);
+    shouldBe(keys(map), '1:10,2:20,3:30');
+    map = new Map([[1, 1]]);
+    map.delete(1);
+    shouldBe(keys(map), '');
+    shouldBe(deleteAhead(makeMap(10)), '0,2,4,6,8');
+    shouldBe(deleteAllAhead(makeMap(10)), '0,1,2');
+    shouldBe(addDuring(makeMap(3)), 43);
+    shouldBe(clearDuring(makeMap(10)), '0,1,2,3');
+    shouldBe(clearAndReadd(makeMap(10)), '0,1,2,3,a,b');
+}

--- a/JSTests/stress/set-for-each-mutation-during-iteration.js
+++ b/JSTests/stress/set-for-each-mutation-during-iteration.js
@@ -1,0 +1,95 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function makeSet(count) {
+    var set = new Set;
+    for (var i = 0; i < count; ++i)
+        set.add(i);
+    return set;
+}
+
+function values(set) {
+    var result = [];
+    set.forEach(function (value, key) { result.push(key + ':' + value); });
+    return result.join(',');
+}
+noInline(values);
+
+function deleteAhead(set) {
+    var result = [];
+    set.forEach(function (value) {
+        result.push(value);
+        if (value % 2 == 0)
+            set.delete(value + 1);
+    });
+    return result.join(',');
+}
+noInline(deleteAhead);
+
+function deleteAllAhead(set) {
+    var result = [];
+    set.forEach(function (value) {
+        result.push(value);
+        if (value == 2) {
+            for (var i = 3; i < 10; ++i)
+                set.delete(i);
+        }
+    });
+    return result.join(',');
+}
+noInline(deleteAllAhead);
+
+function addDuring(set) {
+    var result = [];
+    var added = 0;
+    set.forEach(function (value) {
+        result.push(value);
+        if (added < 40)
+            set.add('x' + added++);
+    });
+    return result.length;
+}
+noInline(addDuring);
+
+function clearDuring(set) {
+    var result = [];
+    set.forEach(function (value) {
+        result.push(value);
+        if (value == 3)
+            set.clear();
+    });
+    return result.join(',');
+}
+noInline(clearDuring);
+
+function clearAndReadd(set) {
+    var result = [];
+    set.forEach(function (value) {
+        result.push(value);
+        if (value == 3) {
+            set.clear();
+            set.add('a');
+            set.add('b');
+        }
+    });
+    return result.join(',');
+}
+noInline(clearAndReadd);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(values(new Set), '');
+    var set = makeSet(5);
+    set.delete(0);
+    set.delete(4);
+    shouldBe(values(set), '1:1,2:2,3:3');
+    set = new Set([1]);
+    set.delete(1);
+    shouldBe(values(set), '');
+    shouldBe(deleteAhead(makeSet(10)), '0,2,4,6,8');
+    shouldBe(deleteAllAhead(makeSet(10)), '0,1,2');
+    shouldBe(addDuring(makeSet(3)), 43);
+    shouldBe(clearDuring(makeSet(10)), '0,1,2,3');
+    shouldBe(clearAndReadd(makeSet(10)), '0,1,2,3,a,b');
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -6085,85 +6085,26 @@ JSC_DEFINE_JIT_OPERATION(operationSetGet, JSValue*, (JSGlobalObject* globalObjec
     OPERATION_RETURN(scope, keySlot);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationMapIterationNext, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell, int32_t index))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMapIterationNext, EncodedJSValue, (VM* vmPointer, JSCell* cell, int32_t index))
 {
-    VM& vm = globalObject->vm();
+    VM& vm = *vmPointer;
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    if (cell == vm.orderedHashTableSentinel())
-        OPERATION_RETURN(scope, JSValue::encode(vm.orderedHashTableSentinel()));
-
-    JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
-    OPERATION_RETURN(scope, JSValue::encode(JSMap::Helper::nextAndUpdateIterationEntry(vm, storage, index)));
-}
-JSC_DEFINE_JIT_OPERATION(operationMapIterationEntry, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell))
-{
-    VM& vm = globalObject->vm();
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    auto scope = DECLARE_THROW_SCOPE(vm);
 
     ASSERT(cell != vm.orderedHashTableSentinel());
     JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
-    OPERATION_RETURN(scope, JSValue::encode(JSMap::Helper::getIterationEntry(storage)));
-}
-JSC_DEFINE_JIT_OPERATION(operationMapIterationEntryKey, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell))
-{
-    VM& vm = globalObject->vm();
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    ASSERT(cell != vm.orderedHashTableSentinel());
-    JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
-    OPERATION_RETURN(scope, JSValue::encode(JSMap::Helper::getIterationEntryKey(storage)));
-}
-JSC_DEFINE_JIT_OPERATION(operationMapIterationEntryValue, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell))
-{
-    VM& vm = globalObject->vm();
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    ASSERT(cell != vm.orderedHashTableSentinel());
-    JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
-    OPERATION_RETURN(scope, JSValue::encode(JSMap::Helper::getIterationEntryValue(storage)));
+    return JSValue::encode(JSMap::Helper::nextAndUpdateIterationEntry(vm, storage, index));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationSetIterationNext, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell, int32_t index))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationSetIterationNext, EncodedJSValue, (VM* vmPointer, JSCell* cell, int32_t index))
 {
-    VM& vm = globalObject->vm();
+    VM& vm = *vmPointer;
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    if (cell == vm.orderedHashTableSentinel())
-        OPERATION_RETURN(scope, JSValue::encode(vm.orderedHashTableSentinel()));
-
-    JSSet::Storage& storage = *uncheckedDowncast<JSSet::Storage>(cell);
-    OPERATION_RETURN(scope, JSValue::encode(JSSet::Helper::nextAndUpdateIterationEntry(vm, storage, index)));
-}
-JSC_DEFINE_JIT_OPERATION(operationSetIterationEntry, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell))
-{
-    VM& vm = globalObject->vm();
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    auto scope = DECLARE_THROW_SCOPE(vm);
 
     ASSERT(cell != vm.orderedHashTableSentinel());
     JSSet::Storage& storage = *uncheckedDowncast<JSSet::Storage>(cell);
-    OPERATION_RETURN(scope, JSValue::encode(JSSet::Helper::getIterationEntry(storage)));
-}
-JSC_DEFINE_JIT_OPERATION(operationSetIterationEntryKey, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell))
-{
-    VM& vm = globalObject->vm();
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    ASSERT(cell != vm.orderedHashTableSentinel());
-    JSSet::Storage& storage = *uncheckedDowncast<JSSet::Storage>(cell);
-    OPERATION_RETURN(scope, JSValue::encode(JSSet::Helper::getIterationEntryKey(storage)));
+    return JSValue::encode(JSSet::Helper::nextAndUpdateIterationEntry(vm, storage, index));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationStringIteratorNext, UGPRPair, (JSGlobalObject* globalObject, JSString* string, int32_t position))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -364,14 +364,8 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMapHashHeapBigInt, UCPUStrictInt32, 
 JSC_DECLARE_JIT_OPERATION(operationMapGet, JSValue*, (JSGlobalObject*, JSCell*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationSetGet, JSValue*, (JSGlobalObject*, JSCell*, EncodedJSValue, int32_t));
 
-JSC_DECLARE_JIT_OPERATION(operationMapIterationNext, EncodedJSValue, (JSGlobalObject*, JSCell*, int32_t));
-JSC_DECLARE_JIT_OPERATION(operationMapIterationEntry, EncodedJSValue, (JSGlobalObject*, JSCell*));
-JSC_DECLARE_JIT_OPERATION(operationMapIterationEntryKey, EncodedJSValue, (JSGlobalObject*, JSCell*));
-JSC_DECLARE_JIT_OPERATION(operationMapIterationEntryValue, EncodedJSValue, (JSGlobalObject*, JSCell*));
-
-JSC_DECLARE_JIT_OPERATION(operationSetIterationNext, EncodedJSValue, (JSGlobalObject*, JSCell*, int32_t));
-JSC_DECLARE_JIT_OPERATION(operationSetIterationEntry, EncodedJSValue, (JSGlobalObject*, JSCell*));
-JSC_DECLARE_JIT_OPERATION(operationSetIterationEntryKey, EncodedJSValue, (JSGlobalObject*, JSCell*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMapIterationNext, EncodedJSValue, (VM*, JSCell*, int32_t));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationSetIterationNext, EncodedJSValue, (VM*, JSCell*, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationStringIteratorNext, UGPRPair, (JSGlobalObject*, JSString*, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMapIteratorNext, UGPRPair, (VM*, JSCell*, JSCell*, int32_t));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -14423,6 +14423,26 @@ void SpeculativeJIT::compileMapStorageOrSentinel(Node* node)
     cellResult(resultGPR, node);
 }
 
+void SpeculativeJIT::loadMapEntryData(bool isMap, GPRReg storageGPR, GPRReg entryGPR, GPRReg scratchGPR, JSValueRegs resultRegs, int32_t indexAdjust)
+{
+    if (isMap) {
+        static_assert(JSMap::Helper::EntrySize == 3);
+        lshift32(entryGPR, TrustedImm32(1), scratchGPR);
+        add32(entryGPR, scratchGPR);
+        load32(Address(storageGPR, JSCellButterfly::offsetOfData() + JSMap::Helper::capacityIndex() * sizeof(uint64_t)), resultRegs.payloadGPR());
+        add32(resultRegs.payloadGPR(), scratchGPR);
+        add32(TrustedImm32(JSMap::Helper::hashTableStartIndex() + indexAdjust), scratchGPR);
+    } else {
+        static_assert(JSSet::Helper::EntrySize == 2);
+        add32(entryGPR, entryGPR, scratchGPR);
+        load32(Address(storageGPR, JSCellButterfly::offsetOfData() + JSSet::Helper::capacityIndex() * sizeof(uint64_t)), resultRegs.payloadGPR());
+        add32(resultRegs.payloadGPR(), scratchGPR);
+        add32(TrustedImm32(JSSet::Helper::hashTableStartIndex() + indexAdjust), scratchGPR);
+    }
+
+    loadValue(BaseIndex(storageGPR, scratchGPR, TimesEight, JSCellButterfly::offsetOfData()), resultRegs);
+}
+
 void SpeculativeJIT::compileMapIteratorKey(Node* node)
 {
     bool isMapIterator = node->bucketOwnerType() == BucketOwnerType::Map;
@@ -14437,22 +14457,7 @@ void SpeculativeJIT::compileMapIteratorKey(Node* node)
     GPRReg scratchGPR2 = scratch2.gpr();
     auto resultRegs = JSValueRegs(scratchGPR1);
 
-    if (isMapIterator) {
-        static_assert(JSMap::Helper::EntrySize == 3);
-        lshift32(entryGPR, TrustedImm32(1), scratchGPR2);
-        add32(entryGPR, scratchGPR2);
-        load32(Address(storageGPR, JSCellButterfly::offsetOfData() + JSMap::Helper::capacityIndex() * sizeof(uint64_t)), scratchGPR1);
-        add32(scratchGPR1, scratchGPR2);
-        add32(TrustedImm32(JSMap::Helper::hashTableStartIndex() - JSMap::Helper::EntrySize), scratchGPR2);
-    } else {
-        static_assert(JSSet::Helper::EntrySize == 2);
-        add32(entryGPR, entryGPR, scratchGPR2);
-        load32(Address(storageGPR, JSCellButterfly::offsetOfData() + JSSet::Helper::capacityIndex() * sizeof(uint64_t)), scratchGPR1);
-        add32(scratchGPR1, scratchGPR2);
-        add32(TrustedImm32(JSSet::Helper::hashTableStartIndex() - JSSet::Helper::EntrySize), scratchGPR2);
-    }
-
-    loadValue(BaseIndex(storageGPR, scratchGPR2, TimesEight, JSCellButterfly::offsetOfData()), resultRegs);
+    loadMapEntryData(isMapIterator, storageGPR, entryGPR, scratchGPR2, resultRegs, -(isMapIterator ? JSMap::Helper::EntrySize : JSSet::Helper::EntrySize));
     jsValueResult(resultRegs, node);
 }
 
@@ -14470,83 +14475,122 @@ void SpeculativeJIT::compileMapIteratorValue(Node* node)
     GPRReg scratchGPR2 = scratch2.gpr();
     auto resultRegs = JSValueRegs(scratchGPR1);
 
-    static_assert(JSMap::Helper::EntrySize == 3);
-    lshift32(entryGPR, TrustedImm32(1), scratchGPR2);
-    add32(entryGPR, scratchGPR2);
-    load32(Address(storageGPR, JSCellButterfly::offsetOfData() + JSMap::Helper::capacityIndex() * sizeof(uint64_t)), scratchGPR1);
-    add32(scratchGPR1, scratchGPR2);
-    add32(TrustedImm32(JSMap::Helper::hashTableStartIndex() - JSMap::Helper::EntrySize + /* value offset */ 1), scratchGPR2);
-
-    loadValue(BaseIndex(storageGPR, scratchGPR2, TimesEight, JSCellButterfly::offsetOfData()), resultRegs);
+    loadMapEntryData(true, storageGPR, entryGPR, scratchGPR2, resultRegs, -JSMap::Helper::EntrySize + /* value offset */ 1);
     jsValueResult(resultRegs, node);
 }
 
 void SpeculativeJIT::compileMapIterationNext(Node* node)
 {
-    SpeculateCellOperand mapStorage(this, node->child1());
-    SpeculateInt32Operand entry(this, node->child2());
+    bool isMap = node->bucketOwnerType() == BucketOwnerType::Map;
+    SpeculateCellOperand storage(this, node->child1());
+    SpeculateInt32Operand currentEntry(this, node->child2());
+    GPRTemporary result(this);
+    GPRTemporary entry(this);
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
 
-    GPRReg mapStorageGPR = mapStorage.gpr();
+    GPRReg storageGPR = storage.gpr();
+    GPRReg currentEntryGPR = currentEntry.gpr();
+    GPRReg resultGPR = result.gpr();
     GPRReg entryGPR = entry.gpr();
+    GPRReg scratchGPR1 = scratch1.gpr();
+    GPRReg scratchGPR2 = scratch2.gpr();
 
-    speculateCellButterfly(node->child1(), mapStorageGPR);
+    speculateCellButterfly(node->child1(), storageGPR);
 
-    flushRegisters();
-    JSValueRegsFlushedCallResult result(this);
-    JSValueRegs resultRegs = result.regs();
-    if (node->bucketOwnerType() == BucketOwnerType::Map)
-        callOperation(operationMapIterationNext, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR, entryGPR);
-    else
-        callOperation(operationSetIterationNext, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR, entryGPR);
-    cellResult(resultRegs.payloadGPR(), node);
+    uint8_t entrySize = isMap ? JSMap::Helper::EntrySize : JSSet::Helper::EntrySize;
+    uint32_t capacityIndex = isMap ? JSMap::Helper::capacityIndex() : JSSet::Helper::capacityIndex();
+    uint32_t hashTableStartIndex = isMap ? JSMap::Helper::hashTableStartIndex() : JSSet::Helper::hashTableStartIndex();
+    uint32_t aliveEntryCountIndex = isMap ? JSMap::Helper::aliveEntryCountIndex() : JSSet::Helper::aliveEntryCountIndex();
+    uint32_t iterationEntryIndex = isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex();
+
+    JITCompiler::JumpList slowCases;
+    JITCompiler::JumpList exhaustedCases;
+
+    exhaustedCases.append(branchLinkableConstant(JITCompiler::Equal, storageGPR, LinkableConstant(*this, vm().orderedHashTableSentinel())));
+
+    load64(Address(storageGPR, JSCellButterfly::offsetOfData() + aliveEntryCountIndex * sizeof(uint64_t)), scratchGPR2);
+    slowCases.append(branchIfNotInt32(JSValueRegs { scratchGPR2 }));
+
+    move(currentEntryGPR, entryGPR);
+    load32(Address(storageGPR, JSCellButterfly::offsetOfData() + capacityIndex * sizeof(uint64_t)), scratchGPR1);
+    add32(TrustedImm32(hashTableStartIndex), scratchGPR1);
+    if (isMap) {
+        static_assert(JSMap::Helper::EntrySize == 3);
+        lshift32(entryGPR, TrustedImm32(1), scratchGPR2);
+        add32(entryGPR, scratchGPR2);
+    } else {
+        static_assert(JSSet::Helper::EntrySize == 2);
+        add32(entryGPR, entryGPR, scratchGPR2);
+    }
+    add32(scratchGPR2, scratchGPR1);
+    loadLinkableConstant(LinkableConstant(*this, vm().orderedHashTableDeletedValue()), resultGPR);
+
+    auto loopStart = label();
+    load64(BaseIndex(storageGPR, scratchGPR1, TimesEight, JSCellButterfly::offsetOfData()), scratchGPR2);
+    exhaustedCases.append(branchTest64(JITCompiler::Zero, scratchGPR2));
+    auto foundEntry = branch64(JITCompiler::NotEqual, scratchGPR2, resultGPR);
+    add32(TrustedImm32(1), entryGPR);
+    add32(TrustedImm32(entrySize), scratchGPR1);
+    jump().linkTo(loopStart, this);
+
+    foundEntry.link(this);
+    boxInt32(entryGPR, JSValueRegs { scratchGPR2 });
+    store64(scratchGPR2, Address(storageGPR, JSCellButterfly::offsetOfData() + iterationEntryIndex * sizeof(uint64_t)));
+    move(storageGPR, resultGPR);
+    auto done = jump();
+
+    exhaustedCases.link(this);
+    loadLinkableConstant(LinkableConstant(*this, vm().orderedHashTableSentinel()), resultGPR);
+
+    done.link(this);
+    addSlowPathGenerator(slowPathCall(slowCases, this, isMap ? operationMapIterationNext : operationSetIterationNext, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, resultGPR, TrustedImmPtr(&vm()), storageGPR, currentEntryGPR));
+    cellResult(resultGPR, node);
 }
 
 void SpeculativeJIT::compileMapIterationEntry(Node* node)
 {
-    SpeculateCellOperand mapStorage(this, node->child1());
-    GPRReg mapStorageGPR = mapStorage.gpr();
+    bool isMap = node->bucketOwnerType() == BucketOwnerType::Map;
+    SpeculateCellOperand storage(this, node->child1());
+    GPRTemporary result(this, Reuse, storage);
 
-    speculateCellButterfly(node->child1(), mapStorageGPR);
+    GPRReg storageGPR = storage.gpr();
+    auto resultRegs = JSValueRegs(result.gpr());
 
-    flushRegisters();
-    JSValueRegsFlushedCallResult result(this);
-    JSValueRegs resultRegs = result.regs();
-    if (node->bucketOwnerType() == BucketOwnerType::Map)
-        callOperation(operationMapIterationEntry, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR);
-    else
-        callOperation(operationSetIterationEntry, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR);
+    speculateCellButterfly(node->child1(), storageGPR);
+
+    loadValue(Address(storageGPR, JSCellButterfly::offsetOfData() + (isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex()) * sizeof(uint64_t)), resultRegs);
+    jsValueResult(resultRegs, node);
+}
+
+void SpeculativeJIT::compileMapIterationEntryData(Node* node, unsigned dataOffset)
+{
+    bool isMap = node->bucketOwnerType() == BucketOwnerType::Map;
+    SpeculateCellOperand storage(this, node->child1());
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
+
+    GPRReg storageGPR = storage.gpr();
+    GPRReg scratchGPR1 = scratch1.gpr();
+    GPRReg scratchGPR2 = scratch2.gpr();
+    auto resultRegs = JSValueRegs(scratchGPR1);
+
+    speculateCellButterfly(node->child1(), storageGPR);
+
+    load32(Address(storageGPR, JSCellButterfly::offsetOfData() + (isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex()) * sizeof(uint64_t)), scratchGPR1);
+    loadMapEntryData(isMap, storageGPR, scratchGPR1, scratchGPR2, resultRegs, dataOffset);
     jsValueResult(resultRegs, node);
 }
 
 void SpeculativeJIT::compileMapIterationEntryKey(Node* node)
 {
-    SpeculateCellOperand mapStorage(this, node->child1());
-    GPRReg mapStorageGPR = mapStorage.gpr();
-
-    speculateCellButterfly(node->child1(), mapStorageGPR);
-
-    flushRegisters();
-    JSValueRegsFlushedCallResult result(this);
-    JSValueRegs resultRegs = result.regs();
-    if (node->bucketOwnerType() == BucketOwnerType::Map)
-        callOperation(operationMapIterationEntryKey, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR);
-    else
-        callOperation(operationSetIterationEntryKey, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR);
-    jsValueResult(resultRegs, node);
+    compileMapIterationEntryData(node, 0);
 }
 
 void SpeculativeJIT::compileMapIterationEntryValue(Node* node)
 {
-    SpeculateCellOperand mapStorage(this, node->child1());
-    GPRReg mapStorageGPR = mapStorage.gpr();
-
-    speculateCellButterfly(node->child1(), mapStorageGPR);
-
-    flushRegisters();
-    JSValueRegsFlushedCallResult result(this);
-    JSValueRegs resultRegs = result.regs();
-    callOperation(operationMapIterationEntryValue, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR);
-    jsValueResult(resultRegs, node);
+    ASSERT(node->bucketOwnerType() == BucketOwnerType::Map);
+    compileMapIterationEntryData(node, 1);
 }
 
 void SpeculativeJIT::compileExtractValueFromWeakMapGet(Node* node)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1377,12 +1377,14 @@ public:
     void compileLoadMapValue(Node*);
     void compileIsEmptyStorage(Node*);
     void compileMapIteratorNext(Node*);
+    void loadMapEntryData(bool isMap, GPRReg storageGPR, GPRReg entryGPR, GPRReg scratchGPR, JSValueRegs resultRegs, int32_t indexAdjust);
     void compileMapIteratorKey(Node*);
     void compileMapIteratorValue(Node*);
     void compileMapStorage(Node*);
     void compileMapStorageOrSentinel(Node*);
     void compileMapIterationNext(Node*);
     void compileMapIterationEntry(Node*);
+    void compileMapIterationEntryData(Node*, unsigned dataOffset);
     void compileMapIterationEntryKey(Node*);
     void compileMapIterationEntryValue(Node*);
     void compileMapOrSetSize(Node*);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -16613,38 +16613,118 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileMapIterationNext()
     {
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-        LValue mapStorage = lowCell(m_node->child1());
-        LValue entry = lowInt32(m_node->child2());
+        bool isMap = m_node->bucketOwnerType() == BucketOwnerType::Map;
+        LValue storage = lowCell(m_node->child1());
+        LValue currentEntry = lowInt32(m_node->child2());
 
-        LValue result = vmCall(Int64, m_node->bucketOwnerType() == BucketOwnerType::Map ? operationMapIterationNext : operationSetIterationNext, weakPointer(globalObject), mapStorage, entry);
-        setJSValue(result);
+        LBasicBlock checkObsolete = m_out.newBlock();
+        LBasicBlock fastPath = m_out.newBlock();
+        LBasicBlock loop = m_out.newBlock();
+        LBasicBlock checkIfDeleted = m_out.newBlock();
+        LBasicBlock foundEntry = m_out.newBlock();
+        LBasicBlock exhausted = m_out.newBlock();
+        LBasicBlock slowPath = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        LValue sentinel = m_out.constIntPtr(std::bit_cast<void*>(vm().orderedHashTableSentinel()));
+        LValue deletedValue = m_out.constIntPtr(std::bit_cast<void*>(vm().orderedHashTableDeletedValue()));
+
+        m_out.branch(m_out.equal(storage, sentinel), rarely(exhausted), usually(checkObsolete));
+
+        LBasicBlock lastNext = m_out.appendTo(checkObsolete, fastPath);
+        LValue butterfly = toButterfly(storage);
+        LValue aliveEntryCount = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::aliveEntryCountIndex() : JSSet::Helper::aliveEntryCountIndex())));
+        m_out.branch(isNotInt32(aliveEntryCount), rarely(slowPath), usually(fastPath));
+
+        m_out.appendTo(fastPath, loop);
+        LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::capacityIndex() : JSSet::Helper::capacityIndex())));
+        LValue dataTableStartIndex = m_out.add(m_out.constInt32(isMap ? JSMap::Helper::hashTableStartIndex() : JSSet::Helper::hashTableStartIndex()), bucketCount);
+        LValue entrySize = m_out.constIntPtr(isMap ? JSMap::Helper::EntrySize : JSSet::Helper::EntrySize);
+
+        LValue multiplied;
+        if (isMap) {
+            static_assert(JSMap::Helper::EntrySize == 3);
+            multiplied = m_out.add(currentEntry, m_out.shl(currentEntry, m_out.constInt32(1)));
+        } else {
+            static_assert(JSSet::Helper::EntrySize == 2);
+            multiplied = m_out.add(currentEntry, currentEntry);
+        }
+        ValueFromBlock initialEntry = m_out.anchor(currentEntry);
+        ValueFromBlock initialEntryIndex = m_out.anchor(m_out.zeroExtPtr(m_out.add(dataTableStartIndex, multiplied)));
+        m_out.jump(loop);
+
+        m_out.appendTo(loop, checkIfDeleted);
+        LValue entry = m_out.phi(Int32, initialEntry);
+        LValue entryIndex = m_out.phi(pointerType(), initialEntryIndex);
+        LValue key = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, entryIndex));
+        m_out.branch(m_out.isZero64(key), rarely(exhausted), usually(checkIfDeleted));
+
+        m_out.appendTo(checkIfDeleted, foundEntry);
+        m_out.addIncomingToPhi(entry, m_out.anchor(m_out.add(entry, m_out.constInt32(1))));
+        m_out.addIncomingToPhi(entryIndex, m_out.anchor(m_out.add(entryIndex, entrySize)));
+        m_out.branch(m_out.equal(key, deletedValue), rarely(loop), usually(foundEntry));
+
+        m_out.appendTo(foundEntry, exhausted);
+        m_out.store64(boxInt32(entry), m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex())));
+        ValueFromBlock foundResult = m_out.anchor(storage);
+        m_out.jump(continuation);
+
+        m_out.appendTo(exhausted, slowPath);
+        ValueFromBlock exhaustedResult = m_out.anchor(sentinel);
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowPath, continuation);
+        ValueFromBlock slowResult = m_out.anchor(vmCall(Int64, isMap ? operationMapIterationNext : operationSetIterationNext, m_vmValue, storage, currentEntry));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setJSValue(m_out.phi(Int64, foundResult, exhaustedResult, slowResult));
     }
 
     void compileMapIterationEntry()
     {
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-        LValue storage = lowCell(m_node->child1());
-        auto operation = m_node->bucketOwnerType() == BucketOwnerType::Map ? operationMapIterationEntry : operationSetIterationEntry;
-        LValue result = vmCall(Int64, operation, weakPointer(globalObject), storage);
-        setJSValue(result);
+        bool isMap = m_node->bucketOwnerType() == BucketOwnerType::Map;
+        LValue butterfly = toButterfly(lowCell(m_node->child1()));
+        setJSValue(m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex()))));
+    }
+
+    LValue loadMapEntryData(LValue butterfly, LValue entry, int32_t indexAdjust)
+    {
+        bool isMap = m_node->bucketOwnerType() == BucketOwnerType::Map;
+        LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::capacityIndex() : JSSet::Helper::capacityIndex())));
+
+        LValue multiplied;
+        int32_t hashTableStartIndex;
+        if (isMap) {
+            static_assert(JSMap::Helper::EntrySize == 3);
+            hashTableStartIndex = JSMap::Helper::hashTableStartIndex();
+            multiplied = m_out.add(entry, m_out.shl(entry, m_out.constInt32(1)));
+        } else {
+            static_assert(JSSet::Helper::EntrySize == 2);
+            hashTableStartIndex = JSSet::Helper::hashTableStartIndex();
+            multiplied = m_out.add(entry, entry);
+        }
+        LValue entryInButterfly = m_out.add(m_out.constInt32(hashTableStartIndex + indexAdjust), m_out.add(bucketCount, multiplied));
+        return m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.zeroExtPtr(entryInButterfly)));
+    }
+
+    LValue loadMapIterationEntryData(int32_t dataOffset)
+    {
+        bool isMap = m_node->bucketOwnerType() == BucketOwnerType::Map;
+        LValue butterfly = toButterfly(lowCell(m_node->child1()));
+        LValue entry = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex())));
+        return loadMapEntryData(butterfly, entry, dataOffset);
     }
 
     void compileMapIterationEntryKey()
     {
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-        LValue storage = lowCell(m_node->child1());
-        auto operation = m_node->bucketOwnerType() == BucketOwnerType::Map ? operationMapIterationEntryKey : operationSetIterationEntryKey;
-        LValue result = vmCall(Int64, operation, weakPointer(globalObject), storage);
-        setJSValue(result);
+        setJSValue(loadMapIterationEntryData(0));
     }
 
     void compileMapIterationEntryValue()
     {
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-        LValue storage = lowCell(m_node->child1());
-        LValue result = vmCall(Int64, operationMapIterationEntryValue, weakPointer(globalObject), storage);
-        setJSValue(result);
+        ASSERT(m_node->bucketOwnerType() == BucketOwnerType::Map);
+        setJSValue(loadMapIterationEntryData(1));
     }
 
     void compileMapStorage()
@@ -16800,46 +16880,17 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileMapIteratorKey()
     {
-        bool isMapIterator = m_node->bucketOwnerType() == BucketOwnerType::Map;
-        LValue storage = lowCell(m_node->child1());
+        LValue butterfly = toButterfly(lowCell(m_node->child1()));
         LValue entry = lowInt32(m_node->child2());
-
-        LValue butterfly = toButterfly(storage);
-        LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMapIterator ? JSMap::Helper::capacityIndex() : JSSet::Helper::capacityIndex())));
-
-        LValue multiplied;
-        int32_t entrySize;
-        int32_t hashTableStartIndex;
-        if (isMapIterator) {
-            static_assert(JSMap::Helper::EntrySize == 3);
-            entrySize = JSMap::Helper::EntrySize;
-            hashTableStartIndex = JSMap::Helper::hashTableStartIndex();
-            multiplied = m_out.add(entry, m_out.shl(entry, m_out.constInt32(1)));
-        } else {
-            static_assert(JSSet::Helper::EntrySize == 2);
-            entrySize = JSSet::Helper::EntrySize;
-            hashTableStartIndex = JSSet::Helper::hashTableStartIndex();
-            multiplied = m_out.add(entry, entry);
-        }
-        LValue entryInButterfly = m_out.add(m_out.constInt32(hashTableStartIndex - entrySize), m_out.add(bucketCount, multiplied));
-        LValue key = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.zeroExtPtr(entryInButterfly)));
-        setJSValue(key);
+        setJSValue(loadMapEntryData(butterfly, entry, -(m_node->bucketOwnerType() == BucketOwnerType::Map ? JSMap::Helper::EntrySize : JSSet::Helper::EntrySize)));
     }
 
     void compileMapIteratorValue()
     {
         ASSERT(m_node->bucketOwnerType() == BucketOwnerType::Map);
-        LValue storage = lowCell(m_node->child1());
+        LValue butterfly = toButterfly(lowCell(m_node->child1()));
         LValue entry = lowInt32(m_node->child2());
-
-        LValue butterfly = toButterfly(storage);
-        LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(JSMap::Helper::capacityIndex())));
-
-        static_assert(JSMap::Helper::EntrySize == 3);
-        LValue multiplied = m_out.add(entry, m_out.shl(entry, m_out.constInt32(1)));
-        LValue entryInButterfly = m_out.add(m_out.add(m_out.constInt32(JSMap::Helper::hashTableStartIndex() - JSMap::Helper::EntrySize), m_out.add(bucketCount, multiplied)), /* value offset */ m_out.constInt32(1));
-        LValue value = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.zeroExtPtr(entryInButterfly)));
-        setJSValue(value);
+        setJSValue(loadMapEntryData(butterfly, entry, -JSMap::Helper::EntrySize + /* value offset */ 1));
     }
 
     void compileExtractValueFromWeakMapGet()


### PR DESCRIPTION
#### ce878e190fef3abba29f10243a8454fde765f573
<pre>
[JSC] Inline `Map#forEach` / `Set#forEach` iteration in DFG and FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=322069">https://bugs.webkit.org/show_bug.cgi?id=322069</a>

Reviewed by Yusuke Suzuki.

Map.prototype.forEach and Set.prototype.forEach are JS builtins that walk the
storage with @mapIterationNext, @mapIterationEntry, @mapIterationEntryKey and
@mapIterationEntryValue. The corresponding DFG nodes were lowered to C++ calls
in both DFG and FTL, so every element paid four operation calls whose bodies
are two or three butterfly loads. The for-of siblings (MapIteratorNext,
MapIteratorKey, MapIteratorValue) already walk the same table inline.

Lower the four nodes the same way. MapIterationNext checks for the sentinel,
falls back to the operation only when the table is obsolete, and otherwise
scans the data table for the next non-deleted key and stores its entry index
into the IterationEntry slot. MapIterationEntry is a single load of that
slot, and MapIterationEntryKey/Value compute the data index from it through
loadMapEntryData, which MapIteratorKey/Value now share as well; the for-of
lowering is unchanged.

The Entry/EntryKey/EntryValue operations are no longer reachable from JIT code
and are removed. The remaining IterationNext operations are only called for
obsolete tables, so they no longer handle the sentinel.

                                         Baseline                  Patched

map-for-each                          2.2298+-0.0516     ^      1.7644+-0.0487        ^ definitely 1.2638x faster
map-for-each-key-value               80.3508+-1.3258     ^     48.7157+-1.0237        ^ definitely 1.6494x faster
set-for-each-value                   68.4946+-1.5632     ^     46.6082+-1.1317        ^ definitely 1.4696x faster
set-for-each                          2.0780+-0.0679     ^      1.6924+-0.0448        ^ definitely 1.2278x faster

Tests: JSTests/microbenchmarks/map-for-each-deleted-entries.js
       JSTests/microbenchmarks/map-for-each-key-value.js
       JSTests/microbenchmarks/set-for-each-value.js
       JSTests/stress/map-for-each-mutation-during-iteration.js
       JSTests/stress/set-for-each-mutation-during-iteration.js

* JSTests/microbenchmarks/map-for-each-deleted-entries.js: Added.
(sumEntries):
* JSTests/microbenchmarks/map-for-each-key-value.js: Added.
(sumEntries):
* JSTests/microbenchmarks/set-for-each-value.js: Added.
(sumValues.set forEach):
* JSTests/stress/map-for-each-mutation-during-iteration.js: Added.
(shouldBe):
(makeMap):
(keys):
(deleteAhead):
(deleteAllAhead):
(addDuring):
(clearDuring):
(clearAndReadd):
* JSTests/stress/set-for-each-mutation-during-iteration.js: Added.
(shouldBe):
(set values.set forEach):
(deleteAhead.set forEach):
(deleteAllAhead.set forEach):
(addDuring.set forEach):
(clearDuring.set forEach):
(clearAndReadd.set forEach):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::loadMapEntryData):
(JSC::DFG::SpeculativeJIT::compileMapIteratorKey):
(JSC::DFG::SpeculativeJIT::compileMapIteratorValue):
(JSC::DFG::SpeculativeJIT::compileMapIterationNext):
(JSC::DFG::SpeculativeJIT::compileMapIterationEntry):
(JSC::DFG::SpeculativeJIT::compileMapIterationEntryData):
(JSC::DFG::SpeculativeJIT::compileMapIterationEntryKey):
(JSC::DFG::SpeculativeJIT::compileMapIterationEntryValue):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/319440@main">https://commits.webkit.org/319440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0421649cee62f32cfd70e11a513fdf78e990760

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191634 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145737 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141580 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43934 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42213 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3986 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10804 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41858 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2791 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42687 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193562 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55027 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150982 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40452 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55714 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150688 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45275 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127995 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123596 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54230 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16857 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53612 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53850 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->