### PR TITLE
[PAL] MediaToolboxSoftLink.h's FigVideoTargetCreateWithVideoReceiverEndpointID macro breaks unified builds

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/MediaToolboxSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/MediaToolboxSoftLink.h
@@ -40,7 +40,6 @@ SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, MediaToolbox)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, MediaToolbox, FigPhotoDecompressionSetHardwareCutoff, void, (int, size_t numPixelsCutoff), (format, numPixelsCutoff))
 
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, MediaToolbox, FigVideoTargetCreateWithVideoReceiverEndpointID, OSStatus, (CFAllocatorRef allocator, xpc_object_t videoReceiverXPCEndpointID, CFDictionaryRef creationOptions, CF_RETURNS_RETAINED FigVideoTargetRef* videoTargetOut), (allocator, videoReceiverXPCEndpointID, creationOptions, videoTargetOut))
-#define FigVideoTargetCreateWithVideoReceiverEndpointID PAL::softLink_MediaToolbox_FigVideoTargetCreateWithVideoReceiverEndpointID
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, MediaToolbox, MTShouldPlayHDRVideo, Boolean, (CFArrayRef displayList), (displayList))
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, MediaToolbox, MTOverrideShouldPlayHDRVideo, void, (Boolean override, Boolean playHDRVideo), (override, playHDRVideo))

--- a/Source/WebCore/platform/graphics/cocoa/VideoTargetFactory.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTargetFactory.mm
@@ -35,7 +35,7 @@ namespace WebCore {
 PlatformVideoTarget VideoTargetFactory::createTargetFromEndpoint(const VideoReceiverEndpoint& endpoint)
 {
     FigVideoTargetRef videoTarget;
-    OSStatus status = FigVideoTargetCreateWithVideoReceiverEndpointID(kCFAllocatorDefault, endpoint.get(), nullptr, &videoTarget);
+    OSStatus status = PAL::softLink_MediaToolbox_FigVideoTargetCreateWithVideoReceiverEndpointID(kCFAllocatorDefault, endpoint.get(), nullptr, &videoTarget);
     if (status != noErr)
         return nullptr;
 


### PR DESCRIPTION
#### bcdddcb81ab8ec1fbfa7053c04696a681363d437
<pre>
[PAL] MediaToolboxSoftLink.h&apos;s FigVideoTargetCreateWithVideoReceiverEndpointID macro breaks unified builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=322110">https://bugs.webkit.org/show_bug.cgi?id=322110</a>
<a href="https://rdar.apple.com/185330340">rdar://185330340</a>

Reviewed by Eric Carlson.

MediaToolboxSoftLink.h renamed the soft-linked function with a #define, and that macro stays in
effect for the rest of the translation unit. When MediaToolbox&apos;s own FigVideoTargetPrivate.h is
reached later in the same TU, the macro rewrites the identifier in its extern &quot;C&quot; declaration,
so the function ends up declared with both C and C++ language linkage:

    FigVideoTargetPrivate.h:205:1: error: declaration of
    &apos;softLink_MediaToolbox_FigVideoTargetCreateWithVideoReceiverEndpointID&apos; has a different
    language linkage

Neither header reaches the other through a single include chain, so nothing catches this until
unified sources put both in one TU. In Source/WebKit that pairing is WebProcessPoolCocoa.mm,
which imports pal/cocoa/MediaToolboxSoftLink.h, with GroupActivitiesCoordinator.mm, which
arrives at the SDK header through AVFoundationSoftLink.h, AVFoundationSPI.h, AVPlayer_Private.h.

The tree builds today only because the current bundle layout happens to keep those two files
apart. Adding any file to Source/WebKit/SourcesCocoa.txt ahead of them shifts the packing along
by one and the build fails somewhere unrelated to the change. Adding
UIProcess/Cocoa/SecurityFlagsControllerCocoa.mm for bug 322074 is what surfaced this, and that
file had to be marked @no-unify to get around it. The next person to add a file under
UIProcess/Cocoa would hit the same wall.

Drop the #define and let the caller use the soft-link name. The function has exactly one caller,
so nothing else has to change, and the identifier can no longer collide with the SDK&apos;s
declaration.

No new tests. Verified by compiling a translation unit that imports
pal/cocoa/MediaToolboxSoftLink.h followed by pal/spi/cocoa/AVFoundationSPI.h, which fails with
the error above before this change and compiles cleanly after it.

* Source/WebCore/PAL/pal/cocoa/MediaToolboxSoftLink.h:
* Source/WebCore/platform/graphics/cocoa/VideoTargetFactory.mm:
(WebCore::VideoTargetFactory::createTargetFromEndpoint):

Canonical link: <a href="https://commits.webkit.org/319480@main">https://commits.webkit.org/319480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0000da575bd96f99bda98d3c812d7460262b2441

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145876 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/145ea0be-4c5c-4624-8bf0-a30f856d6b9d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141703 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10dcd8cf-fd0a-4893-8274-7e4217ec2188) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45388 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162456 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicyWhenSuspendedOrHidden (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122140 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f294fafe-5e56-43e7-bcbd-5c9ca1572006) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44069 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42344 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41982 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2933 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193700 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55166 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151111 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40479 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55855 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150814 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45393 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128138 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123817 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54368 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16976 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53750 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53989 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53815 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->