### PR TITLE
REGRESSION(319079@main): TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackAfterTerminateProcess (api-test) is a constant fail.

### DIFF
--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
@@ -220,7 +220,10 @@ bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigatio
 
 void EnhancedSecurityTracking::handleBackForwardNavigation(const API::Navigation& navigation)
 {
-    EnhancedSecurity priorState = navigation.targetItem() ? navigation.targetItem()->enhancedSecurity() : EnhancedSecurity::Disabled;
+    // targetItem() and reloadItem() are both "the item being navigated to", and only one is ever set.
+    // Reading just targetItem() would treat a reload's missing target as Enhanced Security being off.
+    RefPtr item = navigation.targetItem() ? navigation.targetItem() : navigation.reloadItem();
+    EnhancedSecurity priorState = item ? item->enhancedSecurity() : EnhancedSecurity::Disabled;
 
     if (priorState == EnhancedSecurity::Disabled) {
         if (m_activeState != ActivationState::None)


### PR DESCRIPTION
#### 39b67e68ebc2aed8f549fdf73622f8f6c4871647
<pre>
REGRESSION(319079@main): TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackAfterTerminateProcess (api-test) is a constant fail.
<a href="https://bugs.webkit.org/show_bug.cgi?id=321949">https://bugs.webkit.org/show_bug.cgi?id=321949</a>
<a href="https://rdar.apple.com/185125314">rdar://185125314</a>

Reviewed by Matthew Finkel.

319079@main normalizes an empty document URL to about:blank in NavigationRequester::from so
about:blank inherits its initiator&apos;s policy container rather than a cross-origin one. That also
makes NavigationAction::isEmpty() false for a history restore in a relaunched process, so its
triggering action is preserved and the navigation reports NavigationType::BackForward.
handleBackForwardNavigation then runs for a reload, whose navigation sets reloadItem() rather
than targetItem(), so the prior state reads as Disabled and Enhanced Security goes dormant. The
resulting process swap discards the HTTP fallback state and the reload is upgraded back to https.

Fix by falling back to reloadItem() when there is no targetItem(). Both name the item being
navigated to and only one is ever set, so the item&apos;s stored Enhanced Security state is used
instead of defaulting to Disabled.

* Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp:
(WebKit::EnhancedSecurityTracking::handleBackForwardNavigation):

Canonical link: <a href="https://commits.webkit.org/319481@main">https://commits.webkit.org/319481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09b25daf283776ab71b08d741c9d3335d8a725ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145792 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141627 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122067 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43988 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42258 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41902 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2850 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193617 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55082 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151033 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40480 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55769 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150739 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45317 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128050 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123665 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54285 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16901 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53667 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53905 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53732 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->