### PR TITLE
[GLIB][a11y] WTR: Add missing implementation of focusableAncestor

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1116,12 +1116,6 @@ accessibility/loading-iframe-updates-axtree.html [ Skip ]
 # Missing AccessibilityUIElement::{isBusy, isAtomicLiveRegion, liveRegionStatus, liveRegionRelevant} implementations.
 accessibility/live-region-attributes-update-after-dynamic-change.html [ Skip ]
 
-# Missing AccessibilityUIElement::focusableAncestor implementation.
-accessibility/focusable-ancestor.html [ Failure ]
-
-# Missing AccessibilityUIElement::{editableAncestor, highestEditableAncestor} implementations.
-accessibility/editable-ancestor.html [ Failure ]
-
 # Timing out since it was added in https://bugs.webkit.org/show_bug.cgi?id=239434.
 accessibility/text-updates-after-dynamic-change.html [ Skip ]
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -720,6 +720,33 @@ static bool shouldIncludeOrientationState(const AXCoreObject& coreObject)
         || coreObject.isSlider();
 }
 
+AccessibilityObjectAtspi* AccessibilityObjectAtspi::focusableAncestor() const
+{
+    if (!m_coreObject)
+        return nullptr;
+
+    auto ancestor = m_coreObject->focusableAncestor();
+    return ancestor ? ancestor->wrapper() : nullptr;
+}
+
+AccessibilityObjectAtspi* AccessibilityObjectAtspi::editableAncestor() const
+{
+    if (!m_coreObject)
+        return nullptr;
+
+    auto ancestor = m_coreObject->editableAncestor();
+    return ancestor ? ancestor->wrapper() : nullptr;
+}
+
+AccessibilityObjectAtspi* AccessibilityObjectAtspi::highestEditableAncestor() const
+{
+    if (!m_coreObject)
+        return nullptr;
+
+    auto ancestor = m_coreObject->highestEditableAncestor();
+    return ancestor ? ancestor->wrapper() : nullptr;
+}
+
 OptionSet<Atspi::State> AccessibilityObjectAtspi::states() const
 {
     OptionSet<Atspi::State> states;
@@ -759,7 +786,7 @@ OptionSet<Atspi::State> AccessibilityObjectAtspi::states() const
         if (m_coreObject->supportsChecked())
             states.add(Atspi::State::Checkable);
 
-        if (m_coreObject->isTextControl() || m_coreObject->isNonNativeTextControl())
+        if (m_coreObject->isTextControl() || m_coreObject->isNonNativeTextControl() || m_coreObject->editableAncestor())
             states.add(Atspi::State::Editable);
     } else if (liveObject && liveObject->supportsReadOnly())
         states.add(Atspi::State::ReadOnly);
@@ -1405,7 +1432,9 @@ AccessibilityObjectInclusion AccessibilityObject::accessibilityPlatformIncludesO
         return AccessibilityObjectInclusion::IgnoreObject;
 
     // Entries and password fields have extraneous children which we want to ignore.
-    if (parent->isSecureField() || parent->isTextControl())
+    // Exclude content-editable regions since they can contain valid non-text
+    // descendants (e.g: a button).
+    if (parent->isSecureField() || (parent->isTextControl() && !parent->hasContentEditableAttributeSet()))
         return AccessibilityObjectInclusion::IgnoreObject;
 
     // We expose the slider as a whole but not its value indicator.

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -172,6 +172,10 @@ public:
 
     WEBCORE_EXPORT bool focus() const;
 
+    WEBCORE_EXPORT AccessibilityObjectAtspi* focusableAncestor() const;
+    WEBCORE_EXPORT AccessibilityObjectAtspi* editableAncestor() const;
+    WEBCORE_EXPORT AccessibilityObjectAtspi* highestEditableAncestor() const;
+
 private:
     AccessibilityObjectAtspi(AXCoreObject*, AccessibilityRootAtspi*);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -1894,6 +1894,31 @@ JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::sentenceAtOffset(int offse
     return OpaqueJSString::tryCreate(stringAtOffset(m_element.get(), offset, WebCore::AccessibilityObjectAtspi::TextGranularity::SentenceStart)).leakRef();
 }
 
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::focusableAncestor()
+{
+    m_element->updateBackingStore();
+    if (auto ancestor = m_element->focusableAncestor())
+        return AccessibilityUIElementAtspi::create(ancestor);
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::editableAncestor()
+{
+    m_element->updateBackingStore();
+    if (auto ancestor = m_element->editableAncestor())
+        return AccessibilityUIElementAtspi::create(ancestor);
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::highestEditableAncestor()
+{
+    m_element->updateBackingStore();
+    if (auto ancestor = m_element->highestEditableAncestor())
+        return AccessibilityUIElementAtspi::create(ancestor);
+    return nullptr;
+}
+
 bool AccessibilityUIElementAtspi::replaceTextInRange(JSStringRef, int, int)
 {
     return false;

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h
@@ -268,6 +268,10 @@ public:
     JSRetainPtr<JSStringRef> lineAtOffset(int offset) override;
     JSRetainPtr<JSStringRef> sentenceAtOffset(int offset) override;
 
+    RefPtr<AccessibilityUIElement> focusableAncestor() override;
+    RefPtr<AccessibilityUIElement> editableAncestor() override;
+    RefPtr<AccessibilityUIElement> highestEditableAncestor() override;
+
 private:
     AccessibilityUIElementAtspi(PlatformUIElement);
     AccessibilityUIElementAtspi(const AccessibilityUIElementAtspi&);


### PR DESCRIPTION
#### a4cbb7e2164123007c62e1d2c9cd39d194f57233
<pre>
[GLIB][a11y] WTR: Add missing implementation of focusableAncestor
<a href="https://bugs.webkit.org/show_bug.cgi?id=322094">https://bugs.webkit.org/show_bug.cgi?id=322094</a>

Reviewed by Carlos Garcia Campos.

Changeset 258327@main refactored properties &apos;FocusableAncestor&apos;,
&apos;EditableAncestor&apos; and &apos;HighestEditableAncestor&apos; to resolve them on demand.
A working implementation for macOS/iOS port was added but an equivalent
implementation for GLIB ports was missing.

The core implementation for this functionality is shared across ports, living
in &apos;AXCoreObject.h&apos;. The patch implements the required WKTR interface methods
on GLIB (&apos;focusableAncestor&apos;, &apos;editableAncestor&apos;, etc), which end up
calling the &apos;AXCoreObject&apos; methods via &apos;AccessibilityObjectAtspi&apos;.

Also, the condition in &apos;accessibilityPlatformIncludesObject&apos; that
ignores children of text controls has been relaxed for content-editable
controls, since they can contain valid non-text descendants (such as
a button). Otherwise, &apos;editableAncestor&apos; would return an ignored object.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::focusableAncestor const):
(WebCore::AccessibilityObjectAtspi::editableAncestor const):
(WebCore::AccessibilityObjectAtspi::highestEditableAncestor const):
(WebCore::AccessibilityObject::accessibilityPlatformIncludesObject const):
(WebCore::AccessibilityObjectAtspi::states const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::AccessibilityUIElementAtspi::focusableAncestor):
(WTR::AccessibilityUIElementAtspi::editableAncestor):
(WTR::AccessibilityUIElementAtspi::highestEditableAncestor):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h:

Canonical link: <a href="https://commits.webkit.org/319449@main">https://commits.webkit.org/319449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5dae4ef8949485e5fa6b461240ce83625bd0df5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191723 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141658 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45341 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44019 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41933 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2884 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193651 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55116 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151063 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55803 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150771 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27563 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45346 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128086 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123721 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54319 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16931 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53701 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->