### PR TITLE
[SOUP] An Authorization header set by the page is replaced by cached credentials

### DIFF
--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -173,7 +173,8 @@ void NetworkDataTaskSoup::createRequest(ResourceRequest&& request, WasBlockingCo
     messageFlags |= SOUP_MESSAGE_COLLECT_METRICS;
     if (m_shouldContentSniff == ContentSniffingPolicy::DoNotSniffContent)
         soup_message_disable_feature(m_soupMessage.get(), SOUP_TYPE_CONTENT_SNIFFER);
-    if (m_user.isEmpty() && m_password.isEmpty() && m_storedCredentialsPolicy == StoredCredentialsPolicy::DoNotUse) {
+    if ((m_user.isEmpty() && m_password.isEmpty() && m_storedCredentialsPolicy == StoredCredentialsPolicy::DoNotUse)
+        || m_currentRequest.hasHTTPHeaderField(HTTPHeaderName::Authorization)) {
         messageFlags |= SOUP_MESSAGE_DO_NOT_USE_AUTH_CACHE;
     }
     soup_message_set_flags(m_soupMessage.get(), static_cast<SoupMessageFlags>(soup_message_get_flags(m_soupMessage.get()) | messageFlags));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAuthentication.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAuthentication.cpp
@@ -29,6 +29,7 @@ static const char authTestPassword[] = "password";
 static const char authExpectedSuccessTitle[] = "WebKit2Gtk+ Authentication test";
 static const char authExpectedFailureTitle[] = "401 Authorization Required";
 static const char authExpectedAuthorization[] = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="; // Base64 encoding of "username:password".
+static const char authPageAuthorization[] = "Bearer page-token"; // Authorization header set by the page itself.
 static const char authSuccessHTMLString[] =
     "<html>"
     "<head><title>WebKit2Gtk+ Authentication test</title></head>"
@@ -326,6 +327,30 @@ static void testWebViewAuthenticationSuccess(AuthenticationTest* test, gconstpoi
     g_assert_true(test->m_authenticationSucceededReceived);
 }
 
+static void testWebViewAuthenticationPageProvidedAuthorizationHeader(AuthenticationTest* test, gconstpointer)
+{
+    // Authenticate once, so that the credentials end up in the auth cache for the whole domain.
+    test->loadURI(kServer->getURIForPath("/auth-test.html").data());
+    WebKitAuthenticationRequest* request = test->waitForAuthenticationRequest();
+    WebKitCredential* credential = webkit_credential_new(authTestUsername, authTestPassword, WEBKIT_CREDENTIAL_PERSISTENCE_FOR_SESSION);
+    webkit_authentication_request_authenticate(request, credential);
+    webkit_credential_free(credential);
+    test->waitUntilTitleChanged();
+    g_assert_cmpstr(webkit_web_view_get_title(test->webView()), ==, authExpectedSuccessTitle);
+    g_assert_true(test->m_authenticationSucceededReceived);
+
+    // A request that carries its own Authorization header must be sent as-is, even though the
+    // cached credentials would otherwise be used for this domain.
+    GUniqueOutPtr<GError> error;
+    auto* value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished(
+        "const response = await fetch('echo-authorization', { headers: { 'Authorization': 'Bearer page-token' } });"
+        "return await response.text();", nullptr, nullptr, &error.outPtr());
+    g_assert_no_error(error.get());
+    g_assert_nonnull(value);
+    GUniquePtr<char> authorization(WebViewTest::javascriptResultToCString(value));
+    g_assert_cmpstr(authorization.get(), ==, authPageAuthorization);
+}
+
 static void testWebViewAuthenticationEmptyRealm(AuthenticationTest* test, gconstpointer)
 {
     test->loadURI(kServer->getURIForPath("/empty-realm.html").data());
@@ -439,6 +464,10 @@ static void serverCallback(SoupServer* server, SoupServerMessage* message, const
             soup_server_message_set_status(message, isProxy ? SOUP_STATUS_PROXY_AUTHENTICATION_REQUIRED : SOUP_STATUS_UNAUTHORIZED, nullptr);
             soup_message_body_append(responseBody, SOUP_MEMORY_STATIC, authFailureHTMLString, strlen(authFailureHTMLString));
         }
+    } else if (g_str_has_suffix(path, "/echo-authorization")) {
+        const char* authorization = soup_message_headers_get_one(soup_server_message_get_request_headers(message), "Authorization");
+        soup_server_message_set_status(message, SOUP_STATUS_OK, nullptr);
+        soup_message_body_append(responseBody, SOUP_MEMORY_COPY, authorization ? authorization : "", authorization ? strlen(authorization) : 0);
     } else
         soup_server_message_set_status(message, SOUP_STATUS_NOT_FOUND, nullptr);
 
@@ -531,6 +560,7 @@ void beforeAll()
     EphemeralAuthenticationTest::add("Authentication", "authentication-ephemeral", testWebViewAuthenticationEphemeral);
     AuthenticationTest::add("Authentication", "authentication-storage", testWebViewAuthenticationStorage);
     AuthenticationTest::add("Authentication", "authentication-empty-realm", testWebViewAuthenticationEmptyRealm);
+    AuthenticationTest::add("Authentication", "authentication-page-provided-authorization-header", testWebViewAuthenticationPageProvidedAuthorizationHeader);
     ProxyAuthenticationTest::add("Authentication", "authentication-proxy", testWebViewAuthenticationProxy);
     ProxyAuthenticationTest::add("Authentication", "authentication-proxy-https", testWebViewAuthenticationProxyHTTPS);
 }


### PR DESCRIPTION
#### f76f30efcb689ec60174addc19d38b9150b67c69
<pre>
[SOUP] An Authorization header set by the page is replaced by cached credentials
<a href="https://bugs.webkit.org/show_bug.cgi?id=322068">https://bugs.webkit.org/show_bug.cgi?id=322068</a>

Reviewed by Michael Catanzaro.

nce an authentication challenge has been answered for a host, libsoup&apos;s
SoupAuthManager stamps the cached credentials onto every later request in that
protection space, replacing an Authorization header the page had set itself.
The Fetch standard uses the cached credential only &quot;If httpRequest&apos;s header
list does not contain `Authorization`&quot;, and the Cocoa and curl ports already
behave that way.

Set SOUP_MESSAGE_DO_NOT_USE_AUTH_CACHE, libsoup&apos;s per-message opt-out, when the
request already carries an Authorization header. A challenge still reaches the
authentication handler and the retry authenticates as before.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAuthentication.cpp

* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::createRequest):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAuthentication.cpp:
(testWebViewAuthenticationPageProvidedAuthorizationHeader):
(serverCallback):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/319424@main">https://commits.webkit.org/319424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7bb93e378e4b8d976bf6ff2694921e17c790229

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55389 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191665 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55110 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184397 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/49191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122041 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/49191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2825 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/48015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193593 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/55058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/49191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55745 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150711 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45293 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/123627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54261 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/49191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53643 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/53881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->