### PR TITLE
[JSC] Use `FixedVector` for `RegExp::m_ovector` and `RareData::m_captureGroupNames`

### DIFF
--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -175,7 +175,7 @@ void RegExp::finishCreation(VM& vm)
     if (!pattern.m_captureGroupNames.isEmpty() || !pattern.m_namedGroupToParenIndices.isEmpty()) {
         auto rareData = makeUnique<RareData>();
         rareData->m_numDuplicateNamedCaptureGroups = pattern.m_numDuplicateNamedCaptureGroups;
-        rareData->m_captureGroupNames = WTF::map(pattern.m_captureGroupNames, [](auto& name) {
+        rareData->m_captureGroupNames = FixedVector<AtomString>::map(pattern.m_captureGroupNames, [](auto& name) {
             return AtomString { name };
         });
         rareData->m_namedGroupToParenIndices.swap(pattern.m_namedGroupToParenIndices);
@@ -187,7 +187,7 @@ void RegExp::finishCreation(VM& vm)
     unsigned offsetVectorSize = offsetVectorBaseForNamedCaptures();
     if (hasNamedCaptures())
         offsetVectorSize += m_rareData->m_numDuplicateNamedCaptureGroups;
-    m_ovector.resize(offsetVectorSize);
+    m_ovector = FixedVector<int>(offsetVectorSize);
 }
 
 void RegExp::destroy(JSCell* cell)
@@ -207,7 +207,7 @@ size_t RegExp::estimatedSize(JSCell* cell, VM& vm)
     if (auto* jitCode = thisObject->m_regExpJITCode.get())
         regexDataSize += jitCode->size();
 #endif
-    regexDataSize += thisObject->m_ovector.capacity() * sizeof(int);
+    regexDataSize += thisObject->m_ovector.byteSize();
     if (thisObject->m_firstCharacterBitmap.get())
         regexDataSize += sizeof(WTF::BitSet<256>);
     return Base::estimatedSize(cell, vm) + regexDataSize;

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/YarrErrorCode.h>
 #include <wtf/Atomics.h>
 #include <wtf/BitSet.h>
+#include <wtf/FixedVector.h>
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeLazyUniquePtr.h>
 #include <wtf/text/WTFString.h>
@@ -229,7 +230,7 @@ private:
     struct RareData {
         WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(RareData);
         unsigned m_numDuplicateNamedCaptureGroups;
-        Vector<AtomString> m_captureGroupNames;
+        FixedVector<AtomString> m_captureGroupNames;
 
         // This first element of the RHS vector is the subpatternId in the non-duplicate case.
         // For the duplicate case, the first element is the namedCaptureGroupId.
@@ -250,7 +251,7 @@ private:
     std::unique_ptr<Yarr::YarrCodeBlock> m_regExpJITCode;
 #endif
     std::unique_ptr<RareData> m_rareData;
-    Vector<int> m_ovector;
+    FixedVector<int> m_ovector;
     mutable ThreadSafeLazyUniquePtr<const WTF::BitSet<256>> m_firstCharacterBitmap;
 #if ENABLE(REGEXP_TRACING)
     double m_rtMatchOnlyTotalSubjectStringLen { 0.0 };


### PR DESCRIPTION
#### de9231d86e640102a22bc9a6091eb6dbf94bb4d4
<pre>
[JSC] Use `FixedVector` for `RegExp::m_ovector` and `RareData::m_captureGroupNames`
<a href="https://bugs.webkit.org/show_bug.cgi?id=322090">https://bugs.webkit.org/show_bug.cgi?id=322090</a>

Reviewed by Yusuke Suzuki.

Both vectors are sized once in RegExp::finishCreation and never grow, so
Vector&apos;s capacity field is wasted. Worse, Vector::resize honors the default
minCapacity of 16, so every RegExp allocated 64 bytes of ovector storage even
though most patterns need 2-8 ints.

Switching to FixedVector shrinks RegExp from 88 to 80 bytes (96 -&gt; 80 byte GC
cell) and allocates exactly offsetVectorSize ints. Per RegExp this is 160 -&gt; 96
bytes of cell + ovector storage as reported by generateHeapSnapshot(), and
maximum RSS with 200,000 live RegExps drops from 137.5 MB to 115.0 MB.

RareData::m_captureGroupNames gets the same treatment, shrinking RareData from
48 to 32 bytes for patterns with named groups.

estimatedSize now reports the exact ovector allocation via byteSize().

* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::finishCreation):
(JSC::RegExp::estimatedSize):
* Source/JavaScriptCore/runtime/RegExp.h:

Canonical link: <a href="https://commits.webkit.org/319495@main">https://commits.webkit.org/319495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be33b718a646e50c0a1d630780854824eb6c6bcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191704 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145807 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141642 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122082 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44003 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42274 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4048 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10862 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41917 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2865 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42757 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193632 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55097 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151046 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40485 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55784 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150753 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45331 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128066 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123685 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54300 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16915 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53747 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->