### PR TITLE
[GTK][WPE] Skia compositor: handle video orientation

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -637,6 +637,26 @@ TransformationMatrix SkiaCompositingLayer::combinedTransform(const PaintContext&
     return transform;
 }
 
+static std::optional<SkMatrix> rotateContentsIfNeeded(OptionSet<TextureMapperFlags> flags, const FloatRect& contentsRect)
+{
+    auto rotate = [](float degrees, float x, float y) {
+        auto matrix = SkMatrix::Translate(x, y);
+        matrix.preRotate(degrees);
+        return matrix;
+    };
+
+    if (flags.contains(TextureMapperFlags::ShouldRotateTexture90))
+        return rotate(90, contentsRect.maxX(), contentsRect.y());
+
+    if (flags.contains(TextureMapperFlags::ShouldRotateTexture180))
+        return rotate(180, contentsRect.maxX(), contentsRect.maxY());
+
+    if (flags.contains(TextureMapperFlags::ShouldRotateTexture270))
+        return rotate(270, contentsRect.x(), contentsRect.maxY());
+
+    return std::nullopt;
+}
+
 void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context)
 {
     // Important: the walk does not clip the canvas to the damage, so every content draw below limits
@@ -646,7 +666,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
     // region is never empty, because paint() turns an empty one into a no-op.
     ASSERT(!context.compositingDamageRegion || !context.compositingDamageRegion->isEmpty());
 
-    const SkM44 transform(combinedTransform(context));
+    SkM44 transform(combinedTransform(context));
 
     const auto ctm = transform.asM33();
     bool enableAntialias = !ctm.preservesAxisAlignment() && !ctm.preservesRightAngles();
@@ -749,6 +769,8 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
         }
 
         sk_sp<SkImage> image;
+        std::optional<SkMatrix> rotationMatrix;
+        auto imageRect = m_contentsRect;
 
         if (m_contentsBuffer) {
 #if ENABLE(VIDEO)
@@ -763,6 +785,14 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
             } else
 #endif // ENABLE(VIDEO)
                 image = m_contentsBuffer->skiaImage();
+
+            auto flags = m_contentsBuffer->flags();
+            rotationMatrix = rotateContentsIfNeeded(flags, m_contentsRect);
+            if (rotationMatrix) {
+                imageRect.setLocation({ });
+                if (flags.containsAny({ TextureMapperFlags::ShouldRotateTexture90, TextureMapperFlags::ShouldRotateTexture270 }))
+                    imageRect.setSize(m_contentsRect.size().transposedSize());
+            }
         } else if (auto* buffer = m_imageBackingStore->buffer()) {
             image = buffer->skiaImage();
             if (!m_contentsTiling.size.isEmpty()) {
@@ -778,15 +808,20 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
 
         if (image) {
             if (shouldPaintNow) {
+                if (rotationMatrix)
+                    canvas.concat(*rotationMatrix);
                 SkPaint paint = setupPaint();
-                drawImageRectRestricted(canvas, context.damageRegionOrNull(), image.get(), SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(m_contentsRect),
+                drawImageRectRestricted(canvas, context.damageRegionOrNull(), image.get(), SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(imageRect),
                     SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint);
             } else {
+                if (rotationMatrix)
+                    transform.preConcat(*rotationMatrix);
+
                 // The contents image composites over the backing store, so it must use SrcOver always.
                 if (forcedSrcBlendMode && m_backingStore)
                     context.imageSetBatch.updatePaintProperties(canvas, context.colorFilter, context.blendMode);
 
-                context.imageSetBatch.addImage(canvas, image, m_contentsRect, transform, context.opacity, enableAntialias, context.damageRegionOrNull(), setupPaint());
+                context.imageSetBatch.addImage(canvas, image, imageRect, transform, context.opacity, enableAntialias, context.damageRegionOrNull(), setupPaint());
             }
         }
     }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
@@ -273,7 +273,8 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferYUV::skiaImage()
     }();
 
     SkYUVAInfo info(SkISize::Make(m_size.width(), m_size.height()), planeConfig, subsampling, yuvaColorSpace);
-    GrYUVABackendTextures yuvaBackendTextures(info, backendTextures.data(), kTopLeft_GrSurfaceOrigin);
+    auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
+    GrYUVABackendTextures yuvaBackendTextures(info, backendTextures.data(), origin);
     if (!yuvaBackendTextures.isValid())
         return nullptr;
 


### PR DESCRIPTION
#### fc8bf507185eae7b45fac5851066ddba4ccb0e72
<pre>
[GTK][WPE] Skia compositor: handle video orientation
<a href="https://bugs.webkit.org/show_bug.cgi?id=322102">https://bugs.webkit.org/show_bug.cgi?id=322102</a>

Reviewed by Adrian Perez de Castro.

We need to check the texture mapper flags and rotate the current
transformation when rotation flags are present.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::rotateContentsIfNeeded):
(WebCore::SkiaCompositingLayer::paintContents):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp:
(WebCore::CoordinatedPlatformLayerBufferYUV::skiaImage):

Canonical link: <a href="https://commits.webkit.org/319510@main">https://commits.webkit.org/319510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a0ffe5e8625f3014f559b0a9861bf4e0f1cf039

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141675 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44040 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42311 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41957 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2906 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193673 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55138 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151081 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55825 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150789 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27596 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45369 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128108 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123778 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54341 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16955 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53961 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->