### PR TITLE
[AppKit Gestures] Trackpad swiping between spaces should not trigger back navigation when UseAppKitGesturesForGestureEvents is enabled

### DIFF
--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -1472,7 +1472,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     WebKit::NativeWebWheelEvent nativeEvent { wheelEvent };
 
     CheckedPtr impl = [webView _impl];
-    if (impl->allowsBackForwardNavigationGestures() && protect(impl->ensureGestureController())->handleScrollWheelEvent(nativeEvent)) {
+    bool forwardToGestureController = impl->allowsBackForwardNavigationGestures() && [self prefersForwardingToGestureController:gesture];
+    if (forwardToGestureController && protect(impl->ensureGestureController())->handleScrollWheelEvent(nativeEvent)) {
         WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG([webView _protectedPage]->logIdentifier(), "View gesture controller handled gesture");
         return;
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -1223,9 +1223,12 @@ extension AppKitGesturesTests.Basic {
     }
 
     @Test(
-        .bug("https://webkit.org/b/319256", "Trackpad swiping between spaces should not trigger back navigation")
+        .bug("https://webkit.org/b/319256", "Trackpad swiping between spaces should not trigger back navigation"),
+        arguments: [false, true]
     )
-    func swipingBetweenSpacesShouldNotTriggerBackNavigation() async throws {
+    func swipingBetweenSpacesShouldNotTriggerBackNavigation(gesturesForGestureEvents: Bool) async throws {
+        page.setWebFeature("UseAppKitGesturesForGestureEvents", enabled: gesturesForGestureEvents)
+
         // Establish a back-forward history entry so that a "swipe back" gesture would have somewhere to navigate to.
         try await page.load(URL(string: "about:blank?1")).wait()
 


### PR DESCRIPTION
#### dceda81b08d8e1e0bc50a546dbb3d9a61278c484
<pre>
[AppKit Gestures] Trackpad swiping between spaces should not trigger back navigation when UseAppKitGesturesForGestureEvents is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=322127">https://bugs.webkit.org/show_bug.cgi?id=322127</a>
<a href="https://rdar.apple.com/185354832">rdar://185354832</a>

Reviewed by Richard Robinson.

This is a follow up from 317071@main.

UseAppKitGesturesForGestureEvents enablement produces unwanted wheel
event forwarding to ViewGestureController, so let&apos;s curb that.

Test: AppKitGesturesTests/Basic/swipingBetweenSpacesShouldNotTriggerBackNavigation(gesturesForGestureEvents:)

* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm:
(-[WKAppKitGestureController sendWheelEventForGesture:]):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Augment the existing test case from 317071@main to also toggle
UseAppKitGesturesForGestureEvents, adding coverage for this scenario.

Canonical link: <a href="https://commits.webkit.org/319509@main">https://commits.webkit.org/319509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a4a5e53e0331462d585240b2c830be95d776f71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145909 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7165d7c8-435c-4ded-80e8-47eb1b8cf8fd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141730 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0bb806d6-5325-453a-88df-d7cd9b4b5865) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122167 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/20fb20bc-e7db-4e14-8749-d88bb20ff385) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44099 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42374 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42011 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2966 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193733 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55199 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151139 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55888 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150842 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27595 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45419 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128171 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123861 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54401 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17004 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53783 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54022 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53848 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->