### PR TITLE
[JSC] Add word-sized fast path for localeCompare

### DIFF
--- a/JSTests/stress/string-locale-compare-word-scan.js
+++ b/JSTests/stress/string-locale-compare-word-scan.js
@@ -1,0 +1,90 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// A 16-bit string never takes the 8-bit inline path, so widening both sides yields the reference
+// answer for the same code points.
+function reference(lhs, rhs) {
+    return $vm.make16BitStringIfPossible(lhs).localeCompare($vm.make16BitStringIfPossible(rhs));
+}
+
+// Concatenation yields a rope, which the inline path declines, so force resolution first.
+function resolve(string) {
+    string.charCodeAt(0);
+    return string;
+}
+
+var cases = [];
+function addCase(lhs, rhs) {
+    cases.push([resolve(lhs), resolve(rhs), reference(lhs, rhs)]);
+}
+
+var alphabet = "abcdefghijklmnopqrstuvwxyz";
+function make(length) {
+    var string = "";
+    for (var i = 0; i < length; ++i)
+        string += alphabet[i % alphabet.length];
+    return string;
+}
+
+// The inline path scans 8 bytes at a time and finishes the remainder with a single overlapping
+// 8-byte load, so the lengths that matter are those straddling a multiple of 8. 24 and 25 also
+// run the word loop three times.
+var lengths = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 24, 25];
+
+for (var lengthIndex = 0; lengthIndex < lengths.length; ++lengthIndex) {
+    var length = lengths[lengthIndex];
+    var base = make(length);
+
+    // Equal content in distinct StringImpls: the whole scan runs, including the overlapping load.
+    addCase(base, make(length));
+
+    // A difference at every position covers every byte lane of both the word loop and that
+    // final overlapping load.
+    for (var position = 0; position < length; ++position) {
+        var head = base.slice(0, position);
+        var tail = base.slice(position + 1);
+
+        addCase(base, head + "Z" + tail);
+        // Case differences match at DUCET level 1, so the scan has to continue past them.
+        addCase(base, head + base[position].toUpperCase() + tail);
+        // One side non-ASCII forces a byte-by-byte rescan of the word pair.
+        addCase(base, head + "\u00FF" + tail);
+        // Equal but non-ASCII needs full collation.
+        addCase(head + "\u00FF" + tail, head + "\u00FF" + tail);
+        // A difference in the common part of strings of unequal length: resolving it at the wrong
+        // position would silently fall through to the shorter-string answer instead.
+        addCase(base, head + "Z" + tail + "q");
+
+        // Swapping this position with the last one makes the first and last differences point in
+        // opposite directions, so identifying the wrong differing position inverts the result.
+        if (position < length - 1) {
+            var swapped = head + base[length - 1] + base.slice(position + 1, length - 1) + base[position];
+            addCase(base, swapped);
+        }
+    }
+
+    // A shared prefix with differing lengths, with the extra tail falling short of, landing on,
+    // and reaching past a word boundary.
+    var extras = [1, 7, 8, 9];
+    for (var extraIndex = 0; extraIndex < extras.length; ++extraIndex) {
+        var longer = base + make(extras[extraIndex]);
+        addCase(base, longer);
+        addCase(longer, base);
+    }
+}
+
+function check(lhs, rhs, expected) {
+    shouldBe(lhs.localeCompare(rhs), expected);
+}
+noInline(check);
+
+// The path under test is emitted by the FTL, and the DFG-to-FTL threshold is scaled per code
+// block, so a function this small needs tens of thousands of calls before it is compiled there.
+// A smaller count leaves the compiled code untested.
+var iterations = Math.max(testLoopCount, 150000);
+for (var i = 0; i < iterations; ++i) {
+    var testCase = cases[i % cases.length];
+    check(testCase[0], testCase[1], testCase[2]);
+}

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -3173,7 +3173,7 @@ private:
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         if (m_node->child1().useKind() == Int32Use || m_node->child1().useKind() == KnownInt32Use) {
             LValue operand = lowInt32(m_node->child1());
-            setInt32(m_out.ctlz32(operand));
+            setInt32(m_out.ctlz(operand));
             return;
         }
         DFG_ASSERT(m_graph, m_node, m_node->child1().useKind() == UntypedUse, m_node->child1().useKind());
@@ -12359,6 +12359,18 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock checkDUCET = m_out.newBlock();
         LBasicBlock is8Bit = m_out.newBlock();
         LBasicBlock loopSetup = m_out.newBlock();
+        LBasicBlock shortString = m_out.newBlock();
+        LBasicBlock wordLoop = m_out.newBlock();
+        LBasicBlock wordPairSame = m_out.newBlock();
+        LBasicBlock wordPairAdvance = m_out.newBlock();
+        LBasicBlock wordPairDiffer = m_out.newBlock();
+        LBasicBlock wordPairDifferASCII = m_out.newBlock();
+        LBasicBlock wordPairRescan = m_out.newBlock();
+        LBasicBlock wordTail = m_out.newBlock();
+        LBasicBlock wordTailSame = m_out.newBlock();
+        LBasicBlock wordTailDiffer = m_out.newBlock();
+        LBasicBlock wordTailDifferASCII = m_out.newBlock();
+        LBasicBlock wordTailRescan = m_out.newBlock();
         LBasicBlock loop = m_out.newBlock();
         LBasicBlock checkASCII = m_out.newBlock();
         LBasicBlock checkWeights = m_out.newBlock();
@@ -12402,20 +12414,104 @@ IGNORE_CLANG_WARNINGS_END
             m_out.testIsZero32(m_out.bitAnd(leftFlag, rightFlag), m_out.constInt32(StringImpl::flagIs8Bit())),
             rarely(slowCase), usually(loopSetup));
 
+        // Scanning string content a whole word at a time is much cheaper than the byte loop
+        // below. Semantics must match the byte loop exactly:
+        // - equal words containing a byte >= 128 need full collation for that byte: bail
+        // - differing words locate the first differing byte; when no byte in the pair has the
+        //   high bit set the level-1 lookup at that byte decides, but if any byte >= 128 is
+        //   present the word pair is rescanned byte by byte so that an equal non-ASCII prefix
+        //   bails and a differing non-ASCII byte still goes through the weight table.
+        constexpr uint64_t highBitMask = 0x8080808080808080ULL;
+        constexpr unsigned wordSize = sizeof(uint64_t);
+
+        // The lowest addressed byte is the least significant one, so the earliest differing byte
+        // of a pair is the lowest set bit of their xor.
+        //
+        // For example, "abcdefgh" vs "abXdefgh"
+        //
+        // left         = 0x6867666564636261    ('a' = 0x61 sits in the least significant byte)
+        // right        = 0x6867666564586261    ('X' = 0x58 replaces 'c' = 0x63)
+        // diff         = 0x00000000003B0000    (0x63 ^ 0x58 = 0x3B, in lane 2)
+        // diff & -diff = 0x0000000000010000    (bit 16)
+        // clz = 47  ->  63 - 47 = 16  ->  16 >> 3 = 2
+        auto firstDifferingByteOffset = [&](LValue diff) {
+            LValue lowestSetBit = m_out.bitAnd(diff, m_out.neg(diff));
+            return m_out.lShr(m_out.sub(m_out.constInt64(wordSize * 8 - 1), m_out.ctlz(lowestSetBit)), m_out.constInt32(3));
+        };
+
         // Load lengths and data pointers
-        m_out.appendTo(loopSetup, loop);
+        m_out.appendTo(loopSetup, shortString);
         LValue leftLength = m_out.zeroExtPtr(m_out.load32(leftImpl, m_heaps.StringImpl_length));
         LValue rightLength = m_out.zeroExtPtr(m_out.load32(rightImpl, m_heaps.StringImpl_length));
         LValue leftData = m_out.loadPtr(leftImpl, m_heaps.StringImpl_data);
         LValue rightData = m_out.loadPtr(rightImpl, m_heaps.StringImpl_data);
         LValue commonLength = m_out.select(m_out.below(leftLength, rightLength), leftLength, rightLength);
+        LValue lastWordIndex = m_out.sub(commonLength, m_out.constIntPtr(wordSize));
         LValue tableBase = m_out.constIntPtr(ducetLevel1Weights);
-        ValueFromBlock indexAtStart = m_out.anchor(m_out.intPtrZero);
+        ValueFromBlock wordIndexAtStart = m_out.anchor(m_out.intPtrZero);
+        m_out.branch(m_out.aboveOrEqual(commonLength, m_out.constIntPtr(wordSize)), unsure(wordLoop), unsure(shortString));
+
+        m_out.appendTo(shortString, wordLoop);
+        ValueFromBlock shortStringStart = m_out.anchor(m_out.intPtrZero);
         m_out.branch(m_out.isNull(commonLength), unsure(loopDone), unsure(loop));
+
+        m_out.appendTo(wordLoop, wordPairSame);
+        LValue wordIndex = m_out.phi(pointerType(), wordIndexAtStart);
+        LValue leftWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), m_out.add(leftData, wordIndex)));
+        LValue rightWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), m_out.add(rightData, wordIndex)));
+        LValue wordDiff = m_out.bitXor(leftWord, rightWord);
+        m_out.branch(m_out.notZero64(wordDiff), unsure(wordPairDiffer), unsure(wordPairSame));
+
+        m_out.appendTo(wordPairSame, wordPairAdvance);
+        m_out.branch(
+            m_out.testIsZero64(leftWord, m_out.constInt64(highBitMask)),
+            usually(wordPairAdvance), rarely(slowCase));
+
+        m_out.appendTo(wordPairAdvance, wordPairDiffer);
+        LValue nextWordIndex = m_out.add(wordIndex, m_out.constIntPtr(wordSize));
+        m_out.addIncomingToPhi(wordIndex, m_out.anchor(nextWordIndex));
+        m_out.branch(m_out.belowOrEqual(nextWordIndex, lastWordIndex), unsure(wordLoop), unsure(wordTail));
+
+        m_out.appendTo(wordPairDiffer, wordPairDifferASCII);
+        m_out.branch(
+            m_out.testIsZero64(m_out.bitOr(leftWord, rightWord), m_out.constInt64(highBitMask)),
+            usually(wordPairDifferASCII), unsure(wordPairRescan));
+
+        m_out.appendTo(wordPairDifferASCII, wordPairRescan);
+        ValueFromBlock wordDifferingStart = m_out.anchor(m_out.add(wordIndex, firstDifferingByteOffset(wordDiff)));
+        m_out.jump(loop);
+
+        m_out.appendTo(wordPairRescan, wordTail);
+        ValueFromBlock wordRescanStart = m_out.anchor(wordIndex);
+        m_out.jump(loop);
+
+        m_out.appendTo(wordTail, wordTailSame);
+        LValue leftTailWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), m_out.add(leftData, lastWordIndex)));
+        LValue rightTailWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), m_out.add(rightData, lastWordIndex)));
+        LValue tailDiff = m_out.bitXor(leftTailWord, rightTailWord);
+        m_out.branch(m_out.notZero64(tailDiff), unsure(wordTailDiffer), unsure(wordTailSame));
+
+        m_out.appendTo(wordTailSame, wordTailDiffer);
+        m_out.branch(
+            m_out.testIsZero64(leftTailWord, m_out.constInt64(highBitMask)),
+            usually(loopDone), rarely(slowCase));
+
+        m_out.appendTo(wordTailDiffer, wordTailDifferASCII);
+        m_out.branch(
+            m_out.testIsZero64(m_out.bitOr(leftTailWord, rightTailWord), m_out.constInt64(highBitMask)),
+            usually(wordTailDifferASCII), unsure(wordTailRescan));
+
+        m_out.appendTo(wordTailDifferASCII, wordTailRescan);
+        ValueFromBlock wordTailDifferingStart = m_out.anchor(m_out.add(lastWordIndex, firstDifferingByteOffset(tailDiff)));
+        m_out.jump(loop);
+
+        m_out.appendTo(wordTailRescan, loop);
+        ValueFromBlock wordTailRescanStart = m_out.anchor(nextWordIndex);
+        m_out.jump(loop);
 
         // Main loop: load bytes and branch on equality
         m_out.appendTo(loop, checkASCII);
-        LValue index = m_out.phi(pointerType(), indexAtStart);
+        LValue index = m_out.phi(pointerType(), shortStringStart, wordDifferingStart, wordRescanStart, wordTailDifferingStart, wordTailRescanStart);
         LValue leftByte = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, leftData, index));
         LValue rightByte = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, rightData, index));
         m_out.branch(m_out.notEqual(leftByte, rightByte), unsure(checkWeights), unsure(checkASCII));

--- a/Source/JavaScriptCore/ftl/FTLOutput.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOutput.cpp
@@ -282,7 +282,7 @@ LValue Output::logicalNot(LValue value)
     return m_block->appendNew<B3::Value>(m_proc, B3::Equal, origin(), value, int32Zero);
 }
 
-LValue Output::ctlz32(LValue operand)
+LValue Output::ctlz(LValue operand)
 {
     return m_block->appendNew<B3::Value>(m_proc, B3::Clz, origin(), operand);
 }

--- a/Source/JavaScriptCore/ftl/FTLOutput.h
+++ b/Source/JavaScriptCore/ftl/FTLOutput.h
@@ -181,7 +181,7 @@ public:
     LValue bitNot(LValue);
     LValue logicalNot(LValue);
 
-    LValue ctlz32(LValue);
+    LValue ctlz(LValue);
     LValue doubleAbs(LValue);
     LValue doubleCeil(LValue);
     LValue doubleFloor(LValue);


### PR DESCRIPTION
#### acae5e7707a2612fa33fc7b9ea2bf20dbe7098fa
<pre>
[JSC] Add word-sized fast path for localeCompare
<a href="https://bugs.webkit.org/show_bug.cgi?id=322123">https://bugs.webkit.org/show_bug.cgi?id=322123</a>
<a href="https://rdar.apple.com/185349407">rdar://185349407</a>

Reviewed by NOBODY (OOPS!).

String#localeCompare is already inlined in FTL. This patch extends it to
support word-sized comparison similar to the normal string comparison in
FTL. localeCompare can work well for ASCII strings, thus so long as we
are just handling ASCII characters (highBitMask checks it), we can just
do comparison without querying to the underlying locale. We use
ctlz-based bit hack to detect the different characters&apos; index quickly,
and then going to the byte loop with that index to fallback. Otherwise,
we stay in the word-sized comparison loop.

Test: JSTests/stress/string-locale-compare-word-scan.js

* JSTests/stress/string-locale-compare-word-scan.js: Added.
(shouldBe):
(reference):
(resolve):
(make):
(check):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArithClz32):
(JSC::FTL::DFG::LowerDFGToB3::compileStringLocaleCompare):
* Source/JavaScriptCore/ftl/FTLOutput.cpp:
(JSC::FTL::Output::ctlz):
(JSC::FTL::Output::ctlz32): Deleted.
* Source/JavaScriptCore/ftl/FTLOutput.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acae5e7707a2612fa33fc7b9ea2bf20dbe7098fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145900 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141724 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98377 "3 flakes 14 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be027056-784d-4064-9ba8-bee0721a150e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122161 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/59258ff5-9515-4278-af26-7c72eab69bb3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44093 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42365 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4129 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10948 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42005 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2957 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42852 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193724 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55190 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151132 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55879 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150835 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45415 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128162 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123844 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54392 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16999 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53774 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54013 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53839 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->