### PR TITLE
[JSC] Use StringSwitch with resolved rope strings in FTL

### DIFF
--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -23849,12 +23849,16 @@ IGNORE_CLANG_WARNINGS_END
             return;
         }
 
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+
         LBasicBlock hasImplBlock = m_out.newBlock();
         LBasicBlock is8BitBlock = m_out.newBlock();
         LBasicBlock isRopeBlock = m_out.newBlock();
         LBasicBlock isSubstringBlock = m_out.newBlock();
         LBasicBlock substringBlock = m_out.newBlock();
         LBasicBlock concatRopeBlock = m_out.newBlock();
+        LBasicBlock resolveConcatRopeBlock = m_out.newBlock();
+        LBasicBlock resolvedConcatRopeBlock = m_out.newBlock();
         LBasicBlock binarySwitchBlock = m_out.newBlock();
         LBasicBlock slowBlock = m_out.newBlock();
 
@@ -23904,18 +23908,27 @@ IGNORE_CLANG_WARNINGS_END
         ValueFromBlock substringLength = m_out.anchor(m_out.load32NonNegative(string, m_heaps.JSRopeString_length));
         m_out.jump(binarySwitchBlock);
 
-        m_out.appendTo(concatRopeBlock, binarySwitchBlock);
+        m_out.appendTo(concatRopeBlock, resolveConcatRopeBlock);
         const UnlinkedStringJumpTable& unlinkedTable = m_graph.unlinkedStringSwitchJumpTable(data->switchTableIndex);
         LValue ropeLength;
         if (auto stringLength = tryGetConstantStringLength(edge))
             ropeLength = m_out.constInt32(*stringLength);
         else
             ropeLength = m_out.load32NonNegative(string, m_heaps.JSRopeString_length);
-        m_out.branch(m_out.belowOrEqual(m_out.sub(ropeLength, m_out.constInt32(unlinkedTable.minLength())), m_out.constInt32(unlinkedTable.maxLength() - unlinkedTable.minLength())), unsure(slowBlock), unsure(lowBlock(data->fallThrough.block)));
+        m_out.branch(m_out.belowOrEqual(m_out.sub(ropeLength, m_out.constInt32(unlinkedTable.minLength())), m_out.constInt32(unlinkedTable.maxLength() - unlinkedTable.minLength())), unsure(resolveConcatRopeBlock), unsure(lowBlock(data->fallThrough.block)));
+
+        m_out.appendTo(resolveConcatRopeBlock, resolvedConcatRopeBlock);
+        LValue resolvedRopeCharacters = vmCall(pointerType(), operationSwitchStringResolveRopeAndGetCharacters8, weakPointer(globalObject), string);
+        m_out.branch(m_out.isNull(resolvedRopeCharacters), rarely(slowBlock), usually(resolvedConcatRopeBlock));
+
+        m_out.appendTo(resolvedConcatRopeBlock, binarySwitchBlock);
+        ValueFromBlock resolvedRopeBuffer = m_out.anchor(resolvedRopeCharacters);
+        ValueFromBlock resolvedRopeLength = m_out.anchor(ropeLength);
+        m_out.jump(binarySwitchBlock);
 
         m_out.appendTo(binarySwitchBlock, slowBlock);
-        LValue buffer = m_out.phi(pointerType(), resolvedBuffer, substringBuffer);
-        LValue switchLength = m_out.phi(Int32, resolvedLength, substringLength);
+        LValue buffer = m_out.phi(pointerType(), resolvedBuffer, substringBuffer, resolvedRopeBuffer);
+        LValue switchLength = m_out.phi(Int32, resolvedLength, substringLength, resolvedRopeLength);
 
         // FIXME: We should propagate branch weight data to the cases of this switch.
         // https://bugs.webkit.org/show_bug.cgi?id=144368

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -922,6 +922,21 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationSwitchStringAndGetIndex, UCPUStrictIn
     return toUCPUStrictInt32(unlinkedTable->indexForValue(str->impl(), std::numeric_limits<unsigned>::max()));
 }
 
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationSwitchStringResolveRopeAndGetCharacters8, const Latin1Character*, (JSGlobalObject* globalObject, JSString* string))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    // We intentionally use tryGetValue here instead of value() function not to throw OOM error.
+    // When failing, we will just return a nullptr, and going to the slow path.
+    auto value = string->tryGetValue();
+    StringImpl* impl = value.data.impl();
+    if (!impl || !impl->is8Bit())
+        return nullptr;
+    return impl->span8().data();
+}
+
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationTypeOfObjectAsTypeofType, UCPUStrictInt32, (JSGlobalObject* globalObject, JSCell* object))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/ftl/FTLOperations.h
+++ b/Source/JavaScriptCore/ftl/FTLOperations.h
@@ -45,6 +45,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobal
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompileFTLLazySlowPath, void*, (CallFrame*, unsigned));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationSwitchStringAndGetIndex, UCPUStrictInt32, (JSGlobalObject*, const UnlinkedStringJumpTable*, JSString*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationSwitchStringResolveRopeAndGetCharacters8, const Latin1Character*, (JSGlobalObject*, JSString*));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationTypeOfObjectAsTypeofType, UCPUStrictInt32, (JSGlobalObject*, JSCell*));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationReportBoundsCheckEliminationErrorAndCrash, void, (intptr_t codeBlockAsIntPtr, int32_t, int32_t, int32_t, int32_t, int32_t));


### PR DESCRIPTION
#### 6fbae40455e736badcdd2f44b6062460668866cb
<pre>
[JSC] Use StringSwitch with resolved rope strings in FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=322144">https://bugs.webkit.org/show_bug.cgi?id=322144</a>
<a href="https://rdar.apple.com/185366501">rdar://185366501</a>

Reviewed by Yijia Huang.

FTL StringSwitch is really efficient for non atom strings, so let&apos;s use
it even for resolved rope strings. When we encounter a rope string, we
call a function and resolve them. If it is 8bit string, then returning a
data pointer so that we can use FTL StringSwitch with it.

* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/ftl/FTLOperations.h:

Canonical link: <a href="https://commits.webkit.org/319501@main">https://commits.webkit.org/319501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ee30fb933689eb25f9e0e04b2f0703d451e19ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55625 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191902 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6144556b-b104-49b1-87fd-1f074406632d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55346 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42eef22c-057c-49fc-9945-e72980e26928) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184633 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122244 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29c60cae-7f6f-4666-8b12-dc4ff9105c0d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44181 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4212 "Passed tests") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/11031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3064 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42957 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48256 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193829 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55295 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55984 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150924 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27589 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/45508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128267 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123962 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54497 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53879 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54118 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53944 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->