### PR TITLE
Choosing a spelling suggestion from the context menu fires inputType 'insertText' instead of 'insertReplacementText'

### DIFF
--- a/LayoutTests/editing/mac/spelling/context-menu-spelling-guess-input-events-expected.txt
+++ b/LayoutTests/editing/mac/spelling/context-menu-spelling-guess-input-events-expected.txt
@@ -1,0 +1,23 @@
+
+Verifies that choosing a spelling suggestion from the context menu fires beforeinput and input events with inputType 'insertReplacementText' rather than 'insertText'. To manually test, right click the misspelled word and choose one of the suggestions at the top of the menu.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Rich text (contenteditable):
+PASS inputTypes() is "beforeinput=insertReplacementText, input=insertReplacementText"
+PASS events[0].data is null
+PASS events[0].dataTransfer is non-null.
+PASS events[0].cancelable is true
+PASS events[1].cancelable is false
+
+Plain text (input):
+PASS inputTypes() is "beforeinput=insertReplacementText, input=insertReplacementText"
+PASS events[0].data.length > 0 is true
+PASS events[0].dataTransfer is null
+PASS events[0].cancelable is true
+PASS events[1].cancelable is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/mac/spelling/context-menu-spelling-guess-input-events.html
+++ b/LayoutTests/editing/mac/spelling/context-menu-spelling-guess-input-events.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="editable" contenteditable>welllcome</div>
+<input id="plainText">
+<p id="description"></p>
+<p id="console"></p>
+</body>
+<script>
+description("Verifies that choosing a spelling suggestion from the context menu fires beforeinput and input events with inputType 'insertReplacementText' rather than 'insertText'. To manually test, right click the misspelled word and choose one of the suggestions at the top of the menu.");
+
+let events = [];
+
+function logInputEvent(event)
+{
+    events.push(event);
+}
+
+function chooseFirstSpellingGuess(element)
+{
+    element.focus();
+
+    // Context click over the misspelled word itself; on macOS the word under the cursor is what gets checked.
+    let point;
+    if (element.tagName === "INPUT") {
+        element.setSelectionRange(0, element.value.length);
+        let rect = element.getBoundingClientRect();
+        point = { x: rect.left + 12, y: rect.top + rect.height / 2 };
+    } else {
+        let range = document.createRange();
+        range.selectNodeContents(element);
+        getSelection().removeAllRanges();
+        getSelection().addRange(range);
+        let rect = range.getBoundingClientRect();
+        point = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    }
+
+    eventSender.mouseMoveTo(point.x, point.y);
+    let items = eventSender.contextClick();
+
+    // Spelling suggestions are the leading items, followed by a separator and "Ignore Spelling".
+    // Bail out rather than clicking an arbitrary item if this isn't a misspelled-word menu.
+    if (!items.some(item => item.title === "Ignore Spelling")) {
+        testFailed(`context menu for #${element.id} has no spelling suggestions: ${items.map(item => JSON.stringify(item.title)).join(", ")}`);
+        return false;
+    }
+
+    events = [];
+    items[0].click();
+    return true;
+}
+
+function inputTypes()
+{
+    return events.map(event => `${event.type}=${event.inputType}`).join(", ");
+}
+
+editable = document.getElementById("editable");
+plainText = document.getElementById("plainText");
+plainText.value = "welllcome";
+
+for (let element of [editable, plainText]) {
+    element.addEventListener("beforeinput", logInputEvent);
+    element.addEventListener("input", logInputEvent);
+}
+
+if (window.eventSender) {
+    debug("Rich text (contenteditable):");
+    if (chooseFirstSpellingGuess(editable)) {
+        shouldBeEqualToString("inputTypes()", "beforeinput=insertReplacementText, input=insertReplacementText");
+        shouldBeNull("events[0].data");
+        shouldBeNonNull("events[0].dataTransfer");
+        shouldBeTrue("events[0].cancelable");
+        shouldBeFalse("events[1].cancelable");
+    }
+    debug("");
+
+    debug("Plain text (input):");
+    if (chooseFirstSpellingGuess(plainText)) {
+        shouldBeEqualToString("inputTypes()", "beforeinput=insertReplacementText, input=insertReplacementText");
+        shouldBeTrue("events[0].data.length > 0");
+        shouldBeNull("events[0].dataTransfer");
+        shouldBeTrue("events[0].cancelable");
+        shouldBeFalse("events[1].cancelable");
+    }
+
+    // The chosen suggestion comes from the system dictionary, so don't leave it in the text dump.
+    editable.textContent = "";
+    plainText.value = "";
+}
+</script>
+</html>

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -508,7 +508,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
 
             RefPtr document = frame->document();
             ASSERT(document);
-            Ref command = ReplaceSelectionCommand::create(*document, createFragmentFromMarkup(*document, title, emptyString()), replaceOptions);
+            Ref command = ReplaceSelectionCommand::create(*document, createFragmentFromMarkup(*document, title, emptyString()), replaceOptions, EditAction::InsertReplacement);
             command->apply();
             protect(frame->selection())->revealSelection({ SelectionRevealMode::Reveal, ScrollAlignment::alignToEdgeIfNeeded });
         }

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -86,7 +86,7 @@ static void applyTextTransformation(WebPage& page, NSString *(*transform)(NSStri
     editor->command("selectWord"_s).execute();
 
     RetainPtr selectedString = frame->displayStringModifiedByEncoding(editor->selectedText()).createNSString();
-    page.replaceSelectionWithText(frame.get(), transform(selectedString.get()));
+    page.replaceSelectionWithText(frame.get(), transform(selectedString.get()), WebCore::EditAction::Insert);
 }
 
 void WebEditorClient::uppercaseWord()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6643,7 +6643,7 @@ bool WebPage::hasRichlyEditableSelection() const
 
 void WebPage::changeSpellingToWord(const String& word)
 {
-    replaceSelectionWithText(protect(corePage()->focusController().focusedOrMainFrame()).get(), word);
+    replaceSelectionWithText(protect(corePage()->focusController().focusedOrMainFrame()).get(), word, EditAction::InsertReplacement);
 }
 
 void WebPage::unmarkAllMisspellings()
@@ -6769,9 +6769,9 @@ void WebPage::didSelectItemFromActiveContextMenu(const WebContextMenuItemData& i
 }
 #endif
 
-void WebPage::replaceSelectionWithText(LocalFrame* frame, const String& text)
+void WebPage::replaceSelectionWithText(LocalFrame* frame, const String& text, EditAction editingAction)
 {
-    return protect(frame->editor())->replaceSelectionWithText(text, WebCore::Editor::SelectReplacement::Yes, WebCore::Editor::SmartReplace::No);
+    return protect(frame->editor())->replaceSelectionWithText(text, Editor::SelectReplacement::Yes, Editor::SmartReplace::No, editingAction);
 }
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -249,6 +249,7 @@ enum class DragApplicationFlags : uint8_t;
 enum class DragHandlingMethod : uint8_t;
 enum class DragEventHandled : bool;
 enum class DeviceOrientationOrMotionPermissionState : uint8_t;
+enum class EditAction : uint8_t;
 enum class EventHandling : uint8_t;
 enum class EventMakesGamepadsVisible : bool;
 enum class ExceptionCode : uint8_t;
@@ -1439,7 +1440,7 @@ public:
     bool NODELETE isSelectTrailingWhitespaceEnabled() const;
     void NODELETE setSelectTrailingWhitespaceEnabled(bool);
 
-    void replaceSelectionWithText(WebCore::LocalFrame*, const String&);
+    void replaceSelectionWithText(WebCore::LocalFrame*, const String&, WebCore::EditAction);
     void clearSelection();
     void restoreSelectionInFocusedEditableElement();
 


### PR DESCRIPTION
#### c093ebec8aa0c8f222e03be281957c5010edf6ed
<pre>
Choosing a spelling suggestion from the context menu fires inputType &apos;insertText&apos; instead of &apos;insertReplacementText&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=195846">https://bugs.webkit.org/show_bug.cgi?id=195846</a>
<a href="https://rdar.apple.com/166940428">rdar://166940428</a>

Reviewed by Wenson Hsieh.

Picking a suggestion from the context menu for a misspelled word fired
&quot;insertText&quot; rather than &quot;insertReplacementText&quot;:

      beforeinput: inputType=insertText data=null dataTransfer=&quot;welcome&quot;

Input Events Level 2 [1] section 6.1.2 defines the row as:

      inputType                 | User&apos;s expression of intention
      &quot;insertReplacementText&quot;   | insert or replace existing content by means of
                                | a spell checker, auto-correct, writing
                                | suggestions or similar

with &quot;Part of IME composition: No&quot;, &quot;beforeinput cancelable: Yes&quot; and &quot;State of
selection: Any&quot;. A context menu spelling suggestion is squarely a spell checker
replacement, so this is the correct inputType. The W3C Editing Task Force
reached the same conclusion in [2]: &quot;seems like a bug. probably should be
insertReplacementText&quot;.

EditAction::InsertReplacement already maps to &quot;insertReplacementText&quot; in
inputTypeNameForEditingAction(), and the automatic autocorrection popover
already used it by way of SpellingCorrectionCommand. The context menu handler
simply never passed it, so it took ReplaceSelectionCommand::create()&apos;s default
of EditAction::Insert.

Pass EditAction::InsertReplacement instead. The switch is otherwise inert:
undoRedoLabel() returns the empty string for both, CompositeEditCommand::apply()
accepts both in plain text, AlternativeTextController::respondToAppliedEditing()
does not inspect the action, and the bidi-paste and accessibility paths in
ReplaceSelectionCommand only test for Paste and InsertFromDrop.

WebPage::changeSpellingToWord() had the same defect from the Spelling and
Grammar panel&apos;s Change button, so thread an EditAction through
WebPage::replaceSelectionWithText(). Its only other caller,
applyTextTransformation() (Make Upper Case, Capitalize, Chinese conversion),
stays on EditAction::Insert since those are not &quot;a spell checker, auto-correct,
writing suggestions or similar&quot;. That path is only reachable from the panel,
which no layout test can drive, so it is covered by inspection rather than by
the new test.

Only the inputType was wrong; the attribute values already conformed. Per the
data table in [1], &quot;insertReplacementText&quot; carries &quot;the plain text string to be
inserted&quot; only for an &quot;input or textarea&quot; editing host and otherwise falls to
&quot;All remaining | Any | null&quot;, while the dataTransfer table gives it &quot;a
prepopulated DataTransfer object&quot; only for a &quot;contenteditable&quot; host and
otherwise &quot;null&quot;. WebKit already matched both directions, and beforeinput is
cancelable as the table requires. The new test asserts all of it.

The forward declaration added to WebPage.h is needed because the existing
EditAction declared in that header is WebCore::WritingTools::EditAction.

[1] <a href="https://www.w3.org/TR/input-events-2/#interface-InputEvent-Attributes">https://www.w3.org/TR/input-events-2/#interface-InputEvent-Attributes</a>
[2] <a href="https://github.com/w3c/editing/issues/494">https://github.com/w3c/editing/issues/494</a>

Test: editing/mac/spelling/context-menu-spelling-guess-input-events.html

* LayoutTests/editing/mac/spelling/context-menu-spelling-guess-input-events-expected.txt: Added.
* LayoutTests/editing/mac/spelling/context-menu-spelling-guess-input-events.html: Added.
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::applyTextTransformation):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::changeSpellingToWord):
(WebKit::WebPage::replaceSelectionWithText):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/319540@main">https://commits.webkit.org/319540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b46c8424959a477c7d96dfbdbbe31081743472f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192026 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146130 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/015899e5-0c36-4b6d-bec6-d0caedc2742e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183663 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57062 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141922 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b47815dc-c249-49b3-8fc8-5456869a33a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122357 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dae141d3-8de2-44fa-84e9-907930aae5b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44287 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154684 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42186 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3187 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193952 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151333 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40519 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56107 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38809 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151036 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45608 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128390 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124145 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54620 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17182 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54002 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54241 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54067 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->