### PR TITLE
text-overflow should be supported as an SVG presentation attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-irrelevant-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-irrelevant-expected.txt
@@ -49,7 +49,7 @@ PASS stroke-opacity presentation attribute supported on an irrelevant element
 PASS stroke-width presentation attribute supported on an irrelevant element
 PASS text-anchor presentation attribute supported on an irrelevant element
 PASS text-decoration presentation attribute supported on an irrelevant element
-FAIL text-overflow presentation attribute supported on an irrelevant element assert_true: Presentation attribute text-overflow="ellipsis" should be supported on rect element expected true got false
+PASS text-overflow presentation attribute supported on an irrelevant element
 PASS text-rendering presentation attribute supported on an irrelevant element
 PASS transform-origin presentation attribute supported on an irrelevant element
 PASS unicode-bidi presentation attribute supported on an irrelevant element

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt
@@ -56,7 +56,7 @@ PASS stroke-opacity presentation attribute supported on a relevant element
 PASS stroke-width presentation attribute supported on a relevant element
 PASS text-anchor presentation attribute supported on a relevant element
 PASS text-decoration presentation attribute supported on a relevant element
-FAIL text-overflow presentation attribute supported on a relevant element assert_true: Presentation attribute text-overflow="ellipsis" should be supported on text element expected true got false
+PASS text-overflow presentation attribute supported on a relevant element
 PASS text-rendering presentation attribute supported on a relevant element
 PASS transform-origin presentation attribute supported on a relevant element
 FAIL transform presentation attribute supported on a relevant element assert_true: Presentation attribute transform="scale(2)" should be supported on g element expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-unknown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-unknown-expected.txt
@@ -49,7 +49,7 @@ PASS stroke-opacity presentation attribute supported on an unknown SVG element
 PASS stroke-width presentation attribute supported on an unknown SVG element
 PASS text-anchor presentation attribute supported on an unknown SVG element
 PASS text-decoration presentation attribute supported on an unknown SVG element
-FAIL text-overflow presentation attribute supported on an unknown SVG element assert_true: Presentation attribute text-overflow="ellipsis" should be supported on unknown element expected true got false
+PASS text-overflow presentation attribute supported on an unknown SVG element
 PASS text-rendering presentation attribute supported on an unknown SVG element
 PASS transform-origin presentation attribute supported on an unknown SVG element
 PASS unicode-bidi presentation attribute supported on an unknown SVG element

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/text-overflow-presentation-attribute-foreignobject-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/text-overflow-presentation-attribute-foreignobject-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVG Test Reference</title>
+<style>
+  foreignObject { font: 20px/1.2 monospace; text-overflow: ellipsis; }
+</style>
+<p>Test passes if the text below is truncated with an ellipsis, and matches the reference.</p>
+<svg width="300" height="30" xmlns="http://www.w3.org/2000/svg">
+  <foreignObject width="100" height="24">overflowingwordoverflowingword</foreignObject>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/text-overflow-presentation-attribute-foreignobject-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/text-overflow-presentation-attribute-foreignobject-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVG Test Reference</title>
+<style>
+  foreignObject { font: 20px/1.2 monospace; text-overflow: ellipsis; }
+</style>
+<p>Test passes if the text below is truncated with an ellipsis, and matches the reference.</p>
+<svg width="300" height="30" xmlns="http://www.w3.org/2000/svg">
+  <foreignObject width="100" height="24">overflowingwordoverflowingword</foreignObject>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/text-overflow-presentation-attribute-foreignobject.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/text-overflow-presentation-attribute-foreignobject.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVG Test: text-overflow presentation attribute ellipsizes an overflowing foreignObject line</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#PresentationAttributes">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#text-overflow">
+<link rel="match" href="text-overflow-presentation-attribute-foreignobject-ref.html">
+<style>
+  /* foreignObject gets overflow: hidden from the SVG user agent style sheet, which is
+     the precondition text-overflow needs. The single long word supplies the overflowing
+     line without requiring white-space: nowrap. */
+  foreignObject { font: 20px/1.2 monospace; }
+</style>
+<p>Test passes if the text below is truncated with an ellipsis, and matches the reference.</p>
+<svg width="300" height="30" xmlns="http://www.w3.org/2000/svg">
+  <foreignObject width="100" height="24" text-overflow="ellipsis">overflowingwordoverflowingword</foreignObject>
+</svg>

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1030,6 +1030,8 @@ CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& 
         return CSSPropertyTextAnchor;
     case AttributeNames::text_decorationAttr:
         return CSSPropertyTextDecoration;
+    case AttributeNames::text_overflowAttr:
+        return CSSPropertyTextOverflow;
     case AttributeNames::text_renderingAttr:
         return CSSPropertyTextRendering;
     case AttributeNames::unicode_bidiAttr:

--- a/Source/WebCore/svg/svgattrs.in
+++ b/Source/WebCore/svg/svgattrs.in
@@ -188,6 +188,7 @@ targetX
 targetY
 text-anchor
 text-decoration
+text-overflow
 text-rendering
 textLength
 title


### PR DESCRIPTION
#### 68d3bd351bbf4df2d7ac0dd477d4093f5410eb5c
<pre>
text-overflow should be supported as an SVG presentation attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=313374">https://bugs.webkit.org/show_bug.cgi?id=313374</a>
<a href="https://rdar.apple.com/176146717">rdar://176146717</a>

Reviewed by Nikolas Zimmermann.

SVG 2 lists text-overflow among the presentation attributes that apply to any
element in the SVG namespace, so &lt;text text-overflow=&quot;ellipsis&quot;&gt; in markup should
set the CSS property, the way fill and text-anchor already do. WebKit drops the
attribute before it reaches style: cssPropertyIdForSVGAttributeName() has no case
for it, and svgattrs.in does not carry the name at all.

Fix by adding both. The visible effect is narrow but real. foreignObject takes overflow
hidden from the SVG UA stylesheet and lays out its children with CSS, so
&lt;foreignObject text-overflow=&quot;ellipsis&quot;&gt; ellipsizes an overflowing line where the
attribute used to be inert, with no style sheet involved. On SVG text nothing renders
differently, because SVG 2 gives text-overflow an effect only where the text element has
a wrapping area, and neither inline-size nor shape-inside is implemented in any engine.

white-space, the other attribute named in this bug, is left for bug 293213: the
same treatment there would fight the existing xml:space presentational hint, and
which one won would depend on the order the two attributes appear in.

Add a reftest for the foreignObject case, since the existing upstream coverage only
reads getComputedStyle and would not notice whether the value reaches the paint. The
test sets the attribute and the reference sets the same value in CSS, so the two differ
only in how the property arrives. Before the fix the test renders a hard cut and the
reference an ellipsis; after it they match.

* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-irrelevant-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-unknown-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/text-overflow-presentation-attribute-foreignobject-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/text-overflow-presentation-attribute-foreignobject-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/text-overflow-presentation-attribute-foreignobject.html: Added.
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::cssPropertyIdForSVGAttributeName const):
* Source/WebCore/svg/svgattrs.in:

Canonical link: <a href="https://commits.webkit.org/319563@main">https://commits.webkit.org/319563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b8c68a29809a169ee3a702649cf3a3a99863141

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191876 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145981 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9045b5b9-84a9-460b-862c-b87570a62907) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141784 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dee1b28f-7e4c-41e9-9009-4a5fdf174c9b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122221 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/00ffe376-de9e-43f8-88b9-de663012f444) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44160 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42431 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154560 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42061 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3038 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193803 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151196 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40536 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55958 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38683 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150899 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45479 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128241 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123931 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54471 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17063 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53853 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54092 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53918 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->