### PR TITLE
Clean up comments in HTMLDialogElement

### DIFF
--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -122,6 +122,7 @@ ClosedByState HTMLDialogElement::computedClosedByState() const
     return result;
 }
 
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-show
 ExceptionOr<void> HTMLDialogElement::show()
 {
     // If the element already has an open attribute, then return.
@@ -147,11 +148,7 @@ ExceptionOr<void> HTMLDialogElement::show()
 
     setAttributeWithoutSynchronization(openAttr, emptyAtom());
 
-    // The dialog's cached computed style still says display:none at this point. The focusing steps
-    // below determine focusability from it, and Element::resolveComputedStyle() treats a cached
-    // display:none ancestor as an unrendered subtree unless the ancestor is marked as having an
-    // invalid computed style, so nothing in the dialog would look focusable. showModal() gets this
-    // invalidation from addToTopLayer(). See rdar://185153996 for the underlying issue.
+    // Invalidate style for correct focusability computation in the focusing steps after showing the dialog.
     invalidateStyle();
 
     Ref document = this->document();
@@ -164,16 +161,15 @@ ExceptionOr<void> HTMLDialogElement::show()
     return { };
 }
 
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#show-a-modal-dialog
 ExceptionOr<void> HTMLDialogElement::showModal(Element* source)
 {
-    // If subject already has an open attribute, then throw an "InvalidStateError" DOMException.
     if (isOpen()) {
         if (isModal())
             return { };
         return Exception { ExceptionCode::InvalidStateError, "Cannot call showModal() on an open non-modal dialog."_s };
     }
 
-    // If subject is not connected, then throw an "InvalidStateError" DOMException.
     if (!isConnected())
         return Exception { ExceptionCode::InvalidStateError, "Element is not connected."_s };
 
@@ -236,6 +232,7 @@ ExceptionOr<void> HTMLDialogElement::showModal(Element* source)
     return { };
 }
 
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-close
 void HTMLDialogElement::close(const String& result, Element* source)
 {
     if (!isOpen())
@@ -277,6 +274,7 @@ void HTMLDialogElement::close(const String& result, Element* source)
     queueTaskToDispatchEvent(TaskSource::UserInteraction, Event::create(eventNames().closeEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-requestclose
 void HTMLDialogElement::requestClose(const String& returnValue, Element* source)
 {
     if (!isOpen())


### PR DESCRIPTION
#### 1abaef0188b3b0cacac517aef0fcd6badf857835
<pre>
Clean up comments in HTMLDialogElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=322082">https://bugs.webkit.org/show_bug.cgi?id=322082</a>
<a href="https://rdar.apple.com/185278019">rdar://185278019</a>

Reviewed by Aditya Keerthi and Zak Ridouh.

* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::show):
(WebCore::HTMLDialogElement::showModal):

Canonical link: <a href="https://commits.webkit.org/319458@main">https://commits.webkit.org/319458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb0566377589e89fb66840ee7c05689f07936b5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145780 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/164cfddb-813a-445c-aa79-b2705fd70b2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141617 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db7ba2d3-5adf-4d45-b070-478f1afd3941) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122057 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e768c473-6ea8-4fd9-a18f-a3fbb36eb398) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43977 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42248 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41887 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2838 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193605 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55070 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151021 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55757 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38510 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150727 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27568 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45305 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128038 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123644 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54273 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16886 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53655 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53893 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->