### PR TITLE
[CSS] Implement user-select: -internal-auto-all (nonstandard) for .image-overlay-text

### DIFF
--- a/LayoutTests/fast/images/text-recognition/image-overlay-user-select-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-user-select-expected.txt
@@ -3,14 +3,19 @@ The user-select value of recognized text inside an image overlay should be all o
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS getComputedStyle(overlayText(plain)).webkitUserSelect is "all"
-PASS getComputedStyle(overlayText(unselectable)).webkitUserSelect is "none"
-PASS getComputedStyle(overlayText(inInert)).webkitUserSelect is "all"
-PASS getSelection().toString() is ""
-PASS getComputedStyle(overlayText(plain)).webkitUserSelect is "none"
-PASS getComputedStyle(overlayText(plain)).webkitUserSelect is "all"
+PASS selectedTextInOverlay('plain') is "plain"
+PASS selectedTextAfterExtendingOneCharacter('plain') is "plain"
+PASS selectedTextInOverlay('unselectable') is ""
+PASS selectedTextInOverlay('inInert') is ""
+PASS selectedTextInOverlay('inEditable') is "inEditable"
+PASS selectedTextAfterExtendingOneCharacter('inEditable') is "inEditable"
+PASS selectedTextInOverlay('inEditable') is "inEditable"
+PASS selectedTextAfterExtendingOneCharacter('inEditable') is "inEditable"
+PASS selectedTextInOverlay('plain') is ""
+PASS selectedTextInOverlay('plain') is "plain"
 PASS successfullyParsed is true
 
 TEST COMPLETE
+
 
 

--- a/LayoutTests/fast/images/text-recognition/image-overlay-user-select.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-user-select.html
@@ -7,13 +7,27 @@
 <div inert>
     <img id="inInert" src="../resources/green-400x400.png">
 </div>
+<div contenteditable>
+    <img id="inEditable" src="../resources/green-400x400.png">
+</div>
 <script>
 description('The user-select value of recognized text inside an image overlay should be all or none.');
 
 jsTestIsAsync = true;
 
-function overlayText(image) {
-    return internals.shadowRoot(image).querySelector(".image-overlay-text");
+function overlayText(imageID) {
+    return internals.shadowRoot(document.getElementById(imageID)).querySelector(".image-overlay-text");
+}
+
+function selectedTextInOverlay(imageID) {
+    getSelection().selectAllChildren(overlayText(imageID));
+    return getSelection().toString();
+}
+
+function selectedTextAfterExtendingOneCharacter(imageID) {
+    getSelection().setPosition(overlayText(imageID).firstChild, 0);
+    getSelection().modify("extend", "forward", "character");
+    return getSelection().toString();
 }
 
 addEventListener("load", () => {
@@ -26,7 +40,7 @@ addEventListener("load", () => {
                 bottomLeft : new DOMPointReadOnly(0, 1),
                 children: [
                     {
-                        text : "Hello",
+                        text : image.id,
                         topLeft : new DOMPointReadOnly(0, 0),
                         topRight : new DOMPointReadOnly(1, 0),
                         bottomRight : new DOMPointReadOnly(1, 1),
@@ -37,17 +51,23 @@ addEventListener("load", () => {
         ]);
     }
 
-    shouldBeEqualToString("getComputedStyle(overlayText(plain)).webkitUserSelect", "all");
-    shouldBeEqualToString("getComputedStyle(overlayText(unselectable)).webkitUserSelect", "none");
+    shouldBeEqualToString("selectedTextInOverlay('plain')", "plain");
+    shouldBeEqualToString("selectedTextAfterExtendingOneCharacter('plain')", "plain");
 
-    shouldBeEqualToString("getComputedStyle(overlayText(inInert)).webkitUserSelect", "all");
-    getSelection().selectAllChildren(overlayText(inInert));
-    shouldBeEqualToString("getSelection().toString()", "");
+    shouldBeEqualToString("selectedTextInOverlay('unselectable')", "");
+    shouldBeEqualToString("selectedTextInOverlay('inInert')", "");
+
+    // Being editable overrides none:
+    shouldBeEqualToString("selectedTextInOverlay('inEditable')", "inEditable");
+    shouldBeEqualToString("selectedTextAfterExtendingOneCharacter('inEditable')", "inEditable");
+    inEditable.style.webkitUserSelect = "none";
+    shouldBeEqualToString("selectedTextInOverlay('inEditable')", "inEditable");
+    shouldBeEqualToString("selectedTextAfterExtendingOneCharacter('inEditable')", "inEditable");
 
     plain.style.webkitUserSelect = "none";
-    shouldBeEqualToString("getComputedStyle(overlayText(plain)).webkitUserSelect", "none");
+    shouldBeEqualToString("selectedTextInOverlay('plain')", "");
     plain.style.webkitUserSelect = "text";
-    shouldBeEqualToString("getComputedStyle(overlayText(plain)).webkitUserSelect", "all");
+    shouldBeEqualToString("selectedTextInOverlay('plain')", "plain");
 
     getSelection().removeAllRanges();
     finishJSTest();

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12560,7 +12560,12 @@
                 "auto",
                 "text",
                 "none",
-                "all"
+                "all",
+                {
+                    "value": "-internal-auto-all",
+                    "status": "internal",
+                    "comment": "'none' if the parent's used value is 'none', 'all' otherwise. Used by image overlays so that recognized text can only be selected atomically."
+                }
             ],
             "codegen-properties": {
                 "computed-style-has-explicitly-set-policy": "value-only",
@@ -12587,7 +12592,12 @@
                     "value": "contain",
                     "status": "unimplemented"
                 },
-                "all"
+                "all",
+                {
+                    "value": "-internal-auto-all",
+                    "status": "internal",
+                    "comment": "'none' if the parent's used value is 'none', 'all' otherwise. Used by image overlays so that recognized text can only be selected atomically."
+                }
             ],
             "codegen-properties": {
                 "computed-style-has-explicitly-set-policy": "value-only",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -817,6 +817,7 @@ element
 // CSS_PROP__KHTML_USER_SELECT
 //
 ignore
+-internal-auto-all
 
 //
 // CSS_PROP_WIDTH/MIN_WIDTH/MAX_WIDTH

--- a/Source/WebCore/html/shadow/imageOverlay.css
+++ b/Source/WebCore/html/shadow/imageOverlay.css
@@ -85,6 +85,11 @@ div.image-overlay-line, .image-overlay-text {
     background-color: highlight;
 }
 
+.image-overlay-text {
+    -webkit-user-select: -internal-auto-all;
+    user-select: -internal-auto-all;
+}
+
 div.image-overlay-data-detector-result {
     position: absolute;
     -webkit-user-select: none;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1299,6 +1299,7 @@ TextStream& operator<<(TextStream& ts, UserSelect userSelect)
     case UserSelect::None: ts << "none"_s; break;
     case UserSelect::Text: ts << "text"_s; break;
     case UserSelect::All: ts << "all"_s; break;
+    case UserSelect::AutoAll: ts << "-internal-auto-all"_s; break;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -508,8 +508,13 @@ enum class UserSelect : uint8_t {
     None,
     Text,
     All,
-    Auto
+    Auto,
+    // User agent stylesheets only ('-internal-auto-all'): resolves to 'none' if the parent's
+    // used value is 'none', and to 'all' otherwise. Never appears as a used value.
+    AutoAll
 };
+
+constexpr int userSelectBitWidth = 3;
 
 // CSS3 Image Values
 enum class ObjectFit : uint8_t {

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -821,15 +821,6 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
     adjustForSiteSpecificQuirks(style);
 
     adjustUsedUserSelect(style);
-    // Don't allow selecting individual glyphs on text recognized inside an image:
-#if ENABLE(IMAGE_ANALYSIS)
-    if (m_element && m_element->isInUserAgentShadowTree() && m_element->userAgentPart() == UserAgentParts::internalImageOverlayText()) {
-        auto userSelect = style.usedUserSelectIgnoringEffectivelyInert() == UserSelect::None ? UserSelect::None : UserSelect::All;
-        style.setWebkitUserSelect(userSelect);
-        style.setUserSelect(userSelect);
-        style.setUsedUserSelect(userSelect);
-    }
-#endif
 }
 
 static bool considerUnprefixedUserSelect()
@@ -844,6 +835,12 @@ static bool considerUnprefixedUserSelect()
 
 void Adjuster::adjustUsedUserSelect(Style::ComputedStyle& style) const
 {
+    auto resolveInternalAutoAll = [&](UserSelect value) {
+        if (value != UserSelect::AutoAll)
+            return value;
+        return m_parentStyle.usedUserSelectIgnoringEffectivelyInert() == UserSelect::None ? UserSelect::None : UserSelect::All;
+    };
+
     if (!m_document->settings().cssUserSelectEnabled() || !considerUnprefixedUserSelect()) {
         // Legacy behavior: only -webkit-user-select is consulted and it doesn't behave
         // according to spec; 'user-select' is ignored.
@@ -858,7 +855,7 @@ void Adjuster::adjustUsedUserSelect(Style::ComputedStyle& style) const
         if (value == UserSelect::Auto)
             value = UserSelect::Text;
 
-        style.setUsedUserSelect(value);
+        style.setUsedUserSelect(resolveInternalAutoAll(value));
         return;
     }
 
@@ -883,10 +880,10 @@ void Adjuster::adjustUsedUserSelect(Style::ComputedStyle& style) const
 
     // FIXME: this should be overridden to UserSelect::Contain, which is unimplemented but is how
     // editable content with 'text' already behaves.
-    if (style.userModify() != UserModify::ReadOnly)
+    if (value != UserSelect::AutoAll && style.userModify() != UserModify::ReadOnly)
         value = UserSelect::Text;
 
-    style.setUsedUserSelect(value);
+    style.setUsedUserSelect(resolveInternalAutoAll(value));
 }
 
 static bool NODELETE hasEffectiveDisplayNoneForDisplayContents(const Element& element)

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -183,8 +183,8 @@ public:
     PREFERRED_TYPE(OverflowWrap) unsigned overflowWrap : 2;
     PREFERRED_TYPE(NBSPMode) unsigned nbspMode : 1;
     PREFERRED_TYPE(LineBreak) unsigned lineBreak : 3;
-    PREFERRED_TYPE(UserSelect) unsigned webkitUserSelect : 2;
-    PREFERRED_TYPE(UserSelect) unsigned usedUserSelect : 2;
+    PREFERRED_TYPE(UserSelect) unsigned webkitUserSelect : userSelectBitWidth;
+    PREFERRED_TYPE(UserSelect) unsigned usedUserSelect : userSelectBitWidth;
     PREFERRED_TYPE(SpeakAs) unsigned speakAs : 4;
     PREFERRED_TYPE(Hyphens) unsigned hyphens : 2;
     PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;

--- a/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <WebCore/RenderStyleConstants.h>
 #include <WebCore/StyleAlignContent.h>
 #include <WebCore/StyleAlignItems.h>
 #include <WebCore/StyleAlignSelf.h>
@@ -114,7 +115,7 @@ public:
     PREFERRED_TYPE(TableLayoutType) unsigned tableLayout : 1;
     PREFERRED_TYPE(StyleAppearance) unsigned appearance : appearanceBitWidth;
     PREFERRED_TYPE(StyleAppearance) unsigned usedAppearance : appearanceBitWidth;
-    PREFERRED_TYPE(UserSelect) unsigned userSelect : 2;
+    PREFERRED_TYPE(UserSelect) unsigned userSelect : userSelectBitWidth;
     PREFERRED_TYPE(bool) unsigned textOverflow : 1; // Whether or not lines that spill out should be truncated with "..."
     PREFERRED_TYPE(UserDrag) unsigned userDrag : 2;
     PREFERRED_TYPE(ObjectFit) unsigned objectFit : 3;

--- a/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
+++ b/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
@@ -1242,6 +1242,8 @@ constexpr CSSValueID toCSSValueID(UserSelect e)
         return CSSValueText;
     case UserSelect::All:
         return CSSValueAll;
+    case UserSelect::AutoAll:
+        return CSSValueInternalAutoAll;
     }
     ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
     return CSSValueInvalid;
@@ -1258,6 +1260,8 @@ template<> constexpr UserSelect fromCSSValueID(CSSValueID valueID)
         return UserSelect::Text;
     case CSSValueAll:
         return UserSelect::All;
+    case CSSValueInternalAutoAll:
+        return UserSelect::AutoAll;
     default:
         break;
     }


### PR DESCRIPTION
#### c7adebeba9710a161de602762889b2e650f6481d
<pre>
[CSS] Implement user-select: -internal-auto-all (nonstandard) for .image-overlay-text
<a href="https://bugs.webkit.org/show_bug.cgi?id=322076">https://bugs.webkit.org/show_bug.cgi?id=322076</a>
<a href="https://rdar.apple.com/185263088">rdar://185263088</a>

Reviewed by NOBODY (OOPS!).

Adds user-select: -internal-auto-all and uses it to implement the
behavior of .image-overlay-text, which previously required a standalone
check in the style adjuster. The new value is not exposed to website
authors.

&apos;user-select: -internal-auto-all&apos; causes the used user-select value
to be &apos;all&apos; unless the parent is unselectable, which case it&apos;s &apos;none&apos;
(honoring the parent&apos;s unselectability, like &apos;auto&apos; would). This
behavior could be exposed to website authors in the future - it would
simplify the process of making an entire subtree unselectable since
it&apos;d eliminate the need to toggle every &apos;user-select: all&apos; to
&apos;user-select: none&apos;.

* LayoutTests/fast/images/text-recognition/image-overlay-user-select-expected.txt:
* LayoutTests/fast/images/text-recognition/image-overlay-user-select.html:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/html/shadow/imageOverlay.css:
(.image-overlay-text):
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::Adjuster::adjustUsedUserSelect const):
* Source/WebCore/style/computed/data/StyleInheritedRareData.h:
* Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h:
* Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h:
(WebCore::toCSSValueID):
(WebCore::fromCSSValueID):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7adebeba9710a161de602762889b2e650f6481d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191661 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145764 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/511138a4-626d-4db1-9284-985d02c8f71d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141609 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98264 "2 flakes 12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a7d2b39-ec28-434d-9e8c-dfcbc59f8c14) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122049 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69231e31-12c6-4ce3-b304-b278daec5fe4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43961 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42236 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154364 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41889 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2821 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193589 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151008 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55741 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150713 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45295 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128022 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123623 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54257 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16888 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53639 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53877 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->