### PR TITLE
[JSC] Proxy call/construct traps should use caller's realm

### DIFF
--- a/JSTests/stress/proxy-call-construct-error-realm.js
+++ b/JSTests/stress/proxy-call-construct-error-realm.js
@@ -1,0 +1,56 @@
+function shouldThrowTypeErrorOfThisRealm(f) {
+    try {
+        f();
+    } catch (error) {
+        if (!(error instanceof TypeError))
+            throw new Error(`bad error realm or type: ${String(error)}`);
+        return;
+    }
+    throw new Error("no error thrown");
+}
+
+const OtherProxy = createGlobalObject().Proxy;
+
+{
+    const revocable = OtherProxy.revocable(function () {}, {});
+    revocable.revoke();
+    shouldThrowTypeErrorOfThisRealm(() => revocable.proxy());
+    shouldThrowTypeErrorOfThisRealm(() => new revocable.proxy());
+    shouldThrowTypeErrorOfThisRealm(() => Reflect.apply(revocable.proxy, undefined, []));
+    shouldThrowTypeErrorOfThisRealm(() => Reflect.construct(revocable.proxy, []));
+}
+
+{
+    const proxy = new OtherProxy(function () {}, { apply: {} });
+    shouldThrowTypeErrorOfThisRealm(() => proxy());
+}
+
+{
+    const proxy = new OtherProxy(function () {}, { apply: 42 });
+    shouldThrowTypeErrorOfThisRealm(() => proxy());
+}
+
+{
+    const proxy = new OtherProxy(function () {}, { construct: {} });
+    shouldThrowTypeErrorOfThisRealm(() => new proxy());
+}
+
+{
+    const proxy = new OtherProxy(function () {}, { construct: 42 });
+    shouldThrowTypeErrorOfThisRealm(() => new proxy());
+}
+
+{
+    const proxy = new OtherProxy(function () {}, { construct() { return 42; } });
+    shouldThrowTypeErrorOfThisRealm(() => new proxy());
+}
+
+// A null or undefined trap means the operation is forwarded to the target rather than rejected.
+{
+    let called = 0;
+    const proxy = new OtherProxy(function () { called++; }, { apply: null, construct: undefined });
+    proxy();
+    new proxy();
+    if (called !== 2)
+        throw new Error(`bad call count: ${called}`);
+}

--- a/JSTests/stress/proxy-revoke.js
+++ b/JSTests/stress/proxy-revoke.js
@@ -139,6 +139,7 @@ function allHandlersShouldThrow(proxy) {
     shouldThrowNullHandler(() => Reflect.deleteProperty(proxy, "x"));
     shouldThrowNullHandler(() => Reflect.defineProperty(proxy, "x", {value: 40, enumerable: true, configurable: true}));
     shouldThrowNullHandler(() => Reflect.ownKeys(proxy));
+    shouldThrowNullHandler(() => Reflect.apply(proxy, this, []));
     shouldThrowNullHandler(() => Reflect.construct(proxy, []));
 }
 

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -40,16 +40,7 @@ test/built-ins/Function/prototype/toString/built-in-function-object.js:
 test/built-ins/Proxy/apply/arguments-realm.js:
   default: 3
   strict mode: 3
-test/built-ins/Proxy/apply/null-handler-realm.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Proxy/apply/trap-is-not-callable-realm.js:
-  default: 3
-  strict mode: 3
 test/built-ins/Proxy/construct/arguments-realm.js:
-  default: 3
-  strict mode: 3
-test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
   default: 3
   strict mode: 3
 test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js:

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -599,6 +599,17 @@ bool ProxyObject::putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigne
     return thisObject->putByIndexCommon(globalObject, thisObject, propertyName, value, shouldThrow);
 }
 
+// Proxies, unlike other spec provided callable/constructable objects, don't switch the realm when
+// they are called or constructed, so an error they raise belongs to the caller's realm rather than
+// to the realm the Proxy itself came from.
+// see: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
+static JSGlobalObject* realmOfCaller(VM& vm, CallFrame* callFrame, JSGlobalObject* currentRealm)
+{
+    if (auto* callerRealm = CallFrame::globalObjectOfClosestCodeBlock(vm, callFrame))
+        return callerRealm;
+    return currentRealm;
+}
+
 JSC_DEFINE_HOST_FUNCTION(performProxyCall, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     NO_TAIL_CALLS();
@@ -612,17 +623,22 @@ JSC_DEFINE_HOST_FUNCTION(performProxyCall, (JSGlobalObject* globalObject, CallFr
     ProxyObject* proxy = uncheckedDowncast<ProxyObject>(callFrame->jsCallee());
     JSValue handlerValue = proxy->handler();
     if (handlerValue.isNull())
-        return throwVMTypeError(globalObject, scope, s_proxyAlreadyRevokedErrorMessage);
+        return throwVMTypeError(realmOfCaller(vm, callFrame, globalObject), scope, s_proxyAlreadyRevokedErrorMessage);
 
     JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
-    CallData callData;
-    JSValue applyMethod = handler->getMethod(globalObject, callData, makeIdentifier(vm, "apply"_s), "'apply' property of a Proxy's handler should be callable"_s);
+    JSValue applyMethod = handler->get(globalObject, makeIdentifier(vm, "apply"_s));
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    CallData callData;
+    if (!applyMethod.isUndefinedOrNull()) {
+        callData = JSC::getCallDataInline(applyMethod);
+        if (callData.type == CallData::Type::None)
+            return throwVMTypeError(realmOfCaller(vm, callFrame, globalObject), scope, "'apply' property of a Proxy's handler should be callable"_s);
+    }
     JSObject* target = proxy->target();
-    if (applyMethod.isUndefined()) {
-        auto callData = JSC::getCallDataInline(target);
-        RELEASE_ASSERT(callData.type != CallData::Type::None);
-        RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, target, callData, callFrame->thisValue(), ArgList(callFrame))));
+    if (callData.type == CallData::Type::None) {
+        auto targetCallData = JSC::getCallDataInline(target);
+        RELEASE_ASSERT(targetCallData.type != CallData::Type::None);
+        RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, target, targetCallData, callFrame->thisValue(), ArgList(callFrame))));
     }
 
     JSArray* argArray = constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), ArgList(callFrame));
@@ -661,17 +677,19 @@ JSC_DEFINE_HOST_FUNCTION(performProxyConstruct, (JSGlobalObject* globalObject, C
     ProxyObject* proxy = uncheckedDowncast<ProxyObject>(callFrame->jsCallee());
     JSValue handlerValue = proxy->handler();
     if (handlerValue.isNull())
-        // Proxies, unlike other spec provided callable/constructable objects,
-        // don't switch the realm when called/constructed
-        // see: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget
-        return throwVMTypeError(CallFrame::globalObjectOfClosestCodeBlock(vm, callFrame), scope, s_proxyAlreadyRevokedErrorMessage);
+        return throwVMTypeError(realmOfCaller(vm, callFrame, globalObject), scope, s_proxyAlreadyRevokedErrorMessage);
 
     JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
-    CallData callData;
-    JSValue constructMethod = handler->getMethod(globalObject, callData, makeIdentifier(vm, "construct"_s), "'construct' property of a Proxy's handler should be callable"_s);
+    JSValue constructMethod = handler->get(globalObject, makeIdentifier(vm, "construct"_s));
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    CallData callData;
+    if (!constructMethod.isUndefinedOrNull()) {
+        callData = JSC::getCallDataInline(constructMethod);
+        if (callData.type == CallData::Type::None)
+            return throwVMTypeError(realmOfCaller(vm, callFrame, globalObject), scope, "'construct' property of a Proxy's handler should be callable"_s);
+    }
     JSObject* target = proxy->target();
-    if (constructMethod.isUndefined()) {
+    if (callData.type == CallData::Type::None) {
         auto constructData = JSC::getConstructDataInline(target);
         RELEASE_ASSERT(constructData.type != CallData::Type::None);
         RELEASE_AND_RETURN(scope, JSValue::encode(construct(globalObject, target, constructData, ArgList(callFrame), callFrame->newTarget())));
@@ -687,10 +705,7 @@ JSC_DEFINE_HOST_FUNCTION(performProxyConstruct, (JSGlobalObject* globalObject, C
     JSValue result = call(globalObject, constructMethod, callData, handler, ArgList { arguments.data(), arguments.size() });
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     if (!result.isObject())
-        // Proxies, unlike other spec provided callable/constructable objects,
-        // don't switch the realm when called/constructed
-        // see: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget
-        return throwVMTypeError(CallFrame::globalObjectOfClosestCodeBlock(vm, callFrame), scope, "Result from Proxy handler's 'construct' method should be an object"_s);
+        return throwVMTypeError(realmOfCaller(vm, callFrame, globalObject), scope, "Result from Proxy handler's 'construct' method should be an object"_s);
     return JSValue::encode(result);
 }
 


### PR DESCRIPTION
#### 4ef35c286ca493c75c6d1488c347032627f8fae4
<pre>
[JSC] Proxy call/construct traps should use caller&apos;s realm
<a href="https://bugs.webkit.org/show_bug.cgi?id=322080">https://bugs.webkit.org/show_bug.cgi?id=322080</a>
<a href="https://rdar.apple.com/185273673">rdar://185273673</a>

Reviewed by NOBODY (OOPS!).

Similar to <a href="https://commits.webkit.org/313966@main">313966@main</a>, [[Call]] / [[Construct]] errors should use the
caller&apos;s realm.

Test: JSTests/stress/proxy-call-construct-error-realm.js

* JSTests/stress/proxy-call-construct-error-realm.js: Added.
(shouldThrowTypeErrorOfThisRealm):
(const.revocable.OtherProxy.revocable):
(shouldThrowTypeErrorOfThisRealm.Reflect.construct):
* JSTests/stress/proxy-revoke.js:
(allHandlersShouldThrow):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::realmOfCaller):
(JSC::JSC_DEFINE_HOST_FUNCTION):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ef35c286ca493c75c6d1488c347032627f8fae4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191672 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145775 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df2938fc-1d12-45a1-9e03-f4f5019263a9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55117 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141612 "Found 2 new test failures: imported/w3c/web-platform-tests/dom/events/EventListener-handleEvent-cross-realm.html imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98262 "3 flakes 12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4fce9f3b-396b-4ab8-813c-d129699abd93) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122052 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b4c6641-fa83-4615-bf4a-f937cc7c628c) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43971 "Found 2 new test failures: imported/w3c/web-platform-tests/dom/events/EventListener-handleEvent-cross-realm.html imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42243 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4018 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10834 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154374 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41888 "Found 2 new test failures: imported/w3c/web-platform-tests/dom/events/EventListener-handleEvent-cross-realm.html imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2833 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42725 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48022 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46499 "Found 2 new test failures: imported/w3c/web-platform-tests/dom/events/EventListener-handleEvent-cross-realm.html imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193600 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55065 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151016 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55752 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38511 "Found 2 new test failures: imported/w3c/web-platform-tests/dom/events/EventListener-handleEvent-cross-realm.html imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150722 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45300 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128033 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123634 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54268 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16887 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53650 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53888 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53715 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->