### PR TITLE
Make NetworkProcess a singleton again

### DIFF
--- a/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
+++ b/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
@@ -40,12 +40,6 @@ public:
     }
 };
 
-template<>
-void initializeAuxiliaryProcess<NetworkProcess>(AuxiliaryProcessInitializationParameters&& parameters)
-{
-    static NeverDestroyed<Ref<NetworkProcess>> networkProcess = NetworkProcess::create(WTF::move(parameters));
-}
-
 extern "C" WK_EXPORT void NETWORK_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializerMessage);
 
 void NETWORK_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializerMessage)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -99,6 +99,7 @@
 #include <algorithm>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/OptionSet.h>
 #include <wtf/ProcessPrivilege.h>
 #include <wtf/RunLoop.h>
@@ -171,12 +172,13 @@ static void callExitSoon(IPC::Connection*)
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkProcess);
 
-Ref<NetworkProcess> NetworkProcess::create(AuxiliaryProcessInitializationParameters&& parameters)
+NetworkProcess& NetworkProcess::singleton()
 {
-    return adoptRef(*new NetworkProcess(WTF::move(parameters)));
+    static NeverDestroyed<Ref<NetworkProcess>> networkProcess = adoptRef(*new NetworkProcess);
+    return networkProcess.get().get();
 }
 
-NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parameters)
+NetworkProcess::NetworkProcess()
     : m_downloadManager(*this)
 #if HAVE(LSDATABASECONTEXT)
     , m_launchServicesDatabaseObserver(LaunchServicesDatabaseObserver::create())
@@ -208,8 +210,6 @@ NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parame
         for (auto& webProcessConnection : weakThis->m_webProcessConnections.values())
             webProcessConnection->setOnLineState(isOnLine);
     });
-
-    initialize(WTF::move(parameters));
 }
 
 NetworkProcess::~NetworkProcess() = default;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -161,7 +161,7 @@ public:
     using DomainInNeedOfStorageAccess = WebCore::RegistrableDomain;
     using OpenerDomain = WebCore::RegistrableDomain;
 
-    static Ref<NetworkProcess> create(AuxiliaryProcessInitializationParameters&&);
+    static NetworkProcess& singleton();
     ~NetworkProcess();
     static constexpr WTF::AuxiliaryProcessType processType = WTF::AuxiliaryProcessType::Network;
 
@@ -514,7 +514,7 @@ public:
 #endif
 
 private:
-    explicit NetworkProcess(AuxiliaryProcessInitializationParameters&&);
+    NetworkProcess();
 
     void platformInitializeNetworkProcess(const NetworkProcessCreationParameters&);
 

--- a/Source/WebKit/NetworkProcess/curl/NetworkProcessMainCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkProcessMainCurl.cpp
@@ -32,16 +32,16 @@
 
 namespace WebKit {
 
-class NetworkProcessMainCurl final: public AuxiliaryProcessMainBaseNoSingleton<NetworkProcess> {
+class NetworkProcessMainCurl final: public AuxiliaryProcessMainBase<NetworkProcess> {
 public:
     void platformFinalize() override
     {
         Vector<PAL::SessionID> sessionIDs;
-        process().forEachNetworkSession([&sessionIDs](auto& session) {
+        NetworkProcess::singleton().forEachNetworkSession([&sessionIDs](auto& session) {
             sessionIDs.append(session.sessionID());
         });
         for (auto& sessionID : sessionIDs)
-            process().destroySession(sessionID);
+            NetworkProcess::singleton().destroySession(sessionID);
     }
 };
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp
@@ -38,7 +38,7 @@
 
 namespace WebKit {
 
-class NetworkProcessMainSoup final: public AuxiliaryProcessMainBaseNoSingleton<NetworkProcess> {
+class NetworkProcessMainSoup final: public AuxiliaryProcessMainBase<NetworkProcess> {
 public:
     bool platformInitialize() override
     {
@@ -53,11 +53,11 @@ public:
         // Needed to destroy the SoupSession and SoupCookieJar, e.g. to avoid
         // leaking SQLite temporary journaling files.
         Vector<PAL::SessionID> sessionIDs;
-        process().forEachNetworkSession([&sessionIDs](auto& session) {
+        NetworkProcess::singleton().forEachNetworkSession([&sessionIDs](auto& session) {
             sessionIDs.append(session.sessionID());
         });
         for (auto& sessionID : sessionIDs)
-            process().destroySession(sessionID);
+            NetworkProcess::singleton().destroySession(sessionID);
     }
 };
 

--- a/Source/WebKit/Shared/AuxiliaryProcessMain.h
+++ b/Source/WebKit/Shared/AuxiliaryProcessMain.h
@@ -45,7 +45,7 @@ protected:
     AuxiliaryProcessInitializationParameters m_parameters;
 };
 
-template<typename AuxiliaryProcessType, bool HasSingleton = true>
+template<typename AuxiliaryProcessType>
 class AuxiliaryProcessMainBase : public AuxiliaryProcessMainCommon {
 public:
     virtual bool platformInitialize() { return true; }
@@ -53,8 +53,7 @@ public:
 
     virtual void initializeAuxiliaryProcess(AuxiliaryProcessInitializationParameters&& parameters)
     {
-        if constexpr (HasSingleton)
-            AuxiliaryProcessType::singleton().initialize(WTF::move(parameters));
+        AuxiliaryProcessType::singleton().initialize(WTF::move(parameters));
     }
 
     int run(int argc, char** argv)
@@ -79,20 +78,6 @@ public:
 
         return EXIT_SUCCESS;
     }
-};
-
-template<typename AuxiliaryProcessType>
-class AuxiliaryProcessMainBaseNoSingleton : public AuxiliaryProcessMainBase<AuxiliaryProcessType, false> {
-public:
-    AuxiliaryProcessType& process() { return *m_process; };
-
-    void initializeAuxiliaryProcess(AuxiliaryProcessInitializationParameters&& parameters) override
-    {
-        m_process = AuxiliaryProcessType::create(WTF::move(parameters));
-    }
-
-protected:
-    RefPtr<AuxiliaryProcessType> m_process;
 };
 
 template<typename AuxiliaryProcessMainType>


### PR DESCRIPTION
#### fc6a7726a210ddc669a001d258ccd0f5f466a2bd
<pre>
Make NetworkProcess a singleton again
<a href="https://bugs.webkit.org/show_bug.cgi?id=322141">https://bugs.webkit.org/show_bug.cgi?id=322141</a>
<a href="https://rdar.apple.com/185364481">rdar://185364481</a>

Reviewed by Basuke Suzuki.

It was made a non-singleton as part of an experiment several years ago that never came to anything.
Make it a singleton like WebProcess and GPUProcess.
This will allow us to remove the Ref&lt;NetworkProcess&gt; members on many objects.

* Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm:
(WebKit::initializeAuxiliaryProcess&lt;NetworkProcess&gt;): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::singleton):
(WebKit::NetworkProcess::NetworkProcess):
(WebKit::NetworkProcess::create): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/curl/NetworkProcessMainCurl.cpp:
* Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp:
* Source/WebKit/Shared/AuxiliaryProcessMain.h:
(WebKit::AuxiliaryProcessMainBase::initializeAuxiliaryProcess):
(WebKit::AuxiliaryProcessMainBaseNoSingleton::process): Deleted.
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/319714@main">https://commits.webkit.org/319714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dc1995a7901ee2549367d721d2136ce1fd3eb8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145954 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37165962-b2bc-493c-8f96-a67f0a264ab4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141767 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98409 "8 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af8312c5-a532-4426-b1cf-f8281e473716) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122204 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1967eb68-e93a-46ba-a98d-de867e288136) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44133 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42408 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42043 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3013 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193778 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55244 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151175 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55933 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150877 "Passed tests") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/27723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45458 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128216 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123906 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54446 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17038 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53828 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54067 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53893 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->