### PR TITLE
[list-marker] Lay bullet markers out as marker text so they take part in inline layout

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -65,6 +65,11 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
     if (from == to)
         return 0;
 
+    if (inlineTextBox.hasSynthesizedGlyph()) {
+        // The glyph the counter style's character would draw is not used: TextBoxPainter draws in its place, sized from the font metrics, and reserving that same size here keeps the two in step.
+        return (fontCascade.metricsOfPrimaryFont().intAscent() * 2 / 3 + 1) / 2 + 2;
+    }
+
     if (inlineTextBox.isCombined())
         return fontCascade.size();
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -243,6 +243,12 @@ static EnumSet<Layout::ElementBox::ListMarkerAttribute> calculateListMarkerAttri
     return listMarkerAttributes;
 }
 
+static bool markerTextSynthesizesGlyph(const RenderText& textRenderer)
+{
+    CheckedPtr marker = dynamicDowncast<RenderListMarker>(textRenderer.parent()->parent());
+    return marker && marker->synthesizesGlyph();
+}
+
 UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
 {
     std::unique_ptr<Style::ComputedStyle> firstLineStyle = firstLineStyleFor(renderer);
@@ -287,6 +293,8 @@ UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
             contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasPositionDependentContentWidth);
         if (*hasStrongDirectionalityContent)
             contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasStrongDirectionalityContent);
+        if (markerTextSynthesizesGlyph(*textRenderer))
+            contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasSynthesizedGlyph);
 
         return makeUniqueRef<Layout::InlineTextBox>(text, isCombinedText, contentCharacteristic, WTF::move(style), WTF::move(firstLineStyle));
     }
@@ -368,6 +376,8 @@ static void updateContentCharacteristic(const RenderText& rendererText, Layout::
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasPositionDependentContentWidth);
     if (inlineTextBox.hasStrongDirectionalityContent())
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasStrongDirectionalityContent);
+    if (inlineTextBox.hasSynthesizedGlyph())
+        contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasSynthesizedGlyph);
 
     if (inlineTextBox.canUseSimpleFontCodePath() && Layout::TextUtil::canUseSimplifiedTextMeasuring(inlineTextBox.content(), rendererStyle->fontCascade(), rendererStyle->collapseWhiteSpace(), &rendererText.firstLineStyle()))
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::CanUseSimplifiedContentMeasuring);
@@ -433,6 +443,8 @@ void BoxTreeUpdater::updateContent(const RenderText& textRenderer)
     }
     if (*hasStrongDirectionalityContent)
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasStrongDirectionalityContent);
+    if (markerTextSynthesizesGlyph(textRenderer))
+        contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasSynthesizedGlyph);
 
     inlineTextBox->setContent(text, contentCharacteristic);
 }

--- a/Source/WebCore/layout/layouttree/LayoutInlineTextBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutInlineTextBox.h
@@ -42,7 +42,8 @@ public:
         CanUseSimpleFontCodepath,
         ShouldUseSimpleGlyphOverflowCodePath,
         HasPositionDependentContentWidth,
-        HasStrongDirectionalityContent
+        HasStrongDirectionalityContent,
+        HasSynthesizedGlyph // A list marker's disc, circle or square: the text is the character the counter style produced.
     };
     InlineTextBox(String, bool isCombined, EnumSet<ContentCharacteristic>, Style::ComputedStyle&&, std::unique_ptr<Style::ComputedStyle>&& firstLineStyle = nullptr);
     virtual ~InlineTextBox() = default;
@@ -55,6 +56,7 @@ public:
     bool shouldUseSimpleGlyphOverflowCodePath() const { return m_contentCharacteristicSet.contains(ContentCharacteristic::ShouldUseSimpleGlyphOverflowCodePath); }
     bool hasPositionDependentContentWidth() const { return m_contentCharacteristicSet.contains(ContentCharacteristic::HasPositionDependentContentWidth); }
     bool hasStrongDirectionalityContent() const { return m_contentCharacteristicSet.contains(ContentCharacteristic::HasStrongDirectionalityContent); }
+    bool hasSynthesizedGlyph() const { return m_contentCharacteristicSet.contains(ContentCharacteristic::HasSynthesizedGlyph); }
 
     void setContent(String newContent, EnumSet<ContentCharacteristic>);
     void setContentCharacteristic(EnumSet<ContentCharacteristic> contentCharacteristicSet) { m_contentCharacteristicSet = contentCharacteristicSet; }

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -37,6 +37,7 @@
 #include "GraphicsContext.h"
 #include "InlineIteratorBoxInlines.h"
 #include "PaintInfoInlines.h"
+#include "PseudoElement.h"
 #include "RenderBlockFlow.h"
 #include "RenderBlockInlines.h"
 #include "RenderBoxInlines.h"
@@ -174,7 +175,7 @@ static bool counterStyleChainHasStrongDirectionalitySymbols(const CSSRegisteredC
 
 bool RenderListMarker::textNeedsBidiResolution() const
 {
-    if (hasContentProperty() || isImage() || drawsBulletShape() || style().listStyleType().isNone())
+    if (hasContentProperty() || isImage() || synthesizesGlyph() || style().listStyleType().isNone())
         return false;
 
     if (auto markerString = style().listStyleType().tryString())
@@ -192,7 +193,7 @@ bool RenderListMarker::textNeedsBidiResolution() const
 
 bool RenderListMarker::needsContentContainer() const
 {
-    return hasContentProperty() || textNeedsBidiResolution();
+    return hasContentProperty() || textNeedsBidiResolution() || synthesizesGlyph();
 }
 
 RenderBlockFlow* RenderListMarker::contentContainer() const
@@ -268,7 +269,6 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
         return;
     }
 
-    // The bespoke bullet/text/image painting below only applies to the foreground and accessibility phases.
     if (paintInfo.phase != PaintPhase::Foreground && paintInfo.phase != PaintPhase::Accessibility)
         return;
 
@@ -309,17 +309,6 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
     context.setStrokeStyle(StrokeStyle::SolidStroke);
     context.setStrokeThickness(1.0f);
     context.setFillColor(color);
-
-    if (drawsBulletShape()) {
-        auto listStyleType = style().listStyleType();
-        if (listStyleType.isDisc())
-            context.fillEllipse(markerRect);
-        else if (listStyleType.isCircle())
-            context.strokeEllipse(markerRect);
-        else
-            context.fillRect(markerRect);
-        return;
-    }
 
     if (m_textContent.isEmpty())
         return;
@@ -424,7 +413,7 @@ void RenderListMarker::layoutContentContainer(RenderBlockFlow& container)
     auto contentBaseline = container.firstLineBaseline().value_or(container.logicalHeight());
     container.setLogicalTop(markerAscent - contentBaseline);
 
-    if (textNeedsBidiResolution()) {
+    if (textNeedsBidiResolution() || synthesizesGlyph()) {
         setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
         m_layoutBounds = layoutBoundForTextContent(m_textContent.textWithSuffix);
     } else {
@@ -448,9 +437,12 @@ void RenderListMarker::imageChanged(WrappedImagePtr o, const IntRect* rect)
         RefPtr image = m_image;
         if (image && o == image->data()) {
             if (image->errorOccurred()) {
-                // A failed image turns this into a text marker, and that text may need content subtree.
-                if (RefPtr element = m_listItem ? m_listItem->element() : nullptr)
-                    element->invalidateStyle();
+                // A failed image turns this into a text marker, and that text needs renderers the marker was not built with.
+                RefPtr element = m_listItem ? m_listItem->element() : nullptr;
+                if (RefPtr pseudoElement = dynamicDowncast<PseudoElement>(element.get()))
+                    element = pseudoElement->hostElement();
+                if (element)
+                    element->invalidateStyleAndRenderersForSubtree();
             }
             if (borderBoxWidth() != image->imageSize(this, style().usedZoom()).width() || borderBoxHeight() != image->imageSize(this, style().usedZoom()).height() || image->errorOccurred())
                 setNeedsLayoutAndInvalidateContentLogicalWidths();
@@ -518,7 +510,7 @@ void RenderListMarker::updateContent()
 
     // The marker text is only known here (counter values resolve at layout), while the renderers
     // holding it were created from style. Push the text down so the inline formatting context has something to lay out.
-    if (textNeedsBidiResolution())
+    if (textNeedsBidiResolution() || synthesizesGlyph())
         updateContentContainerText();
 }
 
@@ -533,6 +525,11 @@ void RenderListMarker::updateContentContainerText()
     CheckedPtr textRenderer = dynamicDowncast<RenderText>(container->firstChild());
     if (!textRenderer) {
         ASSERT_NOT_REACHED();
+        return;
+    }
+
+    if (synthesizesGlyph()) {
+        textRenderer->setText(m_textContent.textWithoutSuffix().toString());
         return;
     }
 
@@ -564,6 +561,8 @@ void RenderListMarker::computeIntrinsicLogicalWidthContributions()
         return;
     }
 
+    ASSERT(!hasContentProperty());
+
     std::optional<FontCascade> systemUIFontCascade;
     // Use system-ui font for disclosure triangles
     if (isDisclosureMarker())
@@ -572,9 +571,7 @@ void RenderListMarker::computeIntrinsicLogicalWidthContributions()
     auto& font = systemUIFontCascade ? *systemUIFontCascade : style().fontCascade();
 
     LayoutUnit logicalWidth;
-    if (drawsBulletShape())
-        logicalWidth = (font.metricsOfPrimaryFont().intAscent() * 2 / 3 + 1) / 2 + 2;
-    else if (!m_textContent.isEmpty())
+    if (!m_textContent.isEmpty())
         logicalWidth = font.width(textRunForContent(m_textContent, style()));
 
     m_minContentLogicalWidthContribution = logicalWidth;
@@ -594,7 +591,7 @@ void RenderListMarker::updateInlineMargins()
         if (isImage())
             return { 0, markerPadding };
 
-        if (drawsBulletShape())
+        if (synthesizesGlyph())
             return { -1, fontMetrics.intAscent() - minContentLogicalWidthContribution() + 1 };
 
         return { };
@@ -605,7 +602,7 @@ void RenderListMarker::updateInlineMargins()
             return { -minContentLogicalWidthContribution() - markerPadding, markerPadding };
 
         int offset = fontMetrics.intAscent() * 2 / 3;
-        if (drawsBulletShape())
+        if (synthesizesGlyph())
             return { -offset - markerPadding - 1, offset + markerPadding + 1 - minContentLogicalWidthContribution() };
 
         if (m_textContent.isEmpty() && !contentContainer())
@@ -688,30 +685,23 @@ FloatRect RenderListMarker::relativeMarkerRect()
     if (isImage())
         return { 0.f, 0.f, protect(m_image)->imageSize(this, style().usedZoom()).width(), protect(m_image)->imageSize(this, style().usedZoom()).height() };
 
-    FloatRect relativeRect;
-    if (drawsBulletShape()) {
-        auto& fontMetrics = style().metricsOfPrimaryFont();
-        auto ascent = fontMetrics.ascent();
-        auto bulletWidth = (ascent * 2 / 3 + 1) / 2;
-        relativeRect = { 1, 3 * (ascent - ascent * 2 / 3) / 2, bulletWidth, bulletWidth };
-    } else {
-        if (m_textContent.isEmpty())
-            return { };
+    if (m_textContent.isEmpty())
+        return { };
 
+    FloatRect relativeRect;
+    if (isDisclosureMarker()) {
         // Use system-ui font for disclosure triangles
-        if (isDisclosureMarker()) {
-            auto systemUIFontCascade = disclosureMarkerFontCascade(style(), protect(document()));
-            auto& fontMetrics = style().metricsOfPrimaryFont();
-            auto& systemUIFontMetrics = systemUIFontCascade.metricsOfPrimaryFont();
-            auto width = systemUIFontCascade.width(textRunForContent(m_textContent, style()));
-            auto height = systemUIFontMetrics.height();
-            // Center vertically within the original font metrics
-            auto yOffset = (fontMetrics.height() - height) / 2.0f;
-            relativeRect = { 0.f, yOffset, width, height };
-        } else {
-            auto& font = style().fontCascade();
-            relativeRect = { 0.f, 0.f, font.width(textRunForContent(m_textContent, style())), font.metricsOfPrimaryFont().height() };
-        }
+        auto systemUIFontCascade = disclosureMarkerFontCascade(style(), protect(document()));
+        auto& fontMetrics = style().metricsOfPrimaryFont();
+        auto& systemUIFontMetrics = systemUIFontCascade.metricsOfPrimaryFont();
+        auto width = systemUIFontCascade.width(textRunForContent(m_textContent, style()));
+        auto height = systemUIFontMetrics.height();
+        // Center vertically within the original font metrics
+        auto yOffset = (fontMetrics.height() - height) / 2.0f;
+        relativeRect = { 0.f, yOffset, width, height };
+    } else {
+        auto& font = style().fontCascade();
+        relativeRect = { 0.f, 0.f, font.width(textRunForContent(m_textContent, style())), font.metricsOfPrimaryFont().height() };
     }
 
     if (!writingMode().isHorizontal()) {
@@ -736,10 +726,10 @@ RefPtr<CSSRegisteredCounterStyle> RenderListMarker::counterStyle() const
     return document().counterStyleRegistry().resolvedCounterStyle(*counterStyle);
 }
 
-bool RenderListMarker::drawsBulletShape() const
+bool RenderListMarker::synthesizesGlyph() const
 {
-    // `content` supersedes list-style-type, so a content marker never draws a bullet glyph.
-    if (hasContentProperty())
+    // `content` supersedes list-style-type, so a content marker never draws in place of a glyph, and a list-style-image marker draws the image instead.
+    if (hasContentProperty() || isImage())
         return false;
     auto& listType = style().listStyleType();
     return listType.isCircle() || listType.isDisc() || listType.isSquare();

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -62,6 +62,7 @@ public:
 
     bool NODELETE isInside() const;
     bool isDisclosureMarker() const;
+    bool synthesizesGlyph() const;
 
     void updateInlineMarginsAndContent();
 
@@ -131,7 +132,6 @@ private:
     void paintDisclosureMarker(GraphicsContext&, const FloatRect& markerRect);
 
     RefPtr<CSSRegisteredCounterStyle> counterStyle() const;
-    bool drawsBulletShape() const;
     bool textNeedsBidiResolution() const;
 
 private:

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -549,6 +549,9 @@ void write(TextStream& ts, const RenderObject& renderer, OptionSet<RenderAsTextF
         return;
     }
 
+    if (CheckedPtr listMarker = dynamicDowncast<RenderListMarker>(renderer); listMarker && listMarker->synthesizesGlyph())
+        return;
+
     for (auto& child : childrenOfType<RenderObject>(downcast<RenderElement>(renderer))) {
         if (child.hasLayer())
             continue;

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -37,6 +37,7 @@
 #include "InlineIteratorLineBox.h"
 #include "InlineIteratorTextBoxInlines.h"
 #include "InlineTextBoxStyle.h"
+#include "LayoutInlineTextBox.h"
 #include "LineSelection.h"
 #include "PaintInfo.h"
 #include "PaintInfoInlines.h"
@@ -250,6 +251,16 @@ void TextBoxPainter::paint()
 
     if (m_paintInfo.phase == PaintPhase::Selection && m_paintInfo.paintBehavior.contains(PaintBehavior::IncludeDocumentMarkers))
         paintPlatformDocumentMarkers();
+
+    if (hasSynthesizedGlyph()) {
+        if (m_paintInfo.phase == PaintPhase::Foreground)
+            paintSynthesizedGlyph();
+        if (glyphRotation) {
+            auto backRotation = *glyphRotation == RotationDirection::Clockwise ? RotationDirection::Counterclockwise : RotationDirection::Clockwise;
+            m_paintInfo.context().concatCTM(rotation(m_paintRect, backRotation));
+        }
+        return;
+    }
 
     if (m_paintInfo.phase == PaintPhase::Foreground) {
         auto shouldPaintBackgroundFill = [&] {
@@ -660,6 +671,37 @@ static bool NODELETE isTransparent(const StyledMarkedText& markedText)
     default:
         return false;
     }
+}
+
+bool TextBoxPainter::hasSynthesizedGlyph() const
+{
+    CheckedPtr inlineTextBox = dynamicDowncast<Layout::InlineTextBox>(m_textBox.box().layoutBox());
+    return inlineTextBox && inlineTextBox->hasSynthesizedGlyph();
+}
+
+void TextBoxPainter::paintSynthesizedGlyph()
+{
+    // Drawn from the font metrics rather than from the character the counter style produced, matching the width TextUtil::width reserved for it.
+    auto& fontMetrics = m_style->metricsOfPrimaryFont();
+    auto ascent = fontMetrics.ascent();
+    auto bulletWidth = (ascent * 2 / 3 + 1) / 2;
+    auto markerRect = FloatRect { 1, 3 * (ascent - ascent * 2 / 3) / 2, bulletWidth, bulletWidth };
+    markerRect.moveBy(m_paintRect.location());
+
+    auto& context = m_paintInfo.context();
+    auto color = m_style->visitedDependentTextFillColorApplyingColorFilter();
+    context.setStrokeColor(color);
+    context.setStrokeStyle(StrokeStyle::SolidStroke);
+    context.setStrokeThickness(1.0f);
+    context.setFillColor(color);
+
+    auto listStyleType = m_style->listStyleType();
+    if (listStyleType.isDisc())
+        context.fillEllipse(markerRect);
+    else if (listStyleType.isCircle())
+        context.strokeEllipse(markerRect);
+    else
+        context.fillRect(markerRect);
 }
 
 void TextBoxPainter::paintForeground(const StyledMarkedText& markedText)

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -73,6 +73,8 @@ protected:
     void paintPlatformDocumentMarkers();
 
     void paintForeground(const StyledMarkedText&);
+    bool hasSynthesizedGlyph() const;
+    void paintSynthesizedGlyph();
     bool paintForegroundForShapeRange(TextPainter&);
     TextDecorationPainter createDecorationPainter(const StyledMarkedText&, const FloatRect&);
     void paintBackgroundDecorations(TextDecorationPainter&, const StyledMarkedText&, const FloatRect&);


### PR DESCRIPTION
#### 9518e96ced9f5f2ba70d9e9b651ced426ebc2d8e
<pre>
[list-marker] Lay bullet markers out as marker text so they take part in inline layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=321473">https://bugs.webkit.org/show_bug.cgi?id=321473</a>
&lt;<a href="https://rdar.apple.com/problem/185157814">rdar://problem/185157814</a>&gt;

Reviewed by Antti Koivisto.

Marker content is inline content: what it measures, where it sits on the line and how bidi orders it are inline layout&apos;s answers to give.
Every kind of marker goes through it except a disc, circle or square, which the marker measures and paints itself from the font metrics,
into a box it sizes for that purpose alone. So marker drawing exists twice, and the two have to be kept in step.

It is also what stands in the way of making an inside marker an inline box, which is where this is going:
an inline box has no box of its own to paint into, so anything the marker draws for itself has nowhere to go.

A list-style-image that fails to load now rebuilds the marker rather than relaying it out. It falls
back to its list-style-type, and that text needs renderers the marker was not built with. Nothing
about the element&apos;s style changed, and a pseudo-element list item is only revisited through its host
(RenderTreeUpdater::updateAfterDescendants), so imageChanged() invalidates the host&apos;s renderers
instead of the element&apos;s style.

* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::width):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::markerTextSynthesizesGlyph):
(WebCore::LayoutIntegration::BoxTreeUpdater::createLayoutBox):
(WebCore::LayoutIntegration::updateContentCharacteristic):
(WebCore::LayoutIntegration::BoxTreeUpdater::updateContent):
* Source/WebCore/layout/layouttree/LayoutInlineTextBox.h:
(WebCore::Layout::InlineTextBox::hasSynthesizedGlyph const):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::textNeedsBidiResolution const):
(WebCore::RenderListMarker::needsContentContainer const):
(WebCore::RenderListMarker::paint):
(WebCore::RenderListMarker::layoutContentContainer):
(WebCore::RenderListMarker::imageChanged):
(WebCore::RenderListMarker::updateContent):
(WebCore::RenderListMarker::updateContentContainerText):
(WebCore::RenderListMarker::computeIntrinsicLogicalWidthContributions):
(WebCore::RenderListMarker::updateInlineMargins):
(WebCore::RenderListMarker::relativeMarkerRect):
(WebCore::RenderListMarker::synthesizesGlyph const):
(WebCore::RenderListMarker::drawsBulletShape const): Deleted.
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::write):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paint):
(WebCore::TextBoxPainter::hasSynthesizedGlyph const):
(WebCore::TextBoxPainter::paintSynthesizedGlyph):
* Source/WebCore/rendering/TextBoxPainter.h:

Canonical link: <a href="https://commits.webkit.org/319632@main">https://commits.webkit.org/319632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85802017fee1c05d1d306836ec8d4ea3bbe7dc06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49786 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192258 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146362 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebc3f3e6-d39c-4e0d-8c89-e20c5c4946bd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55703 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192258 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a506c2f-a45b-4752-8c24-76b8ceeddcb0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162862 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192258 "") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea8ad9fb-7c78-4d48-8870-2de9dd761aff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44490 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42760 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192258 "") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42387 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3423 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194186 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55651 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151539 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40583 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56342 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39012 "Too many flaky failures: http/tests/media/video-useragent.html, http/tests/navigation/scrollstate-after-http-equiv-refresh-fragment-identifier.html, http/tests/resourceLoadStatistics/operating-dates-all-website-data-removed.html, http/tests/security/contentSecurityPolicy/report-only-from-header.py, http/tests/site-isolation/iframe-with-transform.html, http/tests/storageAccess/request-and-grant-access-cross-origin-non-sandboxed-iframe.https.html, http/tests/websocket/tests/hybi/websocket-blocked-from-setting-cookie-as-third-party.html, http/tests/workers/service/navigator-serviceWorker-same-object.html, http/tests/xmlhttprequest/access-control-basic-allow-star.html, http/wpt/service-workers/controlled-dedicatedworker.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151243 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45813 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128625 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124446 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54853 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17382 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54234 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54473 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->