### PR TITLE
IntSize::area() and IntSize::unclampedArea() invoke undefined behavior via std::abs(INT_MIN)

### DIFF
--- a/Source/WebCore/platform/graphics/IntSize.h
+++ b/Source/WebCore/platform/graphics/IntSize.h
@@ -146,12 +146,12 @@ public:
 
     template<typename T = CrashOnOverflow> Checked<unsigned, T> area() const
     {
-        return Checked<unsigned, T>(std::abs(m_width)) * std::abs(m_height);
+        return Checked<unsigned, T>(unclampedArea());
     }
 
     uint64_t unclampedArea() const
     {
-        return static_cast<uint64_t>(std::abs(m_width)) * std::abs(m_height);
+        return static_cast<uint64_t>(std::abs(static_cast<int64_t>(m_width) * m_height));
     }
 
     constexpr int diagonalLengthSquared() const

--- a/Tools/TestWebKitAPI/Tests/WebCore/IntSizeTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IntSizeTests.cpp
@@ -27,6 +27,7 @@
 
 #include <WebCore/FloatSize.h>
 #include <WebCore/IntSize.h>
+#include <limits>
 
 #if USE(CG)
 #include <CoreGraphics/CoreGraphics.h>
@@ -117,6 +118,21 @@ TEST(IntSize, DiagonalLengthAndArea)
 
     EXPECT_EQ(1638400, test.diagonalLengthSquared());
     EXPECT_EQ(786432U, test.area().value());
+}
+
+TEST(IntSize, UnclampedArea)
+{
+    constexpr auto intMin = std::numeric_limits<int>::min();
+
+    EXPECT_EQ(786432ULL, WebCore::IntSize(1024, 768).unclampedArea());
+    EXPECT_EQ(786432ULL, WebCore::IntSize(-1024, 768).unclampedArea());
+    EXPECT_EQ(786432ULL, WebCore::IntSize(-1024, -768).unclampedArea());
+    EXPECT_EQ(786432U, WebCore::IntSize(-1024, -768).area().value());
+
+    EXPECT_EQ(2147483648ULL, WebCore::IntSize(intMin, 1).unclampedArea());
+    EXPECT_EQ(2147483648ULL, WebCore::IntSize(1, intMin).unclampedArea());
+    EXPECT_EQ(2147483648ULL, WebCore::IntSize(intMin, 1).area().value());
+    EXPECT_EQ(4611686018427387904ULL, WebCore::IntSize(intMin, intMin).unclampedArea());
 }
 
 TEST(IntSize, Scale)


### PR DESCRIPTION
#### 0fd61004f1b1dcb44797e0e0059910b47be12b85
<pre>
IntSize::area() and IntSize::unclampedArea() invoke undefined behavior via std::abs(INT_MIN)
<a href="https://bugs.webkit.org/show_bug.cgi?id=322149">https://bugs.webkit.org/show_bug.cgi?id=322149</a>
<a href="https://rdar.apple.com/185369722">rdar://185369722</a>

Reviewed by Chris Dumez.

std::abs() on INT_MIN is undefined behavior, since the result is not
representable in int. Both area() and unclampedArea() call it directly on
m_width and m_height.

INT_MIN is reachable: OffscreenCanvas exposes its dimensions as [EnforceRange]
unsigned long and narrows them to int, so new OffscreenCanvas(0x80000000, 1)
stores a width of INT_MIN, and drawing into it reaches unclampedArea() through
CanvasBase::validateArea(). unclampedArea() then returns a garbage value, and
area() crashes because Checked&lt;unsigned, CrashOnOverflow&gt; rejects the negative
result.

Multiply in int64_t before taking the absolute value. The product of two ints
always fits in int64_t, so std::abs() is well defined for every input, and
area() can just bounds-check that product on its way into Checked&lt;unsigned&gt;.
Canvas behavior is unchanged: both the old and corrected areas exceed
maxCanvasArea(), so allocation still fails.

Test: Tools/TestWebKitAPI/Tests/WebCore/IntSizeTests.cpp

* Source/WebCore/platform/graphics/IntSize.h:
(WebCore::IntSize::area const):
(WebCore::IntSize::unclampedArea const):
* Tools/TestWebKitAPI/Tests/WebCore/IntSizeTests.cpp:
(TestWebKitAPI::TEST(IntSize, UnclampedArea)):

Canonical link: <a href="https://commits.webkit.org/319574@main">https://commits.webkit.org/319574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/220e3f713cfa5bb132195a09c73e0fbb92b5bdc5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192042 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146146 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183679 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141939 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77c5d12b-dfad-4994-a039-4f60c0e462fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122375 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0dbaab65-40df-4072-a8e7-82b849b4fb1d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44304 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42574 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42205 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3204 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193968 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55434 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151348 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40543 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56123 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151053 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45626 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128406 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124161 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54636 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17201 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54018 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54257 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54083 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->