### PR TITLE
[GLIB] Use GRefPtrWrapped for printing serializers and remove the GRefPtr forward-declaration special-case

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -762,7 +762,7 @@ def generate_forward_declarations(serialized_types, serialized_enums, additional
                 less_than_index = name.find('<')
                 if less_than_index == -1:
                     result.append(f'{type.cpp_type_from_struct_or_class()} {name};')
-                elif name[:less_than_index] != 'GRefPtr':
+                else:
                     result.append(f'template<typename> {type.cpp_type_from_struct_or_class()} {name[:less_than_index]};')
             if type.condition is not None:
                 result.append('#endif')

--- a/Source/WebKit/Shared/gtk/ArgumentCodersGtk.serialization.in
+++ b/Source/WebKit/Shared/gtk/ArgumentCodersGtk.serialization.in
@@ -28,11 +28,11 @@ header: "CoreIPCGtkPrint.h"
 additional_forward_declaration: typedef struct _GtkPrintSettings GtkPrintSettings
 additional_forward_declaration: typedef struct _GtkPageSetup GtkPageSetup
 
-[Wrapper=WebKit::CoreIPCGtkPrintSettings] class GRefPtr<GtkPrintSettings> {
+[GRefPtrWrapped=GtkPrintSettings, CustomHeader] class WebKit::CoreIPCGtkPrintSettings {
     GRefPtr<GVariant> settings();
 }
 
-[Wrapper=WebKit::CoreIPCGtkPageSetup] class GRefPtr<GtkPageSetup> {
+[GRefPtrWrapped=GtkPageSetup, CustomHeader] class WebKit::CoreIPCGtkPageSetup {
     GRefPtr<GVariant> pageSetup();
 }
 

--- a/Source/WebKit/Shared/gtk/CoreIPCGtkPrint.cpp
+++ b/Source/WebKit/Shared/gtk/CoreIPCGtkPrint.cpp
@@ -33,7 +33,7 @@
 namespace WebKit {
 
 CoreIPCGtkPrintSettings::CoreIPCGtkPrintSettings(const GRefPtr<GtkPrintSettings>& settings)
-    : m_settings(gtk_print_settings_to_gvariant(settings ? settings.get() : adoptGRef(gtk_print_settings_new()).get()))
+    : m_settings(gtk_print_settings_to_gvariant(settings.get()))
 {
 }
 
@@ -45,7 +45,7 @@ CoreIPCGtkPrintSettings::operator GRefPtr<GtkPrintSettings>() const
 }
 
 CoreIPCGtkPageSetup::CoreIPCGtkPageSetup(const GRefPtr<GtkPageSetup>& pageSetup)
-    : m_pageSetup(gtk_page_setup_to_gvariant(pageSetup ? pageSetup.get() : adoptGRef(gtk_page_setup_new()).get()))
+    : m_pageSetup(gtk_page_setup_to_gvariant(pageSetup.get()))
 {
 }
 

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
@@ -184,8 +184,8 @@ void WebPrintOperationGtk::PrintPagesData::incrementPageSequence()
 }
 
 WebPrintOperationGtk::WebPrintOperationGtk(const PrintInfo& printInfo)
-    : m_printSettings(printInfo.printSettings.get())
-    , m_pageSetup(printInfo.pageSetup.get())
+    : m_printSettings(printInfo.printSettings ? printInfo.printSettings : adoptGRef(gtk_print_settings_new()))
+    , m_pageSetup(printInfo.pageSetup ? printInfo.pageSetup : adoptGRef(gtk_page_setup_new()))
     , m_printMode(printInfo.printMode)
 {
 }


### PR DESCRIPTION
#### f37beb01c024669cd3ea581afd13d0e77a03a215
<pre>
[GLIB] Use GRefPtrWrapped for printing serializers and remove the GRefPtr forward-declaration special-case
<a href="https://bugs.webkit.org/show_bug.cgi?id=322107">https://bugs.webkit.org/show_bug.cgi?id=322107</a>

Reviewed by Patrick Griffis.

Now that 319460@main added the GRefPtrWrapped attribute, use it for the
GTK printing classes and drop the temporary GRefPtr special-case that
319454@main added to generate_forward_declarations.

Unlike the previous Wrapper coder, GRefPtrWrapped serializes a null
GRefPtr as null instead of substituting a default, so default the print
settings and page setup in WebPrintOperationGtk, which requires them.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_forward_declarations):
* Source/WebKit/Shared/gtk/ArgumentCodersGtk.serialization.in:
* Source/WebKit/Shared/gtk/CoreIPCGtkPrint.cpp:
(WebKit::CoreIPCGtkPrintSettings::CoreIPCGtkPrintSettings):
(WebKit::CoreIPCGtkPageSetup::CoreIPCGtkPageSetup):
* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp:
(WebKit::WebPrintOperationGtk::WebPrintOperationGtk):

Canonical link: <a href="https://commits.webkit.org/319503@main">https://commits.webkit.org/319503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f39665cf22973d03a15cafd4c9f38cee75f5e083

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191906 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141814 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45504 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122251 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181006 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42091 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3068 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193833 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55299 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151225 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55988 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150928 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27591 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45511 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128271 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123966 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54501 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17087 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53883 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->