### PR TITLE
[JSC] Stop computing free variables twice when popping a function scope

### DIFF
--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -2872,8 +2872,9 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
     const int minimumSourceLengthToCache = functionBodyType == StandardFunctionBodyBlock ? 16 : 8;
     std::unique_ptr<SourceProviderCacheItem> newInfo;
     int sourceLength = functionInfo.endOffset - functionInfo.startOffset;
+    SourceProviderCacheItemCreationParameters parameters;
+    bool hasPrecomputedFreeVariables = false;
     if (TreeBuilder::CanUseFunctionCache && m_functionCache && sourceLength > minimumSourceLengthToCache) {
-        SourceProviderCacheItemCreationParameters parameters;
         parameters.endFunctionOffset = functionInfo.endOffset;
         parameters.lastTokenLine = location.line;
         parameters.lastTokenStartOffset = location.startOffset;
@@ -2888,12 +2889,13 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
             parameters.tokenType = m_token.m_type;
         }
         functionScope->fillParametersForSourceProviderCache(parameters, nonLocalCapturesFromParameterExpressions);
+        hasPrecomputedFreeVariables = true;
         newInfo = SourceProviderCacheItem::create(parameters);
     }
 
     bool functionScopeWasStrictMode = functionScope->strictMode();
     
-    popScope(functionScope, TreeBuilder::NeedsFreeVariableInfo);
+    popScope(functionScope, TreeBuilder::NeedsFreeVariableInfo, hasPrecomputedFreeVariables, parameters.freeVariables());
     
     if (functionBodyType != ArrowFunctionBodyExpression)
         consumeOrFail(CLOSEBRACE, "Expected a closing '}' after a ", stringForFunctionMode(mode), " body");

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -744,7 +744,7 @@ public:
         }
     }
     
-    void collectFreeVariables(Scope* nestedScope, bool shouldTrackClosedVariables)
+    void collectFreeVariablesFrom(Scope* nestedScope, bool shouldTrackClosedVariables, bool hasPrecomputedFreeVariables = false, std::span<UniquedStringImpl* const> precomputedFreeVariables = { })
     {
         if (nestedScope->m_usesEval)
             m_usesEval = true;
@@ -753,21 +753,36 @@ public:
 
         {
             UniquedStringImplPtrSet& destinationSet = m_usedVariables.last();
-            for (const UniquedStringImplPtrSet& usedVariablesSet : nestedScope->m_usedVariables) {
-                for (UniquedStringImpl* impl : usedVariablesSet) {
-                    if (nestedScope->m_declaredVariables.contains(impl) || nestedScope->m_lexicalVariables.contains(impl))
-                        continue;
+            // If nestedScope is a non-arrow function and there is an "arguments" reference,
+            // we need to filter it because it should not propagate out.
+            UniquedStringImpl* argumentsIdentifierOrNull = nestedScope->isFunctionBoundary() && nestedScope->hasArguments() && !nestedScope->isArrowFunctionBoundary()
+                ? m_vm.propertyNames->arguments.impl() : nullptr;
+            // We don't want a declared variable that is used in an inner scope to be thought of as captured if
+            // that inner scope is both a lexical scope and not a function. Only inner functions and "catch"
+            // statements can cause variables to be captured.
+            bool doTrackClosedVariables = shouldTrackClosedVariables && (nestedScope->m_isFunctionBoundary || !nestedScope->m_isLexicalScope);
+            auto propagateFreeVariable = [&](UniquedStringImpl* impl) ALWAYS_INLINE_LAMBDA {
+                if (impl == argumentsIdentifierOrNull)
+                    return;
+                destinationSet.add(impl);
+                if (doTrackClosedVariables)
+                    m_closedVariableCandidates.add(impl);
+            };
 
-                    // "arguments" reference should be resolved at function boudary.
-                    if (nestedScope->isFunctionBoundary() && nestedScope->hasArguments() && impl == m_vm.propertyNames->arguments.impl() && !nestedScope->isArrowFunctionBoundary())
-                        continue;
-
-                    destinationSet.add(impl);
-                    // We don't want a declared variable that is used in an inner scope to be thought of as captured if
-                    // that inner scope is both a lexical scope and not a function. Only inner functions and "catch" 
-                    // statements can cause variables to be captured.
-                    if (shouldTrackClosedVariables && (nestedScope->m_isFunctionBoundary || !nestedScope->m_isLexicalScope))
-                        m_closedVariableCandidates.add(impl);
+            if (hasPrecomputedFreeVariables) {
+#if ASSERT_ENABLED
+                for (UniquedStringImpl* impl : precomputedFreeVariables)
+                    ASSERT(!nestedScope->m_declaredVariables.contains(impl) && !nestedScope->m_lexicalVariables.contains(impl));
+#endif
+                for (UniquedStringImpl* impl : precomputedFreeVariables)
+                    propagateFreeVariable(impl);
+            } else {
+                for (const UniquedStringImplPtrSet& usedVariablesSet : nestedScope->m_usedVariables) {
+                    for (UniquedStringImpl* impl : usedVariablesSet) {
+                        if (nestedScope->m_declaredVariables.contains(impl) || nestedScope->m_lexicalVariables.contains(impl))
+                            continue;
+                        propagateFreeVariable(impl);
+                    }
                 }
             }
         }
@@ -859,6 +874,7 @@ public:
     void fillParametersForSourceProviderCache(SourceProviderCacheItemCreationParameters& parameters, const UniquedStringImplPtrSet& capturesFromParameterExpressions)
     {
         ASSERT(m_isFunction);
+        ASSERT(parameters.usedVariables.isEmpty());
         parameters.usesEval = m_usesEval;
         parameters.usesImportMeta = m_usesImportMeta;
         parameters.lexicallyScopedFeatures = m_lexicallyScopedFeatures;
@@ -867,6 +883,7 @@ public:
         parameters.needsSuperBinding = m_needsSuperBinding;
         for (const UniquedStringImplPtrSet& set : m_usedVariables)
             copyCapturedVariablesToVector(set, parameters.usedVariables);
+        parameters.freeVariableCount = parameters.usedVariables.size();
 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=156962
         // We add these unconditionally because we currently don't keep a separate
@@ -879,6 +896,7 @@ public:
         // is.
         for (UniquedStringImpl* impl : capturesFromParameterExpressions)
             parameters.usedVariables.append(impl);
+        ASSERT(parameters.freeVariableCount + capturesFromParameterExpressions.size() == parameters.usedVariables.size());
     }
 
     void restoreFromSourceProviderCache(const SourceProviderCacheItem* info)
@@ -1361,17 +1379,16 @@ private:
         }
     }
 
-    std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScopeInternal(Scope* scope, bool shouldTrackClosedVariables)
+    std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScopeInternal(Scope* scope, bool shouldTrackClosedVariables, bool hasPrecomputedFreeVariables = false, std::span<UniquedStringImpl* const> precomputedFreeVariables = { })
     {
         EXCEPTION_ASSERT_UNUSED(scope, scope == m_currentScope);
         ASSERT(m_scopeStack.size() > 1);
         Scope* lastScope = m_currentScope;
         Scope* parentScope = lastScope->containingScope();
 
-        // Finalize lexical variables.
         lastScope->finalizeLexicalEnvironment();
 
-        parentScope->collectFreeVariables(lastScope, shouldTrackClosedVariables);
+        parentScope->collectFreeVariablesFrom(lastScope, shouldTrackClosedVariables, hasPrecomputedFreeVariables, precomputedFreeVariables);
 
         if (lastScope->hasSloppyModeFunctionHoistingCandidates())
             lastScope->bubbleSloppyModeFunctionHoistingCandidates(parentScope);
@@ -1395,10 +1412,14 @@ private:
         return popScopeInternal(scope, shouldTrackClosedVariables);
     }
 
-    ALWAYS_INLINE std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScope(AutoPopScope& scope, bool shouldTrackClosedVariables)
+    // If hasPrecomputedFreeVariables is true, precomputedFreeVariables contains nestedScope's
+    // free variables already computed by the caller. Conceptually these two parameters form an
+    // std::optional<std::span>, but we keep them separate so they are passed in registers.
+    // This code is hot enough that it makes a difference.
+    ALWAYS_INLINE std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScope(AutoPopScope& scope, bool shouldTrackClosedVariables, bool hasPrecomputedFreeVariables = false, std::span<UniquedStringImpl* const> precomputedFreeVariables = { })
     {
         scope.setPopped();
-        return popScopeInternal(scope.scope(), shouldTrackClosedVariables);
+        return popScopeInternal(scope.scope(), shouldTrackClosedVariables, hasPrecomputedFreeVariables, precomputedFreeVariables);
     }
 
     ALWAYS_INLINE std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScope(AutoCleanupLexicalScope& cleanupScope, bool shouldTrackClosedVariables)

--- a/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
+++ b/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
@@ -38,15 +38,23 @@
 namespace JSC {
 
 struct SourceProviderCacheItemCreationParameters {
+    std::span<UniquedStringImpl* const> freeVariables() const LIFETIME_BOUND
+    {
+        ASSERT(freeVariableCount <= usedVariables.size());
+        return usedVariables.span().first(freeVariableCount);
+    }
+
     unsigned lastTokenLine { 0 };
     unsigned lastTokenStartOffset { 0 };
     unsigned lastTokenEndOffset { 0 };
     unsigned lastTokenLineStartOffset { 0 };
     unsigned endFunctionOffset { 0 };
     unsigned parameterCount { 0 };
+    unsigned freeVariableCount { 0 };
     LexicallyScopedFeatures lexicallyScopedFeatures { 0 };
     InnerArrowFunctionCodeFeatures innerArrowFunctionFeatures { 0 };
     ImplementationVisibility implementationVisibility { ImplementationVisibility::Public };
+    // Scope's own free variables followed by the captures from its parameter expressions.
     Vector<UniquedStringImpl*, 8> usedVariables;
     JSTokenType tokenType { CLOSEBRACE };
     ConstructorKind constructorKind;


### PR DESCRIPTION
#### 7ef470855921ed52f4a67f07e1b89dd664d1d060
<pre>
[JSC] Stop computing free variables twice when popping a function scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=322157">https://bugs.webkit.org/show_bug.cgi?id=322157</a>
<a href="https://rdar.apple.com/185383752">rdar://185383752</a>

Reviewed by Yusuke Suzuki.

When Parser::parseFunctionInfo creates a record for the function in source provider cache,
the fillParametersForSourceProviderCache function computes the list of the function&apos;s
free variables to save it in the cache. Then, when the function scope is popped,
popScopeInternal calls collectFreeVariables, which effectively computes the same list
again by iterating over the used variables while skipping the declared and lexical ones.

This patch makes it so that if the list was computed for the source provider cache,
the list is given to popScope. collectFreeVariables then avoids repeating the same work.

Conceptually, the information fed to popScope and eventually to collectFreeVariables
is a std::optional&lt;std::span&gt;. However, it is passed down that call chain as two
separate parameters, a bool and a span. That is because a bool + span parameter
pair is passed in registers, unlike an optional&lt;span&gt;, and this code is hot enough
that it makes a difference.

Additionally, collectFreeVariables is renamed to collectFreeVariablesFrom to
better communicate which way the collecting goes.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/319535@main">https://commits.webkit.org/319535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62a77337180e403d135ec172555d7b54adc12787

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146014 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9696373-fff4-49dc-985f-7b3c78d552ac) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141816 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ca6fcc2-67b6-4417-9dfa-7adda9f267aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122253 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/caf50e8a-1f15-4608-8c4a-0e3a50a9c333) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44193 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42461 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4221 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11037 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42095 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3071 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42964 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193836 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55302 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151227 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40517 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55991 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38717 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150933 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45509 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128274 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123969 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54504 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17091 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53886 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54125 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53951 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->