### PR TITLE
Extend WPT coverage for SVG paths and points

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/error-handling/path-data-error-geometry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/error-handling/path-data-error-geometry-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Path data with an error renders up to the command containing it
+PASS A path data command with an incorrect set of parameters renders up to the last correctly defined segment
+PASS Path data whose first command is in error renders nothing
+PASS Path data that is empty or wholly invalid renders nothing
+PASS A path with no d attribute renders nothing
+PASS Path data in error does not rewrite the content attribute
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/error-handling/path-data-error-geometry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/error-handling/path-data-error-geometry.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<title>Path data error handling: geometry of the rendered prefix</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataErrorHandling">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="svg" width="200" height="200"></svg>
+<script>
+// Error handling in path data is normative and long-standing: render up to (but not
+// including) the path command containing the first error, and for a command with an
+// incorrect set of parameters, up to and including the last correctly defined segment.
+//
+// svg/path/error-handling/render-until-error.svg covers the rendering with a reftest
+// and bounding.svg covers the container's bounding box. Neither checks getTotalLength(),
+// which is the observable showing the DOM geometry reports the same prefix that is
+// drawn rather than an empty or initial value.
+//
+// Every case is asserted against an explicitly truncated path rather than against
+// hardcoded coordinates, so the test states "the erroring path is the truncated path"
+// without depending on how the implementation rounds lengths.
+
+const svg = document.getElementById("svg");
+
+function path(d) {
+    const element = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    if (d !== null)
+        element.setAttribute("d", d);
+    element.setAttribute("fill", "none");
+    svg.append(element);
+    return element;
+}
+
+function assertSameGeometry(actual, expected, description) {
+    assert_equals(actual.getTotalLength(), expected.getTotalLength(),
+        description + ": getTotalLength");
+    const a = actual.getBBox();
+    const b = expected.getBBox();
+    assert_equals(a.x, b.x, description + ": bbox x");
+    assert_equals(a.y, b.y, description + ": bbox y");
+    assert_equals(a.width, b.width, description + ": bbox width");
+    assert_equals(a.height, b.height, description + ": bbox height");
+}
+
+test(function() {
+    const errored = path("M10,10 L70,10 L40,50 BOGUS L20,40");
+    const truncated = path("M10,10 L70,10 L40,50");
+
+    // Guard against both being empty, which would make the comparison vacuous.
+    assert_greater_than(truncated.getTotalLength(), 0, "the truncated path has length");
+
+    assertSameGeometry(errored, truncated, "unrecognized content after a complete segment");
+}, "Path data with an error renders up to the command containing it");
+
+test(function() {
+    // The example given in the specification: "there is an odd number of parameters
+    // for the L command, which requires an even number of parameters. The user agent
+    // is required to draw the line from (10,10) to (20,20)".
+    const errored = path("M10,10 L20,20,30");
+    const truncated = path("M10,10 L20,20");
+
+    assert_greater_than(truncated.getTotalLength(), 0, "the truncated path has length");
+
+    assertSameGeometry(errored, truncated, "incorrect set of parameters");
+}, "A path data command with an incorrect set of parameters renders up to the last correctly defined segment");
+
+test(function() {
+    const errored = path("BOGUS M10,10 L70,10 L40,50");
+
+    assert_equals(errored.getTotalLength(), 0, "getTotalLength");
+    const bbox = errored.getBBox();
+    assert_equals(bbox.width, 0, "bbox width");
+    assert_equals(bbox.height, 0, "bbox height");
+}, "Path data whose first command is in error renders nothing");
+
+test(function() {
+    for (const d of ["", "none", "# invalid"]) {
+        const element = path(d);
+        assert_equals(element.getTotalLength(), 0, "getTotalLength for d=" + JSON.stringify(d));
+        const bbox = element.getBBox();
+        assert_equals(bbox.width, 0, "bbox width for d=" + JSON.stringify(d));
+        assert_equals(bbox.height, 0, "bbox height for d=" + JSON.stringify(d));
+    }
+}, "Path data that is empty or wholly invalid renders nothing");
+
+test(function() {
+    const element = path(null);
+
+    assert_equals(element.getAttribute("d"), null, "the attribute is absent");
+    assert_equals(element.getTotalLength(), 0, "getTotalLength");
+    const bbox = element.getBBox();
+    assert_equals(bbox.width, 0, "bbox width");
+    assert_equals(bbox.height, 0, "bbox height");
+}, "A path with no d attribute renders nothing");
+
+test(function() {
+    const d = "M10,10 L70,10 L40,50 BOGUS L20,40";
+    const element = path(d);
+
+    assert_equals(element.getAttribute("d"), d,
+        "the content attribute keeps what was specified");
+}, "Path data in error does not rewrite the content attribute");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPointList-error-handling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPointList-error-handling-expected.txt
@@ -1,0 +1,18 @@
+
+PASS polyline with an odd number of coordinates drops the last one and keeps the rest
+PASS polyline whose points value begins with a non-numeric token renders nothing
+PASS polyline whose points value begins with a separator renders nothing
+PASS polyline with a points value of a single separator renders nothing
+PASS polyline with an empty points value renders nothing
+PASS polyline with a whitespace-only points value renders nothing
+PASS polyline with no points attribute renders nothing
+PASS polyline with a points value in error does not rewrite the content attribute
+PASS polygon with an odd number of coordinates drops the last one and keeps the rest
+PASS polygon whose points value begins with a non-numeric token renders nothing
+PASS polygon whose points value begins with a separator renders nothing
+PASS polygon with a points value of a single separator renders nothing
+PASS polygon with an empty points value renders nothing
+PASS polygon with a whitespace-only points value renders nothing
+PASS polygon with no points attribute renders nothing
+PASS polygon with a points value in error does not rewrite the content attribute
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPointList-error-handling.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPointList-error-handling.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<title>SVGPointList: error handling that does not depend on a valid prefix</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#DataTypePoints">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#PolylineElementPointsAttribute">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#TermInitialValue">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="svg" width="200" height="200"></svg>
+<script>
+// w3c/svgwg#764 asks whether a points value that fails to parse should render the
+// coordinate pairs before the error, as SVG 1.1 required, or nothing, which is what
+// SVG 2 gives once the general initial-value rule applies. That question is open, so
+// this file deliberately avoids it.
+//
+// What it covers is the part both answers agree on:
+//
+//   * an odd number of coordinates, which SVG 2 keeps an explicit rule for and which
+//     matches SVG 1.1;
+//   * an error at or before the start of the list, where there is no valid prefix for
+//     the two readings to disagree about;
+//   * an empty or whitespace-only value, whose observable is the same whether it is
+//     treated as valid-and-empty or as invalid.
+//
+// Both layers are asserted together on every row. Nothing else checks that
+// points.numberOfItems and the rendered geometry agree, and they are what a partial
+// parse would put out of step.
+//
+// A value with an error AFTER at least one complete coordinate pair is intentionally
+// absent from this file until svgwg#764 resolves.
+
+const svg = document.getElementById("svg");
+const ELEMENTS = ["polyline", "polygon"];
+
+function shape(tag, points) {
+    const element = document.createElementNS("http://www.w3.org/2000/svg", tag);
+    if (points !== null)
+        element.setAttribute("points", points);
+    element.setAttribute("fill", "none");
+    svg.append(element);
+    return element;
+}
+
+function assertRendersNothing(element, description) {
+    assert_equals(element.points.numberOfItems, 0, description + ": numberOfItems");
+    assert_throws_dom("IndexSizeError", () => element.points.getItem(0),
+        description + ": getItem(0)");
+    const bbox = element.getBBox();
+    assert_equals(bbox.width, 0, description + ": bbox width");
+    assert_equals(bbox.height, 0, description + ": bbox height");
+}
+
+for (const tag of ELEMENTS) {
+    test(function() {
+        const errored = shape(tag, "10,10 70,10 40,50 20");
+        const truncated = shape(tag, "10,10 70,10 40,50");
+
+        // Guard against a vacuous comparison of two empty shapes.
+        assert_equals(truncated.points.numberOfItems, 3, "the truncated list has 3 items");
+        assert_greater_than(truncated.getBBox().width, 0, "the truncated shape has width");
+
+        assert_equals(errored.points.numberOfItems, 3, "numberOfItems");
+        assert_equals(errored.points.getItem(0).x, 10, "getItem(0).x");
+        assert_equals(errored.points.getItem(0).y, 10, "getItem(0).y");
+
+        const a = errored.getBBox();
+        const b = truncated.getBBox();
+        assert_equals(a.x, b.x, "bbox x");
+        assert_equals(a.y, b.y, "bbox y");
+        assert_equals(a.width, b.width, "bbox width");
+        assert_equals(a.height, b.height, "bbox height");
+    }, tag + " with an odd number of coordinates drops the last one and keeps the rest");
+
+    test(function() {
+        assertRendersNothing(shape(tag, "bogus 10,10 70,10 40,50"),
+            "non-numeric token before any coordinate");
+    }, tag + " whose points value begins with a non-numeric token renders nothing");
+
+    test(function() {
+        assertRendersNothing(shape(tag, ",10,10 70,10 40,50"),
+            "separator before the first coordinate");
+    }, tag + " whose points value begins with a separator renders nothing");
+
+    test(function() {
+        assertRendersNothing(shape(tag, ","), "a separator alone");
+    }, tag + " with a points value of a single separator renders nothing");
+
+    test(function() {
+        const element = shape(tag, "");
+
+        assert_equals(element.points.numberOfItems, 0, "numberOfItems");
+        const bbox = element.getBBox();
+        assert_equals(bbox.width, 0, "bbox width");
+        assert_equals(bbox.height, 0, "bbox height");
+    }, tag + " with an empty points value renders nothing");
+
+    test(function() {
+        const element = shape(tag, "   ");
+
+        assert_equals(element.points.numberOfItems, 0, "numberOfItems");
+        const bbox = element.getBBox();
+        assert_equals(bbox.width, 0, "bbox width");
+        assert_equals(bbox.height, 0, "bbox height");
+    }, tag + " with a whitespace-only points value renders nothing");
+
+    test(function() {
+        const element = shape(tag, null);
+
+        assert_equals(element.getAttribute("points"), null, "the attribute is absent");
+        assert_equals(element.points.numberOfItems, 0, "numberOfItems");
+        const bbox = element.getBBox();
+        assert_equals(bbox.width, 0, "bbox width");
+        assert_equals(bbox.height, 0, "bbox height");
+    }, tag + " with no points attribute renders nothing");
+
+    test(function() {
+        const points = "bogus 10,10 70,10 40,50";
+        const element = shape(tag, points);
+
+        assert_equals(element.getAttribute("points"), points,
+            "the content attribute keeps what was specified");
+    }, tag + " with a points value in error does not rewrite the content attribute");
+}
+</script>


### PR DESCRIPTION
#### 834b97ac1beff72b439f74acfd85da5ca9240200
<pre>
Extend WPT coverage for SVG paths and points
<a href="https://bugs.webkit.org/show_bug.cgi?id=322081">https://bugs.webkit.org/show_bug.cgi?id=322081</a>
<a href="https://rdar.apple.com/185276156">rdar://185276156</a>

Reviewed by Dan Glastonbury.

This is adding a number of WPT tests for path data and SVG points error
processing to avoid regression in the future. It doesn&apos;t cover yet
everything. Some discussions are happening on
<a href="https://github.com/w3c/svgwg/issues/764">https://github.com/w3c/svgwg/issues/764</a>
<a href="https://github.com/w3c/svgwg/issues/763">https://github.com/w3c/svgwg/issues/763</a>
for the trailing part of the error.

This will be exported to WPT.

* LayoutTests/imported/w3c/web-platform-tests/svg/path/error-handling/path-data-error-geometry-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/error-handling/path-data-error-geometry.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPointList-error-handling-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPointList-error-handling.html: Added.

Canonical link: <a href="https://commits.webkit.org/319451@main">https://commits.webkit.org/319451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49a3083ced719deef533ce273bd41c5f593fcfb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191676 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145779 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b939cad8-330a-429a-90e1-9aaca5c24588) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141616 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f1df0a0-a1ff-4e76-acaf-2e6744e54214) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162359 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122056 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56e68438-ef8a-43e7-bc65-0e0968290dd6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43975 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42247 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41885 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2837 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193604 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161863 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151020 "Found 1 new test failure: compositing/geometry/abs-position-inside-opacity.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40459 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55756 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150726 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45304 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123638 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54272 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16884 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53654 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53892 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53719 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->