### PR TITLE
[ews] Safer C++ queues blame unchanged files when results-db has no result for a test

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -174,21 +174,15 @@ class ResultsDatabase(object):
 
     @classmethod
     @defer.inlineCallbacks
-    def does_result_match(cls, test, result_type=None, commit=None, configuration=None, suite=None, default=None):
+    def does_result_match(cls, test, result_type=None, commit=None, configuration=None, suite=None):
         logs = []
         data = yield cls.get_results(suite, test, commit, configuration, logger=lambda log: logs.append(log))
-        if data is None:
+        if not data:
             defer.returnValue(None)
             return
-        if not data:
-            if not default:
-                defer.returnValue(None)
-                return
-            actual = default
-        else:
-            results = data[0].get('results')[0]
-            actual = results.get('actual')
 
+        results = data[0].get('results')[0]
+        actual = results.get('actual')
         does_result_match = actual == result_type
         output = {
             'does_result_match': does_result_match,

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -8140,7 +8140,7 @@ class FindUnexpectedStaticAnalyzerResults(shell.ShellCommand, AnalyzeChange, Add
             self.setProperty('num_failing_files', len(filtered_failures))
         if filtered_passes is not None:
             self.setProperty('num_passing_files', len(filtered_passes))
-        successful_filter = filtered_failures is not None or filtered_passes is not None
+        successful_filter = filtered_failures is not None and filtered_passes is not None
         return defer.returnValue(successful_filter)
 
     @defer.inlineCallbacks
@@ -8160,10 +8160,10 @@ class FindUnexpectedStaticAnalyzerResults(shell.ShellCommand, AnalyzeChange, Add
                         configuration=configuration,
                         commit=identifier,
                         suite=self.suite,
-                        default='PASS'
                     )
                     if not data:
-                        yield self._addToLog(self.results_db_log_name, f"Failed to match results for {test_name}, falling back to tip-of-tree\n")
+                        yield self._addToLog(self.results_db_log_name, f"Could not determine from results-db whether {test_name} is pre-existing at '{identifier}' with configuration {configuration}, falling back to tip-of-tree\n")
+                        yield self._addToLog('stdio', f'Results database cannot say whether {test_name} is pre-existing, rebuilding without the change to find out.\n')
                         return defer.returnValue(None)
                     yield self._addToLog(self.results_db_log_name, f"\n{test_name}: pre-existing={data['does_result_match']}\nResponse from results-db: {data}\n{data['logs']}")
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -56,6 +56,12 @@ from .steps import *
 FakeBuild.addStepsAfterCurrentStep = lambda FakeBuild, step_factories: None
 FakeBuild._builderid = 1
 
+# Several tests below replace FindUnexpectedStaticAnalyzerResults methods on the class rather than
+# with self.patch, so the replacements outlive the test that made them. Capture the real
+# implementations here, at import time, so tests that need them can patch them back.
+REAL_FILTER_RESULTS_USING_RESULTS_DB = FindUnexpectedStaticAnalyzerResults.filter_results_using_results_db
+REAL_WRITE_UNEXPECTED_RESULTS_FILE_TO_MASTER = FindUnexpectedStaticAnalyzerResults.write_unexpected_results_file_to_master
+
 # Prevent unit-tests from talking to live bugzilla and github servers
 BugzillaMixin.fetch_data_from_url_with_authentication_bugzilla = lambda x, y: None
 GitHubMixin.fetch_data_from_url_with_authentication_github = lambda x, y: None
@@ -11646,6 +11652,68 @@ class TestFindUnexpectedStaticAnalyzerResults(BuildStepMixinAdditions, unittest.
         self.assertEqual([], next_steps)
         return rc
 
+    def configureResultsDatabase(self, rows_by_test):
+        self.patch(FindUnexpectedStaticAnalyzerResults, 'filter_results_using_results_db', REAL_FILTER_RESULTS_USING_RESULTS_DB)
+        self.patch(FindUnexpectedStaticAnalyzerResults, 'write_unexpected_results_file_to_master', REAL_WRITE_UNEXPECTED_RESULTS_FILE_TO_MASTER)
+        self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(True)))
+
+        def fake_get_results(cls, suite, test=None, commit=None, configuration=None, logger=None):
+            if test is None:
+                return defer.succeed([{'results': [{'actual': 'FAIL'}]}])
+            return defer.succeed(rows_by_test.get(test, []))
+
+        self.patch(ResultsDatabase, 'get_results', classmethod(fake_get_results))
+
+    def expectCheckExpectationsCommand(self, stdout):
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        log_environ=False,
+                        logfiles={'json': self.jsonFileName},
+                        command=['python3', 'Tools/Scripts/compare-static-analysis-results', 'wkdir/build/new', '--build-output', SCAN_BUILD_OUTPUT_DIR, '--check-expectations', '--platform', 'mac'],
+                        env={'RESULTS_SERVER_API_KEY': 'test-api-key'})
+            .log('stdio', stdout=stdout)
+            .exit(0),
+        )
+
+    @defer.inlineCallbacks
+    def test_no_results_db_data_rebuilds_without_change(self):
+        self.configureStep(True)
+        FindUnexpectedStaticAnalyzerResults.decode_results_data = lambda self: {'passes': {'WebCore': {'UncountedCallArgsChecker': []}}, 'failures': {'WebCore': {'UncountedCallArgsChecker': ['Modules/webtransport/DatagramSink.cpp']}}}
+        self.configureResultsDatabase({})
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
+        self.expectCheckExpectationsCommand('Total unexpected issues: 1\nTotal unexpected failing files: 1\n')
+        self.expect_outcome(result=SUCCESS, state_string='1 new issue 1 failing file ')
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
+            yield self.run_step()
+        self.assertEqual([ValidateChange(verifyBugClosed=False, addURLs=False), RevertAppliedChanges(exclude=['new*', 'scan-build-output*']), ScanBuildWithoutChange()], next_steps)
+
+    @defer.inlineCallbacks
+    def test_no_results_db_data_for_failures_escalates_despite_empty_passes(self):
+        self.configureStep(True)
+        FindUnexpectedStaticAnalyzerResults.decode_results_data = lambda self: {'passes': {}, 'failures': {'WebCore': {'UncountedCallArgsChecker': ['Modules/webtransport/DatagramSink.cpp']}}}
+        self.configureResultsDatabase({})
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
+        self.expectCheckExpectationsCommand('Total unexpected issues: 1\nTotal unexpected failing files: 1\n')
+        self.expect_outcome(result=SUCCESS, state_string='1 new issue 1 failing file ')
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
+            yield self.run_step()
+        self.assertEqual([ValidateChange(verifyBugClosed=False, addURLs=False), RevertAppliedChanges(exclude=['new*', 'scan-build-output*']), ScanBuildWithoutChange()], next_steps)
+
+    @defer.inlineCallbacks
+    def test_pre_existing_failure_is_filtered_without_rebuilding(self):
+        self.configureStep(True)
+        FindUnexpectedStaticAnalyzerResults.decode_results_data = lambda self: {'passes': {'WebCore': {'UncountedCallArgsChecker': []}}, 'failures': {'WebCore': {'UncountedCallArgsChecker': ['Modules/webtransport/DatagramSink.cpp']}}}
+        self.configureResultsDatabase({'WebCore/Modules/webtransport/DatagramSink.cpp/UncountedCallArgsChecker': [{'results': [{'actual': 'FAIL'}]}]})
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
+        self.expectCheckExpectationsCommand('Total unexpected issues: 1\nTotal unexpected failing files: 1\n')
+        self.expect_outcome(result=SUCCESS, state_string='Found no unexpected results')
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
+            yield self.run_step()
+        self.assertEqual([], next_steps)
+
 
 class TestDownloadUnexpectedResultsfromMaster(BuildStepMixinAdditions, unittest.TestCase):
     READ_LIMIT = 1000
@@ -12186,22 +12254,33 @@ class TestResultsDatabaseFailureHandling(unittest.TestCase):
         self.assertNotIn('Reported WithinStepDirtyTree flaky tests:', logs)
 
     @defer.inlineCallbacks
-    def test_does_result_match_returns_none_on_request_failure_even_with_default(self):
+    def test_does_result_match_returns_none_on_request_failure(self):
         with self._mock_twisted_request(None):
             result = yield ResultsDatabase.does_result_match(
                 'JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp/NoDeleteChecker',
-                result_type='FAIL', suite='safer-cpp-checks', default='PASS',
+                result_type='FAIL', suite='safer-cpp-checks',
             )
         self.assertIsNone(result)
 
     @defer.inlineCallbacks
-    def test_does_result_match_uses_default_on_empty_success(self):
+    def test_does_result_match_returns_none_when_there_is_no_result_for_the_test(self):
         with self._mock_twisted_request(self._ok_response([])):
             result = yield ResultsDatabase.does_result_match(
-                'foo.cpp/Checker', result_type='FAIL', suite='safer-cpp-checks', default='PASS',
+                'foo.cpp/Checker', result_type='FAIL', suite='safer-cpp-checks',
             )
-        self.assertIsNotNone(result)
-        self.assertFalse(result['does_result_match'])
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_does_result_match_compares_a_real_result(self):
+        with self._mock_twisted_request(self._ok_response([{'results': [{'actual': 'FAIL'}]}])):
+            failing = yield ResultsDatabase.does_result_match(
+                'foo.cpp/Checker', result_type='FAIL', suite='safer-cpp-checks',
+            )
+            passing = yield ResultsDatabase.does_result_match(
+                'foo.cpp/Checker', result_type='PASS', suite='safer-cpp-checks',
+            )
+        self.assertTrue(failing['does_result_match'])
+        self.assertFalse(passing['does_result_match'])
 
     @defer.inlineCallbacks
     def test_is_test_pre_existing_failure_flags_request_failure(self):


### PR DESCRIPTION
#### c1cf2708c73ea9655690d0ee93acb1ebb1680ef4
<pre>
[ews] Safer C++ queues blame unchanged files when results-db has no result for a test
<a href="https://bugs.webkit.org/show_bug.cgi?id=321829">https://bugs.webkit.org/show_bug.cgi?id=321829</a>
<a href="https://rdar.apple.com/185229829">rdar://185229829</a>

Reviewed by NOBODY (OOPS!).

The iOS Safer C++ queue reported Modules/webtransport/DatagramSink.cpp as a new failing file on
PR 71664, which does not touch it. The build was based on <a href="https://commits.webkit.org/319210@main">319210@main</a> and the expectations update
adding that file landed at <a href="https://commits.webkit.org/319223@main">319223@main</a>, so it did look new and check_results_db asked the results
database whether the failure was pre-existing. The response was empty:

    Response from results-db: {&apos;does_result_match&apos;: False, &apos;raw_data&apos;: [], &apos;logs&apos;: &apos;&apos;}

An empty raw_data means the request succeeded but held no result for that test. does_result_match
then fell through to the caller&apos;s default of &apos;PASS&apos;, compared it against &apos;FAIL&apos;, and declared the
file not pre-existing. Because a dict rather than None came back, check_results_db treated that as
a successful verdict and skipped the tip-of-tree fallback, which would have rebuilt without
the change and shown the failure was not caused by it.

Removing the `default` parameter collapses both &quot;cannot answer&quot; cases in does_result_match into a
single None return, so the fallback in check_results_db always runs.

filter_results_using_results_db combined its two categories with `or`. Since check_results_db
returns an empty set for a category with nothing to check, an unresolved failures result was masked
by a non-None empty passes result, so it has to require both categories to resolve.

* Tools/CISupport/ews-build/results_db.py:
(ResultsDatabase.does_result_match): Remove the `default` parameter, which had no other production
caller, and return None for both a failed request and a response with no result for the test.
* Tools/CISupport/ews-build/steps.py:
(FindUnexpectedStaticAnalyzerResults.filter_results_using_results_db): Require both checks to resolve.
(FindUnexpectedStaticAnalyzerResults.check_results_db): Stop passing default=&apos;PASS&apos;. Log the test,
identifier and configuration that produced no answer, and note in stdio that a build without the
change is being run.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestFindUnexpectedStaticAnalyzerResults.configureResultsDatabase): Stub only has_commit and
get_results so the real filtering runs, and restore the two methods other tests in this class
replace on the class rather than with self.patch. Three tests cover escalation on a missing result,
escalation when only the passes category is empty, and filtering of a genuine pre-existing failure.
(TestResultsDatabaseFailureHandling.test_does_result_match_returns_none_when_there_is_no_result_for_the_test):
Replaces test_does_result_match_uses_default_on_empty_success, which asserted the behavior fixed here.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1cf2708c73ea9655690d0ee93acb1ebb1680ef4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182543 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/56490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/50296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184405 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/57806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/192778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185498 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/57806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/50296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/57806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/56213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/50296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/57806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/3937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/56213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/194700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/181944 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/56161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/50296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/194700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/50296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/194700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27715 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/55363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/50296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->