### PR TITLE
[web-animations] Animations targeting ::picker-icon and ::-webkit-scrollbar have the wrong composite order

### DIFF
--- a/LayoutTests/webanimations/pseudo-element-composite-order-expected.txt
+++ b/LayoutTests/webanimations/pseudo-element-composite-order-expected.txt
@@ -1,0 +1,87 @@
+
+PASS [div] full sequence
+PASS [select] full sequence
+PASS [option] full sequence
+PASS [div] element sorts before ::marker
+PASS [div] element sorts before ::before
+PASS [div] element sorts before ::-webkit-scrollbar
+PASS [div] element sorts before ::first-letter
+PASS [div] element sorts before ::first-line
+NOTRUN [div] element sorts before ::grammar-error no animation created for ::grammar-error
+NOTRUN [div] element sorts before ::highlight(hl) no animation created for ::highlight(hl)
+NOTRUN [div] element sorts before ::selection no animation created for ::selection
+NOTRUN [div] element sorts before ::spelling-error no animation created for ::spelling-error
+NOTRUN [div] element sorts before ::target-text no animation created for ::target-text
+PASS [div] element sorts before ::after
+PASS [div] ::marker sorts before ::before
+PASS [div] ::marker sorts before ::-webkit-scrollbar
+PASS [div] ::marker sorts before ::first-letter
+PASS [div] ::marker sorts before ::first-line
+NOTRUN [div] ::marker sorts before ::grammar-error no animation created for ::grammar-error
+NOTRUN [div] ::marker sorts before ::highlight(hl) no animation created for ::highlight(hl)
+NOTRUN [div] ::marker sorts before ::selection no animation created for ::selection
+NOTRUN [div] ::marker sorts before ::spelling-error no animation created for ::spelling-error
+NOTRUN [div] ::marker sorts before ::target-text no animation created for ::target-text
+PASS [div] ::marker sorts before ::after
+PASS [div] ::before sorts before ::-webkit-scrollbar
+PASS [div] ::before sorts before ::first-letter
+PASS [div] ::before sorts before ::first-line
+NOTRUN [div] ::before sorts before ::grammar-error no animation created for ::grammar-error
+NOTRUN [div] ::before sorts before ::highlight(hl) no animation created for ::highlight(hl)
+NOTRUN [div] ::before sorts before ::selection no animation created for ::selection
+NOTRUN [div] ::before sorts before ::spelling-error no animation created for ::spelling-error
+NOTRUN [div] ::before sorts before ::target-text no animation created for ::target-text
+PASS [div] ::before sorts before ::after
+PASS [div] ::-webkit-scrollbar sorts before ::first-letter
+PASS [div] ::-webkit-scrollbar sorts before ::first-line
+NOTRUN [div] ::-webkit-scrollbar sorts before ::grammar-error no animation created for ::grammar-error
+NOTRUN [div] ::-webkit-scrollbar sorts before ::highlight(hl) no animation created for ::highlight(hl)
+NOTRUN [div] ::-webkit-scrollbar sorts before ::selection no animation created for ::selection
+NOTRUN [div] ::-webkit-scrollbar sorts before ::spelling-error no animation created for ::spelling-error
+NOTRUN [div] ::-webkit-scrollbar sorts before ::target-text no animation created for ::target-text
+PASS [div] ::-webkit-scrollbar sorts before ::after
+PASS [div] ::first-letter sorts before ::first-line
+NOTRUN [div] ::first-letter sorts before ::grammar-error no animation created for ::grammar-error
+NOTRUN [div] ::first-letter sorts before ::highlight(hl) no animation created for ::highlight(hl)
+NOTRUN [div] ::first-letter sorts before ::selection no animation created for ::selection
+NOTRUN [div] ::first-letter sorts before ::spelling-error no animation created for ::spelling-error
+NOTRUN [div] ::first-letter sorts before ::target-text no animation created for ::target-text
+PASS [div] ::first-letter sorts before ::after
+NOTRUN [div] ::first-line sorts before ::grammar-error no animation created for ::grammar-error
+NOTRUN [div] ::first-line sorts before ::highlight(hl) no animation created for ::highlight(hl)
+NOTRUN [div] ::first-line sorts before ::selection no animation created for ::selection
+NOTRUN [div] ::first-line sorts before ::spelling-error no animation created for ::spelling-error
+NOTRUN [div] ::first-line sorts before ::target-text no animation created for ::target-text
+PASS [div] ::first-line sorts before ::after
+NOTRUN [div] ::grammar-error sorts before ::highlight(hl) no animation created for ::grammar-error or ::highlight(hl)
+NOTRUN [div] ::grammar-error sorts before ::selection no animation created for ::grammar-error or ::selection
+NOTRUN [div] ::grammar-error sorts before ::spelling-error no animation created for ::grammar-error or ::spelling-error
+NOTRUN [div] ::grammar-error sorts before ::target-text no animation created for ::grammar-error or ::target-text
+NOTRUN [div] ::grammar-error sorts before ::after no animation created for ::grammar-error
+NOTRUN [div] ::highlight(hl) sorts before ::selection no animation created for ::highlight(hl) or ::selection
+NOTRUN [div] ::highlight(hl) sorts before ::spelling-error no animation created for ::highlight(hl) or ::spelling-error
+NOTRUN [div] ::highlight(hl) sorts before ::target-text no animation created for ::highlight(hl) or ::target-text
+NOTRUN [div] ::highlight(hl) sorts before ::after no animation created for ::highlight(hl)
+NOTRUN [div] ::selection sorts before ::spelling-error no animation created for ::selection or ::spelling-error
+NOTRUN [div] ::selection sorts before ::target-text no animation created for ::selection or ::target-text
+NOTRUN [div] ::selection sorts before ::after no animation created for ::selection
+NOTRUN [div] ::spelling-error sorts before ::target-text no animation created for ::spelling-error or ::target-text
+NOTRUN [div] ::spelling-error sorts before ::after no animation created for ::spelling-error
+NOTRUN [div] ::target-text sorts before ::after no animation created for ::target-text
+PASS [select] element sorts before ::before
+PASS [select] element sorts before ::picker-icon
+PASS [select] element sorts before ::after
+PASS [select] ::before sorts before ::picker-icon
+PASS [select] ::before sorts before ::after
+PASS [select] ::picker-icon sorts before ::after
+PASS [option] element sorts before ::marker
+PASS [option] element sorts before ::before
+NOTRUN [option] element sorts before ::checkmark no animation created for ::checkmark
+PASS [option] element sorts before ::after
+PASS [option] ::marker sorts before ::before
+NOTRUN [option] ::marker sorts before ::checkmark no animation created for ::checkmark
+PASS [option] ::marker sorts before ::after
+NOTRUN [option] ::before sorts before ::checkmark no animation created for ::checkmark
+PASS [option] ::before sorts before ::after
+NOTRUN [option] ::checkmark sorts before ::after no animation created for ::checkmark
+

--- a/LayoutTests/webanimations/pseudo-element-composite-order.html
+++ b/LayoutTests/webanimations/pseudo-element-composite-order.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Composite order of animations targeting pseudo-elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-composite-order">
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/#dom-animatable-getanimations">
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/#the-effect-stack">
+<meta name="assert" content="Animations on the pseudo-elements of a single originating element sort as: the element, ::marker, ::before, any other pseudo-element in ascending order of the Unicode codepoints of its selector, ::after.">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<style>
+@keyframes colorAnim {
+    from { color: red; }
+    to { color: blue; }
+}
+</style>
+<body>
+<div id="scratch"></div>
+<script>
+'use strict';
+
+// Animatable.getAnimations() returns its list "sorted using the composite order described
+// for the associated animations of effects in § 5.4.2 The effect stack". Every animation
+// here is a CSS Animation, so steps 1 and 3 of that comparison do not apply and it resolves
+// entirely on step 2, the class-specific composite order — for CSS Animations that is:
+//
+//     https://drafts.csswg.org/css-animations-2/#animation-composite-order
+//
+// which sorts animations with a common owning element but different pseudo-element
+// identifiers as:
+//
+//     - the element itself
+//     - ::marker
+//     - ::before
+//     - any other pseudo-element, in ascending order of the Unicode codepoints of its selector
+//     - ::after
+//
+// So the sequence getAnimations() returns is a direct probe of that ordering. Animation
+// event dispatch order uses the same comparison, but getAnimations() is synchronous and
+// so needs no waiting on events that may never be dispatched.
+//
+// The ::view-transition pseudo-element tree is deliberately out of scope here: its
+// ordering is additionally constrained by css-view-transitions.
+//
+// ::-webkit-scrollbar is not standardized, which is why this test is not in
+// web-platform-tests: Firefox has no such pseudo-element, so the ordering it takes part
+// in cannot be tested cross-engine. It participates in the same codepoint ordering
+// wherever it is supported, and it is the only entry in the third group whose selector
+// begins with a character below "a".
+//
+// Pseudo-elements for which no animation is created report their subtests as
+// optional-feature-unsupported rather than failing them, so that an unsupported
+// pseudo-element cannot mask a misordering.
+
+// All ASCII, so code-unit order matches codepoint order.
+const codepointOrder = (a, b) => a < b ? -1 : a > b ? 1 : 0;
+
+const OTHER_PSEUDOS = [
+    '::-webkit-scrollbar',
+    '::checkmark',
+    '::first-letter',
+    '::first-line',
+    '::grammar-error',
+    '::highlight(hl)',
+    '::picker-icon',
+    '::selection',
+    '::spelling-error',
+    '::target-text',
+].sort(codepointOrder);
+
+// `null` stands for the originating element itself.
+const EXPECTED_ORDER = [null, '::marker', '::before', ...OTHER_PSEUDOS, '::after'];
+
+const display = pseudo => pseudo === null ? 'element' : pseudo;
+
+const nextFrame = () => new Promise(requestAnimationFrame);
+
+let hostCounter = 0;
+
+function declarationsFor(pseudo) {
+    switch (pseudo) {
+    case '::before':
+    case '::after':
+        return "content: 'x';";
+    case '::-webkit-scrollbar':
+        // Styling ::-webkit-scrollbar at all opts the scroller into custom scrollbars,
+        // which is what makes the pseudo-element exist on platforms with overlay scrollbars.
+        return 'width: 10px; height: 10px; background-color: gray;';
+    case '::checkmark':
+    case '::picker-icon':
+        return 'display: block;';
+    default:
+        return '';
+    }
+}
+
+function addStyle(test, id, pseudos, extraRules = '') {
+    const rules = pseudos.map(pseudo => {
+        const selector = pseudo === null ? `#${id}` : `#${id}${pseudo}`;
+        return `${selector} { ${declarationsFor(pseudo)} animation: colorAnim 100s linear; }`;
+    });
+    const style = document.createElement('style');
+    style.textContent = extraRules + '\n' + rules.join('\n');
+    document.head.appendChild(style);
+    test.add_cleanup(() => { style.remove(); });
+}
+
+// A single element that can simultaneously own ::marker, ::before, ::after,
+// ::first-letter, ::first-line, ::selection, ::highlight(), ::-webkit-scrollbar,
+// ::grammar-error, ::spelling-error and ::target-text.
+function buildDivHost(test, pseudos) {
+    const id = `host-${hostCounter++}`;
+    const host = document.createElement('div');
+    host.id = id;
+    host.textContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+    host.style.cssText = 'display: list-item; list-style-position: inside; overflow: scroll; width: 100px; height: 40px;';
+
+    addStyle(test, id, pseudos);
+    document.getElementById('scratch').appendChild(host);
+    test.add_cleanup(() => { host.remove(); });
+
+    if (pseudos.includes('::selection')) {
+        getSelection().selectAllChildren(host);
+        test.add_cleanup(() => { getSelection().removeAllRanges(); });
+    }
+
+    if (pseudos.includes('::highlight(hl)') && window.Highlight && window.CSS && CSS.highlights) {
+        const range = new Range();
+        range.selectNodeContents(host);
+        CSS.highlights.set('hl', new Highlight(range));
+        test.add_cleanup(() => { CSS.highlights.delete('hl'); });
+    }
+
+    return host;
+}
+
+// ::picker-icon is owned by the <select>, ::checkmark by the <option>, so they can
+// never be compared against each other by this table — only against pseudo-elements
+// of their own originating element.
+function buildSelectHost(test, pseudos) {
+    const id = `host-${hostCounter++}`;
+    const select = document.createElement('select');
+    select.id = id;
+    select.innerHTML = '<option>one</option><option>two</option>';
+
+    addStyle(test, id, pseudos, `#${id} { appearance: base-select; }`);
+    document.getElementById('scratch').appendChild(select);
+    test.add_cleanup(() => { select.remove(); });
+
+    return select;
+}
+
+function buildOptionHost(test, pseudos) {
+    const id = `host-${hostCounter++}`;
+    const select = document.createElement('select');
+    select.id = `select-${hostCounter++}`;
+    const option = document.createElement('option');
+    option.id = id;
+    option.textContent = 'one';
+    select.appendChild(option);
+    select.appendChild(document.createElement('option')).textContent = 'two';
+
+    // ::checkmark only exists on the :checked option, which is the first one here.
+    addStyle(test, id, pseudos, `#${select.id} { appearance: base-select; } #${id} { display: list-item; list-style-position: inside; }`);
+    document.getElementById('scratch').appendChild(select);
+    test.add_cleanup(() => { select.remove(); });
+
+    return option;
+}
+
+function compositeOrder(host) {
+    // getAnimations() is specified to return animations in composite order.
+    return host.getAnimations({ subtree: true }).map(animation => animation.effect.pseudoElement ?? null);
+}
+
+function sequenceTest(family) {
+    const name = `[${family.label}] full sequence`;
+    const pseudos = family.pseudos;
+    promise_test(async test => {
+        const host = family.build(test, pseudos);
+        await nextFrame();
+        await nextFrame();
+
+        const actual = compositeOrder(host);
+
+        // Only the pseudo-elements that an animation was actually created for take part
+        // in the comparison, so an unsupported pseudo-element cannot mask a misordering.
+        const expected = pseudos.filter(pseudo => actual.includes(pseudo));
+
+        assert_array_equals(actual.map(display), expected.map(display));
+    }, name);
+}
+
+function pairTest(family, a, b) {
+    const name = `[${family.label}] ${display(a)} sorts before ${display(b)}`;
+    promise_test(async test => {
+        const host = family.build(test, [a, b]);
+        await nextFrame();
+        await nextFrame();
+
+        const actual = compositeOrder(host);
+        const indexOfA = actual.indexOf(a);
+        const indexOfB = actual.indexOf(b);
+
+        if (indexOfA < 0 || indexOfB < 0) {
+            assert_implements_optional(false,
+                `no animation created for ${[[a, indexOfA], [b, indexOfB]].filter(([, i]) => i < 0).map(([pseudo]) => display(pseudo)).join(' or ')}`);
+        }
+
+        assert_less_than(indexOfA, indexOfB,
+            `getAnimations() returned ${actual.map(display).join(', ')}`);
+    }, name);
+}
+
+function pairTests(family) {
+    const pseudos = family.pseudos;
+    for (let i = 0; i < pseudos.length; ++i) {
+        for (let j = i + 1; j < pseudos.length; ++j)
+            pairTest(family, pseudos[i], pseudos[j]);
+    }
+}
+
+// Each family is one originating element carrying every pseudo-element it can own.
+// The pseudo-element list is always in the order the spec requires.
+const FAMILIES = [{
+    label: 'div',
+    build: buildDivHost,
+    pseudos: EXPECTED_ORDER.filter(pseudo => pseudo !== '::checkmark' && pseudo !== '::picker-icon'),
+}, {
+    label: 'select',
+    build: buildSelectHost,
+    pseudos: EXPECTED_ORDER.filter(pseudo => [null, '::before', '::picker-icon', '::after'].includes(pseudo)),
+}, {
+    label: 'option',
+    build: buildOptionHost,
+    pseudos: EXPECTED_ORDER.filter(pseudo => [null, '::marker', '::before', '::checkmark', '::after'].includes(pseudo)),
+}];
+
+for (const family of FAMILIES)
+    sequenceTest(family);
+
+for (const family of FAMILIES)
+    pairTests(family);
+</script>
+</body>
+

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -65,7 +65,13 @@ static bool compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeO
     //     - any other pseudo-elements not mentioned specifically in this list, sorted in ascending order by the Unicode codepoints that make up each selector
     //     - ::after
     //     - element children
-    enum SortingIndex : uint8_t { NotPseudo, Marker, Before, FirstLetter, FirstLine, GrammarError, Highlight, WebKitScrollbar, Selection, SpellingError, TargetText, Checkmark, After, PickerIcon, ViewTransition, ViewTransitionGroup, ViewTransitionImagePair, ViewTransitionOld, ViewTransitionNew, Other };
+    //
+    // The enumerators below are listed in that sort order, since their numeric values are what
+    // the comparison uses. A new pseudo-element must therefore be inserted at its place in this
+    // list rather than appended at the end. For the "any other pseudo-elements" group, that place
+    // is where its selector falls in ascending codepoint order: "-" sorts before "c", "c" before
+    // "f", and so on.
+    enum SortingIndex : uint8_t { NotPseudo, Marker, Before, WebKitScrollbar, Checkmark, FirstLetter, FirstLine, GrammarError, Highlight, PickerIcon, Selection, SpellingError, TargetText, After, ViewTransition, ViewTransitionGroup, ViewTransitionImagePair, ViewTransitionOld, ViewTransitionNew, Other };
     auto sortingIndex = [](const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) -> SortingIndex {
         if (!pseudoElementIdentifier)
             return NotPseudo;


### PR DESCRIPTION
#### 02f6ec0873f7cb4cccf05facfddda6f6b0753f13
<pre>
[web-animations] Animations targeting ::picker-icon and ::-webkit-scrollbar have the wrong composite order
<a href="https://bugs.webkit.org/show_bug.cgi?id=322079">https://bugs.webkit.org/show_bug.cgi?id=322079</a>
<a href="https://rdar.apple.com/185270753">rdar://185270753</a>

Reviewed by Antoine Quint.

Animatable.getAnimations() returns its list &quot;sorted using the composite order
described for the associated animations of effects in § 5.4.2 The effect
stack&quot; [1][2].

For two CSS Animations that comparison resolves entirely on step 2 of § 5.4.2,
the class-specific composite order. Since an owning element is an (element,
pseudo-element) pair, two animations on different pseudo-elements of a single
element take the &quot;if the owning element of A and B differs&quot; branch of
css-animations-2 § 2.2 [3], which orders pseudo-elements as:

    element, ::marker, ::before, any other pseudo-elements not mentioned
    specifically in this list, sorted in ascending order by the Unicode
    codepoints that make up each selector, ::after, element children

The SortingIndex enum in
compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder()
deviated from that order in three ways, because each newly-supported
pseudo-element was appended to the enum instead of being inserted in codepoint
order:

    - PickerIcon sorted after After, so an animation on ::picker-icon was
      composited and returned after one on ::after.
    - WebKitScrollbar sorted after FirstLetter, FirstLine, GrammarError and
      Highlight, but &quot;-&quot; (U+002D) sorts before &quot;f&quot;, &quot;g&quot; and &quot;h&quot;.
    - Checkmark sorted after TargetText, but &quot;c&quot; sorts before &quot;f&quot;.

Reorder the enum to match the order specified in [3], and spell out in the
comment above it that the enumerators are listed in sort order, so that a future
pseudo-element is inserted at its codepoint position rather than appended.

The ::view-transition pseudo-elements are left after After: their relative order
is additionally constrained by css-view-transitions [4] and is already
special-cased above by nameOrPart.

This is observable both through getAnimations() [1] and through the dispatch
order of animation and transition events, since
compareAnimationEventsByCompositeOrder() sorts with the same comparison. Chrome
already returns ::picker-icon before ::after; Firefox creates no animations for
any of the affected pseudo-elements. ::checkmark&apos;s position is corrected by the
same rule but is not yet observable, as no engine creates an animation for it.

The new test is a WebKit test rather than a web-platform-test because the
ordering ::-webkit-scrollbar takes part in cannot be tested cross-engine: it is
not a standardized pseudo-element, and Firefox has no equivalent. It reports the
subtests for the pseudo-elements WebKit creates no animation for — ::checkmark,
::selection, ::highlight(), ::grammar-error, ::spelling-error and ::target-text —
as unsupported rather than asserting on them, so that an unsupported
pseudo-element cannot mask a misordering.

[1] <a href="https://drafts.csswg.org/web-animations-1/#dom-animatable-getanimations">https://drafts.csswg.org/web-animations-1/#dom-animatable-getanimations</a>
[2] <a href="https://drafts.csswg.org/web-animations-1/#the-effect-stack">https://drafts.csswg.org/web-animations-1/#the-effect-stack</a>
[3] <a href="https://drafts.csswg.org/css-animations-2/#animation-composite-order">https://drafts.csswg.org/css-animations-2/#animation-composite-order</a>
[4] <a href="https://drafts.csswg.org/css-view-transitions-1/">https://drafts.csswg.org/css-view-transitions-1/</a>

Test: webanimations/pseudo-element-composite-order.html

* LayoutTests/webanimations/pseudo-element-composite-order-expected.txt: Added.
* LayoutTests/webanimations/pseudo-element-composite-order.html: Added.
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder):

Canonical link: <a href="https://commits.webkit.org/319448@main">https://commits.webkit.org/319448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7976bb43c63344b7944b7f2578c655695537a25a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191715 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145818 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a47c869-0a02-4065-ba80-4a19921f3414) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55160 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db9df7d9-0266-41ba-866c-b5f81d413c24) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45334 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122091 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37812b08-53fe-4846-bfa4-cfbfecdbebcc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154414 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/41926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2876 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48065 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193643 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161903 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151056 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40455 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55795 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150763 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45340 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128078 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123709 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54311 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16924 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53693 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53931 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53758 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->