### PR TITLE
REGRESSION(318622@main)[Tools][JSC]: test262 runner not longer honors the env var NUMBER_OF_PROCESSORS

### DIFF
--- a/Tools/Scripts/test262/runner.py
+++ b/Tools/Scripts/test262/runner.py
@@ -51,6 +51,7 @@ for _lib_path in (str(_SCRIPTS_DIR), str(_SCRIPTS_DIR / "libraries" / "webkitcor
         sys.path.insert(0, _lib_path)
 
 from webkitcorepy import TaskPool, Version  # noqa: E402
+from webkitpy.common.system.executive import Executive  # noqa: E402
 from webkitpy.common.system.filesystem import FileSystem  # noqa: E402
 from webkitpy.common.system.platforminfo import PlatformInfo  # noqa: E402
 from webkitpy.common.webkit_finder import WebKitFinder  # noqa: E402
@@ -1268,7 +1269,7 @@ def main() -> None:
         )
 
     # --- Process count ---
-    num_processes = args.child_processes or os.cpu_count() or 1
+    num_processes = args.child_processes or Executive().cpu_count() or 1
 
     # --- Print settings ---
     print(f"\nSettings:")

--- a/Tools/Scripts/test262/runner_unittest.py
+++ b/Tools/Scripts/test262/runner_unittest.py
@@ -30,6 +30,7 @@
 import contextlib
 import io
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -1128,10 +1129,10 @@ class TestEndToEnd(unittest.TestCase):
             yaml.dump(contents, f)
         return path
 
-    def _run(self, *extra_args):
+    def _run(self, *extra_args, child_processes=("-p", "1")):
         argv = [
             "test262-runner",
-            "-p", "1",
+            *child_processes,
             "--release",
             "--no-progress",
             "--jsc", self.jsc,
@@ -1232,6 +1233,22 @@ class TestEndToEnd(unittest.TestCase):
                 "test/failing.js": {"default": 3, "strict mode": 3},
             },
         )
+
+    def _child_processes(self, number_of_processors, *extra_args):
+        with mock.patch.dict(os.environ, {"NUMBER_OF_PROCESSORS": number_of_processors}):
+            code, out = self._run("-i", "-x", "-o", "test/passing.js", *extra_args, child_processes=())
+        self.assertEqual(code, 0)
+        match = re.search(r"^Child Processes: (\d+)$", out, re.MULTILINE)
+        self.assertIsNotNone(match, out)
+        return int(match.group(1))
+
+    def test_number_of_processors_is_honored(self):
+        # Linux CI bots cap the parallelism of each container with this env var. Ensure it is honored.
+        self.assertEqual(self._child_processes("3"), 3)
+        self.assertEqual(self._child_processes("5"), 5)
+
+    def test_child_processes_option_overrides_number_of_processors(self):
+        self.assertEqual(self._child_processes("3", "-p", "1"), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### 1a924f4dcb18e148f2a73b9816e06c9b39f27b2b
<pre>
REGRESSION(318622@main)[Tools][JSC]: test262 runner not longer honors the env var NUMBER_OF_PROCESSORS
<a href="https://bugs.webkit.org/show_bug.cgi?id=322138">https://bugs.webkit.org/show_bug.cgi?id=322138</a>

Reviewed by Nikolas Zimmermann.

Since 318622@main rewrote the test262 runner script from perl to python,
the env var NUMBER_OF_PROCESSORS is not longer honored.

We use this env var on the CI extensively to tell the WebKit tooling
how much parellelism it can use on each bot container.

Fix that by calling cpu_count() from the webkitpy executive class.

* Tools/Scripts/test262/runner.py:
(main):
* Tools/Scripts/test262/runner_unittest.py:
(TestEndToEnd._run):
(TestEndToEnd._child_processes):
(TestEndToEnd):
(TestEndToEnd.test_number_of_processors_is_honored):
(TestEndToEnd.test_child_processes_option_overrides_number_of_processors):

Canonical link: <a href="https://commits.webkit.org/319491@main">https://commits.webkit.org/319491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5c73ace992f39ee838f96049d1c25931bc1bc62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191849 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/145952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55293 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/145952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184580 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122198 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3011 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193776 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55242 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55931 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150873 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27582 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45455 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123904 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54444 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54065 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->