### PR TITLE
offset-path walks the path three times per style change

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -173,12 +173,15 @@ TransformationMatrix AcceleratedEffectValues::computedTransformationMatrix(const
             auto computedTransformOrigin = boundingBox.location() + transformOrigin.value;
 
             // FIXME: It is a layering violation to use `MotionPath::applyMotionPathTransform` here, as it is defined in the rendering directory.
+            // FIXME: The path is walked here for its length on every frame, even though the constructor
+            // already walked it for the same value. Carrying the length would need it serialized with the rest.
             MotionPath::applyMotionPathTransform(
                 matrix,
                 *transformOperationData,
                 computedTransformOrigin,
                 toTransformBox(transformBox),
                 *path,
+                path->length(),
                 offsetAnchor.value,
                 offsetDistance.value,
                 offsetRotate.angle,

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -134,9 +134,8 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
     return data;
 }
 
-static PathTraversalState traversalStateAtDistance(const Path& path, float distanceValue)
+static PathTraversalState traversalStateAtDistance(const Path& path, float distanceValue, float pathLength)
 {
-    auto pathLength = path.length();
     float resolvedLength = 0;
     if (path.isClosed()) {
         if (pathLength) {
@@ -151,7 +150,7 @@ static PathTraversalState traversalStateAtDistance(const Path& path, float dista
     return path.traversalStateAtLength(resolvedLength);
 }
 
-void MotionPath::applyMotionPathTransform(TransformationMatrix& matrix, const TransformOperationData& transformData, FloatPoint transformOrigin, TransformBox transformBox, const Path& offsetPath, std::optional<FloatPoint> offsetAnchor, float offsetDistance, float offsetRotate, bool offsetRotateHasAuto)
+void MotionPath::applyMotionPathTransform(TransformationMatrix& matrix, const TransformOperationData& transformData, FloatPoint transformOrigin, TransformBox transformBox, const Path& offsetPath, float offsetPathLength, std::optional<FloatPoint> offsetAnchor, float offsetDistance, float offsetRotate, bool offsetRotateHasAuto)
 {
     auto boundingBox = transformData.boundingBox;
     auto anchor = transformOrigin;
@@ -164,7 +163,7 @@ void MotionPath::applyMotionPathTransform(TransformationMatrix& matrix, const Tr
     if (transformData.isSVGRenderer && transformBox != TransformBox::ViewBox)
         anchor += boundingBox.location();
 
-    auto traversalState = traversalStateAtDistance(offsetPath, offsetDistance);
+    auto traversalState = traversalStateAtDistance(offsetPath, offsetDistance, offsetPathLength);
     matrix.translate(traversalState.current().x(), traversalState.current().y());
 
     // Shift element to the anchor specified by offset-anchor.

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -56,7 +56,7 @@ public:
     static std::optional<MotionPathData> motionPathDataForRenderer(const RenderElement&);
     static bool NODELETE needsUpdateAfterContainingBlockLayout(const Style::OffsetPath&);
 
-    static void applyMotionPathTransform(TransformationMatrix&, const TransformOperationData&, FloatPoint transformOrigin, TransformBox, const Path&, std::optional<FloatPoint> offsetAnchor, float offsetDistance, float offsetRotate, bool offsetRotateHasAuto);
+    static void applyMotionPathTransform(TransformationMatrix&, const TransformOperationData&, FloatPoint transformOrigin, TransformBox, const Path&, float offsetPathLength, std::optional<FloatPoint> offsetAnchor, float offsetDistance, float offsetRotate, bool offsetRotateHasAuto);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleTransformResolver.cpp
+++ b/Source/WebCore/style/StyleTransformResolver.cpp
@@ -180,7 +180,8 @@ void TransformResolver::applyMotionPathTransform(const TransformOperationData& t
     auto transformOrigin = computeTransformOrigin(boundingBox).xy();
     auto transformBox = m_style->transformBox();
 
-    auto offsetDistance = evaluate<float>(m_style->offsetDistance(), offsetPath->length(), zoom);
+    auto offsetPathLength = offsetPath->length();
+    auto offsetDistance = evaluate<float>(m_style->offsetDistance(), offsetPathLength, zoom);
     auto offsetAnchor = WTF::switchOn(m_style->offsetAnchor(),
         [&](const Position& position) -> std::optional<FloatPoint> {
             return evaluate<FloatPoint>(position, boundingBox.size(), zoom);
@@ -198,6 +199,7 @@ void TransformResolver::applyMotionPathTransform(const TransformOperationData& t
         transformOrigin,
         transformBox,
         *offsetPath,
+        offsetPathLength,
         offsetAnchor,
         offsetDistance,
         offsetRotate,


### PR DESCRIPTION
#### ff50349b835f5ea1de74c850278e3ae453d7f689
<pre>
offset-path walks the path three times per style change
<a href="https://bugs.webkit.org/show_bug.cgi?id=322095">https://bugs.webkit.org/show_bug.cgi?id=322095</a>
<a href="https://rdar.apple.com/185293755">rdar://185293755</a>

Reviewed by NOBODY (OOPS!).

Moving an element along an offset-path means walking the path to find the point
at a given distance. WebKit was walking it twice to get the same number: once in
StyleTransformResolver, to turn a percentage offset-distance into a length, then
again inside traversalStateAtDistance.

Walking is not cheap. Every curve gets cut in half over and over until the pieces
are flat enough, which runs into hundreds of pieces for one curve.

This patch hands the first result over instead of measuring again. It is the same
float, so no position or angle moves. I checked with a temporary log: a style
change now walks the path twice instead of three times.

The accelerated path still walks for its own length on every frame. Its
constructor already has that number, but holding on to it means adding a field to
AcceleratedEffectValues, which is sent between processes, so that goes with the
PathArcLengthMapper work.

* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::computedTransformationMatrix const):
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::traversalStateAtDistance):
(WebCore::MotionPath::applyMotionPathTransform):
* Source/WebCore/rendering/MotionPath.h:
* Source/WebCore/style/StyleTransformResolver.cpp:
(WebCore::Style::TransformResolver::applyMotionPathTransform):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff50349b835f5ea1de74c850278e3ae453d7f689

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145833 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0c45db6-5860-4430-9bf2-76a54a743a24) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141664 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98318 "2 flakes 13 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cca8037f-02b3-4c30-b37f-0e25f32811a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122104 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09d81e93-4bdf-4194-bcc9-28e4249b9d79) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44027 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42298 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41940 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2891 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193658 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55123 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151069 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55810 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150777 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45354 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128093 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123738 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54326 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16938 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53708 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53946 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53773 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->