### PR TITLE
[JSC] Apply StringSwitch for substrings

### DIFF
--- a/JSTests/stress/switch-string-substring-rope.js
+++ b/JSTests/stress/switch-string-substring-rope.js
@@ -1,0 +1,75 @@
+// Coverage for the DFG and FTL binary string switch reading a substring rope in place, which
+// depends on decoding the rope's base pointer and character offset correctly.
+
+function shouldBe(actual, expected, tag, detail) {
+    if (actual !== expected) {
+        let where = detail === undefined ? tag : `${tag} [${String(detail)}]`;
+        throw new Error(`${where}: expected ${String(expected)} but got ${String(actual)}`);
+    }
+}
+
+function switchOnKeys(scrutinee) {
+    switch (scrutinee) {
+    case "a": return "a";
+    case "no": return "no";
+    case "for": return "for";
+    case "fort": return "fort";
+    case "forte": return "forte";
+    case "with": return "with";
+    case "abcdefghij": return "abcdefghij";
+    default: return "default";
+    }
+}
+noInline(switchOnKeys);
+
+// Keys appear at several offsets, adjacent to and overlapping one another, so a base pointer or
+// character offset that is off by any amount decodes into a different case.
+const base8Bit = "xanoforteforwithabcdefghijnofortex";
+const base16Bit = $vm.make16BitStringIfPossible(base8Bit);
+
+// Oracle: the same dispatch over a string built character by character, which is resolved rather
+// than a rope and so never takes the path under test.
+const keyToResult = new Map([
+    ["a", "a"], ["no", "no"], ["for", "for"], ["fort", "fort"],
+    ["forte", "forte"], ["with", "with"], ["abcdefghij", "abcdefghij"],
+]);
+function expectedFor(offset, length) {
+    let characters = [];
+    for (let i = offset; i < Math.min(offset + length, base8Bit.length); ++i)
+        characters.push(base8Bit.charCodeAt(i));
+    const key = String.fromCharCode(...characters);
+    return keyToResult.has(key) ? keyToResult.get(key) : "default";
+}
+
+const substringCases = [];
+for (let offset = 0; offset <= base8Bit.length; ++offset) {
+    for (let length = 0; length <= 11; ++length)
+        substringCases.push([offset, length, expectedFor(offset, length)]);
+}
+
+// A substring of a substring collapses onto the original base, exercising a decode of a rope whose
+// offset is the sum of two slices.
+function substringOfSubstring(string) {
+    return string.substring(2, 12).substring(2, 5);
+}
+
+function check([offset, length, expected]) {
+    const detail = `${offset},${length}`;
+    shouldBe(switchOnKeys(base8Bit.substring(offset, offset + length)), expected, "8-bit base", detail);
+    shouldBe(switchOnKeys(base16Bit.substring(offset, offset + length)), expected, "16-bit base", detail);
+    // A concat rope of the same characters must reach the same case.
+    shouldBe(switchOnKeys(base8Bit.substring(offset, offset + length) + ""), expected, "concat rope", detail);
+}
+
+// Sweep every offset and length once, then keep one rotating case hot so the switch tiers up with
+// substring ropes flowing through it.
+for (const substringCase of substringCases)
+    check(substringCase);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    check(substringCases[i % substringCases.length]);
+    shouldBe(switchOnKeys(substringOfSubstring(base8Bit)), "for", "substring of substring");
+    shouldBe(switchOnKeys(substringOfSubstring(base16Bit)), "for", "substring of substring, 16-bit base");
+    // An unsliced substring yields the base itself rather than a rope.
+    shouldBe(switchOnKeys("for".substring(0, 3)), "for", "whole-string substring");
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -12885,7 +12885,7 @@ void SpeculativeJIT::emitBinarySwitchStringRecurse(
     addBranch(binarySwitch.fallThrough(), data->fallThrough.block);
 }
 
-void SpeculativeJIT::emitSwitchStringOnString(Node* node, SwitchData* data, GPRReg string, Edge stringEdge)
+void SpeculativeJIT::emitSwitchStringOnString(Node* node, SwitchData* data, GPRReg stringGPR, Edge stringEdge)
 {
     data->didUseJumpTable = true;
 
@@ -12911,51 +12911,73 @@ void SpeculativeJIT::emitSwitchStringOnString(Node* node, SwitchData* data, GPRR
 
     if (!canDoBinarySwitch || totalLength > Options::maximumBinaryStringSwitchTotalLength()) {
         flushRegisters();
-        callOperation(operationSwitchString, string, LinkableConstant::globalObject(*this, node), static_cast<size_t>(data->switchTableIndex), TrustedImmPtr(&unlinkedTable), string);
-        farJump(string, JSSwitchPtrTag);
+        callOperation(operationSwitchString, stringGPR, LinkableConstant::globalObject(*this, node), static_cast<size_t>(data->switchTableIndex), TrustedImmPtr(&unlinkedTable), stringGPR);
+        farJump(stringGPR, JSSwitchPtrTag);
         return;
     }
-    
+
     GPRTemporary length(this);
     GPRTemporary temp(this);
-    
+
     GPRReg lengthGPR = length.gpr();
     GPRReg tempGPR = temp.gpr();
-    
+
     JumpList isRopeCases;
     JumpList slowCases;
-    loadPtr(Address(string, JSString::offsetOfValue()), tempGPR);
+    JumpList atBinarySwitch;
+    loadPtr(Address(stringGPR, JSString::offsetOfValue()), tempGPR);
     if (canBeRope(stringEdge))
         isRopeCases.append(branchIfRopeStringImpl(tempGPR));
     load32(Address(tempGPR, StringImpl::lengthMemoryOffset()), lengthGPR);
-    
+
     slowCases.append(branchTest32(
         Zero,
         Address(tempGPR, StringImpl::flagsOffset()),
         TrustedImm32(StringImpl::flagIs8Bit())));
-    
-    loadPtr(Address(tempGPR, StringImpl::dataOffset()), string);
-    
+
+    loadPtr(Address(tempGPR, StringImpl::dataOffset()), stringGPR);
+
+    if (!isRopeCases.empty()) {
+        atBinarySwitch.append(jump());
+
+        isRopeCases.link(this);
+        JumpList notReadableInPlace;
+        notReadableInPlace.append(branchTest64(Zero, tempGPR, TrustedImm64(JSRopeString::isSubstringInPointer)));
+        notReadableInPlace.append(branchTest64(Zero, tempGPR, TrustedImm64(JSRopeString::is8BitInPointer)));
+
+        load64(Address(stringGPR, JSRopeString::offsetOfFiber1Lower()), tempGPR);
+        and64(TrustedImm64(JSRopeString::CompactFibers::addressMask), tempGPR);
+        loadPtr(Address(tempGPR, JSString::offsetOfValue()), tempGPR);
+
+        load32(Address(stringGPR, JSRopeString::offsetOfFiber2Lower()), lengthGPR);
+        loadPtr(Address(tempGPR, StringImpl::dataOffset()), tempGPR);
+        addPtr(lengthGPR, tempGPR);
+        load32(Address(stringGPR, JSRopeString::offsetOfLength()), lengthGPR);
+        move(tempGPR, stringGPR);
+        atBinarySwitch.append(jump());
+
+        notReadableInPlace.link(this);
+        load32(Address(stringGPR, JSRopeString::offsetOfLength()), tempGPR);
+        sub32(TrustedImm32(unlinkedTable.minLength()), tempGPR);
+        branch32(Above, tempGPR, TrustedImm32(unlinkedTable.maxLength() - unlinkedTable.minLength()), data->fallThrough.block);
+        slowCases.append(jump());
+
+        atBinarySwitch.link(this);
+    }
+
     Vector<StringSwitchCase> cases;
     for (unsigned i = 0; i < data->cases.size(); ++i) {
         cases.append(
             StringSwitchCase(data->cases[i].value.stringImpl(), data->cases[i].target.block));
     }
-    
-    std::sort(cases.begin(), cases.end());
-    
-    emitBinarySwitchStringRecurse(data, cases, 0, 0, cases.size(), string, lengthGPR, tempGPR, 0, false);
 
-    if (!isRopeCases.empty()) {
-        isRopeCases.link(this);
-        load32(Address(string, JSRopeString::offsetOfLength()), tempGPR);
-        sub32(TrustedImm32(unlinkedTable.minLength()), tempGPR);
-        branch32(Above, tempGPR, TrustedImm32(unlinkedTable.maxLength() - unlinkedTable.minLength()), data->fallThrough.block);
-    }
-    
+    std::sort(cases.begin(), cases.end());
+
+    emitBinarySwitchStringRecurse(data, cases, 0, 0, cases.size(), stringGPR, lengthGPR, tempGPR, 0, false);
+
     slowCases.link(this);
-    callOperationWithSilentSpill(operationSwitchString, string, LinkableConstant::globalObject(*this, node), static_cast<size_t>(data->switchTableIndex), TrustedImmPtr(&unlinkedTable), string);
-    farJump(string, JSSwitchPtrTag);
+    callOperationWithSilentSpill(operationSwitchString, stringGPR, LinkableConstant::globalObject(*this, node), static_cast<size_t>(data->switchTableIndex), TrustedImmPtr(&unlinkedTable), stringGPR);
+    farJump(stringGPR, JSSwitchPtrTag);
 }
 
 void SpeculativeJIT::emitSwitchString(Node* node, SwitchData* data)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1322,7 +1322,7 @@ public:
         SwitchData*, const Vector<StringSwitchCase>&, unsigned numChecked,
         unsigned begin, unsigned end, GPRReg buffer, GPRReg length, GPRReg temp,
         unsigned alreadyCheckedLength, bool checkedExactLength);
-    void emitSwitchStringOnString(Node*, SwitchData*, GPRReg string, Edge stringEdge);
+    void emitSwitchStringOnString(Node*, SwitchData*, GPRReg stringGPR, Edge stringEdge);
     void emitSwitchString(Node*, SwitchData*);
     void emitSwitch(Node*);
     

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -23801,6 +23801,10 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock hasImplBlock = m_out.newBlock();
         LBasicBlock is8BitBlock = m_out.newBlock();
         LBasicBlock isRopeBlock = m_out.newBlock();
+        LBasicBlock isSubstringBlock = m_out.newBlock();
+        LBasicBlock substringBlock = m_out.newBlock();
+        LBasicBlock concatRopeBlock = m_out.newBlock();
+        LBasicBlock binarySwitchBlock = m_out.newBlock();
         LBasicBlock slowBlock = m_out.newBlock();
 
         m_out.branch(isRopeString(string, edge), rarely(isRopeBlock), usually(hasImplBlock));
@@ -23821,8 +23825,46 @@ IGNORE_CLANG_WARNINGS_END
             rarely(slowBlock), usually(is8BitBlock));
 
         m_out.appendTo(is8BitBlock, isRopeBlock);
+        ValueFromBlock resolvedBuffer = m_out.anchor(m_out.loadPtr(stringImpl, m_heaps.StringImpl_data));
+        ValueFromBlock resolvedLength = m_out.anchor(length);
+        m_out.jump(binarySwitchBlock);
 
-        LValue buffer = m_out.loadPtr(stringImpl, m_heaps.StringImpl_data);
+        m_out.appendTo(isRopeBlock, isSubstringBlock);
+        LValue fiber0 = m_out.loadPtr(string, m_heaps.JSRopeString_fiber0);
+        m_out.branch(
+            m_out.testIsZeroPtr(fiber0, m_out.constIntPtr(JSRopeString::isSubstringInPointer)),
+            unsure(concatRopeBlock), unsure(isSubstringBlock));
+
+        m_out.appendTo(isSubstringBlock, substringBlock);
+        m_out.branch(
+            m_out.testIsZeroPtr(fiber0, m_out.constIntPtr(JSRopeString::is8BitInPointer)),
+            unsure(concatRopeBlock), unsure(substringBlock));
+
+        m_out.appendTo(substringBlock, concatRopeBlock);
+        LValue packedLengthAndBaseLower = m_out.load64(string, m_heaps.JSRopeString_fiber1);
+        LValue packedBaseUpperAndOffset = m_out.load64(string, m_heaps.JSRopeString_fiber2);
+        LValue substringBase = m_out.bitOr(
+            m_out.lShr(packedLengthAndBaseLower, m_out.constInt32(32)),
+            m_out.shl(m_out.bitAnd(packedBaseUpperAndOffset, m_out.constInt64(0xffff)), m_out.constInt32(32)));
+        LValue substringOffset = m_out.lShr(packedBaseUpperAndOffset, m_out.constInt32(16));
+        LValue baseImpl = m_out.loadPtr(substringBase, m_heaps.JSString_value);
+        ValueFromBlock substringBuffer = m_out.anchor(
+            m_out.add(m_out.loadPtr(baseImpl, m_heaps.StringImpl_data), substringOffset));
+        ValueFromBlock substringLength = m_out.anchor(m_out.load32NonNegative(string, m_heaps.JSRopeString_length));
+        m_out.jump(binarySwitchBlock);
+
+        m_out.appendTo(concatRopeBlock, binarySwitchBlock);
+        const UnlinkedStringJumpTable& unlinkedTable = m_graph.unlinkedStringSwitchJumpTable(data->switchTableIndex);
+        LValue ropeLength;
+        if (auto stringLength = tryGetConstantStringLength(edge))
+            ropeLength = m_out.constInt32(*stringLength);
+        else
+            ropeLength = m_out.load32NonNegative(string, m_heaps.JSRopeString_length);
+        m_out.branch(m_out.belowOrEqual(m_out.sub(ropeLength, m_out.constInt32(unlinkedTable.minLength())), m_out.constInt32(unlinkedTable.maxLength() - unlinkedTable.minLength())), unsure(slowBlock), unsure(lowBlock(data->fallThrough.block)));
+
+        m_out.appendTo(binarySwitchBlock, slowBlock);
+        LValue buffer = m_out.phi(pointerType(), resolvedBuffer, substringBuffer);
+        LValue switchLength = m_out.phi(Int32, resolvedLength, substringLength);
 
         // FIXME: We should propagate branch weight data to the cases of this switch.
         // https://bugs.webkit.org/show_bug.cgi?id=144368
@@ -23831,16 +23873,7 @@ IGNORE_CLANG_WARNINGS_END
         for (DFG::SwitchCase myCase : data->cases)
             cases.append(StringSwitchCase(myCase.value.stringImpl(), lowBlock(myCase.target.block)));
         std::sort(cases.begin(), cases.end());
-        switchStringRecurse(data, buffer, length, cases, 0, 0, cases.size(), 0, false);
-
-        m_out.appendTo(isRopeBlock, slowBlock);
-        const UnlinkedStringJumpTable& unlinkedTable = m_graph.unlinkedStringSwitchJumpTable(data->switchTableIndex);
-        LValue ropeLength;
-        if (auto stringLength = tryGetConstantStringLength(edge))
-            ropeLength = m_out.constInt32(*stringLength);
-        else
-            ropeLength = m_out.load32NonNegative(string, m_heaps.JSRopeString_length);
-        m_out.branch(m_out.belowOrEqual(m_out.sub(ropeLength, m_out.constInt32(unlinkedTable.minLength())), m_out.constInt32(unlinkedTable.maxLength() - unlinkedTable.minLength())), unsure(slowBlock), unsure(lowBlock(data->fallThrough.block)));
+        switchStringRecurse(data, buffer, switchLength, cases, 0, 0, cases.size(), 0, false);
 
         m_out.appendTo(slowBlock, lastNext);
         switchStringSlow(data, string);


### PR DESCRIPTION
#### 9516ed8a4ffc897ddca5eebfbf7b7218a729c406
<pre>
[JSC] Apply StringSwitch for substrings
<a href="https://bugs.webkit.org/show_bug.cgi?id=322078">https://bugs.webkit.org/show_bug.cgi?id=322078</a>
<a href="https://rdar.apple.com/185270122">rdar://185270122</a>

Reviewed by Yijia Huang.

Like 313752@main, if rope is substring, we can access to the underlying
string data cheaply. This patch extends StringSwitch to substring 8-bit
ropes (previously only non-rope 8-bit string is supported).

Test: JSTests/stress/switch-string-substring-rope.js

* JSTests/stress/switch-string-substring-rope.js: Added.
(shouldBe):
(expectedFor):
(substringOfSubstring):
(check):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::emitSwitchStringOnString):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/319433@main">https://commits.webkit.org/319433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea85653d852544cb2253078b4e994dc9fdbecbf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145772 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf0c9138-c6df-4993-9942-8de802a8ae80) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141607 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a5c4c719-f90d-4733-86de-9661d07100ed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45290 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122047 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/645fe68b-47d6-44a4-9063-e930d2bd6d36) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43968 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4013 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10826 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41880 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2830 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42722 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193597 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55062 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151013 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55749 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150718 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27555 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45297 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128030 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123631 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54265 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16879 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53647 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53885 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53712 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->