### PR TITLE
[Tools] linux_get_crash_log: run GDB with a maximum timeout of 30 minutes and improve checking of DEBUGINFOD_URLS

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_get_crash_log.py
+++ b/Tools/Scripts/webkitpy/port/linux_get_crash_log.py
@@ -29,6 +29,7 @@
 
 import datetime
 import fcntl
+import hashlib
 import json
 import logging
 import os
@@ -36,6 +37,7 @@ import re
 import resource
 import requests
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -57,7 +59,7 @@ if sys.version_info < (3, 11):
 else:
     from enum import StrEnum
 
-from webkitcorepy import string_utils
+from webkitcorepy import TaskPool, string_utils
 from webkitpy.common.memoized import memoized
 from webkitpy.common.system.executive import ScriptError
 from webkitpy.common.webkit_finder import WebKitFinder
@@ -163,6 +165,7 @@ class LockFile:
 
 
 CORE_PATTERN_RECOMMEND_COMMAND = "echo /var/tmp/core-%f-pid_%p.dump | sudo tee /proc/sys/kernel/core_pattern"
+GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS = 30 * 60
 
 
 class CoreDumpMethod(StrEnum):
@@ -176,6 +179,7 @@ class CrashLogEnvVars(StrEnum):
     allow_unreliable_fallback_to_latest_coredump = 'WEBKIT_CRASHLOG_ALLOW_UNRELIABLE_FALLBACK_TO_LATEST_COREDUMP'
     core_dumps_autodelete = 'WEBKIT_CORE_DUMPS_AUTODELETE'
     gdb_concurrent_execution_limit = 'WEBKIT_CRASHLOG_GDB_CONCURRENT_EXECUTION_LIMIT'
+    gdb_execution_timeout = 'WEBKIT_CRASHLOG_GDB_EXECUTION_TIMEOUT'
 
 
 class CrashLogUtils:
@@ -196,18 +200,34 @@ class CrashLogUtils:
         return 0
 
     @staticmethod
+    def get_gdb_execution_timeout():
+        configured_timeout = os.environ.get(CrashLogEnvVars.gdb_execution_timeout, str(GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS))
+        try:
+            timeout = int(configured_timeout)
+            if timeout > 0:
+                return timeout
+        except ValueError:
+            pass
+        _log.warning(f"Invalid value: {CrashLogEnvVars.gdb_execution_timeout}={configured_timeout}. Using the default of {GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS} seconds.")
+        return GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS
+
+    @staticmethod
+    def is_taskpool_worker_terminating():
+        return TaskPool.Process.name is not None and not TaskPool.Process.working
+
+    @staticmethod
     @memoized
     def _get_gdb_lock_configuration():
         max_concurrent_gdb_processes = CrashLogUtils.get_gdb_concurrent_execution_limit()
         if max_concurrent_gdb_processes:
-            for base in ('/run/lock', os.environ.get('XDG_RUNTIME_DIR'), tempfile.gettempdir(), '/tmp', '/var/tmp'):
-                if not base:
+            for lock_directory_parent in ('/run/lock', os.environ.get('XDG_RUNTIME_DIR'), tempfile.gettempdir(), '/tmp', '/var/tmp'):
+                if not lock_directory_parent:
                     continue
-                lock_base_dir = os.path.join(base, f'webkit-crashlog-{os.getuid()}')
+                lock_directory = CrashLogUtils.get_crashlog_temp_dir(lock_directory_parent)
                 try:
-                    os.makedirs(lock_base_dir, exist_ok=True)
-                    if os.path.isdir(lock_base_dir) and os.access(lock_base_dir, os.W_OK | os.X_OK):
-                        return os.path.join(lock_base_dir, 'gdb-serial-execution.lock'), max_concurrent_gdb_processes
+                    os.makedirs(lock_directory, exist_ok=True)
+                    if os.path.isdir(lock_directory) and os.access(lock_directory, os.W_OK | os.X_OK):
+                        return os.path.join(lock_directory, 'gdb-serial-execution.lock'), max_concurrent_gdb_processes
                 except OSError:
                     continue
             _log.warning("No writable directory found for the gdb lock. GDB processes will not be serialized.")
@@ -228,8 +248,16 @@ class CrashLogUtils:
 
     @staticmethod
     @memoized
+    def get_crashlog_temp_dir(parent_dir=None):
+        return os.path.join(parent_dir or tempfile.gettempdir(), f'webkit-crashlog-{os.getuid()}')
+
+    @staticmethod
     def get_thread_data_dir():
-        return os.path.join(tempfile.gettempdir(), f'webkit-crashlog-thread-name-data-{os.getuid()}')
+        return os.path.join(CrashLogUtils.get_crashlog_temp_dir(), 'thread-name-data')
+
+    @staticmethod
+    def get_debuginfod_cache_dir():
+        return os.path.join(CrashLogUtils.get_crashlog_temp_dir(), 'debuginfod-cache')
 
     @staticmethod
     @memoized
@@ -441,6 +469,278 @@ class CrashLogUtils:
         return '(?P<pid>' in pid_regex
 
 
+# This class runs any long-lived process and ensures that such process
+# is not allowed to run for more time than $timeout seconds, and also
+# ensures that when the TaskPool that manages this worker signals that
+# this worker should end (SIGINT, SIGTERM) then the process executed by
+# this class is terminated and control is returned to the caller/worker.
+class TaskPooledProcessRunner(object):
+    PROCESS_TERMINATION_GRACE_PERIOD_SECONDS = 60
+    PROCESS_CLEANUP_TIMEOUT_SECONDS = 10
+    PROCESS_COMMUNICATE_POLL_INTERVAL_SECONDS = 1
+    PROCESS_STATUS_LINE_INTERVAL_SECONDS = 60
+
+    def __init__(self, executive, command, environment, timeout, target_is_child=False):
+        self._executive = executive
+        self._command = command
+        self._environment = environment
+        self._timeout = timeout
+        self._target_is_child = target_is_child
+        self._proc = None
+
+    def _communicate(self, timeout):
+        # Wake periodically to notice when TaskPool requests worker shutdown.
+        now = time.monotonic()
+        deadline = now + timeout
+        next_status_line = now + self.PROCESS_STATUS_LINE_INTERVAL_SECONDS
+        while not CrashLogUtils.is_taskpool_worker_terminating():
+            remaining = deadline - time.monotonic()
+            try:
+                return self._proc.communicate(timeout=min(
+                    max(0, remaining), self.PROCESS_COMMUNICATE_POLL_INTERVAL_SECONDS))
+            except subprocess.TimeoutExpired:
+                now = time.monotonic()
+                if now >= deadline:
+                    raise
+                if now >= next_status_line:
+                    tproc_pid, tproc_name = self._get_target_pid_and_name()
+                    _log.debug(f'Process "{tproc_name}" running (pid {tproc_pid}), {int(remaining)} seconds remain until timeout deadline.')
+                    next_status_line = now + self.PROCESS_STATUS_LINE_INTERVAL_SECONDS
+        self._terminate_after_interruption()
+        return b'', b''
+
+    def _signal_process_group(self, sig):
+        # nice and time may wrap the target. The process starts a new session,
+        # so its pid is also the process group id for every wrapper.
+        try:
+            os.killpg(self._proc.pid, sig)
+        except ProcessLookupError:
+            pass
+        except OSError as e:
+            _log.warning(f'Failed to send signal {sig} to process group {self._proc.pid}: {e}')
+            try:
+                self._proc.send_signal(sig)
+            except OSError:
+                pass
+
+    def _get_target_pid_and_name(self):
+        try:
+            pid = self._proc.pid
+            if self._target_is_child:
+                pid = self._get_child_pids()[0]
+        except (AttributeError, IndexError):
+            pid = None
+        name = None
+        if pid:
+            comm_path = f'/proc/{pid}/comm'
+            try:
+                with open(comm_path, 'r') as f:
+                    name = f.read().strip()
+            except OSError:
+                name = None
+        return pid, name
+
+    def _get_child_pids(self):
+        try:
+            pid = self._proc.pid
+            with open(f'/proc/{pid}/task/{pid}/children', 'r') as children_file:
+                return [int(child_pid) for child_pid in children_file.read().split()]
+        except FileNotFoundError:
+            return []
+        except (AttributeError, OSError, ValueError) as e:
+            _log.warning(f'Unable to find child processes of pid {pid}: {e}')
+            return []
+
+    def _signal_target(self, sig):
+        if not self._target_is_child:
+            try:
+                self._proc.send_signal(sig)
+            except ProcessLookupError:
+                pass
+            except OSError as e:
+                _log.warning(f'Failed to send signal {sig} to process {self._proc.pid}: {e}')
+            return
+
+        # GNU time remains the process-group leader while it waits for the target,
+        # so first signal SIGTERM/SIGKILL to the children without terminating time.
+        for child_pid in self._get_child_pids():
+            try:
+                os.kill(child_pid, sig)
+            except ProcessLookupError:
+                pass
+            except OSError as e:
+                _log.warning(f'Failed to send signal {sig} to process {child_pid}: {e}')
+
+    def _force_kill_and_reap(self):
+        self._signal_process_group(signal.SIGKILL)
+        # An unkillable or escaped descendant could retain one of these pipes.
+        for pipe in (self._proc.stdout, self._proc.stderr):
+            if pipe:
+                try:
+                    pipe.close()
+                except OSError:
+                    pass
+        try:
+            self._proc.wait(timeout=self.PROCESS_CLEANUP_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            _log.warning(f'Process {self._proc.pid} did not exit after being killed; continuing without waiting for it.')
+        except OSError as e:
+            _log.warning(f'Unable to reap process {self._proc.pid} after killing it: {e}')
+
+    def _terminate_after_interruption(self):
+        self._signal_target(signal.SIGTERM)
+        try:
+            self._proc.communicate(timeout=self.PROCESS_CLEANUP_TIMEOUT_SECONDS)
+        except BaseException:
+            # Cleanup must not replace the exception which interrupted the process.
+            self._force_kill_and_reap()
+
+    def run(self):
+        try:
+            if CrashLogUtils.is_taskpool_worker_terminating():
+                return b'', b'', None, False
+            self._proc = self._executive.popen(
+                self._command, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                env=self._environment, start_new_session=True)
+            try:
+                stdout, stderr = self._communicate(self._timeout)
+                return stdout, stderr, self._proc.returncode, False
+            except subprocess.TimeoutExpired as e:
+                stdout, stderr = e.output or b'', e.stderr or b''
+
+            self._signal_target(signal.SIGTERM)
+            try:
+                stdout, stderr = self._communicate(self.PROCESS_TERMINATION_GRACE_PERIOD_SECONDS)
+                return stdout, stderr, self._proc.returncode, True
+            except subprocess.TimeoutExpired as e:
+                stdout, stderr = e.output or stdout, e.stderr or stderr
+
+            # SIGTERM has been ignored by the target process, so send SIGKILL to the target
+            # first: that should let the wrapper (time) end properly and write its report.
+            self._signal_target(signal.SIGKILL)
+            try:
+                stdout, stderr = self._communicate(self.PROCESS_CLEANUP_TIMEOUT_SECONDS)
+                return stdout, stderr, self._proc.returncode, True
+            except subprocess.TimeoutExpired as e:
+                stdout, stderr = e.output or stdout, e.stderr or stderr
+            # Last resort: kill everything inside the process group
+            self._force_kill_and_reap()
+            return stdout, stderr, self._proc.returncode, True
+        except BaseException:
+            if self._proc:
+                self._terminate_after_interruption()
+            raise
+
+
+# GDB can wait indefinitely when a server in DEBUGINFOD_URLS stops answering. Check the configured
+# servers immediately before GDB starts, but share results younger than five minutes between
+# layout-test workers because each network check can take several seconds.
+class DebuginfodServerCache(object):
+    MAX_AGE_SECONDS = 5 * 60
+    REQUEST_TIMEOUT_SECONDS = 5
+    CACHE_FILENAME_PREFIX = 'availability-'
+    CACHE_FILENAME_SUFFIX = '.json'
+
+    @classmethod
+    def _cache_path(cls, servers):
+        server_list_hash = hashlib.md5('\0'.join(servers).encode('utf-8')).hexdigest()
+        return os.path.join(CrashLogUtils.get_debuginfod_cache_dir(),
+                            f'{cls.CACHE_FILENAME_PREFIX}{server_list_hash}{cls.CACHE_FILENAME_SUFFIX}')
+
+    @classmethod
+    def _is_server_available(cls, url):
+        try:
+            response = requests.get(url.rstrip('/') + '/metrics', timeout=cls.REQUEST_TIMEOUT_SECONDS)
+        except requests.RequestException:
+            return False
+        if response.status_code != 200:
+            return False
+        required_markers = ('thread_busy', 'http_requests_total', 'groom', 'debuginfo')
+        return all(marker in response.text for marker in required_markers)
+
+    @classmethod
+    def _probe(cls, servers):
+        working_servers = []
+        for server in servers:
+            if server.startswith('file://'):
+                working_servers.append(server)
+            elif server.startswith(('http://', 'https://')):
+                if cls._is_server_available(server):
+                    working_servers.append(server)
+                else:
+                    _log.warning(f'Disabling debuginfod server {server} which seems offline.')
+            else:
+                _log.warning(f'Disabling debuginfod server {server}: do not know how to handle it. Only http/https/file URIs are supported.')
+        return working_servers
+
+    @classmethod
+    def _read(cls, cache_path, servers):
+        try:
+            with open(cache_path, 'r') as cache_file:
+                working_servers = json.load(cache_file)
+                checked_at = os.fstat(cache_file.fileno()).st_mtime
+            if (not isinstance(working_servers, list)
+                    or not all(isinstance(server, str) and server in servers for server in working_servers)):
+                raise ValueError('unexpected server list')
+        except FileNotFoundError:
+            return None
+        except ValueError as e:
+            _log.warning(f'Ignoring invalid debuginfod availability cache at {cache_path}: {e}')
+            return None
+        age = time.time() - checked_at
+        if not 0 <= age < cls.MAX_AGE_SECONDS:
+            return None
+        _log.debug(f'Reusing debuginfod server availability checked {age:.0f} seconds ago.')
+        return working_servers
+
+    @classmethod
+    def _write(cls, cache_path, working_servers):
+        temporary_path = cache_path + '.tmp'
+        try:
+            with open(temporary_path, 'w') as cache_file:
+                json.dump(working_servers, cache_file)
+            os.replace(temporary_path, cache_path)
+        finally:
+            try:
+                os.remove(temporary_path)
+            except OSError:
+                pass
+
+    @classmethod
+    def _get_working_servers(cls, servers):
+        if not servers:
+            return []
+        cache_path = cls._cache_path(servers)
+        try:
+            os.makedirs(os.path.dirname(cache_path), mode=0o700, exist_ok=True)
+            with LockFile(cache_path + '.lock', log_wait_each_seconds=60):
+                cached_result = cls._read(cache_path, servers)
+                if cached_result is not None:
+                    return cached_result
+                working_servers = cls._probe(servers)
+                try:
+                    cls._write(cache_path, working_servers)
+                except OSError as e:
+                    _log.warning(f'Unable to update the debuginfod availability cache: {e}')
+                return working_servers
+        except OSError as e:
+            # Cache and lock failures must not abort crash-log generation. An
+            # uncached probe is slower but still protects GDB from dead servers.
+            _log.warning(f'Unable to use the debuginfod availability cache: {e}')
+            return cls._probe(servers)
+
+    @classmethod
+    def environment_for_gdb(cls):
+        environment = os.environ.copy()
+        servers = sorted(set(environment.get('DEBUGINFOD_URLS', '').split()))
+        working_servers = cls._get_working_servers(servers)
+        if working_servers:
+            environment['DEBUGINFOD_URLS'] = ' '.join(working_servers)
+        else:
+            environment.pop('DEBUGINFOD_URLS', None)
+        return environment
+
+
 # This runs inside a thread that watches (with inotify) the directory where the coredumps are generated
 # And saves the names of the threads of the crashing pid as soon as the coredump is started to be generated,
 # this info is later added into the generated crash log report. Even when it is naturally racy it works
@@ -570,18 +870,19 @@ class ThreadNamesCrashLogCapturer(object):
                     f.write(f'# Program name: {program_name}\n')
                     f.write('\n')
                     f.write(f'{"LWP/TID":<12} {"Thread Name"}\n')
-                    f.write(f'{"-"*12} {"-"*20}\n')
+                    f.write(f'{"-" * 12} {"-" * 20}\n')
                     for tid, name in sorted(thread_info.items(), key=lambda x: int(x[0])):
                         f.write(f'{tid:<12} {name}\n')
         except OSError as e:
             _log.error(f'Failed to write {output_path}: {e}')
 
 
-# This runs only once when the test suite start, it optionally cleans old cores and old thread-info files,
-# and then starts the thread for generating the thread-info files
+# This runs only once when the test suite starts. It cleans old debuginfod caches, optionally cleans
+# old cores and thread-info files, and starts the thread for generating thread-info files.
 class GDBCrashLogStartupHandler(object):
     def __init__(self):
         self._coredump_method, self._coredump_pattern, self._coredump_directory, self._coredump_directory_has_variable_format_specifiers = CrashLogUtils.determine_coredump_method_and_dir()
+        self.clean_old_debuginfod_server_caches()
         if os.environ.get(CrashLogEnvVars.core_dumps_autodelete, '0') == '1':
             # Even when we try to clean the coredumps as soon as those are processed sometimes there are uncleaned coredumps (usually caused by crashes not detected by this tooling),
             # so this opt-in helps to clean those anyway at startup time (used on the bots).
@@ -599,17 +900,14 @@ class GDBCrashLogStartupHandler(object):
             _log.warning("Running inside a pid namespace different than the host. This causes non-reliable crash detection. Please disable the pid namespace or switch to using an abspath for kernel.core_pattern.")
         elif self._coredump_method == CoreDumpMethod.Unknown:
             _log.error("Directory for coredumps not defined. Please use coredumpctl or define an abspath at kernel.core_pattern")
-        # Check if the debuginfod server is available to avoid hangs when generating the backtraces if the server is not responding
-        self._check_debuginfod_servers()
         # Start the thread-info capturer
         ThreadNamesCrashLogCapturer()
 
-    def _maybe_remove_file_if_old(self, path):
-        # Define old as "more than 30 minutes"
+    def _maybe_remove_file_if_old(self, path, max_age_seconds=30 * 60):
         mtime = CrashLogUtils.safe_getmtime(path)
         if mtime is None:
             return  # already gone (another worker cleaned it)
-        is_old = (time.time() - mtime) > 1800
+        is_old = (time.time() - mtime) > max_age_seconds
         if is_old:
             _log.debug(f'Cleaning old file at: {path}')
             try:
@@ -618,40 +916,6 @@ class GDBCrashLogStartupHandler(object):
                 pass  # likely another worker already removed it
         else:
             _log.debug(f'Skipping non-old file at: {path}')
-
-    def _is_debuginfod_server_available(self, url, timeout=5):
-        try:
-            r = requests.get(url.rstrip("/") + "/metrics", timeout=timeout)
-        except requests.RequestException:
-            return False
-
-        if r.status_code != 200:
-            return False
-
-        required_markers = ('thread_busy', 'http_requests_total', 'groom', 'debuginfo')
-        return all(marker in r.text for marker in required_markers)
-
-    def _check_debuginfod_servers(self):
-        if 'DEBUGINFOD_URLS' in os.environ:
-            working_debuginfod_servers = []
-            debuginfo_servers = os.environ.get('DEBUGINFOD_URLS').split()
-            if not debuginfo_servers:
-                return
-            for server in debuginfo_servers:
-                if server.startswith('file://'):
-                    working_debuginfod_servers.append(server)
-                elif server.startswith('http://') or server.startswith('https://'):
-                    if self._is_debuginfod_server_available(server):
-                        working_debuginfod_servers.append(server)
-                    else:
-                        _log.warning(f'Disabling debuginfod server {server} which seems offline.')
-                else:
-                    _log.warning(f'Disabling debuginfod server {server}: do not know how to handle it. Only http/https/file URIs are supported.')
-            if working_debuginfod_servers:
-                os.environ['DEBUGINFOD_URLS'] = ' '.join(working_debuginfod_servers)
-            else:
-                del os.environ['DEBUGINFOD_URLS']
-            _log.debug(f'Environment variable DEBUGINFOD_URLS updated to "{os.environ.get("DEBUGINFOD_URLS", "")}"')
 
     def clean_old_coredumps(self):
         candidate_coredumps = [os.path.join(self._coredump_directory, f) for f in os.listdir(self._coredump_directory) if os.path.isfile(os.path.join(self._coredump_directory, f))]
@@ -669,6 +933,21 @@ class GDBCrashLogStartupHandler(object):
                 path = os.path.join(webkit_thread_info_crashlog_dir, name)
                 if os.path.isfile(path) and name.startswith(prefix) and name.endswith(suffix):
                     self._maybe_remove_file_if_old(path)
+
+    def clean_old_debuginfod_server_caches(self):
+        cache_dir = CrashLogUtils.get_debuginfod_cache_dir()
+        if not os.path.isdir(cache_dir):
+            return
+        try:
+            cache_entries = os.listdir(cache_dir)
+        except OSError as e:
+            _log.warning(f'Unable to clean old debuginfod availability caches: {e}')
+            return
+        for name in cache_entries:
+            is_cache_entry = name.startswith(DebuginfodServerCache.CACHE_FILENAME_PREFIX) and name.endswith((DebuginfodServerCache.CACHE_FILENAME_SUFFIX, DebuginfodServerCache.CACHE_FILENAME_SUFFIX + '.tmp'))
+            path = os.path.join(cache_dir, name)
+            if os.path.isfile(path) and is_cache_entry:
+                self._maybe_remove_file_if_old(path, DebuginfodServerCache.MAX_AGE_SECONDS)
 
 
 class GDBCrashLogGenerator(object):
@@ -700,33 +979,62 @@ class GDBCrashLogGenerator(object):
         # than other tester process to help avoiding timeouts. But this can starve the system RAM.
         # On the CI is recommended to set a limit.
         gdb_cmd_wrapper = [] if CrashLogUtils.get_gdb_concurrent_execution_limit() else ['nice']
-        time_output_tmp = None
+        time_output_path = None
         time_output_content = ""
-        if shutil.which('time'):
-            time_output_tmp = CrashLogUtils.make_temp_path(suffix='.log')
-            gdb_cmd_wrapper += ['time', '-v', f'--output={time_output_tmp}']
-        gdb_cmd = ['gdb', '-iex', 'set debuginfod enabled on',
-                   '-ex', 'thread apply all -ascending bt full 1024', '--batch', process_name, coredump_path]
-        with CrashLogUtils.get_gdb_lock():
-            _log.debug(f'Starting GDB process to generate a backtrace for {process_name} (pid {self._effective_coredump_pid})')
-            proc = self._executive.popen(gdb_cmd_wrapper + gdb_cmd, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = proc.communicate()
-        if proc.returncode != 0:
-            stdout = (b'ERROR: The gdb process exited with non-zero return code %s\n\n' % str(proc.returncode).encode('utf8', 'ignore')) + stdout
-        # Read time stats
-        if time_output_tmp and os.path.isfile(time_output_tmp):
-            with open(time_output_tmp, 'r') as f:
-                lines = []
-                for line in f:
-                    line = line.strip()
-                    # Skip lines with zero values: most rusage fields (average sizes, swaps, I/O, signals) are always zero on Linux
-                    # because the kernel never implemented them -- they exist only for compatibility with BSD. See getrusage(2).
-                    if line.endswith(': 0') and 'Exit status' not in line:
-                        continue
-                    lines.append(line)
-                time_output_content = '\n'.join(lines)
-            os.remove(time_output_tmp)
-        return (stdout.decode('utf8', 'ignore'), stderr.decode('utf8', 'ignore'), time_output_content)
+        try:
+            gdb_cmd = ['gdb', '-iex', 'set debuginfod enabled on',
+                       '-ex', 'thread apply all -ascending bt full 1024', '--batch', process_name, coredump_path]
+            gdb_timeout = CrashLogUtils.get_gdb_execution_timeout()
+
+            with CrashLogUtils.get_gdb_lock():
+                if CrashLogUtils.is_taskpool_worker_terminating():
+                    _log.warning(f'GDB not started because taskpool requested worker termination while preparing to generate a backtrace for {process_name} (pid {self._effective_coredump_pid}).')
+                    return '', '', ''
+                # Do this after waiting for a GDB slot, so a long queue cannot make
+                # an otherwise fresh availability check stale before GDB starts.
+                gdb_environment = DebuginfodServerCache.environment_for_gdb()
+                if shutil.which('time'):
+                    try:
+                        crashlog_temp_dir = CrashLogUtils.get_crashlog_temp_dir()
+                        os.makedirs(crashlog_temp_dir, exist_ok=True)
+                        time_output_path = CrashLogUtils.make_temp_path(dir=crashlog_temp_dir, prefix='gdb-time-', suffix='.log')
+                        gdb_cmd_wrapper += ['time', '-v', f'--output={time_output_path}']
+                    except OSError as e:
+                        _log.warning(f'Unable to create GDB timing output file: {e}. Continuing without timing statistics.')
+                _log.debug(f'Starting GDB process to generate a backtrace for {process_name} (pid {self._effective_coredump_pid}) with an execution timeout of {gdb_timeout} seconds')
+                stdout, stderr, returncode, timed_out = TaskPooledProcessRunner(self._executive, gdb_cmd_wrapper + gdb_cmd, gdb_environment, gdb_timeout, target_is_child=bool(time_output_path)).run()
+                if CrashLogUtils.is_taskpool_worker_terminating():
+                    _log.warning(f'GDB was terminated because taskpool requested worker termination while generating a backtrace for {process_name} (pid {self._effective_coredump_pid}).')
+                    return '', '', ''
+            if timed_out:
+                _log.error(f'GDB was terminated after exceeding its {gdb_timeout}-second timeout while generating a backtrace for {process_name} (pid {self._effective_coredump_pid}).')
+                timeout_message = f'ERROR: GDB was terminated because it did not finish within {gdb_timeout} seconds.\n' + \
+                                  f'       It was sent SIGTERM and given up to {TaskPooledProcessRunner.PROCESS_TERMINATION_GRACE_PERIOD_SECONDS} seconds to exit before SIGKILL escalation.\n' + \
+                                  '       Any backtrace below is incomplete.\n' + \
+                                  f'       DEBUGINFOD_URLS used: "{gdb_environment.get("DEBUGINFOD_URLS", "")}"\n' + \
+                                  f'       The timeout can be changed with {CrashLogEnvVars.gdb_execution_timeout}.\n\n'
+                stdout = timeout_message.encode('utf8') + stdout
+            elif returncode != 0:
+                stdout = (b'ERROR: The gdb process exited with non-zero return code %s\n\n' % str(returncode).encode('utf8', 'ignore')) + stdout
+            # Read time stats
+            if time_output_path and os.path.isfile(time_output_path):
+                with open(time_output_path, 'r') as f:
+                    lines = []
+                    for line in f:
+                        line = line.strip()
+                        # Skip lines with zero values: most rusage fields (average sizes, swaps, I/O, signals) are always zero on Linux
+                        # because the kernel never implemented them -- they exist only for compatibility with BSD. See getrusage(2).
+                        if line.endswith(': 0') and 'Exit status' not in line:
+                            continue
+                        lines.append(line)
+                    time_output_content = '\n'.join(lines)
+            return (stdout.decode('utf8', 'ignore'), stderr.decode('utf8', 'ignore'), time_output_content)
+        finally:
+            if time_output_path:
+                try:
+                    os.remove(time_output_path)
+                except OSError:
+                    pass
 
     def _coredump_pattern_has_pid_format_string(self):
         return CrashLogUtils.core_pattern_has_pid_format_string(self._coredump_pattern)

--- a/Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py
+++ b/Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py
@@ -29,21 +29,27 @@
 
 import builtins
 import collections
+import contextlib
 import io
 import os
 import json
 import re
+import requests
 import shutil
+import signal
+import subprocess
 import resource
+import sys
 import tempfile
 import threading
 import time
 import unittest
 from unittest import mock
 
+from webkitcorepy import TaskPool
 from webkitpy.common.system.executive_mock import MockExecutive
 from webkitpy.common.system.filesystem_mock import MockFileSystem
-from webkitpy.port.linux_get_crash_log import CoreDumpMethod, CrashLogEnvVars, CrashLogUtils, GDBCrashLogGenerator, GDBCrashLogStartupHandler, LockFile, ThreadNamesCrashLogCapturer
+from webkitpy.port.linux_get_crash_log import GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS, CoreDumpMethod, CrashLogEnvVars, CrashLogUtils, DebuginfodServerCache, GDBCrashLogGenerator, GDBCrashLogStartupHandler, LockFile, TaskPooledProcessRunner, ThreadNamesCrashLogCapturer
 
 
 # GDBCrashLogGenerator with determine_coredump_method_and_dir patched
@@ -190,6 +196,17 @@ class MakeTempPathTest(unittest.TestCase):
         self.addCleanup(os.unlink, p1)
         self.addCleanup(os.unlink, p2)
         self.assertNotEqual(p1, p2)
+
+
+class CrashLogTemporaryDirectoriesTest(unittest.TestCase):
+
+    def test_thread_and_debuginfod_directories_share_crashlog_root(self):
+        root = CrashLogUtils.get_crashlog_temp_dir()
+
+        self.assertEqual(root, os.path.join(tempfile.gettempdir(), f'webkit-crashlog-{os.getuid()}'))
+        self.assertEqual(CrashLogUtils.get_crashlog_temp_dir('/parent'), os.path.join('/parent', os.path.basename(root)))
+        self.assertEqual(CrashLogUtils.get_thread_data_dir(), os.path.join(root, 'thread-name-data'))
+        self.assertEqual(CrashLogUtils.get_debuginfod_cache_dir(), os.path.join(root, 'debuginfod-cache'))
 
 
 class SafeGetmtimeMostRecentExistingTest(unittest.TestCase):
@@ -637,9 +654,8 @@ class CoredumpDeletionGatingTest(unittest.TestCase):
             'a vanished coredump must not be renamed/claimed')
 
 
-class CleanOldCoredumpsTest(unittest.TestCase):
-    """clean_old_coredumps() reaps old files matching the core_pattern AND old
-    claimed (being-processed) leftovers, while leaving fresh and unrelated files."""
+class CleanOldCrashLogFilesTest(unittest.TestCase):
+    """Startup cleanup reaps recognized stale files while preserving fresh and unrelated files."""
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
@@ -649,6 +665,9 @@ class CleanOldCoredumpsTest(unittest.TestCase):
         self.handler = GDBCrashLogStartupHandler.__new__(GDBCrashLogStartupHandler)
         self.handler._coredump_directory = self.tmpdir
         self.handler._coredump_pattern = 'core-%e-pid_%p.dump'
+        patcher = mock.patch.object(CrashLogUtils, 'get_debuginfod_cache_dir', return_value=self.tmpdir)
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def _touch(self, name, age_seconds):
         path = os.path.join(self.tmpdir, name)
@@ -674,6 +693,39 @@ class CleanOldCoredumpsTest(unittest.TestCase):
         self.assertFalse(os.path.exists(old_claimed), 'old claimed leftover should be reaped')
         self.assertTrue(os.path.exists(fresh_claimed), 'fresh (in-flight) claimed file should be kept')
         self.assertTrue(os.path.exists(unrelated), 'unrelated file should be left untouched')
+
+    def test_removes_only_old_cache_and_temporary_files(self):
+        old_age = DebuginfodServerCache.MAX_AGE_SECONDS + 1
+        old_cache = self._touch('availability-old.json', old_age)
+        fresh_cache = self._touch('availability-fresh.json', 1)
+        old_temporary = self._touch('availability-old.json.tmp', old_age)
+        fresh_temporary = self._touch('availability-fresh.json.tmp', 1)
+        old_lock = self._touch('availability-old.json.lock', old_age)
+        unrelated = self._touch('unrelated', old_age)
+
+        self.handler.clean_old_debuginfod_server_caches()
+
+        self.assertFalse(os.path.exists(old_cache))
+        self.assertTrue(os.path.exists(fresh_cache))
+        self.assertFalse(os.path.exists(old_temporary))
+        self.assertTrue(os.path.exists(fresh_temporary))
+        self.assertTrue(os.path.exists(old_lock))
+        self.assertTrue(os.path.exists(unrelated))
+
+    def test_keeps_cache_directory_when_last_cache_is_removed(self):
+        old_cache = self._touch('availability-old.json', DebuginfodServerCache.MAX_AGE_SECONDS + 1)
+
+        self.handler.clean_old_debuginfod_server_caches()
+
+        self.assertFalse(os.path.exists(old_cache))
+        self.assertTrue(os.path.isdir(self.tmpdir))
+
+    def test_list_failure_does_not_abort_cleanup(self):
+        with mock.patch('os.listdir', side_effect=PermissionError('read-only')), \
+             mock.patch('webkitpy.port.linux_get_crash_log._log.warning') as warning:
+            self.handler.clean_old_debuginfod_server_caches()
+
+        self.assertIn('Unable to clean old debuginfod availability caches', warning.call_args.args[0])
 
 
 class DetermineCoredumpMethodAndDirTest(unittest.TestCase):
@@ -1458,3 +1510,699 @@ Thread 2 (Thread 0x... (LWP 5678)):
         self.assertIn("real_thread_1_frame ()", result)
         self.assertNotIn("PREAMBLE_FRAME_should_be_ignored", result)
         self.assertNotIn("NON_CRASHING_FRAME_should_be_ignored", result)
+
+
+class DebuginfodServerCacheTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+        patcher = mock.patch.object(CrashLogUtils, 'get_debuginfod_cache_dir', return_value=self.tmpdir)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.servers = sorted(['https://up.example.com', 'https://flaky.example.com'])
+        self.cache_path = DebuginfodServerCache._cache_path(self.servers)
+        self.environment_patch = mock.patch.dict(os.environ, {'DEBUGINFOD_URLS': ' '.join(self.servers)}, clear=True)
+        self.environment_patch.start()
+        self.addCleanup(self.environment_patch.stop)
+
+    def _age_cache(self):
+        mtime = time.time() - DebuginfodServerCache.MAX_AGE_SECONDS - 1
+        os.utime(self.cache_path, (mtime, mtime))
+
+    def test_recent_result_is_shared_without_reprobing(self):
+        with mock.patch.object(DebuginfodServerCache, '_probe', return_value=self.servers) as probe:
+            first = DebuginfodServerCache._get_working_servers(self.servers)
+            second = DebuginfodServerCache._get_working_servers(self.servers)
+
+        self.assertEqual(first, self.servers)
+        self.assertEqual(second, self.servers)
+        probe.assert_called_once_with(self.servers)
+
+    def test_environment_canonicalizes_reordered_and_duplicate_servers(self):
+        reordered_servers = list(reversed(self.servers)) + [self.servers[0]]
+        with mock.patch.object(DebuginfodServerCache, '_probe', return_value=self.servers) as probe:
+            with mock.patch.dict(os.environ, {'DEBUGINFOD_URLS': ' '.join(reordered_servers)}, clear=True):
+                first_environment = DebuginfodServerCache.environment_for_gdb()
+            second_environment = DebuginfodServerCache.environment_for_gdb()
+
+        self.assertEqual(first_environment['DEBUGINFOD_URLS'], ' '.join(self.servers))
+        self.assertEqual(second_environment['DEBUGINFOD_URLS'], ' '.join(self.servers))
+        probe.assert_called_once_with(self.servers)
+
+    def test_probe_keeps_file_urls_and_drops_unsupported_urls(self):
+        servers = ['file:///usr/lib/debug', 'ftp://unsupported.example.com', self.servers[0]]
+        with mock.patch.object(DebuginfodServerCache, '_is_server_available', return_value=True) as is_available:
+            working_servers = DebuginfodServerCache._probe(servers)
+
+        self.assertEqual(working_servers, ['file:///usr/lib/debug', self.servers[0]])
+        is_available.assert_called_once_with(self.servers[0])
+
+    def test_http_availability_probe(self):
+        required_metrics = 'thread_busy http_requests_total groom debuginfo'
+        cases = (
+            ('available', 200, required_metrics, True),
+            ('server error', 503, required_metrics, False),
+            ('missing metrics', 200, 'missing required metrics', False),
+        )
+        for name, status, text, expected in cases:
+            response = mock.Mock(status_code=status, text=text)
+            with self.subTest(name=name), \
+                 mock.patch('webkitpy.port.linux_get_crash_log.requests.get', return_value=response) as request:
+                self.assertEqual(DebuginfodServerCache._is_server_available('https://debuginfod.example.com/'), expected)
+                request.assert_called_once_with('https://debuginfod.example.com/metrics',
+                                                timeout=DebuginfodServerCache.REQUEST_TIMEOUT_SECONDS)
+
+        with mock.patch('webkitpy.port.linux_get_crash_log.requests.get',
+                        side_effect=requests.RequestException('unavailable')):
+            self.assertFalse(DebuginfodServerCache._is_server_available('https://debuginfod.example.com'))
+
+    def test_concurrent_refresh_is_coalesced_by_file_lock(self):
+        barrier = threading.Barrier(3)
+        results = []
+
+        def slow_probe(servers):
+            time.sleep(0.05)
+            return servers
+
+        def worker():
+            barrier.wait()
+            results.append(DebuginfodServerCache._get_working_servers(self.servers))
+
+        with mock.patch.object(DebuginfodServerCache, '_probe', side_effect=slow_probe) as probe:
+            threads = [threading.Thread(target=worker) for _ in range(2)]
+            for thread in threads:
+                thread.start()
+            barrier.wait()
+            for thread in threads:
+                thread.join(timeout=5)
+
+        self.assertTrue(all(not thread.is_alive() for thread in threads))
+        self.assertEqual(results, [self.servers, self.servers])
+        probe.assert_called_once_with(self.servers)
+
+    def test_environment_for_gdb_filters_copy_without_changing_process_environment(self):
+        def only_first_server_works(servers):
+            return [servers[0]]
+
+        configured_urls = os.environ['DEBUGINFOD_URLS']
+        with mock.patch.object(DebuginfodServerCache, '_probe', side_effect=only_first_server_works) as probe:
+            gdb_environment = DebuginfodServerCache.environment_for_gdb()
+
+        self.assertEqual(os.environ['DEBUGINFOD_URLS'], configured_urls)
+        self.assertEqual(gdb_environment['DEBUGINFOD_URLS'], self.servers[0])
+        probe.assert_called_once_with(self.servers)
+
+    def test_server_offline_during_first_crash_can_recover(self):
+        configured_urls = os.environ['DEBUGINFOD_URLS']
+        with mock.patch.object(DebuginfodServerCache, '_probe', return_value=[]) as probe:
+            first_gdb_environment = DebuginfodServerCache.environment_for_gdb()
+            second_gdb_environment = DebuginfodServerCache.environment_for_gdb()
+        self.assertNotIn('DEBUGINFOD_URLS', first_gdb_environment)
+        self.assertNotIn('DEBUGINFOD_URLS', second_gdb_environment)
+        self.assertEqual(os.environ['DEBUGINFOD_URLS'], configured_urls)
+        probe.assert_called_once_with(self.servers)
+
+        self._age_cache()
+        with mock.patch.object(DebuginfodServerCache, '_probe', return_value=self.servers) as probe:
+            gdb_environment = DebuginfodServerCache.environment_for_gdb()
+
+        self.assertEqual(gdb_environment['DEBUGINFOD_URLS'], ' '.join(self.servers))
+        probe.assert_called_once_with(self.servers)
+
+    def test_cache_path_failure_falls_back_to_uncached_probe(self):
+        with mock.patch('os.makedirs', side_effect=PermissionError('read-only')), \
+             mock.patch.object(DebuginfodServerCache, '_probe', return_value=self.servers) as probe:
+            working_servers = DebuginfodServerCache._get_working_servers(self.servers)
+
+        self.assertEqual(working_servers, self.servers)
+        probe.assert_called_once_with(self.servers)
+
+    def test_cache_write_failure_does_not_repeat_probe_or_raise(self):
+        with mock.patch.object(DebuginfodServerCache, '_probe', return_value=self.servers) as probe, \
+             mock.patch.object(DebuginfodServerCache, '_write', side_effect=OSError('disk full')):
+            working_servers = DebuginfodServerCache._get_working_servers(self.servers)
+
+        self.assertEqual(working_servers, self.servers)
+        probe.assert_called_once_with(self.servers)
+
+    def test_corrupted_cache_is_ignored(self):
+        with open(self.cache_path, 'w') as cache_file:
+            cache_file.write('not JSON')
+        with mock.patch.object(DebuginfodServerCache, '_probe', return_value=self.servers) as probe:
+            self.assertEqual(DebuginfodServerCache._get_working_servers(self.servers), self.servers)
+        probe.assert_called_once_with(self.servers)
+
+    def test_different_server_lists_use_independent_cached_results(self):
+        with mock.patch.object(DebuginfodServerCache, '_probe', side_effect=lambda servers: servers) as probe:
+            DebuginfodServerCache._get_working_servers(self.servers)
+            self.assertEqual(DebuginfodServerCache._get_working_servers(self.servers[:1]), self.servers[:1])
+        self.assertEqual(probe.call_count, 2)
+
+    def test_no_configured_servers_does_not_probe_or_set_gdb_environment(self):
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch.object(DebuginfodServerCache, '_probe') as probe:
+            gdb_environment = DebuginfodServerCache.environment_for_gdb()
+
+        probe.assert_not_called()
+        self.assertNotIn('DEBUGINFOD_URLS', gdb_environment)
+
+
+class GDBExecutionTimeoutConfigurationTest(unittest.TestCase):
+
+    def _timeout_with_value(self, value):
+        environment = {} if value is None else {CrashLogEnvVars.gdb_execution_timeout: value}
+        with mock.patch.dict(os.environ, environment, clear=True):
+            return CrashLogUtils.get_gdb_execution_timeout()
+
+    def test_timeout_configuration(self):
+        cases = (
+            (None, GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS),
+            ('60', 60),
+            ('invalid', GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS),
+            ('0', GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS),
+            ('-1', GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS),
+            ('-01', GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS),
+            ('', GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS),
+            ('²', GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS),
+        )
+        with mock.patch('webkitpy.port.linux_get_crash_log._log.warning') as warning:
+            for value, expected in cases:
+                with self.subTest(value=value):
+                    self.assertEqual(self._timeout_with_value(value), expected)
+                    if value is not None and expected == GDB_EXECUTION_TIMEOUT_DEFAULT_SECONDS:
+                        self.assertIn(f'={value}.', warning.call_args.args[0])
+
+
+class FakeGDBProcess(object):
+
+    def __init__(self, communicate_result, pid=4242, wait_times_out=False):
+        self.pid = pid
+        self.returncode = None
+        self.stdout = io.BytesIO()
+        self.stderr = io.BytesIO()
+        self.communicate_results = communicate_result if isinstance(communicate_result, list) else [communicate_result]
+        self.wait_times_out = wait_times_out
+        self.communicate_timeouts = []
+        self.wait_timeouts = []
+        self.signals_sent = []
+
+    def communicate(self, timeout=None):
+        self.communicate_timeouts.append(timeout)
+        result_index = min(len(self.communicate_timeouts) - 1, len(self.communicate_results) - 1)
+        communicate_result = self.communicate_results[result_index]
+        if isinstance(communicate_result, BaseException):
+            raise communicate_result
+        self.returncode = 0
+        return communicate_result
+
+    def send_signal(self, sig):
+        self.signals_sent.append(sig)
+
+    def wait(self, timeout=None):
+        self.wait_timeouts.append(timeout)
+        if self.wait_times_out:
+            raise subprocess.TimeoutExpired('gdb', timeout)
+        self.returncode = -signal.SIGKILL
+        return self.returncode
+
+
+class FakeGDBExecutive(object):
+
+    def __init__(self, process):
+        self.process = process
+        self.popen_kwargs = None
+
+    def popen(self, _, **kwargs):
+        self.popen_kwargs = kwargs
+        return self.process
+
+
+class SubprocessExecutive(object):
+
+    @staticmethod
+    def popen(command, **kwargs):
+        return subprocess.Popen(command, **kwargs)
+
+
+def _run_process(executive, command, environment, timeout, target_is_child=False):
+    return TaskPooledProcessRunner(executive, command, environment, timeout, target_is_child).run()
+
+
+class TaskPooledProcessRunnerCommunicateTest(unittest.TestCase):
+
+    @staticmethod
+    def _runner(process):
+        runner = TaskPooledProcessRunner(FakeGDBExecutive(process), ['gdb'], {}, 10)
+        runner._proc = process
+        return runner
+
+    def test_retries_with_bounded_timeouts_until_process_exits(self):
+        process = FakeGDBProcess([
+            subprocess.TimeoutExpired('gdb', 1),
+            (b'backtrace', b''),
+        ])
+
+        with mock.patch('webkitpy.port.linux_get_crash_log.time.monotonic',
+                        side_effect=(0, 0, 1, 1)):
+            result = self._runner(process)._communicate(10)
+
+        self.assertEqual(result, (b'backtrace', b''))
+        self.assertEqual(process.communicate_timeouts, [1, 1])
+
+    def test_raises_when_overall_deadline_expires(self):
+        process = FakeGDBProcess(subprocess.TimeoutExpired(
+            'gdb', 1, output=b'partial backtrace', stderr=b'partial stderr'))
+
+        with mock.patch('webkitpy.port.linux_get_crash_log.time.monotonic',
+                        side_effect=(0, 0, 1, 1, 2, 2, 3)), \
+             self.assertRaises(subprocess.TimeoutExpired) as raised:
+            self._runner(process)._communicate(3)
+
+        self.assertEqual(raised.exception.output, b'partial backtrace')
+        self.assertEqual(raised.exception.stderr, b'partial stderr')
+        self.assertEqual(process.communicate_timeouts, [1, 1, 1])
+
+    def test_termination_request_stops_communicating(self):
+        process = FakeGDBProcess(subprocess.TimeoutExpired('gdb', 1))
+        runner = self._runner(process)
+
+        with mock.patch('webkitpy.port.linux_get_crash_log.time.monotonic',
+                        side_effect=(0, 0, 0)), \
+             mock.patch.object(CrashLogUtils, 'is_taskpool_worker_terminating',
+                               side_effect=(False, True)), \
+             mock.patch.object(runner, '_terminate_after_interruption') as terminate:
+            result = runner._communicate(10)
+
+        self.assertEqual(result, (b'', b''))
+        terminate.assert_called_once_with()
+        self.assertEqual(process.communicate_timeouts, [1])
+
+
+class TaskPooledProcessRunnerTest(unittest.TestCase):
+
+    def setUp(self):
+        # These tests exercise the process timeout state machine. Test bounded
+        # communicate polling separately without making every fake timeout wait
+        # for a real deadline.
+        def communicate(runner, timeout):
+            result = runner._proc.communicate(timeout=timeout)
+            if CrashLogUtils.is_taskpool_worker_terminating():
+                runner._terminate_after_interruption()
+                return b'', b''
+            return result
+
+        communicate = mock.patch.object(
+            TaskPooledProcessRunner, '_communicate', autospec=True, side_effect=communicate)
+        communicate.start()
+        self.addCleanup(communicate.stop)
+
+    def test_success_uses_timeout_environment_and_new_session(self):
+        process = FakeGDBProcess((b'backtrace', b''))
+        executive = FakeGDBExecutive(process)
+        environment = {'DEBUGINFOD_URLS': 'file:///debug'}
+
+        result = _run_process(executive, ['gdb'], environment, 1800)
+
+        self.assertEqual(result, (b'backtrace', b'', 0, False))
+        self.assertEqual(process.communicate_timeouts, [1800])
+        self.assertEqual(executive.popen_kwargs['env'], environment)
+        self.assertTrue(executive.popen_kwargs['start_new_session'])
+
+    def test_termination_requested_before_run_prevents_process_start(self):
+        process = FakeGDBProcess((b'backtrace', b''))
+        executive = FakeGDBExecutive(process)
+
+        with mock.patch.object(CrashLogUtils, 'is_taskpool_worker_terminating', return_value=True):
+            result = TaskPooledProcessRunner(executive, ['gdb'], {}, 1800).run()
+
+        self.assertEqual(result, (b'', b'', None, False))
+        self.assertIsNone(executive.popen_kwargs)
+
+    def test_timeout_escalates_to_sigkill_and_preserves_partial_output(self):
+        timeout = subprocess.TimeoutExpired('gdb', 1800, output=b'partial backtrace', stderr=b'partial stderr')
+        process = FakeGDBProcess(timeout)
+
+        with mock.patch('webkitpy.port.linux_get_crash_log.os.killpg') as signal_process_group:
+            result = _run_process(FakeGDBExecutive(process), ['gdb'], {}, 1800)
+
+        self.assertEqual(result, (b'partial backtrace', b'partial stderr', -signal.SIGKILL, True))
+        self.assertEqual(process.signals_sent, [signal.SIGTERM, signal.SIGKILL])
+        signal_process_group.assert_called_once_with(4242, signal.SIGKILL)
+        self.assertEqual(process.communicate_timeouts, [1800, TaskPooledProcessRunner.PROCESS_TERMINATION_GRACE_PERIOD_SECONDS,
+                                                        TaskPooledProcessRunner.PROCESS_CLEANUP_TIMEOUT_SECONDS])
+        self.assertEqual(process.wait_timeouts, [TaskPooledProcessRunner.PROCESS_CLEANUP_TIMEOUT_SECONDS])
+        self.assertTrue(process.stdout.closed and process.stderr.closed)
+
+    def test_sigterm_grace_period_collects_additional_output_without_sigkill(self):
+        timeout = subprocess.TimeoutExpired('gdb', 1800, output=b'partial backtrace\n', stderr=b'')
+        process = FakeGDBProcess([timeout, (b'partial backtrace\ntermination details\n', b'gdb terminated\n')])
+
+        with mock.patch('webkitpy.port.linux_get_crash_log.os.killpg') as signal_process_group:
+            result = _run_process(FakeGDBExecutive(process), ['gdb'], {}, 1800)
+
+        self.assertEqual(result, (b'partial backtrace\ntermination details\n', b'gdb terminated\n', 0, True))
+        self.assertEqual(process.signals_sent, [signal.SIGTERM])
+        signal_process_group.assert_not_called()
+        self.assertEqual(process.communicate_timeouts, [1800, TaskPooledProcessRunner.PROCESS_TERMINATION_GRACE_PERIOD_SECONDS])
+
+    def test_gdb_sigkill_allows_time_wrapper_to_return_output(self):
+        timeout = subprocess.TimeoutExpired('gdb', 1800, output=b'partial backtrace\n', stderr=b'')
+        grace_timeout = subprocess.TimeoutExpired('gdb', 60, output=b'partial backtrace\n', stderr=b'')
+        process = FakeGDBProcess([timeout, grace_timeout, (b'partial backtrace\ntime report\n', b'')])
+
+        real_open = builtins.open
+        children_paths = []
+
+        # Read the children of the time wrapper straight from /proc, so the pid used
+        # to locate them is covered rather than supplied by the test.
+        def fake_open(path, *args, **kwargs):
+            if str(path).startswith('/proc/'):
+                children_paths.append(path)
+                return io.StringIO('4343\n')
+            return real_open(path, *args, **kwargs)
+
+        with mock.patch('builtins.open', side_effect=fake_open), \
+             mock.patch('webkitpy.port.linux_get_crash_log.os.kill') as signal_gdb, \
+             mock.patch('webkitpy.port.linux_get_crash_log.os.killpg') as signal_process_group:
+            result = _run_process(
+                FakeGDBExecutive(process), ['time', 'gdb'], {}, 1800, target_is_child=True)
+
+        self.assertEqual(result, (b'partial backtrace\ntime report\n', b'', 0, True))
+        self.assertEqual(signal_gdb.call_args_list,
+                         [mock.call(4343, signal.SIGTERM), mock.call(4343, signal.SIGKILL)])
+        self.assertEqual(children_paths, ['/proc/4242/task/4242/children'] * 2)
+        signal_process_group.assert_not_called()
+        self.assertEqual(process.communicate_timeouts, [1800, TaskPooledProcessRunner.PROCESS_TERMINATION_GRACE_PERIOD_SECONDS,
+                                                        TaskPooledProcessRunner.PROCESS_CLEANUP_TIMEOUT_SECONDS])
+
+    def test_unreapable_process_does_not_make_cleanup_unbounded(self):
+        process = FakeGDBProcess(subprocess.TimeoutExpired('gdb', 1800), wait_times_out=True)
+        with mock.patch('webkitpy.port.linux_get_crash_log.os.killpg'):
+            result = _run_process(FakeGDBExecutive(process), ['gdb'], {}, 1800)
+
+        self.assertTrue(result[3])
+        self.assertEqual(process.communicate_timeouts, [1800, TaskPooledProcessRunner.PROCESS_TERMINATION_GRACE_PERIOD_SECONDS,
+                                                        TaskPooledProcessRunner.PROCESS_CLEANUP_TIMEOUT_SECONDS])
+        self.assertEqual(process.wait_timeouts, [TaskPooledProcessRunner.PROCESS_CLEANUP_TIMEOUT_SECONDS])
+
+    def test_killpg_failure_uses_direct_process_fallback(self):
+        process = FakeGDBProcess(subprocess.TimeoutExpired('gdb', 1800))
+        with mock.patch('webkitpy.port.linux_get_crash_log.os.killpg', side_effect=OSError('failed')):
+            result = _run_process(FakeGDBExecutive(process), ['gdb'], {}, 1800)
+
+        self.assertTrue(result[3])
+        self.assertEqual(process.signals_sent, [signal.SIGTERM, signal.SIGKILL, signal.SIGKILL])
+        self.assertEqual(process.communicate_timeouts, [1800, TaskPooledProcessRunner.PROCESS_TERMINATION_GRACE_PERIOD_SECONDS,
+                                                        TaskPooledProcessRunner.PROCESS_CLEANUP_TIMEOUT_SECONDS])
+
+    def test_reap_failure_does_not_mask_grace_period_keyboard_interrupt(self):
+        process = FakeGDBProcess([subprocess.TimeoutExpired('gdb', 1800), KeyboardInterrupt()])
+        with mock.patch('webkitpy.port.linux_get_crash_log.os.killpg') as signal_process_group, \
+             mock.patch.object(process, 'wait', side_effect=OSError('no child')), \
+             mock.patch('webkitpy.port.linux_get_crash_log._log.warning') as warning, \
+             self.assertRaises(KeyboardInterrupt):
+            _run_process(FakeGDBExecutive(process), ['gdb'], {}, 1800)
+
+        self.assertEqual(process.signals_sent, [signal.SIGTERM, signal.SIGTERM])
+        signal_process_group.assert_called_once_with(4242, signal.SIGKILL)
+        self.assertTrue(process.stdout.closed and process.stderr.closed)
+        self.assertIn('Unable to reap process 4242', warning.call_args.args[0])
+
+    def test_termination_request_terminates_process(self):
+        process = FakeGDBProcess((b'', b''))
+
+        def request_termination(*_args, **_kwargs):
+            TaskPool.Process.working = False
+            return b'', b''
+
+        with mock.patch.object(TaskPool.Process, 'name', 'worker/0'), \
+             mock.patch.object(TaskPool.Process, 'working', True), \
+             mock.patch.object(process, 'communicate', side_effect=request_termination), \
+             mock.patch('webkitpy.port.linux_get_crash_log.os.killpg') as signal_process_group:
+            result = TaskPooledProcessRunner(FakeGDBExecutive(process), ['gdb'], {}, 1800).run()
+
+        self.assertEqual(result, (b'', b'', None, False))
+        self.assertEqual(process.signals_sent, [signal.SIGTERM])
+        signal_process_group.assert_not_called()
+
+    def test_interrupted_process_ignoring_sigterm_is_force_killed(self):
+        process = FakeGDBProcess((b'', b''))
+
+        def interrupt_then_timeout(*_args, **_kwargs):
+            if process.communicate.call_count == 1:
+                TaskPool.Process.working = False
+                return b'', b''
+            raise subprocess.TimeoutExpired('gdb', 10)
+
+        with mock.patch.object(TaskPool.Process, 'name', 'worker/0'), \
+             mock.patch.object(TaskPool.Process, 'working', True), \
+             mock.patch.object(process, 'communicate', side_effect=interrupt_then_timeout), \
+             mock.patch.object(TaskPooledProcessRunner, '_force_kill_and_reap', autospec=True) as force_kill:
+            result = TaskPooledProcessRunner(FakeGDBExecutive(process), ['gdb'], {}, 1800).run()
+
+        self.assertEqual(result, (b'', b'', None, False))
+        self.assertEqual(process.signals_sent, [signal.SIGTERM])
+        force_kill.assert_called_once()
+
+    def test_real_wrapper_and_child_are_both_killed_after_grace_period(self):
+        wrapper_script = (
+            "import signal, subprocess, sys, time; "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "child = subprocess.Popen([sys.executable, '-c', "
+            "'import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)']); "
+            "print(child.pid, flush=True); "
+            "time.sleep(60)"
+        )
+        with mock.patch.object(TaskPooledProcessRunner, 'PROCESS_TERMINATION_GRACE_PERIOD_SECONDS', 0.2), \
+             mock.patch.object(TaskPooledProcessRunner, 'PROCESS_CLEANUP_TIMEOUT_SECONDS', 0.2):
+            stdout, _, returncode, timed_out = _run_process(
+                SubprocessExecutive(), [sys.executable, '-c', wrapper_script], os.environ.copy(), 0.5,
+                target_is_child=True)
+
+        child_pid = int(stdout.decode('ascii').strip())
+
+        def child_is_running():
+            try:
+                with open(f'/proc/{child_pid}/stat', 'r') as stat_file:
+                    # A zombie has terminated and is only waiting for its parent to reap it.
+                    return stat_file.read().split(') ', 1)[1][0] != 'Z'
+            except (FileNotFoundError, ProcessLookupError):
+                return False
+
+        try:
+            deadline = time.monotonic() + 2
+            while child_is_running() and time.monotonic() < deadline:
+                time.sleep(0.05)
+            self.assertTrue(timed_out)
+            self.assertEqual(returncode, -signal.SIGKILL)
+            self.assertFalse(child_is_running())
+        finally:
+            if child_is_running():
+                os.kill(child_pid, signal.SIGKILL)
+
+    # Signalling the target below the wrapper needs the child list from
+    # /proc/<pid>/task/<pid>/children, which only Linux provides.
+    @unittest.skipUnless(sys.platform.startswith('linux'), 'requires Linux procfs')
+    def test_gdb_sigkill_allows_real_wrapper_to_write_output(self):
+        child_script = (
+            "import signal, time; "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "print('child ready', flush=True); "
+            "time.sleep(60)"
+        )
+        wrapper_script = (
+            "import pathlib, subprocess, sys; "
+            "child = subprocess.Popen([sys.executable, '-c', sys.argv[2]]); "
+            "child.wait(); "
+            "pathlib.Path(sys.argv[1]).write_text('wrapper report')"
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report_path = os.path.join(temp_dir, 'time.log')
+            with mock.patch.object(TaskPooledProcessRunner, 'PROCESS_TERMINATION_GRACE_PERIOD_SECONDS', 0.2), \
+                 mock.patch.object(TaskPooledProcessRunner, 'PROCESS_CLEANUP_TIMEOUT_SECONDS', 2):
+                stdout, _, returncode, timed_out = _run_process(
+                    SubprocessExecutive(), [sys.executable, '-c', wrapper_script, report_path, child_script],
+                    os.environ.copy(), 1, target_is_child=True)
+
+            self.assertTrue(timed_out)
+            self.assertEqual(returncode, 0)
+            self.assertIn(b'child ready', stdout)
+            with open(report_path, 'r') as report_file:
+                self.assertEqual(report_file.read(), 'wrapper report')
+
+    def test_taskpool_sigint_handler_interrupts_gdb(self):
+        child_script = (
+            "import os, pathlib, sys, time; "
+            "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+            "time.sleep(60)"
+        )
+        helper_script = (
+            "import os, signal, subprocess, sys, threading, time\n"
+            "from webkitpy.port.linux_get_crash_log import TaskPooledProcessRunner, TaskPool\n"
+            "TaskPool.Process.name = 'worker/0'\n"
+            "TaskPool.Process.working = True\n"
+            "signal.signal(signal.SIGINT, TaskPool.Process.handler)\n"
+            "executive = type('Executive', (), {'popen': staticmethod(subprocess.Popen)})()\n"
+            "def interrupt_from_this_thread():\n"
+            "    while not os.path.isfile(sys.argv[1]):\n"
+            "        time.sleep(0.01)\n"
+            "    signal.pthread_kill(threading.get_ident(), signal.SIGINT)\n"
+            "threading.Thread(target=interrupt_from_this_thread, daemon=True).start()\n"
+            "TaskPooledProcessRunner(executive, [sys.executable, '-c', sys.argv[2], sys.argv[1]], "
+            "os.environ.copy(), 60).run()\n"
+        )
+
+        child_pid = None
+        with tempfile.TemporaryDirectory() as temp_dir:
+            child_pid_path = os.path.join(temp_dir, 'child-pid')
+            helper = subprocess.Popen(
+                [sys.executable, '-c', helper_script, child_pid_path, child_script],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            try:
+                _, stderr = helper.communicate(timeout=5)
+                self.assertEqual(helper.returncode, 0, stderr.decode('utf8', 'replace'))
+                self.assertTrue(os.path.isfile(child_pid_path))
+                with open(child_pid_path, 'r') as child_pid_file:
+                    child_pid = int(child_pid_file.read())
+                with self.assertRaises(ProcessLookupError):
+                    os.kill(child_pid, 0)
+            finally:
+                if helper.poll() is None:
+                    helper.kill()
+                    helper.wait()
+                if child_pid:
+                    try:
+                        os.kill(child_pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+
+
+class GDBTimeoutCrashLogTest(unittest.TestCase):
+
+    def test_worker_termination_after_lock_prevents_gdb_start(self):
+        generator = _make_generator(name='WebKitWebProcess', pid=99)
+        generator._path_to_driver = lambda: '/build/bin/WebKitWebProcess'
+
+        @contextlib.contextmanager
+        def gdb_lock():
+            TaskPool.Process.working = False
+            yield
+
+        with mock.patch.object(TaskPool.Process, 'name', 'worker/0'), \
+             mock.patch.object(TaskPool.Process, 'working', True), \
+             mock.patch.object(CrashLogUtils, 'get_gdb_lock', side_effect=gdb_lock), \
+             mock.patch.object(DebuginfodServerCache, 'environment_for_gdb') as environment_for_gdb, \
+             mock.patch.object(TaskPooledProcessRunner, 'run', autospec=True) as run_process:
+            result = generator._get_gdb_output('/tmp/core.dump')
+
+        self.assertEqual(result, ('', '', ''))
+        environment_for_gdb.assert_not_called()
+        run_process.assert_not_called()
+
+    def test_worker_termination_while_gdb_runs_discards_output(self):
+        generator = _make_generator(name='WebKitWebProcess', pid=99)
+        generator._path_to_driver = lambda: '/build/bin/WebKitWebProcess'
+
+        def run_process(_):
+            TaskPool.Process.working = False
+            return b'partial backtrace\n', b'gdb stderr\n', -signal.SIGKILL, False
+
+        with mock.patch.object(TaskPool.Process, 'name', 'worker/0'), \
+             mock.patch.object(TaskPool.Process, 'working', True), \
+             mock.patch.object(CrashLogUtils, 'get_gdb_lock', return_value=contextlib.nullcontext()), \
+             mock.patch.object(DebuginfodServerCache, 'environment_for_gdb', return_value={}), \
+             mock.patch.object(TaskPooledProcessRunner, 'run', autospec=True, side_effect=run_process), \
+             mock.patch('webkitpy.port.linux_get_crash_log.shutil.which', return_value=None):
+            result = generator._get_gdb_output('/tmp/core.dump')
+
+        self.assertEqual(result, ('', '', ''))
+
+    def test_time_output_setup_failure_does_not_abort_gdb(self):
+        generator = _make_generator(name='WebKitWebProcess', pid=99)
+        generator._path_to_driver = lambda: '/build/bin/WebKitWebProcess'
+
+        with mock.patch.object(CrashLogUtils, 'get_crashlog_temp_dir', return_value='/unwritable'), \
+             mock.patch.object(CrashLogUtils, 'get_gdb_lock', return_value=contextlib.nullcontext()), \
+             mock.patch.object(TaskPooledProcessRunner, 'run', autospec=True, return_value=(b'backtrace\n', b'', 0, False)) as run_process, \
+             mock.patch.object(DebuginfodServerCache, 'environment_for_gdb', return_value={}), \
+             mock.patch.object(CrashLogUtils, 'get_gdb_execution_timeout', return_value=1800), \
+             mock.patch('webkitpy.port.linux_get_crash_log.shutil.which', return_value='/usr/bin/time'), \
+             mock.patch('webkitpy.port.linux_get_crash_log.os.makedirs', side_effect=PermissionError('read-only')), \
+             mock.patch('webkitpy.port.linux_get_crash_log._log.warning') as warning:
+            stdout, _, _ = generator._get_gdb_output('/tmp/core.dump')
+
+        process_runner = run_process.call_args.args[0]
+        command = process_runner._command
+        self.assertEqual(stdout, 'backtrace\n')
+        self.assertNotIn('time', command)
+        self.assertFalse(any(argument.startswith('--output=') for argument in command))
+        self.assertFalse(process_runner._target_is_child)
+        self.assertIn('Unable to create GDB timing output file', warning.call_args.args[0])
+
+    def test_time_output_uses_crashlog_directory_and_is_removed_on_failure(self):
+        generator = _make_generator(name='WebKitWebProcess', pid=99)
+        generator._path_to_driver = lambda: '/build/bin/WebKitWebProcess'
+
+        with tempfile.TemporaryDirectory() as crashlog_directory:
+            def fail_after_checking_time_output(process_runner):
+                command = process_runner._command
+                output_argument = next(argument for argument in command if argument.startswith('--output='))
+                time_output_path = output_argument.split('=', 1)[1]
+                self.assertEqual(os.path.dirname(time_output_path), crashlog_directory)
+                self.assertTrue(os.path.isfile(time_output_path))
+                self.assertTrue(process_runner._target_is_child)
+                raise RuntimeError('gdb failed')
+
+            with mock.patch.object(CrashLogUtils, 'get_crashlog_temp_dir', return_value=crashlog_directory), \
+                 mock.patch.object(CrashLogUtils, 'get_gdb_lock', return_value=contextlib.nullcontext()), \
+                 mock.patch.object(TaskPooledProcessRunner, 'run', autospec=True, side_effect=fail_after_checking_time_output), \
+                 mock.patch.object(DebuginfodServerCache, 'environment_for_gdb', return_value={}), \
+                 mock.patch.object(CrashLogUtils, 'get_gdb_execution_timeout', return_value=1800), \
+                 mock.patch('webkitpy.port.linux_get_crash_log.shutil.which', return_value='/usr/bin/time'), \
+                 self.assertRaisesRegex(RuntimeError, 'gdb failed'):
+                generator._get_gdb_output('/tmp/core.dump')
+
+            self.assertEqual(os.listdir(crashlog_directory), [])
+
+    def test_timeout_is_reported_and_filtered_environment_reaches_process(self):
+        generator = _make_generator(name='WebKitWebProcess', pid=99)
+        generator._path_to_driver = lambda: '/build/bin/WebKitWebProcess'
+        generator._effective_coredump_pid = 99
+        filtered_environment = {'DEBUGINFOD_URLS': 'https://up.example.com'}
+        process_result = (b'partial backtrace\n', b'gdb stderr\n', -signal.SIGKILL, True)
+        events = []
+
+        @contextlib.contextmanager
+        def gdb_lock():
+            events.append('lock acquired')
+            try:
+                yield
+            finally:
+                events.append('lock released')
+
+        def environment_for_gdb():
+            events.append('environment prepared')
+            return filtered_environment
+
+        def run_process(_):
+            events.append('process started')
+            return process_result
+
+        with mock.patch.object(CrashLogUtils, 'get_gdb_lock', side_effect=gdb_lock), \
+             mock.patch.object(TaskPooledProcessRunner, 'run', autospec=True, side_effect=run_process) as run_process_mock, \
+             mock.patch.object(DebuginfodServerCache, 'environment_for_gdb', side_effect=environment_for_gdb), \
+             mock.patch.object(CrashLogUtils, 'get_gdb_execution_timeout', return_value=1800), \
+             mock.patch('webkitpy.port.linux_get_crash_log.shutil.which', return_value=None):
+            stdout, stderr, _ = generator._get_gdb_output('/tmp/core.dump')
+
+        process_runner = run_process_mock.call_args.args[0]
+        self.assertEqual(events, ['lock acquired', 'environment prepared', 'process started', 'lock released'])
+        self.assertIn('gdb', process_runner._command)
+        self.assertEqual(process_runner._environment, filtered_environment)
+        self.assertEqual(process_runner._timeout, 1800)
+        self.assertFalse(process_runner._target_is_child)
+        self.assertTrue(stdout.startswith('ERROR: GDB was terminated'))
+        self.assertIn('It was sent SIGTERM and given up to 60 seconds to exit before SIGKILL escalation.', stdout)
+        self.assertIn('partial backtrace', stdout)
+        self.assertEqual(stderr, 'gdb stderr\n')


### PR DESCRIPTION
#### 6131f147456111c0c430607b0c94c11fdb53eaf6
<pre>
[Tools] linux_get_crash_log: run GDB with a maximum timeout of 30 minutes and improve checking of DEBUGINFOD_URLS
<a href="https://bugs.webkit.org/show_bug.cgi?id=321783">https://bugs.webkit.org/show_bug.cgi?id=321783</a>

Reviewed by Nikolas Zimmermann.

GDB can spend days generating a Linux layout-test crash log on the Debug bots.
We are not sure what causes that. A hypothesis is related to the DEBUGINFOD
servers which on Ubuntu are kind of unstable, and when those don&apos;t reply on time
they can stall GDB waiting for a reply. However, if this was the issue we should
see the problem in Release build as well. A possible problem is that we currently
check if those servers are online at the moment of starting the test run, but we
no longer check if the servers are still online in the middle of the run. And a
Debug build is slower by nature (several hours), so it has more chances of hitting
the corner case of a DEBUGINFOD going offline in the middle of the run.

This patch addresses that hypothetical corner case. The DEBUGINFOD servers are now
checked immediately before each GDB process starts instead of once per run. Because
probing an offline server is slow, the result is cached for five minutes and shared
between workers through a file keyed by an MD5 of the server list, so concurrent runs
with different DEBUGINFOD_URLS do not share a cache entry. The check no longer rewrites
DEBUGINFOD_URLS in os.environ: each GDB invocation gets its own environment.

Since we are not certain that stalled DEBUGINFOD servers are the cause, the patch
adds a second, independent layer of protection against long-lived GDB processes.
A new TaskPooledProcessRunner class bounds any process by two limits: an execution
timeout, and a request from the TaskPool for the worker to end. Once either fires,
the target is sent SIGTERM, given a grace period, then sent SIGKILL, and only as a
last resort is the whole process group killed. This guarantees GDB cannot run beyond
its timeout, and that a run interrupted with SIGTERM or SIGINT terminates GDB and
returns control to the worker in time for the TaskPool coordinator.

The GDB execution timeout defaults to 30 minutes and can be changed with env var
WEBKIT_CRASHLOG_GDB_EXECUTION_TIMEOUT. When it expires, the generated crash log
starts with the reason it was truncated, the DEBUGINFOD_URLS that were in use, and
the name of that variable, so a truncated backtrace on a bot explains itself. While
GDB runs, a debug line is logged every 60 seconds naming the process and how much
of its budget remains.

On top of that, several improvements are made to make the code more robust, like the
handling of the GNU &quot;time&quot; wrapper: SIGKILL is first sent to GDB rather than to the
wrapper, so &quot;time&quot; survives to write its resource statistics even when GDB had to
be killed, and its output file is created inside the crash-log temporary directory
and removed afterwards.

* Tools/Scripts/webkitpy/port/linux_get_crash_log.py:
(CrashLogEnvVars):
(CrashLogUtils):
(CrashLogUtils.get_gdb_execution_timeout):
(CrashLogUtils.is_taskpool_worker_terminating):
(CrashLogUtils._get_gdb_lock_configuration):
(CrashLogUtils.get_crashlog_temp_dir):
(CrashLogUtils.get_thread_data_dir):
(CrashLogUtils.get_debuginfod_cache_dir):
(CrashLogUtils.core_pattern_has_pid_format_string):
(TaskPooledProcessRunner):
(TaskPooledProcessRunner.__init__):
(TaskPooledProcessRunner._communicate):
(TaskPooledProcessRunner._signal_process_group):
(TaskPooledProcessRunner._get_target_pid_and_name):
(TaskPooledProcessRunner._get_child_pids):
(TaskPooledProcessRunner._signal_target):
(TaskPooledProcessRunner._force_kill_and_reap):
(TaskPooledProcessRunner._terminate_after_interruption):
(TaskPooledProcessRunner.run):
(DebuginfodServerCache):
(DebuginfodServerCache._cache_path):
(DebuginfodServerCache._is_server_available):
(DebuginfodServerCache._probe):
(DebuginfodServerCache._read):
(DebuginfodServerCache._write):
(DebuginfodServerCache._get_working_servers):
(DebuginfodServerCache.environment_for_gdb):
(ThreadNamesCrashLogCapturer.handle_coredump):
(GDBCrashLogStartupHandler.__init__):
(GDBCrashLogStartupHandler._maybe_remove_file_if_old):
(GDBCrashLogStartupHandler.clean_old_debuginfod_server_caches):
(GDBCrashLogGenerator._get_gdb_output):
(GDBCrashLogStartupHandler._is_debuginfod_server_available): Deleted.
(GDBCrashLogStartupHandler._check_debuginfod_servers): Deleted.
* Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py:
(CrashLogTemporaryDirectoriesTest):
(CrashLogTemporaryDirectoriesTest.test_thread_and_debuginfod_directories_share_crashlog_root):
(CleanOldCrashLogFilesTest):
(CleanOldCrashLogFilesTest.setUp):
(CleanOldCrashLogFilesTest.test_removes_only_old_cache_and_temporary_files):
(CleanOldCrashLogFilesTest.test_keeps_cache_directory_when_last_cache_is_removed):
(CleanOldCrashLogFilesTest.test_list_failure_does_not_abort_cleanup):
(DebuginfodServerCacheTest):
(DebuginfodServerCacheTest.setUp):
(DebuginfodServerCacheTest._age_cache):
(DebuginfodServerCacheTest.test_recent_result_is_shared_without_reprobing):
(DebuginfodServerCacheTest.test_environment_canonicalizes_reordered_and_duplicate_servers):
(DebuginfodServerCacheTest.test_probe_keeps_file_urls_and_drops_unsupported_urls):
(DebuginfodServerCacheTest.test_http_availability_probe):
(DebuginfodServerCacheTest.test_concurrent_refresh_is_coalesced_by_file_lock):
(DebuginfodServerCacheTest.test_concurrent_refresh_is_coalesced_by_file_lock.slow_probe):
(DebuginfodServerCacheTest.test_concurrent_refresh_is_coalesced_by_file_lock.worker):
(DebuginfodServerCacheTest.test_environment_for_gdb_filters_copy_without_changing_process_environment):
(DebuginfodServerCacheTest.test_environment_for_gdb_filters_copy_without_changing_process_environment.only_first_server_works):
(DebuginfodServerCacheTest.test_server_offline_during_first_crash_can_recover):
(DebuginfodServerCacheTest.test_cache_path_failure_falls_back_to_uncached_probe):
(DebuginfodServerCacheTest.test_cache_write_failure_does_not_repeat_probe_or_raise):
(DebuginfodServerCacheTest.test_corrupted_cache_is_ignored):
(DebuginfodServerCacheTest.test_different_server_lists_use_independent_cached_results):
(DebuginfodServerCacheTest.test_no_configured_servers_does_not_probe_or_set_gdb_environment):
(GDBExecutionTimeoutConfigurationTest):
(GDBExecutionTimeoutConfigurationTest._timeout_with_value):
(GDBExecutionTimeoutConfigurationTest.test_timeout_configuration):
(FakeGDBProcess):
(FakeGDBProcess.__init__):
(FakeGDBProcess.communicate):
(FakeGDBProcess.send_signal):
(FakeGDBProcess.wait):
(FakeGDBExecutive):
(FakeGDBExecutive.__init__):
(FakeGDBExecutive.popen):
(SubprocessExecutive):
(SubprocessExecutive.popen):
(_run_process):
(TaskPooledProcessRunnerCommunicateTest):
(TaskPooledProcessRunnerCommunicateTest._runner):
(TaskPooledProcessRunnerCommunicateTest.test_retries_with_bounded_timeouts_until_process_exits):
(TaskPooledProcessRunnerCommunicateTest.test_raises_when_overall_deadline_expires):
(TaskPooledProcessRunnerCommunicateTest.test_termination_request_stops_communicating):
(TaskPooledProcessRunnerTest):
(TaskPooledProcessRunnerTest.setUp):
(TaskPooledProcessRunnerTest.setUp.communicate):
(TaskPooledProcessRunnerTest.test_success_uses_timeout_environment_and_new_session):
(TaskPooledProcessRunnerTest.test_termination_requested_before_run_prevents_process_start):
(TaskPooledProcessRunnerTest.test_timeout_escalates_to_sigkill_and_preserves_partial_output):
(TaskPooledProcessRunnerTest.test_sigterm_grace_period_collects_additional_output_without_sigkill):
(TaskPooledProcessRunnerTest.test_gdb_sigkill_allows_time_wrapper_to_return_output):
(TaskPooledProcessRunnerTest.test_gdb_sigkill_allows_time_wrapper_to_return_output.fake_open):
(TaskPooledProcessRunnerTest.test_unreapable_process_does_not_make_cleanup_unbounded):
(TaskPooledProcessRunnerTest.test_killpg_failure_uses_direct_process_fallback):
(TaskPooledProcessRunnerTest.test_reap_failure_does_not_mask_grace_period_keyboard_interrupt):
(TaskPooledProcessRunnerTest.test_termination_request_terminates_process):
(TaskPooledProcessRunnerTest.test_termination_request_terminates_process.request_termination):
(TaskPooledProcessRunnerTest.test_interrupted_process_ignoring_sigterm_is_force_killed):
(TaskPooledProcessRunnerTest.test_interrupted_process_ignoring_sigterm_is_force_killed.interrupt_then_timeout):
(TaskPooledProcessRunnerTest.test_real_wrapper_and_child_are_both_killed_after_grace_period):
(TaskPooledProcessRunnerTest.test_real_wrapper_and_child_are_both_killed_after_grace_period.child_is_running):
(TaskPooledProcessRunnerTest.test_gdb_sigkill_allows_real_wrapper_to_write_output):
(TaskPooledProcessRunnerTest.test_taskpool_sigint_handler_interrupts_gdb):
(GDBTimeoutCrashLogTest):
(GDBTimeoutCrashLogTest.test_worker_termination_after_lock_prevents_gdb_start):
(GDBTimeoutCrashLogTest.test_worker_termination_after_lock_prevents_gdb_start.gdb_lock):
(GDBTimeoutCrashLogTest.test_worker_termination_while_gdb_runs_discards_output):
(GDBTimeoutCrashLogTest.test_worker_termination_while_gdb_runs_discards_output.run_process):
(GDBTimeoutCrashLogTest.test_time_output_setup_failure_does_not_abort_gdb):
(GDBTimeoutCrashLogTest.test_time_output_uses_crashlog_directory_and_is_removed_on_failure):
(GDBTimeoutCrashLogTest.test_time_output_uses_crashlog_directory_and_is_removed_on_failure.fail_after_checking_time_output):
(GDBTimeoutCrashLogTest.test_timeout_is_reported_and_filtered_environment_reaches_process):
(GDBTimeoutCrashLogTest.test_timeout_is_reported_and_filtered_environment_reaches_process.gdb_lock):
(GDBTimeoutCrashLogTest.test_timeout_is_reported_and_filtered_environment_reaches_process.environment_for_gdb):
(GDBTimeoutCrashLogTest.test_timeout_is_reported_and_filtered_environment_reaches_process.run_process):
(CleanOldCoredumpsTest): Deleted.
(CleanOldCoredumpsTest.setUp): Deleted.
(CleanOldCoredumpsTest._touch): Deleted.
(CleanOldCoredumpsTest.test_reaps_old_pattern_and_claimed_keeps_fresh_and_unrelated): Deleted.

Canonical link: <a href="https://commits.webkit.org/319483@main">https://commits.webkit.org/319483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/047df7556f51836274be885ac63d443e3addbd29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55537 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191814 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183452 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55258 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184545 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/49340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/122174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180914 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44107 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/49340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2974 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193741 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55207 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/49340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55896 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/150850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27577 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45427 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/123869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54409 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/49340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53791 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54030 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->