### PR TITLE
Extension scripts/style sheets are injected into denied domains if Other Websites are set to allow.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -1389,7 +1389,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
 
         HashSet<String> excludeMatchPatternsSet;
         excludeMatchPatternsSet.addAll(injectedContentData.expandedExcludeMatchPatternStrings());
-        excludeMatchPatternsSet.unionWith(baseExcludeMatchPatternsSet);
+        excludeMatchPatternsSet.addAll(baseExcludeMatchPatternsSet);
 
         auto excludeMatchPatterns = copyToVector(excludeMatchPatternsSet);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "Helpers/cocoa/HTTPServer.h"
+#import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/WebExtensionUtilities.h"
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKUserContentControllerPrivate.h>
@@ -2147,6 +2148,80 @@ TEST(WKWebExtensionAPIScripting, ContentScriptsAndStyleSheetsWithManyMatchPatter
 
     constexpr size_t maxExpectedFootprint = 100 * 1024 * 1024;
     EXPECT_LT(totalFootprint, maxExpectedFootprint);
+}
+
+TEST(WKWebExtensionAPIScripting, ContentScriptsRespectDeniedMatchPatterns)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Content Scripts Test",
+        @"description": @"Content Scripts Test",
+        @"version": @"1.0",
+
+        @"content_scripts": @[ @{
+            @"matches": @[ @"*://*/*" ],
+            @"js": @[ @"content.js" ],
+            @"css": @[ @"content.css" ],
+            @"run_at": @"document_end"
+        } ]
+    };
+
+    auto *contentScript = Util::constructScript(@[
+        @"document.body.dataset.scriptInjected = 'true'"
+    ]);
+
+    auto *contentStyle = @"body { background-color: rgb(255, 0, 0) !important; }";
+
+    auto *resources = @{
+        @"content.js": contentScript,
+        @"content.css": contentStyle
+    };
+
+    auto manager = Util::loadExtension(manifest, resources);
+
+    // Grant all hosts and schemes, but deny localhost specifically
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:WKWebExtensionMatchPattern.allHostsAndSchemesMatchPattern];
+
+    auto *localhostRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forURL:localhostRequest.URL];
+
+    // Test 1: Load localhost, verify script and style are NOT injected due to denied pattern
+    [manager.get().defaultTab.webView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView _test_waitForDidFinishNavigation];
+
+    // Verify the script and style were NOT injected by checking the page
+    __block bool doneCheckingLocalhost = false;
+    [manager.get().defaultTab.webView evaluateJavaScript:@"({ scriptInjected: document.body.dataset.scriptInjected === 'true', backgroundColor: getComputedStyle(document.body).backgroundColor })" completionHandler:^(id result, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_NS_EQUAL([result objectForKey:@"scriptInjected"], @NO);
+        EXPECT_FALSE([[result objectForKey:@"backgroundColor"] isEqualToString:@"rgb(255, 0, 0)"]);
+        doneCheckingLocalhost = true;
+    }];
+
+    TestWebKitAPI::Util::run(&doneCheckingLocalhost);
+
+    // Test 2: Load 127.0.0.1 (loopback), verify script and style ARE injected
+    // This should work because allHostsAndSchemesMatchPattern is granted and loopback is not denied
+    auto *loopbackRequest = server.request();
+
+    [manager.get().defaultTab.webView loadRequest:loopbackRequest];
+    [manager.get().defaultTab.webView _test_waitForDidFinishNavigation];
+
+    // Verify the script and style WERE injected
+    __block bool doneCheckingLoopback = false;
+    [manager.get().defaultTab.webView evaluateJavaScript:@"({ scriptInjected: document.body.dataset.scriptInjected === 'true', backgroundColor: getComputedStyle(document.body).backgroundColor })" completionHandler:^(id result, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_NS_EQUAL([result objectForKey:@"scriptInjected"], @YES);
+        EXPECT_NS_EQUAL([result objectForKey:@"backgroundColor"], @"rgb(255, 0, 0)");
+        doneCheckingLoopback = true;
+    }];
+
+    TestWebKitAPI::Util::run(&doneCheckingLoopback);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 15fa22b107d107d2c48bb99373ac9767dcf1bf62
<pre>
Extension scripts/style sheets are injected into denied domains if Other Websites are set to allow.
<a href="https://webkit.org/b/309516">https://webkit.org/b/309516</a>
<a href="https://rdar.apple.com/171724038">rdar://171724038</a>

Reviewed by Brian Weinstein.

During Objective-C++ to C++ conversion, NSMutableSet&apos;s unionSet: (modifies in place) was incorrectly
translated to HashSet::unionWith() (returns new set). Changed to addAll() to match original semantics.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::addInjectedContent): Use addAll() instead of unionWith().
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ContentScriptsRespectDeniedMatchPatterns)): Added.

Originally-landed-as: 305413.426@safari-7624-branch (7f6a77dee81b). <a href="https://rdar.apple.com/176067024">rdar://176067024</a>
Canonical link: <a href="https://commits.webkit.org/319487@main">https://commits.webkit.org/319487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7910a35aecc70c929bee9f8dfbdf9b71caf6b3bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191811 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145914 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f01e4c7-6d9a-443e-818b-f84bb68de195) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141734 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98e6ba12-5ae2-4291-8476-2d1fb8c4b5ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122171 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9e4af7d-7dad-409b-a26d-8a5f000271c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44105 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154506 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42018 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2971 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48165 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46633 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193738 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55204 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40482 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55893 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150847 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45426 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128176 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123866 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54406 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17011 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54027 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->