### PR TITLE
inspector/heap/getPreview.html is a flaky failure

### DIFF
--- a/LayoutTests/inspector/heap/getPreview.html
+++ b/LayoutTests/inspector/heap/getPreview.html
@@ -32,6 +32,15 @@ function test()
         return value;
     }
 
+    function findNodeByPropertyName(nodes, propertyName, callback) {
+        for (let node of nodes) {
+            node.retainers((retainerNodes, edges) => {
+                if (edges.some((edge) => (edge.type === "Property" || edge.type === "Variable") && edge.data === propertyName))
+                    callback(node);
+            });
+        }
+    }
+
     suite.addTestCase({
         name: "GetPreviewNoSnapshot",
         description: "Calling Heap.getPreview when no snapshot exists should result in an error.",
@@ -56,11 +65,12 @@ function test()
                     workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
                         let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                         snapshot.instancesWithClassName("string", (strings) => {
-                            let heapSnapshotNode = strings.reduce((result, x) => result.id < x.id ? x : result, strings[0]);
-                            HeapAgent.getPreview(heapSnapshotNode.id, (error, string, functionDetails, objectPreviewPayload) => {
-                                InspectorTest.expectThat(!error, "Should not have an error getting preview.");
-                                InspectorTest.log("STRING: " + string);
-                                resolve();
+                            findNodeByPropertyName(strings, "myString", (heapSnapshotNode) => {
+                                HeapAgent.getPreview(heapSnapshotNode.id, (error, string, functionDetails, objectPreviewPayload) => {
+                                    InspectorTest.expectThat(!error, "Should not have an error getting preview.");
+                                    InspectorTest.log("STRING: " + string);
+                                    resolve();
+                                });
                             });
                         });
                     });
@@ -81,11 +91,12 @@ function test()
                     workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
                         let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                         snapshot.instancesWithClassName("Function", (functions) => {
-                            let heapSnapshotNode = functions.reduce((result, x) => result.id < x.id ? x : result, functions[0]);
-                            HeapAgent.getPreview(heapSnapshotNode.id, (error, string, functionDetails, objectPreviewPayload) => {
-                                InspectorTest.expectThat(!error, "Should not have an error getting preview.");
-                                InspectorTest.log("FUNCTION DETAILS: " + JSON.stringify(functionDetails, jsonFilter, 4));
-                                resolve();
+                            findNodeByPropertyName(functions, "myFunction", (heapSnapshotNode) => {
+                                HeapAgent.getPreview(heapSnapshotNode.id, (error, string, functionDetails, objectPreviewPayload) => {
+                                    InspectorTest.expectThat(!error, "Should not have an error getting preview.");
+                                    InspectorTest.log("FUNCTION DETAILS: " + JSON.stringify(functionDetails, jsonFilter, 4));
+                                    resolve();
+                                });
                             });
                         });
                     });
@@ -106,11 +117,12 @@ function test()
                     workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
                         let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                         snapshot.instancesWithClassName("Map", (maps) => {
-                            let heapSnapshotNode = maps.reduce((result, x) => result.id < x.id ? x : result, maps[0]);
-                            HeapAgent.getPreview(heapSnapshotNode.id, (error, string, functionDetails, objectPreviewPayload) => {
-                                InspectorTest.expectThat(!error, "Should not have an error getting preview.");
-                                InspectorTest.log("OBJECT PREVIEW: " + JSON.stringify(objectPreviewPayload, jsonFilter, 4));
-                                resolve();
+                            findNodeByPropertyName(maps, "myMap", (heapSnapshotNode) => {
+                                HeapAgent.getPreview(heapSnapshotNode.id, (error, string, functionDetails, objectPreviewPayload) => {
+                                    InspectorTest.expectThat(!error, "Should not have an error getting preview.");
+                                    InspectorTest.log("OBJECT PREVIEW: " + JSON.stringify(objectPreviewPayload, jsonFilter, 4));
+                                    resolve();
+                                });
                             });
                         });
                     });
@@ -150,11 +162,12 @@ function test()
                         HeapAgent.gc();
 
                         snapshot.instancesWithClassName("Map", (maps) => {
-                            let heapSnapshotNode = maps.reduce((result, x) => result.id < x.id ? x : result, maps[0]);
-                            HeapAgent.getPreview(heapSnapshotNode.id, (error, string, functionDetails, objectPreviewPayload) => {
-                                InspectorTest.expectThat(error, "Should get an error when object has been collected.");
-                                InspectorTest.pass(error);
-                                resolve();
+                            findNodeByPropertyName(maps, "myMap", (heapSnapshotNode) => {
+                                HeapAgent.getPreview(heapSnapshotNode.id, (error, string, functionDetails, objectPreviewPayload) => {
+                                    InspectorTest.expectThat(error, "Should get an error when object has been collected.");
+                                    InspectorTest.pass(error);
+                                    resolve();
+                                });
                             });
                         });
                     });

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1057,7 +1057,6 @@ imported/w3c/web-platform-tests/css/filter-effects/blur-text.html [ ImageOnlyFai
 webkit.org/b/264680 fast/scrolling/gtk/user-scroll-snapping-interaction.html [ Timeout ]
 webkit.org/b/264680 [ Release ] http/wpt/service-workers/controlled-sharedworker.https.html [ Failure Pass ]
 webkit.org/b/264680 imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251.html?include=loading [ Failure Pass ]
-webkit.org/b/264680 inspector/heap/getPreview.html [ Failure Pass ]
 webkit.org/b/264680 scrollbars/scrollbar-selectors.html [ Pass Timeout ]
 
 # Crash due to unimplemented event type.

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -838,8 +838,6 @@ webkit.org/b/207166 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavai
 
 webkit.org/b/228934 inspector/canvas/shaderProgram-add-remove-webgl2.html [ Pass Crash Timeout Failure ]
 
-webkit.org/b/207209 inspector/heap/getPreview.html [ Pass Failure Timeout ]
-
 webkit.org/b/207269 [ Debug ] http/tests/websocket/tests/hybi/server-close.html [ Pass Crash ]
 
 webkit.org/b/207465 [ Debug ] storage/indexeddb/intversion-long-queue.html [ Pass Failure ]


### PR DESCRIPTION
#### 1d20142e3c43b9199c3db94eb963d84c64bc4ae0
<pre>
inspector/heap/getPreview.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=207209">https://bugs.webkit.org/show_bug.cgi?id=207209</a>

Reviewed by Alexey Proskuryakov.

The test picked its target heap-snapshot node using an unreliable
heuristic: the instance with the highest &apos;id&apos; among all instances of
a given class. That is not guaranteed to be the specific object the
test just created (window.myString/myFunction/myMap), since other
incidental allocations of the same class can happen in the same
snapshot window and end up with a higher id, making the test flaky.

Replaced all four occurrences of this heuristic (GetPreviewForString,
GetPreviewForFunction, GetPreviewForObject, and the collected-object
case) with a deterministic findNodeByPropertyName() helper: walk each
candidate node&apos;s retainer edges and pick the one actually referenced
by the expected property/variable name.

Local reproduction went from failing in roughly 16-18% of iterations
before this change to 0 failures in 400 iterations after it.

Also removed the now-stale flaky-test expectations for GTK and
mac-wk2.

* LayoutTests/inspector/heap/getPreview.html:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/319611@main">https://commits.webkit.org/319611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdc2271f69c823c1c8e1bfabcf2301a79bbfcd30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192197 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146301 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142076 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122511 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44436 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42704 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42334 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3362 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194125 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151488 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56281 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151192 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27644 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45758 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124361 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54792 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17329 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54173 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->