### PR TITLE
[CMake][Cocoa] ENGINEERING_BUILD is never defined, disabling JSC restricted options in all CMake builds

### DIFF
--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -225,6 +225,9 @@ set(CMAKE_LINK_DEPENDS_NO_SHARED ON)
 
 set(USE_ANGLE_EGL ON)
 
+# FIXME: CMake is not used for Production at this moment. https://bugs.webkit.org/show_bug.cgi?id=322112
+SET_AND_EXPOSE_TO_BUILD(ENGINEERING_BUILD ON)
+
 function(WEBKIT_ADD_SDK_IMPORTED_LIBRARY _target _library)
     if (NOT TARGET ${_target})
         add_library(${_target} UNKNOWN IMPORTED)


### PR DESCRIPTION
#### e322518ca67badebab1e4aacd5adb84b6f6eaa47
<pre>
[CMake][Cocoa] ENGINEERING_BUILD is never defined, disabling JSC restricted options in all CMake builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=322112">https://bugs.webkit.org/show_bug.cgi?id=322112</a>
<a href="https://rdar.apple.com/185330809">rdar://185330809</a>

Reviewed by Elliott Williams.

Configurations/CommonBase.xcconfig defines ENGINEERING_BUILD=1 for Debug and Release and 0 for
Production, and JSC gates Config::enableRestrictedOptions() on it. Nothing under Source/cmake/
defines the macro, so JSC Restricted options (useDollarVM, functionOverrides, dumpJITMemoryPath,
validateAbstractInterpreterState, ...) cannot be set through JSC_* environment variables in a CMake
build. The jsc shell and WebKitTestRunner reach into JSC directly and are unaffected; the broken
case is running MiniBrowser or another client against a CMake-built WebKit.

Expose ENGINEERING_BUILD from OptionsCocoa.cmake, unconditionally. CMake does not build the Cocoa
port for Production, so every configuration it can produce today corresponds to an Xcode
configuration where the macro is 1. The FIXME marks this as the line to revisit if that changes.

No new tests (build configuration change, no behavior change in shipping builds).

* Source/cmake/OptionsCocoa.cmake:

Canonical link: <a href="https://commits.webkit.org/319565@main">https://commits.webkit.org/319565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85f366d4009c27d620b5b3771e92eb3cb483cbd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192135 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96b2343a-0715-450b-81d8-c0fd445c90e6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55579 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c7d7cb8-0707-46a5-8cb8-1f8f4fc40bb2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184865 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122454 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18388163-4658-47e3-baec-3aac612cdd69) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44378 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/4421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/11218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42275 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3299 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43189 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194062 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55527 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40532 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56216 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151135 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45699 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124261 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54730 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17271 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54111 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54350 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54176 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->