### PR TITLE
WebCodecsImageDecoder generates VideoFrames with zero durations

### DIFF
--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp
@@ -194,7 +194,7 @@ void WebCodecsImageDecoder::fulfillPendingDecodePromises(size_t frameIndex, RefP
     IntSize frameSize = internalDecoder->frameSizeAtIndex(frameIndex);
 
     WebCodecsVideoFrame::Init init {
-        .duration = static_cast<uint64_t>(internalDecoder->frameDurationAtIndex(frameIndex).value()),
+        .duration = static_cast<uint64_t>(internalDecoder->frameDurationAtIndex(frameIndex).microseconds()),
         .timestamp = std::nullopt,
         .alpha = WebCodecsAlphaOption::Keep,
         .visibleRect = std::nullopt,


### PR DESCRIPTION
#### 7da23e6eff7f6411e94eb393d56eee818d372fca
<pre>
WebCodecsImageDecoder generates VideoFrames with zero durations
<a href="https://bugs.webkit.org/show_bug.cgi?id=322067">https://bugs.webkit.org/show_bug.cgi?id=322067</a>
<a href="https://rdar.apple.com/185257570">rdar://185257570</a>

Reviewed by Jean-Yves Avenard.

According to the spec of VideoFrame[1], the duration of the VideoFrame should be
in microseconds. WebCodecsImageDecoder creates VideoFrames with duration in
seconds. When casting the Second values()to uint64_t, all of them become zeros.

[1] <a href="https://www.w3.org/TR/webcodecs/#videoframe">https://www.w3.org/TR/webcodecs/#videoframe</a>

* Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp:
(WebCore::WebCodecsImageDecoder::fulfillPendingDecodePromises):

Canonical link: <a href="https://commits.webkit.org/319526@main">https://commits.webkit.org/319526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/059cc9ab84d319da4e7bf2e90fbd7ea9e3a6be18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145742 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55084 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141585 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98237 "1 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e8454053-dd75-4d6a-aa84-4922774a5f2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122025 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43943 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42215 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41861 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2796 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193567 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55032 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40504 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55719 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38484 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150691 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45270 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128000 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123601 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54235 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16860 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53617 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53855 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53682 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->