### PR TITLE
[JSC] DFG SwitchChar releases its operand before speculating that it is a string

### DIFF
--- a/JSTests/stress/switch-char-scrutinee-live-at-osr-exit.js
+++ b/JSTests/stress/switch-char-scrutinee-live-at-osr-exit.js
@@ -1,0 +1,13 @@
+//@ requireOptions("--useLLInt=0", "--forceEagerCompilation=1", "--poisonDeadOSRExitVariables=1")
+
+function opt(a4) {
+    switch (a4) {
+    case 'a':
+        function f() { a4 }
+    case 'b':
+    case 'c':
+    }
+}
+
+opt('');
+opt([]);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -12709,9 +12709,9 @@ void SpeculativeJIT::emitSwitchChar(Node* node, SwitchData* data)
         GPRReg op1GPR = op1.gpr();
         GPRReg tempGPR = temp.gpr();
 
+        speculateString(node->child1(), op1GPR);
         op1.use();
 
-        speculateString(node->child1(), op1GPR);
         emitSwitchCharStringJump(node, data, op1GPR, tempGPR, node->child1());
         noResult(node, UseChildrenCalledExplicitly);
         break;


### PR DESCRIPTION
#### 3ddc7045b7c5a9ccb6ef09124c7b8efb93527208
<pre>
[JSC] DFG SwitchChar releases its operand before speculating that it is a string
<a href="https://bugs.webkit.org/show_bug.cgi?id=322101">https://bugs.webkit.org/show_bug.cgi?id=322101</a>
<a href="https://rdar.apple.com/183337191">rdar://183337191</a>

Reviewed by Yusuke Suzuki.

emitSwitchChar()&apos;s StringUse case called op1.use() before speculateString(), so
the operand&apos;s death event preceded the BadType exit in the variable event stream.
Reconstruction then handed out a dead-value recovery for every bytecode local
whose MovHint pointed at that node (here the scrutinee temporary, whose
SetLocal the DFG had eliminated) and baseline re-executed op_switch_char on it.

Speculate before releasing the operand, as emitSwitchString() already does.

Test: JSTests/stress/switch-char-scrutinee-live-at-osr-exit.js

* JSTests/stress/switch-char-scrutinee-live-at-osr-exit.js: Added.
(opt.switch.case.string_appeared_here):
(opt):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::emitSwitchChar):

Canonical link: <a href="https://commits.webkit.org/319462@main">https://commits.webkit.org/319462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8348292a900659b06cc03994dde5b60e1f4adcf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145846 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141674 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/027646ec-55bb-4442-b919-e6d70efe9d6a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122114 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c9bc31bc-0cdc-4cae-beb2-3555396eda68) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44041 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42310 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4080 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10896 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41951 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2904 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42796 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193671 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55136 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151080 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40465 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55823 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150788 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45368 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128106 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123776 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54339 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16949 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53721 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53786 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->