### PR TITLE
[list-marker] A dynamic font change does not reach the list marker's content renderers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-font-size-mutation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-font-size-mutation-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<style>
+li { list-style-type: "\627\644\641"; font-size: 32px; }
+</style>
+<ul><li>text</li></ul>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-font-size-mutation-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-font-size-mutation-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<style>
+li { list-style-type: "\627\644\641"; font-size: 32px; }
+</style>
+<ul><li>text</li></ul>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-font-size-mutation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-font-size-mutation.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: marker follows a font change made after layout</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#marker-pseudo">
+<link rel="match" href="list-marker-font-size-mutation-ref.html">
+<meta name="assert" content="Changing the font-size of a list item updates its marker, including when the marker text needs bidi resolution.">
+<style>
+li {
+  list-style-type: "\627\644\641";
+  font-size: 16px;
+}
+</style>
+<ul><li>text</li></ul>
+<script>
+document.body.offsetLeft;
+document.querySelector("li").style.fontSize = "32px";
+</script>

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -107,6 +107,8 @@ void RenderListMarker::styleDidChange(Style::Difference diff, const Style::Compu
         diff = adjustedStyleDifference(diff, *oldStyle, style());
     RenderBox::styleDidChange(diff, oldStyle);
 
+    propagateStyleToAnonymousChildren(StylePropagationType::AllChildren);
+
     if (RefPtr newImage = style().listStyleImage().tryStyleImage(); m_image != newImage) {
         if (m_image)
             protect(m_image)->removeClient(*this);


### PR DESCRIPTION
#### 13bd343994335cc3c8ca209e4c4291615bb4749e
<pre>
[list-marker] A dynamic font change does not reach the list marker&apos;s content renderers
<a href="https://bugs.webkit.org/show_bug.cgi?id=322111">https://bugs.webkit.org/show_bug.cgi?id=322111</a>
&lt;<a href="https://rdar.apple.com/problem/185330733">rdar://problem/185330733</a>&gt;

Reviewed by Antti Koivisto.

  &lt;style&gt;
  li { list-style-type: &quot;\627\644\641&quot;; font-size: 16px }
  &lt;/style&gt;
  &lt;ul&gt;&lt;li&gt;text
  &lt;script&gt;
  document.body.offsetTop;
  document.querySelector(&quot;li&quot;).style.fontSize = &quot;32px&quot;;
  &lt;/script&gt;

Now that markers create their own subtrees, style needs to get propagated too.

* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::styleDidChange):
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-font-size-mutation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-font-size-mutation-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/list-marker-font-size-mutation-expected.html: Added.

Canonical link: <a href="https://commits.webkit.org/319476@main">https://commits.webkit.org/319476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a12ab97316796f9b5012766b5bd32a4ad2da90dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145873 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae0d940d-4c24-4385-8d83-4f3fed65d4e2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141699 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15775f71-ec15-4878-8a14-3d5c2c9d7983) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122136 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c7ca1ac-d840-4bd1-8dde-d7a4600db2af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44067 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42340 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41980 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2930 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48124 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193697 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151108 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40476 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55852 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150811 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45389 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128135 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123814 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54365 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16974 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53747 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53986 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53812 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->