### PR TITLE
SourceBufferParserWebM can emit negative MediaSample.duration

### DIFF
--- a/LayoutTests/media/media-source/media-source-real-webm-backwards-timecode-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-webm-backwards-timecode-expected.txt
@@ -1,0 +1,30 @@
+Tests WebM block timecodes that precede their cluster, and clusters appended out of order.
+
+A block preceding its cluster is a decode error
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(error)
+EVENT(updateend)
+EXPECTED (source.readyState == 'closed') OK
+Two clusters appended out of order are accepted
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (source.readyState == 'open') OK
+EXPECTED (sourceBuffer.buffered.length == '2') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '2') OK
+EXPECTED (sourceBuffer.buffered.start(1) == '5') OK
+EXPECTED (sourceBuffer.buffered.end(1) == '7') OK
+Out of order clusters over a populated track buffer
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+RUN(sourceBuffer.abort())
+EVENT(updateend)
+EXPECTED (source.readyState == 'open') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1) == '7') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-webm-backwards-timecode.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-backwards-timecode.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-webm-backwards-timecode</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Block timecodes must increase within a cluster, but media segments may be appended out of
+    // order. Tests that the former is rejected and the latter does not produce a sample with a
+    // negative duration.
+
+    var source;
+    var sourceBuffer;
+
+    function cluster(baseDecodeTime)
+    {
+        return WebM.mediaSegment({
+            simpleBlock: true,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: baseDecodeTime, samples: [
+                { duration: 1000, isSync: true },
+                { duration: 1000, isSync: true },
+            ]}]
+        });
+    }
+
+    // A cluster whose second block precedes its first: absolute timecodes 2000ms then 500ms.
+    function backwardsCluster()
+    {
+        return WebM.mediaSegment({
+            simpleBlock: true,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 2000, samples: [
+                { duration: 1000, isSync: true },
+                { duration: 1000, isSync: true, relativeTime: -1500 },
+            ]}]
+        });
+    }
+
+    function concat(first, second)
+    {
+        var buffer = new Uint8Array(first.length + second.length);
+        buffer.set(first, 0);
+        buffer.set(second, first.length);
+        return buffer;
+    }
+
+    async function openSource()
+    {
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+        sourceBuffer.appendBuffer(WebM.initSegment({ tracks: [{ id: 1, type: 'video' }] }));
+        await waitFor(sourceBuffer, 'updateend');
+    }
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        consoleWrite('A block preceding its cluster is a decode error');
+        await openSource();
+
+        // Both events are queued together by the append error algorithm, so listen for them
+        // before the append rather than in sequence.
+        var errorFired = waitFor(sourceBuffer, 'error');
+        var updateEnded = waitFor(sourceBuffer, 'updateend');
+        sourceBuffer.appendBuffer(backwardsCluster());
+        await errorFired;
+        await updateEnded;
+        testExpected('source.readyState', 'closed');
+
+        consoleWrite('Two clusters appended out of order are accepted');
+        await openSource();
+
+        // The queued last sample of the first cluster cannot take its duration from the second
+        // cluster's first frame; it falls back to the track's default duration.
+        sourceBuffer.appendBuffer(concat(cluster(5000), cluster(0)));
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('source.readyState', 'open');
+        testExpected('sourceBuffer.buffered.length', 2);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 2, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(1)', 5, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(1)', 7, 0.05);
+
+        consoleWrite('Out of order clusters over a populated track buffer');
+        await openSource();
+
+        sourceBuffer.appendBuffer(cluster(0));
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 1);
+
+        // abort() unsets the highest presentation timestamp on the track buffer while leaving its
+        // samples in place, which is what reaches the coded frame removal steps below.
+        run('sourceBuffer.abort()');
+
+        sourceBuffer.appendBuffer(concat(cluster(5000), cluster(1000)));
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('source.readyState', 'open');
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 0, 0.05);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1)', 7, 0.05);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <div>Tests WebM block timecodes that precede their cluster, and clusters appended out of order.</div>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/webm-generator.js
+++ b/LayoutTests/media/media-source/webm-generator.js
@@ -379,6 +379,9 @@ const WebM = (function() {
         //     .duration    - Sample duration in milliseconds
         //     .isSync      - true for keyframe
         //     .data        - Override frame data (Uint8Array, optional)
+        //     .relativeTime - Override the block's timecode relative to the cluster's,
+        //                     in milliseconds (optional, may be negative). Only affects
+        //                     this block; the running timecode keeps accumulating durations.
         mediaSegment(options) {
             const tracks = options.tracks;
             const clusterTimecode = (tracks[0] && tracks[0].baseDecodeTime) || 0;
@@ -415,7 +418,7 @@ const WebM = (function() {
                             : OPUS_SILENCE);
                     currentBlocks.push({
                         trackId: track.id,
-                        relativeTime,
+                        relativeTime: sample.relativeTime !== undefined ? sample.relativeTime : relativeTime,
                         isSync: sample.isSync,
                         duration: sample.duration,
                         data: frameData,

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -608,6 +608,8 @@ media/media-source/media-source-video-seek-pause.html [ Failure Pass ]
 # GStreamer incorrectly demux the webm and creates gaps.
 webkit.org/b/266195 media/media-source/media-managedmse-multipletracks-bufferedchange.html [ Failure ]
 
+webkit.org/b/322164 media/media-source/media-source-real-webm-backwards-timecode.html [ Failure ]
+
 # Support to pause with 0 rate playback seems to work only in GStreamer ports
 media/media-source/media-source-play-zero-playbackrate.html [ Pass ]
 

--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -324,6 +324,9 @@ DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterDecodeIt
 
 PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSamplesBetweenPresentationTimes(const MediaTime& beginTime, const MediaTime& endTime) LIFETIME_BOUND
 {
+    if (endTime <= beginTime)
+        return { end(), end() };
+
     // startTime is inclusive, so use lower_bound to include samples wich start exactly at startTime.
     // endTime is not inclusive, so use lower_bound to exclude samples which start exactly at endTime.
     auto lower_bound = m_samples.lower_bound(beginTime);
@@ -335,6 +338,9 @@ PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSampl
 
 PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSamplesBetweenPresentationTimesFromEnd(const MediaTime& beginTime, const MediaTime& endTime) LIFETIME_BOUND
 {
+    if (endTime <= beginTime)
+        return { end(), end() };
+
     reverse_iterator rangeEnd = std::find_if(rbegin(), rend(), [&endTime](const auto& value) {
         return value.first < endTime;
     });

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -562,6 +562,9 @@ ExceptionOr<int> WebMParser::parse(Ref<const SharedBuffer>&& segment)
         continue;
     }
 
+    // The append is rejected: drop the samples queued by the partially parsed media segment.
+    discardPendingVideoSamples();
+
     return m_status.code;
 }
 
@@ -750,6 +753,11 @@ Status WebMParser::OnClusterBegin(const ElementMetadata&, const Cluster& cluster
 
     if (cluster.timecode.is_present())
         m_currentTimecode = cluster.timecode.value();
+
+    // A WebM media segment is a single cluster, and media segments may be appended in any order,
+    // so timecodes are only required to increase within a cluster.
+    for (auto& track : m_tracks)
+        track->resetLastAbsoluteTimecode();
 
     *action = Action::kRead;
 
@@ -979,7 +987,19 @@ webm::Status WebMParser::OnFrame(const FrameMetadata& metadata, Reader* reader, 
         return Skip(reader, bytesRemaining);
     }
 
-    auto result = trackData->consumeFrameData(*reader, metadata, bytesRemaining, MediaTime(block->timecode + m_currentTimecode, m_timescale) + m_currentDuration, isKey);
+    auto presentationTime = MediaTime(static_cast<int64_t>(m_currentTimecode + block->timecode), m_timescale) + m_currentDuration;
+
+    // https://w3c.github.io/mse-byte-stream-format-webm/
+    // The append error algorithm must run unless "Block & SimpleBlock elements are in time
+    // increasing order consistent with [WEBM]". The timecodes are compared per track within the
+    // current cluster: a cluster interleaves the blocks of all of its tracks, and audio blocks
+    // sharing a video block's timecode are written before it.
+    if (!trackData->updateLastAbsoluteTimecode(presentationTime)) {
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "Timecode ", presentationTime, " on track ", trackNumber, " is not monotonically increasing");
+        return Status(Status::Code(ErrorCode::NonMonotonicTimecode));
+    }
+
+    auto result = trackData->consumeFrameData(*reader, metadata, bytesRemaining, presentationTime, isKey);
     if (std::holds_alternative<webm::Status>(result))
         return std::get<webm::Status>(result);
     m_currentDuration += std::get<MediaTime>(result);
@@ -1037,6 +1057,14 @@ void WebMParser::flushPendingVideoSamples()
     for (auto& track : m_tracks) {
         if (auto* videoTrack = dynamicDowncast<WebMParser::VideoTrackData>(track.get()))
             videoTrack->flushPendingSamples();
+    }
+}
+
+void WebMParser::discardPendingVideoSamples()
+{
+    for (auto& track : m_tracks) {
+        if (auto* videoTrack = dynamicDowncast<WebMParser::VideoTrackData>(track.get()))
+            videoTrack->discardPendingSamples();
     }
 }
 
@@ -1109,6 +1137,12 @@ WebMParser::ConsumeFrameDataResult WebMParser::VideoTrackData::consumeFrameData(
     }
 #endif
 
+    // A frame's duration is the start time of the frame that follows it. The queued sample may come
+    // from an earlier cluster, which need not precede this one in time; a frame starting before it
+    // can't close it, so give it the same fallback duration it would get at the end of an append.
+    if (m_pendingMediaSamples.size() && presentationTime < m_pendingMediaSamples.last().presentationTime)
+        flushPendingSamples();
+
     processPendingMediaSamples(presentationTime);
 
     if (formatDescription() && (!m_trackInfo || *formatDescription() != *m_trackInfo)) {
@@ -1168,6 +1202,11 @@ void WebMParser::VideoTrackData::processPendingMediaSamples(const MediaTime& pre
     if (!m_pendingMediaSamples.size())
         return;
     auto& lastSample = m_pendingMediaSamples.last();
+    // The queued sample may come from an earlier cluster, which need not precede this one in time;
+    // a frame starting before it can't close it, so leave it queued, as is done for frames sharing
+    // a presentation time.
+    if (presentationTime < lastSample.presentationTime)
+        return;
     lastSample.duration = presentationTime - lastSample.presentationTime;
     if (presentationTime == lastSample.presentationTime)
         return;
@@ -1215,6 +1254,15 @@ void WebMParser::VideoTrackData::flushPendingSamples()
     else if (m_lastDuration)
         duration = *m_lastDuration;
     processPendingMediaSamples(presentationTime + duration);
+    m_lastPresentationTime.reset();
+}
+
+void WebMParser::VideoTrackData::discardPendingSamples()
+{
+    // The media segment those samples belong to was rejected; they must not be emitted, and the
+    // duration of the next segment's first sample must not be derived from them.
+    m_pendingMediaSamples.clear();
+    m_lastDuration.reset();
     m_lastPresentationTime.reset();
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -100,6 +100,7 @@ public:
         VariableFrameDuration,
         ReaderFailed,
         ParserShutdown,
+        NonMonotonicTimecode,
     };
 
     enum class State : uint8_t {
@@ -167,6 +168,19 @@ public:
 
         virtual void consumeAdditionalBlockData(const webm::BlockAdditions&) { }
 
+        // Tracks the highest absolute timecode seen in the current cluster. Equal timecodes are
+        // allowed: frames sharing a presentation time are to be decoded but not displayed.
+        // Returns false if the timecode goes backwards.
+        bool updateLastAbsoluteTimecode(const MediaTime& presentationTime)
+        {
+            if (m_lastAbsoluteTimecode && presentationTime < *m_lastAbsoluteTimecode)
+                return false;
+            m_lastAbsoluteTimecode = presentationTime;
+            return true;
+        }
+
+        void resetLastAbsoluteTimecode() { m_lastAbsoluteTimecode.reset(); }
+
         virtual void resetCompletedFramesState()
         {
             m_completeBlockBuffer = nullptr;
@@ -209,6 +223,7 @@ public:
         std::optional<size_t> m_completePacketSize;
         // Size of the currently incomplete parsed packet.
         size_t m_partialBytesRead { 0 };
+        std::optional<MediaTime> m_lastAbsoluteTimecode;
     };
 
     class VideoTrackData : public TrackData {
@@ -225,6 +240,7 @@ public:
         }
 
         void flushPendingSamples();
+        void discardPendingSamples();
 
     private:
         ASCIILiteral logClassName() const { return "VideoTrackData"_s; }
@@ -276,6 +292,7 @@ private:
     bool isSupportedVideoCodec(StringView);
     bool isSupportedAudioCodec(StringView);
     void flushPendingVideoSamples();
+    void discardPendingVideoSamples();
 
     // webm::Callback
     webm::Status OnElementBegin(const webm::ElementMetadata&, webm::Action*) final;

--- a/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
@@ -231,6 +231,15 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)
     iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(30, 1), MediaTime(31, 1));
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
+
+    // An inverted range must not produce a pair whose first iterator follows its second.
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(20, 1), MediaTime(5, 1));
+    EXPECT_TRUE(presentationMap.end() == iterator_range.first);
+    EXPECT_TRUE(presentationMap.end() == iterator_range.second);
+
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(10, 1), MediaTime(10, 1));
+    EXPECT_TRUE(presentationMap.end() == iterator_range.first);
+    EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 }
 
 TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)
@@ -266,6 +275,14 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 
     iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(30, 1), MediaTime(31, 1));
+    EXPECT_TRUE(presentationMap.end() == iterator_range.first);
+    EXPECT_TRUE(presentationMap.end() == iterator_range.second);
+
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(20, 1), MediaTime(5, 1));
+    EXPECT_TRUE(presentationMap.end() == iterator_range.first);
+    EXPECT_TRUE(presentationMap.end() == iterator_range.second);
+
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(10, 1), MediaTime(10, 1));
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 }


### PR DESCRIPTION
#### bc0b5db0e5d31ca7a15a2bf334188ed71004e553
<pre>
SourceBufferParserWebM can emit negative MediaSample.duration
<a href="https://bugs.webkit.org/show_bug.cgi?id=322152">https://bugs.webkit.org/show_bug.cgi?id=322152</a>
<a href="https://rdar.apple.com/179030051">rdar://179030051</a>

Reviewed by Jer Noble.

We guard against non-monotonically increasing timestamps within a cluster as an error.
If from one cluster to another it&apos;s treated as a discontinuity.

Tests: Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
       media/media-source/media-source-real-webm-backwards-timecode.html

* LayoutTests/media/media-source/media-source-real-webm-backwards-timecode-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-webm-backwards-timecode.html: Added.
* LayoutTests/media/media-source/webm-generator.js:
(const.WebM):
* Source/WebCore/Modules/mediasource/SampleMap.cpp:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::OnClusterBegin):
(WebCore::WebMParser::OnFrame):
(WebCore::WebMParser::VideoTrackData::consumeFrameData):
(WebCore::WebMParser::VideoTrackData::processPendingMediaSamples):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
(WebCore::WebMParser::TrackData::updateLastAbsoluteTimecode):
(WebCore::WebMParser::TrackData::resetLastAbsoluteTimecode):
* Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp:
(TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)):
(TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)):

Canonical link: <a href="https://commits.webkit.org/319595@main">https://commits.webkit.org/319595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e4a6e0e74cac408ba178b5b0c03930df4d16900

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146241 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53b80d44-978f-46a1-b3fd-de851865e010) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142017 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce58c10d-5a5b-43d2-88f4-b4389cd6aeb3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122453 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e23e82a-bf7f-4b0d-8f4f-881670395cdf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44381 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42649 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154778 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42277 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3301 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194064 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151431 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40556 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56218 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151137 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45703 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128501 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124263 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54732 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17273 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54113 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54352 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54178 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->