### PR TITLE
[JSC] B3::hoistLoopInvariantValues should be better at handling interference between control dependence and side exits

### DIFF
--- a/JSTests/wasm/stress/licm-trapping-load-in-try.js
+++ b/JSTests/wasm/stress/licm-trapping-load-in-try.js
@@ -1,0 +1,137 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// LICM may hoist a trapping load out of a loop, but only to a point where the load was going to
+// run anyway and where nothing observable happens first. These check the cases where hoisting
+// would be wrong.
+
+// The load is guarded by a condition that is never true, so it must never run. Hoisting it to the
+// pre-header unconditionally would turn a clean return into a trap.
+let watNeverTaken = `
+(module
+    (memory 1)
+    (func (export "test") (param $iterations i32) (param $addr i32) (result i32)
+        (local $i i32)
+        (loop $loop
+            local.get $i
+            i32.const -1
+            i32.eq
+            if
+                local.get $addr
+                i32.load
+                drop
+            end
+            local.get $i
+            i32.const 1
+            i32.add
+            local.set $i
+            local.get $i
+            local.get $iterations
+            i32.lt_s
+            br_if $loop
+        )
+        i32.const 42
+    )
+)
+`;
+
+// A wasm trap tears down to the entry frame, so stores the loop already made stay visible to the
+// embedder. The load may only trap after the iteration that stored, never before.
+let watStoresStayVisible = `
+(module
+    (memory (export "mem") 1)
+    (func (export "test") (param $trapAt i32) (param $addr i32)
+        (local $i i32)
+        (loop $loop
+            i32.const 0
+            i32.const 0
+            i32.load
+            i32.const 1
+            i32.add
+            i32.store
+
+            local.get $i
+            local.get $trapAt
+            i32.eq
+            if
+                local.get $addr
+                i32.load
+                drop
+            end
+
+            local.get $i
+            i32.const 1
+            i32.add
+            local.set $i
+            local.get $i
+            local.get $trapAt
+            i32.le_s
+            br_if $loop
+        )
+    )
+)
+`;
+
+// A loop-invariant load sharing a try with a call that throws every iteration. The catch edge is a
+// side exit inside the loop, which is the case the pass used to reject outright.
+let watLoadInTry = `
+(module
+    (memory 1)
+    (tag $e)
+    (func $thrower (throw $e))
+    (func (export "test") (param $iterations i32) (param $addr i32) (result i32)
+        (local $i i32)
+        (local $caught i32)
+        (loop $loop
+            try
+                local.get $addr
+                i32.load
+                drop
+                call $thrower
+            catch_all
+                local.get $caught
+                i32.const 1
+                i32.add
+                local.set $caught
+            end
+            local.get $i
+            i32.const 1
+            i32.add
+            local.set $i
+            local.get $i
+            local.get $iterations
+            i32.lt_s
+            br_if $loop
+        )
+        local.get $caught
+    )
+)
+`;
+
+const iterations = 2000;
+const unmappedAddress = 0xFFFFFF0;
+
+async function test() {
+    {
+        const { test } = (await instantiate(watNeverTaken, {}, {})).exports;
+        for (let i = 0; i < 10; ++i)
+            assert.eq(test(iterations, unmappedAddress), 42);
+    }
+
+    {
+        const instance = await instantiate(watStoresStayVisible, {}, {});
+        const { test, mem } = instance.exports;
+        const view = new Int32Array(mem.buffer);
+        const trapAt = 500;
+        assert.throws(() => test(trapAt, unmappedAddress), WebAssembly.RuntimeError, "Out of bounds memory access");
+        assert.eq(view[0], trapAt + 1);
+    }
+
+    {
+        const { test } = (await instantiate(watLoadInTry, {}, { exceptions: true })).exports;
+        for (let i = 0; i < 10; ++i)
+            assert.eq(test(iterations, 0), iterations);
+    }
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/b3/B3Effects.h
+++ b/Source/JavaScriptCore/b3/B3Effects.h
@@ -137,9 +137,19 @@ public:
         return result;
     }
 
+    constexpr bool isWrite() const
+    {
+        return writesLocalState || writes || writesPinned || fence;
+    }
+
+    constexpr bool isTrapBarrier() const
+    {
+        return exitsSideways || isWrite();
+    }
+
     constexpr bool mustExecute() const
     {
-        return terminal || exitsSideways || writesLocalState || writes || writesPinned || fence;
+        return terminal || isTrapBarrier();
     }
 
     // Returns true if reordering instructions with these respective effects would change program

--- a/Source/JavaScriptCore/b3/B3HoistLoopInvariantValues.cpp
+++ b/Source/JavaScriptCore/b3/B3HoistLoopInvariantValues.cpp
@@ -39,6 +39,76 @@
 
 namespace JSC { namespace B3 {
 
+// A load that can trap reports exitsSideways, which normally disqualifies it from hoisting. The
+// fault is its only escaping effect, so it can still move to a point where it is certain to run and
+// where nothing observable precedes it. WasmGC field and length loads depend on this: their null
+// check is a trap rather than a branch, which would otherwise be all that blocks hoisting them.
+static bool isTrappingLoad(const Value* value)
+{
+    if (!value->traps())
+        return false;
+    switch (value->opcode()) {
+    case Load8Z:
+    case Load8S:
+    case Load16Z:
+    case Load16S:
+    case Load:
+        // A fenced load also orders memory, which is an effect that cannot move.
+        return !value->as<MemoryValue>()->hasFence();
+    case WasmStructGet:
+    case WasmArrayLength:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool isReachedWithoutTrapBarrier(const NaturalLoops& loops, const NaturalLoop& loop, BasicBlock* block, const IndexSet<BasicBlock*>& blockBarriers)
+{
+    if (block == loop.header())
+        return true;
+
+    // Tracing ancestors from the block. If any blocks belonging to this loop has a trap,
+    // then we cannot hoist since that trap needs to be executed before the hoisted value causes
+    // a trap at a pre-header block.
+    Vector<BasicBlock*, 8> worklist;
+    IndexSet<BasicBlock*> seen;
+    auto push = [&](BasicBlock* predecessor) {
+        if (loops.belongsTo(predecessor, loop)) {
+            if (seen.add(predecessor)) {
+                // Every value in these blocks runs before the one being hoisted.
+                if (blockBarriers.contains(predecessor))
+                    return false;
+
+                // Stopping at the header is enough even though earlier iterations run other blocks:
+                // callers only reach here for a value whose block backwards-dominates the pre-header,
+                // and backwards dominance counts a back edge as a way for the procedure to end, so
+                // such a value always runs before any iteration completes.
+                if (predecessor == loop.header())
+                    return true;
+
+                worklist.append(predecessor);
+            }
+        }
+        return true;
+    };
+
+    for (BasicBlock* predecessor : block->predecessors()) {
+        if (!push(predecessor))
+            return false;
+    }
+
+    while (!worklist.isEmpty()) {
+        BasicBlock* current = worklist.takeLast();
+        for (BasicBlock* predecessor : current->predecessors()) {
+            if (!push(predecessor))
+                return false;
+        }
+    }
+
+    return true;
+}
+
 bool hoistLoopInvariantValues(Procedure& proc)
 {
     PhaseScope phaseScope(proc, "hoistLoopInvariantValues"_s);
@@ -59,12 +129,13 @@ bool hoistLoopInvariantValues(Procedure& proc)
         RangeSet<HeapRange> writes;
         bool writesLocalState { false };
         bool writesPinned { false };
-        bool sideExits { false };
+        bool exitsSideways { false };
         BasicBlock* preHeader { nullptr };
     };
-    
+
     IndexMap<NaturalLoop, LoopData> data(loops.numLoops());
-    
+    IndexSet<BasicBlock*> blockBarriers;
+
     for (unsigned loopIndex = loops.numLoops(); loopIndex--;) {
         const NaturalLoop& loop = loops.loop(loopIndex);
         for (BasicBlock* predecessor : loop.header()->predecessors()) {
@@ -84,7 +155,9 @@ bool hoistLoopInvariantValues(Procedure& proc)
             data[*loop].writes.add(effects.writes);
             data[*loop].writesLocalState |= effects.writesLocalState;
             data[*loop].writesPinned |= effects.writesPinned;
-            data[*loop].sideExits |= effects.exitsSideways;
+            data[*loop].exitsSideways |= effects.exitsSideways;
+            if (effects.isTrapBarrier())
+                blockBarriers.add(block);
         }
     }
     
@@ -94,7 +167,7 @@ bool hoistLoopInvariantValues(Procedure& proc)
             data[*current].writes.addAll(data[loop].writes);
             data[*current].writesLocalState |= data[loop].writesLocalState;
             data[*current].writesPinned |= data[loop].writesPinned;
-            data[*current].sideExits |= data[loop].sideExits;
+            data[*current].exitsSideways |= data[loop].exitsSideways;
         }
     }
     
@@ -106,52 +179,66 @@ bool hoistLoopInvariantValues(Procedure& proc)
         Vector<const NaturalLoop*> blockLoops = loops.loopsOf(block);
         if (blockLoops.isEmpty())
             continue;
-        
+
+        // Values that stay in this block run before everything later in it, so once one of them is a
+        // trap barrier nothing after it can be hoisted out on the strength of trapping first.
+        bool trapBarrierInBlock = false;
         for (Value*& value : *block) {
             Effects effects = value->effects();
-            
-            // We never hoist write effects or control constructs.
-            if (effects.mustExecute())
-                continue;
+            bool trappingLoad = isTrappingLoad(value);
+            bool hoisted = false;
 
-            // Try outermost loop first.
-            for (unsigned i = blockLoops.size(); i--;) {
-                const NaturalLoop& loop = *blockLoops[i];
-                
-                bool ok = true;
-                for (Value* child : value->children()) {
-                    if (!dominators.dominates(child->owner, data[loop].preHeader)) {
-                        ok = false;
-                        break;
+            // We never hoist write effects or control constructs. A trapping load is allowed
+            // through. The fault it reports as a side exit is its own, and the checks below decide
+            // whether it may move.
+            if (!effects.mustExecute() || trappingLoad) {
+                // Try outermost loop first.
+                for (unsigned i = blockLoops.size(); i--;) {
+                    const NaturalLoop& loop = *blockLoops[i];
+
+                    bool ok = true;
+                    for (Value* child : value->children()) {
+                        if (!dominators.dominates(child->owner, data[loop].preHeader)) {
+                            ok = false;
+                            break;
+                        }
                     }
-                }
-                if (!ok)
-                    continue;
-                
-                if (effects.controlDependent) {
-                    if (!backwardsDominators.dominates(block, data[loop].preHeader))
+                    if (!ok)
                         continue;
-                    
-                    // FIXME: This is super conservative. In reality, we just need to make sure that there
-                    // aren't any side exits between here and the pre-header according to backwards search.
-                    // https://bugs.webkit.org/show_bug.cgi?id=174763
-                    if (data[loop].sideExits)
+
+                    if (effects.controlDependent || trappingLoad) {
+                        // The block is backward-dominating the pre-header.
+                        // The value needs to be guaranteed to run on every iteration.
+                        if (!backwardsDominators.dominates(block, data[loop].preHeader))
+                            continue;
+
+                        if (data[loop].exitsSideways) {
+                            // Even if the loop can exit (after this value for example), if we do not have
+                            // any exit between pre-header to this value, we can still hoist a value because
+                            // this can be a first value causing a trap.
+                            if (trapBarrierInBlock || !isReachedWithoutTrapBarrier(loops, loop, block, blockBarriers))
+                                continue;
+                        }
+                    }
+
+                    if (effects.readsPinned && data[loop].writesPinned)
                         continue;
+
+                    if (effects.readsLocalState && data[loop].writesLocalState)
+                        continue;
+
+                    if (data[loop].writes.overlaps(effects.reads))
+                        continue;
+
+                    data[loop].preHeader->appendNonTerminal(value);
+                    value = proc.add<Value>(Nop, Void, value->origin());
+                    changed = true;
+                    hoisted = true;
                 }
-                
-                if (effects.readsPinned && data[loop].writesPinned)
-                    continue;
-                
-                if (effects.readsLocalState && data[loop].writesLocalState)
-                    continue;
-                
-                if (data[loop].writes.overlaps(effects.reads))
-                    continue;
-                
-                data[loop].preHeader->appendNonTerminal(value);
-                value = proc.add<Value>(Nop, Void, value->origin());
-                changed = true;
             }
+
+            if (!hoisted)
+                trapBarrierInBlock |= effects.isTrapBarrier();
         }
     }
     

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1269,6 +1269,8 @@ void testLICMWritesPinned();
 void testLICMControlDependent();
 void testLICMControlDependentNotBackwardsDominant();
 void testLICMControlDependentSideExits();
+void testLICMControlDependentSideExitInPredecessor();
+void testLICMControlDependentSideExitInEarlierIteration();
 void testLICMReadsPinnedWritesPinned();
 void testLICMReadsWritesDifferentHeaps();
 void testLICMReadsWritesOverlappingHeaps();

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1153,6 +1153,8 @@ void run(const TestConfig* config)
     RUN(testLICMControlDependent());
     RUN(testLICMControlDependentNotBackwardsDominant());
     RUN(testLICMControlDependentSideExits());
+    RUN(testLICMControlDependentSideExitInPredecessor());
+    RUN(testLICMControlDependentSideExitInEarlierIteration());
     RUN(testLICMReadsPinnedWritesPinned());
     RUN(testLICMReadsWritesDifferentHeaps());
     RUN(testLICMReadsWritesOverlappingHeaps());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -1518,6 +1518,151 @@ void testLICMControlDependentSideExits()
     CHECK_EQ(callCount, 100u);
 }
 
+// The side exit is taken on only some iterations, so it sits in a block of its own rather than in the
+// block holding the control-dependent value. Finding it requires walking back to the loop header over
+// the value's predecessors.
+void testLICMControlDependentSideExitInPredecessor()
+{
+    Procedure proc;
+    if (proc.optLevel() < 2)
+        return;
+
+    auto array = makeArrayForLoops();
+
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* header = proc.addBlock();
+    BasicBlock* exiting = proc.addBlock();
+    BasicBlock* footer = proc.addBlock();
+    BasicBlock* end = proc.addBlock();
+
+    auto arguments = cCallArgumentValues<unsigned*>(proc, root);
+    Value* callCountArgument = arguments[0];
+    UpsilonValue* initialIndex = root->appendNew<UpsilonValue>(
+        proc, Origin(), root->appendNew<Const32Value>(proc, Origin(), 0));
+    root->appendNew<Value>(proc, Jump, Origin());
+    root->setSuccessors(header);
+
+    // if (array[index])
+    Value* index = header->appendNew<Value>(proc, Phi, Int32, Origin());
+    initialIndex->setPhi(index);
+    header->appendNew<Value>(
+        proc, Branch, Origin(),
+        header->appendNew<MemoryValue>(
+            proc, Load, Int32, Origin(),
+            header->appendNew<Value>(
+                proc, Add, Origin(),
+                header->appendNew<ConstPtrValue>(proc, Origin(), &array),
+                header->appendNew<Value>(
+                    proc, Mul, Origin(),
+                    header->appendNew<Value>(proc, ZExt32, Origin(), index),
+                    header->appendNew<ConstPtrValue>(proc, Origin(), sizeof(int))))));
+    header->setSuccessors(exiting, footer);
+
+    Effects effects = Effects::none();
+    effects.exitsSideways = true;
+    effects.reads = HeapRange::top();
+    exiting->appendNew<CCallValue>(
+        proc, Void, Origin(), effects,
+        exiting->appendNew<ConstPtrValue>(proc, Origin(), tagCFunction<OperationPtrTag>(noOpFunction)));
+    exiting->appendNew<Value>(proc, Jump, Origin());
+    exiting->setSuccessors(footer);
+
+    effects = Effects::none();
+    effects.controlDependent = true;
+    Value* one = footer->appendNew<CCallValue>(
+        proc, Int32, Origin(), effects,
+        footer->appendNew<ConstPtrValue>(proc, Origin(), tagCFunction<OperationPtrTag>(oneFunction)),
+        callCountArgument);
+
+    Value* nextIndex = footer->appendNew<Value>(proc, Add, Origin(), index, one);
+    UpsilonValue* loopIndex = footer->appendNew<UpsilonValue>(proc, Origin(), nextIndex);
+    loopIndex->setPhi(index);
+    footer->appendNew<Value>(
+        proc, Branch, Origin(),
+        footer->appendNew<Value>(
+            proc, LessThan, Origin(), nextIndex,
+            footer->appendNew<Const32Value>(proc, Origin(), 100)));
+    footer->setSuccessors(header, end);
+
+    end->appendNew<Value>(proc, Return, Origin());
+
+    unsigned callCount = 0;
+    compileAndRun<void>(proc, &callCount);
+    CHECK_EQ(callCount, 100u);
+}
+
+// The side exit runs in the first iteration and the control-dependent value's block is first entered
+// in the second, so the exit precedes the value while sitting in no block between the loop header and
+// it. Rejecting this relies on backwards dominance counting a back edge as a way for the procedure to
+// end, which makes the value's block not backwards-dominate the pre-header.
+void testLICMControlDependentSideExitInEarlierIteration()
+{
+    Procedure proc;
+    if (proc.optLevel() < 2)
+        return;
+
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* header = proc.addBlock();
+    BasicBlock* exiting = proc.addBlock();
+    BasicBlock* body = proc.addBlock();
+    BasicBlock* end = proc.addBlock();
+
+    auto arguments = cCallArgumentValues<unsigned*>(proc, root);
+    Value* callCountArgument = arguments[0];
+    UpsilonValue* initialIndex = root->appendNew<UpsilonValue>(
+        proc, Origin(), root->appendNew<Const32Value>(proc, Origin(), 0));
+    root->appendNew<Value>(proc, Jump, Origin());
+    root->setSuccessors(header);
+
+    // if (!index), so only the first iteration takes the exiting block.
+    Value* index = header->appendNew<Value>(proc, Phi, Int32, Origin());
+    initialIndex->setPhi(index);
+    header->appendNew<Value>(
+        proc, Branch, Origin(),
+        header->appendNew<Value>(
+            proc, Equal, Origin(), index,
+            header->appendNew<Const32Value>(proc, Origin(), 0)));
+    header->setSuccessors(exiting, body);
+
+    Effects effects = Effects::none();
+    effects.exitsSideways = true;
+    effects.reads = HeapRange::top();
+    exiting->appendNew<CCallValue>(
+        proc, Void, Origin(), effects,
+        exiting->appendNew<ConstPtrValue>(proc, Origin(), tagCFunction<OperationPtrTag>(noOpFunction)));
+    UpsilonValue* indexAfterExiting = exiting->appendNew<UpsilonValue>(
+        proc, Origin(),
+        exiting->appendNew<Value>(
+            proc, Add, Origin(), index,
+            exiting->appendNew<Const32Value>(proc, Origin(), 1)));
+    indexAfterExiting->setPhi(index);
+    exiting->appendNew<Value>(proc, Jump, Origin());
+    exiting->setSuccessors(header);
+
+    effects = Effects::none();
+    effects.controlDependent = true;
+    Value* one = body->appendNew<CCallValue>(
+        proc, Int32, Origin(), effects,
+        body->appendNew<ConstPtrValue>(proc, Origin(), tagCFunction<OperationPtrTag>(oneFunction)),
+        callCountArgument);
+
+    Value* nextIndex = body->appendNew<Value>(proc, Add, Origin(), index, one);
+    UpsilonValue* loopIndex = body->appendNew<UpsilonValue>(proc, Origin(), nextIndex);
+    loopIndex->setPhi(index);
+    body->appendNew<Value>(
+        proc, Branch, Origin(),
+        body->appendNew<Value>(
+            proc, LessThan, Origin(), nextIndex,
+            body->appendNew<Const32Value>(proc, Origin(), 100)));
+    body->setSuccessors(header, end);
+
+    end->appendNew<Value>(proc, Return, Origin());
+
+    unsigned callCount = 0;
+    compileAndRun<void>(proc, &callCount);
+    CHECK_EQ(callCount, 99u);
+}
+
 void testLICMReadsPinnedWritesPinned()
 {
     Procedure proc;


### PR DESCRIPTION
#### a5fa580c849f0d81096e8650be79392ae1517f59
<pre>
[JSC] B3::hoistLoopInvariantValues should be better at handling interference between control dependence and side exits
<a href="https://bugs.webkit.org/show_bug.cgi?id=174763">https://bugs.webkit.org/show_bug.cgi?id=174763</a>
<a href="https://rdar.apple.com/185360182">rdar://185360182</a>

Reviewed by Keith Miller.

This patch extends B3&apos;s LICM to handle trapping loads. Currently we were
really conservative: we gave up when the value traps. But we can handle
these control-dependent trapping loads,

1. Since we are already ensuring that pre-header is backward-dominated
   by the current block, this ensures that when value is executed,
   pre-header must be executed before as well.
2. If we do not find any different traps between the pre-header and this
   value in the current block, then this trap is the first one. Hoisting
   it to the pre-header and trapping early is totally fine since there
   is no other traps we may observe first.

Test: JSTests/wasm/stress/licm-trapping-load-in-try.js

* JSTests/wasm/stress/licm-trapping-load-in-try.js: Added.
(async test):
* Source/JavaScriptCore/b3/B3Effects.h:
(JSC::B3::Effects::isWrite const):
(JSC::B3::Effects::isTrapBarrier const):
(JSC::B3::Effects::mustExecute const):
* Source/JavaScriptCore/b3/B3HoistLoopInvariantValues.cpp:
(JSC::B3::isTrappingLoad):
(JSC::B3::isReachedWithoutTrapBarrier):
(JSC::B3::hoistLoopInvariantValues):
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testLICMControlDependentSideExitInPredecessor):
(testLICMControlDependentSideExitInEarlierIteration):

Canonical link: <a href="https://commits.webkit.org/319502@main">https://commits.webkit.org/319502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1c4b35ee74b8d91cda7612b508f56c75ef2d039

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191888 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145993 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/97cf70e4-e097-4866-b8be-594243901cac) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141799 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cdf6153c-ad5d-4f89-a6c1-11874bf682e8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45487 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122236 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d92b878e-16b2-42e5-a307-c3f3a508adde) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44170 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42442 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4204 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11017 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154570 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42075 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3050 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42943 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48242 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193815 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55281 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151209 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55970 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150912 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27590 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45494 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128253 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123945 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54483 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17071 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53865 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53930 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->