### PR TITLE
[JSC] Use `objectCloneFast` for the first source in `Object.assign`'s batching path

### DIFF
--- a/JSTests/microbenchmarks/object-assign-clone-multiple-sources.js
+++ b/JSTests/microbenchmarks/object-assign-clone-multiple-sources.js
@@ -1,0 +1,4 @@
+var cities = ["a", "b", "c", "d", "e", "f", "g", "h"];
+var state = { id: 1, name: "x", age: 3, city: "z", zip: 0, flag: true, score: 1.5, tag: "t" };
+for (var i = 0; i < 1e4; ++i)
+    state = Object.assign({}, state, { city: cities[i & 7], zip: i });

--- a/JSTests/stress/object-assign-clone-multiple-sources.js
+++ b/JSTests/stress/object-assign-clone-multiple-sources.js
@@ -1,0 +1,58 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (var i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+function makeState() {
+    var state = {};
+    for (var i = 0; i < 8; ++i)
+        state["k" + i] = i;
+    return state;
+}
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var state = makeState();
+    var result = Object.assign({}, state, { k3: -1, extra: i });
+    shouldBeArray(Object.keys(result), ["k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7", "extra"]);
+    shouldBe(result.k3, -1);
+    shouldBe(result.k7, 7);
+    shouldBe(result.extra, i);
+    shouldBe(state.k3, 3);
+    result.k0 = 42;
+    shouldBe(state.k0, 0);
+
+    var empty = Object.assign({}, state, {});
+    shouldBeArray(Object.keys(empty), Object.keys(state));
+    shouldBe(Object.getPrototypeOf(empty), Object.prototype);
+    shouldBe(Object.isFrozen(empty), false);
+
+    var three = Object.assign({}, { a: 1 }, { b: 2 }, { a: 3 });
+    shouldBeArray(Object.keys(three), ["a", "b"]);
+    shouldBe(three.a, 3);
+
+    var frozen = Object.freeze(makeState());
+    var fromFrozen = Object.assign({}, frozen, { k1: "x" });
+    shouldBe(Object.isFrozen(fromFrozen), false);
+    fromFrozen.k0 = "y";
+    shouldBe(fromFrozen.k0, "y");
+    shouldBe(fromFrozen.k1, "x");
+    shouldBe(frozen.k1, 1);
+
+    var sym = Symbol("s");
+    var withSymbol = makeState();
+    withSymbol[sym] = "sym";
+    Object.defineProperty(withSymbol, "hidden", { value: 1, enumerable: false });
+    var copied = Object.assign({}, withSymbol, { k2: 2 });
+    shouldBe(copied[sym], "sym");
+    shouldBe(Object.getOwnPropertyDescriptor(copied, "hidden"), undefined);
+
+    var nonEmptyTarget = Object.assign({ first: 0 }, state, {});
+    shouldBe(Object.keys(nonEmptyTarget)[0], "first");
+    shouldBe(Object.keys(nonEmptyTarget).length, 9);
+}

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -348,7 +348,10 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorAssign, (JSGlobalObject* globalObject,
             Vector<UniquedStringImpl*, 32> properties; // structures ensures the lifetimes of these strings.
             MarkedArgumentBufferWithSize<32> values;
             MarkedArgumentBuffer structures;
-            for (unsigned i = 1; i < argsCount; ++i) {
+            unsigned startIndex = 1;
+            if (objectCloneFast(vm, targetObject, asObject(callFrame->uncheckedArgument(1))))
+                startIndex = 2;
+            for (unsigned i = startIndex; i < argsCount; ++i) {
                 JSValue sourceValue = callFrame->uncheckedArgument(i);
                 JSObject* source = asObject(sourceValue);
                 auto sourceStructure = source->structure();


### PR DESCRIPTION
#### 96ca975b2a61a52093cccecd9249e2b410085eea
<pre>
[JSC] Use `objectCloneFast` for the first source in `Object.assign`&apos;s batching path
<a href="https://bugs.webkit.org/show_bug.cgi?id=322161">https://bugs.webkit.org/show_bug.cgi?id=322161</a>

Reviewed by Yusuke Suzuki.

Object.assign({}, state, patch) with 2 or 3 sources goes through the batching path in
objectConstructorAssign, which enumerates every source and replays the first source&apos;s
shape one property at a time via putOwnDataPropertyBatching. objectCloneFast is only
reachable from objectAssignFast, which is used for a single source or 5+ arguments.

Try objectCloneFast for the first source at the start of the batching path and start
the per-source loop from the second source when it succeeds. The batching path&apos;s
existing preconditions already satisfy what objectCloneFast requires.

                                               Baseline                  Patched

object-assign-clone-multiple-sources        0.9998+-0.0420     ^      0.7104+-0.0486        ^ definitely 1.4073x faster
object-assign-multiple-sources              9.5170+-0.2249     ^      6.2294+-0.2320        ^ definitely 1.5278x faster

Tests: JSTests/microbenchmarks/object-assign-clone-multiple-sources.js
       JSTests/stress/object-assign-clone-multiple-sources.js

* JSTests/microbenchmarks/object-assign-clone-multiple-sources.js: Added.
* JSTests/stress/object-assign-clone-multiple-sources.js: Added.
(shouldBe):
(shouldBeArray):
(makeState):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/319645@main">https://commits.webkit.org/319645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/494588f07831cd591217fcb127d729b4a9ac64a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146025 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141826 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98453 "5 flakes 15 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45517 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162577 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicyWhenSuspendedOrHidden (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122262 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44201 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42470 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4230 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11045 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42103 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3082 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42975 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193847 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55313 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151239 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40592 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56002 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150946 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45523 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128285 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123980 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54515 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17099 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53897 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54136 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->