### PR TITLE
TextMeasurementCache with out-of-line long-text table

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -142,8 +142,9 @@ public:
         ShapedTextCacheDefaults::initialInterval,
         ShapedTextCacheDefaults::minInterval,
         ShapedTextCacheDefaults::maxInterval,
-        ShapedTextCacheDefaults::maxSize,
-        ShapedTextCacheDefaults::maxTextLength
+        ShapedTextCacheDefaults::maxTextLength,
+        ShapedTextCacheDefaults::maxTextLength, // InlineKeyCapacity == MaxTextLength: keep every entry inline, out-of-line table intentionally unused.
+        ShapedTextCacheDefaults::maxSize
     >;
     ShapedTextCache& shapedTextCache() LIFETIME_BOUND { return m_shapedTextCache; }
     const ShapedTextCache& shapedTextCache() const LIFETIME_BOUND { return m_shapedTextCache; }

--- a/Source/WebCore/platform/graphics/TextMeasurementCache.h
+++ b/Source/WebCore/platform/graphics/TextMeasurementCache.h
@@ -35,6 +35,7 @@
 #include <wtf/ZippedRange.h>
 #include <wtf/text/RapidHash.h>
 #include <wtf/text/StringCommon.h>
+#include <wtf/text/StringHash.h>
 #include <wtf/text/StringImpl.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -53,17 +54,29 @@ struct TextShapingContext {
 namespace TextMeasurementCacheDefaults {
 static constexpr int minInterval = -3; // A cache hit pays for about 3 cache misses.
 static constexpr int maxInterval = 20; // Sampling at this interval has almost no overhead.
-static constexpr unsigned maxSize = 500000; // Just enough to guard against pathological growth.
-static constexpr unsigned maxTextLength = 64; // Maximum text length for SmallStringKey.
+static constexpr unsigned maxTextLength = 64; // Maximum text length that can be cached.
+static constexpr unsigned inlineKeyCapacity = 16; // Text this long or shorter is stored inline in SmallStringKey; longer text (up to maxTextLength) is stored out-of-line, keyed by String.
+static constexpr size_t maxBytes = 20 * 1024 * 1024; // ~20MiB. Rough budget above which the cache is cleared to avoid pathological growth.
+
+template<typename CachedType, unsigned InlineKeyCapacity>
+constexpr unsigned maxSizeForByteBudget(size_t bytes = maxBytes)
+{
+    // Approximate SmallStringKey's inline char16_t array plus its hash/length word and the cache payload.
+    constexpr size_t slotBytes = sizeof(char16_t) * InlineKeyCapacity + sizeof(unsigned) + sizeof(CachedType);
+    size_t entries = bytes / slotBytes;
+    return static_cast<unsigned>(entries ? entries : 1);
+}
 }
 
 template <typename CachedType,
     int InitialInterval = TextMeasurementCacheDefaults::maxInterval,
     int MinInterval = TextMeasurementCacheDefaults::minInterval,
     int MaxInterval = TextMeasurementCacheDefaults::maxInterval,
-    unsigned MaxSize = TextMeasurementCacheDefaults::maxSize,
-    unsigned MaxTextLength = TextMeasurementCacheDefaults::maxTextLength>
+    unsigned MaxTextLength = TextMeasurementCacheDefaults::maxTextLength,
+    unsigned InlineKeyCapacity = TextMeasurementCacheDefaults::inlineKeyCapacity,
+    unsigned MaxSize = TextMeasurementCacheDefaults::maxSizeForByteBudget<CachedType, InlineKeyCapacity>()>
 class TextMeasurementCache {
+    static_assert(InlineKeyCapacity >= 1 && InlineKeyCapacity <= MaxTextLength, "InlineKeyCapacity must be in [1, MaxTextLength]");
 private:
     // Used to optimize small strings as hash table keys. Avoids malloc'ing an out-of-line StringImpl.
     class SmallStringKey {
@@ -100,7 +113,7 @@ private:
         friend bool operator==(const SmallStringKey&, const SmallStringKey&) = default;
 
     private:
-        static constexpr unsigned s_capacity = MaxTextLength;
+        static constexpr unsigned s_capacity = InlineKeyCapacity;
         static constexpr unsigned s_deletedValueLength = s_capacity + 1;
 
         template<typename CharacterType>
@@ -117,6 +130,8 @@ private:
         std::array<char16_t, s_capacity> m_characters { };
         unsigned m_hashAndLength { 0 };
     };
+
+    static_assert(sizeof(SmallStringKey) == sizeof(std::array<char16_t, InlineKeyCapacity>) + sizeof(unsigned), "Revisit maxSizeForByteBudget computation");
 
     struct SmallStringKeyHashTraits : SimpleClassHashTraits<SmallStringKey> {
         static constexpr bool emptyValueIsZero = true;
@@ -180,9 +195,14 @@ public:
         ASSERT(isMainThread());
         m_singleCharMap.clear();
         m_map.clear();
+        m_outOfLineMap.clear();
     }
 
-    bool isEmpty() const { return m_singleCharMap.isEmpty() && m_map.isEmpty(); }
+    bool isEmpty() const { return m_singleCharMap.isEmpty() && m_map.isEmpty() && m_outOfLineMap.isEmpty(); }
+
+    static constexpr unsigned inlineKeyCapacity() { return InlineKeyCapacity; }
+    static constexpr unsigned maxTextLength() { return MaxTextLength; }
+    static constexpr unsigned maxSize() { return MaxSize; }
 
 private:
 
@@ -201,8 +221,12 @@ private:
             auto addResult = m_singleCharMap.fastAdd(character + 1, WTF::move(entry));
             isNewEntry = addResult.isNewEntry;
             value = &addResult.iterator->value;
-        } else {
+        } else if (length <= InlineKeyCapacity) {
             auto addResult = m_map.fastAdd(text, WTF::move(entry));
+            isNewEntry = addResult.isNewEntry;
+            value = &addResult.iterator->value;
+        } else {
+            auto addResult = m_outOfLineMap.fastAdd(text.toString(), WTF::move(entry));
             isNewEntry = addResult.isNewEntry;
             value = &addResult.iterator->value;
         }
@@ -218,12 +242,13 @@ private:
             ++m_interval;
         m_countdown = m_interval;
 
-        if ((m_singleCharMap.size() + m_map.size()) < MaxSize)
+        if ((m_singleCharMap.size() + m_map.size() + m_outOfLineMap.size()) < MaxSize)
             return value;
 
         // No need to be fancy: we're just trying to avoid pathological growth.
         m_singleCharMap.clear();
         m_map.clear();
+        m_outOfLineMap.clear();
         return nullptr;
     }
 
@@ -246,11 +271,13 @@ private:
 
     using Map = HashMap<SmallStringKey, CachedType, DefaultHash<SmallStringKey>, SmallStringKeyHashTraits>;
     using SingleCharMap = HashMap<uint32_t, CachedType, DefaultHash<uint32_t>, HashTraits<uint32_t>>;
+    using OutOfLineMap = HashMap<String, CachedType>;
 
     int m_interval;
     int m_countdown;
     SingleCharMap m_singleCharMap;
     Map m_map;
+    OutOfLineMap m_outOfLineMap;
     bool m_hasSeenIdeograph;
 };
 

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -275,6 +275,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/StyleGradient.cpp
         Tests/WebCore/TestPlatformStrategies.cpp
         Tests/WebCore/TextIterator.cpp
+        Tests/WebCore/TextMeasurementCache.cpp
         Tests/WebCore/TimeRanges.cpp
         Tests/WebCore/TransformationMatrix.cpp
         Tests/WebCore/URLParserTextEncoding.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -824,6 +824,7 @@
 				WebCore/TextBoundaries.cpp,
 				WebCore/TextCodec.cpp,
 				WebCore/TextIterator.cpp,
+				WebCore/TextMeasurementCache.cpp,
 				WebCore/TimeRanges.cpp,
 				WebCore/TransformationMatrix.cpp,
 				WebCore/U2fCommandConstructorTest.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/TextMeasurementCache.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TextMeasurementCache.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/FontCascadeFonts.h>
+#include <WebCore/TextMeasurementCache.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+namespace {
+
+// InitialInterval = MinInterval = MaxInterval = 0 disables the sampling countdown, so every add() reaches addSlowCase() immediately.
+constexpr unsigned testMaxTextLength = 32;
+constexpr unsigned testInlineKeyCapacity = 8;
+constexpr unsigned testMaxSize = 4;
+using TestCache = TextMeasurementCache<int, 0, 0, 0, testMaxTextLength, testInlineKeyCapacity, testMaxSize>;
+
+String stringOfLength(unsigned length, char16_t fill = 'a')
+{
+    Vector<char16_t> characters(length);
+    characters.fill(fill);
+    return String(std::span<const char16_t> { characters });
+}
+
+}
+
+TEST(TextMeasurementCacheTest, SingleCharacterIsCached)
+{
+    TestCache cache;
+    EXPECT_TRUE(cache.isEmpty());
+
+    auto* entry = cache.add("a"_s, 1);
+    ASSERT_TRUE(entry);
+    EXPECT_FALSE(cache.isEmpty());
+
+    auto* sameEntry = cache.add("a"_s, 2);
+    EXPECT_EQ(entry, sameEntry);
+}
+
+TEST(TextMeasurementCacheTest, ShortTextUsesInlineTable)
+{
+    TestCache cache;
+    String text = stringOfLength(testInlineKeyCapacity);
+
+    auto* entry = cache.add(text, 1);
+    ASSERT_TRUE(entry);
+    EXPECT_FALSE(cache.isEmpty());
+
+    auto* sameEntry = cache.add(text, 2);
+    EXPECT_EQ(entry, sameEntry);
+
+    cache.clear();
+    EXPECT_TRUE(cache.isEmpty());
+}
+
+TEST(TextMeasurementCacheTest, LongTextUsesOutOfLineTable)
+{
+    TestCache cache;
+    String text = stringOfLength(testInlineKeyCapacity + 1);
+    ASSERT_LE(text.length(), testMaxTextLength);
+
+    auto* entry = cache.add(text, 1);
+    ASSERT_TRUE(entry);
+    EXPECT_FALSE(cache.isEmpty());
+
+    // A repeated add() with the same out-of-line key must hit the existing entry, not silently re-insert.
+    auto* sameEntry = cache.add(text, 2);
+    EXPECT_EQ(entry, sameEntry);
+    EXPECT_EQ(1, *entry);
+
+    cache.clear();
+    EXPECT_TRUE(cache.isEmpty());
+}
+
+TEST(TextMeasurementCacheTest, TextLongerThanMaxTextLengthIsRejected)
+{
+    TestCache cache;
+    String text = stringOfLength(testMaxTextLength + 1);
+
+    auto* entry = cache.add(text, 1);
+    EXPECT_FALSE(entry);
+    EXPECT_TRUE(cache.isEmpty());
+}
+
+TEST(TextMeasurementCacheTest, ClearAndIsEmptyCoverAllThreeTables)
+{
+    TestCache cache;
+    EXPECT_TRUE(cache.isEmpty());
+
+    cache.add("a"_s, 1);
+    EXPECT_FALSE(cache.isEmpty());
+    cache.clear();
+    EXPECT_TRUE(cache.isEmpty());
+
+    cache.add(stringOfLength(testInlineKeyCapacity), 1);
+    EXPECT_FALSE(cache.isEmpty());
+    cache.clear();
+    EXPECT_TRUE(cache.isEmpty());
+
+    cache.add(stringOfLength(testInlineKeyCapacity + 1), 1);
+    EXPECT_FALSE(cache.isEmpty());
+    cache.clear();
+    EXPECT_TRUE(cache.isEmpty());
+}
+
+TEST(TextMeasurementCacheTest, PathologicalGrowthFullyFlushes)
+{
+    TestCache cache;
+    for (unsigned i = 0; i < testMaxSize - 1; ++i) {
+        String text = stringOfLength(testInlineKeyCapacity + 1, static_cast<char16_t>('a' + i));
+        auto* entry = cache.add(text, static_cast<int>(i));
+        ASSERT_TRUE(entry);
+    }
+    EXPECT_FALSE(cache.isEmpty());
+
+    // The MaxSize-th distinct entry crosses the ceiling: addSlowCase() rejects it and fully flushes the cache.
+    String overflowText = stringOfLength(testInlineKeyCapacity + 1, static_cast<char16_t>('a' + testMaxSize));
+    auto* entry = cache.add(overflowText, -1);
+    EXPECT_FALSE(entry);
+    EXPECT_TRUE(cache.isEmpty());
+}
+
+}


### PR DESCRIPTION
#### a78e3ee1842cbfc64ae6926eb79b9d99851d438f
<pre>
TextMeasurementCache with out-of-line long-text table
<a href="https://rdar.apple.com/185264188">rdar://185264188</a>

Reviewed by NOBODY (OOPS!).

TextMeasurementCache.h: Distinguish InlineKeyCapacity (16) from
MaxTextLength (64), add out-of-line String-keyed table for 17–64 char
text. MaxSize is computed from a 20MiB byte budget.

FontCascadeFonts.h: Update ShapedTextCache with InlineKeyCapacity ==
MaxTextLength so it stays fully inline.

* Source/WebCore/platform/graphics/FontCascadeFonts.h:
* Source/WebCore/platform/graphics/TextMeasurementCache.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/TextMeasurementCache.cpp: Added.
(TestWebKitAPI::WebCore::stringOfLength):
(TestWebKitAPI::TEST(TextMeasurementCacheTest, SingleCharacterIsCached)):
(TestWebKitAPI::TEST(TextMeasurementCacheTest, ShortTextUsesInlineTable)):
(TestWebKitAPI::TEST(TextMeasurementCacheTest, LongTextUsesOutOfLineTable)):
(TestWebKitAPI::TEST(TextMeasurementCacheTest, TextLongerThanMaxTextLengthIsRejected)):
(TestWebKitAPI::TEST(TextMeasurementCacheTest, ClearAndIsEmptyCoverAllThreeTables)):
(TestWebKitAPI::TEST(TextMeasurementCacheTest, PathologicalGrowthFullyFlushes)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a78e3ee1842cbfc64ae6926eb79b9d99851d438f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146798 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cbf3c875-ede3-49e6-8d22-67b1d1b22b56) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142432 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98907 "2 flakes 19 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e4044d0-71a9-49ae-8696-b8165f1ad422) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122865 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e245b9a0-17d6-48aa-9a95-238d334cd315) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44818 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43089 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155219 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42714 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3863 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194626 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56087 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151863 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56778 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151561 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46142 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129062 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125061 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55289 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17713 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54670 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54909 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54737 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->