### PR TITLE
[AppKit Gestures] Unable to position caret after <img> element

### DIFF
--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -1046,8 +1046,9 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
             }
 
             if (strongDeferring == strongSelf->_secondaryClickDeferringGestureRecognizer) {
-                const auto isSelectable = info.isSelectable();
-                WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG([webView _protectedPage]->logIdentifier(), "Resolved deferral: isSelectable=%d", isSelectable);
+                const auto isEditableWithoutText = info.selectability == WebKit::InteractionInformationAtPosition::Selectability::UnselectableDueToFocusableElement && info.isContentEditable;
+                const auto isSelectable = info.isSelectable() || isEditableWithoutText;
+                WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG([webView _protectedPage]->logIdentifier(), "Resolved deferral: isSelectable=%d (selectability=%hhu contentEditable=%d)", isSelectable, static_cast<uint8_t>(info.selectability), info.isContentEditable);
                 return !isSelectable && !overLiveTextImage;
             }
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
@@ -216,6 +216,8 @@ extension JavaScriptMessages {
         // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
         public static var expression: String {
             """
+            const containerID = node => (node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement).id;
+
             const selection = getSelection();
             if (selection.rangeCount === 0 || selection.anchorNode === null) {
                 return { "kind": "none" };
@@ -224,7 +226,7 @@ extension JavaScriptMessages {
                 return {
                     "kind": "collapsed",
                     "position": {
-                        "container": selection.anchorNode.parentElement.id,
+                        "container": containerID(selection.anchorNode),
                         "offset": selection.anchorOffset,
                     },
                 };
@@ -232,11 +234,11 @@ extension JavaScriptMessages {
                 return {
                     "kind": "range",
                     "base": {
-                        "container": selection.anchorNode.parentElement.id,
+                        "container": containerID(selection.anchorNode),
                         "offset": selection.anchorOffset,
                     },
                     "extent": {
-                        "container": selection.focusNode.parentElement.id,
+                        "container": containerID(selection.focusNode),
                         "offset": selection.focusOffset,
                     },
                 };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -1319,6 +1319,35 @@ extension AppKitGesturesTests.Basic {
         // The test succeeds if it does not timeout.
     }
 
+    @Test
+    func clickingAfterImageInEditableContentPlacesCaretAfterImage() async throws {
+        let html = """
+            <body style="margin: 0">
+            <div id="editor" contenteditable style="font-size: 30px; padding: 20px;"><img id="img" src="400x400-green.png" style="width: 150px; height: 100px;"></div>
+            </body>
+            """
+
+        let baseURL = try #require(Bundle.testResources.resourceURL)
+        try await page.load(html: html, baseURL: baseURL).wait()
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "editor", offset: 0))
+
+        await page.waitForNextPresentationUpdate()
+
+        let imageBounds = try await screenBounds(ofElementWithID: "img")
+        let pointAfterImage = CGPoint(x: imageBounds.maxX + 50, y: imageBounds.midY)
+
+        await recap.play { composer in
+            composer._wk_click(at: pointAfterImage, for: .seconds(0.1))
+        }
+
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+
+        let selection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+        #expect(selection == .collapsed(.init(in: "editor", at: 1)))
+    }
+
     @Test(.disabled("This test takes an unavoidable ~10 seconds to run"))
     func consecutiveQuickFlicksAccelerateScrolling() async throws {
         let html = """


### PR DESCRIPTION
#### 4f1afd534daedeb4615793a827556a4b699a077b
<pre>
[AppKit Gestures] Unable to position caret after &lt;img&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=322088">https://bugs.webkit.org/show_bug.cgi?id=322088</a>
<a href="https://rdar.apple.com/181260984">rdar://181260984</a>

Reviewed by Abrar Rahman Protyasha.

When clicking over an empty area in editable content, a hit-test receives the focusable editable
root. Consequently, `shouldDeferGesturesForEventThatWillBeginAction` considered it to be non selectable
and therefore prevented the text selection manager from handling the selection.

Fix by relaxing the deferral requirement such that this case is allowed and selection proceeds.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift

* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm:
(-[WKAppKitGestureController deferringGestureRecognizer:shouldDeferGesturesForEventThatWillBeginAction:]):
* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift:
(GetSelection.expression):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/319504@main">https://commits.webkit.org/319504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d05b5fc2b1dfcc087fcd6bc8844a253c78c78d5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55645 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49448 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55366 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/191923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184653 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3084 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48276 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193849 "Failed to checkout and rebase branch from PR 71924") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55315 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/193849 "Failed to checkout and rebase branch from PR 71924") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56004 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/193849 "Failed to checkout and rebase branch from PR 71924") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27592 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/45525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128287 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123983 "Failed to checkout and rebase branch from PR 71924") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54517 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53899 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54138 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53964 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->