### PR TITLE
[CMake] Build prewarm target early enough to benefit performance

### DIFF
--- a/Source/WebKitLegacy/PlatformCocoa.cmake
+++ b/Source/WebKitLegacy/PlatformCocoa.cmake
@@ -94,6 +94,13 @@ add_custom_command(
     VERBATIM
 )
 
+# Put the generated header into a separate target so that dependents can build
+# without waiting for the rest of WebCore to compile and link.
+add_custom_target(WebKitLegacyPreferences DEPENDS
+    ${WebKitLegacy_DERIVED_SOURCES_DIR}/WebPreferencesDefinitions.h
+)
+add_dependencies(WebKitLegacy WebKitLegacyPreferences)
+
 list(APPEND WebKitLegacy_SOURCES
     ${WebKitLegacy_DERIVED_SOURCES_DIR}/WebViewPreferencesChangedGenerated.mm
     ${WebKitLegacy_DERIVED_SOURCES_DIR}/WebPreferencesInternalFeatures.mm

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -1110,7 +1110,7 @@ endfunction()
 # Format (one token per line): -DNAME for truthy HAVE_/USE_/ENABLE_/
 # WTF_PLATFORM_/ASSERT_ macros from wtf/Platform.h, plus -Xcc -DNAME=VALUE
 # for every cmakeconfig.h entry. DEPFILE re-runs it on Platform header changes.
-function(_webkit_generate_platform_swift_args _target _resp_path _ordering_dep)
+function(_webkit_generate_platform_swift_args _target _resp_path)
     set(_depfile "${_resp_path}.d")
     _webkit_platform_args_empty_input(_empty_input)
     _webkit_platform_args_clang_prefix(_clang_cmd
@@ -1131,20 +1131,6 @@ function(_webkit_generate_platform_swift_args _target _resp_path _ordering_dep)
     list(APPEND _clang_cmd ${ENABLED_COMPILER_SANITIZERS})
     list(APPEND _clang_cmd "${_empty_input}")
 
-    # Order resp generation after the framework's headers are staged: the
-    # clang preprocess -include's wtf/Platform.h from WTF_FRAMEWORK_HEADERS_DIR.
-    # Targets declared after this macro call are skipped (not yet visible to
-    # if(TARGET ...)); for current callers WTF_CopyHeaders is already created.
-    set(_header_deps "")
-    foreach (_lib IN ITEMS WTF "${_target}" ${${_target}_FRAMEWORKS})
-        foreach (_suffix IN ITEMS _CopyHeaders _CopyPrivateHeaders)
-            if (TARGET "${_lib}${_suffix}")
-                list(APPEND _header_deps "${_lib}${_suffix}")
-            endif ()
-        endforeach ()
-    endforeach ()
-    list(REMOVE_DUPLICATES _header_deps)
-
     set(_script "${CMAKE_SOURCE_DIR}/Source/WTF/Scripts/generate-platform-args")
     add_custom_command(
         OUTPUT "${_resp_path}"
@@ -1159,8 +1145,7 @@ function(_webkit_generate_platform_swift_args _target _resp_path _ordering_dep)
         DEPENDS
             "${_script}"
             "${CMAKE_BINARY_DIR}/cmakeconfig.h"
-            ${_ordering_dep}
-            ${_header_deps}
+            WTF_CopyHeaders
         COMMENT "Generating ${_target} platform-swift-args.resp"
         VERBATIM
     )
@@ -1270,9 +1255,9 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         # The platform-derived feature flags (HAVE_/USE_/ENABLE_/WTF_PLATFORM_/
         # ASSERT_) plus the cmakeconfig.h seed defines for the clang importer
         # are produced as a build-time @-response file. The custom command that
-        # writes it is created later (after the SwiftGeneratedDeps placeholder
-        # exists); we just thread the @-flag here so it ends up in the swiftc
-        # invocation that CMake assembles from target_compile_options.
+        # writes it is created further down; we just thread the @-flag here so
+        # it ends up in the swiftc invocation that CMake assembles from
+        # target_compile_options.
         set(_resp_path "${CMAKE_CURRENT_BINARY_DIR}/${_target}.platform-swift-args.resp")
         set(_swift_options "@${_resp_path}")
         # Other options needed by Swift for C++ interop, including the location
@@ -1457,7 +1442,7 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         # Generate the @-response file with platform-derived -D flags. The
         # @-flag itself is already in _swift_options above, which gets fed to
         # target_compile_options via _swift_only_options earlier in the macro.
-        _webkit_generate_platform_swift_args(${_target} "${_resp_path}" ${_target}_SwiftGeneratedDeps)
+        _webkit_generate_platform_swift_args(${_target} "${_resp_path}")
 
         # Trigger source whose mtime tracks the resp (and the emit-clang-header
         # stamp / INTEROP_HEADERS when applicable). target_sources is how we

--- a/Source/cmake/WebKitSwiftPrewarm.cmake
+++ b/Source/cmake/WebKitSwiftPrewarm.cmake
@@ -43,9 +43,51 @@ function(WEBKIT_ADD_SWIFT_PREWARM _consumer _swift_source)
         endif ()
     endforeach ()
 
-    get_target_property(_consumer_bindir ${_consumer} BINARY_DIR)
-    set_property(SOURCE "${_swift_source}" APPEND PROPERTY OBJECT_DEPENDS
-        "${_consumer_bindir}/${_consumer}.platform-swift-args.resp")
+    # Depend on the headers and modulemaps needed to do the prewarming. WTF is
+    # special because it's not directly linked against, but its interface is
+    # still needed.
+    foreach (_lib IN ITEMS WTF ${${_consumer}_FRAMEWORKS} LISTS _linked_libraries)
+        if (_lib STREQUAL _consumer)
+            continue ()
+        endif ()
+        foreach (_suffix IN ITEMS _CopyHeaders _CopyPrivateHeaders _CopyModules _CopyPrivateModuleMap)
+            if (TARGET "${_lib}${_suffix}")
+                list(APPEND _staging_deps "${_lib}${_suffix}")
+            endif ()
+        endforeach ()
+    endforeach ()
+    if (_staging_deps)
+        list(REMOVE_DUPLICATES _staging_deps)
+        add_dependencies(${_prewarm} ${_staging_deps})
+    endif ()
 
-    add_dependencies(${_consumer} ${_prewarm})
+    # Depend on platform-swift-args.resp
+    set_source_files_properties(${_swift_source} OBJECT_DEPENDS
+        "${CMAKE_CURRENT_BINARY_DIR}/${_consumer}.platform-swift-args.resp")
+
+    # ninja prioritizes tasks with a large number of downstream edges, which is
+    # only an optimal ordering if tasks take the same amount of time to
+    # execute. Swift tasks are large and slow (because ninja is scheduling the
+    # swift driver, not individual compilations). To trick it into scheduling
+    # prewarm to run early enough to benefit performance, add a chain of
+    # meaningless dependent tasks to increase the critical path weight.
+    #
+    # See ninja-build/ninja#2177 for details of the critical path scheduler.
+    set(_dispatch_edges 9)
+    set(_dispatch_dep "$<TARGET_OBJECTS:${_prewarm}>")
+    foreach (_i RANGE 1 ${_dispatch_edges})
+        set(_stamp "${CMAKE_CURRENT_BINARY_DIR}/${_prewarm}-dispatch-${_i}.stamp")
+        add_custom_command(
+            OUTPUT "${_stamp}"
+            COMMAND ${CMAKE_COMMAND} -E touch "${_stamp}"
+            DEPENDS "${_dispatch_dep}"
+            VERBATIM
+        )
+        set(_dispatch_dep "${_stamp}")
+    endforeach ()
+    add_custom_target(${_prewarm}_Dispatch DEPENDS "${_dispatch_dep}")
+
+    # Transitively an ordering dependency on ${_prewarm} itself, through the
+    # stamp chain above.
+    add_dependencies(${_consumer} ${_prewarm}_Dispatch)
 endfunction()


### PR DESCRIPTION
#### 082af0d00c982ba01fcbc0e131973c07163ff1e8
<pre>
[CMake] Build prewarm target early enough to benefit performance
<a href="https://bugs.webkit.org/show_bug.cgi?id=322075">https://bugs.webkit.org/show_bug.cgi?id=322075</a>

Reviewed by Geoffrey Garen.

Right now, the SwiftPrewarmMac target is part of the build&apos;s critical path,
which also includes WebKit&apos;s swift target. So moving work from
WebKit.swiftmodule&apos;s build to prewarming does not actually improve
performance.

Fix by removing some overspecified dependencies that blocked the
prewarming target on waiting for WebCore to finish linking, and by
artifically adding a chain of dependents to prewarm, to trick Ninja into
scheduling it earlier (exploiting its critical-path scheduling algorithm
added in ninja-build/ninja#232).

On an M5 Max, this is worth about 6 sec (2%). Combined with #71911 it&apos;s
about 13 sec (4%).

* Source/WebKitLegacy/PlatformCocoa.cmake:
* Source/cmake/WebKitMacros.cmake:
* Source/cmake/WebKitSwiftPrewarm.cmake:

Canonical link: <a href="https://commits.webkit.org/319543@main">https://commits.webkit.org/319543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9513d533b05ed0f62641dc2090031f2998d94b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55770 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192048 "Failed to checkout and rebase branch from PR 71912") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57084 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192048 "Failed to checkout and rebase branch from PR 71912") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184778 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192048 "Failed to checkout and rebase branch from PR 71912") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192048 "Failed to checkout and rebase branch from PR 71912") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/11151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3210 "Failed to checkout and rebase branch from PR 71912") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/43102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/48401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/55491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193974 "Failed to checkout and rebase branch from PR 71912") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/55440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/193974 "Failed to checkout and rebase branch from PR 71912") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56129 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/193974 "Failed to checkout and rebase branch from PR 71912") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27609 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/45631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124170 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54642 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54089 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->