### PR TITLE
[WebAudio] Stop allocating Vector for entire input in BiquadDSPKernel and IIRDSPKernel

### DIFF
--- a/LayoutTests/webaudio/filter-getFrequencyResponse-chunking-expected.txt
+++ b/LayoutTests/webaudio/filter-getFrequencyResponse-chunking-expected.txt
@@ -1,0 +1,32 @@
+Tests that BiquadFilterNode/IIRFilterNode getFrequencyResponse() is computed correctly for arrays longer than one render quantum.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS BiquadFilterNode.getFrequencyResponse() with length 1 matches per-frequency results.
+PASS IIRFilterNode.getFrequencyResponse() with length 1 matches per-frequency results.
+PASS BiquadFilterNode.getFrequencyResponse() with length 2 matches per-frequency results.
+PASS IIRFilterNode.getFrequencyResponse() with length 2 matches per-frequency results.
+PASS BiquadFilterNode.getFrequencyResponse() with length 127 matches per-frequency results.
+PASS IIRFilterNode.getFrequencyResponse() with length 127 matches per-frequency results.
+PASS BiquadFilterNode.getFrequencyResponse() with length 128 matches per-frequency results.
+PASS IIRFilterNode.getFrequencyResponse() with length 128 matches per-frequency results.
+PASS BiquadFilterNode.getFrequencyResponse() with length 129 matches per-frequency results.
+PASS IIRFilterNode.getFrequencyResponse() with length 129 matches per-frequency results.
+PASS BiquadFilterNode.getFrequencyResponse() with length 255 matches per-frequency results.
+PASS IIRFilterNode.getFrequencyResponse() with length 255 matches per-frequency results.
+PASS BiquadFilterNode.getFrequencyResponse() with length 256 matches per-frequency results.
+PASS IIRFilterNode.getFrequencyResponse() with length 256 matches per-frequency results.
+PASS BiquadFilterNode.getFrequencyResponse() with length 257 matches per-frequency results.
+PASS IIRFilterNode.getFrequencyResponse() with length 257 matches per-frequency results.
+PASS BiquadFilterNode.getFrequencyResponse() with length 300 matches per-frequency results.
+PASS IIRFilterNode.getFrequencyResponse() with length 300 matches per-frequency results.
+PASS magResponse.every(Number.isNaN) && phaseResponse.every(Number.isNaN) is true
+PASS biquad.getFrequencyResponse(new Float32Array(4), new Float32Array(4), new Float32Array(5)) threw exception InvalidAccessError: The arrays passed as arguments must have the same length.
+PASS biquad.getFrequencyResponse(new Float32Array(0), new Float32Array(0), new Float32Array(0)) did not throw exception.
+PASS iir.getFrequencyResponse(new Float32Array(4), new Float32Array(4), new Float32Array(5)) threw exception InvalidAccessError: Arrays must have the same length.
+PASS iir.getFrequencyResponse(new Float32Array(0), new Float32Array(0), new Float32Array(0)) did not throw exception.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/filter-getFrequencyResponse-chunking.html
+++ b/LayoutTests/webaudio/filter-getFrequencyResponse-chunking.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that BiquadFilterNode/IIRFilterNode getFrequencyResponse() is computed correctly for arrays longer than one render quantum.");
+
+var context = new OfflineAudioContext({ sampleRate: 44100, length: 100 });
+var biquad = new BiquadFilterNode(context);
+var iir = new IIRFilterNode(context, { feedforward: [0.5, 0.5], feedback: [1, -0.5] });
+
+// getFrequencyResponse() normalizes the input frequencies in fixed-size chunks internally, so
+// exercise lengths that are shorter than, equal to and longer than that chunk size, including
+// lengths that are not a multiple of it.
+const lengths = [1, 2, 127, 128, 129, 255, 256, 257, 300];
+
+// Each frequency is answered independently of the others, so computing the response for a whole
+// array must give the same result as computing the response for each frequency on its own. This
+// catches any chunk-boundary mistake in the internal chunking.
+function testChunking(node, nodeName, length)
+{
+    const frequencyHz = new Float32Array(length);
+    for (let k = 0; k < length; ++k)
+        frequencyHz[k] = k * (0.5 * context.sampleRate) / length;
+
+    const magResponse = new Float32Array(length);
+    const phaseResponse = new Float32Array(length);
+    node.getFrequencyResponse(frequencyHz, magResponse, phaseResponse);
+
+    const singleFrequency = new Float32Array(1);
+    const singleMag = new Float32Array(1);
+    const singlePhase = new Float32Array(1);
+    for (let k = 0; k < length; ++k) {
+        singleFrequency[0] = frequencyHz[k];
+        node.getFrequencyResponse(singleFrequency, singleMag, singlePhase);
+        if (magResponse[k] !== singleMag[0] || phaseResponse[k] !== singlePhase[0]) {
+            testFailed(`${nodeName}.getFrequencyResponse() with length ${length} differs at index ${k}: `
+                + `got (${magResponse[k]}, ${phaseResponse[k]}), expected (${singleMag[0]}, ${singlePhase[0]})`);
+            return;
+        }
+    }
+    testPassed(`${nodeName}.getFrequencyResponse() with length ${length} matches per-frequency results.`);
+}
+
+for (const length of lengths) {
+    testChunking(biquad, "BiquadFilterNode", length);
+    testChunking(iir, "IIRFilterNode", length);
+}
+
+// Out-of-range frequencies must report NaN, including past the first chunk.
+var outOfRangeFrequencyHz = new Float32Array(300);
+outOfRangeFrequencyHz.fill(-1);
+var magResponse = new Float32Array(300);
+var phaseResponse = new Float32Array(300);
+biquad.getFrequencyResponse(outOfRangeFrequencyHz, magResponse, phaseResponse);
+shouldBeTrue("magResponse.every(Number.isNaN) && phaseResponse.every(Number.isNaN)");
+
+// Mismatched lengths still throw, and a zero length is still a no-op.
+shouldThrowErrorName("biquad.getFrequencyResponse(new Float32Array(4), new Float32Array(4), new Float32Array(5))", "InvalidAccessError");
+shouldNotThrow("biquad.getFrequencyResponse(new Float32Array(0), new Float32Array(0), new Float32Array(0))");
+shouldThrowErrorName("iir.getFrequencyResponse(new Float32Array(4), new Float32Array(4), new Float32Array(5))", "InvalidAccessError");
+shouldNotThrow("iir.getFrequencyResponse(new Float32Array(0), new Float32Array(0), new Float32Array(0))");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
@@ -35,7 +35,6 @@
 #include "FloatConversion.h"
 #include <limits.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/Vector.h>
 
 #if CPU(X86_SSE2)
 #include <immintrin.h>
@@ -210,23 +209,24 @@ void BiquadDSPKernel::process(std::span<const float> source, std::span<float> de
     m_biquad.process(source, destination);
 }
 
-void BiquadDSPKernel::getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
+void BiquadDSPKernel::getFrequencyResponse(std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
 {
-    bool isGood = nFrequencies > 0 && frequencyHz.data() && magResponse.data() && phaseResponse.data();
+    bool isGood = !frequencyHz.empty() && magResponse.size() >= frequencyHz.size() && phaseResponse.size() >= frequencyHz.size();
     ASSERT(isGood);
     if (!isGood)
         return;
 
-    Vector<float> frequency(nFrequencies);
-
     double nyquist = this->nyquist();
 
-    // Convert from frequency in Hz to normalized frequency (0 -> 1),
-    // with 1 equal to the Nyquist frequency.
-    for (unsigned k = 0; k < nFrequencies; ++k)
-        frequency[k] = frequencyHz[k] / nyquist;
+    // Convert from frequency in Hz to normalized frequency (0 -> 1), with 1 equal to the Nyquist frequency.
+    std::array<float, AudioUtilities::renderQuantumSize> frequency;
+    for (size_t offset = 0; offset < frequencyHz.size(); offset += frequency.size()) {
+        auto chunk = std::span { frequency }.first(std::min(frequency.size(), frequencyHz.size() - offset));
+        for (size_t k = 0; k < chunk.size(); ++k)
+            chunk[k] = frequencyHz[offset + k] / nyquist;
 
-    m_biquad.getFrequencyResponse(nFrequencies, frequency.span(), magResponse, phaseResponse);
+        m_biquad.getFrequencyResponse(chunk, magResponse.subspan(offset, chunk.size()), phaseResponse.subspan(offset, chunk.size()));
+    }
 }
 
 double BiquadDSPKernel::tailTime() const

--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
@@ -49,7 +49,7 @@ public:
 
     // Get the magnitude and phase response of the filter at the given
     // set of frequencies (in Hz). The phase response is in radians.
-    void getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
+    void getFrequencyResponse(std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
 
     double NODELETE tailTime() const override;
     double NODELETE latencyTime() const override;

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
@@ -82,12 +82,12 @@ void BiquadFilterNode::setType(BiquadFilterType type)
 
 ExceptionOr<void> BiquadFilterNode::getFrequencyResponse(const Ref<Float32Array>& frequencyHz, const Ref<Float32Array>& magResponse, const Ref<Float32Array>& phaseResponse)
 {
-    unsigned length = frequencyHz->length();
+    size_t length = frequencyHz->length();
     if (magResponse->length() != length || phaseResponse->length() != length)
         return Exception { ExceptionCode::InvalidAccessError, "The arrays passed as arguments must have the same length"_s };
 
     if (length)
-        protect(biquadProcessor())->getFrequencyResponse(length, frequencyHz->typedSpan(), magResponse->typedMutableSpan(), phaseResponse->typedMutableSpan());
+        protect(biquadProcessor())->getFrequencyResponse(frequencyHz->typedSpan(), magResponse->typedMutableSpan(), phaseResponse->typedMutableSpan());
     return { };
 }
 

--- a/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
@@ -129,7 +129,7 @@ void BiquadProcessor::setType(BiquadFilterType type)
     }
 }
 
-void BiquadProcessor::getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
+void BiquadProcessor::getFrequencyResponse(std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
 {
     // Compute the frequency response on a separate temporary kernel
     // to avoid interfering with the processing running in the audio
@@ -145,7 +145,7 @@ void BiquadProcessor::getFrequencyResponse(unsigned nFrequencies, std::span<cons
     float detune = parameter4().value();
 
     responseKernel->updateCoefficients(1, singleElementSpan(cutoffFrequency), singleElementSpan(q), singleElementSpan(gain), singleElementSpan(detune));
-    responseKernel->getFrequencyResponse(nFrequencies, frequencyHz, magResponse, phaseResponse);
+    responseKernel->getFrequencyResponse(frequencyHz, magResponse, phaseResponse);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/BiquadProcessor.h
+++ b/Source/WebCore/Modules/webaudio/BiquadProcessor.h
@@ -53,7 +53,7 @@ public:
 
     // Get the magnitude and phase response of the filter at the given
     // set of frequencies (in Hz). The phase response is in radians.
-    void getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
+    void getFrequencyResponse(std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
 
     void checkForDirtyCoefficients();
     

--- a/Source/WebCore/Modules/webaudio/IIRDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRDSPKernel.cpp
@@ -27,6 +27,8 @@
 
 #if ENABLE(WEB_AUDIO)
 #include "IIRDSPKernel.h"
+
+#include "AudioUtilities.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -40,20 +42,22 @@ IIRDSPKernel::IIRDSPKernel(IIRProcessor& processor)
 {
 }
 
-void IIRDSPKernel::getFrequencyResponse(unsigned length, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
+void IIRDSPKernel::getFrequencyResponse(std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
 {
-    ASSERT(frequencyHz.data());
-    ASSERT(magResponse.data());
-    ASSERT(phaseResponse.data());
+    ASSERT(magResponse.size() >= frequencyHz.size());
+    ASSERT(phaseResponse.size() >= frequencyHz.size());
 
-    Vector<float> frequency(length);
     double nyquist = this->nyquist();
 
     // Convert from frequency in Hz to normalized frequency (0 -> 1), with 1 equal to the Nyquist frequency.
-    for (unsigned k = 0; k < length; ++k)
-        frequency[k] = frequencyHz[k] / nyquist;
+    std::array<float, AudioUtilities::renderQuantumSize> frequency;
+    for (size_t offset = 0; offset < frequencyHz.size(); offset += frequency.size()) {
+        auto chunk = std::span { frequency }.first(std::min(frequency.size(), frequencyHz.size() - offset));
+        for (size_t k = 0; k < chunk.size(); ++k)
+            chunk[k] = frequencyHz[offset + k] / nyquist;
 
-    m_iirFilter.getFrequencyResponse(length, frequency.span(), magResponse, phaseResponse);
+        m_iirFilter.getFrequencyResponse(chunk, magResponse.subspan(offset, chunk.size()), phaseResponse.subspan(offset, chunk.size()));
+    }
 }
 
 void IIRDSPKernel::process(std::span<const float> source, std::span<float> destination)

--- a/Source/WebCore/Modules/webaudio/IIRDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/IIRDSPKernel.h
@@ -38,7 +38,7 @@ public:
     explicit IIRDSPKernel(IIRProcessor&);
 
     // Get the magnitude and phase response of the filter at the given set of frequencies (in Hz). The phase response is in radians.
-    void getFrequencyResponse(unsigned length, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
+    void getFrequencyResponse(std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
 
 private:
     IIRProcessor* iirProcessor() { return downcast<IIRProcessor>(processor()); }

--- a/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
@@ -130,7 +130,7 @@ ExceptionOr<void> IIRFilterNode::getFrequencyResponse(Float32Array& frequencyHz,
 
     // Nothing to do if the length is 0.
     if (expectedLength > 0)
-        iirProcessor()->getFrequencyResponse(expectedLength, frequencyHz.typedSpan(), magResponse.typedMutableSpan(), phaseResponse.typedMutableSpan());
+        iirProcessor()->getFrequencyResponse(frequencyHz.typedSpan(), magResponse.typedMutableSpan(), phaseResponse.typedMutableSpan());
 
     return { };
 }

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
@@ -98,9 +98,9 @@ void IIRProcessor::process(const AudioBus& source, AudioBus& destination, size_t
         m_kernels[i]->process(source.channel(i)->span().first(framesToProcess), destination.channel(i)->mutableSpan());
 }
 
-void IIRProcessor::getFrequencyResponse(unsigned length, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
+void IIRProcessor::getFrequencyResponse(std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
 {
-    m_responseKernel->getFrequencyResponse(length, frequencyHz, magResponse, phaseResponse);
+    m_responseKernel->getFrequencyResponse(frequencyHz, magResponse, phaseResponse);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.h
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.h
@@ -45,7 +45,7 @@ public:
     std::unique_ptr<AudioDSPKernel> createKernel() final;
 
     // Get the magnitude and phase response of the filter at the given set of frequencies (in Hz). The phase response is in radians.
-    void getFrequencyResponse(unsigned length, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
+    void getFrequencyResponse(std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
 
     const Vector<double>& feedforward() const LIFETIME_BOUND { return m_feedforward; }
     const Vector<double>& feedback() const LIFETIME_BOUND { return m_feedback; }

--- a/Source/WebCore/platform/audio/Biquad.cpp
+++ b/Source/WebCore/platform/audio/Biquad.cpp
@@ -552,7 +552,7 @@ void Biquad::setBandpassParams(size_t index, double frequency, double Q)
     }
 }
 
-void Biquad::getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequency, std::span<float> magResponse, std::span<float> phaseResponse)
+void Biquad::getFrequencyResponse(std::span<const float> frequency, std::span<float> magResponse, std::span<float> phaseResponse)
 {
     // Evaluate the Z-transform of the filter at given normalized
     // frequency from 0 to 1. (1 corresponds to the Nyquist
@@ -577,7 +577,7 @@ void Biquad::getFrequencyResponse(unsigned nFrequencies, std::span<const float> 
     double a1 = m_a1[0];
     double a2 = m_a2[0];
     
-    for (unsigned k = 0; k < nFrequencies; ++k) {
+    for (size_t k = 0; k < frequency.size(); ++k) {
         if (frequency[k] < 0 || frequency[k] > 1) {
             // Out-of-bounds frequencies should return NaN.
             magResponse[k] = std::nanf("");

--- a/Source/WebCore/platform/audio/Biquad.h
+++ b/Source/WebCore/platform/audio/Biquad.h
@@ -66,10 +66,10 @@ public:
     // Resets filter state
     void NODELETE reset();
 
-    // Filter response at a set of n frequencies. The magnitude and
+    // Filter response at a set of normalized frequencies. The magnitude and
     // phase response are returned in magResponse and phaseResponse.
     // The phase response is in radians.
-    void getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequency, std::span<float> magResponse, std::span<float> phaseResponse);
+    void getFrequencyResponse(std::span<const float> frequency, std::span<float> magResponse, std::span<float> phaseResponse);
 
     // Compute tail frame based on the filter coefficents at index
     // |coefIndex|. The tail frame is the frame number where the

--- a/Source/WebCore/platform/audio/IIRFilter.cpp
+++ b/Source/WebCore/platform/audio/IIRFilter.cpp
@@ -123,7 +123,7 @@ void IIRFilter::process(std::span<const float> source, std::span<float> destinat
     }
 }
 
-void IIRFilter::getFrequencyResponse(unsigned length, std::span<const float> frequency, std::span<float> magResponse, std::span<float> phaseResponse)
+void IIRFilter::getFrequencyResponse(std::span<const float> frequency, std::span<float> magResponse, std::span<float> phaseResponse)
 {
     // Evaluate the z-transform of the filter at the given normalized frequencies
     // from 0 to 1. (One corresponds to the Nyquist frequency.)
@@ -139,7 +139,7 @@ void IIRFilter::getFrequencyResponse(unsigned length, std::span<const float> fre
     // the sums in H(z) is equivalent to evaluating a polynomial at the point
     // 1/z.
 
-    for (unsigned k = 0; k < length; ++k) {
+    for (size_t k = 0; k < frequency.size(); ++k) {
         if (frequency[k] < 0 || frequency[k] > 1) {
             // Out-of-bounds frequencies should return NaN.
             magResponse[k] = std::nanf("");

--- a/Source/WebCore/platform/audio/IIRFilter.h
+++ b/Source/WebCore/platform/audio/IIRFilter.h
@@ -39,7 +39,7 @@ public:
     void reset();
 
     void process(std::span<const float> source, std::span<float> destination);
-    void getFrequencyResponse(unsigned length, std::span<const float> frequency, std::span<float> magResponse, std::span<float> phaseResponse);
+    void getFrequencyResponse(std::span<const float> frequency, std::span<float> magResponse, std::span<float> phaseResponse);
     double tailTime(double sampleRate, bool isFilterStable);
 
     const Vector<double>& feedforward() const { return m_feedforward; }


### PR DESCRIPTION
#### 881f4ce6eeec70475b32781987b845ab67477948
<pre>
[WebAudio] Stop allocating Vector for entire input in BiquadDSPKernel and IIRDSPKernel
<a href="https://bugs.webkit.org/show_bug.cgi?id=322084">https://bugs.webkit.org/show_bug.cgi?id=322084</a>
<a href="https://rdar.apple.com/184496889">rdar://184496889</a>

Reviewed by NOBODY (OOPS!).

BiquadDSPKernel and IIRDSPKernel is allocating Vector for entire input,
and it may crash when input size is larger than 2GB / sizeof(float) as
Vector&apos;s backing-size limit is 2GB. But we do not need to allocate
entire memory: we should just process input data per-chunk basis. This
patch follows to the other kernel&apos;s design.

Test: webaudio/filter-getFrequencyResponse-chunking.html

* LayoutTests/webaudio/filter-getFrequencyResponse-chunking-expected.txt: Added.
* LayoutTests/webaudio/filter-getFrequencyResponse-chunking.html: Added.
* Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp:
(WebCore::BiquadDSPKernel::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/BiquadDSPKernel.h:
* Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp:
(WebCore::BiquadFilterNode::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/BiquadProcessor.cpp:
(WebCore::BiquadProcessor::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/BiquadProcessor.h:
* Source/WebCore/Modules/webaudio/IIRDSPKernel.cpp:
(WebCore::IIRDSPKernel::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/IIRDSPKernel.h:
* Source/WebCore/Modules/webaudio/IIRFilterNode.cpp:
(WebCore::IIRFilterNode::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/IIRProcessor.cpp:
(WebCore::IIRProcessor::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/IIRProcessor.h:
* Source/WebCore/platform/audio/Biquad.cpp:
(WebCore::Biquad::getFrequencyResponse):
* Source/WebCore/platform/audio/Biquad.h:
* Source/WebCore/platform/audio/IIRFilter.cpp:
(WebCore::IIRFilter::getFrequencyResponse):
* Source/WebCore/platform/audio/IIRFilter.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/881f4ce6eeec70475b32781987b845ab67477948

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145787 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ee642f2-e1b0-4b1a-bda4-facffd52d1e6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141624 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98273 "4 flakes 14 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/503650ba-9308-466b-8ad4-eee61104d0f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122064 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/576b1887-abb2-4c01-b673-50b16fd9e026) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43986 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42255 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41897 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2845 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193612 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151027 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55764 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150733 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45311 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128045 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123659 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54280 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16896 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53662 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53900 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53727 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->