### PR TITLE
Aborting a dead key composition fires no compositionend event, or one with empty data

### DIFF
--- a/LayoutTests/editing/input/compositionend-after-clicking-outside-editable-expected.txt
+++ b/LayoutTests/editing/input/compositionend-after-clicking-outside-editable-expected.txt
@@ -1,0 +1,11 @@
+Some text.^
+Not editable.
+compositionstart target=editable data=""
+compositionupdate target=editable data="^"
+compositionend target=editable data="^"
+activeElement=BODY
+editable.textContent="Some text.^"
+hasMarkedText=false
+
+PASS compositionend is fired on the editable element when a composition is aborted by clicking outside of it
+

--- a/LayoutTests/editing/input/compositionend-after-clicking-outside-editable.html
+++ b/LayoutTests/editing/input/compositionend-after-clicking-outside-editable.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="editable" contenteditable>Some text.</div>
+<div id="outside">Not editable.</div>
+<pre id="log"></pre>
+<script>
+let observed = [];
+for (const type of ["compositionstart", "compositionupdate", "compositionend"]) {
+    document.addEventListener(type, event => {
+        observed.push({ type: event.type, data: event.data, target: event.target.id || event.target.nodeName });
+    }, true);
+}
+
+function clickOutsideTheEditableElement() {
+    let rect = outside.getBoundingClientRect();
+    eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+}
+
+test(() => {
+    assert_own_property(window, "textInputController", "this test needs textInputController to start a composition");
+    assert_own_property(window, "eventSender", "this test needs eventSender to click outside the editable element");
+
+    editable.focus();
+    getSelection().setPosition(editable.firstChild, editable.firstChild.length);
+    textInputController.setMarkedText("^", 1, 0);
+    assert_true(textInputController.hasMarkedText(), "the dead key should start a composition");
+
+    clickOutsideTheEditableElement();
+
+    log.textContent = observed.map(event => `${event.type} target=${event.target} data=${JSON.stringify(event.data)}`).join("\n")
+        + `\nactiveElement=${document.activeElement.id || document.activeElement.nodeName}`
+        + `\neditable.textContent=${JSON.stringify(editable.textContent)}`
+        + `\nhasMarkedText=${textInputController.hasMarkedText()}`;
+
+    let compositionEndEvents = observed.filter(event => event.type === "compositionend");
+    assert_equals(compositionEndEvents.length, 1, "a compositionend event should be fired when the composition is aborted by clicking outside the editable element");
+    assert_equals(compositionEndEvents[0].target, "editable", "compositionend should target the element the composition started on");
+    assert_equals(compositionEndEvents[0].data, "^", "compositionend data should be the composition text left behind in the document");
+}, "compositionend is fired on the editable element when a composition is aborted by clicking outside of it");
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/input/compositionend-data-after-aborting-composition-expected.txt
+++ b/LayoutTests/editing/input/compositionend-data-after-aborting-composition-expected.txt
@@ -1,0 +1,5 @@
+Some text.^
+Not editable.
+
+PASS compositionend reports the text left behind in the document when a composition is aborted
+

--- a/LayoutTests/editing/input/compositionend-data-after-aborting-composition.html
+++ b/LayoutTests/editing/input/compositionend-data-after-aborting-composition.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="editable" contenteditable>Some text.</div>
+<div id="outside">Not editable.</div>
+<script>
+test(() => {
+    assert_own_property(window, "textInputController", "this test needs textInputController to start a composition");
+
+    let events = [];
+    for (const type of ["compositionstart", "compositionupdate", "compositionend"])
+        editable.addEventListener(type, event => events.push({ type: event.type, data: event.data }));
+
+    editable.focus();
+    getSelection().setPosition(editable.firstChild, editable.firstChild.length);
+
+    textInputController.setMarkedText("^", 1, 0);
+    assert_true(textInputController.hasMarkedText(), "the dead key should start a composition");
+
+    getSelection().setPosition(outside.firstChild, 0);
+
+    assert_false(textInputController.hasMarkedText(), "moving the selection out of the editable element should end the composition");
+    assert_equals(editable.textContent, "Some text.^", "the composition text should be left behind in the document");
+
+    let compositionEndEvents = events.filter(event => event.type === "compositionend");
+    assert_equals(compositionEndEvents.length, 1, "exactly one compositionend event should be fired");
+    assert_equals(compositionEndEvents[0].data, "^", "compositionend data should be the composition text left behind in the document");
+}, "compositionend reports the text left behind in the document when a composition is aborted");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1586,6 +1586,13 @@ webkit.org/b/239345 editing/execCommand/insert-ordered-list-and-delete.html [ Fa
 
 webkit.org/b/179605 editing/execCommand/underline-selection-containing-image.html [ Failure ]
 
+# Moving the selection out of a composition only aborts the composition on macOS, where
+# Editor::selectionWillChange() cancels it. That function is an empty stub on every other
+# port, so no compositionend is dispatched. Same gap as
+# fast/events/ime-compositionend-on-selection-change.html.
+editing/input/compositionend-after-clicking-outside-editable.html [ Failure ]
+editing/input/compositionend-data-after-aborting-composition.html [ Failure ]
+
 # Assertion failure if ASSERT_ENABLED
 webkit.org/b/286128 [ Release ] editing/inserting/insert-list-user-select-none-crash.html [ Crash Pass Timeout ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1640,6 +1640,13 @@ webkit.org/b/180725 editing/caret/color-span-inside-editable.html [ ImageOnlyFai
 
 webkit.org/b/180286 editing/input/editable-container-with-word-wrap-normal.html [ Failure ]
 
+# Moving the selection out of a composition only aborts the composition on macOS, where
+# Editor::selectionWillChange() cancels it. That function is an empty stub on every other
+# port, so no compositionend is dispatched. Same gap as
+# fast/events/ime-compositionend-on-selection-change.html.
+editing/input/compositionend-after-clicking-outside-editable.html [ Failure ]
+editing/input/compositionend-data-after-aborting-composition.html [ Failure ]
+
 # Font tests that fail:
 fonts/font-fallback-prefers-pictographs.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -2457,6 +2457,10 @@ void Editor::setComposition(const String& text, SetCompositionMode mode)
     else
         selectComposition();
 
+    // Cancelling a composition does not remove the pending composition text from the document, so the
+    // compositionend event has to report the text that is left behind rather than the empty string.
+    String textForCompositionEndEvent = mode == CancelComposition ? compositionText() : text;
+
     RefPtr previousCompositionNode = m_compositionNode;
     m_compositionNode = nullptr;
     m_customCompositionUnderlines.clear();
@@ -2477,8 +2481,19 @@ void Editor::setComposition(const String& text, SetCompositionMode mode)
 
     insertTextForConfirmedComposition(text);
 
-    if (RefPtr target = document->focusedElement())
-        target->dispatchEvent(CompositionEvent::create(eventNames().compositionendEvent, document->windowProxy(), text));
+    // Clicking outside the editable element moves focus away before the composition is torn down, so
+    // there is no focused element left to dispatch to. Fall back to the element the composition belongs
+    // to rather than dropping the compositionend event altogether.
+    RefPtr<Element> target = document->focusedElement();
+    if (!target && previousCompositionNode) {
+        if (RefPtr textControl = enclosingTextFormControl(firstPositionInOrBeforeNode(previousCompositionNode.get())))
+            target = WTF::move(textControl);
+        else
+            target = previousCompositionNode->rootEditableElement();
+    }
+
+    if (target)
+        target->dispatchEvent(CompositionEvent::create(eventNames().compositionendEvent, document->windowProxy(), textForCompositionEndEvent));
 
     if (mode == CancelComposition) {
         // An open typing command that disagrees about current selection would cause issues with typing later on.


### PR DESCRIPTION
#### 36cbace2163012041a2e59ae7ad39394b8123775
<pre>
Aborting a dead key composition fires no compositionend event, or one with empty data
<a href="https://bugs.webkit.org/show_bug.cgi?id=304068">https://bugs.webkit.org/show_bug.cgi?id=304068</a>
<a href="https://rdar.apple.com/166881240">rdar://166881240</a>

Reviewed by Ryosuke Niwa.

Pressing a dead key in an editable element starts a composition, and clicking
outside the element aborts it, leaving the dead key character in the document. Two
separate problems in Editor::setComposition() meant a page could not observe what
had happened.

First, compositionend was dispatched to document-&gt;focusedElement(). Clicking
outside the editable element fires focusout before the composition is torn down,
so there is no focused element left by then and the event was dropped entirely:
the composition state was cleared and the text left behind with nothing
dispatched. Fall back to the element the composition belongs to when focus has
already moved. A composition inside a text form control lives in a shadow tree, so
retarget to the form control rather than to the inner text element.

Second, on the paths where the event was dispatched, its data was the empty
string. Cancelling a composition does not remove the pending composition text from
the document: setComposition() skips the deleteSelection() call when the mode is
CancelComposition, and insertTextForConfirmedComposition() early-returns for the
empty string it is handed. Report the composition text instead, captured before
m_compositionNode is cleared.

Chrome and Firefox both fire compositionend with the character left in the
document.

The tests only pass on macOS. Aborting a composition when the selection moves out
of it is driven by Editor::selectionWillChange(), which calls cancelComposition()
in EditorMac.mm and is an empty stub for every other port, so nothing tears the
composition down and setComposition() is never reached. That is the same gap
fast/events/ime-compositionend-on-selection-change.html already tracks as a
failure on the GLib ports and iOS, so mark the new tests accordingly.

Tests: editing/input/compositionend-after-clicking-outside-editable.html
       editing/input/compositionend-data-after-aborting-composition.html

* LayoutTests/editing/input/compositionend-after-clicking-outside-editable-expected.txt: Added.
* LayoutTests/editing/input/compositionend-after-clicking-outside-editable.html: Added.
* LayoutTests/editing/input/compositionend-data-after-aborting-composition-expected.txt: Added.
* LayoutTests/editing/input/compositionend-data-after-aborting-composition.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::setComposition):

Canonical link: <a href="https://commits.webkit.org/319578@main">https://commits.webkit.org/319578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/832b52389ce1deccfc25d3fb9dfabb735f61e982

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146182 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141965 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122401 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44331 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42601 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42231 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3240 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194005 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151378 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40546 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56159 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151084 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45652 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128442 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124201 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54672 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17227 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54054 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54293 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54119 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->