### PR TITLE
swiftc-wrapper changes for Windows

### DIFF
--- a/Tools/Scripts/swift/swiftc-wrapper.py
+++ b/Tools/Scripts/swift/swiftc-wrapper.py
@@ -9,9 +9,11 @@
 # CMAKE_Swift_COMPILER_LAUNCHER, which testing showed CMake/Ninja can
 # silently fail to apply to some Swift rules).
 
+import os
 import re
 import subprocess
 import sys
+import tempfile
 
 # Swift's C++ interop changes which imported members are @unsafe between
 # toolchain versions, so an `unsafe` that is required on one toolchain emits
@@ -114,6 +116,12 @@ def process_args(argv):
             # Split -Wl,arg1,arg2 into -Xlinker arg1 -Xlinker arg2
             for wl_arg in arg[len("-Wl,"):].split(","):
                 args.extend(["-Xlinker", wl_arg])
+        elif os.name == "nt" and arg.startswith("/") and len(arg) > 1:
+            # CMake passes raw MSVC linker switches like /machine:x64 and
+            # /INCREMENTAL:NO straight through. A leading "/" is
+            # never a plain path on Windows (paths use "\" or a drive letter),
+            # so this is unambiguous.
+            args.extend(["-Xlinker", arg])
         elif arg.startswith("--original-swift-compiler="):
             real_swiftc = arg[len("--original-swift-compiler="):]
         elif arg.startswith("-D") and "=" in arg:
@@ -134,14 +142,56 @@ def process_args(argv):
     return real_swiftc, args
 
 
+def quote_response_file_token(arg):
+    if not re.search(r"\s", arg):
+        return arg
+    # Windows argv-unescaping rules (the platform this is used on):
+    # a backslash is literal unless it precedes a quote, and N backslashes
+    # before a quote collapse to N/2.
+    escaped = arg.replace("\\", "\\\\").replace('"', '\\"')
+    return '"' + escaped + '"'
+
+
+def write_response_file(args):
+    fd, path = tempfile.mkstemp(prefix="swiftc-wrapper-", suffix=".rsp")
+    with os.fdopen(fd, "w") as f:
+        for arg in args:
+            f.write(quote_response_file_token(arg))
+            f.write("\n")
+    return path
+
+
 def main(argv):
     real_swiftc, args = process_args(argv)
+    flat_command = [real_swiftc] + args
 
-    process = subprocess.run(
-        [real_swiftc] + args,
-        stdout=sys.stdout,
-        stderr=subprocess.PIPE,
-    )
+    if os.name == "nt" and "-explicit-module-build" not in args:
+        # WebKit's swiftc invocations run tens of thousands of characters long
+        # (hundreds of -I flags); Windows' CreateProcess caps a command line at
+        # ~32767 characters
+        response_file = write_response_file(args)
+        command = [real_swiftc, "@" + response_file]
+    else:
+        if os.name == "nt":
+            cmdline = subprocess.list2cmdline(flat_command)
+            if len(cmdline) >= 32767:
+                sys.stderr.write(
+                    f"swiftc-wrapper: command line is {len(cmdline)} characters, "
+                    "over the Windows 32767 limit, and -explicit-module-build "
+                    "prevents relaying it through a response file\n")
+                return 1
+        command = flat_command
+        response_file = None
+
+    try:
+        process = subprocess.run(
+            command,
+            stdout=sys.stdout,
+            stderr=subprocess.PIPE,
+        )
+    finally:
+        if response_file:
+            os.remove(response_file)
 
     stderr_text = process.stderr.decode(errors="replace")
     filtered_lines = filter_benign_warnings(stderr_text.splitlines(keepends=True))


### PR DESCRIPTION
#### b296b1e1a8775e072ed3bcb3519b41e1bd83beed
<pre>
swiftc-wrapper changes for Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=322148">https://bugs.webkit.org/show_bug.cgi?id=322148</a>
<a href="https://rdar.apple.com/185368624">rdar://185368624</a>

Reviewed by Richard Robinson.

Two improvements to the swiftc wrapper under Windows.

1) Allow flags like /INCREMENTAL to pass through.
2) Avoid CreateProcess&apos; 32767 character limit.

Canonical link: <a href="https://commits.webkit.org/319589@main">https://commits.webkit.org/319589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6bddd576554ea904c35ee12ad958cd9ab5d167f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145967 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7cdea81e-388f-43ae-a661-0b4f862c59d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141777 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98418 "2 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6faf771c-b38a-4a4c-828e-942800dff109) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122214 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0654f863-54fe-41c4-ab5d-bd5db1eeb648) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44152 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42421 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42055 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3026 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193791 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55257 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151188 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40554 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55946 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150890 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45473 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123919 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54459 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17050 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53841 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54080 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53906 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->