### PR TITLE
[SecurityFlags] Allow disabling security flags locally through a user default

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -466,6 +466,7 @@ UIProcess/Cocoa/PlaybackSessionManagerProxy.mm @nonARC
 UIProcess/Cocoa/ProcessAssertionCocoa.mm @nonARC
 UIProcess/Cocoa/ResourceLoadDelegate.mm @nonARC
 UIProcess/Cocoa/SafeBrowsingUtilities.mm @nonARC
+UIProcess/Cocoa/SecurityFlagsControllerCocoa.mm @nonARC
 UIProcess/Cocoa/SessionStateCoding.mm @nonARC
 UIProcess/Cocoa/SystemPreviewControllerCocoa.mm @nonARC
 UIProcess/Cocoa/TextCheckingController.mm @nonARC

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1524,7 +1524,7 @@ struct WKWebsiteData {
 + (void)_setDisabledSecurityFlagsForTesting:(NSArray<NSString *> *)flagNames
 {
 #if defined(ENGINEERING_BUILD) && ENGINEERING_BUILD
-    WebKit::SecurityFlagsController::singleton().setDisabledFlagsNamed(makeVector<String>(flagNames));
+    WebKit::SecurityFlagsController::singleton().setDisabledFlagsNamedForTesting(makeVector<String>(flagNames));
 #endif // ENGINEERING_BUILD
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -154,6 +154,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 -(void)_getAppBadgeForTesting:(void(^)(NSNumber *))completionHandler WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 
 // Resets every security flag to its secure default, then turns off the named ones, so an empty array resets.
+// Ignores the WebKitDebugDisabledSecurityFlags user default, which every other path honours.
 + (void)_setDisabledSecurityFlagsForTesting:(NSArray<NSString *> *)flagNames WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 // Answers nil if this build has no flag by that name.
 - (void)_isSecurityFlagEnabledInNetworkProcessForTesting:(NSString *)flagName completionHandler:(void(^)(NSNumber *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));

--- a/Source/WebKit/UIProcess/Cocoa/SecurityFlagsControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SecurityFlagsControllerCocoa.mm
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SecurityFlagsController.h"
+
+#import "Logging.h"
+#import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
+
+namespace WebKit {
+
+#if defined(ENGINEERING_BUILD) && ENGINEERING_BUILD
+
+static NSString * const disabledSecurityFlagsDefaultsKey = @"WebKitDebugDisabledSecurityFlags";
+
+Vector<String> SecurityFlagsController::platformPersistentlyDisabledFlagNames()
+{
+    RetainPtr value = [NSUserDefaults.standardUserDefaults objectForKey:disabledSecurityFlagsDefaultsKey];
+    if (!value)
+        return { };
+
+    // A bare string rather than an array is what writing the default without -array produces.
+    if (RetainPtr name = dynamic_objc_cast<NSString>(value.get()))
+        return { String { name.get() } };
+
+    RetainPtr names = dynamic_objc_cast<NSArray>(value.get());
+    if (!names) {
+        RELEASE_LOG_ERROR(Process, "SecurityFlagsController: ignoring %" PUBLIC_LOG_STRING ", which is neither an array of strings nor a string", disabledSecurityFlagsDefaultsKey.UTF8String);
+        return { };
+    }
+
+    return makeVector(names.get(), [](id name) -> std::optional<String> {
+        if (RetainPtr string = dynamic_objc_cast<NSString>(name))
+            return String { string.get() };
+        return std::nullopt;
+    });
+}
+
+#else
+
+Vector<String> SecurityFlagsController::platformPersistentlyDisabledFlagNames()
+{
+    return { };
+}
+
+#endif // ENGINEERING_BUILD
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/SecurityFlagsController.cpp
+++ b/Source/WebKit/UIProcess/SecurityFlagsController.cpp
@@ -42,32 +42,68 @@ SecurityFlagsController& SecurityFlagsController::singleton()
     return controller.get();
 }
 
-void SecurityFlagsController::setDisabledFlagsNamed(const Vector<String>& names)
+// No propagation: every path that launches a privileged child process reads this singleton, so nothing can
+// have launched yet.
+SecurityFlagsController::SecurityFlagsController()
+    : m_persistentlyDisabledNames(platformPersistentlyDisabledFlagNames())
 {
-    ASSERT(RunLoop::isMain());
+    m_securityFlags.replaceWith(flagsWithNamesDisabled({ }, IncludePersistentNames::Yes));
 
-    SecurityFlags newFlags;
-    Vector<String> knownNames;
+    for (auto& name : m_persistentlyDisabledNames) {
+        UNUSED_VARIABLE(name);
+        RELEASE_LOG(Process, "SecurityFlagsController: security flag %" PUBLIC_LOG_STRING " is disabled by a user default and cannot be enforced again at runtime", name.utf8().data());
+    }
+}
+
+SecurityFlags SecurityFlagsController::flagsWithNamesDisabled(const Vector<String>& names, IncludePersistentNames includePersistentNames) const
+{
+    SecurityFlags flags;
+    size_t unknownNameCount = 0;
+
     for (auto& name : names) {
-        if (newFlags.disableFlagNamed(name))
-            knownNames.append(name);
+        if (!flags.disableFlagNamed(name))
+            ++unknownNameCount;
     }
 
-    // Logged even when nothing changes, because that is the case to diagnose when a disablement does not take effect.
-    if (knownNames.size() < names.size())
-        RELEASE_LOG(Process, "SecurityFlagsController: ignoring %zu of %zu names, which no flag in this build has", names.size() - knownNames.size(), names.size());
+    // Logged before the caller's early return, because a disablement that does not take effect is the case to diagnose.
+    if (unknownNameCount)
+        RELEASE_LOG(Process, "SecurityFlagsController: ignoring %zu of %zu names, which no flag in this build has", unknownNameCount, names.size());
+
+    if (includePersistentNames == IncludePersistentNames::Yes) {
+        for (auto& name : m_persistentlyDisabledNames)
+            flags.disableFlagNamed(name);
+    }
+
+    return flags;
+}
+
+void SecurityFlagsController::setDisabledFlagsNamed(const Vector<String>& names)
+{
+    apply(flagsWithNamesDisabled(names, IncludePersistentNames::Yes));
+}
+
+void SecurityFlagsController::setDisabledFlagsNamedForTesting(const Vector<String>& names)
+{
+    apply(flagsWithNamesDisabled(names, IncludePersistentNames::No));
+}
+
+void SecurityFlagsController::apply(const SecurityFlags& newFlags)
+{
+    ASSERT(RunLoop::isMain());
 
     if (newFlags == m_securityFlags)
         return;
 
-    for (auto& name : knownNames) {
-        UNUSED_VARIABLE(name);
-        RELEASE_LOG(Process, "SecurityFlagsController: security flag %" PUBLIC_LOG_STRING " is disabled", name.utf8().data());
-    }
-
     m_securityFlags.replaceWith(newFlags);
     propagateToChildProcesses();
 }
+
+#if !PLATFORM(COCOA)
+Vector<String> SecurityFlagsController::platformPersistentlyDisabledFlagNames()
+{
+    return { };
+}
+#endif
 
 void SecurityFlagsController::propagateToChildProcesses()
 {

--- a/Source/WebKit/UIProcess/SecurityFlagsController.h
+++ b/Source/WebKit/UIProcess/SecurityFlagsController.h
@@ -29,6 +29,7 @@
 #include <wtf/Forward.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -43,14 +44,24 @@ public:
     const SecurityFlags& securityFlags() const LIFETIME_BOUND { return m_securityFlags; }
 
     // The list is the whole truth: every flag it does not name is enforced, so an empty list resets everything.
+    // Flags named by the user default stay disabled regardless.
     void setDisabledFlagsNamed(const Vector<String>&);
+
+    // Ignores the user default, so a test gets the state it asked for on a device that has one set.
+    void setDisabledFlagsNamedForTesting(const Vector<String>&);
 
 private:
     friend class WTF::NeverDestroyed<SecurityFlagsController>;
-    SecurityFlagsController() = default;
+    SecurityFlagsController();
 
+    enum class IncludePersistentNames : bool { No, Yes };
+    SecurityFlags flagsWithNamesDisabled(const Vector<String>&, IncludePersistentNames) const;
+    void apply(const SecurityFlags&);
     void propagateToChildProcesses();
 
+    static Vector<String> platformPersistentlyDisabledFlagNames();
+
+    Vector<String> m_persistentlyDisabledNames;
     SecurityFlags m_securityFlags;
 };
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6927,6 +6927,7 @@
 		5CFFD8472DEF511B00C421F5 /* SwiftDemoLogo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDemoLogo.swift; sourceTree = "<group>"; };
 		5DAD73F1116FF90C00EE5396 /* BaseTarget.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = BaseTarget.xcconfig; sourceTree = "<group>"; };
 		5E55104200000000000B0001 /* SecurityFlagsController.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SecurityFlagsController.cpp; sourceTree = "<group>"; };
+		5E55104200000000000B0003 /* SecurityFlagsControllerCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SecurityFlagsControllerCocoa.mm; sourceTree = "<group>"; };
 		5E55104200000000000B0002 /* SecurityFlagsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SecurityFlagsController.h; sourceTree = "<group>"; };
 		5E55104100000000000A0001 /* SessionHistoryTraversalQueue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SessionHistoryTraversalQueue.cpp; sourceTree = "<group>"; };
 		5E55104100000000000A0002 /* SessionHistoryTraversalQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SessionHistoryTraversalQueue.h; sourceTree = "<group>"; };
@@ -10929,6 +10930,7 @@
 				5CB7AFDE23C5273D00E49CF3 /* ResourceLoadDelegate.mm */,
 				F46CCD8E2EDD1B9C00D4BA3E /* SafeBrowsingUtilities.h */,
 				F46CCD8F2EDD1B9C00D4BA3E /* SafeBrowsingUtilities.mm */,
+				5E55104200000000000B0003 /* SecurityFlagsControllerCocoa.mm */,
 				1A002D47196B345D00B9AD44 /* SessionStateCoding.h */,
 				1A002D46196B345D00B9AD44 /* SessionStateCoding.mm */,
 				3157135C2040A9B20084F9CF /* SystemPreviewControllerCocoa.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SecurityFlags.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SecurityFlags.mm
@@ -117,6 +117,30 @@ TEST_F(SecurityFlagsTest, UnknownFlagNameIsIgnored)
     EXPECT_EQ(flagStateInNetworkProcess(dataStore.get(), @"radar99999999"), FlagState::NoSuchFlag);
 }
 
+static NSString * const disabledSecurityFlagsDefaultsKey = @"WebKitDebugDisabledSecurityFlags";
+
+class SecurityFlagsUserDefaultTest : public testing::Test {
+public:
+    void SetUp() final { [NSUserDefaults.standardUserDefaults setObject:@[testSecurityFlagName] forKey:disabledSecurityFlagsDefaultsKey]; }
+
+    void TearDown() final { [NSUserDefaults.standardUserDefaults removeObjectForKey:disabledSecurityFlagsDefaultsKey]; }
+};
+
+TEST_F(SecurityFlagsUserDefaultTest, DisablesFlagAtStartup)
+{
+    auto dataStore = launchNetworkProcess();
+    EXPECT_EQ(flagStateInNetworkProcess(dataStore.get(), testSecurityFlagName), FlagState::Disabled);
+}
+
+TEST_F(SecurityFlagsUserDefaultTest, TestingSPIIgnoresTheUserDefault)
+{
+    auto dataStore = launchNetworkProcess();
+    EXPECT_EQ(flagStateInNetworkProcess(dataStore.get(), testSecurityFlagName), FlagState::Disabled);
+
+    [WKWebsiteDataStore _setDisabledSecurityFlagsForTesting:@[]];
+    EXPECT_EQ(flagStateInNetworkProcess(dataStore.get(), testSecurityFlagName), FlagState::Enforced);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENGINEERING_BUILD


### PR DESCRIPTION
#### 9a2bcc01a9a8b84bf10d7d994562ced6343c596c
<pre>
[SecurityFlags] Allow disabling security flags locally through a user default
<a href="https://bugs.webkit.org/show_bug.cgi?id=322074">https://bugs.webkit.org/show_bug.cgi?id=322074</a>
<a href="https://rdar.apple.com/185262053">rdar://185262053</a>

Reviewed by Chris Dumez.

There is no way to flip a security flag on a running build yet: the server-side list delivery
does not exist, and the only entry point is a testing SPI that has to be called from code. Add a
user default the UIProcess reads at startup, so someone who has built WebKit can turn a flag off
without recompiling:

    defaults write -g WebKitDebugDisabledSecurityFlags -array radar184485266

Read in the SecurityFlagsController constructor. Every path that launches a privileged child
process reads the singleton, so the default always lands before the first creation parameters,
and nothing has launched yet for the constructor to propagate to. Reading goes through
NSUserDefaults like every other user default in the UIProcess; its search list covers the
application domain and the global domain, so one key serves per-app and device-wide testing. A
bare string is accepted as well as an array, because writing the default without -array is the
easiest mistake to make.

The names are sticky: flagsWithNamesDisabled() unions them into every value the controller
computes, so a flag named by the default stays disabled whatever list arrives later, including
the future server list. setDisabledFlagsNamedForTesting() is the one exception. Without it a
developer with the default set could not run the existing API tests, which reset the flags
through the SPI and then assert they are enforced, and the carve-out only ever leaves fewer
flags disabled. The sticky names are logged at construction, since a flag that cannot be
enforced again at runtime is something someone will have to explain from a log later.

Only read when ENGINEERING_BUILD is set, matching the SPI, so it does not exist on a customer
build. QE reaches the same flags through the IDS Server Bag once that lands, so this only has to
serve someone who has built WebKit.

Tests: SecurityFlagsUserDefaultTest.DisablesFlagAtStartup
       SecurityFlagsUserDefaultTest.TestingSPIIgnoresTheUserDefault

SecurityFlagsUserDefaultTest is separate because SecurityFlagsTest&apos;s SetUp calls the SPI, which
would clear the flag before the test body ran. Each API test runs in its own process, so writing
the default in SetUp happens before anything constructs the controller.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Cocoa/SecurityFlagsControllerCocoa.mm: Added.
(WebKit::SecurityFlagsController::platformPersistentlyDisabledFlagNames):
* Source/WebKit/UIProcess/SecurityFlagsController.h:
* Source/WebKit/UIProcess/SecurityFlagsController.cpp:
(WebKit::SecurityFlagsController::SecurityFlagsController):
(WebKit::SecurityFlagsController::flagsWithNamesDisabled):
(WebKit::SecurityFlagsController::setDisabledFlagsNamed):
(WebKit::SecurityFlagsController::setDisabledFlagsNamedForTesting):
(WebKit::SecurityFlagsController::apply):
(WebKit::SecurityFlagsController::platformPersistentlyDisabledFlagNames):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore _setDisabledSecurityFlagsForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SecurityFlags.mm:
(TestWebKitAPI::TEST_F(SecurityFlagsUserDefaultTest, DisablesFlagAtStartup)):
(TestWebKitAPI::TEST_F(SecurityFlagsUserDefaultTest, TestingSPIIgnoresTheUserDefault)):

Canonical link: <a href="https://commits.webkit.org/319525@main">https://commits.webkit.org/319525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da4191ce9e35201934f613f0cc45985a7686c485

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146090 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af08ffca-efbb-4451-9553-db27ae7da74f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55429 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141884 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1625b1d5-f2d1-45b1-86f3-40923003c343) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45570 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122319 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1aecd94-5675-476b-96cd-a1e1899e31d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44256 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42524 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154653 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42156 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3147 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48339 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193912 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55378 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40502 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56067 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150999 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45575 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128350 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124096 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54580 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17152 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53962 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54201 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54027 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->