### PR TITLE
Cache InlineTextItem widths per inline text box content to speed up retrieving cached widths

### DIFF
--- a/LayoutTests/fast/inline/inline-item-width-cache-stale-after-font-cache-invalidation-expected.txt
+++ b/LayoutTests/fast/inline/inline-item-width-cache-stale-after-font-cache-invalidation-expected.txt
@@ -1,0 +1,3 @@
+aaaa bbbb cccc dddd eeee
+PASS the accessibility bold system font measures differently from the normal system font.
+PASS the width measured after the font cache invalidation does not come from a stale cache.

--- a/LayoutTests/fast/inline/inline-item-width-cache-stale-after-font-cache-invalidation.html
+++ b/LayoutTests/fast/inline/inline-item-width-cache-stale-after-font-cache-invalidation.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inline item widths cached per font cascade must not survive a font cache invalidation</title>
+<style>
+#container {
+    width: 900px;
+    font-family: system-ui;
+    font-size: 20px;
+}
+</style>
+</head>
+<body>
+<div id="container"><span id="text">aaaa bbbb cccc dddd eeee</span></div>
+<pre id="log"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+const results = [];
+
+function rebuildInlineItemsAndMeasure()
+{
+    container.style.display = "none";
+    document.body.offsetHeight;
+    container.style.display = "";
+    document.body.offsetHeight;
+    return text.getBoundingClientRect().width;
+}
+
+if (!window.internals)
+    results.push("FAIL this test requires window.internals.");
+else {
+    internals.settings.setShouldMockBoldSystemFontForAccessibility(false);
+    const normalWidth = rebuildInlineItemsAndMeasure();
+
+    internals.settings.setShouldMockBoldSystemFontForAccessibility(true);
+    const widthFromCache = rebuildInlineItemsAndMeasure();
+
+    internals.releaseMemoryNow();
+    const widthMeasuredFresh = rebuildInlineItemsAndMeasure();
+
+    results.push(widthMeasuredFresh !== normalWidth
+        ? "PASS the accessibility bold system font measures differently from the normal system font."
+        : "FAIL inconclusive: the accessibility bold system font measures the same as the normal system font (" + normalWidth + ").");
+
+    results.push(widthFromCache === widthMeasuredFresh
+        ? "PASS the width measured after the font cache invalidation does not come from a stale cache."
+        : "FAIL stale cached widths were reused: got " + widthFromCache + ", expected " + widthMeasuredFresh + " (the width before the invalidation was " + normalWidth + ").");
+}
+
+log.textContent = results.join("\n");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3986,6 +3986,7 @@ webkit.org/b/168430 fast/inline/outline-corners-with-offset.html [ ImageOnlyFail
 webkit.org/b/258146 fast/inline/box-decoration-clone-with-padding-end.html [ ImageOnlyFailure ]
 webkit.org/b/258149 fast/inline/line-clamp-with-max-height-overflow.html [ ImageOnlyFailure ]
 webkit.org/b/304002 fast/inline/missing-content-on-autofill-with-out-of-flow-input-descendant.html [ Skip ]
+webkit.org/b/322063 fast/inline/inline-item-width-cache-stale-after-font-cache-invalidation.html [ Skip ]
 webkit.org/b/168551 http/tests/misc/slow-loading-animated-image.html [ ImageOnlyFailure ]
 webkit.org/b/168719 fast/css/paint-order-shadow.html [ ImageOnlyFailure ]
 webkit.org/b/169909 fast/css-generated-content/initial-letter-pagination-sunken.html [ ImageOnlyFailure ]

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -27,6 +27,7 @@
 #include "InlineItemsBuilder.h"
 
 #include "FontCascade.h"
+#include "FontCascadeCache.h"
 #include "FontCascadeFonts.h"
 #include "InlineFormattingUtils.h"
 #include "FontCascadeInlines.h"
@@ -894,6 +895,24 @@ static inline bool canCacheWidthOnInlineTextItem(const InlineTextBox& inlineText
     return !inlineTextBox.hasPositionDependentContentWidth();
 }
 
+static bool textBoxMayHaveGlyphOverflow(const InlineTextBox& inlineTextBox)
+{
+    CheckedRef fontCascade = inlineTextBox.style().fontCascade();
+    return !inlineTextBox.canUseSimpleFontCodePath() || fontCascade->primaryFont().origin() == FontOrigin::Remote;
+}
+
+static bool inlineTextBoxWidthsAreCacheable(const InlineTextBox& inlineTextBox, bool contentMayAdjustWidths, bool mayHaveGlyphOverflow)
+{
+    if (contentMayAdjustWidths || mayHaveGlyphOverflow || !canCacheWidthOnInlineTextItem(inlineTextBox, false))
+        return false;
+    return inlineTextBox.canUseSimplifiedContentMeasuring();
+}
+
+static FontCascadeCacheKey fontCascadeIdentifier(const FontCascade& fontCascade)
+{
+    return makeFontCascadeCacheKey(fontCascade.fontDescription(), protect(fontCascade.fontSelector()));
+}
+
 static void handleTextSpacing(TextSpacing::SpacingState& spacingState, TrimmableTextSpacings& trimmableTextSpacings, const InlineTextItem& inlineTextItem, size_t inlineItemIndex)
 {
     auto autospace = inlineTextItem.style().textAutospace();
@@ -940,7 +959,7 @@ void InlineItemsBuilder::computeInlineTextItemWidthsAndTextSpacing(InlineItemLis
                 auto width = InlineLayoutUnit { };
                 auto mayHaveGlyphOverflow = [&] {
                     if (currentInlineTextBox != &inlineTextItem->inlineTextBox()) {
-                        currentInlineTextBoxMayHaveGlyphOverflow = !inlineTextItem->inlineTextBox().canUseSimpleFontCodePath() || fontCascade->primaryFont().origin() == FontOrigin::Remote;
+                        currentInlineTextBoxMayHaveGlyphOverflow = textBoxMayHaveGlyphOverflow(inlineTextItem->inlineTextBox());
                         currentInlineTextBox = &inlineTextItem->inlineTextBox();
                     }
                     return currentInlineTextBoxMayHaveGlyphOverflow;
@@ -966,9 +985,11 @@ void InlineItemsBuilder::computeInlineTextItemWidthsAndTextSpacing(InlineItemLis
 bool InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache(const InlineTextBox& inlineTextBox, InlineItemList& inlineItemList)
 {
     auto& text = inlineTextBox.content();
-    auto* breakingPositions = TextBreakingPositionCache::singleton().get({ text, { inlineTextBox.style() }, m_securityOrigin.data() });
-    if (!breakingPositions)
+    TextBreakingPositionCache::Key cacheKey { text, { inlineTextBox.style() }, m_securityOrigin.data() };
+    auto* cacheEntry = TextBreakingPositionCache::singleton().get(cacheKey);
+    if (!cacheEntry)
         return false;
+    auto& breakingPositions = cacheEntry->breakingPositions;
 
     auto shouldPreserveNewline = TextUtil::shouldPreserveNewline(inlineTextBox);
     auto shouldPreserveSpacesAndTabs = TextUtil::shouldPreserveSpacesAndTabs(inlineTextBox);
@@ -981,11 +1002,34 @@ bool InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache(co
     CheckedRef fontCascade = style->fontCascade();
     auto [ deferNonWhitespaceMeasurement, deferWhitespaceMeasurement ] = shouldDeferTextMeasurement(inlineTextBox);
     auto singleSpaceWidth = !deferWhitespaceMeasurement ? std::optional(std::max(0.f, TextUtil::singleSpaceWidth(fontCascade.get(), inlineTextBox.canUseSimplifiedContentMeasuring()))) : std::nullopt;
-    auto mayHaveGlyphOverflow = !inlineTextBox.canUseSimpleFontCodePath() || fontCascade->primaryFont().origin() == FontOrigin::Remote;
+    auto mayHaveGlyphOverflow = textBoxMayHaveGlyphOverflow(inlineTextBox);
 
-    inlineItemList.reserveCapacity(inlineItemList.size() + breakingPositions->size());
-    size_t previousPosition = 0;
-    for (auto endPosition : *breakingPositions) {
+    auto widthCacheEligible = inlineTextBoxWidthsAreCacheable(inlineTextBox, contentRequiresVisualReordering() || m_hasTextAutospace, mayHaveGlyphOverflow);
+    std::optional<FontCascadeCacheKey> widthCacheFontCascadeIdentifier;
+    const TextBreakingPositionCache::WidthList* cachedWidths = nullptr;
+    TextBreakingPositionCache::WidthList measuredWidths;
+    if (widthCacheEligible) {
+        widthCacheFontCascadeIdentifier = fontCascadeIdentifier(fontCascade);
+        cachedWidths = TextBreakingPositionCache::singleton().widths(*cacheEntry, *widthCacheFontCascadeIdentifier);
+    }
+    size_t nonWhitespaceIndex = 0;
+
+    auto nonWhitespaceItemWidth = [&](unsigned startPosition, unsigned endPosition) -> WidthAndGlyphOverflow {
+        if (cachedWidths && nonWhitespaceIndex < cachedWidths->size()) {
+            auto cachedWidth = (*cachedWidths)[nonWhitespaceIndex];
+            ASSERT(cachedWidth == nonWhitespaceContentWidth(inlineTextBox, startPosition, endPosition, mayHaveGlyphOverflow).width);
+            ASSERT(!mayHaveGlyphOverflow);
+            return { cachedWidth, { } };
+        }
+        auto measured = nonWhitespaceContentWidth(inlineTextBox, startPosition, endPosition, mayHaveGlyphOverflow);
+        if (widthCacheEligible && !cachedWidths)
+            measuredWidths.append(measured.width);
+        return measured;
+    };
+
+    inlineItemList.reserveCapacity(inlineItemList.size() + breakingPositions.size());
+    unsigned previousPosition = 0;
+    for (auto endPosition : breakingPositions) {
         auto startPosition = std::exchange(previousPosition, endPosition);
         if (endPosition > contentLength || startPosition >= endPosition) {
             ASSERT_NOT_REACHED();
@@ -1019,13 +1063,18 @@ bool InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache(co
         ASSERT(endPosition);
         auto hasTrailingSoftHyphen = text[endPosition - 1] == softHyphen;
         auto length = endPosition - startPosition;
-        if (deferNonWhitespaceMeasurement || !length)
+        if (deferNonWhitespaceMeasurement || !length) {
             inlineItemList.append(InlineTextItem::createNonWhitespaceItem(inlineTextBox, startPosition, length, UBIDI_DEFAULT_LTR, hasTrailingSoftHyphen));
-        else {
-            auto widthAndGlyphOverflow = nonWhitespaceContentWidth(inlineTextBox, startPosition, endPosition, mayHaveGlyphOverflow);
-            inlineItemList.append(InlineTextItem::createNonWhitespaceItem(inlineTextBox, startPosition, length, UBIDI_DEFAULT_LTR, hasTrailingSoftHyphen, widthAndGlyphOverflow.width, widthAndGlyphOverflow.topBottomOverflow));
+            continue;
         }
+        auto [width, topBottomOverflow] = nonWhitespaceItemWidth(startPosition, endPosition);
+        inlineItemList.append(InlineTextItem::createNonWhitespaceItem(inlineTextBox, startPosition, length, UBIDI_DEFAULT_LTR, hasTrailingSoftHyphen, width, topBottomOverflow));
+        ++nonWhitespaceIndex;
     }
+
+    if (widthCacheEligible && !cachedWidths && !measuredWidths.isEmpty())
+        TextBreakingPositionCache::singleton().addWidths(cacheKey, *widthCacheFontCascadeIdentifier, WTF::move(measuredWidths));
+
     return true;
 }
 
@@ -1051,7 +1100,7 @@ void InlineItemsBuilder::handleTextContent(const InlineTextBox& inlineTextBox, I
     CheckedRef style = inlineTextBox.style();
     CheckedRef fontCascade = style->fontCascade();
     auto [ deferNonWhitespaceMeasurement, deferWhitespaceMeasurement ] = shouldDeferTextMeasurement(inlineTextBox);
-    auto mayHaveGlyphOverflow = !inlineTextBox.canUseSimpleFontCodePath() || fontCascade->primaryFont().origin() == FontOrigin::Remote;
+    auto mayHaveGlyphOverflow = textBoxMayHaveGlyphOverflow(inlineTextBox);
     auto singleSpaceWidth = !deferWhitespaceMeasurement ? std::optional(std::max(0.f, TextUtil::singleSpaceWidth(fontCascade.get(), inlineTextBox.canUseSimplifiedContentMeasuring()))) : std::nullopt;
     auto shouldPreserveSpacesAndTabs = TextUtil::shouldPreserveSpacesAndTabs(inlineTextBox);
     auto shouldPreserveNewline = TextUtil::shouldPreserveNewline(inlineTextBox);
@@ -1193,7 +1242,25 @@ void InlineItemsBuilder::handleInlineLevelBox(const Box& layoutBox, InlineItemLi
     ASSERT_NOT_REACHED();
 }
 
-void InlineItemsBuilder::populateBreakingPositionCache(const InlineItemList& inlineItemList, const Document& document)
+static TextBreakingPositionCache::WidthList collectWidthsFromBuiltItems(const InlineTextBox& inlineTextBox, std::span<const InlineItem> span, bool contentMayAdjustWidths)
+{
+    if (!inlineTextBoxWidthsAreCacheable(inlineTextBox, contentMayAdjustWidths, textBoxMayHaveGlyphOverflow(inlineTextBox)))
+        return { };
+
+    TextBreakingPositionCache::WidthList widths;
+    for (auto& inlineItem : span) {
+        auto* textItem = dynamicDowncast<InlineTextItem>(inlineItem);
+        if (!textItem || textItem->isWhitespace())
+            continue;
+        auto width = textItem->width();
+        if (!width)
+            return { };
+        widths.append(*width);
+    }
+    return widths;
+}
+
+void InlineItemsBuilder::populateBreakingPositionCache(const InlineItemList& inlineItemList, const Document& document, bool contentMayAdjustWidths)
 {
     if (inlineItemList.size() < TextBreakingPositionCache::minimumRequiredContentBreaks)
         return;
@@ -1255,8 +1322,15 @@ void InlineItemsBuilder::populateBreakingPositionCache(const InlineItemList& inl
         }
 
         ASSERT(!breakingPositionList.isEmpty());
-        if (breakingPositionList.size() >= TextBreakingPositionCache::minimumRequiredContentBreaks)
-            breakingPositionCache.set({ inlineTextBox->content(), context, securityOrigin->data() }, WTF::move(breakingPositionList));
+        if (breakingPositionList.size() >= TextBreakingPositionCache::minimumRequiredContentBreaks) {
+            auto widths = collectWidthsFromBuiltItems(*inlineTextBox, span, contentMayAdjustWidths);
+            TextBreakingPositionCache::Key key { inlineTextBox->content(), context, securityOrigin->data() };
+            breakingPositionCache.set(key, WTF::move(breakingPositionList));
+            if (!widths.isEmpty()) {
+                CheckedRef fontCascade = inlineTextBox->style().fontCascade();
+                breakingPositionCache.addWidths(key, fontCascadeIdentifier(fontCascade), WTF::move(widths));
+            }
+        }
         index += span.size();
     }
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h
@@ -47,7 +47,7 @@ public:
     InlineItemsBuilder(InlineContentCache&, const ElementBox& root, const SecurityOrigin&);
     void build(InlineItemPosition startPosition);
 
-    static void populateBreakingPositionCache(const InlineItemList&, const Document&);
+    static void populateBreakingPositionCache(const InlineItemList&, const Document&, bool contentMayAdjustWidths);
 
 private:
     void collectInlineItems(InlineItemList&, InlineItemPosition startPosition);

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "TextBreakingPositionCache.h"
 
+#include "FontCache.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -33,8 +34,9 @@ namespace WebCore {
 namespace Layout {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextBreakingPositionCache);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextBreakingPositionCache::Entry);
 
-static constexpr size_t evictionSoftThreshold = 500000; // At this amount of content (string + breaking position list) we should start evicting
+static constexpr size_t evictionSoftThreshold = 500000; // At this amount of content (string + breaking position list + width lists) we should start evicting
 static constexpr size_t evictionHardCapMultiplier = 5; // Do not let the cache grow beyond this
 static constexpr Seconds idleIntervalForEviction { 10_s };
 
@@ -49,11 +51,75 @@ TextBreakingPositionCache::TextBreakingPositionCache()
 {
 }
 
+static size_t widthsBytes(const TextBreakingPositionCache::Entry& entry)
+{
+    size_t bytes = 0;
+    for (auto& cascadeWidths : entry.widthsByFontCascade)
+        bytes += sizeof(float) * cascadeWidths.widths.size() + sizeof(FontCascadeCacheKey);
+    return bytes;
+}
+
+bool TextBreakingPositionCache::clearWidthsIfGenerationChanged()
+{
+    auto currentGeneration = FontCache::forCurrentThread().generation();
+    if (m_widthsGeneration == currentGeneration)
+        return false;
+    m_widthsGeneration = currentGeneration;
+    for (auto& entry : m_breakingPositionMap.values()) {
+        m_cachedContentSize -= widthsBytes(*entry);
+        entry->widthsByFontCascade.clear();
+    }
+    return true;
+}
+
+const TextBreakingPositionCache::WidthList* TextBreakingPositionCache::widths(const Entry& entry, const FontCascadeCacheKey& fontCascade)
+{
+    if (clearWidthsIfGenerationChanged())
+        return nullptr;
+
+    for (auto& cascadeWidths : entry.widthsByFontCascade) {
+        if (cascadeWidths.fontCascade == fontCascade)
+            return &cascadeWidths.widths;
+    }
+    return nullptr;
+}
+
+void TextBreakingPositionCache::addWidths(const Key& key, const FontCascadeCacheKey& fontCascade, WidthList&& widthList)
+{
+    auto iterator = m_breakingPositionMap.find(key);
+    if (iterator == m_breakingPositionMap.end())
+        return;
+    auto& entry = *iterator->value;
+
+    ASSERT(m_cachedContentSize >= widthsBytes(entry));
+    m_cachedContentSize -= widthsBytes(entry);
+
+    auto replaced = false;
+    for (auto& cascadeWidths : entry.widthsByFontCascade) {
+        if (cascadeWidths.fontCascade == fontCascade) {
+            cascadeWidths.widths = WTF::move(widthList);
+            replaced = true;
+            break;
+        }
+    }
+    if (!replaced)
+        entry.widthsByFontCascade.append(Entry::FontCascadeWidths { fontCascade, WTF::move(widthList) });
+
+    m_cachedContentSize += widthsBytes(entry);
+}
+
+size_t TextBreakingPositionCache::approximateEntrySizeBytes(const String& text, const Entry& entry)
+{
+    return text.length() + sizeof(unsigned) * entry.breakingPositions.size() + widthsBytes(entry);
+}
+
 void TextBreakingPositionCache::evict()
 {
     while (m_cachedContentSize > evictionSoftThreshold && !m_breakingPositionMap.isEmpty()) {
         auto evictedEntry = m_breakingPositionMap.random();
-        m_cachedContentSize -= (std::get<0>(evictedEntry->key).length() + 4 * evictedEntry->value.size());
+        auto entrySize = approximateEntrySizeBytes(std::get<0>(evictedEntry->key), *evictedEntry->value);
+        ASSERT(m_cachedContentSize >= entrySize);
+        m_cachedContentSize -= entrySize;
         m_breakingPositionMap.remove(evictedEntry->key);
     }
 }
@@ -76,16 +142,17 @@ void TextBreakingPositionCache::set(const Key& key, List&& breakingPositionList)
     };
     evictIfNeeded();
 
-    m_cachedContentSize += (std::get<0>(key).length() + 4 * breakingPositionList.size());
-    m_breakingPositionMap.set(key, WTF::move(breakingPositionList));
+    auto entry = makeUnique<Entry>(WTF::move(breakingPositionList));
+    m_cachedContentSize += approximateEntrySizeBytes(std::get<0>(key), *entry);
+    m_breakingPositionMap.set(key, WTF::move(entry));
 }
 
-const TextBreakingPositionCache::List* TextBreakingPositionCache::get(const Key& key) const
+const TextBreakingPositionCache::Entry* TextBreakingPositionCache::get(const Key& key) const
 {
     auto iterator = m_breakingPositionMap.find(key);
     if (iterator == m_breakingPositionMap.end())
-        return { };
-    return &iterator->value;
+        return nullptr;
+    return iterator->value.get();
 }
 
 void TextBreakingPositionCache::clear()

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Document.h"
+#include "FontCascadeCache.h"
 #include "SecurityOriginData.h"
 #include "TextBreakingPositionContext.h"
 #include "Timer.h"
@@ -46,19 +47,42 @@ public:
     TextBreakingPositionCache();
 
     using Key = std::tuple<String, TextBreakingPositionContext, SecurityOriginData>;
-    using List = Vector<size_t, 8>;
+    using List = Vector<unsigned, 8>;
+    using WidthList = Vector<float>;
+
+    struct Entry {
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(Entry);
+
+        explicit Entry(List&& positions)
+            : breakingPositions(WTF::move(positions))
+        { }
+
+        const List breakingPositions;
+
+        struct FontCascadeWidths {
+            FontCascadeCacheKey fontCascade;
+            WidthList widths;
+        };
+        Vector<FontCascadeWidths> widthsByFontCascade;
+    };
+
     void set(const Key&, List&& breakingPositionList);
-    const List* get(const Key&) const;
+    const Entry* get(const Key&) const;
+    const WidthList* widths(const Entry&, const FontCascadeCacheKey&);
+    void addWidths(const Key&, const FontCascadeCacheKey&, WidthList&&);
 
     void clear();
 
 private:
     void evict();
+    bool clearWidthsIfGenerationChanged();
+    static size_t approximateEntrySizeBytes(const String& text, const Entry&);
 
 private:
-    using TextBreakingPositionMap = HashMap<Key, List>;
+    using TextBreakingPositionMap = HashMap<Key, std::unique_ptr<Entry>>;
     TextBreakingPositionMap m_breakingPositionMap;
     size_t m_cachedContentSize { 0 };
+    unsigned short m_widthsGeneration { 0 };
     Timer m_delayedEvictionTimer;
 };
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -218,8 +218,11 @@ LineLayout::~LineLayout()
             return false;
         return !m_inlineContentCache.inlineItems().isPopulatedFromCache();
     };
-    if (shouldPopulateBreakingPositionCache())
-        Layout::InlineItemsBuilder::populateBreakingPositionCache(m_inlineContentCache.inlineItems().content(), protect(rootRenderer->document()));
+    if (shouldPopulateBreakingPositionCache()) {
+        auto& inlineItems = m_inlineContentCache.inlineItems();
+        auto contentMayAdjustWidths = inlineItems.requiresVisualReordering() || inlineItems.hasTextAutospace();
+        Layout::InlineItemsBuilder::populateBreakingPositionCache(inlineItems.content(), protect(rootRenderer->document()), contentMayAdjustWidths);
+    }
 
     auto prepareAndDetachInlineContent = [&] {
         if (!m_inlineContent)

--- a/Source/WebCore/platform/graphics/FontCascadeCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.cpp
@@ -101,7 +101,7 @@ void FontCascadeCache::pruneSystemFallbackFonts()
         Ref { entry->fonts }->pruneSystemFallbacks();
 }
 
-static FontCascadeCacheKey makeFontCascadeCacheKey(const FontCascadeDescription& description, FontSelector* fontSelector)
+FontCascadeCacheKey makeFontCascadeCacheKey(const FontCascadeDescription& description, FontSelector* fontSelector)
 {
     unsigned familyCount = description.familyCount();
     auto hasComplexFontSelector = fontSelector && !fontSelector->isSimpleFontSelectorForDescription();

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -233,6 +233,8 @@ inline void add(Hasher& hasher, const FontCascadeCacheKey& key)
     add(hasher, key.fontDescriptionKey, key.families, key.fontSelectorId, key.fontSelectorVersion);
 }
 
+FontCascadeCacheKey makeFontCascadeCacheKey(const FontCascadeDescription&, FontSelector*);
+
 struct FontCascadeCacheEntry {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(FontCascadeCacheEntry);
 


### PR DESCRIPTION
#### b0212ef741e072bf886c5d5a065875245e072a18
<pre>
Cache InlineTextItem widths per inline text box content to speed up retrieving cached widths
<a href="https://bugs.webkit.org/show_bug.cgi?id=322063">https://bugs.webkit.org/show_bug.cgi?id=322063</a>
<a href="https://rdar.apple.com/184939583">rdar://184939583</a>

Reviewed by Alan Baradlay.

On relayout, we rebuild the InlineItemsList using the TextBreakingPositionCache. We
already utilize the glyphGeometryCache to retrieve the cached width of an inlineTextBox&apos;s
content that we have seen before and it already has a high hit rate. However, we query
this cache essentially per word. The overhead of retrieving the cached width for workloads
with large amounts of text can be significant. To speed up the performance of retrieving
cached widths, change the value of TextBreakingPositionCache to also hold a list, where
each element is for each FontCascade of the keyed text content, and each of these elements
holds a list of non-whitespace widths.

When we populate the TextBreakingPositionCache for the first time or rebuild the
inlineItemList using the TextBreakingPositionCache and don&apos;t already have an entry for the
cached widths, populate the cache with all the non whitespace widths for a given inline
text box. Then, when we rebuild the InlineItems list during relayout and use the
TextBreakingPositionCache, use the list of cached widths to avoid calling
TextUtil::width() (and its per-word glyphGeometryCache lookup) for each InlineTextItem.
This improves locality of fetching and reading the cached widths compared to just using
glyphGeometryCache. The glyphGeometryCache is still used as fallback if the cached widths
lookup misses.

* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::textBoxMayHaveGlyphOverflow):
(WebCore::Layout::inlineTextBoxWidthsAreCacheable):
(WebCore::Layout::fontCascadeIdentifier):
(WebCore::Layout::InlineItemsBuilder::computeInlineTextItemWidthsAndTextSpacing):
(WebCore::Layout::InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache):
(WebCore::Layout::InlineItemsBuilder::handleTextContent):
(WebCore::Layout::collectWidthsFromBuiltItems):
(WebCore::Layout::InlineItemsBuilder::populateBreakingPositionCache):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.cpp:
(WebCore::Layout::TextBreakingPositionCache::Entry::widths const):
(WebCore::Layout::widthsBytes):
(WebCore::Layout::TextBreakingPositionCache::addWidths):
(WebCore::Layout::TextBreakingPositionCache::approximateEntrySizeBytes):
(WebCore::Layout::TextBreakingPositionCache::evict):
(WebCore::Layout::TextBreakingPositionCache::set):
(WebCore::Layout::TextBreakingPositionCache::get const):
(WebCore::Layout::TextBreakingPositionCache::clearWidthsIfGenerationChanged):
(WebCore::Layout::TextBreakingPositionCache::widths):
* Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.h:
(WebCore::Layout::TextBreakingPositionCache::Entry::Entry):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::~LineLayout):
* Source/WebCore/platform/graphics/FontCascadeCache.cpp:
(WebCore::makeFontCascadeCacheKey):
* Source/WebCore/platform/graphics/FontCascadeCache.h:
* LayoutTests/fast/inline/inline-item-width-cache-stale-after-font-cache-invalidation-expected.txt: Added.
* LayoutTests/fast/inline/inline-item-width-cache-stale-after-font-cache-invalidation.html: Added.
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/319820@main">https://commits.webkit.org/319820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/def43da435d1e71f0ce385dd2af262d44fe915bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193079 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/147150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4282bc9e-5566-48de-b7eb-e45fdd874833) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56520 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/147150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/153f6c76-f657-4eb4-ad87-ce1d657c6841) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46440 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/163488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123155 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45132 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/43382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43017 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4252 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49432 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/47645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195020 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162982 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/152180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40767 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57159 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151877 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46442 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/129428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125510 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55667 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/18027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55038 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55275 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->