### PR TITLE
[JSC] Remove `CallLinkInfo::m_slowPathCount`

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -226,11 +226,6 @@ public:
             m_maxArgumentCountIncludingThisForVarargs = std::min<unsigned>(argumentCountIncludingThisForVarargs, maxProfiledArgumentCountIncludingThisForVarargs);
     }
 
-    static constexpr ptrdiff_t offsetOfSlowPathCount()
-    {
-        return OBJECT_OFFSETOF(CallLinkInfo, m_slowPathCount);
-    }
-
     static constexpr ptrdiff_t offsetOfCallee()
     {
         return OBJECT_OFFSETOF(CallLinkInfo, m_callee);
@@ -249,11 +244,6 @@ public:
     static constexpr ptrdiff_t offsetOfStub()
     {
         return OBJECT_OFFSETOF(CallLinkInfo, m_stub);
-    }
-
-    uint32_t slowPathCount()
-    {
-        return m_slowPathCount;
     }
 
     CodeOrigin codeOrigin() const { return m_codeOrigin; }
@@ -305,7 +295,6 @@ protected:
     unsigned m_type : 1; // Type
     unsigned m_mode : 3 { static_cast<unsigned>(Mode::Init) }; // Mode
     uint8_t m_maxArgumentCountIncludingThisForVarargs { 0 }; // For varargs: the profiled maximum number of arguments. For direct: the number of stack slots allocated for arguments.
-    uint32_t m_slowPathCount { 0 };
 
     CodeBlock* m_codeBlock { nullptr }; // This is weakly held. And cleared whenever m_monomorphicCallDestination is changed.
     CodePtr<JSEntryPtrTag> m_monomorphicCallDestination { nullptr };

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -150,8 +150,8 @@ CallLinkStatus CallLinkStatus::computeFromCallLinkInfo(
     // them. So, there is no way for either the caller of CallLinkInfo::unlock() or unlock()
     // itself to figure out which lock to lock.
     //
-    // Fortunately, that doesn't matter. The only things we ask of CallLinkInfo - the slow
-    // path count, the stub, and the target - can all be asked racily. Stubs and targets can
+    // Fortunately, that doesn't matter. The only things we ask of CallLinkInfo - the stub
+    // and the target - can all be asked racily. Stubs and targets can
     // only be deleted at next GC, so if we load a non-null one, then it must contain data
     // that is still marginally valid (i.e. the pointers ain't stale). This kind of raciness
     // is probably OK for now.
@@ -186,7 +186,7 @@ CallLinkStatus CallLinkStatus::computeFromCallLinkInfo(
         RELEASE_ASSERT(edges.first().count() >= edges.last().count());
         
         double totalCallsToKnown = 0;
-        double totalCallsToUnknown = callLinkInfo.slowPathCount();
+        double totalCallsToUnknown = 0;
         CallVariantList variants;
         for (size_t i = 0; i < edges.size(); ++i) {
             CallEdge edge = edges[i];
@@ -232,8 +232,6 @@ CallLinkStatus CallLinkStatus::computeFromCallLinkInfo(
         result.m_variants.append(variant);
     }
     
-    result.m_couldTakeSlowPath = !!callLinkInfo.slowPathCount();
-
     return result;
 }
 

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -228,12 +228,6 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> virtualThunkFor(VM& vm, CallMode mo
 
     CCallHelpers::JumpList slowCase;
 
-    // This is a slow path execution, and regT2 contains the CallLinkInfo. Count the
-    // slow path execution for the profiler.
-    jit.add32(
-        CCallHelpers::TrustedImm32(1),
-        CCallHelpers::Address(GPRInfo::regT2, CallLinkInfo::offsetOfSlowPathCount()));
-
     // FIXME: we should have a story for eliminating these checks. In many cases,
     // the DFG knows that the value is definitely a cell, or definitely a function.
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2688,7 +2688,6 @@ end
 # t0 is callee
 # t2 is CallLinkInfo*
 macro virtualThunkFor(offsetOfJITCodeWithArityCheck, offsetOfCodeBlock, internalFunctionTrampoline, slowCase)
-    addi 1, CallLinkInfo::m_slowPathCount[t2]
     btqnz t0, NotCellMask, slowCase
     bbneq JSCell::m_type[t0], JSFunctionType, .notJSFunction
     loadp JSFunction::m_executableOrRareData[t0], t5


### PR DESCRIPTION
#### 9d03f483401c594b5e54d32a80dd1993f4346100
<pre>
[JSC] Remove `CallLinkInfo::m_slowPathCount`
<a href="https://bugs.webkit.org/show_bug.cgi?id=322096">https://bugs.webkit.org/show_bug.cgi?id=322096</a>

Reviewed by Yusuke Suzuki.

m_slowPathCount is only incremented by the virtual call thunks, and the only
way for a call site to reach those thunks is setVirtualCall(), which also sets
m_clearedByVirtual. CallLinkStatus::computeFromCallLinkInfo bails out with
takesSlowPath() for any CallLinkInfo with that bit set before it ever looks at
the count, so the two remaining reads always observe zero. The other user of
the thunks, op_call_direct_eval&apos;s fallback call, is never consulted through
CallLinkStatus at all.

Drop the field and the increments in the LLInt and JIT virtual thunks, and
fold the two reads in CallLinkStatus into the zero they always produced.

* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
(JSC::CallLinkInfo::offsetOfSlowPathCount): Deleted.
(JSC::CallLinkInfo::slowPathCount): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkStatus.cpp:
(JSC::CallLinkStatus::computeFromCallLinkInfo):
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::virtualThunkFor):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:

Canonical link: <a href="https://commits.webkit.org/319494@main">https://commits.webkit.org/319494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a5364e7f04caf8c632d2d5982585e2d800e9997

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145815 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141650 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122090 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44012 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42282 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4056 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10872 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154413 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41927 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2873 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42765 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48062 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193640 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55105 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151055 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40486 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55792 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38549 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150762 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45339 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128075 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123704 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54308 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16925 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53690 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53755 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->