### PR TITLE
[line-clamp] text-overflow ellipsis should show on non-clamped content

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4185,7 +4185,6 @@ imported/w3c/web-platform-tests/css/css-overflow/line-clamp/line-clamp-with-floa
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/line-clamp-with-text-overflow-string-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/webkit-line-clamp-024.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/webkit-line-clamp-036.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-overflow/line-clamp/webkit-line-clamp-037.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/webkit-line-clamp-040.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/webkit-line-clamp-044.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-overflow/line-clamp/webkit-line-clamp-045.html [ ImageOnlyFailure ]

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -589,12 +589,15 @@ std::pair<InlineLayoutUnit, InlineLayoutUnit> InlineFormattingUtils::textEmphasi
 LineEndingTruncationPolicy InlineFormattingUtils::lineEndingTruncationPolicy(const Style::ComputedStyle& rootStyle, size_t numberOfContentfulLines, std::optional<size_t> numberOfVisibleLinesAllowed, bool currentLineIsContentful)
 {
     if (numberOfVisibleLinesAllowed) {
-        // text-overflow: ellipsis should not apply inside clamping content.
         if (!currentLineIsContentful) {
             // Content with no inline should never ever receive ellipsis.
             return LineEndingTruncationPolicy::NoTruncation;
         }
-        return *numberOfVisibleLinesAllowed == numberOfContentfulLines ? LineEndingTruncationPolicy::WhenContentOverflowsInBlockDirection : LineEndingTruncationPolicy::NoTruncation;
+        if (numberOfContentfulLines >= *numberOfVisibleLinesAllowed) {
+            // The clamped line's block ellipsis replaces the text-overflow ellipsis, while the lines below it are not visible at all.
+            return numberOfContentfulLines == *numberOfVisibleLinesAllowed ? LineEndingTruncationPolicy::WhenContentOverflowsInBlockDirection : LineEndingTruncationPolicy::NoTruncation;
+        }
+        // Lines above the clamp point are not affected by clamping, so text-overflow is what may truncate them.
     }
 
     // Truncation is in effect when the block container has overflow other than visible.


### PR DESCRIPTION
#### 12920a284e78c330070d9a3264014f84b18df8c9
<pre>
[line-clamp] text-overflow ellipsis should show on non-clamped content
<a href="https://bugs.webkit.org/show_bug.cgi?id=322122">https://bugs.webkit.org/show_bug.cgi?id=322122</a>
&lt;<a href="https://rdar.apple.com/problem/185348784">rdar://problem/185348784</a>&gt;

Reviewed by Antti Koivisto.

  &lt;div style=&quot;display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3;
    width: 50px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap&quot;&gt;
    This content overflows
  &lt;/div&gt;

There is one line and room for three, so nothing is clamped and text-overflow should end
the line with an ellipsis. Instead the line was clipped mid-glyph with no ellipsis at all.

See <a href="https://github.com/w3c/csswg-drafts/issues/10823">https://github.com/w3c/csswg-drafts/issues/10823</a>

* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::lineEndingTruncationPolicy):
* LayoutTests/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/319597@main">https://commits.webkit.org/319597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/609d0863704e2df4771f729b2ae2e013c2bc511c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145949 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e812ab97-ef14-4f98-803a-157b4fd56a9d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141758 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98406 "3 flakes 16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b32e72d7-e36c-45f1-aa62-7124990d88ed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122195 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6131fb46-4306-476a-a6ee-4ba22816ccbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44130 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42406 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154531 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42039 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3007 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193773 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151170 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40558 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55928 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38661 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150872 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45453 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128211 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123901 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54441 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17033 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53823 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54062 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53888 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->