### PR TITLE
Trailing whitespace is not trimmed when setting a value containing var() through the CSSOM

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-variable-reference-whitespace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-variable-reference-whitespace-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Longhand set to a color through an IDL attribute is trimmed
+PASS Longhand set to a variable reference through an IDL attribute is trimmed
+PASS Longhand set to a variable reference through setProperty() is trimmed
+PASS Shorthand set to a variable reference through an IDL attribute is trimmed
+PASS Shorthand set to a variable reference through setProperty() is trimmed
+PASS Custom property set to a variable reference through setProperty() is trimmed
+PASS Whitespace other than spaces is trimmed too
+PASS Whitespace inside a variable reference is preserved
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-variable-reference-whitespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-variable-reference-whitespace.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM - Values set through the CSSOM are trimmed of leading and trailing whitespace</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyleproperties-cssfloat">
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty">
+<link rel="help" href="https://drafts.csswg.org/css-variables/#serializing-custom-props">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="target"></div>
+<script>
+    const target = document.getElementById('target');
+
+    function setUp() {
+        target.style.cssText = '';
+        return target.style;
+    }
+
+    test(function() {
+        const style = setUp();
+        style.color = '    #202FF2   ';
+
+        assert_equals(style.color, 'rgb(32, 47, 242)');
+        assert_equals(style.cssText, 'color: rgb(32, 47, 242);');
+    }, 'Longhand set to a color through an IDL attribute is trimmed');
+
+    test(function() {
+        const style = setUp();
+        style.color = '    var(--a)   ';
+
+        assert_equals(style.color, 'var(--a)');
+        assert_equals(style.cssText, 'color: var(--a);');
+    }, 'Longhand set to a variable reference through an IDL attribute is trimmed');
+
+    test(function() {
+        const style = setUp();
+        style.setProperty('color', '    var(--a)   ');
+
+        assert_equals(style.getPropertyValue('color'), 'var(--a)');
+        assert_equals(style.cssText, 'color: var(--a);');
+    }, 'Longhand set to a variable reference through setProperty() is trimmed');
+
+    test(function() {
+        const style = setUp();
+        style.font = '    var(--a)   ';
+
+        assert_equals(style.font, 'var(--a)');
+        assert_equals(style.cssText, 'font: var(--a);');
+    }, 'Shorthand set to a variable reference through an IDL attribute is trimmed');
+
+    test(function() {
+        const style = setUp();
+        style.setProperty('font', '    var(--a)   ');
+
+        assert_equals(style.getPropertyValue('font'), 'var(--a)');
+        assert_equals(style.cssText, 'font: var(--a);');
+    }, 'Shorthand set to a variable reference through setProperty() is trimmed');
+
+    test(function() {
+        const style = setUp();
+        style.setProperty('--a', '    var(--b)   ');
+
+        assert_equals(style.getPropertyValue('--a'), 'var(--b)');
+        assert_equals(style.cssText, '--a: var(--b);');
+    }, 'Custom property set to a variable reference through setProperty() is trimmed');
+
+    test(function() {
+        const style = setUp();
+        style.color = '\t\n  var(--a) \n\t ';
+
+        assert_equals(style.color, 'var(--a)');
+    }, 'Whitespace other than spaces is trimmed too');
+
+    test(function() {
+        const style = setUp();
+        style.color = '   var(--a,   fallback   )   ';
+
+        assert_equals(style.color, 'var(--a,   fallback   )');
+    }, 'Whitespace inside a variable reference is preserved');
+</script>

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -226,6 +226,7 @@ bool CSSPropertyParser::parseValue(CSSPropertyID property, IsImportant important
     int initialParsedPropertiesSize = parsedProperties.size();
 
     range.consumeWhitespace();
+    range.trimTrailingWhitespace();
 
     CSS::PropertyParserResult result { parsedProperties };
 


### PR DESCRIPTION
#### d140987bf3e107e7bda5dca4eca9082b7569f289
<pre>
Trailing whitespace is not trimmed when setting a value containing var() through the CSSOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=320186">https://bugs.webkit.org/show_bug.cgi?id=320186</a>
<a href="https://rdar.apple.com/183735232">rdar://183735232</a>

Reviewed by Sam Weinig and Antti Koivisto.

Setting a property to a value that contains an arbitrary substitution function
(var(), env(), attr(), ...) through the CSSOM kept any trailing whitespace in
the serialized value:

    element.style.color = &apos;    var(--a)   &apos;;
    element.style.color; // &quot;var(--a)   &quot; instead of &quot;var(--a)&quot;

Such a value cannot be parsed into a CSSValue, so it is stored as the original
token sequence in a CSSSubstitutionValue and serialized back from those tokens.
CSSPropertyParser::parseValue only consumed leading whitespace, so the trailing
whitespace tokens ended up in the sequence and in its serialization. Values
that do parse (e.g. &quot;red &quot;) were unaffected, as was any value coming from
a style attribute or a style sheet, since CSSParser::consumeDeclaration trims
trailing whitespace per the &quot;consume a declaration&quot; algorithm, and so does the
CSSOM path for custom properties in CSSParser::parseCustomPropertyValue.

Trim trailing whitespace in CSSPropertyParser::parseValue as well, which covers
both the longhand and the shorthand case. Firefox and Chrome both trim here.

Test: imported/w3c/web-platform-tests/css/cssom/serialize-variable-reference-whitespace.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-variable-reference-whitespace-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-variable-reference-whitespace.html: Added.
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseValue):

Canonical link: <a href="https://commits.webkit.org/319554@main">https://commits.webkit.org/319554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f21ef53bf88ed3ba7884e0fcfa3c15c2faa1b96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145789 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80d8178b-26ae-4024-92f3-5f9c596178af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141625 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98275 "1 flakes 12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68dcb6be-c2b8-4c12-949c-babfdea3c32b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122065 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1be484aa-4361-48c0-8fc8-d7709d5e015f) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43989 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42257 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41899 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2847 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193614 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40528 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55766 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150735 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45314 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128047 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123661 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54282 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16898 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53664 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53729 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->