### PR TITLE
[macOS][Site Isolation] Video Viewer is confined to the inline iframe rect instead of filling the web view

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/viewer-mode-fullscreens-owner-iframe-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/viewer-mode-fullscreens-owner-iframe-frame.html
@@ -1,0 +1,30 @@
+<video muted width="640" height="480" src="/media-resources/content/test.mp4"></video>
+<script>
+const video = document.querySelector("video");
+
+video.addEventListener("canplay", () => {
+    if (!window.internals)
+        return window.parent.postMessage("FAIL: no internals", "*");
+
+    let reported = false;
+    const reportReady = async () => {
+        if (reported)
+            return;
+        reported = true;
+        if (window.testRunner)
+            await testRunner.updatePresentation();
+        window.parent.postMessage("entered viewer mode", "*");
+    };
+
+    window.addEventListener("resize", reportReady, { once: true });
+    document.addEventListener("fullscreenchange", () => {
+        setTimeout(reportReady, 1000);
+    }, { once: true });
+
+    internals.withUserGesture(() => {
+        internals.enterViewerMode(video);
+    });
+}, { once: true });
+
+video.addEventListener("error", () => window.parent.postMessage("FAIL: video failed to load", "*"), { once: true });
+</script>

--- a/LayoutTests/http/tests/site-isolation/viewer-mode-fullscreens-owner-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/viewer-mode-fullscreens-owner-iframe-expected.txt
@@ -1,0 +1,12 @@
+Entering viewer mode (in-window fullscreen) on a video in a cross-site iframe must also put the ancestor iframe element into fullscreen. The iframe lives in the main frame's process, so this checks that fullscreen propagates across the process boundary; without it the viewer is sized by viewport units against the iframe's small inline box.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS frameResult is "entered viewer mode"
+PASS document.querySelector('iframe').matches(':fullscreen') is true
+PASS document.querySelector('iframe').getBoundingClientRect().width is > 200
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/viewer-mode-fullscreens-owner-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/viewer-mode-fullscreens-owner-iframe.html
@@ -1,0 +1,31 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Entering viewer mode (in-window fullscreen) on a video in a cross-site iframe must also put the ancestor iframe element into fullscreen. The iframe lives in the main frame's process, so this checks that fullscreen propagates across the process boundary; without it the viewer is sized by viewport units against the iframe's small inline box.");
+jsTestIsAsync = true;
+
+onload = () => {
+    const iframe = document.createElement("iframe");
+    iframe.width = 200;
+    iframe.height = 100;
+    iframe.allowFullscreen = true;
+    iframe.src = "http://localhost:8000/site-isolation/resources/viewer-mode-fullscreens-owner-iframe-frame.html";
+
+    window.onmessage = (event) => {
+        frameResult = event.data;
+        shouldBeEqualToString("frameResult", "entered viewer mode");
+        shouldBeTrue("document.querySelector('iframe').matches(':fullscreen')");
+        shouldBeGreaterThan("document.querySelector('iframe').getBoundingClientRect().width", "200");
+        finishJSTest();
+    };
+
+    document.body.appendChild(iframe);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -284,6 +284,7 @@ fullscreen
 http/tests/fullscreen
 imported/w3c/web-platform-tests/fullscreen
 compositing/no-compositing-when-full-screen-is-present.html
+http/tests/site-isolation/viewer-mode-fullscreens-owner-iframe.html
 webkit.org/b/200308 fast/events/touch/ios/content-observation/non-visible-content-change-in-fullscreen-mode.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations.html [ Skip ]

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9483,7 +9483,7 @@ PlatformMediaSession::DisplayType HTMLMediaElement::displayType() const
         return PlatformMediaSession::DisplayType::Fullscreen;
     if (m_videoFullscreenMode & VideoFullscreenModePictureInPicture)
         return PlatformMediaSession::DisplayType::Optimized;
-    if (m_videoFullscreenMode == VideoFullscreenModeNone)
+    if (m_videoFullscreenMode == VideoFullscreenModeNone || m_videoFullscreenMode == VideoFullscreenModeInWindow)
         return PlatformMediaSession::DisplayType::Normal;
 
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -170,6 +170,7 @@ extern ASCIILiteral errorAsString(Error);
 
 #define MESSAGE_CHECK_BASE(assertion, connection) MESSAGE_CHECK_COMPLETION_BASE(assertion, connection, (void)0)
 #define MESSAGE_CHECK_BASE_COROUTINE(assertion, connection) MESSAGE_CHECK_COMPLETION_BASE_COROUTINE(assertion, connection, (void)0)
+#define MESSAGE_CHECK_BASE_COROUTINE_VOID(assertion, connection) MESSAGE_CHECK_COMPLETION_BASE_COROUTINE_VOID(assertion, connection, (void)0)
 
 #define MESSAGE_CHECK_OPTIONAL_CONNECTION_BASE(assertion, connection) do { \
     if (!(assertion)) [[unlikely]] { \
@@ -197,6 +198,16 @@ extern ASCIILiteral errorAsString(Error);
         CRASH_IF_TESTING \
         { completion; } \
         co_return { }; \
+    } \
+} while (0)
+
+#define MESSAGE_CHECK_COMPLETION_BASE_COROUTINE_VOID(assertion, connection, completion) do { \
+    if (!(assertion)) [[unlikely]] { \
+        RELEASE_LOG_FAULT_WITH_PAYLOAD(IPC, __FILE__ " " CONNECTION_STRINGIFY_MACRO(__LINE__) ": Invalid message dispatched %s", CString(WTF_PRETTY_FUNCTION)); \
+        IPC::markCurrentlyDispatchedMessageAsInvalid(connection, "Message check failed: " #assertion ## _s); \
+        CRASH_IF_TESTING \
+        { completion; } \
+        co_return; \
     } \
 } while (0)
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -363,6 +363,15 @@ Awaitable<void> WebFullScreenManagerProxy::exitFullScreen()
         page->fullscreenClient().willExitFullscreen(page.get());
 }
 
+Awaitable<void> WebFullScreenManagerProxy::enterInWindowFullScreen(IPC::Connection& connection, FrameIdentifier frameID)
+{
+    MESSAGE_CHECK_BASE_COROUTINE_VOID(isFrameInSendingProcess(frameID, connection), connection);
+
+    co_await AwaitableFromCompletionHandler<NeedsPresentationUpdate> { [this, protectedThis = Ref { *this }, frameID] (auto completionHandler) {
+        enterFullScreenForOwnerElementsInOtherProcesses(frameID, WTF::move(completionHandler));
+    } };
+}
+
 #if ENABLE(QUICKLOOK_FULLSCREEN)
 void WebFullScreenManagerProxy::prepareQuickLookImageURL(CompletionHandler<void(URL&&)>&& completionHandler) const
 {

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -137,6 +137,7 @@ private:
     void updateImageSource(FullScreenMediaDetails&&);
 #endif
     Awaitable<void> exitFullScreen();
+    Awaitable<void> enterInWindowFullScreen(IPC::Connection&, WebCore::FrameIdentifier);
     Awaitable<bool> beganEnterFullScreen(IPC::Connection&, WebCore::FrameIdentifier, WebCore::IntRect initialFrameInRootViewCoordinates, WebCore::IntRect finalFrameInRootViewCoordinates);
     Awaitable<void> beganExitFullScreen(WebCore::IntRect initialFrameInRootViewCoordinates, WebCore::IntRect finalFrameInRootViewCoordinates);
     void closeFullScreen(IPC::Connection&);

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -33,6 +33,7 @@ messages -> WebFullScreenManagerProxy {
     UpdateImageSource(struct WebKit::FullScreenMediaDetails mediaDetails)
 #endif
     ExitFullScreen() -> ()
+    EnterInWindowFullScreen(WebCore::FrameIdentifier frameID) -> ()
     BeganEnterFullScreen(WebCore::FrameIdentifier frameID, WebCore::IntRect initialRect, WebCore::IntRect finalRect) -> (bool success)
     BeganExitFullScreen(WebCore::IntRect initialRect, WebCore::IntRect finalRect) -> ()
     CloseFullScreen()

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -479,8 +479,18 @@ void WebFullScreenManager::performEnterFullScreen()
     }
 
     if (m_pendingMode == HTMLMediaElementEnums::VideoFullscreenModeInWindow) {
-        willEnterFullScreen(*element, WTF::move(m_pendingWillEnterCallback), WTF::move(m_pendingDidEnterCallback), m_pendingMode);
-        m_inWindowFullScreenMode = true;
+        ASSERT(m_elementFrameIdentifier);
+        m_page->sendWithAsyncReply(Messages::WebFullScreenManagerProxy::EnterInWindowFullScreen(*m_elementFrameIdentifier), [
+            this,
+            protectedThis = Ref { *this },
+            element = Ref { *element },
+            mode = m_pendingMode,
+            willEnterFullScreenCallback = WTF::move(m_pendingWillEnterCallback),
+            didEnterFullScreenCallback = WTF::move(m_pendingDidEnterCallback)
+        ] mutable {
+            willEnterFullScreen(element, WTF::move(willEnterFullScreenCallback), WTF::move(didEnterFullScreenCallback), mode);
+            m_inWindowFullScreenMode = true;
+        });
     } else {
         ASSERT(m_elementFrameIdentifier);
         m_page->sendWithAsyncReply(Messages::WebFullScreenManagerProxy::EnterFullScreen(*m_elementFrameIdentifier, protect(m_element->document())->quirks().blocksReturnToFullscreenFromPictureInPictureQuirk(), WTF::move(mediaDetails)), [
@@ -951,6 +961,9 @@ void WebFullScreenManager::enterFullScreenForOwnerElements(WebCore::FrameIdentif
     }
     for (auto element : elements | std::views::reverse)
         DocumentFullscreen::elementEnterFullscreen(element);
+
+    if (!elements.isEmpty())
+        protect(elements.last()->document())->updateLayout();
 
     completionHandler();
 }


### PR DESCRIPTION
#### 9bf21c1a9cf50180658b540b346fed5fae16bc7d
<pre>
[macOS][Site Isolation] Video Viewer is confined to the inline iframe rect instead of filling the web view
<a href="https://bugs.webkit.org/show_bug.cgi?id=322145">https://bugs.webkit.org/show_bug.cgi?id=322145</a>
<a href="https://rdar.apple.com/185362319">rdar://185362319</a>

Reviewed by Alex Christensen.

In-window fullscreen is sized by UA styles in viewport units, which resolve against the element&apos;s own
document — the iframe&apos;s box under Site Isolation. willEnterFullscreen() normally expands the enclosing
iframe by fullscreening ancestor owner elements, but it walks Frame::ownerElement() and stops at a
RemoteFrame. Send EnterInWindowFullScreen so the in-window path calls the existing cross-process
equivalent, enterFullScreenForOwnerElementsInOtherProcesses(). Exit already worked via
BeganExitFullScreen.

elementEnterFullscreen() only resolves style, so also lay out before replying; otherwise the
requesting process&apos;s first layout still uses the inline size.

HTMLMediaElement::displayType() did not handle VideoFullscreenModeInWindow and hit
ASSERT_NOT_REACHED(). In-window has no separate presentation surface, so report Normal.

Test: http/tests/site-isolation/viewer-mode-fullscreens-owner-iframe.html

* LayoutTests/http/tests/site-isolation/resources/viewer-mode-fullscreens-owner-iframe-frame.html: Added.
* LayoutTests/http/tests/site-isolation/viewer-mode-fullscreens-owner-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/viewer-mode-fullscreens-owner-iframe.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::displayType const):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterInWindowFullScreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::performEnterFullScreen):
(WebKit::WebFullScreenManager::enterFullScreenForOwnerElements):

Canonical link: <a href="https://commits.webkit.org/319579@main">https://commits.webkit.org/319579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e3e107f30ff1f04596c4d5f99d58b676dc33450

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146036 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/897e2fa8-637b-4349-9c3d-c63648daebd5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141838 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/831f1bb6-1da7-4e14-93e3-170ba0f32698) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122274 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d4b9e0c-b8a6-4be6-b7b3-e17e722a9ac8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44216 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42482 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42114 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3093 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193858 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151250 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40547 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56013 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150955 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45534 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128296 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124006 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54526 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17110 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53908 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54147 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53973 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->