### PR TITLE
[JSC] Use UnlinkedCodeBlock's constants

### DIFF
--- a/JSTests/stress/codeblock-linked-metadata.js
+++ b/JSTests/stress/codeblock-linked-metadata.js
@@ -1,0 +1,80 @@
+// Values that differ per realm live in the metadata of the instruction that needs them rather than in
+// the constant pool, which CodeBlock now shares with its UnlinkedCodeBlock.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+// op_get_template_object: a tagged template site must yield the identical frozen array every time it
+// is evaluated, and distinct sites must not share one.
+function tag(strings) { return strings; }
+function site(x) { return tag`a${x}b`; }
+function otherSite(x) { return tag`a${x}b`; }
+
+const first = site(0);
+shouldBe(Object.isFrozen(first), true);
+shouldBe(Object.isFrozen(first.raw), true);
+for (let i = 0; i < 1e5; ++i)
+    shouldBe(site(i), first);
+if (otherSite(0) === first)
+    throw new Error("distinct tagged template sites must not share a template object");
+
+function invalidEscape() { return tag`\unicode${0}`; }
+shouldBe(invalidEscape()[0], undefined);
+shouldBe(invalidEscape().raw[0], "\\unicode");
+
+// op_new_array_buffer: once the allocation profile wants an indexing type the constant does not have,
+// the re-typed butterfly is cached in metadata. Fresh allocations must not observe mutations made to
+// earlier ones.
+function literal() { return [1, 2, 3]; }
+for (let i = 0; i < 3e5; ++i) {
+    const array = literal();
+    shouldBe(array.length, 3);
+    shouldBe(`${array[0]}${array[1]}${array[2]}`, "123");
+    array[1] = 2.5;
+    shouldBe(array[1], 2.5);
+}
+for (let i = 0; i < 1e3; ++i)
+    shouldBe(literal()[1], 2);
+
+// op_create_lexical_environment and op_create_generator_frame_environment take their per-realm
+// SymbolTable clone from metadata; op_put_to_scope holds the clone its WatchpointSet points into.
+function counter(start) {
+    let value = start;
+    return { bump() { return ++value; }, read() { return value; } };
+}
+const counters = [];
+for (let i = 0; i < 1e3; ++i)
+    counters.push(counter(i));
+for (let round = 0; round < 20; ++round) {
+    for (const c of counters)
+        c.bump();
+}
+shouldBe(counters[0].read(), 20);
+shouldBe(counters[999].read(), 1019);
+
+function blockScopes() {
+    const closures = [];
+    for (let i = 0; i < 8; ++i) {
+        let captured = i * 2;
+        closures.push(() => captured);
+    }
+    return closures.map(f => f()).join(",");
+}
+for (let i = 0; i < 2e4; ++i)
+    shouldBe(blockScopes(), "0,2,4,6,8,10,12,14");
+
+function* generator(n) {
+    let sum = 0;
+    for (let i = 0; i < n; ++i) {
+        sum += i;
+        yield sum;
+    }
+}
+for (let i = 0; i < 2e4; ++i) {
+    let last = 0;
+    for (const value of generator(5))
+        last = value;
+    shouldBe(last, 10);
+}

--- a/JSTests/stress/link-time-constant-register-allocation.js
+++ b/JSTests/stress/link-time-constant-register-allocation.js
@@ -1,0 +1,72 @@
+// Link time constants are materialized by op_get_link_time_constant into a temporary rather than
+// occupying a constant register. A temporary must not be allocated while a CallArguments block is
+// live, and must not be stolen as a call's result register by finalDestination().
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+// @copyDataProperties is loaded while the rest-element CallArguments block is already reserved.
+function objectRest(o) {
+    const { x, ...rest } = o;
+    return `${x}:${rest.y}:${rest.z}`;
+}
+
+// @cloneObject, reached through object spread.
+function objectSpread(o) {
+    return { ...o, w: 4 };
+}
+
+for (let i = 0; i < 1e5; ++i) {
+    shouldBe(objectRest({ x: 1, y: 2, z: 3 }), "1:2:3");
+    const spread = objectSpread({ x: 1, y: 2, z: 3 });
+    shouldBe(spread.x + spread.y + spread.z + spread.w, 10);
+    const both = objectSpread({ x: 1, y: 2, z: 3 });
+    shouldBe(objectRest(both), "1:2:3");
+}
+
+// @createPrivateSymbol is called once per private name. With both an instance and a static private
+// name the second call must not reuse the register still holding the first call's callee.
+class C {
+    #instance = 1;
+    static #staticField = 2;
+    #method() { return 3; }
+    instance() { return this.#instance; }
+    static staticField() { return C.#staticField; }
+    method() { return this.#method(); }
+}
+
+for (let i = 0; i < 1e5; ++i) {
+    const c = new C();
+    shouldBe(c.instance(), 1);
+    shouldBe(C.staticField(), 2);
+    shouldBe(c.method(), 3);
+}
+
+// op_jneq_ptr / op_jeq_ptr carry a LinkTimeConstant operand. sentinelString is index 128, which does
+// not fit a signed narrow operand, so these must still encode without silently widening.
+function forIn(o) {
+    let keys = "";
+    for (const key in o)
+        keys += key;
+    return keys;
+}
+shouldBe(forIn({}), "");
+shouldBe(forIn(null), "");
+for (let i = 0; i < 1e5; ++i)
+    shouldBe(forIn({ a: 1, b: 2 }), "ab");
+
+// f.call / f.apply guards, and their negative paths.
+function callee(a, b) { return this.base + a + b; }
+const receiver = { base: 100 };
+const impostor = function () { return "impostor"; };
+const shadowed = function () { };
+shadowed.call = impostor;
+shadowed.apply = impostor;
+for (let i = 0; i < 1e5; ++i) {
+    shouldBe(callee.call(receiver, 1, 2), 103);
+    shouldBe(callee.apply(receiver, [1, 2]), 103);
+    shouldBe(shadowed.call(receiver, 1, 2), "impostor");
+    shouldBe(shadowed.apply(receiver, [1, 2]), "impostor");
+}

--- a/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
@@ -133,7 +133,7 @@ void CodeBlockBytecodeDumper<Block>::dumpIdentifiers()
 template<class Block>
 void CodeBlockBytecodeDumper<Block>::dumpConstants()
 {
-    if (!this->block()->constantRegisters().isEmpty()) {
+    if (this->block()->constantRegisters().size()) {
         this->m_out.printf("\nConstants:\n");
         size_t i = 0;
         for (const auto& constant : this->block()->constantRegisters()) {
@@ -147,9 +147,6 @@ void CodeBlockBytecodeDumper<Block>::dumpConstants()
                 break;
             case SourceCodeRepresentation::Other:
                 sourceCodeRepresentationDescription = "";
-                break;
-            case SourceCodeRepresentation::LinkTimeConstant:
-                sourceCodeRepresentationDescription = ": in source as link-time-constant";
                 break;
             }
             this->m_out.printf("   k%u = %s%s\n", static_cast<unsigned>(i), toCString(constant.get()).data(), sourceCodeRepresentationDescription);

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -32,6 +32,7 @@ types [
     :DebugHookType,
     :ECMAMode,
     :ErrorTypeWithExtension,
+    :FunctionExecutable,
     :EnumeratorMetadata,
     :GetByIdMode,
     :GetByIdModeMetadata,
@@ -39,6 +40,7 @@ types [
     :IndexingType,
     :IterationModeMetadata,
     :JSCell,
+    :JSCellButterfly,
     :JSGlobalLexicalEnvironment,
     :JSGlobalObject,
     :JSModuleEnvironment,
@@ -46,6 +48,7 @@ types [
     :JSScope,
     :JSType,
     :JSValue,
+    :LinkTimeConstant,
     :ResultType,
     :OperandTypes,
     :PrivateFieldPutKind,
@@ -405,6 +408,9 @@ op :new_array_buffer,
     },
     metadata: {
         arrayAllocationProfile: ArrayAllocationProfile,
+        # Starts out as the constant named by immutableButterfly, but is replaced by a re-typed copy
+        # once the allocation profile asks for an indexing type the constant does not have.
+        immutableButterfly: WriteBarrierBase[JSCellButterfly],
     }
 
 op :get_by_id,
@@ -578,6 +584,9 @@ op :put_to_scope,
             watchpointSet: WatchpointSet.*,
         },
         operand: uintptr_t,
+        # For ResolvedClosureVar, watchpointSet points into an entry of this SymbolTable, which is a
+        # per-realm clone held only here, so it cannot be reconstructed or treated as weak.
+        symbolTable: WriteBarrierBase[SymbolTable],
     },
     metadata_initializers: {
         getPutInfo: :getPutInfo,
@@ -639,6 +648,97 @@ op :get_private_name,
         structureID: StructureID,
         offset: unsigned,
         property: WriteBarrier[JSCell],
+    }
+
+# functionDecl indexes UnlinkedCodeBlock's decl list for the plain forms and its expr list for the _exp
+# forms. The metadata holds the FunctionExecutable linked from it, so CodeBlock needs no vector of them.
+op_group :NewFunction,
+    [
+        :new_func,
+        :new_func_exp,
+        :new_generator_func,
+        :new_generator_func_exp,
+        :new_async_func,
+        :new_async_func_exp,
+        :new_async_generator_func,
+        :new_async_generator_func_exp,
+    ],
+    args: {
+        dst: VirtualRegister,
+        scope: VirtualRegister,
+        functionDecl: unsigned,
+    },
+    metadata: {
+        functionExecutable: WriteBarrierBase[FunctionExecutable],
+    }
+
+# The templateObject metadata is the realm's JSArray for the tagged template site named by the
+# descriptor operand, which stays the shared JSTemplateObjectDescriptor in the constant pool.
+op :get_template_object,
+    args: {
+        dst: VirtualRegister,
+        descriptor: VirtualRegister,
+    },
+    metadata: {
+        templateObject: WriteBarrierBase[JSObject],
+    }
+
+# The symbolTable metadata is the per-realm clone of the SymbolTable named by the symbolTable operand,
+# which stays the shared master in the constant pool.
+op :create_lexical_environment,
+    args: {
+        dst: VirtualRegister,
+        scope: VirtualRegister,
+        symbolTable: VirtualRegister,
+        initialValue: VirtualRegister,
+    },
+    metadata: {
+        symbolTable: WriteBarrierBase[SymbolTable],
+    }
+
+op :create_generator_frame_environment,
+    args: {
+        dst: VirtualRegister,
+        scope: VirtualRegister,
+        symbolTable: VirtualRegister,
+        initialValue: VirtualRegister,
+    },
+    metadata: {
+        symbolTable: WriteBarrierBase[SymbolTable],
+    }
+
+# The metadata caches globalObject->linkTimeConstant(linkTimeConstant), which the shared Baseline JIT
+# code cannot embed because it differs per realm.
+op :get_link_time_constant,
+    args: {
+        dst: VirtualRegister,
+        linkTimeConstant: LinkTimeConstant,
+    },
+    metadata: {
+        constant: WriteBarrierBase[JSCell],
+    }
+
+# The specialPointer metadata caches globalObject->linkTimeConstant(specialPointer), which the shared
+# Baseline JIT code cannot embed because it differs per realm.
+op :jeq_ptr,
+    args: {
+        value: VirtualRegister,
+        specialPointer: LinkTimeConstant,
+        targetLabel: BoundLabel,
+    },
+    metadata: {
+        specialPointer: WriteBarrierBase[JSCell],
+    }
+
+op :jneq_ptr,
+    args: {
+        value: VirtualRegister,
+        specialPointer: LinkTimeConstant,
+        targetLabel: BoundLabel,
+    },
+    metadata: {
+        specialPointer: WriteBarrierBase[JSCell],
+        hasJumped: bool,
     }
 
 # Alignment: 4
@@ -792,17 +892,6 @@ op :get_by_id_direct,
     metadata: {
         structureID: StructureID,
         offset: unsigned,
-    }
-
-# Alignment: 1
-op :jneq_ptr,
-    args: {
-        value: VirtualRegister,
-        specialPointer: VirtualRegister,
-        targetLabel: BoundLabel,
-    },
-    metadata: {
-        hasJumped: bool,
     }
 
 # Opcodes without metadata are last
@@ -1007,13 +1096,6 @@ op :jnundefined_or_null,
         targetLabel: BoundLabel,
     }
 
-op :jeq_ptr,
-    args: {
-        value: VirtualRegister,
-        specialPointer: VirtualRegister,
-        targetLabel: BoundLabel,
-    }
-
 op_group :BinaryJmp,
     [
         :jeq,
@@ -1048,23 +1130,6 @@ op_group :SwitchValue,
     args: {
         tableIndex: unsigned,
         scrutinee: VirtualRegister,
-    }
-
-op_group :NewFunction,
-    [
-        :new_func,
-        :new_func_exp,
-        :new_generator_func,
-        :new_generator_func_exp,
-        :new_async_func,
-        :new_async_func_exp,
-        :new_async_generator_func,
-        :new_async_generator_func_exp,
-    ],
-    args: {
-        dst: VirtualRegister,
-        scope: VirtualRegister,
-        functionDecl: unsigned,
     }
 
 op :set_function_name,
@@ -1115,22 +1180,6 @@ op :push_with_scope,
         dst: VirtualRegister,
         currentScope: VirtualRegister,
         newScope: VirtualRegister,
-    }
-
-op :create_lexical_environment,
-    args: {
-        dst: VirtualRegister,
-        scope: VirtualRegister,
-        symbolTable: VirtualRegister,
-        initialValue: VirtualRegister,
-    }
-
-op :create_generator_frame_environment,
-    args: {
-        dst: VirtualRegister,
-        scope: VirtualRegister,
-        symbolTable: VirtualRegister,
-        initialValue: VirtualRegister,
     }
 
 op :get_parent_scope,

--- a/Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp
@@ -84,6 +84,8 @@ void computeUsesForBytecodeIndexImpl(const JSInstruction* instruction, Checkpoin
 
     // No uses.
     case op_new_reg_exp:
+    case op_get_link_time_constant:
+    case op_get_template_object:
     case op_loop_hint:
     case op_jmp:
     case op_new_object:
@@ -138,8 +140,8 @@ void computeUsesForBytecodeIndexImpl(const JSInstruction* instruction, Checkpoin
     USES(OpJnstricteq, lhs, rhs)
     USES(OpJbelow, lhs, rhs)
     USES(OpJbeloweq, lhs, rhs)
-    USES(OpJeqPtr, value, specialPointer)
-    USES(OpJneqPtr, value, specialPointer)
+    USES(OpJeqPtr, value)
+    USES(OpJneqPtr, value)
 
     USES(OpSetFunctionName, function, name)
     USES(OpLogShadowChickenTail, thisValue, scope)
@@ -587,6 +589,8 @@ void computeDefsForBytecodeIndexImpl(unsigned numVars, const JSInstruction* inst
     DEFS(OpNeqNull, dst)
     DEFS(OpEqNull, dst)
     DEFS(OpNot, dst)
+    DEFS(OpGetLinkTimeConstant, dst)
+    DEFS(OpGetTemplateObject, dst)
     DEFS(OpMov, dst)
     DEFS(OpNewObject, dst)
     DEFS(OpNewPromise, dst)

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -313,9 +313,7 @@ CodeBlock::CodeBlock(VM& vm, Structure* structure, CopyParsedBlockTag, CodeBlock
     , m_vm(other.m_vm)
     , m_instructionsRawPointer(other.m_instructionsRawPointer)
     , m_metadata(other.m_metadata)
-    , m_constantRegisters(other.m_constantRegisters)
-    , m_functionDecls(other.m_functionDecls)
-    , m_functionExprs(other.m_functionExprs)
+    , m_constants(other.m_constants)
     , m_creationTime(ApproximateTime::now())
 #if ASSERT_ENABLED
     , m_magic(CODEBLOCK_MAGIC)
@@ -410,34 +408,30 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
     // We wait to initialize template objects until the end of finishCreation beecause it can
     // throw. We rely on linking to put the CodeBlock into a coherent state, so we can't throw
     // until we're all done linking.
-    Vector<unsigned> templateObjectIndices = setConstantRegisters(unlinkedCodeBlock->constantRegisters(), unlinkedCodeBlock->constantsSourceCodeRepresentation());
+    m_constants = unlinkedCodeBlock->constantRegisters().span().data();
 
-    // We already have the cloned symbol table for the module environment since we need to instantiate
-    // the module environments before linking the code block. We replace the stored symbol table with the already cloned one.
+    // The module environment has to be instantiated before the code block is linked, so its symbol table
+    // was already cloned. Seed the memo with it so linkSymbolTable() below hands out that same clone.
     if (UnlinkedModuleProgramCodeBlock* unlinkedModuleProgramCodeBlock = dynamicDowncast<UnlinkedModuleProgramCodeBlock>(unlinkedCodeBlock)) {
         SymbolTable* clonedSymbolTable = uncheckedDowncast<ModuleProgramExecutable>(ownerExecutable)->moduleEnvironmentSymbolTable();
         if (m_unlinkedCode->wasCompiledWithTypeProfilerOpcodes()) {
             ConcurrentJSLocker locker(clonedSymbolTable->m_lock);
             clonedSymbolTable->prepareForTypeProfiling(locker);
         }
-        replaceConstant(VirtualRegister(unlinkedModuleProgramCodeBlock->moduleEnvironmentSymbolTableConstantRegisterOffset()), clonedSymbolTable);
+        SymbolTable* master = uncheckedDowncast<SymbolTable>(unlinkedCodeBlock->getConstant(VirtualRegister(unlinkedModuleProgramCodeBlock->moduleEnvironmentSymbolTableConstantRegisterOffset())).asCell());
+        m_globalObject->symbolTableCache().set(master, clonedSymbolTable);
     }
 
-    bool shouldUpdateFunctionHasExecutedCache = m_unlinkedCode->wasCompiledWithTypeProfilerOpcodes() || m_unlinkedCode->wasCompiledWithControlFlowProfilerOpcodes();
-    m_functionDecls = FixedVector<WriteBarrier<FunctionExecutable>>(unlinkedCodeBlock->numberOfFunctionDecls());
-    for (size_t count = unlinkedCodeBlock->numberOfFunctionDecls(), i = 0; i < count; ++i) {
-        UnlinkedFunctionExecutable* unlinkedExecutable = unlinkedCodeBlock->functionDecl(i);
-        if (shouldUpdateFunctionHasExecutedCache)
-            vm.functionHasExecutedCache()->insertUnexecutedRange(ownerExecutable->sourceID(), unlinkedExecutable->unlinkedFunctionStart(), unlinkedExecutable->unlinkedFunctionEnd());
-        m_functionDecls[i].set(vm, this, unlinkedExecutable->link(vm, topLevelExecutable, ownerExecutable->source(), std::nullopt, NoIntrinsic, ownerExecutable->isInsideOrdinaryFunction()));
-    }
-
-    m_functionExprs = FixedVector<WriteBarrier<FunctionExecutable>>(unlinkedCodeBlock->numberOfFunctionExprs());
-    for (size_t count = unlinkedCodeBlock->numberOfFunctionExprs(), i = 0; i < count; ++i) {
-        UnlinkedFunctionExecutable* unlinkedExecutable = unlinkedCodeBlock->functionExpr(i);
-        if (shouldUpdateFunctionHasExecutedCache)
-            vm.functionHasExecutedCache()->insertUnexecutedRange(ownerExecutable->sourceID(), unlinkedExecutable->unlinkedFunctionStart(), unlinkedExecutable->unlinkedFunctionEnd());
-        m_functionExprs[i].set(vm, this, unlinkedExecutable->link(vm, topLevelExecutable, ownerExecutable->source(), std::nullopt, NoIntrinsic, ownerExecutable->isInsideOrdinaryFunction()));
+    // FunctionExecutables themselves are linked lazily into the metadata of the op_new_func that names
+    // them. This covers every unlinked entry instead, including declarations that exist only to be
+    // hoisted by Interpreter::executeEval and are named by no instruction.
+    if (m_unlinkedCode->wasCompiledWithTypeProfilerOpcodes() || m_unlinkedCode->wasCompiledWithControlFlowProfilerOpcodes()) {
+        auto insertUnexecutedRanges = [&](std::span<const WriteBarrier<UnlinkedFunctionExecutable>> executables) {
+            for (auto& unlinkedExecutable : executables)
+                vm.functionHasExecutedCache()->insertUnexecutedRange(ownerExecutable->sourceID(), unlinkedExecutable->unlinkedFunctionStart(), unlinkedExecutable->unlinkedFunctionEnd());
+        };
+        insertUnexecutedRanges(unlinkedCodeBlock->functionDecls());
+        insertUnexecutedRanges(unlinkedCodeBlock->functionExprs());
     }
 
     if (unlinkedCodeBlock->numberOfExceptionHandlers()) {
@@ -458,15 +452,40 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
         }
     }
 
-    // Bookkeep the strongly referenced module environments.
-    UncheckedKeyHashSet<JSModuleEnvironment*> stronglyReferencedModuleEnvironments;
-
     auto link_objectAllocationProfile = [&](const auto& /*instruction*/, auto bytecode, auto& metadata) {
         metadata.m_objectAllocationProfile.initializeProfile(vm, m_globalObject.get(), this, m_globalObject->objectPrototype(), bytecode.m_inlineCapacity);
     };
 
     auto link_arrayAllocationProfile = [&](const auto& /*instruction*/, auto bytecode, auto& metadata) {
         metadata.m_arrayAllocationProfile.initializeIndexingMode(bytecode.m_recommendedIndexingType);
+    };
+
+    auto link_immutableButterfly = [&](const auto& /*instruction*/, auto bytecode, auto& metadata) {
+        metadata.m_immutableButterfly.set(vm, this, uncheckedDowncast<JSCellButterfly>(unlinkedCodeBlock->getConstant(bytecode.m_immutableButterfly).asCell()));
+    };
+
+    auto link_specialPointer = [&](const auto& /*instruction*/, auto bytecode, auto& metadata) {
+        metadata.m_specialPointer.set(vm, this, m_globalObject->linkTimeConstant(bytecode.m_specialPointer));
+    };
+
+    auto link_constant = [&](const auto& /*instruction*/, auto bytecode, auto& metadata) {
+        metadata.m_constant.set(vm, this, m_globalObject->linkTimeConstant(bytecode.m_linkTimeConstant));
+    };
+
+    auto link_symbolTable = [&](const auto& /*instruction*/, auto bytecode, auto& metadata) {
+        metadata.m_symbolTable.set(vm, this, linkSymbolTable(bytecode.m_symbolTable));
+    };
+
+    auto link_functionExecutable = [&](const auto& /*instruction*/, auto bytecode, auto& metadata) {
+        using Bytecode = decltype(bytecode);
+        constexpr bool isExpression = Bytecode::opcodeID == op_new_func_exp
+            || Bytecode::opcodeID == op_new_generator_func_exp
+            || Bytecode::opcodeID == op_new_async_func_exp
+            || Bytecode::opcodeID == op_new_async_generator_func_exp;
+        UnlinkedFunctionExecutable* unlinkedExecutable = isExpression
+            ? unlinkedCodeBlock->functionExpr(bytecode.m_functionDecl)
+            : unlinkedCodeBlock->functionDecl(bytecode.m_functionDecl);
+        metadata.m_functionExecutable.set(vm, this, unlinkedExecutable->link(vm, topLevelExecutable, ownerExecutable->source(), std::nullopt, NoIntrinsic, ownerExecutable->isInsideOrdinaryFunction()));
     };
 
     auto link_callLinkInfo = [&](const auto& instruction, auto bytecode, auto& metadata) {
@@ -527,7 +546,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
 
         LINK(OpNewArray)
         LINK(OpNewArrayWithSize)
-        LINK(OpNewArrayBuffer, arrayAllocationProfile)
+        LINK(OpNewArrayBuffer, arrayAllocationProfile, immutableButterfly)
 
         LINK(OpNewObject, objectAllocationProfile)
 
@@ -536,7 +555,19 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
         LINK(OpCreatePromise)
         LINK(OpCreateGenerator)
 
-        LINK(OpJneqPtr)
+        LINK(OpJneqPtr, specialPointer)
+        LINK(OpJeqPtr, specialPointer)
+        LINK(OpGetLinkTimeConstant, constant)
+        LINK(OpCreateLexicalEnvironment, symbolTable)
+        LINK(OpCreateGeneratorFrameEnvironment, symbolTable)
+        LINK(OpNewFunc, functionExecutable)
+        LINK(OpNewFuncExp, functionExecutable)
+        LINK(OpNewGeneratorFunc, functionExecutable)
+        LINK(OpNewGeneratorFuncExp, functionExecutable)
+        LINK(OpNewAsyncFunc, functionExecutable)
+        LINK(OpNewAsyncFuncExp, functionExecutable)
+        LINK(OpNewAsyncGeneratorFunc, functionExecutable)
+        LINK(OpNewAsyncGeneratorFuncExp, functionExecutable)
 
         LINK(OpCatch)
         LINK(OpProfileControlFlow)
@@ -572,12 +603,9 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
             metadata.m_resolveType = op.type;
             metadata.m_localScopeDepth = op.depth;
             if (op.lexicalEnvironment) {
-                if (op.type == ModuleVar) {
-                    // Keep the linked module environment strongly referenced.
-                    if (stronglyReferencedModuleEnvironments.add(uncheckedDowncast<JSModuleEnvironment>(op.lexicalEnvironment)).isNewEntry)
-                        addConstant(ConcurrentJSLocker(m_lock), op.lexicalEnvironment);
+                if (op.type == ModuleVar)
                     metadata.m_lexicalEnvironment.set(vm, this, op.lexicalEnvironment);
-                } else
+                else
                     metadata.m_symbolTable.set(vm, this, op.lexicalEnvironment->symbolTable());
             } else if (JSScope* constantScope = JSScope::constantScopeForCodeBlock(op.type, this)) {
                 metadata.m_constantScope.set(vm, this, constantScope);
@@ -619,7 +647,8 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
             if (bytecode.m_getPutInfo.resolveType() == ResolvedClosureVar) {
                 // Only do watching if the property we're putting to is not anonymous.
                 if (bytecode.m_var != UINT_MAX) {
-                    SymbolTable* symbolTable = uncheckedDowncast<SymbolTable>(getConstant(bytecode.m_symbolTableOrScopeDepth.symbolTable()));
+                    SymbolTable* symbolTable = linkSymbolTable(bytecode.m_symbolTableOrScopeDepth.symbolTable());
+                    metadata.m_symbolTable.set(vm, this, symbolTable);
                     const Identifier& ident = identifier(bytecode.m_var);
                     ConcurrentJSLocker locker(symbolTable->m_lock);
                     auto iter = symbolTable->find(locker, ident.impl());
@@ -690,7 +719,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
                 break;
             }
             case ProfileTypeBytecodeLocallyResolved: {
-                SymbolTable* symbolTable = uncheckedDowncast<SymbolTable>(getConstant(bytecode.m_symbolTableOrScopeDepth.symbolTable()));
+                SymbolTable* symbolTable = linkSymbolTable(bytecode.m_symbolTableOrScopeDepth.symbolTable());
                 const Identifier& ident = identifier(bytecode.m_identifier);
                 ConcurrentJSLocker locker(symbolTable->m_lock);
                 // If our parent scope was created while profiling was disabled, it will not have prepared for profiling yet.
@@ -769,7 +798,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
     if (m_metadata)
         vm.heap.reportExtraMemoryAllocated(this, m_metadata->sizeInBytesForGC());
 
-    initializeTemplateObjects(topLevelExecutable, templateObjectIndices);
+    initializeTemplateObjects(topLevelExecutable);
     RETURN_IF_EXCEPTION(throwScope, false);
 
     return true;
@@ -801,7 +830,7 @@ void CodeBlock::setupWithUnlinkedBaselineCode(Ref<BaselineJITCode> jitCode)
 
     {
         ASSERT(!m_jitData);
-        auto baselineJITData = BaselineJITData::create(jitCode->m_unlinkedPropertyInlineCaches.size(), jitCode->m_constantPool.size(), this);
+        auto baselineJITData = BaselineJITData::create(jitCode->m_unlinkedPropertyInlineCaches.size(), this);
 
         for (unsigned index = 0; index < jitCode->m_unlinkedPropertyInlineCaches.size(); ++index) {
             BaselineUnlinkedPropertyInlineCache& unlinkedPropertyCache = jitCode->m_unlinkedPropertyInlineCaches[index];
@@ -809,21 +838,6 @@ void CodeBlock::setupWithUnlinkedBaselineCode(Ref<BaselineJITCode> jitCode)
             propertyCache.initializeFromUnlinkedPropertyInlineCache(vm(), this, unlinkedPropertyCache);
         }
 
-        for (size_t i = 0; i < jitCode->m_constantPool.size(); ++i) {
-            auto entry = jitCode->m_constantPool.at(i);
-            switch (entry.type()) {
-            case JITConstantPool::Type::FunctionDecl: {
-                unsigned index = std::bit_cast<uintptr_t>(entry.pointer());
-                baselineJITData->trailingSpan()[i] = functionDecl(index);
-                break;
-            }
-            case JITConstantPool::Type::FunctionExpr: {
-                unsigned index = std::bit_cast<uintptr_t>(entry.pointer());
-                baselineJITData->trailingSpan()[i] = functionExpr(index);
-                break;
-            }
-            }
-        }
         setBaselineJITData(WTF::move(baselineJITData));
 
         // Set optimization thresholds only after instructions is initialized and JITData is initialized, since these
@@ -1020,100 +1034,56 @@ CodeBlock::~CodeBlock()
     }
 }
 
-bool CodeBlock::isConstantOwnedByUnlinkedCodeBlock(VirtualRegister reg) const
-{
-    // This needs to correspond to what we do inside setConstantRegisters.
-    switch (unlinkedCodeBlock()->constantSourceCodeRepresentation(reg)) {
-    case SourceCodeRepresentation::Integer:
-    case SourceCodeRepresentation::Double:
-        return true;
-    case SourceCodeRepresentation::Other: {
-        JSValue value = unlinkedCodeBlock()->getConstant(reg);
-        if (!value || !value.isCell())
-            return true;
-        JSCell* cell = value.asCell();
-        if (cell->inherits<SymbolTable>() || cell->inherits<JSTemplateObjectDescriptor>())
-            return false;
-        return true;
-    }
-    case SourceCodeRepresentation::LinkTimeConstant:
-        return false;
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-}
-
-Vector<unsigned> CodeBlock::setConstantRegisters(const FixedVector<WriteBarrier<Unknown>>& constants, const FixedVector<SourceCodeRepresentation>& constantsSourceCodeRepresentation)
+// The constant pool holds the master SymbolTable, shared by every realm. Scopes need a per-realm clone,
+// memoized on the global object so that all CodeBlocks of a realm agree: constant watchpointing depends
+// on there being exactly one clone, otherwise a jettison caused by a changed constant could leave a
+// stale-but-valid watchpoint on a different clone.
+SymbolTable* CodeBlock::linkSymbolTable(SymbolTable* master)
 {
     VM& vm = *m_vm;
     JSGlobalObject* globalObject = m_globalObject.get();
 
-    Vector<unsigned> templateObjectIndices;
-
-    ASSERT(constants.size() == constantsSourceCodeRepresentation.size());
-    size_t count = constants.size();
-    {
-        ConcurrentJSLocker locker(m_lock);
-        m_constantRegisters.resizeToFit(count);
-    }
-    for (size_t i = 0; i < count; i++) {
-        JSValue constant = constants[i].get();
-        SourceCodeRepresentation representation = constantsSourceCodeRepresentation[i];
-        switch (representation) {
-        case SourceCodeRepresentation::LinkTimeConstant:
-            constant = globalObject->linkTimeConstant(static_cast<LinkTimeConstant>(constant.asInt32AsAnyInt()));
-            ASSERT(constant.isCell()); // Unlinked Baseline JIT requires this.
-            break;
-        case SourceCodeRepresentation::Other:
-        case SourceCodeRepresentation::Integer:
-        case SourceCodeRepresentation::Double:
-            if (!constant.isEmpty()) {
-                if (constant.isCell()) {
-                    JSCell* cell = constant.asCell();
-                    if (SymbolTable* symbolTable = dynamicDowncast<SymbolTable>(cell)) {
-                        if (m_unlinkedCode->wasCompiledWithTypeProfilerOpcodes()) {
-                            ConcurrentJSLocker locker(symbolTable->m_lock);
-                            symbolTable->prepareForTypeProfiling(locker);
-                        }
-
-                        // We have to make sure to use a single code block for constant watchpointing.
-                        // If we didn't then we could jettison a compilation because that constant changed
-                        // but invalidate the clone. Then the next compilation would see the original
-                        // watchpoint intact and assume the value is still the original constant.
-                        SymbolTable* clone = globalObject->symbolTableCache().get(symbolTable);
-                        if (!clone) {
-                            // For non-builtin code, link the clone's singleton watchpoint to the master
-                            // SymbolTable held inside the UnlinkedCodeBlock so that all per-realm clones
-                            // share one InferredValue. This avoids re-firing the singleton watchpoint
-                            // independently in every realm (e.g. on navigation) for the same code.
-                            auto propagateCloneInvalidationToOriginal = m_unlinkedCode->isBuiltinFunction() ? SymbolTable::PropagateCloneInvalidationToOriginal::No : SymbolTable::PropagateCloneInvalidationToOriginal::Yes;
-                            clone = symbolTable->cloneScopePart(vm, propagateCloneInvalidationToOriginal);
-                            globalObject->symbolTableCache().set(symbolTable, clone);
-                        }
-                        if (wasCompiledWithDebuggingOpcodes())
-                            clone->collectDebuggerInfo(this);
-
-                        constant = clone;
-                    } else if (is<JSTemplateObjectDescriptor>(cell))
-                        templateObjectIndices.append(i);
-                }
-            }
-            break;
-        }
-        m_constantRegisters[i].set(vm, this, constant);
+    if (m_unlinkedCode->wasCompiledWithTypeProfilerOpcodes()) {
+        ConcurrentJSLocker locker(master->m_lock);
+        master->prepareForTypeProfiling(locker);
     }
 
-    return templateObjectIndices;
+    SymbolTable* clone = globalObject->symbolTableCache().get(master);
+    if (!clone) {
+        // For non-builtin code, link the clone's singleton watchpoint to the master SymbolTable held
+        // inside the UnlinkedCodeBlock so that all per-realm clones share one InferredValue. This avoids
+        // re-firing the singleton watchpoint independently in every realm (e.g. on navigation) for the
+        // same code.
+        auto propagateCloneInvalidationToOriginal = m_unlinkedCode->isBuiltinFunction() ? SymbolTable::PropagateCloneInvalidationToOriginal::No : SymbolTable::PropagateCloneInvalidationToOriginal::Yes;
+        clone = master->cloneScopePart(vm, propagateCloneInvalidationToOriginal);
+        globalObject->symbolTableCache().set(master, clone);
+    }
+    if (wasCompiledWithDebuggingOpcodes())
+        clone->collectDebuggerInfo(this);
+
+    return clone;
 }
 
-void CodeBlock::initializeTemplateObjects(ScriptExecutable* topLevelExecutable, const Vector<unsigned>& templateObjectIndices)
+SymbolTable* CodeBlock::linkSymbolTable(VirtualRegister masterConstant)
 {
+    return linkSymbolTable(uncheckedDowncast<SymbolTable>(m_unlinkedCode->getConstant(masterConstant).asCell()));
+}
+
+void CodeBlock::initializeTemplateObjects(ScriptExecutable* topLevelExecutable)
+{
+    if (!m_metadata)
+        return;
+
     auto scope = DECLARE_THROW_SCOPE(vm());
-    for (unsigned i : templateObjectIndices) {
-        auto* descriptor = uncheckedDowncast<JSTemplateObjectDescriptor>(m_constantRegisters[i].get());
+    const auto& instructionStream = instructions();
+    for (const auto& instruction : instructionStream) {
+        if (!instruction->is<OpGetTemplateObject>())
+            continue;
+        auto bytecode = instruction->as<OpGetTemplateObject>();
+        auto* descriptor = uncheckedDowncast<JSTemplateObjectDescriptor>(m_unlinkedCode->getConstant(bytecode.m_descriptor).asCell());
         auto* templateObject = topLevelExecutable->createTemplateObject(globalObject(), descriptor);
         RETURN_IF_EXCEPTION(scope, void());
-        m_constantRegisters[i].set(vm(), this, templateObject);
+        bytecode.metadata(this).m_templateObject.set(vm(), this, templateObject);
     }
 }
 
@@ -1955,14 +1925,59 @@ void CodeBlock::stronglyVisitStrongReferences(const ConcurrentJSLocker& locker, 
     visitor.append(m_unlinkedCode);
     if (m_rareData)
         m_rareData->m_directEvalCodeCache.visitAggregate(visitor);
-    visitor.appendValues(m_constantRegisters.span().data(), m_constantRegisters.size());
-    for (auto& functionExpr : m_functionExprs)
-        visitor.append(functionExpr);
-    for (auto& functionDecl : m_functionDecls)
-        visitor.append(functionDecl);
     forEachObjectAllocationProfile([&](ObjectAllocationProfile& objectAllocationProfile) {
         objectAllocationProfile.visitAggregate(visitor);
     });
+    if (m_metadata) {
+        // Unlike OpResolveScope's m_symbolTable, this is the only reference to the module environment,
+        // so it cannot be treated as weak and cleared when dead.
+        m_metadata->forEach<OpResolveScope>([&](auto& metadata) {
+            if (metadata.m_resolveType == ModuleVar)
+                visitor.append(metadata.m_lexicalEnvironment);
+        });
+        m_metadata->forEach<OpNewArrayBuffer>([&](auto& metadata) {
+            visitor.append(metadata.m_immutableButterfly);
+        });
+        // The per-realm SymbolTable clones are memoized in a WeakGCMap, so these are the only strong
+        // references keeping them alive, and OpPutToScope's m_watchpointSet points into one of them.
+        m_metadata->forEach<OpCreateLexicalEnvironment>([&](auto& metadata) {
+            visitor.append(metadata.m_symbolTable);
+        });
+        m_metadata->forEach<OpCreateGeneratorFrameEnvironment>([&](auto& metadata) {
+            visitor.append(metadata.m_symbolTable);
+        });
+        m_metadata->forEach<OpPutToScope>([&](auto& metadata) {
+            visitor.append(metadata.m_symbolTable);
+        });
+        // The top level executable's TemplateObjectMap already keeps these alive, but this CodeBlock
+        // reaches that map only indirectly, so mark them here rather than rely on it.
+        m_metadata->forEach<OpGetTemplateObject>([&](auto& metadata) {
+            visitor.append(metadata.m_templateObject);
+        });
+        auto visitFunctionExecutable = [&](auto& metadata) {
+            visitor.append(metadata.m_functionExecutable);
+        };
+        m_metadata->forEach<OpNewFunc>(visitFunctionExecutable);
+        m_metadata->forEach<OpNewFuncExp>(visitFunctionExecutable);
+        m_metadata->forEach<OpNewGeneratorFunc>(visitFunctionExecutable);
+        m_metadata->forEach<OpNewGeneratorFuncExp>(visitFunctionExecutable);
+        m_metadata->forEach<OpNewAsyncFunc>(visitFunctionExecutable);
+        m_metadata->forEach<OpNewAsyncFuncExp>(visitFunctionExecutable);
+        m_metadata->forEach<OpNewAsyncGeneratorFunc>(visitFunctionExecutable);
+        m_metadata->forEach<OpNewAsyncGeneratorFuncExp>(visitFunctionExecutable);
+        // A link time constant is owned by the global object, which this CodeBlock references strongly,
+        // so in principle these need no marking. Mark them anyway: the cost is one scan of metadata that
+        // already exists, and relying on a second owner for a raw cached cell is not worth the risk.
+        m_metadata->forEach<OpGetLinkTimeConstant>([&](auto& metadata) {
+            visitor.append(metadata.m_constant);
+        });
+        m_metadata->forEach<OpJeqPtr>([&](auto& metadata) {
+            visitor.append(metadata.m_specialPointer);
+        });
+        m_metadata->forEach<OpJneqPtr>([&](auto& metadata) {
+            visitor.append(metadata.m_specialPointer);
+        });
+    }
 
 #if ENABLE(JIT)
     forEachPropertyInlineCache([&](PropertyInlineCache& propertyCache) {
@@ -1976,6 +1991,8 @@ void CodeBlock::stronglyVisitStrongReferences(const ConcurrentJSLocker& locker, 
             statuses->visitAggregate(visitor);
         for (auto& cache : dfgCommon->m_concatKeyAtomStringCaches)
             cache->visitAggregate(visitor);
+        for (auto& strongReference : dfgCommon->m_strongReferences)
+            visitor.append(strongReference);
         visitOSRExitTargets(locker, visitor);
 #endif
     }
@@ -2206,12 +2223,6 @@ bool CodeBlock::hasOpDebugForLineAndColumn(unsigned line, std::optional<unsigned
         }
     }
     return false;
-}
-
-void CodeBlock::shrinkToFit(const ConcurrentJSLocker&, ShrinkMode shrinkMode)
-{
-    UNUSED_PARAM(shrinkMode);
-    m_constantRegisters.shrinkToFit();
 }
 
 void CodeBlock::linkIncomingCall(JSCell* caller, CallLinkInfoBase* incoming)
@@ -3344,7 +3355,7 @@ size_t CodeBlock::predictedMachineCodeSize()
 
 String CodeBlock::nameForRegister(VirtualRegister virtualRegister)
 {
-    for (auto& constantRegister : m_constantRegisters) {
+    for (auto& constantRegister : m_unlinkedCode->constantRegisters()) {
         if (constantRegister.get().isEmpty())
             continue;
         if (SymbolTable* symbolTable = dynamicDowncast<SymbolTable>(constantRegister.get())) {
@@ -3621,18 +3632,17 @@ void CodeBlock::insertBasicBlockBoundariesForControlFlowProfiler()
         // This is necessary because in the original source text of a JavaScript program, 
         // function literals form new basic blocks boundaries, but they aren't represented 
         // inside the CodeBlock's instruction stream.
-        auto insertFunctionGaps = [basicBlockLocation, basicBlockStartOffset, basicBlockEndOffset] (const WriteBarrier<FunctionExecutable>& functionExecutable) {
-            const UnlinkedFunctionExecutable* executable = functionExecutable->unlinkedExecutable();
-            int functionStart = executable->unlinkedFunctionStart();
-            int functionEnd = executable->unlinkedFunctionEnd();
-            if (functionStart >= basicBlockStartOffset && functionEnd <= basicBlockEndOffset)
-                basicBlockLocation->insertGap(functionStart, functionEnd);
+        auto insertFunctionGaps = [basicBlockLocation, basicBlockStartOffset, basicBlockEndOffset] (std::span<const WriteBarrier<UnlinkedFunctionExecutable>> executables) {
+            for (auto& executable : executables) {
+                int functionStart = executable->unlinkedFunctionStart();
+                int functionEnd = executable->unlinkedFunctionEnd();
+                if (functionStart >= basicBlockStartOffset && functionEnd <= basicBlockEndOffset)
+                    basicBlockLocation->insertGap(functionStart, functionEnd);
+            }
         };
 
-        for (const WriteBarrier<FunctionExecutable>& executable : m_functionDecls)
-            insertFunctionGaps(executable);
-        for (const WriteBarrier<FunctionExecutable>& executable : m_functionExprs)
-            insertFunctionGaps(executable);
+        insertFunctionGaps(m_unlinkedCode->functionDecls());
+        insertFunctionGaps(m_unlinkedCode->functionExprs());
 
         metadata.m_basicBlockLocation = basicBlockLocation;
     }

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -501,35 +501,16 @@ public:
     bool wasDestructed();
 #endif
 
-    Vector<WriteBarrier<Unknown>>& constants() LIFETIME_BOUND { return m_constantRegisters; }
-    unsigned addConstant(const ConcurrentJSLocker&, JSValue v)
-    {
-        unsigned result = m_constantRegisters.size();
-        m_constantRegisters.append(WriteBarrier<Unknown>());
-        m_constantRegisters.last().set(*m_vm, this, v);
-        return result;
-    }
-
-    unsigned addConstantLazily(const ConcurrentJSLocker&)
-    {
-        unsigned result = m_constantRegisters.size();
-        m_constantRegisters.append(WriteBarrier<Unknown>());
-        return result;
-    }
-
-    const Vector<WriteBarrier<Unknown>>& constantRegisters() LIFETIME_BOUND { return m_constantRegisters; }
-    WriteBarrier<Unknown>& constantRegister(VirtualRegister reg) { return m_constantRegisters[reg.toConstantIndex()]; }
-    ALWAYS_INLINE JSValue getConstant(VirtualRegister reg) const { return m_constantRegisters[reg.toConstantIndex()].get(); }
-    bool NODELETE isConstantOwnedByUnlinkedCodeBlock(VirtualRegister) const;
+    unsigned numberOfConstantRegisters() const { return m_unlinkedCode->constantRegisters().size(); }
+    std::span<const WriteBarrier<Unknown>> constantRegisters() const LIFETIME_BOUND { return { m_constants, numberOfConstantRegisters() }; }
+    const WriteBarrier<Unknown>& constantRegister(VirtualRegister reg) const LIFETIME_BOUND { return m_constants[reg.toConstantIndex()]; }
+    ALWAYS_INLINE JSValue getConstant(VirtualRegister reg) const { return m_constants[reg.toConstantIndex()].get(); }
+    SymbolTable* linkSymbolTable(SymbolTable* master);
+    SymbolTable* linkSymbolTable(VirtualRegister masterConstant);
     ALWAYS_INLINE SourceCodeRepresentation constantSourceCodeRepresentation(VirtualRegister reg) const { return m_unlinkedCode->constantSourceCodeRepresentation(reg); }
     ALWAYS_INLINE SourceCodeRepresentation constantSourceCodeRepresentation(unsigned index) const { return m_unlinkedCode->constantSourceCodeRepresentation(index); }
-    static constexpr ptrdiff_t offsetOfConstantsVectorBuffer() { return OBJECT_OFFSETOF(CodeBlock, m_constantRegisters) + decltype(m_constantRegisters)::dataMemoryOffset(); }
+    static constexpr ptrdiff_t offsetOfConstants() { return OBJECT_OFFSETOF(CodeBlock, m_constants); }
 
-    FunctionExecutable* functionDecl(int index) { return m_functionDecls[index].get(); }
-    int numberOfFunctionDecls() { return m_functionDecls.size(); }
-    std::span<const WriteBarrier<FunctionExecutable>> functionDecls() { return m_functionDecls.span(); }
-    FunctionExecutable* functionExpr(int index) { return m_functionExprs[index].get(); }
-    std::span<const WriteBarrier<FunctionExecutable>> functionExprs() { return m_functionExprs.span(); }
     
     const BitVector& bitVector(size_t i) LIFETIME_BOUND { return m_unlinkedCode->bitVector(i); }
 
@@ -589,17 +570,6 @@ public:
     const UnlinkedStringJumpTable& unlinkedStringSwitchJumpTable(int tableIndex) LIFETIME_BOUND { return m_unlinkedCode->unlinkedStringSwitchJumpTable(tableIndex); }
 
     DirectEvalCodeCache& directEvalCodeCache() { createRareDataIfNecessary(); return m_rareData->m_directEvalCodeCache; }
-
-    enum class ShrinkMode {
-        // Shrink prior to generating machine code that may point directly into vectors.
-        EarlyShrink,
-
-        // Shrink after generating machine code, and after possibly creating new vectors
-        // and appending to others. At this time it is not safe to shrink certain vectors
-        // because we would have generated machine code that references them directly.
-        LateShrink,
-    };
-    void shrinkToFit(const ConcurrentJSLocker&, ShrinkMode);
 
     // Functions for controlling when JITting kicks in, in a mixed mode
     // execution world.
@@ -915,19 +885,12 @@ private:
 
     void updateAllNonLazyValueProfilePredictionsAndCountLiveness(const ConcurrentJSLocker&, unsigned& numberOfLiveNonArgumentValueProfiles, unsigned& numberOfSamplesInProfiles);
 
-    Vector<unsigned> setConstantRegisters(const FixedVector<WriteBarrier<Unknown>>& constants, const FixedVector<SourceCodeRepresentation>& constantsSourceCodeRepresentation);
-    void initializeTemplateObjects(ScriptExecutable* topLevelExecutable, const Vector<unsigned>& templateObjectIndices);
-
-    void replaceConstant(VirtualRegister reg, JSValue value)
-    {
-        ASSERT(reg.isConstant() && static_cast<size_t>(reg.toConstantIndex()) < m_constantRegisters.size());
-        m_constantRegisters[reg.toConstantIndex()].set(*m_vm, this, value);
-    }
+    void initializeTemplateObjects(ScriptExecutable* topLevelExecutable);
 
     template<typename Visitor> bool shouldVisitStrongly(const ConcurrentJSLocker&, Visitor&);
     bool shouldJettisonDueToWeakReference(VM&);
     template<typename Visitor> bool shouldJettisonDueToOldAge(const ConcurrentJSLocker&, Visitor&);
-    
+
     template<typename Visitor> void propagateTransitions(const ConcurrentJSLocker&, Visitor&);
     template<typename Visitor> void determineLiveness(const ConcurrentJSLocker&, Visitor&);
         
@@ -1008,13 +971,12 @@ private:
 #endif
     FixedVector<ArgumentValueProfile> m_argumentValueProfiles;
 
-    // Constant Pool
+    // Constant Pool. Points directly at m_unlinkedCode's immutable buffer: every entry is identical in
+    // every realm, so nothing here is per-CodeBlock. Anything that does differ per realm (link time
+    // constants, SymbolTable clones, template objects, re-typed array literal butterflies) lives in the
+    // metadata of the instruction that needs it.
     static_assert(sizeof(Register) == sizeof(WriteBarrier<Unknown>), "Register must be same size as WriteBarrier Unknown");
-    // FIXME: This could just be a pointer to m_unlinkedCodeBlock's data, but the DFG mutates
-    // it, so we're stuck with it for now.
-    Vector<WriteBarrier<Unknown>> m_constantRegisters;
-    FixedVector<WriteBarrier<FunctionExecutable>> m_functionDecls;
-    FixedVector<WriteBarrier<FunctionExecutable>> m_functionExprs;
+    const WriteBarrier<Unknown>* m_constants { nullptr };
 
     WriteBarrier<CodeBlock> m_alternative;
 
@@ -1032,7 +994,7 @@ private:
 };
 /* This check is for normal Release builds; ASSERT_ENABLED changes the size. */
 #if !ASSERT_ENABLED
-static_assert(sizeof(CodeBlock) <= 224, "Keep it small for memory saving");
+static_assert(sizeof(CodeBlock) <= 200, "Keep it small for memory saving");
 #endif
 
 template <typename ExecutableType>
@@ -1065,10 +1027,10 @@ void ScriptExecutable::prepareForExecution(VM& vm, JSFunction* function, JSScope
 void setPrinter(Printer::PrintRecord&, CodeBlock*);
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-inline Register& CallFrame::r(VirtualRegister reg)
+inline const Register& CallFrame::r(VirtualRegister reg)
 {
     if (reg.isConstant())
-        SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<Register*>(&this->codeBlock()->constantRegister(reg));
+        SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<const Register*>(&this->codeBlock()->constantRegister(reg));
     return this[reg.offset()];
 }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/bytecode/Fits.h
+++ b/Source/JavaScriptCore/bytecode/Fits.h
@@ -28,6 +28,7 @@
 #include "GetPutInfo.h"
 #include "Interpreter.h"
 #include "Label.h"
+#include "LinkTimeConstant.h"
 #include "OpcodeSize.h"
 #include "PrivateFieldPutKind.h"
 #include "ProfileTypeBytecodeFlag.h"
@@ -152,6 +153,30 @@ struct Fits<VirtualRegister, size> {
         if (i >= s_firstConstantIndex)
             return VirtualRegister { (i - s_firstConstantIndex) + FirstConstantRegisterIndex };
         return VirtualRegister { i };
+    }
+};
+
+// LinkTimeConstant would otherwise go through the generic enum specialization below and be encoded as
+// its signed underlying type, capping the narrow form at 127 even though the values are all
+// non-negative and there are more than that many of them.
+template<OpcodeSize size>
+    requires (size != OpcodeSize::Wide32)
+struct Fits<LinkTimeConstant, size> : public Fits<unsigned, size> {
+    static_assert(numberOfLinkTimeConstants <= std::numeric_limits<typename TypeBySize<OpcodeSize::Narrow>::unsignedType>::max() + 1,
+        "A LinkTimeConstant no longer fits the narrow operand form; widen it deliberately rather than silently.");
+    using TargetType = typename TypeBySize<size>::unsignedType;
+    using Base = Fits<unsigned, size>;
+
+    static bool check(LinkTimeConstant constant) { return Base::check(static_cast<unsigned>(constant)); }
+
+    static TargetType convert(LinkTimeConstant constant)
+    {
+        return Base::convert(static_cast<unsigned>(constant));
+    }
+
+    static LinkTimeConstant convert(TargetType constant)
+    {
+        return static_cast<LinkTimeConstant>(Base::convert(constant));
     }
 };
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
@@ -136,16 +136,6 @@ public:
         m_constantsSourceCodeRepresentation.append(sourceCodeRepresentation);
         return result;
     }
-    unsigned addConstant(LinkTimeConstant linkTimeConstant)
-    {
-        ASSERT(m_vm.heap.isDeferred());
-        unsigned result = m_constantRegisters.size();
-        m_constantRegisters.append(WriteBarrier<Unknown>());
-        m_constantRegisters.last().setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(linkTimeConstant)));
-        m_constantsSourceCodeRepresentation.append(SourceCodeRepresentation::LinkTimeConstant);
-        return result;
-    }
-
     unsigned addFunctionDecl(UnlinkedFunctionExecutable* n)
     {
         ASSERT(m_vm.heap.isDeferred());

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -1618,32 +1618,32 @@ void BytecodeGenerator::emitJumpIfFalse(RegisterID* cond, Label& target)
 
 void BytecodeGenerator::emitJumpIfNotFunctionCall(RegisterID* cond, Label& target)
 {
-    OpJneqPtr::emit(this, cond, moveLinkTimeConstant(nullptr, LinkTimeConstant::callFunction), target.bind(this));
+    OpJneqPtr::emit(this, cond, LinkTimeConstant::callFunction, target.bind(this));
 }
 
 void BytecodeGenerator::emitJumpIfNotFunctionApply(RegisterID* cond, Label& target)
 {
-    OpJneqPtr::emit(this, cond, moveLinkTimeConstant(nullptr, LinkTimeConstant::applyFunction), target.bind(this));
+    OpJneqPtr::emit(this, cond, LinkTimeConstant::applyFunction, target.bind(this));
 }
 
 void BytecodeGenerator::emitJumpIfNotEvalFunction(RegisterID* cond, Label& target)
 {
-    OpJneqPtr::emit(this, cond, moveLinkTimeConstant(nullptr, LinkTimeConstant::evalFunction), target.bind(this));
+    OpJneqPtr::emit(this, cond, LinkTimeConstant::evalFunction, target.bind(this));
 }
 
 void BytecodeGenerator::emitJumpIfEmptyPropertyNameEnumerator(RegisterID* cond, Label& target)
 {
-    OpJeqPtr::emit(this, cond, moveLinkTimeConstant(nullptr, LinkTimeConstant::emptyPropertyNameEnumerator), target.bind(this));
+    OpJeqPtr::emit(this, cond, LinkTimeConstant::emptyPropertyNameEnumerator, target.bind(this));
 }
 
 void BytecodeGenerator::emitJumpIfSentinelString(RegisterID* cond, Label& target)
 {
-    OpJeqPtr::emit(this, cond, moveLinkTimeConstant(nullptr, LinkTimeConstant::sentinelString), target.bind(this));
+    OpJeqPtr::emit(this, cond, LinkTimeConstant::sentinelString, target.bind(this));
 }
 
 unsigned BytecodeGenerator::emitWideJumpIfNotFunctionHasOwnProperty(RegisterID* cond, Label& target)
 {
-    OpJneqPtr::emit<OpcodeSize::Wide32>(this, cond, moveLinkTimeConstant(nullptr, LinkTimeConstant::hasOwnPropertyFunction), target.bind(this));
+    OpJneqPtr::emit<OpcodeSize::Wide32>(this, cond, LinkTimeConstant::hasOwnPropertyFunction, target.bind(this));
     return m_lastInstruction.offset();
 }
 
@@ -1703,15 +1703,10 @@ RegisterID* BytecodeGenerator::addConstantValue(JSValue v, SourceCodeRepresentat
 
 RegisterID* BytecodeGenerator::moveLinkTimeConstant(RegisterID* dst, LinkTimeConstant type)
 {
-    RegisterID* constant = m_linkTimeConstantRegisters.ensure(type, [&] {
-        int index = addConstantIndex();
-        m_codeBlock->addConstant(type);
-        return &m_constantPoolRegisters[index];
-    }).iterator->value;
     if (!dst)
-        return constant;
-
-    return move(dst, constant);
+        dst = newTemporary();
+    OpGetLinkTimeConstant::emit(this, dst, type);
+    return dst;
 }
 
 RegisterID* BytecodeGenerator::moveEmptyValue(RegisterID* dst)
@@ -3067,7 +3062,7 @@ void BytecodeGenerator::emitCreatePrivateBrand(const JSTextPosition& divot, cons
     CallArguments arguments(*this, nullptr, 1);
     emitLoad(arguments.thisRegister(), jsUndefined());
     emitLoad(arguments.argumentRegister(0), jsEmptyString(m_vm));
-    RegisterID* newSymbol = emitCall(finalDestination(nullptr, createPrivateSymbol.get()), createPrivateSymbol.get(), NoExpectedFunction, arguments, divot, divotStart, divotEnd, DebuggableCall::No);
+    RegisterID* newSymbol = emitCall(finalDestination(nullptr), createPrivateSymbol.get(), NoExpectedFunction, arguments, divot, divotStart, divotEnd, DebuggableCall::No);
 
     Variable privateBrandVar = variable(propertyNames().builtinNames().privateBrandPrivateName());
 
@@ -3744,7 +3739,7 @@ ExpectedFunction BytecodeGenerator::emitExpectedFunctionSnippet(RegisterID* dst,
         if (callArguments.argumentCountIncludingThis() >= 2)
             return NoExpectedFunction;
         
-        OpJneqPtr::emit(this, func, moveLinkTimeConstant(nullptr, LinkTimeConstant::Object), realCall->bind(this));
+        OpJneqPtr::emit(this, func, LinkTimeConstant::Object, realCall->bind(this));
         
         if (dst != ignoredResult())
             emitNewObject(dst);
@@ -3760,7 +3755,7 @@ ExpectedFunction BytecodeGenerator::emitExpectedFunctionSnippet(RegisterID* dst,
         if (callArguments.argumentCountIncludingThis() > 2)
             return NoExpectedFunction;
         
-        OpJneqPtr::emit(this, func, moveLinkTimeConstant(nullptr, LinkTimeConstant::Array), realCall->bind(this));
+        OpJneqPtr::emit(this, func, LinkTimeConstant::Array, realCall->bind(this));
         
         if (dst != ignoredResult()) {
             if (callArguments.argumentCountIncludingThis() == 2)
@@ -5091,10 +5086,11 @@ RegisterID* BytecodeGenerator::emitGetTemplateObject(RegisterID* dst, TaggedTemp
         else
             cookedStrings.append(string->cooked()->impl());
     }
-    RefPtr<RegisterID> constant = addTemplateObjectConstant(TemplateObjectDescriptor::create(WTF::move(rawStrings), WTF::move(cookedStrings)), taggedTemplate->endOffset());
+    RefPtr<RegisterID> descriptor = addTemplateObjectConstant(TemplateObjectDescriptor::create(WTF::move(rawStrings), WTF::move(cookedStrings)), taggedTemplate->endOffset());
     if (!dst)
-        return constant.unsafeGet();
-    return move(dst, constant.get());
+        dst = newTemporary();
+    OpGetTemplateObject::emit(this, dst, descriptor.get());
+    return dst;
 }
 
 RegisterID* BytecodeGenerator::emitGetGlobalPrivate(RegisterID* dst, const Identifier& property)

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1360,7 +1360,6 @@ namespace JSC {
         RegisterID* m_emptyValueRegister { nullptr };
         RegisterID* m_newTargetRegister { nullptr };
         RegisterID* m_isDerivedConstuctor { nullptr };
-        UncheckedKeyHashMap<LinkTimeConstant, RegisterID*, WTF::IntHash<LinkTimeConstant>, WTF::StrongEnumHashTraits<LinkTimeConstant>> m_linkTimeConstantRegisters;
         RegisterID* m_arrowFunctionContextLexicalEnvironmentRegister { nullptr };
         RegisterID* m_promiseRegister { nullptr };
 

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -243,7 +243,7 @@ RegisterID* ImportNode::emitBytecode(BytecodeGenerator& generator, RegisterID* d
         generator.emitLoad(arguments.argumentRegister(1), jsUndefined());
     if (m_deferred)
         generator.emitLoad(arguments.argumentRegister(2), jsBoolean(true));
-    return generator.emitCall(generator.finalDestination(dst, importModule.get()), importModule.get(), NoExpectedFunction, arguments, divot(), divotStart(), divotEnd(), DebuggableCall::No);
+    return generator.emitCall(generator.finalDestination(dst), importModule.get(), NoExpectedFunction, arguments, divot(), divotStart(), divotEnd(), DebuggableCall::No);
 }
 
 // ------------------------------ NewTargetNode ----------------------------------
@@ -603,7 +603,7 @@ RegisterID* ObjectLiteralNode::emitBytecode(BytecodeGenerator& generator, Regist
             RefPtr<RegisterID> src = generator.emitNode(static_cast<ObjectSpreadExpressionNode*>(propertyList->m_node->m_assign)->expression());
             CallArguments args(generator, nullptr, 0);
             generator.move(args.thisRegister(), src.get());
-            return generator.emitCall(generator.finalDestination(dst, function.get()), function.get(), NoExpectedFunction, args, position(), position(), position(), DebuggableCall::No);
+            return generator.emitCall(generator.finalDestination(dst), function.get(), NoExpectedFunction, args, position(), position(), position(), DebuggableCall::No);
         }
 
         bool foundNonConstant = false;
@@ -656,7 +656,7 @@ void PropertyListNode::emitDeclarePrivateFieldNames(BytecodeGenerator& generator
             CallArguments arguments(generator, nullptr, 1);
             generator.emitLoad(arguments.thisRegister(), jsUndefined());
             generator.emitLoad(arguments.argumentRegister(0), *node.name());
-            RefPtr<RegisterID> symbol = generator.emitCall(generator.finalDestination(nullptr, createPrivateSymbol.get()), createPrivateSymbol.get(), NoExpectedFunction, arguments, position(), position(), position(), DebuggableCall::No);
+            RefPtr<RegisterID> symbol = generator.emitCall(generator.finalDestination(nullptr), createPrivateSymbol.get(), NoExpectedFunction, arguments, position(), position(), position(), DebuggableCall::No);
 
             Variable var = generator.variable(*node.name());
             generator.emitPutToScope(scope, var, symbol.get(), DoNotThrowIfNotFound, InitializationMode::ConstInitialization);
@@ -6015,6 +6015,7 @@ void ObjectPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs)
         RefPtr<RegisterID> restElementBase;
         RefPtr<RegisterID> restElementPropertyName;
         RefPtr<RegisterID> newObject;
+        RefPtr<RegisterID> copyDataProperties;
         IdentifierSet excludedSet;
         std::optional<CallArguments> args;
         unsigned numberOfComputedProperties = 0;
@@ -6031,6 +6032,9 @@ void ObjectPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs)
             restElementBase = generator.newTemporary();
             restElementPropertyName = generator.newTemporary();
             newObject = generator.newTemporary();
+            // Must be loaded before the CallArguments below, since those registers have to stay
+            // topmost until the call is emitted.
+            copyDataProperties = generator.moveLinkTimeConstant(nullptr, LinkTimeConstant::copyDataProperties);
             args.emplace(generator, nullptr, indexInArguments + numberOfComputedProperties);
         }
 
@@ -6120,9 +6124,6 @@ void ObjectPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs)
                     targetBaseAndPropertyName = static_cast<AssignmentElementNode*>(target.pattern)->emitNodesForDestructuring(generator, restElementBase.get(), restElementPropertyName.get());
 
                 generator.emitNewObject(newObject.get());
-
-                // load and call @copyDataProperties
-                RefPtr<RegisterID> copyDataProperties = generator.moveLinkTimeConstant(nullptr, LinkTimeConstant::copyDataProperties);
 
                 // This must be non-tail-call because @copyDataProperties accesses caller-frame.
                 generator.move(args->thisRegister(), newObject.get());

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -8510,10 +8510,10 @@ void ByteCodeParser::parseBlock(unsigned limit)
             auto bytecode = currentInstruction->as<OpNewArrayBuffer>();
             // Unfortunately, we can't allocate a new JSCellButterfly if the profile tells us new information because we
             // cannot allocate from compilation threads.
-            FrozenValue* frozen = get(VirtualRegister(bytecode.m_immutableButterfly))->constant();
+            JSCellButterfly* immutableButterfly = bytecode.metadata(m_inlineStackTop->m_codeBlock).m_immutableButterfly.get();
             WTF::dependentLoadLoadFence();
 
-            JSCellButterfly* immutableButterfly = frozen->cast<JSCellButterfly*>();
+            FrozenValue* frozen = m_graph.freezeStrong(immutableButterfly);
             NewArrayBufferData data { };
             unsigned vectorLengthHint = immutableButterfly->toButterfly()->vectorLength();
 
@@ -10259,11 +10259,21 @@ void ByteCodeParser::parseBlock(unsigned limit)
             NEXT_OPCODE(op_iterator_next);
         }
 
+        case op_get_template_object: {
+            auto bytecode = currentInstruction->as<OpGetTemplateObject>();
+            set(bytecode.m_dst, jsConstant(bytecode.metadata(m_inlineStackTop->m_codeBlock).m_templateObject.get()));
+            NEXT_OPCODE(op_get_template_object);
+        }
+
+        case op_get_link_time_constant: {
+            auto bytecode = currentInstruction->as<OpGetLinkTimeConstant>();
+            set(bytecode.m_dst, jsConstant(bytecode.metadata(m_inlineStackTop->m_codeBlock).m_constant.get()));
+            NEXT_OPCODE(op_get_link_time_constant);
+        }
+
         case op_jeq_ptr: {
             auto bytecode = currentInstruction->as<OpJeqPtr>();
-            JSValue constant = m_inlineStackTop->m_codeBlock->getConstant(bytecode.m_specialPointer);
-            FrozenValue* frozenPointer = m_graph.freezeStrong(constant);
-            ASSERT(frozenPointer->cell() == constant);
+            FrozenValue* frozenPointer = m_graph.freezeStrong(bytecode.metadata(m_inlineStackTop->m_codeBlock).m_specialPointer.get());
             unsigned relativeOffset = jumpTarget(bytecode.m_targetLabel);
             Node* child = get(bytecode.m_value);
             Node* condition = addToGraph(CompareEqPtr, OpInfo(frozenPointer), child);
@@ -10273,7 +10283,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
 
         case op_jneq_ptr: {
             auto bytecode = currentInstruction->as<OpJneqPtr>();
-            FrozenValue* frozenPointer = m_graph.freezeStrong(m_inlineStackTop->m_codeBlock->getConstant(bytecode.m_specialPointer));
+            FrozenValue* frozenPointer = m_graph.freezeStrong(bytecode.metadata(m_inlineStackTop->m_codeBlock).m_specialPointer.get());
             unsigned relativeOffset = jumpTarget(bytecode.m_targetLabel);
             Node* child = get(bytecode.m_value);
             if (bytecode.metadata(codeBlock).m_hasJumped) {
@@ -10766,7 +10776,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
         case op_create_lexical_environment: {
             auto bytecode = currentInstruction->as<OpCreateLexicalEnvironment>();
             ASSERT(bytecode.m_symbolTable.isConstant() && bytecode.m_initialValue.isConstant());
-            FrozenValue* symbolTable = m_graph.freezeStrong(m_inlineStackTop->m_codeBlock->getConstant(bytecode.m_symbolTable));
+            FrozenValue* symbolTable = m_graph.freezeStrong(bytecode.metadata(m_inlineStackTop->m_codeBlock).m_symbolTable.get());
             FrozenValue* initialValue = m_graph.freezeStrong(m_inlineStackTop->m_codeBlock->getConstant(bytecode.m_initialValue));
             Node* scope = get(bytecode.m_scope);
             Node* lexicalEnvironment = addToGraph(CreateActivation, OpInfo(symbolTable), OpInfo(initialValue), scope);
@@ -11725,7 +11735,7 @@ void ByteCodeParser::handlePutAccessorByVal(NodeType op, Bytecode bytecode)
 template <typename Bytecode>
 void ByteCodeParser::handleNewFunc(NodeType op, Bytecode bytecode)
 {
-    FunctionExecutable* decl = m_inlineStackTop->m_profiledBlock->functionDecl(bytecode.m_functionDecl);
+    FunctionExecutable* decl = bytecode.metadata(m_inlineStackTop->m_profiledBlock).m_functionExecutable.get();
     FrozenValue* frozen = m_graph.freezeStrong(decl);
     Node* scope = get(bytecode.m_scope);
     set(bytecode.m_dst, addToGraph(op, OpInfo(frozen), scope));
@@ -11742,7 +11752,7 @@ void ByteCodeParser::handleNewFunc(NodeType op, Bytecode bytecode)
 template <typename Bytecode>
 void ByteCodeParser::handleNewFuncExp(NodeType op, Bytecode bytecode)
 {
-    FunctionExecutable* expr = m_inlineStackTop->m_profiledBlock->functionExpr(bytecode.m_functionDecl);
+    FunctionExecutable* expr = bytecode.metadata(m_inlineStackTop->m_profiledBlock).m_functionExecutable.get();
     FrozenValue* frozen = m_graph.freezeStrong(expr);
     Node* scope = get(bytecode.m_scope);
     set(bytecode.m_dst, addToGraph(op, OpInfo(frozen), scope));

--- a/Source/JavaScriptCore/dfg/DFGCommonData.h
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.h
@@ -121,6 +121,9 @@ public:
     
     FixedVector<Identifier> m_dfgIdentifiers;
     FixedVector<WeakReferenceTransition> m_transitions;
+    // Values the compiled code embeds directly. Unlike m_weakReferences these are visited
+    // unconditionally, since the code cannot survive their collection.
+    FixedVector<WriteBarrier<JSCell>> m_strongReferences;
     FixedVector<WriteBarrier<JSCell>> m_weakReferences;
     FixedVector<StructureID> m_weakStructureReferences;
     FixedVector<CatchEntrypointData> m_catchEntrypoints;

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1635,12 +1635,10 @@ const WTF::BitSet<256>* Graph::regExpFirstCharacterBitmap(RegExp* regExp, FirstC
 
 void Graph::registerFrozenValues()
 {
-    ConcurrentJSLocker locker(m_codeBlock->m_lock);
-    m_codeBlock->constants().shrink(0);
     for (FrozenValue& value : m_frozenValues) {
         if (!value.pointsToHeap())
             continue;
-        
+
         ASSERT(value.structure());
         ASSERT(m_plan.weakReferences().contains(value.structure()));
 
@@ -1650,13 +1648,10 @@ void Graph::registerFrozenValues()
             break;
         }
         case StrongValue: {
-            unsigned constantIndex = m_codeBlock->addConstantLazily(locker);
-            // We already have a barrier on the code block.
-            m_codeBlock->constants()[constantIndex].setWithoutWriteBarrier(value.value());
+            m_plan.addStrongReference(value.value().asCell());
             break;
         } }
     }
-    m_codeBlock->constants().shrinkToFit();
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
@@ -63,6 +63,7 @@ bool JITFinalizer::finalize()
 
     CodeBlock* codeBlock = m_plan.codeBlock();
 
+    m_plan.installStrongReferences(&m_jitCode->common);
     codeBlock->setJITCode(m_jitCode.copyRef());
 
     auto data = m_plan.tryFinalizeJITData(m_jitCode.get());

--- a/Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp
@@ -275,7 +275,8 @@ void LazyJSValue::emit(CCallHelpers& jit, JSValueRegs result, Plan& planRef) con
             JSValue realValue = thisValue.value.getValue(codeBlock->vm());
             RELEASE_ASSERT(realValue.isCell());
 
-            codeBlock->addConstant(ConcurrentJSLocker(codeBlock->m_lock), realValue);
+            // Runs before Plan::reallyAdd, so this still reaches DFG::CommonData::m_strongReferences.
+            plan->addStrongReference(realValue.asCell());
 
             MacroAssembler::repatchPointer(patchLocation, realValue.asCell());
         });

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -5590,10 +5590,10 @@ JSC_DEFINE_JIT_OPERATION(operationLoadVarargs, void, (JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue arguments = JSValue::decode(encodedArguments);
     
-    loadVarargs(globalObject, std::bit_cast<JSValue*>(&callFrame->r(firstElement)), arguments, offset, lengthIncludingThis - 1);
+    loadVarargs(globalObject, std::bit_cast<JSValue*>(&callFrame->uncheckedR(firstElement)), arguments, offset, lengthIncludingThis - 1);
     
     for (uint32_t i = lengthIncludingThis - 1; i < mandatoryMinimum; ++i)
-        callFrame->r(firstElement + i) = jsUndefined();
+        callFrame->uncheckedR(firstElement + i) = jsUndefined();
     OPERATION_RETURN(scope);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -219,16 +219,6 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         changed |= phase(dfg);                                   \
     } while (false);                                             \
 
-    
-    // By this point the DFG bytecode parser will have potentially mutated various tables
-    // in the CodeBlock. This is a good time to perform an early shrink, which is more
-    // powerful than a late one. It's safe to do so because we haven't generated any code
-    // that references any of the tables directly, yet.
-    {
-        ConcurrentJSLocker locker(m_codeBlock->m_lock);
-        m_codeBlock->shrinkToFit(locker, CodeBlock::ShrinkMode::EarlyShrink);
-    }
-
     if (validationEnabled())
         validate(dfg);
     
@@ -546,6 +536,30 @@ bool Plan::isStillValidCodeBlock()
     return true;
 }
 
+// Must run before the CodeBlock adopts the new JITCode. Once it does, the CodeBlock is what keeps these
+// alive, and until then only the plan does - but the plan has already been taken off the worklist by
+// removeAllReadyPlansForVM, so it is no longer visited. Populating any later leaves a window where a
+// concurrent marker can reach none of these values and condemn cells the new code has baked in.
+void Plan::installStrongReferences(CommonData* commonData)
+{
+    ASSERT(m_vm->heap.isDeferred());
+    // No WriteBarriers: GC is deferred and Plan::finalize emits one on the CodeBlock at the end.
+    ASSERT(commonData->m_strongReferences.isEmpty());
+    if (m_strongReferences.isEmpty())
+        return;
+    FixedVector<WriteBarrier<JSCell>> strongReferences(m_strongReferences.size());
+    for (unsigned index = 0; index < m_strongReferences.size(); ++index)
+        strongReferences[index].setWithoutWriteBarrier(m_strongReferences[index]);
+
+    // Parallel marker threads read CommonData through CodeBlock::stronglyVisitStrongReferences while
+    // this store happens, and they synchronize with nothing here. Assigning a FixedVector is one
+    // pointer store, so without this fence a marker can observe the new buffer before the slot writes
+    // above and then trace uninitialized cells.
+    static_assert(sizeof(strongReferences) == sizeof(void*));
+    WTF::storeStoreFence();
+    commonData->m_strongReferences = WTF::move(strongReferences);
+}
+
 bool Plan::reallyAdd(CommonData* commonData)
 {
     if (!m_watchpoints.areStillValidOnMainThread(*m_vm, m_identifiers))
@@ -595,11 +609,6 @@ CompilationResult Plan::finalize()
             return CompilationResult::CompilationInvalidated;
         }
 
-        {
-            ConcurrentJSLocker locker(m_codeBlock->m_lock);
-            m_codeBlock->shrinkToFit(locker, CodeBlock::ShrinkMode::LateShrink);
-        }
-
         // Since Plan::reallyAdd could fire watchpoints (see ArrayBufferViewWatchpointAdaptor::add),
         // it is possible that the current CodeBlock is now invalidated & jettisoned.
         if (m_codeBlock->isJettisoned()) {
@@ -614,8 +623,8 @@ CompilationResult Plan::finalize()
                 trackedReferences.add(reference.get());
             for (StructureID structureID : m_codeBlock->jitCode()->dfgCommon()->m_weakStructureReferences)
                 trackedReferences.add(structureID.decode());
-            for (WriteBarrier<Unknown>& constant : m_codeBlock->constants())
-                trackedReferences.add(constant.get());
+            for (WriteBarrier<JSCell>& reference : m_codeBlock->jitCode()->dfgCommon()->m_strongReferences)
+                trackedReferences.add(reference.get());
 
             for (auto* inlineCallFrame : *m_inlineCallFrames) {
                 ASSERT(inlineCallFrame->baselineCodeBlock.get());
@@ -682,6 +691,8 @@ bool Plan::checkLivenessAndVisitChildren(AbstractSlotVisitor& visitor)
 
     m_weakReferences.visitChildren(visitor);
     m_transitions.visitChildren(visitor);
+    for (JSCell* cell : m_strongReferences)
+        visitor.appendUnbarriered(cell);
     return true;
 }
 

--- a/Source/JavaScriptCore/dfg/DFGPlan.h
+++ b/Source/JavaScriptCore/dfg/DFGPlan.h
@@ -94,6 +94,12 @@ public:
     DesiredTransitions& transitions() LIFETIME_BOUND { return m_transitions; }
     RecordedStatuses& recordedStatuses() LIFETIME_BOUND { return *m_recordedStatuses.get(); }
 
+    // Cells the generated code embeds directly, so the code cannot outlive them. The plan keeps them
+    // alive via checkLivenessAndVisitChildren until reallyAdd() hands them to DFG::CommonData, which
+    // is why they may be appended right up until then, including from a main thread finalization task.
+    void addStrongReference(JSCell* cell) { m_strongReferences.append(cell); }
+    void installStrongReferences(CommonData*);
+
     bool willTryToTierUp() const { return m_willTryToTierUp; }
     void setWillTryToTierUp(bool willTryToTierUp) { m_willTryToTierUp = willTryToTierUp; }
 
@@ -132,6 +138,7 @@ private:
     DesiredIdentifiers m_identifiers;
     DesiredWeakReferences m_weakReferences;
     DesiredTransitions m_transitions;
+    Vector<JSCell*> m_strongReferences;
     std::unique_ptr<RecordedStatuses> m_recordedStatuses;
 
     UncheckedKeyHashMap<BytecodeIndex, FixedVector<BytecodeIndex>> m_tierUpInLoopHierarchy;

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
@@ -60,6 +60,7 @@ bool JITFinalizer::finalize()
 
     CodeBlock* codeBlock = m_plan.codeBlock();
     m_jitCode->setSize(m_codeSize);
+    m_plan.installStrongReferences(&m_jitCode->common);
     codeBlock->setJITCode(*m_jitCode);
 
     if (Options::dumpFTLCodeSize()) [[unlikely]] {

--- a/Source/JavaScriptCore/ftl/FTLOSREntry.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSREntry.cpp
@@ -143,7 +143,7 @@ void* prepareOSREntry(
     // At this point, we're committed to triggering an OSR entry immediately after we return. Hence, it is safe to modify stack here.
     if (result) {
         if (reconstructedThis)
-            callFrame->r(virtualRegisterForArgumentIncludingThis(0)) = JSValue::encode(reconstructedThis.value());
+            callFrame->uncheckedR(virtualRegisterForArgumentIncludingThis(0)) = JSValue::encode(reconstructedThis.value());
     }
     
     return result;

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -784,7 +784,8 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
             return CommonSlowPaths::allocateNewArrayBuffer(vm, structure, immutableButterfly);
         }
         auto newArrayBuffer = currentInstruction->as<OpNewArrayBuffer>();
-        ArrayAllocationProfile* profile = &newArrayBuffer.metadata(codeBlock).m_arrayAllocationProfile;
+        auto& metadata = newArrayBuffer.metadata(codeBlock);
+        ArrayAllocationProfile* profile = &metadata.m_arrayAllocationProfile;
 
         // FIXME: Share the code with CommonSlowPaths. Currently, codeBlock etc. are slightly different.
         IndexingType indexingMode = profile->selectIndexingType();
@@ -798,11 +799,11 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
                 newButterfly->setIndex(vm, i, immutableButterfly->get(i));
             immutableButterfly = newButterfly;
 
-            // FIXME: This is kinda gross and only works because we can't inline new_array_bufffer in the baseline.
-            // We also cannot allocate a new butterfly from compilation threads since it's invalid to allocate cells from
-            // a compilation thread.
+            // We cannot allocate a new butterfly from a compilation thread, so the re-typed one is
+            // published here for the DFG to pick up. The fences order the butterfly's initializing stores
+            // against the pointer store, and pair with the dependentLoadLoadFence in the DFG parser.
             WTF::storeStoreFence();
-            codeBlock->constantRegister(newArrayBuffer.m_immutableButterfly).set(vm, codeBlock, immutableButterfly);
+            metadata.m_immutableButterfly.set(vm, codeBlock, immutableButterfly);
             WTF::storeStoreFence();
         }
 

--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -278,7 +278,7 @@ using JSInstruction = BaseInstruction<JSOpcodeTraits>;
         inline void setScope(int scopeRegisterOffset, JSScope*);
 
         // Read a register from the codeframe (or constant from the CodeBlock).
-        Register& r(VirtualRegister);
+        const Register& r(VirtualRegister);
         // Read a register for a known non-constant
         Register& uncheckedR(VirtualRegister);
 

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1521,7 +1521,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
             ASSERT(codeBlock && codeBlock->numParameters() == 1); // 1 parameter for 'this'.
         }
 
-        auto functionDecls = codeBlock->functionDecls();
+        auto functionDecls = codeBlock->unlinkedCodeBlock()->functionDecls();
         BatchedTransitionOptimizer optimizer(vm, variableObject);
         if (variableObject->next() && !eval->isInStrictContext())
             variableObject->realm()->varInjectionWatchpointSet().fireAll(vm, "Executed eval, fired VarInjection watchpoint");
@@ -1535,7 +1535,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
             }
 
             for (auto& slot : functionDecls) {
-                FunctionExecutable* function = slot.get();
+                UnlinkedFunctionExecutable* function = slot.get();
                 JSValue resolvedScope = JSScope::resolveScopeForHoistingFuncDeclInEval(globalObject, scope, function->name());
                 RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
                 if (resolvedScope.isUndefined())
@@ -1546,7 +1546,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
         bool isGlobalVariableEnvironment = variableObject->isGlobalObject();
         if (isGlobalVariableEnvironment) {
             for (auto& slot : functionDecls) {
-                FunctionExecutable* function = slot.get();
+                UnlinkedFunctionExecutable* function = slot.get();
                 bool canDeclare = uncheckedDowncast<JSGlobalObject>(variableObject)->canDeclareGlobalFunction(function->name());
                 RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
                 if (!canDeclare)
@@ -1595,7 +1595,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
         }
 
         for (auto& slot : functionDecls) {
-            FunctionExecutable* function = slot.get();
+            UnlinkedFunctionExecutable* function = slot.get();
             if (isGlobalVariableEnvironment) {
                 uncheckedDowncast<JSGlobalObject>(variableObject)->createGlobalFunctionBinding<BindingCreationContext::Eval>(function->name());
                 RETURN_IF_EXCEPTION(throwScope, throwScope.exception());

--- a/Source/JavaScriptCore/jit/BaselineJITCode.h
+++ b/Source/JavaScriptCore/jit/BaselineJITCode.h
@@ -57,34 +57,6 @@ private:
     Bag<JITSubIC> m_subICs;
 };
 
-class JITConstantPool {
-    WTF_MAKE_NONCOPYABLE(JITConstantPool);
-public:
-    using Constant = unsigned;
-
-    enum class Type : uint8_t {
-        FunctionDecl,
-        FunctionExpr,
-    };
-
-    using Value = JITConstant<Type>;
-
-    JITConstantPool() = default;
-    JITConstantPool(JITConstantPool&&) = default;
-    JITConstantPool& operator=(JITConstantPool&&) = default;
-
-    JITConstantPool(Vector<Value>&& constants)
-        : m_constants(WTF::move(constants))
-    {
-    }
-
-    size_t size() const { return m_constants.size(); }
-    Value at(size_t i) const { return m_constants[i]; }
-
-private:
-    FixedVector<Value> m_constants;
-};
-
 
 class BaselineJITCode : public DirectJITCode, public MathICHolder {
 public:
@@ -104,7 +76,6 @@ public:
     FixedVector<SimpleJumpTable> m_switchJumpTables;
     FixedVector<StringJumpTable> m_stringSwitchJumpTables;
     JITCodeMap m_jitCodeMap;
-    JITConstantPool m_constantPool;
     std::unique_ptr<PCToCodeOriginMap> m_pcToCodeOriginMap;
 private:
     // The percentage of ValueProfiles that had some profiling data in them.
@@ -120,9 +91,9 @@ class BaselineJITData final : public ButterflyArray<BaselineJITData, HandlerProp
 public:
     using Base = ButterflyArray<BaselineJITData, HandlerPropertyInlineCache, void*>;
 
-    static std::unique_ptr<BaselineJITData> create(unsigned propertyCacheSize, unsigned poolSize, CodeBlock* codeBlock)
+    static std::unique_ptr<BaselineJITData> create(unsigned propertyCacheSize, CodeBlock* codeBlock)
     {
-        return std::unique_ptr<BaselineJITData> { createImpl(propertyCacheSize, poolSize, codeBlock) };
+        return std::unique_ptr<BaselineJITData> { createImpl(propertyCacheSize, 0, codeBlock) };
     }
 
     explicit BaselineJITData(unsigned poolSize, unsigned propertyCacheSize, CodeBlock*);

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -84,12 +84,6 @@ JIT::JIT(VM& vm, BaselineJITPlan& plan, CodeBlock* codeBlock)
 
 JIT::~JIT() = default;
 
-JITConstantPool::Constant JIT::addToConstantPool(JITConstantPool::Type type, void* payload)
-{
-    unsigned result = m_constantPool.size();
-    m_constantPool.append(JITConstantPool::Value { payload, type });
-    return result;
-}
 
 std::tuple<BaselineUnlinkedPropertyInlineCache*, PropertyInlineCacheIndex> JIT::addUnlinkedPropertyInlineCache()
 {
@@ -344,6 +338,8 @@ void JIT::privateCompileMainPass()
         DEFINE_OP(op_jneq_null)
         DEFINE_OP(op_jundefined_or_null)
         DEFINE_OP(op_jnundefined_or_null)
+        DEFINE_OP(op_get_link_time_constant)
+        DEFINE_OP(op_get_template_object)
         DEFINE_OP(op_jeq_ptr)
         DEFINE_OP(op_jneq_ptr)
         DEFINE_OP(op_less)
@@ -1012,7 +1008,6 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
     jitCode->m_stringSwitchJumpTables = WTF::move(m_stringSwitchJumpTables);
     jitCode->m_jitCodeMap = jitCodeMapBuilder.finalize();
     jitCode->adoptMathICs(m_mathICs);
-    jitCode->m_constantPool = WTF::move(m_constantPool);
     jitCode->m_isShareable = m_isShareable;
     jitCode->m_pcToCodeOriginMap = WTF::move(pcToCodeOriginMap);
 

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -242,7 +242,6 @@ namespace JSC {
         void materializePointerIntoMetadata(const Bytecode&, size_t offset, GPRReg);
 
     public:
-        void loadConstant(unsigned constantIndex, GPRReg);
         void loadPropertyInlineCache(PropertyInlineCacheIndex, GPRReg);
         static void emitMaterializeMetadataAndConstantPoolRegisters(CCallHelpers&);
     private:
@@ -250,11 +249,8 @@ namespace JSC {
 
         // Assuming GPRInfo::jitDataRegister is available.
         static void loadGlobalObject(CCallHelpers&, GPRReg);
-        static void loadConstant(CCallHelpers&, unsigned constantIndex, GPRReg);
         static void loadPropertyInlineCache(CCallHelpers&, PropertyInlineCacheIndex, GPRReg);
 
-        void loadCodeBlockConstant(VirtualRegister, JSValueRegs);
-        void loadCodeBlockConstantPayload(VirtualRegister, RegisterID);
 
         void exceptionCheck(Jump jumpToHandler);
         void exceptionCheck();
@@ -438,6 +434,8 @@ namespace JSC {
         void emit_op_jneq_null(const JSInstruction*);
         void emit_op_jundefined_or_null(const JSInstruction*);
         void emit_op_jnundefined_or_null(const JSInstruction*);
+        void emit_op_get_link_time_constant(const JSInstruction*);
+        void emit_op_get_template_object(const JSInstruction*);
         void emit_op_jeq_ptr(const JSInstruction*);
         void emit_op_jneq_ptr(const JSInstruction*);
         void emit_op_less(const JSInstruction*);
@@ -843,7 +841,6 @@ namespace JSC {
 
         void resetSP();
 
-        JITConstantPool::Constant addToConstantPool(JITConstantPool::Type, void* payload = nullptr);
         std::tuple<BaselineUnlinkedPropertyInlineCache*, PropertyInlineCacheIndex> addUnlinkedPropertyInlineCache();
         BaselineUnlinkedCallLinkInfo* addUnlinkedCallLinkInfo();
 
@@ -908,7 +905,6 @@ namespace JSC {
 
         MathICHolder m_mathICs;
 
-        Vector<JITConstantPool::Value> m_constantPool;
         SaSegmentedVector<BaselineUnlinkedCallLinkInfo> m_unlinkedCalls;
         SaSegmentedVector<BaselineUnlinkedPropertyInlineCache> m_unlinkedPropertyInlineCaches;
         FixedVector<SimpleJumpTable> m_switchJumpTables;

--- a/Source/JavaScriptCore/jit/JITInlines.h
+++ b/Source/JavaScriptCore/jit/JITInlines.h
@@ -37,16 +37,12 @@ ALWAYS_INLINE bool JIT::isOperandConstantDouble(VirtualRegister src)
 {
     if (!src.isConstant())
         return false;
-    if (m_unlinkedCodeBlock->constantSourceCodeRepresentation(src) == SourceCodeRepresentation::LinkTimeConstant)
-        return false;
     return getConstantOperand(src).isDouble();
 }
 
 ALWAYS_INLINE bool JIT::isOperandConstantInt(VirtualRegister src)
 {
     if (!src.isConstant())
-        return false;
-    if (m_unlinkedCodeBlock->constantSourceCodeRepresentation(src) == SourceCodeRepresentation::LinkTimeConstant)
         return false;
     return getConstantOperand(src).isInt32();
 }
@@ -55,17 +51,12 @@ ALWAYS_INLINE bool JIT::isKnownCell(VirtualRegister src)
 {
     if (!src.isConstant())
         return false;
-    if (m_unlinkedCodeBlock->constantSourceCodeRepresentation(src) == SourceCodeRepresentation::LinkTimeConstant) {
-        // All link time constants are cells.
-        return true;
-    }
     return getConstantOperand(src).isCell();
 }
 
 ALWAYS_INLINE JSValue JIT::getConstantOperand(VirtualRegister src)
 {
     ASSERT(src.isConstant());
-    RELEASE_ASSERT(m_unlinkedCodeBlock->constantSourceCodeRepresentation(src) != SourceCodeRepresentation::LinkTimeConstant);
     return m_unlinkedCodeBlock->getConstant(src);
 }
 
@@ -303,8 +294,6 @@ ALWAYS_INLINE bool JIT::isOperandConstantChar(VirtualRegister src)
 {
     if (!src.isConstant())
         return false;
-    if (m_unlinkedCodeBlock->constantSourceCodeRepresentation(src) == SourceCodeRepresentation::LinkTimeConstant)
-        return false;
     return getConstantOperand(src).isString() && asString(getConstantOperand(src).asCell())->length() == 1;
 }
 
@@ -361,10 +350,7 @@ ALWAYS_INLINE void JIT::emitGetVirtualRegister(VirtualRegister src, JSValueRegs 
 {
     ASSERT(m_bytecodeIndex); // This method should only be called during hot/cold path generation, so that m_bytecodeIndex is set.
     if (src.isConstant()) {
-        if (m_profiledCodeBlock->isConstantOwnedByUnlinkedCodeBlock(src))
-            moveValue(m_unlinkedCodeBlock->getConstant(src), dst);
-        else
-            loadCodeBlockConstant(src, dst);
+        moveValue(m_unlinkedCodeBlock->getConstant(src), dst);
         return;
     }
     loadValue(addressFor(src), dst);
@@ -543,19 +529,10 @@ ALWAYS_INLINE void JIT::materializePointerIntoMetadata(const Bytecode& bytecode,
     addPtr(TrustedImm32(m_profiledCodeBlock->metadataTable()->offsetInMetadataTable(bytecode) + offset), GPRInfo::metadataTableRegister, result);
 }
 
-ALWAYS_INLINE void JIT::loadConstant(CCallHelpers& jit, JITConstantPool::Constant constantIndex, GPRReg result)
-{
-    jit.loadPtr(Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfTrailingData() + static_cast<uintptr_t>(constantIndex) * sizeof(void*)), result);
-}
 
 ALWAYS_INLINE void JIT::loadGlobalObject(CCallHelpers& jit, GPRReg result)
 {
     jit.loadPtr(Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfGlobalObject()), result);
-}
-
-ALWAYS_INLINE void JIT::loadConstant(JITConstantPool::Constant constantIndex, GPRReg result)
-{
-    loadConstant(*this, constantIndex, result);
 }
 
 ALWAYS_INLINE void JIT::loadGlobalObject(GPRReg result)
@@ -573,26 +550,6 @@ ALWAYS_INLINE void JIT::loadPropertyInlineCache(PropertyInlineCacheIndex index, 
     loadPropertyInlineCache(*this, index, result);
 }
 
-ALWAYS_INLINE static void loadAddrOfCodeBlockConstantBuffer(JIT &jit, GPRReg dst)
-{
-    jit.loadPtr(jit.addressFor(CallFrameSlot::codeBlock), dst);
-    jit.loadPtr(JIT::Address(dst, CodeBlock::offsetOfConstantsVectorBuffer()), dst);
-}
-
-ALWAYS_INLINE void JIT::loadCodeBlockConstant(VirtualRegister constant, JSValueRegs dst)
-{
-    RELEASE_ASSERT(constant.isConstant());
-    loadAddrOfCodeBlockConstantBuffer(*this, dst.payloadGPR());
-    loadValue(Address(dst.payloadGPR(), constant.toConstantIndex() * sizeof(Register)), dst);
-}
-
-ALWAYS_INLINE void JIT::loadCodeBlockConstantPayload(VirtualRegister constant, RegisterID dst)
-{
-    RELEASE_ASSERT(constant.isConstant());
-    loadAddrOfCodeBlockConstantBuffer(*this, dst);
-    Address address(dst, constant.toConstantIndex() * sizeof(Register));
-    load64(address, dst);
-}
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -55,12 +55,7 @@ void JIT::emit_op_mov(const JSInstruction* currentInstruction)
     VirtualRegister src = bytecode.m_src;
 
     if (src.isConstant()) {
-        if (m_profiledCodeBlock->isConstantOwnedByUnlinkedCodeBlock(src)) {
-            storeValue(m_unlinkedCodeBlock->getConstant(src), addressFor(dst));
-        } else {
-            loadCodeBlockConstant(src, jsRegT10);
-            storeValue(jsRegT10, addressFor(dst));
-        }
+        storeValue(m_unlinkedCodeBlock->getConstant(src), addressFor(dst));
         return;
     }
 
@@ -502,6 +497,20 @@ void JIT::emit_op_jnundefined_or_null(const JSInstruction* currentInstruction)
     addJump(branchIfNotNull(jsRegT10), target);
 }
 
+void JIT::emit_op_get_link_time_constant(const JSInstruction* currentInstruction)
+{
+    auto bytecode = currentInstruction->as<OpGetLinkTimeConstant>();
+    loadPtrFromMetadata(bytecode, OpGetLinkTimeConstant::Metadata::offsetOfConstant(), jsRegT10.payloadGPR());
+    storeValue(jsRegT10, addressFor(bytecode.m_dst));
+}
+
+void JIT::emit_op_get_template_object(const JSInstruction* currentInstruction)
+{
+    auto bytecode = currentInstruction->as<OpGetTemplateObject>();
+    loadPtrFromMetadata(bytecode, OpGetTemplateObject::Metadata::offsetOfTemplateObject(), jsRegT10.payloadGPR());
+    storeValue(jsRegT10, addressFor(bytecode.m_dst));
+}
+
 void JIT::emit_op_jeq_ptr(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpJeqPtr>();
@@ -509,7 +518,7 @@ void JIT::emit_op_jeq_ptr(const JSInstruction* currentInstruction)
     unsigned target = jumpTarget(currentInstruction, bytecode.m_targetLabel);
 
     emitGetVirtualRegister(src, jsRegT10);
-    loadCodeBlockConstantPayload(bytecode.m_specialPointer, regT2);
+    loadPtrFromMetadata(bytecode, OpJeqPtr::Metadata::offsetOfSpecialPointer(), regT2);
     addJump(branchPtr(Equal, jsRegT10.payloadGPR(), regT2), target);
 }
 
@@ -520,7 +529,7 @@ void JIT::emit_op_jneq_ptr(const JSInstruction* currentInstruction)
     unsigned target = jumpTarget(currentInstruction, bytecode.m_targetLabel);
     
     emitGetVirtualRegister(src, jsRegT10);
-    loadCodeBlockConstantPayload(bytecode.m_specialPointer, regT2);
+    loadPtrFromMetadata(bytecode, OpJneqPtr::Metadata::offsetOfSpecialPointer(), regT2);
     CCallHelpers::Jump equal = branchPtr(Equal, jsRegT10.payloadGPR(), regT2);
     store8ToMetadata(TrustedImm32(1), bytecode, OpJneqPtr::Metadata::offsetOfHasJumped());
     addJump(jump(), target);
@@ -682,8 +691,6 @@ void JIT::compileOpStrictEq(const JSInstruction* currentInstruction)
     auto tryGetBitwiseComparableConstant = [&](VirtualRegister src) -> JSValue {
         if (!src.isConstant())
             return { };
-        if (!m_profiledCodeBlock->isConstantOwnedByUnlinkedCodeBlock(src))
-            return { };
         JSValue value = m_unlinkedCodeBlock->getConstant(src);
         if (value.isUndefinedOrNull())
             return value;
@@ -720,8 +727,6 @@ void JIT::compileOpStrictEq(const JSInstruction* currentInstruction)
 
     auto tryGetAtomStringConstant = [&](VirtualRegister src) -> JSString* {
         if (!src.isConstant())
-            return nullptr;
-        if (!m_profiledCodeBlock->isConstantOwnedByUnlinkedCodeBlock(src))
             return nullptr;
         JSValue value = m_unlinkedCodeBlock->getConstant(src);
         if (!value.isString())
@@ -861,8 +866,6 @@ void JIT::compileOpStrictEqJump(const JSInstruction* currentInstruction)
     auto tryGetBitwiseComparableConstant = [&](VirtualRegister src) -> JSValue {
         if (!src.isConstant())
             return { };
-        if (!m_profiledCodeBlock->isConstantOwnedByUnlinkedCodeBlock(src))
-            return { };
         JSValue value = m_unlinkedCodeBlock->getConstant(src);
         if (value.isUndefinedOrNull())
             return value;
@@ -897,8 +900,6 @@ void JIT::compileOpStrictEqJump(const JSInstruction* currentInstruction)
 
     auto tryGetAtomStringConstant = [&](VirtualRegister src) -> JSString* {
         if (!src.isConstant())
-            return nullptr;
-        if (!m_profiledCodeBlock->isConstantOwnedByUnlinkedCodeBlock(src))
             return nullptr;
         JSValue value = m_unlinkedCodeBlock->getConstant(src);
         if (!value.isString())
@@ -1839,8 +1840,7 @@ void JIT::emitNewFuncCommon(const JSInstruction* currentInstruction)
 
     loadGlobalObject(argumentGPR0);
     emitGetVirtualRegister(bytecode.m_scope, argumentGPR1);
-    auto constant = addToConstantPool(JITConstantPool::Type::FunctionDecl, std::bit_cast<void*>(static_cast<uintptr_t>(bytecode.m_functionDecl)));
-    loadConstant(constant, argumentGPR2);
+    loadPtrFromMetadata(bytecode, Op::Metadata::offsetOfFunctionExecutable(), argumentGPR2);
 
     OpcodeID opcodeID = Op::opcodeID;
     auto function = operationNewFunction;
@@ -1886,8 +1886,7 @@ void JIT::emitNewFuncExprCommon(const JSInstruction* currentInstruction)
 
     loadGlobalObject(argumentGPR0);
     emitGetVirtualRegister(bytecode.m_scope, argumentGPR1);
-    auto constant = addToConstantPool(JITConstantPool::Type::FunctionExpr, std::bit_cast<void*>(static_cast<uintptr_t>(bytecode.m_functionDecl)));
-    loadConstant(constant, argumentGPR2);
+    loadPtrFromMetadata(bytecode, Op::Metadata::offsetOfFunctionExecutable(), argumentGPR2);
 
     OpcodeID opcodeID = Op::opcodeID;
     auto function = operationNewFunction;
@@ -1958,16 +1957,14 @@ void JIT::emit_op_create_lexical_environment(const JSInstruction* currentInstruc
     auto bytecode = currentInstruction->as<OpCreateLexicalEnvironment>();
     VirtualRegister dst = bytecode.m_dst;
     VirtualRegister scope = bytecode.m_scope;
-    VirtualRegister symbolTable = bytecode.m_symbolTable;
     VirtualRegister initialValue = bytecode.m_initialValue;
 
     ASSERT(initialValue.isConstant());
-    ASSERT(m_profiledCodeBlock->isConstantOwnedByUnlinkedCodeBlock(initialValue));
     JSValue value = m_unlinkedCodeBlock->getConstant(initialValue);
 
     loadGlobalObject(argumentGPR0);
     emitGetVirtualRegister(scope, argumentGPR1);
-    emitGetVirtualRegister(symbolTable, argumentGPR2);
+    loadPtrFromMetadata(bytecode, OpCreateLexicalEnvironment::Metadata::offsetOfSymbolTable(), argumentGPR2);
     callOperationNoExceptionCheck(value == jsUndefined() ? operationCreateLexicalEnvironmentUndefined : operationCreateLexicalEnvironmentTDZ, dst, argumentGPR0, argumentGPR1, argumentGPR2);
 }
 

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -698,7 +698,7 @@ LLINT_SLOW_PATH_DECL(slow_path_create_lexical_environment)
     LLINT_BEGIN();
     auto bytecode = pc->as<OpCreateLexicalEnvironment>();
     JSScope* currentScope = callFrame->uncheckedR(bytecode.m_scope).Register::scope();
-    SymbolTable* symbolTable = uncheckedDowncast<SymbolTable>(getOperand(callFrame, bytecode.m_symbolTable));
+    SymbolTable* symbolTable = bytecode.metadata(codeBlock).m_symbolTable.get();
     JSValue initialValue = getOperand(callFrame, bytecode.m_initialValue);
     ASSERT(initialValue == jsUndefined() || initialValue == jsTDZValue());
     JSScope* newScope = JSLexicalEnvironment::create(vm, globalObject, currentScope, symbolTable, initialValue);
@@ -1916,7 +1916,7 @@ LLINT_SLOW_PATH_DECL(slow_path_new_func)
     auto bytecode = pc->as<OpNewFunc>();
     JSScope* scope = callFrame->uncheckedR(bytecode.m_scope).Register::scope();
     slowPathLogF("Creating function!\n");
-    LLINT_RETURN(JSFunction::create(vm, globalObject, codeBlock->functionDecl(bytecode.m_functionDecl), scope));
+    LLINT_RETURN(JSFunction::create(vm, globalObject, bytecode.metadata(codeBlock).m_functionExecutable.get(), scope));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_new_generator_func)
@@ -1925,7 +1925,7 @@ LLINT_SLOW_PATH_DECL(slow_path_new_generator_func)
     auto bytecode = pc->as<OpNewGeneratorFunc>();
     JSScope* scope = callFrame->uncheckedR(bytecode.m_scope).Register::scope();
     slowPathLogF("Creating function!\n");
-    LLINT_RETURN(JSGeneratorFunction::create(vm, globalObject, codeBlock->functionDecl(bytecode.m_functionDecl), scope));
+    LLINT_RETURN(JSGeneratorFunction::create(vm, globalObject, bytecode.metadata(codeBlock).m_functionExecutable.get(), scope));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_new_async_func)
@@ -1934,7 +1934,7 @@ LLINT_SLOW_PATH_DECL(slow_path_new_async_func)
     auto bytecode = pc->as<OpNewAsyncFunc>();
     JSScope* scope = callFrame->uncheckedR(bytecode.m_scope).Register::scope();
     slowPathLogF("Creating async function!\n");
-    LLINT_RETURN(JSAsyncFunction::create(vm, globalObject, codeBlock->functionDecl(bytecode.m_functionDecl), scope));
+    LLINT_RETURN(JSAsyncFunction::create(vm, globalObject, bytecode.metadata(codeBlock).m_functionExecutable.get(), scope));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_new_async_generator_func)
@@ -1943,7 +1943,7 @@ LLINT_SLOW_PATH_DECL(slow_path_new_async_generator_func)
     auto bytecode = pc->as<OpNewAsyncGeneratorFunc>();
     JSScope* scope = callFrame->uncheckedR(bytecode.m_scope).Register::scope();
     slowPathLogF("Creating async generator function!\n");
-    LLINT_RETURN(JSAsyncGeneratorFunction::create(vm, globalObject, codeBlock->functionDecl(bytecode.m_functionDecl), scope));
+    LLINT_RETURN(JSAsyncGeneratorFunction::create(vm, globalObject, bytecode.metadata(codeBlock).m_functionExecutable.get(), scope));
 }
     
 LLINT_SLOW_PATH_DECL(slow_path_new_func_exp)
@@ -1952,7 +1952,7 @@ LLINT_SLOW_PATH_DECL(slow_path_new_func_exp)
     
     auto bytecode = pc->as<OpNewFuncExp>();
     JSScope* scope = callFrame->uncheckedR(bytecode.m_scope).Register::scope();
-    FunctionExecutable* executable = codeBlock->functionExpr(bytecode.m_functionDecl);
+    FunctionExecutable* executable = bytecode.metadata(codeBlock).m_functionExecutable.get();
     
     LLINT_RETURN(JSFunction::create(vm, globalObject, executable, scope));
 }
@@ -1963,7 +1963,7 @@ LLINT_SLOW_PATH_DECL(slow_path_new_generator_func_exp)
 
     auto bytecode = pc->as<OpNewGeneratorFuncExp>();
     JSScope* scope = callFrame->uncheckedR(bytecode.m_scope).Register::scope();
-    FunctionExecutable* executable = codeBlock->functionExpr(bytecode.m_functionDecl);
+    FunctionExecutable* executable = bytecode.metadata(codeBlock).m_functionExecutable.get();
 
     LLINT_RETURN(JSGeneratorFunction::create(vm, globalObject, executable, scope));
 }
@@ -1974,7 +1974,7 @@ LLINT_SLOW_PATH_DECL(slow_path_new_async_func_exp)
     
     auto bytecode = pc->as<OpNewAsyncFuncExp>();
     JSScope* scope = callFrame->uncheckedR(bytecode.m_scope).Register::scope();
-    FunctionExecutable* executable = codeBlock->functionExpr(bytecode.m_functionDecl);
+    FunctionExecutable* executable = bytecode.metadata(codeBlock).m_functionExecutable.get();
     
     LLINT_RETURN(JSAsyncFunction::create(vm, globalObject, executable, scope));
 }
@@ -1985,7 +1985,7 @@ LLINT_SLOW_PATH_DECL(slow_path_new_async_generator_func_exp)
         
     auto bytecode = pc->as<OpNewAsyncGeneratorFuncExp>();
     JSScope* scope = callFrame->uncheckedR(bytecode.m_scope).Register::scope();
-    FunctionExecutable* executable = codeBlock->functionExpr(bytecode.m_functionDecl);
+    FunctionExecutable* executable = bytecode.metadata(codeBlock).m_functionExecutable.get();
         
     LLINT_RETURN(JSAsyncGeneratorFunction::create(vm, globalObject, executable, scope));
 }

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2793,8 +2793,8 @@ op(llint_polymorphic_closure_call_trampoline, macro ()
 end)
 
 if JIT
-    macro loadBaselineJITConstantPool()
-        # Baseline uses LLInt's PB register for its JIT constant pool.
+    macro loadBaselineJITData()
+        # Baseline uses LLInt's PB register to address its BaselineJITData.
         loadp CodeBlock[cfr], PB
         loadp CodeBlock::m_jitData[PB], PB
     end
@@ -2805,15 +2805,15 @@ if JIT
         # LLInt. However, during OSR exit for checkpoints, we might return to
         # JIT code if it's already compiled. After the OSR exit gets compiled,
         # we can tier up to JIT code. And checkpoint exit will jump to it.
-        # That means we always need to set up our constant pool GPR, because the OSR
+        # That means we always need to set up our JIT data GPR, because the OSR
         # exit code might not have done it.
         bpneq r0, 1, .notBaselineJIT
-        loadBaselineJITConstantPool()
+        loadBaselineJITData()
     .notBaselineJIT:
 
     end
 else
-    macro loadBaselineJITConstantPool()
+    macro loadBaselineJITData()
     end
 
     macro setupReturnToBaselineAfterCheckpointExitIfNeeded()

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -471,7 +471,7 @@ if JIT
                 btpz r0, .recover
                 move r1, sp
 
-                loadBaselineJITConstantPool()
+                loadBaselineJITData()
 
                 if ARM64E
                     leap _g_config, a2
@@ -555,19 +555,19 @@ end
 macro loadConstant(size, index, value)
     macro loadNarrow()
         loadp CodeBlock[cfr], value
-        loadp CodeBlock::m_constantRegisters + VectorBufferOffset[value], value
+        loadp CodeBlock::m_constants[value], value
         loadq -(FirstConstantRegisterIndexNarrow * 8)[value, index, 8], value
     end
 
     macro loadWide16()
         loadp CodeBlock[cfr], value
-        loadp CodeBlock::m_constantRegisters + VectorBufferOffset[value], value
+        loadp CodeBlock::m_constants[value], value
         loadq -(FirstConstantRegisterIndexWide16 * 8)[value, index, 8], value
     end
 
     macro loadWide32()
         loadp CodeBlock[cfr], value
-        loadp CodeBlock::m_constantRegisters + VectorBufferOffset[value], value
+        loadp CodeBlock::m_constants[value], value
         subp FirstConstantRegisterIndexWide32, index
         loadq [value, index, 8], value
     end
@@ -2208,10 +2208,24 @@ undefinedOrNullJumpOp(jundefined_or_null, OpJundefinedOrNull,
 undefinedOrNullJumpOp(jnundefined_or_null, OpJnundefinedOrNull,
     macro (value, target) bqneq value, ValueNull, target end)
 
-llintOpWithReturn(op_jeq_ptr, OpJeqPtr, macro (size, get, dispatch, return)
+llintOpWithMetadata(op_get_template_object, OpGetTemplateObject, macro (size, get, dispatch, metadata, return)
+    metadata(t5, t0)
+    loadp OpGetTemplateObject::Metadata::m_templateObject[t5], t0
+    return(t0)
+end)
+
+
+llintOpWithMetadata(op_get_link_time_constant, OpGetLinkTimeConstant, macro (size, get, dispatch, metadata, return)
+    metadata(t5, t0)
+    loadp OpGetLinkTimeConstant::Metadata::m_constant[t5], t0
+    return(t0)
+end)
+
+
+llintOpWithMetadata(op_jeq_ptr, OpJeqPtr, macro (size, get, dispatch, metadata, return)
     get(m_value, t0)
-    get(m_specialPointer, t1)
-    loadConstant(size, t1, t2)
+    metadata(t5, t2)
+    loadp OpJeqPtr::Metadata::m_specialPointer[t5], t2
     bpeq t2, [cfr, t0, 8], .opJeqPtrTarget
     dispatch()
 
@@ -2223,13 +2237,12 @@ end)
 
 llintOpWithMetadata(op_jneq_ptr, OpJneqPtr, macro (size, get, dispatch, metadata, return)
     get(m_value, t0)
-    get(m_specialPointer, t1)
-    loadConstant(size, t1, t2)
+    metadata(t5, t2)
+    loadp OpJneqPtr::Metadata::m_specialPointer[t5], t2
     bpneq t2, [cfr, t0, 8], .opJneqPtrTarget
     dispatch()
 
 .opJneqPtrTarget:
-    metadata(t5, t0)
     storeb 1, OpJneqPtr::Metadata::m_hasJumped[t5]
     get(m_targetLabel, t0)
     jumpImpl(dispatchIndirect, t0)

--- a/Source/JavaScriptCore/lol/LOLJIT.cpp
+++ b/Source/JavaScriptCore/lol/LOLJIT.cpp
@@ -417,6 +417,8 @@ void LOLJIT::privateCompileMainPass()
         DEFINE_OP(op_jneq_null)
         DEFINE_OP(op_jundefined_or_null)
         DEFINE_OP(op_jnundefined_or_null)
+        DEFINE_OP(op_get_link_time_constant)
+        DEFINE_OP(op_get_template_object)
         DEFINE_OP(op_jeq_ptr)
         DEFINE_OP(op_jneq_ptr)
         DEFINE_OP(op_less)
@@ -734,6 +736,8 @@ void LOLJIT::privateCompileSlowCases()
         REPLAY_ALLOCATION_FOR_OP(op_jneq_null, OpJneqNull)
         REPLAY_ALLOCATION_FOR_OP(op_jundefined_or_null, OpJundefinedOrNull)
         REPLAY_ALLOCATION_FOR_OP(op_jnundefined_or_null, OpJnundefinedOrNull)
+        REPLAY_ALLOCATION_FOR_OP(op_get_link_time_constant, OpGetLinkTimeConstant)
+        REPLAY_ALLOCATION_FOR_OP(op_get_template_object, OpGetTemplateObject)
         REPLAY_ALLOCATION_FOR_OP(op_jeq_ptr, OpJeqPtr)
         REPLAY_ALLOCATION_FOR_OP(op_jneq_ptr, OpJneqPtr)
         REPLAY_ALLOCATION_FOR_OP(op_jbelow, OpJbelow)
@@ -1493,13 +1497,12 @@ void LOLJIT::emit_op_create_lexical_environment(const JSInstruction* currentInst
 {
     auto bytecode = currentInstruction->as<OpCreateLexicalEnvironment>();
     auto allocations = m_fastAllocator.allocate(*this, bytecode, m_bytecodeIndex);
-    auto [ scopeRegs, symbolTableRegs ] = allocations.uses;
+    auto [ scopeRegs ] = allocations.uses;
 
     VirtualRegister dst = bytecode.m_dst;
     VirtualRegister initialValue = bytecode.m_initialValue;
 
     ASSERT(initialValue.isConstant());
-    ASSERT(m_profiledCodeBlock->isConstantOwnedByUnlinkedCodeBlock(initialValue));
     JSValue value = m_unlinkedCodeBlock->getConstant(initialValue);
 
     using Operation = decltype(operationCreateLexicalEnvironmentUndefined);
@@ -1507,7 +1510,8 @@ void LOLJIT::emit_op_create_lexical_environment(const JSInstruction* currentInst
     constexpr GPRReg scopeGPR = preferredArgumentGPR<Operation, 1>();
     constexpr GPRReg symbolTableGPR = preferredArgumentGPR<Operation, 2>();
 
-    shuffleRegisters<GPRReg, 2>({ scopeRegs.payloadGPR(), symbolTableRegs.payloadGPR() }, { scopeGPR, symbolTableGPR });
+    shuffleRegisters<GPRReg, 1>({ scopeRegs.payloadGPR() }, { scopeGPR });
+    loadPtrFromMetadata(bytecode, OpCreateLexicalEnvironment::Metadata::offsetOfSymbolTable(), symbolTableGPR);
     loadGlobalObject(globalObjectGPR);
     callOperationNoExceptionCheck(value == jsUndefined() ? operationCreateLexicalEnvironmentUndefined : operationCreateLexicalEnvironmentTDZ, dst, globalObjectGPR, scopeGPR, symbolTableGPR);
 
@@ -1626,8 +1630,7 @@ void LOLJIT::emitNewFuncCommon(const JSInstruction* currentInstruction)
     // Move allocated register first before it can be clobbered
     move(scopeRegs.payloadGPR(), scopeGPR);
     loadGlobalObject(globalObjectGPR);
-    auto constant = addToConstantPool(JITConstantPool::Type::FunctionDecl, std::bit_cast<void*>(static_cast<uintptr_t>(bytecode.m_functionDecl)));
-    loadConstant(constant, functionDeclGPR);
+    loadPtrFromMetadata(bytecode, Op::Metadata::offsetOfFunctionExecutable(), functionDeclGPR);
 
     OpcodeID opcodeID = Op::opcodeID;
     auto function = operationNewFunction;
@@ -1684,8 +1687,7 @@ void LOLJIT::emitNewFuncExprCommon(const JSInstruction* currentInstruction)
     // Move allocated register first before it can be clobbered
     move(scopeRegs.payloadGPR(), scopeGPR);
     loadGlobalObject(globalObjectGPR);
-    auto constant = addToConstantPool(JITConstantPool::Type::FunctionExpr, std::bit_cast<void*>(static_cast<uintptr_t>(bytecode.m_functionDecl)));
-    loadConstant(constant, functionDeclGPR);
+    loadPtrFromMetadata(bytecode, Op::Metadata::offsetOfFunctionExecutable(), functionDeclGPR);
 
     OpcodeID opcodeID = Op::opcodeID;
     auto function = operationNewFunction;
@@ -2269,6 +2271,28 @@ void LOLJIT::emit_op_jnundefined_or_null(const JSInstruction* currentInstruction
     m_fastAllocator.releaseScratches(allocations);
 }
 
+void LOLJIT::emit_op_get_link_time_constant(const JSInstruction* currentInstruction)
+{
+    auto bytecode = currentInstruction->as<OpGetLinkTimeConstant>();
+    auto allocations = m_fastAllocator.allocate(*this, bytecode, m_bytecodeIndex);
+    auto [ destRegs ] = allocations.defs;
+
+    loadPtrFromMetadata(bytecode, OpGetLinkTimeConstant::Metadata::offsetOfConstant(), destRegs.payloadGPR());
+
+    m_fastAllocator.releaseScratches(allocations);
+}
+
+void LOLJIT::emit_op_get_template_object(const JSInstruction* currentInstruction)
+{
+    auto bytecode = currentInstruction->as<OpGetTemplateObject>();
+    auto allocations = m_fastAllocator.allocate(*this, bytecode, m_bytecodeIndex);
+    auto [ destRegs ] = allocations.defs;
+
+    loadPtrFromMetadata(bytecode, OpGetTemplateObject::Metadata::offsetOfTemplateObject(), destRegs.payloadGPR());
+
+    m_fastAllocator.releaseScratches(allocations);
+}
+
 void LOLJIT::emit_op_jeq_ptr(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpJeqPtr>();
@@ -2276,7 +2300,7 @@ void LOLJIT::emit_op_jeq_ptr(const JSInstruction* currentInstruction)
     auto allocations = m_fastAllocator.allocate(*this, bytecode, m_bytecodeIndex);
     auto [ valueRegs ] = allocations.uses;
 
-    loadCodeBlockConstantPayload(bytecode.m_specialPointer, s_scratch);
+    loadPtrFromMetadata(bytecode, OpJeqPtr::Metadata::offsetOfSpecialPointer(), s_scratch);
     addJump(branchPtr(Equal, valueRegs.payloadGPR(), s_scratch), target);
 
     m_fastAllocator.releaseScratches(allocations);
@@ -2289,7 +2313,7 @@ void LOLJIT::emit_op_jneq_ptr(const JSInstruction* currentInstruction)
     auto allocations = m_fastAllocator.allocate(*this, bytecode, m_bytecodeIndex);
     auto [ valueRegs ] = allocations.uses;
 
-    loadCodeBlockConstantPayload(bytecode.m_specialPointer, s_scratch);
+    loadPtrFromMetadata(bytecode, OpJneqPtr::Metadata::offsetOfSpecialPointer(), s_scratch);
     CCallHelpers::Jump equal = branchPtr(Equal, valueRegs.payloadGPR(), s_scratch);
     store8ToMetadata(TrustedImm32(1), bytecode, OpJneqPtr::Metadata::offsetOfHasJumped());
     addJump(jump(), target);

--- a/Source/JavaScriptCore/lol/LOLJIT.h
+++ b/Source/JavaScriptCore/lol/LOLJIT.h
@@ -101,6 +101,8 @@ namespace JSC::LOL {
     macro(op_jneq_null) \
     macro(op_jundefined_or_null) \
     macro(op_jnundefined_or_null) \
+    macro(op_get_link_time_constant) \
+    macro(op_get_template_object) \
     macro(op_jeq_ptr) \
     macro(op_jneq_ptr) \
     macro(op_jeq) \

--- a/Source/JavaScriptCore/lol/LOLRegisterAllocator.h
+++ b/Source/JavaScriptCore/lol/LOLRegisterAllocator.h
@@ -84,9 +84,9 @@ public:
     RegisterAllocator(Backend& backend, CodeBlock* codeBlock)
         : m_numVars(codeBlock->numVars())
         , m_constantsOffset(codeBlock->numCalleeLocals())
-        , m_headersOffset(m_constantsOffset + codeBlock->constantRegisters().size())
+        , m_headersOffset(m_constantsOffset + codeBlock->numberOfConstantRegisters())
         , m_numArguments(codeBlock->numParameters())
-        , m_locations(codeBlock->numCalleeLocals() + codeBlock->constantRegisters().size() + CallFrame::headerSizeInRegisters + codeBlock->numParameters())
+        , m_locations(codeBlock->numCalleeLocals() + codeBlock->numberOfConstantRegisters() + CallFrame::headerSizeInRegisters + codeBlock->numParameters())
         , m_backend(backend)
     {
         RegisterSet gprs = RegisterSet::allGPRs();
@@ -406,6 +406,22 @@ auto RegisterAllocator<Backend>::allocate(Backend& jit, const OpGetArgument& ins
 }
 
 template<typename Backend>
+auto RegisterAllocator<Backend>::allocate(Backend& jit, const OpGetLinkTimeConstant& instruction, BytecodeIndex index)
+{
+    std::array<AllocationHint, 0> uses = { };
+    std::array<AllocationHint, 1> defs = { instruction.m_dst };
+    return allocateImpl<0>(jit, instruction, index, uses, defs);
+}
+
+template<typename Backend>
+auto RegisterAllocator<Backend>::allocate(Backend& jit, const OpGetTemplateObject& instruction, BytecodeIndex index)
+{
+    std::array<AllocationHint, 0> uses = { };
+    std::array<AllocationHint, 1> defs = { instruction.m_dst };
+    return allocateImpl<0>(jit, instruction, index, uses, defs);
+}
+
+template<typename Backend>
 auto RegisterAllocator<Backend>::allocate(Backend& jit, const OpArgumentCount& instruction, BytecodeIndex index)
 {
     std::array<AllocationHint, 0> uses = { };
@@ -445,7 +461,7 @@ auto RegisterAllocator<Backend>::allocate(Backend& jit, const OpNewObject& instr
 template<typename Backend>
 auto RegisterAllocator<Backend>::allocate(Backend& jit, const OpCreateLexicalEnvironment& instruction, BytecodeIndex index)
 {
-    std::array<AllocationHint, 2> uses = { instruction.m_scope, instruction.m_symbolTable };
+    std::array<AllocationHint, 1> uses = { instruction.m_scope };
     std::array<AllocationHint, 0> defs = { };
     auto result = allocateImpl<0>(jit, instruction, index, uses, defs);
     m_allocator.flushAllRegisters(*this);

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -1661,8 +1661,9 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_new_array_buffer)
     BEGIN();
     auto bytecode = pc->as<OpNewArrayBuffer>();
     ASSERT(bytecode.m_immutableButterfly.isConstant());
-    JSCellButterfly* immutableButterfly = std::bit_cast<JSCellButterfly*>(GET_C(bytecode.m_immutableButterfly).jsValue().asCell());
-    auto& profile = bytecode.metadata(codeBlock).m_arrayAllocationProfile;
+    auto& metadata = bytecode.metadata(codeBlock);
+    JSCellButterfly* immutableButterfly = metadata.m_immutableButterfly.get();
+    auto& profile = metadata.m_arrayAllocationProfile;
 
     IndexingType indexingMode = profile.selectIndexingType();
     Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(indexingMode);
@@ -1675,11 +1676,11 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_new_array_buffer)
             newButterfly->setIndex(vm, i, immutableButterfly->get(i));
         immutableButterfly = newButterfly;
 
-        // FIXME: This is kinda gross and only works because we can't inline new_array_bufffer in the baseline.
-        // We also cannot allocate a new butterfly from compilation threads since it's invalid to allocate cells from
-        // a compilation thread.
+        // We cannot allocate a new butterfly from a compilation thread, so the re-typed one is
+        // published here for the DFG to pick up. The fences order the butterfly's initializing stores
+        // against the pointer store, and pair with the dependentLoadLoadFence in the DFG parser.
         WTF::storeStoreFence();
-        codeBlock->constantRegister(bytecode.m_immutableButterfly).set(vm, codeBlock, immutableButterfly);
+        metadata.m_immutableButterfly.set(vm, codeBlock, immutableButterfly);
         WTF::storeStoreFence();
     }
 

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -92,7 +92,6 @@ enum class SourceCodeRepresentation : uint8_t {
     Other,
     Integer,
     Double,
-    LinkTimeConstant,
 };
 
 extern JS_EXPORT_PRIVATE const ASCIILiteral SymbolCoercionError;


### PR DESCRIPTION
#### a8e3c1f1728cb4c929a30b60602fe556b3c13842
<pre>
[JSC] Use UnlinkedCodeBlock&apos;s constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=322147">https://bugs.webkit.org/show_bug.cgi?id=322147</a>
<a href="https://rdar.apple.com/185368411">rdar://185368411</a>

Reviewed by NOBODY (OOPS!).

WIP: A/B test is ongoing.

Tests: JSTests/stress/codeblock-linked-metadata.js
       JSTests/stress/link-time-constant-register-allocation.js

* JSTests/stress/codeblock-linked-metadata.js: Added.
(shouldBe):
(site):
(otherSite):
(invalidEscape):
(literal):
(counter):
(blockScopes):
(generator):
* JSTests/stress/link-time-constant-register-allocation.js: Added.
(shouldBe):
(objectSpread):
(C.method):
(C.prototype.instance):
(C.staticField):
(C.prototype.method):
(C):
(forIn):
(callee):
(const.impostor):
(const.shadowed):
* Source/JavaScriptCore/bytecode/BytecodeDumper.cpp:
(JSC::CodeBlockBytecodeDumper&lt;Block&gt;::dumpConstants):
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp:
(JSC::computeUsesForBytecodeIndexImpl):
(JSC::computeDefsForBytecodeIndexImpl):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::CodeBlock):
(JSC::CodeBlock::finishCreation):
(JSC::CodeBlock::setupWithUnlinkedBaselineCode):
(JSC::CodeBlock::linkSymbolTable):
(JSC::CodeBlock::initializeTemplateObjects):
(JSC::CodeBlock::stronglyVisitStrongReferences):
(JSC::CodeBlock::nameForRegister):
(JSC::CodeBlock::insertBasicBlockBoundariesForControlFlowProfiler):
(JSC::CodeBlock::isConstantOwnedByUnlinkedCodeBlock const): Deleted.
(JSC::CodeBlock::setConstantRegisters): Deleted.
(JSC::CodeBlock::shrinkToFit): Deleted.
* Source/JavaScriptCore/bytecode/CodeBlock.h:
(JSC::CodeBlock::numberOfConstantRegisters const):
(JSC::CodeBlock::getConstant const):
(JSC::CodeBlock::offsetOfConstants):
(JSC::CallFrame::r):
(JSC::CodeBlock::addConstant): Deleted.
(JSC::CodeBlock::addConstantLazily): Deleted.
(JSC::CodeBlock::constantRegister): Deleted.
(JSC::CodeBlock::offsetOfConstantsVectorBuffer): Deleted.
(JSC::CodeBlock::functionDecl): Deleted.
(JSC::CodeBlock::numberOfFunctionDecls): Deleted.
(JSC::CodeBlock::functionDecls): Deleted.
(JSC::CodeBlock::functionExpr): Deleted.
(JSC::CodeBlock::functionExprs): Deleted.
(JSC::CodeBlock::replaceConstant): Deleted.
* Source/JavaScriptCore/bytecode/Fits.h:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h:
(JSC::UnlinkedCodeBlockGenerator::addConstant):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitJumpIfNotFunctionCall):
(JSC::BytecodeGenerator::emitJumpIfNotFunctionApply):
(JSC::BytecodeGenerator::emitJumpIfNotEvalFunction):
(JSC::BytecodeGenerator::emitJumpIfEmptyPropertyNameEnumerator):
(JSC::BytecodeGenerator::emitJumpIfSentinelString):
(JSC::BytecodeGenerator::emitWideJumpIfNotFunctionHasOwnProperty):
(JSC::BytecodeGenerator::moveLinkTimeConstant):
(JSC::BytecodeGenerator::emitCreatePrivateBrand):
(JSC::BytecodeGenerator::emitExpectedFunctionSnippet):
(JSC::BytecodeGenerator::emitGetTemplateObject):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ImportNode::emitBytecode):
(JSC::ObjectLiteralNode::emitBytecode):
(JSC::PropertyListNode::emitDeclarePrivateFieldNames):
(JSC::ObjectPatternNode::bindValue const):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
(JSC::DFG::ByteCodeParser::handleNewFunc):
(JSC::DFG::ByteCodeParser::handleNewFuncExp):
* Source/JavaScriptCore/dfg/DFGCommonData.h:
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::registerFrozenValues):
* Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp:
(JSC::DFG::JITFinalizer::finalize):
* Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp:
(JSC::DFG::LazyJSValue::emit const):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
(JSC::DFG::Plan::installStrongReferences):
(JSC::DFG::Plan::finalize):
(JSC::DFG::Plan::checkLivenessAndVisitChildren):
* Source/JavaScriptCore/dfg/DFGPlan.h:
* Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp:
(JSC::FTL::JITFinalizer::finalize):
* Source/JavaScriptCore/ftl/FTLOSREntry.cpp:
(JSC::FTL::prepareOSREntry):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/interpreter/CallFrame.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeEval):
* Source/JavaScriptCore/jit/BaselineJITCode.h:
(JSC::JITConstantPool::JITConstantPool): Deleted.
(JSC::JITConstantPool::size const): Deleted.
(JSC::JITConstantPool::at const): Deleted.
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::privateCompileMainPass):
(JSC::JIT::link):
(JSC::JIT::addToConstantPool): Deleted.
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITInlines.h:
(JSC::JIT::isOperandConstantDouble):
(JSC::JIT::isOperandConstantInt):
(JSC::JIT::isKnownCell):
(JSC::JIT::getConstantOperand):
(JSC::JIT::isOperandConstantChar):
(JSC::JIT::emitGetVirtualRegister):
(JSC::JIT::loadConstant): Deleted.
(JSC::loadAddrOfCodeBlockConstantBuffer): Deleted.
(JSC::JIT::loadCodeBlockConstant): Deleted.
(JSC::JIT::loadCodeBlockConstantPayload): Deleted.
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_mov):
(JSC::JIT::emit_op_get_link_time_constant):
(JSC::JIT::emit_op_get_template_object):
(JSC::JIT::emit_op_jeq_ptr):
(JSC::JIT::emit_op_jneq_ptr):
(JSC::JIT::compileOpStrictEq):
(JSC::JIT::compileOpStrictEqJump):
(JSC::JIT::emitNewFuncCommon):
(JSC::JIT::emitNewFuncExprCommon):
(JSC::JIT::emit_op_create_lexical_environment):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/lol/LOLJIT.cpp:
(JSC::LOL::LOLJIT::privateCompileMainPass):
(JSC::LOL::LOLJIT::privateCompileSlowCases):
(JSC::LOL::LOLJIT::emit_op_create_lexical_environment):
(JSC::LOL::LOLJIT::emitNewFuncCommon):
(JSC::LOL::LOLJIT::emitNewFuncExprCommon):
(JSC::LOL::LOLJIT::emit_op_get_link_time_constant):
(JSC::LOL::LOLJIT::emit_op_get_template_object):
(JSC::LOL::LOLJIT::emit_op_jeq_ptr):
(JSC::LOL::LOLJIT::emit_op_jneq_ptr):
* Source/JavaScriptCore/lol/LOLJIT.h:
* Source/JavaScriptCore/lol/LOLRegisterAllocator.h:
(JSC::LOL::RegisterAllocator::RegisterAllocator):
(JSC::LOL::RegisterAllocator&lt;Backend&gt;::allocate):
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::JSC_DEFINE_COMMON_SLOW_PATH):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8e3c1f1728cb4c929a30b60602fe556b3c13842

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181641 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145978 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a812790a-113c-4866-9651-9f465137bb09) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141790 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98423 "2 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d02ed94f-3e6a-4015-af4d-d81ed42e2418) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45474 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162536 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicyWhenSuspendedOrHidden (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122227 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44157 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42427 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4195 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11004 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42062 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3027 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42920 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193792 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55258 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151197 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55947 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150900 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45480 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128230 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123920 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54460 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17057 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53842 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54081 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53907 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->