### PR TITLE
[resultsdbpy] Allow results-ews to fetch multiple tests in one batch

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller.py
@@ -34,6 +34,7 @@ from webkitflaskpy.util import AssertRequest, query_as_kwargs, limit_for_query, 
 class EWSController(HasCommitContext):
     DEFAULT_LIMIT = 100
     TIMESTAMP_TOLERANCE_SECONDS = 5 * 60
+    MAX_TESTS_PER_QUERY = 100
 
     def __init__(self, commit_controller, ews_context):
         super().__init__(commit_controller.commit_context)
@@ -100,40 +101,50 @@ class EWSController(HasCommitContext):
     @configuration_for_query()
     @time_range_for_query()
     def find(
-        self, configurations=None, suite=None, test=None, recent=None, flaky=None,
+        self, configurations=None, suite=None, tests=None, recent=None, flaky=None,
         branch=None, begin_query_time=None, end_query_time=None,
         limit=None, **kwargs
     ):
+        """Results for one or more tests, one entry per test and configuration.
+
+        limit is per test rather than shared across the batch, since a shared one would be spent on
+        whichever test happened to be queried first. A test with no results is absent from the
+        response rather than present and empty, and a batch where no test has any results is a 404.
+        """
         AssertRequest.is_type(['GET'])
         AssertRequest.query_kwargs_empty(**kwargs)
 
         if not suite or not suite[0]:
             abort(400, description='No valid test suite specified')
-        if not test or not test[0]:
+        if not (tests := sorted({name for name in tests or [] if name})):
             abort(400, description='No valid test specified')
+        if len(tests) > self.MAX_TESTS_PER_QUERY:
+            abort(400, description=f'Cannot query more than {self.MAX_TESTS_PER_QUERY} tests at a time, got {len(tests)} tests')
 
         recent = boolean_query(*recent)[0] if recent else True
         flaky = boolean_query(*flaky)[0] if flaky else False
 
-        results = self.ews_context.find_for_test(
+        found = self.ews_context.find_for_tests(
             configurations=configurations, suite=suite[0], branch=branch[0] if branch else None,
             begin_query_time=begin_query_time, end_query_time=end_query_time, limit=limit,
-            test=test[0], flaky=flaky, recent=recent,
+            tests=tests, flaky=flaky, recent=recent,
         )
-        if not results:
+        if not found:
             abort(404, description='No EWS results matching the specified criteria')
 
         response = []
-        for config, entries in results.items():
-            response.append({
-                'configuration': Configuration.Encoder().default(config),
-                'results': sorted(entries, key=lambda result: (result['uuid'], result['start_time'])),
-            })
+        for name, by_configuration in found.items():
+            for config, entries in by_configuration.items():
+                response.append({
+                    'test': name,
+                    'configuration': Configuration.Encoder().default(config),
+                    'results': sorted(entries, key=lambda result: (result['uuid'], result['start_time'])),
+                })
         return jsonify(response)
 
     @query_as_kwargs()
     @limit_for_query(DEFAULT_LIMIT)
-    def list_tests(self, suite=None, test=None, flaky=None, limit=None, **kwargs):
+    def list_tests(self, suite=None, prefixes=None, flaky=None, limit=None, **kwargs):
         """Names recorded in the EWS tables by any configuration & branch."""
         AssertRequest.is_type(['GET'])
         AssertRequest.query_kwargs_empty(**kwargs)
@@ -144,7 +155,7 @@ class EWSController(HasCommitContext):
         flaky = boolean_query(*flaky)[0] if flaky else False
 
         names = set()
-        for prefix in test or [None]:
+        for prefix in prefixes or [None]:
             if len(names) >= limit:
                 break
             names.update(self.ews_context.names(

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller_unittest.py
@@ -27,6 +27,7 @@ from fakeredis import FakeStrictRedis
 from redis import StrictRedis
 from resultsdbpy.controller.api_routes import APIRoutes
 from resultsdbpy.controller.configuration import Configuration
+from resultsdbpy.controller.ews_controller import EWSController
 from resultsdbpy.flask_support.flask_testcase import FlaskTestCase
 from resultsdbpy.model.cassandra_context import CassandraContext
 from resultsdbpy.model.mock_model_factory import MockModelFactory
@@ -81,19 +82,21 @@ class EWSControllerTest(FlaskTestCase, WaitForDockerTestCase):
         return client.post(f'{cls.URL}/{cls.EWS_UPLOAD_ENDPOINT}', data=json.dumps(data))
 
     @classmethod
-    def find_ews_results(cls, client, configuration=None, suite='layout-tests', test=..., flaky=None, recent=None, after_time=None, before_time=None):
+    def find_ews_results(cls, client, configuration=None, suite='layout-tests', tests=..., flaky=None, recent=None, after_time=None, before_time=None):
         if configuration is None:
             configuration = ConfigurationContextTest.CONFIGURATIONS[0]
-        if test is ...:
-            test = cls.REGRESSION_TEST
+        if tests is ...:
+            tests = [cls.REGRESSION_TEST]
         params = {
-            'suite': suite, 'test': test, 'flaky': flaky, 'recent': recent,
+            'suite': suite, 'flaky': flaky, 'recent': recent,
             'after_time': after_time, 'before_time': before_time,
             'platform': configuration.platform, 'style': configuration.style, 'flavor': configuration.flavor,
         }
         query = '&'.join(
-            f'{key}={str(value).lower() if isinstance(value, bool) else value}'
-            for key, value in params.items() if value is not None
+            [
+                f'{key}={str(value).lower() if isinstance(value, bool) else value}'
+                for key, value in params.items() if value is not None
+            ] + [f'tests={quote(name, safe="")}' for name in tests or []]
         )
         return client.get(f'{cls.URL}/{cls.EWS_RESULTS_ENDPOINT}?{query}')
 
@@ -126,7 +129,7 @@ class EWSControllerTest(FlaskTestCase, WaitForDockerTestCase):
         self.assertEqual(details.get('build_number'), 678)
         self.assertEqual(details.get('link'), 'https://ews.example.com/build/1')
 
-        response = self.find_ews_results(client, test='fast/encoding/css-charset.html')
+        response = self.find_ews_results(client, tests=['fast/encoding/css-charset.html'])
         self.assertEqual(response.status_code, 200, response.json())
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
@@ -151,7 +154,7 @@ class EWSControllerTest(FlaskTestCase, WaitForDockerTestCase):
         self.assertEqual((result.get('details') or {}).get('pr_number'), 12345)
 
         # A test that wasn't reported flaky is not in the flaky table.
-        response = self.find_ews_results(client, test='fast/encoding/css-charset.html', flaky=True)
+        response = self.find_ews_results(client, tests=['fast/encoding/css-charset.html'], flaky=True)
         self.assertEqual(response.status_code, 404)
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
@@ -213,20 +216,90 @@ class EWSControllerTest(FlaskTestCase, WaitForDockerTestCase):
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     @FlaskTestCase.run_with_webserver()
+    def test_find_a_batch_names_the_test_each_entry_answers_for(self, client, **kwargs):
+        """A client batching its queries can only match answers to questions by the test field, and
+        can only tell a test with no history from one it never asked about by its absence."""
+        response = self.upload_ews_results(client)
+        self.assertEqual(response.status_code, 200, response.json())
+
+        reported = sorted(self.DEFAULT_TEST_RESULTS['results'])
+        self.assertGreater(len(reported), 1)
+        never_reported = 'fast/never/reported.html'
+
+        response = self.find_ews_results(client, tests=reported + [never_reported])
+        self.assertEqual(response.status_code, 200, response.json())
+
+        by_test = {}
+        for entry in response.json():
+            by_test.setdefault(entry['test'], []).extend(entry['results'])
+
+        self.assertEqual(sorted(by_test), reported)
+        self.assertNotIn(never_reported, by_test)
+        for test in reported:
+            self.assertTrue(by_test[test], test)
+            for result in by_test[test]:
+                self.assertEqual(result['result'], self.DEFAULT_TEST_RESULTS['results'][test])
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
     def test_find_rejects_a_commit_range(self, client, **kwargs):
         # Results are clustered by start_time, so a commit range could only be honored as a
         # client-side filter over rows Cassandra already truncated with LIMIT. Reject it instead.
         for param in ('ref=6', 'uuid=153802947300000', 'timestamp=1538029473', 'begin=5', 'end=7'):
-            response = client.get(f'{self.URL}/{self.EWS_RESULTS_ENDPOINT}?suite=layout-tests&test={self.REGRESSION_TEST}&{param}')
+            response = client.get(f'{self.URL}/{self.EWS_RESULTS_ENDPOINT}?suite=layout-tests&tests={self.REGRESSION_TEST}&{param}')
             self.assertEqual(response.status_code, 400, f'{param} gave {response.status_code}')
             self.assertIn('not supported in queries by this endpoint', response.json()['description'])
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     @FlaskTestCase.run_with_webserver()
     def test_find_without_test(self, client, **kwargs):
-        response = self.find_ews_results(client, test=None)
+        response = self.find_ews_results(client, tests=None)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['description'], 'No valid test specified')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_find_a_test_whose_name_needs_escaping(self, client, **kwargs):
+        """WPT names carry their own query string. Unescaped, everything from the first & on is read
+        as further query parameters, so the name arrives truncated and the request is rejected."""
+        test = 'imported/w3c/web-platform-tests/webrtc/RTCIceTransport.html?type=relay&mode=full'
+        response = self.upload_ews_results(client, test_results={'results': {
+            test: {'report': 'REGRESSION', 'expected': 'PASS', 'actual': 'TEXT'},
+        }})
+        self.assertEqual(response.status_code, 200, response.json())
+
+        response = self.find_ews_results(client, tests=[test])
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual([entry['test'] for entry in response.json()], [test])
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_find_ignores_blank_and_repeated_names(self, client, **kwargs):
+        """A blank repeated value must not reject a batch that names a real test, nor reach the
+        database as an empty test name, and a name repeated twice must not cost two queries."""
+        self.assertEqual(self.upload_ews_results(client).status_code, 200)
+
+        for tests in (['', self.REGRESSION_TEST], [self.REGRESSION_TEST, ''], [self.REGRESSION_TEST] * 2):
+            response = self.find_ews_results(client, tests=tests)
+            self.assertEqual(response.status_code, 200, f'{tests} gave {response.status_code}')
+            self.assertEqual([entry['test'] for entry in response.json()], [self.REGRESSION_TEST], tests)
+
+        response = self.find_ews_results(client, tests=['', ''])
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['description'], 'No valid test specified')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_find_rejects_an_oversized_batch(self, client, **kwargs):
+        """The limit is per test, so an unbounded batch is an unbounded response and one query per test."""
+        cap = EWSController.MAX_TESTS_PER_QUERY
+
+        response = self.find_ews_results(client, tests=[f'fast/{index}.html' for index in range(cap)])
+        self.assertEqual(response.status_code, 404, response.json())
+
+        response = self.find_ews_results(client, tests=[f'fast/{index}.html' for index in range(cap + 1)])
+        self.assertEqual(response.status_code, 400, response.json())
+        self.assertIn(f'Cannot query more than {cap} tests at a time', response.json()['description'])
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     @FlaskTestCase.run_with_webserver()
@@ -351,7 +424,7 @@ class EWSControllerTest(FlaskTestCase, WaitForDockerTestCase):
     def test_list_tests_prefix(self, client, **kwargs):
         self.assertEqual(self.upload_ews_results(client).status_code, 200)
 
-        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests&test=fast/encoding/css-c')
+        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests&prefixes=fast/encoding/css-c')
         self.assertEqual(response.status_code, 200, response.json())
         self.assertEqual(response.json(), ['fast/encoding/css-cached-bom.html', 'fast/encoding/css-charset.html'])
 
@@ -362,7 +435,7 @@ class EWSControllerTest(FlaskTestCase, WaitForDockerTestCase):
         # cqlengine reads a limit of 0 as no limit, so exhausting it must stop the loop.
         self.assertEqual(self.upload_ews_results(client).status_code, 200)
 
-        prefixes = '&'.join(f'test={name}' for name in sorted(self.DEFAULT_TEST_RESULTS['results']))
+        prefixes = '&'.join(f'prefixes={name}' for name in sorted(self.DEFAULT_TEST_RESULTS['results']))
         response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests&limit=2&{prefixes}')
         self.assertEqual(response.status_code, 200, response.json())
         self.assertEqual(len(response.json()), 2)
@@ -375,7 +448,7 @@ class EWSControllerTest(FlaskTestCase, WaitForDockerTestCase):
         results = {test: {'report': 'REGRESSION', 'expected': 'PASS', 'actual': 'TEXT'}}
         self.assertEqual(self.upload_ews_results(client, test_results=dict(results=results)).status_code, 200)
 
-        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests&test={quote(test, safe="")}')
+        response = client.get(f'{self.URL}/{self.EWS_TESTS_ENDPOINT}?suite=layout-tests&prefixes={quote(test, safe="")}')
         self.assertEqual(response.status_code, 200, response.json())
         self.assertEqual(response.json(), list(results))
 

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/configuration_context.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/configuration_context.py
@@ -253,11 +253,11 @@ class ConfigurationContext(object):
                 attributes=json.dumps(attributes_dict),
                 **kwargs)
 
-    def select_from_table_with_configurations(self, table_name, configurations=None, branch=None, recent=True, limit=100, **kwargs):
+    def complete_configurations_for(self, configurations=None, branch=None, recent=True):
         if not isinstance(configurations, Iterable):
             raise TypeError('Expected configurations to be iterable')
         if not configurations:
-            configurations.append(Configuration())
+            configurations = [Configuration()]
 
         with self:
             complete_configurations = set()
@@ -267,12 +267,18 @@ class ConfigurationContext(object):
                 if config.is_complete():
                     complete_configurations.add(config)
                 elif recent:
-                    [complete_configurations.add(element) for element in self.search_for_recent_configuration(config, branch=branch)]
+                    complete_configurations.update(self.search_for_recent_configuration(config, branch=branch))
                 else:
-                    [complete_configurations.add(element) for element in self.search_for_configuration(config, branch=branch)]
+                    complete_configurations.update(self.search_for_configuration(config, branch=branch))
+            return complete_configurations
 
+    def select_from_table_with_complete_configurations(self, table_name, complete_configurations, branch=None, limit=100, **kwargs):
+        with self:
             results = {}
             for configuration in complete_configurations:
+                if not isinstance(configuration, Configuration):
+                    raise TypeError(f'Expected type {Configuration}, got {type(configuration)}')
+
                 attributes_dict = OrderedDict()
                 for member in Configuration.OPTIONAL_MEMBERS:
                     if getattr(configuration, member) is not None:
@@ -297,3 +303,11 @@ class ConfigurationContext(object):
                     results[full_config].append(row)
 
             return results
+
+    def select_from_table_with_configurations(self, table_name, configurations=None, branch=None, recent=True, limit=100, **kwargs):
+        # Held across both halves so they share one connection, as they did when this was one method.
+        with self:
+            complete_configs = self.complete_configurations_for(configurations, branch=branch, recent=recent)
+            return self.select_from_table_with_complete_configurations(
+                table_name, complete_configs, branch=branch, limit=limit, **kwargs
+            )

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/configuration_context_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/configuration_context_unittest.py
@@ -90,6 +90,90 @@ class ConfigurationContextTest(WaitForDockerTestCase):
             self.database.register_configuration(Configuration(platform='iOS'))
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_complete_configurations_for_expands_a_partial_configuration(self, redis=StrictRedis, cassandra=CassandraContext):
+        """Every caller reaches this through select_from_table_with_configurations, so it has to
+        agree with the search it replaced on both the recent and the expired paths."""
+        self.init_database(redis=redis, cassandra=cassandra)
+        self.register_configurations()
+
+        partial = Configuration(platform='Mac', style='Release')
+        for recent in (True, False):
+            search = self.database.search_for_recent_configuration if recent else self.database.search_for_configuration
+            expanded = self.database.complete_configurations_for([partial], recent=recent)
+
+            self.assertEqual(expanded, set(search(partial)), f'recent={recent}')
+            self.assertTrue(expanded, f'recent={recent}')
+            for configuration in expanded:
+                self.assertTrue(configuration.is_complete(), configuration)
+                self.assertEqual(configuration, partial)
+
+        # The expired path knows about configurations that stopped reporting, so it sees more.
+        self.assertLess(
+            len(self.database.complete_configurations_for([partial], recent=True)),
+            len(self.database.complete_configurations_for([partial], recent=False)),
+        )
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_complete_configurations_for_passes_a_complete_configuration_through(self, redis=StrictRedis, cassandra=CassandraContext):
+        self.init_database(redis=redis, cassandra=cassandra)
+        self.register_configurations()
+
+        complete = self.CONFIGURATIONS[0]
+        self.assertTrue(complete.is_complete())
+        self.assertEqual(self.database.complete_configurations_for([complete]), {complete})
+
+        # No configurations at all means every configuration, not none of them.
+        self.assertEqual(
+            self.database.complete_configurations_for([]),
+            self.database.complete_configurations_for([Configuration()]),
+        )
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_complete_configurations_for_rejects_an_invalid_configuration(self, redis=StrictRedis, cassandra=CassandraContext):
+        self.init_database(redis=redis, cassandra=cassandra)
+
+        with self.assertRaises(TypeError):
+            self.database.complete_configurations_for('invalid object')
+        with self.assertRaises(TypeError):
+            self.database.complete_configurations_for(['invalid object'])
+        with self.assertRaises(TypeError):
+            self.database.select_from_table_with_complete_configurations('example_table', ['invalid object'])
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_selecting_with_configurations_opens_one_connection(self, redis=StrictRedis, cassandra=CassandraContext):
+        """Expanding the configurations and querying the table used to share a session. Split across
+        two methods, each would open and tear down its own unless the wrapper holds one open."""
+        self.init_database(redis=redis, cassandra=cassandra)
+        self.register_configurations()
+
+        class ExampleModel(ClusteredByConfiguration):
+            __table_name__ = 'example_table'
+            branch = columns.Text(partition_key=True, required=True)
+            index = columns.Integer(primary_key=True, required=True)
+
+        with self.database:
+            self.database.cassandra.create_table(ExampleModel)
+
+        opened = []
+        cassandra_context = self.database.cassandra
+        original = type(cassandra_context).__enter__
+
+        def counting_enter(context):
+            if context._depth == 0:
+                opened.append(context)
+            return original(context)
+
+        try:
+            type(cassandra_context).__enter__ = counting_enter
+            self.database.select_from_table_with_configurations(
+                ExampleModel.__table_name__, [Configuration(platform='Mac')], index=1,
+            )
+        finally:
+            type(cassandra_context).__enter__ = original
+
+        self.assertEqual(len(opened), 1)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     def test_no_style_configuration(self, redis=StrictRedis, cassandra=CassandraContext):
         self.init_database(redis=redis, cassandra=cassandra)
 

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py
@@ -125,19 +125,29 @@ class EWSContext(UploadCallbackContext):
                 args.update(test__gte=test, test__lte=test + '~')
             return [row.test for row in self.cassandra.select_from_table(self.EWSTestNameBySuite.__table_name__, **args)]
 
-    def find_for_test(self, configurations, suite, test, flaky, branch=None, recent=True, begin_query_time=None, end_query_time=None, limit=100):
+    def find_for_tests(self, configurations, suite, tests, flaky, branch=None, recent=True, begin_query_time=None, end_query_time=None, limit=100):
+        """Results for several tests at once, keyed by test name."""
         table = self.EWSFlakesByStartTime if flaky else self.EWSFailedTestsByStartTime
 
         def get_time(time):
             return time if isinstance(time, datetime) else datetime.utcfromtimestamp(int(time)) if time else None
 
+        found = {}
         with self:
-            return {
-                config: [row.unpack() for row in rows]
-                for config, rows in self.configuration_context.select_from_table_with_configurations(
-                    table.__table_name__, configurations=configurations,
-                    suite=suite, branch=branch or self.commit_context.DEFAULT_BRANCH_KEY, test=test,
-                    start_time__gte=get_time(begin_query_time), start_time__lte=get_time(end_query_time),
-                    recent=recent, limit=limit,
-                ).items()
-            }
+            branch = branch or self.commit_context.DEFAULT_BRANCH_KEY
+            complete_configurations = self.configuration_context.complete_configurations_for(
+                configurations, branch=branch, recent=recent,
+            )
+            for test in tests:
+                by_configuration = {
+                    config: [row.unpack() for row in rows]
+                    for config, rows in self.configuration_context.select_from_table_with_complete_configurations(
+                        table.__table_name__, complete_configurations,
+                        suite=suite, branch=branch, test=test,
+                        start_time__gte=get_time(begin_query_time), start_time__lte=get_time(end_query_time),
+                        limit=limit,
+                    ).items()
+                }
+                if by_configuration:
+                    found[test] = by_configuration
+        return found

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py
@@ -58,10 +58,10 @@ class EWSContextTest(WaitForDockerTestCase):
                 )
 
     def _find(self, test, flaky=False):
-        return self.model.ews_context.find_for_test(
+        return self.model.ews_context.find_for_tests(
             configurations=[Configuration(platform='Mac', style='Release', flavor='wk1')],
-            suite='layout-tests', test=test, recent=True, flaky=flaky,
-        )
+            suite='layout-tests', tests=[test], recent=True, flaky=flaky,
+        ).get(test, {})
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     def test_ttl_is_an_integer(self, redis=StrictRedis, cassandra=CassandraContext):
@@ -101,6 +101,81 @@ class EWSContextTest(WaitForDockerTestCase):
         for test, leaf in self.DEFAULT_TEST_RESULTS['results'].items():
             stored = list(self._find(test).values())[0][0]['result']
             self.assertEqual(stored, leaf)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_several_tests_are_answered_in_one_call(self, redis=StrictRedis, cassandra=CassandraContext):
+        """Keyed by test name, so a caller asking about a batch can tell the answers apart."""
+        self.init_database(redis=redis, cassandra=cassandra)
+        reported = sorted(self.DEFAULT_TEST_RESULTS['results'])
+
+        found = self.model.ews_context.find_for_tests(
+            configurations=[Configuration(platform='Mac', style='Release', flavor='wk1')],
+            suite='layout-tests', tests=reported + ['fast/never/reported.html'],
+            recent=True, flaky=False,
+        )
+
+        # A test with nothing recorded is absent rather than present and empty.
+        self.assertEqual(sorted(found), reported)
+        for test in reported:
+            rows = [row for rows in found[test].values() for row in rows]
+            self.assertTrue(rows, test)
+            for row in rows:
+                self.assertEqual(row['result'], self.DEFAULT_TEST_RESULTS['results'][test])
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_the_limit_is_spent_per_test_rather_than_shared(self, redis=StrictRedis, cassandra=CassandraContext):
+        """Shared across the batch, the limit would be spent on whichever test was queried first and
+        every later test would come back empty. It bounds each test and configuration separately."""
+        base = int(time.time())
+        self.init_database(redis=redis, cassandra=cassandra, timestamps=[base - 3600, base])
+        reported = sorted(self.DEFAULT_TEST_RESULTS['results'])
+        self.assertGreater(len(reported), 1)
+
+        def rows_per_configuration(limit):
+            found = self.model.ews_context.find_for_tests(
+                configurations=[Configuration(platform='Mac', style='Release', flavor='wk1')],
+                suite='layout-tests', tests=reported, recent=True, flaky=False, limit=limit,
+            )
+            self.assertEqual(sorted(found), reported)
+            return {test: sorted(len(rows) for rows in by_configuration.values()) for test, by_configuration in found.items()}
+
+        # Every test has more rows than the limit will allow, so a limit that is ignored would show.
+        unlimited = rows_per_configuration(100)
+        for test, counts in unlimited.items():
+            self.assertTrue(counts, test)
+            self.assertTrue(all(count > 1 for count in counts), f'{test}: {counts}')
+
+        limited = rows_per_configuration(1)
+        for test, counts in limited.items():
+            self.assertEqual(counts, [1] * len(unlimited[test]), test)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    def test_the_configurations_are_expanded_once_for_the_batch(self, redis=StrictRedis, cassandra=CassandraContext):
+        """EWS never queries with a complete configuration, so every read has to expand a partial one
+        against redis. That expansion does not depend on the test, so a batch must only pay it once."""
+        self.init_database(redis=redis, cassandra=cassandra)
+        reported = sorted(self.DEFAULT_TEST_RESULTS['results'])
+        self.assertGreater(len(reported), 1)
+
+        expansions = []
+        configuration_context = self.model.ews_context.configuration_context
+        original = configuration_context.search_for_recent_configuration
+
+        def record(configuration, **kwargs):
+            expansions.append(configuration)
+            return original(configuration, **kwargs)
+
+        try:
+            configuration_context.search_for_recent_configuration = record
+            found = self.model.ews_context.find_for_tests(
+                configurations=[Configuration(platform='Mac', style='Release', flavor='wk1')],
+                suite='layout-tests', tests=reported, recent=True, flaky=False,
+            )
+        finally:
+            del configuration_context.search_for_recent_configuration
+
+        self.assertEqual(sorted(found), reported)
+        self.assertEqual(len(expansions), 1)
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     def test_metadata_stored(self, redis=StrictRedis, cassandra=CassandraContext):
@@ -172,11 +247,11 @@ class EWSContextTest(WaitForDockerTestCase):
         self.init_database(redis=redis, cassandra=cassandra, timestamps=[recent, day_old, old])
 
         def start_times_within(cutoff):
-            results = self.model.ews_context.find_for_test(
+            results = self.model.ews_context.find_for_tests(
                 configurations=[Configuration(platform='Mac', style='Release', flavor='wk1')],
-                suite='layout-tests', test=self.REGRESSION_TEST, flaky=False, recent=False,
+                suite='layout-tests', tests=[self.REGRESSION_TEST], flaky=False, recent=False,
                 begin_query_time=cutoff,
-            )
+            ).get(self.REGRESSION_TEST, {})
             return {row['start_time'] for rows in results.values() for row in rows}
 
         self.assertEqual(start_times_within(now - 24 * HOUR), {recent})


### PR DESCRIPTION
#### a5a2fc6134cdf98953b605e6a01942bb3f4cc547
<pre>
[resultsdbpy] Allow results-ews to fetch multiple tests in one batch
<a href="https://rdar.apple.com/185337989">rdar://185337989</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=322114">https://bugs.webkit.org/show_bug.cgi?id=322114</a>

Reviewed by Aakash Jain.

`results-ews` answers for one test, but a step filtering failures asks about
all of them. Sixty failures cost sixty round trips per table, each re-expanding
the same configuration server-side, twice per build once the re-run repeats it.

`find` now takes several tests. Repeated query parameters already arrive as a
tuple, so it reads all of them rather than the first, and each response entry
names the test it answers for. The limit stays per test, since a shared one
would be spent on whichever test came first. Cassandra still reads once per
test because `test` is part of the partition key: round trips collapse, not
reads.

Expanding a partial configuration depends on the configurations and the branch,
not the test, so it moves out of the per-test loop.
`select_from_table_with_configurations` splits into
`complete_configurations_for` and
`select_from_table_with_complete_configurations`, holding one session across
both so a caller outside a context manager still opens one connection rather
than two. EWS never sends a version or architecture, so that expansion always
runs; a batch now pays its redis scan once.

`select_from_table_with_complete_configurations` validates its configurations,
being reachable without the expansion that used to. `find` dedupes and drops
blank names before validating, so a repeated blank neither rejects a batch
naming a real test nor reaches Cassandra as an empty name, and a batch over
`MAX_TESTS_PER_QUERY` is rejected.

Both parameters are plural now that they take several values: `find` takes
`tests`, `list_tests` takes `prefixes`, which is what its repeated values
always were. Each renames a parameter on a landed endpoint whose only consumer
is the unlanded EWS client. The empty-configurations fallback also stops
appending into the caller&apos;s list.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller.py:
(EWSController):
(EWSController.find):
(EWSController.list_tests):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/ews_controller_unittest.py:
(EWSControllerTest.find_ews_results):
(EWSControllerTest.test_upload_and_find):
(EWSControllerTest.test_flaky_upload_and_find):
(EWSControllerTest):
(EWSControllerTest.test_find_a_batch_names_the_test_each_entry_answers_for):
(EWSControllerTest.test_find_rejects_a_commit_range):
(EWSControllerTest.test_find_without_test):
(EWSControllerTest.test_find_a_test_whose_name_needs_escaping):
(EWSControllerTest.test_find_ignores_blank_and_repeated_names):
(EWSControllerTest.test_find_rejects_an_oversized_batch):
(EWSControllerTest.test_list_tests_prefix):
(EWSControllerTest.test_list_tests_honours_the_limit_across_prefixes):
(EWSControllerTest.test_list_tests_percent_encoded_name):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/configuration_context.py:
(ConfigurationContext.complete_configurations_for):
(ConfigurationContext.select_from_table_with_complete_configurations):
(ConfigurationContext):
(ConfigurationContext.select_from_table_with_configurations):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/configuration_context_unittest.py:
(ConfigurationContextTest):
(ConfigurationContextTest.test_complete_configurations_for_expands_a_partial_configuration):
(ConfigurationContextTest.test_complete_configurations_for_passes_a_complete_configuration_through):
(ConfigurationContextTest.test_complete_configurations_for_rejects_an_invalid_configuration):
(ConfigurationContextTest.test_selecting_with_configurations_opens_one_connection):
(ConfigurationContextTest.test_selecting_with_configurations_opens_one_connection.ExampleModel):
(ConfigurationContextTest.test_selecting_with_configurations_opens_one_connection.counting_enter):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context.py:
(EWSContext.find_for_tests):
(EWSContext.find_for_test): Deleted.
(EWSContext.find_for_test.get_time): Deleted.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/ews_context_unittest.py:
(EWSContextTest._find):
(EWSContextTest):
(EWSContextTest.test_several_tests_are_answered_in_one_call):
(EWSContextTest.test_the_limit_is_spent_per_test_rather_than_shared):
(EWSContextTest.test_the_limit_is_spent_per_test_rather_than_shared.rows_per_configuration):
(EWSContextTest.test_the_configurations_are_expanded_once_for_the_batch):
(EWSContextTest.test_the_configurations_are_expanded_once_for_the_batch.record):
(EWSContextTest.test_time_window_query.start_times_within):

Canonical link: <a href="https://commits.webkit.org/319538@main">https://commits.webkit.org/319538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23be4678dc36df8e85114060d605e56c879ce728

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192023 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55466 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141919 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184753 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122354 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181122 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44292 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154689 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42184 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3184 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193949 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/181199 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55415 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151331 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40516 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56104 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151034 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45607 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124142 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54617 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17180 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53999 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->