### PR TITLE
[WPE][GTK] FlatpakLauncher should not attempt to expose paths under /app or /usr

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp
@@ -36,6 +36,12 @@
 
 namespace WebKit {
 
+static bool canPossiblyExposePath(const String& path)
+{
+    // The child process's /app and /usr will both be identical to the parent process's.
+    return !path.startsWith("/app"_s) && !path.startsWith("/usr"_s);
+}
+
 GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher* launcher, const WebKit::ProcessLauncher::LaunchOptions& launchOptions, Vector<char*>& argv, int childProcessSocket, GError** error)
 {
     ASSERT(launcher);
@@ -66,22 +72,28 @@ GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher* launcher, const WebKit::P
         // GST_DEBUG_FILE points to an absolute file path, so we need write permissions for its parent directory.
         if (const char* debugFilePath = g_getenv("GST_DEBUG_FILE")) {
             auto parentDir = FileSystem::parentPath(FileSystem::stringFromFileSystemRepresentation(debugFilePath));
-            GUniquePtr<gchar> pathArg(g_strdup_printf("--sandbox-expose-path=%s", parentDir.utf8().data()));
-            flatpakArgs.append(pathArg.get());
+            if (canPossiblyExposePath(parentDir)) {
+                GUniquePtr<gchar> pathArg(g_strdup_printf("--sandbox-expose-path=%s", parentDir.utf8().data()));
+                flatpakArgs.append(pathArg.get());
+            }
         }
 
         // GST_DEBUG_DUMP_DOT_DIR might not exist when the application starts, so we need write
         // permissions for its parent directory.
         if (const char* dotDir = g_getenv("GST_DEBUG_DUMP_DOT_DIR")) {
             auto parentDir = FileSystem::parentPath(FileSystem::stringFromFileSystemRepresentation(dotDir));
-            GUniquePtr<gchar> pathArg(g_strdup_printf("--sandbox-expose-path=%s", parentDir.utf8().data()));
-            flatpakArgs.append(pathArg.get());
+            if (canPossiblyExposePath(parentDir)) {
+                GUniquePtr<gchar> pathArg(g_strdup_printf("--sandbox-expose-path=%s", parentDir.utf8().data()));
+                flatpakArgs.append(pathArg.get());
+            }
         }
 
         for (const auto& pathAndPermission : launchOptions.extraSandboxPaths) {
-            const char* formatString = pathAndPermission.value == SandboxPermission::ReadOnly ? "--sandbox-expose-path-ro=%s": "--sandbox-expose-path=%s";
-            GUniquePtr<gchar> pathArg(g_strdup_printf(formatString, pathAndPermission.key.data()));
-            flatpakArgs.append(pathArg.get());
+            if (canPossiblyExposePath(String { pathAndPermission.key.span() })) {
+                const char* formatString = pathAndPermission.value == SandboxPermission::ReadOnly ? "--sandbox-expose-path-ro=%s": "--sandbox-expose-path=%s";
+                GUniquePtr<gchar> pathArg(g_strdup_printf(formatString, pathAndPermission.key.data()));
+                flatpakArgs.append(pathArg.get());
+            }
         }
 
 #if USE(ATSPI)


### PR DESCRIPTION
#### 60477f5f174c70623c6b3feeb2c5d30d5b2bee85
<pre>
[WPE][GTK] FlatpakLauncher should not attempt to expose paths under /app or /usr
<a href="https://bugs.webkit.org/show_bug.cgi?id=321951">https://bugs.webkit.org/show_bug.cgi?id=321951</a>

Reviewed by Patrick Griffis.

The auxiliary process always has the same view of /app and /usr as the
UI process, so trying to expose them to the sandbox is pointless at
best. In the past, it has uncovered bugs in Flatpak. See:
<a href="https://github.com/flatpak/flatpak/issues/6584">https://github.com/flatpak/flatpak/issues/6584</a>

* Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp:
(WebKit::canPossiblyExposePath):
(WebKit::flatpakSpawn):

Canonical link: <a href="https://commits.webkit.org/319841@main">https://commits.webkit.org/319841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c7ece118afa994cf7ad443d0ba991f43199b86f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49268 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191742 "Hash 1c7ece11 for PR 71934 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145845 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55187 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/191742 "Hash 1c7ece11 for PR 71934 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98328 "4 flakes 13 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162427 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/191742 "Hash 1c7ece11 for PR 71934 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44039 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42309 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/191742 "Hash 1c7ece11 for PR 71934 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41953 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2903 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193670 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55135 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151079 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40789 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55822 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38576 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150787 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45365 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128105 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123775 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54338 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16951 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53720 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->