### PR TITLE
marketwatch.com: "Subscribe now" drop-down does not render anything

### DIFF
--- a/LayoutTests/fast/dynamic/display-none-iframe-async-layout-expected.html
+++ b/LayoutTests/fast/dynamic/display-none-iframe-async-layout-expected.html
@@ -1,1 +1,1 @@
-<iframe style="border: none;" srcdoc="some content"></iframe><pre>40</pre>
+<iframe style="border: none;" srcdoc="some content"></iframe><pre>0</pre>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-ancestor-does-not-cancel-subframe-animations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-ancestor-does-not-cancel-subframe-animations-expected.txt
@@ -1,0 +1,6 @@
+
+
+
+PASS Changing an ancestor's display type does not restart animations inside a subframe
+PASS Hiding and showing an ancestor does not restart animations inside a subframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-ancestor-does-not-cancel-subframe-animations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-ancestor-does-not-cancel-subframe-animations.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Changing an ancestor's display does not restart animations inside a subframe</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#animations">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.wrapper {
+  display: block;
+  width: 320px;
+}
+iframe {
+  width: 300px;
+  height: 70px;
+  border: 0;
+}
+</style>
+<body>
+<!--
+  A subframe's content lives in its own document, so its animations are not applied to a descendant of
+  anything in this document. Changing the display of an ancestor here must not terminate them, whether
+  the ancestor merely changes display type or is hidden outright. Compare
+  display-none-prevents-starting-in-subtree.html, which covers the same rule within one document.
+-->
+<div class="wrapper" id="displayTypeWrapper">
+  <iframe id="displayTypeFrame" srcdoc="
+    <style>
+      @keyframes slide {
+        from { transform: translateX(0px) }
+        to { transform: translateX(240px) }
+      }
+      #animated {
+        width: 50px;
+        height: 50px;
+        background: green;
+        animation: slide 10s linear infinite;
+      }
+      body { margin: 0 }
+    </style>
+    <div id='animated'></div>
+  "></iframe>
+</div>
+
+<div class="wrapper" id="hiddenWrapper">
+  <iframe id="hiddenFrame" srcdoc="
+    <style>
+      @keyframes slide {
+        from { transform: translateX(0px) }
+        to { transform: translateX(240px) }
+      }
+      #animated {
+        width: 50px;
+        height: 50px;
+        background: green;
+        animation: slide 10s linear infinite;
+      }
+      body { margin: 0 }
+    </style>
+    <div id='animated'></div>
+  "></iframe>
+</div>
+
+<script>
+const loaded = new Promise(resolve => addEventListener("load", resolve));
+
+// Seek far enough into the animation that a restart is unmistakable.
+const seekTime = 500;
+
+function seekAnimationIn(frameId) {
+  const contentDocument = document.getElementById(frameId).contentDocument;
+  const animations = contentDocument.getAnimations();
+  assert_equals(animations.length, 1, "subframe should have exactly one animation");
+  animations[0].currentTime = seekTime;
+  return animations[0];
+}
+
+// Reading a layout property flushes style and the render tree update, which is where a subframe's
+// render tree would be torn down.
+function flushRenderTreeUpdate() {
+  document.body.offsetHeight;
+}
+
+promise_test(async () => {
+  await loaded;
+  const animation = seekAnimationIn("displayTypeFrame");
+
+  document.getElementById("displayTypeWrapper").style.display = "inline-block";
+  flushRenderTreeUpdate();
+
+  assert_not_equals(animation.playState, "idle", "animation must not be canceled");
+  assert_greater_than_equal(animation.currentTime, seekTime, "animation must not restart");
+}, "Changing an ancestor's display type does not restart animations inside a subframe");
+
+promise_test(async () => {
+  await loaded;
+  const animation = seekAnimationIn("hiddenFrame");
+
+  const wrapper = document.getElementById("hiddenWrapper");
+  wrapper.style.display = "none";
+  flushRenderTreeUpdate();
+  wrapper.style.display = "block";
+  flushRenderTreeUpdate();
+
+  assert_not_equals(animation.playState, "idle", "animation must not be canceled");
+  assert_greater_than_equal(animation.currentTime, seekTime, "animation must not restart");
+}, "Hiding and showing an ancestor does not restart animations inside a subframe");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-in-subframe-reflects-owner-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-in-subframe-reflects-owner-document-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Hiding an ancestor of the frame is reflected in a resolved value read from inside it
+PASS Displaying an ancestor of the frame is reflected in a resolved value read from inside it
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-in-subframe-reflects-owner-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-in-subframe-reflects-owner-document.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>A resolved value in a subframe reflects a pending display change in the owner document</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#resolved-values">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.wrapper { width: 320px; }
+.wrapper iframe { width: 300px; height: 100px; border: 0; }
+#toShowWrapper { display: none; }
+</style>
+<body>
+<!--
+  Whether a subframe's contents generate boxes depends on the frame's owner element in the parent
+  document, so a resolved value read from the subframe depends on style the parent has not resolved yet.
+  #box has no width of its own, so its computed value is "auto" while its used value is a length, which
+  is what makes it possible to tell which one was returned.
+
+  Each test asserts that a value read straight after the mutation matches the one read once everything
+  has settled, rather than asserting particular values, so nothing here depends on scrollbar widths or
+  on which fallback an implementation reports.
+-->
+<div class="wrapper" id="toHideWrapper"><iframe></iframe></div>
+<div class="wrapper" id="toShowWrapper"><iframe></iframe></div>
+
+<script>
+const frameMarkup = "<style>body { margin: 0 }</style><div id='box' style='height: 40px'></div>";
+
+function boxIn(wrapperId)
+{
+    return document.getElementById(wrapperId).querySelector("iframe").contentDocument.getElementById("box");
+}
+
+function widthOf(wrapperId)
+{
+    return getComputedStyle(boxIn(wrapperId)).width;
+}
+
+// Resolves style and layout in this document, which is what settles whether the frame's owner element
+// generates a box.
+function settleThisDocument()
+{
+    document.documentElement.offsetHeight;
+}
+
+function loadFrames()
+{
+    return Promise.all(Array.from(document.querySelectorAll("iframe"), frame => {
+        return new Promise(resolve => {
+            frame.addEventListener("load", resolve, { once: true });
+            frame.srcdoc = frameMarkup;
+        });
+    }));
+}
+
+promise_setup(loadFrames);
+
+promise_test(async () => {
+    // Displayed, everything settled: a used value, so a length rather than "auto".
+    const beforeHiding = widthOf("toHideWrapper");
+    assert_not_equals(beforeHiding, "auto", "a displayed frame should report a used value");
+
+    document.getElementById("toHideWrapper").style.display = "none";
+    const unsettled = widthOf("toHideWrapper");
+
+    settleThisDocument();
+    assert_equals(unsettled, widthOf("toHideWrapper"),
+        "value read straight after hiding the ancestor should match the settled value");
+}, "Hiding an ancestor of the frame is reflected in a resolved value read from inside it");
+
+promise_test(async () => {
+    document.getElementById("toShowWrapper").style.display = "block";
+    const unsettled = widthOf("toShowWrapper");
+
+    settleThisDocument();
+    const settled = widthOf("toShowWrapper");
+
+    assert_not_equals(settled, "auto", "a displayed frame should report a used value");
+    assert_equals(unsettled, settled,
+        "value read straight after displaying the ancestor should match the settled value");
+}, "Displaying an ancestor of the frame is reflected in a resolved value read from inside it");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-animated-to-none-content-not-laid-out-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-animated-to-none-content-not-laid-out-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Subframe content is not laid out when the frame's own display animates to none
+PASS Subframe content is not laid out when an ancestor's display animates to none
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-animated-to-none-content-not-laid-out.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-animated-to-none-content-not-laid-out.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Subframe content is not laid out when display reaches none through an animation</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.wrapper {
+  display: block;
+  width: 320px;
+}
+iframe {
+  width: 300px;
+  height: 80px;
+  border: 0;
+}
+</style>
+<body>
+<!--
+  Reaching display:none through an animation must suppress the subframe's content the same way a plain
+  display:none does. An implementation that decides this from the kind of render tree teardown in
+  progress can miss it, because an animated removal is indistinguishable from a renderer being
+  replaced.
+-->
+<div class="wrapper">
+  <iframe id="selfFrame" srcdoc="
+    <style>
+      body { margin: 0 }
+      #box {
+        width: 250px;
+        height: 40px;
+      }
+    </style>
+    <div id='box'></div>
+  "></iframe>
+</div>
+
+<div class="wrapper" id="ancestorWrapper">
+  <iframe id="ancestorFrame" srcdoc="
+    <style>
+      body { margin: 0 }
+      #box {
+        width: 250px;
+        height: 40px;
+      }
+    </style>
+    <div id='box'></div>
+  "></iframe>
+</div>
+
+<script>
+const loaded = new Promise(resolve => addEventListener("load", resolve));
+
+function boxRectIn(frameId) {
+  const contentDocument = document.getElementById(frameId).contentDocument;
+  return contentDocument.getElementById("box").getBoundingClientRect();
+}
+
+// Reaching display:none through an animation, jumped to its end so no time passes. The forwards fill
+// keeps the animation affecting display after it has finished.
+function hideByAnimatingDisplay(element) {
+  element.animate([{ display: "block" }, { display: "none" }],
+    { duration: 1000, fill: "forwards" }).finish();
+}
+
+// Reading a layout property flushes style and the render tree update.
+function flushParent() {
+  document.body.offsetHeight;
+}
+
+promise_test(async () => {
+  await loaded;
+  const frame = document.getElementById("selfFrame");
+  assert_equals(boxRectIn("selfFrame").width, 250, "subframe content should start out laid out");
+
+  hideByAnimatingDisplay(frame);
+  flushParent();
+
+  const rect = boxRectIn("selfFrame");
+  assert_equals(rect.width, 0, "width once the frame's display animates to none");
+  assert_equals(rect.height, 0, "height once the frame's display animates to none");
+}, "Subframe content is not laid out when the frame's own display animates to none");
+
+promise_test(async () => {
+  await loaded;
+  assert_equals(boxRectIn("ancestorFrame").width, 250, "subframe content should start out laid out");
+
+  hideByAnimatingDisplay(document.getElementById("ancestorWrapper"));
+  flushParent();
+
+  const rect = boxRectIn("ancestorFrame");
+  assert_equals(rect.width, 0, "width once the ancestor's display animates to none");
+  assert_equals(rect.height, 0, "height once the ancestor's display animates to none");
+}, "Subframe content is not laid out when an ancestor's display animates to none");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Subframe content inside a display:none ancestor reports no geometry until displayed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Content of a display:none iframe is not laid out until the frame is displayed</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+#hidden {
+  display: none;
+  width: 300px;
+}
+#hidden iframe {
+  width: 0;
+  height: 0;
+  border: 0;
+}
+</style>
+<body>
+<div id="hidden">
+  <iframe id="frame" srcdoc="<!doctype html><body style='margin: 0'><div id='box' style='font: 20px/1 Ahem; width: 100px; height: 40px'>X</div></body>"></iframe>
+</div>
+<script>
+function boxRect() {
+  const contentDocument = document.getElementById("frame").contentDocument;
+  return contentDocument.getElementById("box").getBoundingClientRect();
+}
+
+promise_test(async () => {
+  await new Promise(resolve => addEventListener("load", resolve));
+
+  const whileHidden = boxRect();
+  assert_equals(whileHidden.width, 0, "width while the ancestor is display:none");
+  assert_equals(whileHidden.height, 0, "height while the ancestor is display:none");
+
+  document.getElementById("hidden").style.display = "block";
+
+  const whenShown = boxRect();
+  assert_equals(whenShown.width, 100, "width once the ancestor is displayed");
+  assert_equals(whenShown.height, 40, "height once the ancestor is displayed");
+}, "Subframe content inside a display:none ancestor reports no geometry until displayed");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-preserves-content-scroll-offset.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-preserves-content-scroll-offset.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+
+
+PASS Hiding and showing an ancestor preserves a subframe's scroll offset
+PASS Reading a subframe's scroll offset while an ancestor is hidden does not reset it
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-preserves-content-scroll-offset.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-preserves-content-scroll-offset.tentative.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Hiding and showing an ancestor preserves a subframe's scroll offset</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.wrapper {
+  display: block;
+  width: 320px;
+}
+iframe {
+  width: 300px;
+  height: 100px;
+  border: 0;
+}
+</style>
+<body>
+<!--
+  Tentative: no specification says what happens to a subframe's scroll offset while its frame is not
+  rendered. An implementation that drops the content render tree while the frame is hidden must not let
+  the resulting empty layout clamp the offset away, otherwise showing the frame again silently scrolls
+  its content back to the top.
+-->
+<div class="wrapper" id="delayedWrapper">
+  <iframe id="delayedFrame" srcdoc="
+    <style>
+      body { margin: 0 }
+      #tall {
+        width: 100px;
+        height: 2000px;
+      }
+    </style>
+    <div id='tall'></div>
+  "></iframe>
+</div>
+
+<div class="wrapper" id="probedWrapper">
+  <iframe id="probedFrame" srcdoc="
+    <style>
+      body { margin: 0 }
+      #tall {
+        width: 100px;
+        height: 2000px;
+      }
+    </style>
+    <div id='tall'></div>
+  "></iframe>
+</div>
+
+<script>
+const loaded = new Promise(resolve => addEventListener("load", resolve));
+const targetOffset = 500;
+
+// Reading a layout property flushes style and the render tree update, which is where a subframe's
+// render tree is torn down or rebuilt.
+function flushParent() {
+  document.body.offsetHeight;
+}
+
+function flushSubframe(frame) {
+  frame.contentDocument.documentElement.offsetHeight;
+}
+
+function scrollSubframeToTarget(frame) {
+  flushSubframe(frame);
+  frame.contentWindow.scrollTo(0, targetOffset);
+  flushSubframe(frame);
+  assert_equals(frame.contentWindow.scrollY, targetOffset, "subframe should start out scrolled");
+}
+
+function nextFrame() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+promise_test(async () => {
+  await loaded;
+  const frame = document.getElementById("delayedFrame");
+  scrollSubframeToTarget(frame);
+
+  const wrapper = document.getElementById("delayedWrapper");
+  wrapper.style.display = "none";
+  flushParent();
+
+  // Give any layout scheduled by hiding the frame a chance to run.
+  await nextFrame();
+  await nextFrame();
+
+  wrapper.style.display = "block";
+  flushParent();
+  flushSubframe(frame);
+
+  assert_equals(frame.contentWindow.scrollY, targetOffset);
+}, "Hiding and showing an ancestor preserves a subframe's scroll offset");
+
+promise_test(async () => {
+  await loaded;
+  const frame = document.getElementById("probedFrame");
+  scrollSubframeToTarget(frame);
+
+  const wrapper = document.getElementById("probedWrapper");
+  wrapper.style.display = "none";
+  flushParent();
+
+  // Reading the offset while the frame is hidden runs layout in the content document, which is the
+  // synchronous version of the same hazard.
+  assert_equals(frame.contentWindow.scrollY, targetOffset, "offset while the ancestor is hidden");
+
+  wrapper.style.display = "block";
+  flushParent();
+  flushSubframe(frame);
+
+  assert_equals(frame.contentWindow.scrollY, targetOffset, "offset once the ancestor is shown again");
+}, "Reading a subframe's scroll offset while an ancestor is hidden does not reset it");
+</script>
+</body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3008,6 +3008,12 @@ bool Document::updateStyleIfNeeded()
         if (!frameView || frameView->layoutContext().isInRenderTreeLayout())
             return false;
 
+        // Whether this document gets a render tree at all depends on its owner element having a
+        // renderer, so the owner documents have to resolve first. updateLayout() walks them the same
+        // way. Each one bails on its own guards above, so an owner mid-layout is left alone.
+        if (RefPtr owner = ownerElement())
+            protect(owner->document())->updateStyleIfNeeded();
+
         styleScope().flushPendingUpdate();
 
         if (!needsStyleRecalc())

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -56,7 +56,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLFrameElementBase);
 using namespace HTMLNames;
 
 HTMLFrameElementBase::HTMLFrameElementBase(const QualifiedName& tagName, Document& document)
-    : HTMLFrameOwnerElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLFrameOwnerElement(tagName, document)
 {
 }
 
@@ -196,6 +196,7 @@ void HTMLFrameElementBase::didAttachRenderers()
         if (RefPtr frame = contentFrame())
             part->setWidget(frame->virtualView());
     }
+    HTMLFrameOwnerElement::didAttachRenderers();
 }
 
 void HTMLFrameElementBase::setLocation(const String& str)

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLFrameOwnerElement);
 
 HTMLFrameOwnerElement::HTMLFrameOwnerElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> constructionType)
-    : HTMLElement(tagName, document, constructionType)
+    : HTMLElement(tagName, document, constructionType | TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -138,6 +138,17 @@ void HTMLFrameOwnerElement::scheduleInvalidateStyleAndLayerComposition()
         });
     } else
         invalidateStyleAndLayerComposition();
+}
+
+void HTMLFrameOwnerElement::didAttachRenderers()
+{
+    RefPtr contentDocument = this->contentDocument();
+    if (!contentDocument || !contentDocument->documentElement())
+        return;
+
+    RefPtr documentElement = contentDocument->documentElement();
+    if (!documentElement->renderer())
+        documentElement->invalidateStyleAndRenderersForSubtree();
 }
 
 bool HTMLFrameOwnerElement::isProhibitedSelfReference(const URL& completeURL) const

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -74,6 +74,8 @@ protected:
     bool isProhibitedSelfReference(const URL&) const;
     bool isKeyboardFocusable(const FocusEventData&) const override;
 
+    void didAttachRenderers() override;
+
 private:
     bool isHTMLFrameOwnerElement() const final { return true; }
 

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -105,7 +105,7 @@ using namespace HTMLNames;
 constexpr auto HTMLPlugInElement::pluginElementTypeFlags() -> OptionSet<TypeFlag>
 {
     using enum TypeFlag;
-    return { HasCustomStyleResolveCallbacks, HasDidMoveToNewDocument };
+    return { HasDidMoveToNewDocument };
 }
 
 HTMLPlugInElement::HTMLPlugInElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> typeFlags)

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -586,7 +586,7 @@ void LocalFrameView::setContentsSize(const IntSize& size)
 void LocalFrameView::adjustViewSize()
 {
     CheckedPtr renderView = this->renderView();
-    if (!renderView)
+    if (!renderView || !renderView->ownerFrameIsRendered())
         return;
 
     ASSERT(m_frame->view() == this);

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -175,6 +175,16 @@ bool RenderView::isChildAllowed(const RenderObject& child, const Style::Computed
     return child.isRenderBox();
 }
 
+bool RenderView::ownerFrameIsRendered() const
+{
+    // <iframe style="display: none"> makes this tree not-rendered.
+    CheckedPtr ownerElement = document().ownerElement();
+    if (!ownerElement || ownerElement->renderer())
+        return true;
+
+    return document().printing() || document().isPluginDocument();
+}
+
 void RenderView::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;
@@ -862,7 +872,7 @@ FloatSize RenderView::sizeForCSSDefaultViewportUnits() const
 
 Node* RenderView::nodeForHitTest() const
 {
-    return document().documentElement();
+    return ownerFrameIsRendered() ? document().documentElement() : nullptr;
 }
 
 void RenderView::updateHitTestResult(HitTestResult& result, const LayoutPoint& point) const

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -56,6 +56,8 @@ public:
 
     bool isChildAllowed(const RenderObject&, const Style::ComputedStyle&) const override;
 
+    bool ownerFrameIsRendered() const;
+
     void layout() override;
     void updateLogicalWidth() override;
     LogicalExtentComputedValues computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const override;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -30,6 +30,7 @@
 #include "AXObjectCache.h"
 #include "DocumentView.h"
 #include "FrameSelection.h"
+#include "HTMLFrameOwnerElement.h"
 #include "HTMLMarqueeElement.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "LegacyRenderSVGContainer.h"
@@ -194,6 +195,11 @@ RenderTreeBuilder::RenderTreeBuilder(RenderView& view)
 RenderTreeBuilder::~RenderTreeBuilder()
 {
     s_current = m_previous;
+}
+
+void RenderTreeBuilder::addFrameWithDetachedRenderer(HTMLFrameOwnerElement& frameOwner)
+{
+    m_framesWithDetachedRenderers.add(frameOwner);
 }
 
 bool RenderTreeBuilder::isRebuildRootForChildren(const RenderElement& renderer)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -27,11 +27,14 @@
 
 #include "RenderTreePosition.h"
 #include "RenderWidget.h"
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
 class RenderGrid;
 class RenderTreeUpdater;
+class HTMLFrameOwnerElement;
+class WeakPtrImplWithEventTargetData;
 
 class RenderTreeBuilder {
 public:
@@ -67,6 +70,9 @@ public:
     void updateAfterDescendants(RenderElement&);
     void destroyAndCleanUpAnonymousWrappers(RenderObject& child, const RenderElement* destroyRoot);
     void normalizeTreeAfterStyleChange(RenderElement&, Style::ComputedStyle& oldStyle);
+
+    void addFrameWithDetachedRenderer(HTMLFrameOwnerElement&);
+    const WeakHashSet<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData>& framesWithDetachedRenderers() const LIFETIME_BOUND { return m_framesWithDetachedRenderers; }
 
 private:
     static void markBoxForRelayoutAfterSplit(RenderBoxModelObject&);
@@ -150,6 +156,7 @@ private:
     IsInternalMove m_internalMovesType { IsInternalMove::No };
     TearDownType m_tearDownType { TearDownType::Root };
     CheckedPtr<const RenderElement> m_subtreeDestroyRoot;
+    WeakHashSet<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_framesWithDetachedRenderers;
     SingleThreadWeakPtr<const RenderObject> m_anonymousDestroyRoot;
 };
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -33,6 +33,7 @@
 #include "Document.h"
 #include "Element.h"
 #include "FrameSelection.h"
+#include "HTMLFrameOwnerElement.h"
 #include "HTMLSlotElement.h"
 #include "LayoutState.h"
 #include "LayoutTreeBuilder.h"
@@ -142,6 +143,8 @@ void RenderTreeUpdater::commit(std::unique_ptr<Style::Update> styleUpdate)
 
     m_builder.updateAfterDescendants(renderView());
 
+    tearDownRenderersForNonRenderedFrames();
+
     m_styleUpdate = nullptr;
 }
 
@@ -227,6 +230,8 @@ void RenderTreeUpdater::updateRebuildRoots()
 static bool shouldCreateRenderer(const Element& element, const RenderElement& parentRenderer)
 {
     if (!parentRenderer.canHaveChildren() && !(element.isPseudoElement() && parentRenderer.canHaveGeneratedChildren()))
+        return false;
+    if (CheckedPtr renderView = dynamicDowncast<RenderView>(parentRenderer); renderView && !renderView->ownerFrameIsRendered())
         return false;
     if (parentRenderer.element() && !protect(parentRenderer.element())->childShouldCreateRenderer(element))
         return false;
@@ -424,6 +429,13 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
 
     auto elementUpdateStyle = Style::ComputedStyle::cloneIncludingPseudoElements(*elementUpdate.style);
 
+    bool hasDisplayContents = elementUpdate.style->display() == Style::DisplayType::Contents;
+    bool hasDisplayNonePreventingRendererCreation = elementUpdate.style->display() == Style::DisplayType::None && !element.rendererIsNeeded(elementUpdateStyle);
+    bool hasDisplayContentsOrNone = hasDisplayContents || hasDisplayNonePreventingRendererCreation;
+
+    bool willHaveRenderer = !hasDisplayContentsOrNone && !(element.isInTopLayer() && renderTreePosition().parent().style().isSkippedRootOrSkippedContent());
+    bool rendererWillBeReplaced = willHaveRenderer && shouldCreateRenderer(element, renderTreePosition().parent()) && element.rendererIsNeeded(elementUpdateStyle);
+
     bool shouldTearDownRenderers = [&]() {
         if (element.isInTopLayer() && elementUpdate.changes.contains(Style::Change::Inherited) && elementUpdate.style->isSkippedRootOrSkippedContent())
             return true;
@@ -443,14 +455,11 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
             return TeardownType::RendererUpdate;
         }();
 
-        tearDownRenderers(element, teardownType, m_builder);
+        tearDownRenderers(element, teardownType, m_builder, rendererWillBeReplaced ? IsRendererReplacement::Yes : IsRendererReplacement::No);
 
         renderingParent().didCreateOrDestroyChildRenderer = true;
     }
 
-    bool hasDisplayContents = elementUpdate.style->display() == Style::DisplayType::Contents;
-    bool hasDisplayNonePreventingRendererCreation = elementUpdate.style->display() == Style::DisplayType::None && !element.rendererIsNeeded(elementUpdateStyle);
-    bool hasDisplayContentsOrNone = hasDisplayContents || hasDisplayNonePreventingRendererCreation;
     if (hasDisplayContentsOrNone)
         element.storeDisplayContentsOrNoneStyle(makeUnique<Style::ComputedStyle>(WTF::move(elementUpdateStyle)));
     else
@@ -473,7 +482,7 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
         }
     });
 
-    bool shouldCreateNewRenderer = !element.renderer() && !hasDisplayContentsOrNone && !(element.isInTopLayer() && renderTreePosition().parent().style().isSkippedRootOrSkippedContent());
+    bool shouldCreateNewRenderer = !element.renderer() && willHaveRenderer;
     if (shouldCreateNewRenderer) {
         if (element.hasCustomStyleResolveCallbacks())
             element.willAttachRenderers();
@@ -869,7 +878,7 @@ static std::optional<DidRepaintAndMarkContainingBlock> repaintAndMarkContainingB
 }
 
 template<RenderTreeUpdater::TeardownScope scope>
-void RenderTreeUpdater::tearDownRenderersInternal(Element& root, TeardownType teardownType, RenderTreeBuilder& builder)
+void RenderTreeUpdater::tearDownRenderersInternal(Element& root, TeardownType teardownType, RenderTreeBuilder& builder, IsRendererReplacement isRendererReplacement)
 {
     Vector<Element*, 30> teardownStack;
 
@@ -947,6 +956,15 @@ void RenderTreeUpdater::tearDownRenderersInternal(Element& root, TeardownType te
                     builder.destroyAndCleanUpAnonymousWrappers(*backdropRenderer, { });
                 builder.destroyAndCleanUpAnonymousWrappers(*renderer, root.renderer());
                 element->setRenderer(nullptr);
+
+                if (isRendererReplacement == IsRendererReplacement::No) {
+                    if (RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(element.get())) {
+                        RefPtr contentDocument = frameOwner->contentDocument();
+                        CheckedPtr contentRenderView = contentDocument ? contentDocument->renderView() : nullptr;
+                        if (contentRenderView && !contentRenderView->ownerFrameIsRendered())
+                            builder.addFrameWithDetachedRenderer(*frameOwner);
+                    }
+                }
             }
 
             if (element->hasCustomStyleResolveCallbacks())
@@ -976,14 +994,42 @@ void RenderTreeUpdater::tearDownRenderersInternal(Element& root, TeardownType te
         tearDownLeftoverPaginationRenderersIfNeeded(root, builder);
 }
 
-void RenderTreeUpdater::tearDownRenderers(Element& root, TeardownType teardownType, RenderTreeBuilder& builder)
+void RenderTreeUpdater::tearDownRenderers(Element& root, TeardownType teardownType, RenderTreeBuilder& builder, IsRendererReplacement isRendererReplacement)
 {
-    tearDownRenderersInternal<TeardownScope::IncludingRoot>(root, teardownType, builder);
+    tearDownRenderersInternal<TeardownScope::IncludingRoot>(root, teardownType, builder, isRendererReplacement);
+}
+
+void RenderTreeUpdater::tearDownRenderersForNonRenderedFrames()
+{
+    auto frameOwners = copyToVectorOf<Ref<HTMLFrameOwnerElement>>(m_builder.framesWithDetachedRenderers());
+
+    while (!frameOwners.isEmpty()) {
+        Vector<Ref<HTMLFrameOwnerElement>> nestedFrameOwners;
+
+        for (auto& frameOwner : frameOwners) {
+            RefPtr contentDocument = frameOwner->contentDocument();
+            if (!contentDocument || !contentDocument->documentElement() || !contentDocument->renderView()) {
+                ASSERT_NOT_REACHED();
+                continue;
+            }
+            RefPtr documentElement = contentDocument->documentElement();
+            if (!documentElement->renderer()) {
+                ASSERT_NOT_REACHED();
+                continue;
+            }
+
+            RenderTreeBuilder builder(*contentDocument->renderView());
+            tearDownRenderers(*documentElement, TeardownType::RendererUpdate, builder);
+            nestedFrameOwners.appendVector(copyToVectorOf<Ref<HTMLFrameOwnerElement>>(builder.framesWithDetachedRenderers()));
+        }
+
+        frameOwners = WTF::move(nestedFrameOwners);
+    }
 }
 
 void RenderTreeUpdater::tearDownDescendantRenderers(Element& root, TeardownType teardownType, RenderTreeBuilder& builder)
 {
-    tearDownRenderersInternal<TeardownScope::DescendantsOnly>(root, teardownType, builder);
+    tearDownRenderersInternal<TeardownScope::DescendantsOnly>(root, teardownType, builder, IsRendererReplacement::No);
 }
 
 void RenderTreeUpdater::tearDownTextRenderer(Text& text, const ContainerNode* root, RenderTreeBuilder& builder, NeedsRepaintAndLayout needsRepaintAndLayout)

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -101,11 +101,13 @@ private:
 
     // FIXME: Use OptionSet.
     enum class TeardownType { Full, FullAfterShadowRootInsertion, RendererUpdate, RendererUpdateCancelingAnimations };
+    enum class IsRendererReplacement : bool { No, Yes };
     static void tearDownRenderers(Element&, TeardownType);
-    static void tearDownRenderers(Element&, TeardownType, RenderTreeBuilder&);
+    static void tearDownRenderers(Element&, TeardownType, RenderTreeBuilder&, IsRendererReplacement = IsRendererReplacement::No);
+    void tearDownRenderersForNonRenderedFrames();
     static void tearDownDescendantRenderers(Element&, TeardownType, RenderTreeBuilder&);
     enum class TeardownScope { IncludingRoot, DescendantsOnly };
-    template<TeardownScope> static void tearDownRenderersInternal(Element&, TeardownType, RenderTreeBuilder&);
+    template<TeardownScope> static void tearDownRenderersInternal(Element&, TeardownType, RenderTreeBuilder&, IsRendererReplacement);
     enum class NeedsRepaintAndLayout : bool { No, Yes };
     static void tearDownTextRenderer(Text&, const ContainerNode* root, RenderTreeBuilder&, NeedsRepaintAndLayout = NeedsRepaintAndLayout::Yes);
     static void tearDownLeftoverChildrenOfComposedTree(Element&, RenderTreeBuilder&);

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -185,6 +185,14 @@ bool Extractor::updateStyleIfNeededForProperty(Element& element, CSSPropertyID p
 {
     Ref document = element.document();
 
+    // While the owner element has no renderer this element has none either, and resolving the owner
+    // documents is what would give it one, so they have to resolve before this element's style validity
+    // says anything about whether a resolved value is available. An owner that already has a renderer
+    // needs nothing: losing it later is handled by the layout Document::updateLayout() forces, which
+    // walks owner documents itself.
+    if (RefPtr owner = document->ownerElement(); owner && !owner->renderer())
+        protect(owner->document())->updateStyleIfNeeded();
+
     document->styleScope().flushPendingUpdate();
 
     auto hasValidStyle = [&] {

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -271,6 +271,11 @@ void TreeResolver::resetStyleForNonRenderedDescendants(Element& subtreeRoot)
 
 static bool affectsRenderedSubtree(Element& element, const Style::ComputedStyle& newStyle)
 {
+    if (&element == element.document().documentElement()) {
+        CheckedPtr renderView = element.document().renderView();
+        if (renderView && !renderView->ownerFrameIsRendered())
+            return false;
+    }
     if (newStyle.display() != DisplayType::None)
         return true;
     if (element.renderOrDisplayContentsStyle())


### PR DESCRIPTION
#### 019c11a2ad5ff58b70a7203918706b8d7405c229
<pre>
marketwatch.com: &quot;Subscribe now&quot; drop-down does not render anything
<a href="https://bugs.webkit.org/show_bug.cgi?id=321146">https://bugs.webkit.org/show_bug.cgi?id=321146</a>
&lt;<a href="https://rdar.apple.com/181639379">rdar://181639379</a>&gt;

Reviewed by NOBODY (OOPS!).

  &lt;div style=&quot;display: none; width: 300px&quot;&gt;
    &lt;iframe srcdoc=&quot;&lt;div style=&apos;width: 250px; height: 169px&apos;&gt;&lt;/div&gt;&quot;&gt;&lt;/iframe&gt;
  &lt;/div&gt;

The box inside the iframe should measure 0x0 while the ancestor is display:none. Instead it was 250x169.

We build a render tree for the content of a display:none iframe so that script can ask for geometry. Nothing propagates a size to that content document&apos;s view
though, so it lays out against a 0x0 viewport.

Build no renderers under the content document&apos;s RenderView while the frame owner has no renderer.

The RenderView itself stays: hasLivingRenderTree() is renderView() &amp;&amp; !renderTreeBeingDestroyed(), which the rest of the engine reads as &quot;this document takes part in rendering&quot;.
Taking the view away would flip all of it for a hidden frame at once - contenteditable turns read-only, form state stops reaching the history item,
hit testing answers nothing, images stop loading and their load events stop firing, and Style::Scope::updateActiveStyleSheets drops a pending stylesheet update instead of collecting it.
Each would need its own workaround, and resolveStyle() returns early with no view before clearing its dirty bits, so needsStyleRecalc() sticks and
updateIntersectionObservers() reschedules a rendering update forever. Keeping the view leaves the document an ordinary participant and confines this to which renderers get built beneath it.

Refusing them is a creation policy, not a RenderView::canHaveChildren() override: detachFromRenderElement() asserts on canHaveChildren(), so a view answering no could not have its existing
renderers taken back out. Style resolution stops at the content document element too, so an unrendered frame does not  resolve its whole subtree only to discard it.

Building the tree back happens in didAttachRenderers, since nothing in the content document watches its owner element. Taking it down cannot happen in the middle of the owner&apos;s teardown, so
unrendered frames are recorded on the RenderTreeBuilder and settled after the update, with RendererUpdate rather than a
Full teardown so the content document keeps its animations and hover state.

Withholding those renderers also makes a subframe&apos;s renderers depend on its owner document having resolved style, which getComputedStyle did not model: it flushed
only its own document, so a resolved value read before the owner was up to date came back unresolved. Document::updateStyleIfNeeded() now resolves owner
documents first, the way updateLayout() already did for layout.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateStyleIfNeeded):
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::HTMLFrameElementBase):
(WebCore::HTMLFrameElementBase::didAttachRenderers):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::HTMLFrameOwnerElement):
(WebCore::HTMLFrameOwnerElement::didAttachRenderers):
* Source/WebCore/html/HTMLFrameOwnerElement.h:
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::pluginElementTypeFlags):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::adjustViewSize):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::ownerFrameIsRendered const):
(WebCore::RenderView::nodeForHitTest const):
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::addFrameWithDetachedRenderer):
* Source/WebCore/rendering/updating/RenderTreeBuilder.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::shouldCreateRenderer):
(WebCore::RenderTreeUpdater::commit):
(WebCore::RenderTreeUpdater::updateElementRenderer):
(WebCore::RenderTreeUpdater::tearDownRenderersInternal):
(WebCore::RenderTreeUpdater::tearDownRenderers):
(WebCore::RenderTreeUpdater::tearDownRenderersForNonRenderedFrames):
* Source/WebCore/rendering/updating/RenderTreeUpdater.h:
* Source/WebCore/style/StyleExtractor.cpp:
(WebCore::Style::Extractor::updateStyleIfNeededForProperty):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::affectsRenderedSubtree):
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-content-not-laid-out-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-animated-to-none-content-not-laid-out.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-animated-to-none-content-not-laid-out-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-preserves-content-scroll-offset.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/iframe-display-none-preserves-content-scroll-offset.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-ancestor-does-not-cancel-subframe-animations.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-ancestor-does-not-cancel-subframe-animations-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-in-subframe-reflects-owner-document.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-in-subframe-reflects-owner-document-expected.txt: Added.
* LayoutTests/fast/dynamic/display-none-iframe-async-layout-expected.html: Updated for the new behavior.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/019c11a2ad5ff58b70a7203918706b8d7405c229

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145979 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4caf625-28ee-4b12-bc2f-5db5288945d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55319 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141782 "Found 2 new test failures: fast/selectors/focus-visible-crash.html imported/w3c/web-platform-tests/selection/deleteFromDocument.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98425 "1 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3844fccf-cbf4-40bc-82f8-73bd9da4fa99) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184606 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45473 "Found 2 new test failures: fast/selectors/focus-visible-crash.html webarchive/loading/object.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122219 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65a86c5e-b63f-4ba7-922b-a3c67ffda76c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44156 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42429 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154556 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42060 "Found 1 new test failure: fast/selectors/focus-visible-crash.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3037 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48229 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46685 "Found 2 new test failures: fast/selectors/focus-visible-crash.html imported/w3c/web-platform-tests/selection/deleteFromDocument.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193802 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55268 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162031 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151193 "Found 1 new test failure: imported/w3c/web-platform-tests/selection/deleteFromDocument.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55957 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38682 "Found 1 new test failure: fast/selectors/focus-visible-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150895 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45478 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128240 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123930 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54470 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17055 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53852 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54091 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53917 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->