### PR TITLE
[GLIB][a11y] accessibility/svg-text.html is failing since added in r262500

### DIFF
--- a/LayoutTests/accessibility/svg-text.html
+++ b/LayoutTests/accessibility/svg-text.html
@@ -17,11 +17,17 @@
 
     if (window.accessibilityController) {
         text1 = accessibilityController.accessibleElementById("text1");
-        shouldBe("text1.role", "'AXRole: AXGroup'");
-        shouldBe("text1.childrenCount", "1");
-        staticText = text1.childAtIndex(0);
-        shouldBe("staticText.role", "'AXRole: AXStaticText'");
-        shouldBe("staticText.stringValue", "'AXValue: Hello World!'");
+        if (accessibilityController.platformName == "atspi") {
+            shouldBe("text1.role", "'AXRole: AXSection'");
+            shouldBe("text1.childrenCount", "0");
+            shouldBe("text1.stringValue", "'AXValue: Hello World!'");
+        } else {
+            shouldBe("text1.role", "'AXRole: AXGroup'");
+            shouldBe("text1.childrenCount", "1");
+            staticText = text1.childAtIndex(0);
+            shouldBe("staticText.role", "'AXRole: AXStaticText'");
+            shouldBe("staticText.stringValue", "'AXValue: Hello World!'");
+        }
     }
 </script>
 </body>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1165,8 +1165,6 @@ accessibility/visible-character-range-vertical-rl.html [ Skip ]
 
 accessibility/display-contents/tree-and-treeitems.html [ Failure ]
 
-webkit.org/b/212805 accessibility/svg-text.html [ Failure ]
-
 accessibility/combobox/mac [ Skip ]
 accessibility/shadow-dom/reference-target/mac [ Skip ]
 

--- a/LayoutTests/platform/glib/accessibility/svg-text-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/svg-text-expected.txt
@@ -1,0 +1,13 @@
+Hello World!
+This tests SVGText elements and their content are properly handled as static text.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS text1.role is 'AXRole: AXSection'
+PASS text1.childrenCount is 0
+PASS text1.stringValue is 'AXValue: Hello World!'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+


### PR DESCRIPTION
#### c5eba5138685519363fd6acc999cd79e0de5cf62
<pre>
[GLIB][a11y] accessibility/svg-text.html is failing since added in r262500
<a href="https://bugs.webkit.org/show_bug.cgi?id=212805">https://bugs.webkit.org/show_bug.cgi?id=212805</a>

Reviewed by Tyler Wilcock.

The test needs a separate codepath for GLIB ports and a specific
baseline. There are several reasons for that:

1) ATSPI returns &apos;AXRole: AXSection&apos; for an SVGText element, while the
   general baseline expected &apos;AXRole: AXGroup&apos;.
2) ATSPI exposes a text-node directly on the object, instead of doing
   it in a separate object. That makes &apos;childrenCount&apos; equal to 0 on
   GLIB ports while the general baseline expects 1 child.

* LayoutTests/accessibility/svg-text.html:
* LayoutTests/platform/glib/accessibility/svg-text-expected.txt: Added.
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/319459@main">https://commits.webkit.org/319459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14a00cacb5d6e304d83afa792ce04766fa559752

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145841 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141671 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122111 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44035 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42305 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41948 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2899 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193666 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151076 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55818 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38570 "Found 4 new test failures: http/tests/media/now-playing-info-private-browsing.html http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html http/tests/websocket/tests/hybi/contentextensions/block-cookies.py (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150784 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27569 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45361 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123755 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54334 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16946 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53716 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53781 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->