### PR TITLE
AudioBufferSourceNode ignores the start() offset for a negative playbackRate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt
@@ -4,12 +4,12 @@ PASS AudioBufferSourceNode supports high negative playbackRate (-2.0)
 PASS AudioBufferSourceNode supports high negative playbackRate (-5.0)
 PASS AudioBufferSourceNode supports fractional negative playbackRate
 PASS AudioBufferSourceNode supports very low negative playbackRate (-0.02)
-FAIL AudioBufferSourceNode enters loop backwards from offset > loopEnd assert_equals: Frame 0 should be 7 expected 7 but got 3
+PASS AudioBufferSourceNode enters loop backwards from offset > loopEnd
 PASS AudioBufferSourceNode clamps offset to loopStart for playbackRate < 0
-FAIL AudioBufferSourceNode loops backwards with negative rate (offset in loop) assert_equals: Frame 0 should be 3 expected 3 but got 2
-FAIL AudioBufferSourceNode handles offset exactly at duration with negative rate assert_equals: Frame 0 should be 0 expected 0 but got 4
-FAIL AudioBufferSourceNode handles out-of-bounds start offset correctly assert_equals: Frame 0 should be silence expected 0 but got 4
-FAIL AudioBufferSourceNode performs sub-sample interpolation backwards assert_approx_equals: Frame 0 should be approx 3.5 expected 3.5 +/- 0.0001 but got 4
+PASS AudioBufferSourceNode loops backwards with negative rate (offset in loop)
+FAIL AudioBufferSourceNode handles offset exactly at duration with negative rate assert_equals: Frame 1 should be 4 expected 4 but got 0
+FAIL AudioBufferSourceNode handles out-of-bounds start offset correctly assert_equals: Frame 1 should be 4.0 expected 4 but got 0
+PASS AudioBufferSourceNode performs sub-sample interpolation backwards
 PASS AudioBufferSourceNode ran successfully with zero delta and playbackRate 0
 PASS AudioBufferSourceNode loops backwards using entire buffer when loopStart > loopEnd
 FAIL AudioBufferSourceNode loops backwards using clamped loopStart when loopStart < 0 assert_array_equals: expected property 4 to be 2 but got 4 (expected array [4, 3, 2, 1, 2, 1, 2, 1] got object "4,3,2,1,4,3,2,1")

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated-loop.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated-loop.html
@@ -36,7 +36,7 @@
         bufferSource.loop = true;
         bufferSource.loopStart = startLoop;
         bufferSource.loopEnd = endLoop;
-        bufferSource.start(0, startLoop, loopDuration);
+        bufferSource.start(0, endLoop - 1 / sampleRate, loopDuration);
         bufferSource.stop(loopDuration * 2);
 
         context.oncomplete = checkAllTests;

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated.html
@@ -30,7 +30,7 @@
 
         bufferSource.connect(context.destination);
         bufferSource.playbackRate.value = -0.75;
-        bufferSource.start(0);
+        bufferSource.start(0, (sourceFrames - 1) / sampleRate);
 
         context.oncomplete = checkAllTests;
         context.startRendering();

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-loop.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate-loop.html
@@ -36,7 +36,7 @@
         bufferSource.loop = true;
         bufferSource.loopStart = startLoop;
         bufferSource.loopEnd = endLoop;
-        bufferSource.start(0, startLoop, loopDuration);
+        bufferSource.start(0, endLoop - 1 / sampleRate, loopDuration);
         bufferSource.stop(loopDuration * 2);
 
         context.oncomplete = checkAllTests;

--- a/LayoutTests/webaudio/audiobuffersource-negative-playbackrate.html
+++ b/LayoutTests/webaudio/audiobuffersource-negative-playbackrate.html
@@ -30,7 +30,7 @@
 
         bufferSource.connect(context.destination);
         bufferSource.playbackRate.value = -1;
-        bufferSource.start(0);
+        bufferSource.start(0, (sourceFrames - 1) / sampleRate);
 
         context.oncomplete = checkAllTests;
         context.startRendering();

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -52,6 +52,14 @@ constexpr double DefaultGrainDuration = 0.020; // 20ms
 // to minimize linear interpolation aliasing.
 const double MaxRate = 1024;
 
+// Converts a time to a sample frame, keeping any genuine sub-sample position but snapping values
+// that are only off by floating-point round-off (sampleRate * (k / sampleRate) != k for integer k).
+SUPPRESS_NODELETE static double NODELETE timeToFractionalSampleFrame(double time, double sampleRate)
+{
+    constexpr double oversampleFactor = 1024;
+    return std::round(time * sampleRate * oversampleFactor) / oversampleFactor;
+}
+
 static float NODELETE computeSampleUsingLinearInterpolation(std::span<const float> source, unsigned readIndex, unsigned readIndex2, float interpolationFactor)
 {
     if (readIndex == readIndex2 && readIndex >= 1) {
@@ -248,14 +256,26 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
         virtualDeltaFrames = virtualMaxFrame - virtualMinFrame;
     }
 
-    if (m_virtualReadIndex >= virtualMaxFrame) {
-        // Early exit to avoid going past the end of the source buffer.
-        if (!m_isLooping)
-            return false;
+    if (!reverse) {
+        if (m_virtualReadIndex >= virtualMaxFrame) {
+            // Early exit to avoid going past the end of the source buffer.
+            if (!m_isLooping)
+                return false;
 
-        // Wrap back to the beginning of the loop.
-        m_virtualReadIndex = (m_loopStart < 0) ? 0 : (m_loopStart * m_buffer->sampleRate());
-        m_virtualReadIndex = std::min(m_virtualReadIndex, static_cast<double>(bufferLength) - 1);
+            // Wrap back to the beginning of the loop.
+            m_virtualReadIndex = (m_loopStart < 0) ? 0 : (m_loopStart * m_buffer->sampleRate());
+            m_virtualReadIndex = std::min(m_virtualReadIndex, static_cast<double>(bufferLength) - 1);
+        }
+    } else if (m_isLooping && m_virtualReadIndex < virtualMinFrame) {
+        // https://webaudio.github.io/web-audio-api/#playback-AudioBufferSourceNode
+        // For a negative playback rate, only an offset before the loop start is clamped, to the
+        // loop start. An offset past the loop end is left alone so playback descends into the loop.
+        m_virtualReadIndex = virtualMinFrame;
+    } else if (m_virtualReadIndex >= bufferLength) {
+        // The playhead starts past the end of the buffer, e.g. for an offset at the buffer
+        // duration. There is nothing to read, so output silence rather than a partially
+        // written bus.
+        return false;
     }
 
     // Sanity check that our playback rate isn't larger than the loop size.
@@ -265,10 +285,14 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
     // Get local copy.
     double virtualReadIndex = m_virtualReadIndex;
 
+    int framesToProcess = numberOfFrames;
+
     // Adjust the read index by the startFrameOffset (compensated by the pitch rate) because
     // we always start output on a frame boundary with interpolation if necessary.
-    if (startFrameOffset < 0 && pitchRate)
-        virtualReadIndex += std::abs(startFrameOffset * pitchRate);
+    if (startFrameOffset < 0 && pitchRate) {
+        double skippedFrames = std::abs(startFrameOffset * pitchRate);
+        virtualReadIndex += reverse ? -skippedFrames : skippedFrames;
+    }
 
     bool needsInterpolation = virtualReadIndex != floor(virtualReadIndex)
         || virtualDeltaFrames != floor(virtualDeltaFrames)
@@ -276,7 +300,6 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
         || virtualMinFrame != floor(virtualMinFrame);
 
     // Render loop - reading from the source buffer to the destination using linear interpolation.
-    int framesToProcess = numberOfFrames;
 
     // Optimize for the very common case of playing back with pitchRate == 1.
     // We can avoid the linear interpolation.
@@ -307,9 +330,7 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
     } else if (pitchRate == -1 && !needsInterpolation) {
         int readIndex = static_cast<int>(virtualReadIndex);
         int deltaFrames = static_cast<int>(virtualDeltaFrames);
-        int maxFrame = static_cast<int>(virtualMaxFrame);
-        if (readIndex > maxFrame)
-            readIndex = maxFrame;
+        readIndex = std::min(readIndex, static_cast<int>(bufferLength) - 1);
 
         int minFrame = static_cast<int>(virtualMinFrame) - 1;
         while (framesToProcess > 0) {
@@ -614,14 +635,11 @@ void AudioBufferSourceNode::adjustGrainParameters()
     } else
         m_grainDuration = clampTo(m_grainDuration, 0.0,  bufferDuration - m_grainOffset);
 
-    // We call timeToSampleFrame here since at playbackRate == 1 we don't want to go through linear interpolation
-    // at a sub-sample position since it will degrade the quality.
-    // When aligned to the sample-frame the playback will be identical to the PCM data stored in the buffer.
-    // Since playbackRate == 1 is very common, it's worth considering quality.
-    if (playbackRate().value() < 0)
-        m_virtualReadIndex = AudioUtilities::timeToSampleFrame(m_grainOffset + m_grainDuration, m_buffer->sampleRate()) - 1;
-    else
-        m_virtualReadIndex = AudioUtilities::timeToSampleFrame(m_grainOffset, m_buffer->sampleRate());
+    // The playhead starts at offset, whatever the sign of the playback rate.
+    // https://webaudio.github.io/web-audio-api/#playback-AudioBufferSourceNode
+    // A whole-frame offset stays whole so that playback at |rate| == 1 is a straight copy of the
+    // PCM data rather than a quality-degrading interpolation at a sub-sample position.
+    m_virtualReadIndex = timeToFractionalSampleFrame(m_grainOffset, m_buffer->sampleRate());
 }
 
 double AudioBufferSourceNode::totalPitchRate()


### PR DESCRIPTION
#### 52e6da77b135861b49039098e00873cf895b9c18
<pre>
AudioBufferSourceNode ignores the start() offset for a negative playbackRate
<a href="https://bugs.webkit.org/show_bug.cgi?id=320870">https://bugs.webkit.org/show_bug.cgi?id=320870</a>
<a href="https://rdar.apple.com/184484940">rdar://184484940</a>

Reviewed by Darin Adler.

adjustGrainParameters() placed the initial playhead at the *end* of the grain
when the playback rate was negative, at offset + duration - 1, rather than at
offset. With no explicit duration, m_grainDuration defaults to the remainder of
the buffer, so the playhead always landed on the last frame of the buffer and
the caller&apos;s offset had no effect at all: start(0, 2 / sampleRate) on an
8-frame buffer at rate -1 played 8,7,6,5,4,3,2,1 instead of 3,2,1.

The spec places the playhead at offset regardless of the sign of the rate, then
clamps it only in the direction playback is heading:

    if (loop &amp;&amp; computedPlaybackRate &gt;= 0 &amp;&amp; offset &gt;= actualLoopEnd)
        offset = actualLoopEnd;
    if (computedPlaybackRate &lt; 0 &amp;&amp; loop &amp;&amp; offset &lt; actualLoopStart)
        offset = actualLoopStart;

<a href="https://webaudio.github.io/web-audio-api/#playback-AudioBufferSourceNode">https://webaudio.github.io/web-audio-api/#playback-AudioBufferSourceNode</a>

Blink already implements exactly this, and this patch brings us in line with it.
Every change below matches the structure of Blink&apos;s
AudioBufferSourceHandler::RenderFromBuffer(), which splits the playhead setup
into an explicit &quot;directional playhead setup&quot; with a forward branch and a
reverse branch.

renderFromBuffer() applied only the forward half of the spec&apos;s clamping,
wrapping to loopStart whenever the playhead was at or past virtualMaxFrame. For
a negative rate that is the wrong direction: an offset past loopEnd should
descend into the loop from above, not jump to the loop start. The forward wrap
is now forward-only and the reverse path gets the clamp the spec asks for, the
same split Blink makes between its &quot;Forward Loop Clamping&quot; and &quot;Reverse Loop
Clamping&quot; cases. Because skipping the forward wrap also removes its implicit
end-of-buffer guard, a reverse playhead starting at or past the end of the
buffer now returns false so process() zeroes the output bus instead of leaving
it partially written.

Two smaller bugs in the reverse path fell out of the above. The sub-quantum
startFrameOffset adjustment advanced the playhead forward for both signs of the
rate, moving a reverse playhead away from where it was about to read; it now
subtracts for a negative rate, as Blink&apos;s &quot;Reverse Start Time Adjustment&quot; does.
The pitchRate == -1 fast path clamped the read index down to loopEnd, which
defeats the point of not clamping the offset, and now only bounds it by the
buffer length.

The offset is converted with a new timeToFractionalSampleFrame() helper rather
than AudioUtilities::timeToSampleFrame(). The latter rounds to whole frames,
which would quantize away a genuine sub-sample offset; the helper keeps the
sub-sample position but still snaps values that differ from a whole frame only
by floating-point round-off, preserving the existing property that playback of a
whole-frame offset at |rate| == 1 is a straight copy of the PCM data rather than
an interpolation. Blink splits these two cases apart instead, rounding only when
the rate is exactly 1 and the detune is 0 and multiplying raw otherwise; the
helper gets the same result for both without branching on the rate.

This fixes 3 of the 6 failing subtests in the WPT test: an offset inside the
loop, an offset past loopEnd, and sub-sample interpolation backwards. The
remaining 3 are unrelated to the offset handling and stay in the rebaselined
expectation. Two are out-of-bounds offsets, which Blink handles with a reverse
out-of-bounds catch-up loop that renders silence until the playhead descends
into the buffer. The third is a negative loopStart, where we implement the
algorithm&apos;s guard and so fall back to looping the entire buffer, while the test
asserts the attribute definition&apos;s clamp to [0, loopEnd). The spec contradicted
itself here; the Audio WG resolved in
<a href="https://github.com/WebAudio/web-audio-api/issues/2689">https://github.com/WebAudio/web-audio-api/issues/2689</a> to make the algorithm
clamp the loop points before validating them, which is what Blink already does
in UpdateEffectiveLoopPoints(). Both are larger changes than the offset fix and
are left for follow-up.

The prose describing offset in the spec still states the negative-rate condition
backwards, saying an offset *greater* than loopStart is clamped. That is a
transcription error, not a second normative rule; the Audio WG resolved to
correct the prose to match the algorithm in
<a href="https://github.com/WebAudio/web-audio-api/issues/2690.">https://github.com/WebAudio/web-audio-api/issues/2690.</a> This patch follows the
algorithm, as Blink does.

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-playbackrate-negative-expected.txt:
Rebaselined: 3 subtests now pass.

* LayoutTests/webaudio/audiobuffersource-negative-playbackrate.html:
* LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated.html:
* LayoutTests/webaudio/audiobuffersource-negative-playbackrate-loop.html:
* LayoutTests/webaudio/audiobuffersource-negative-playbackrate-interpolated-loop.html:
These called start(0) or start(0, loopStart) with a negative rate and depended
on the playhead jumping to the end of the buffer or loop. Under the spec that
starts playback at frame 0 or at loopStart, which immediately runs off the front
and renders silence. Each now passes the explicit offset it relied on
implicitly, so they keep testing what they were written to test rather than
being rebaselined to the new output.

* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::timeToFractionalSampleFrame):
(WebCore::AudioBufferSourceNode::renderFromBuffer):
(WebCore::AudioBufferSourceNode::adjustGrainParameters):

Canonical link: <a href="https://commits.webkit.org/319674@main">https://commits.webkit.org/319674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/245a04bf808ac150e6373c488b14c868e0816214

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191939 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146043 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/008fb88b-50b1-48bc-9367-50178861adfa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55382 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141856 "Failure limit exceed. At least found 500 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98463 "2 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5ded5a4-9c45-45e8-bd31-0b42ab37730d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162592 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122284 "Found 150 new API test failures: TestCookieManager:/webkit/WebKitCookieManager/add-cookie, TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/form-controls-associated-signal, TestWebKit.WebKit.ReloadPageAfterCrash, TestAuthentication:/webkit/Authentication/authentication-page-provided-authorization-header, TestLoaderClient:/webkit/WebKitWebView/user-agent, TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/page-id, TestWebKit.WebKit.NewFirstVisuallyNonEmptyLayoutFails, TestWebsiteData:/webkit/WebKitWebsiteData/file-system, TestCookieManager:/webkit/WebKitCookieManager/persistent-storage-delete-all ... (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af0c81cd-cccc-4ecb-b8a3-e4a35445ca9d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44214 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42486 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42118 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3100 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48292 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193865 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151255 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56020 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150959 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27687 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45538 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128303 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124016 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54533 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17114 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53915 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53980 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->