### PR TITLE
[GLIB] Use GRefPtrWrapped for the GByteArray IPC serializer

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -72,6 +72,7 @@ endif ()
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/AvailableInputDevices.serialization.in
+    Shared/glib/CoreIPCGByteArray.serialization.in
     Shared/glib/CoreIPCGVariant.serialization.in
     Shared/glib/DMABufBufferAttributes.serialization.in
     Shared/glib/InputMethodState.serialization.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -116,6 +116,7 @@ endif ()
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/AvailableInputDevices.serialization.in
+    Shared/glib/CoreIPCGByteArray.serialization.in
     Shared/glib/CoreIPCGVariant.serialization.in
     Shared/glib/DMABufBufferAttributes.serialization.in
     Shared/glib/InputMethodState.serialization.in

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -188,6 +188,7 @@
     [Legacy] StructureParam WebCore::PixelBufferSourceView.bytes()
     [Legacy] StructureParam JSC::ArrayBufferContents.span()
 
+    [NeedsReview] StructureParam GRefPtr<GByteArray>.data()
     [NeedsReview] StructureParam GRefPtr<GVariant>.data()
 
     [SecurityGatedReply] MessageParamReply WebPage.OpenPDFWithPreview data

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ArgumentCodersGLib.h"
 
+#include "GeneratedSerializers.h"
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
 #include <wtf/Vector.h>
@@ -34,36 +35,6 @@
 #include <wtf/text/CString.h>
 
 namespace IPC {
-
-void ArgumentCoder<GRefPtr<GByteArray>>::encode(Encoder& encoder, const GRefPtr<GByteArray>& array)
-{
-    if (!array) {
-        encoder << false;
-        return;
-    }
-
-    encoder << true;
-    encoder << span(array);
-}
-
-std::optional<GRefPtr<GByteArray>> ArgumentCoder<GRefPtr<GByteArray>>::decode(Decoder& decoder)
-{
-    auto isEngaged = decoder.decode<bool>();
-    if (!isEngaged) [[unlikely]]
-        return std::nullopt;
-
-    if (!(*isEngaged))
-        return GRefPtr<GByteArray>();
-
-    auto data = decoder.decode<std::span<const uint8_t>>();
-    if (!data) [[unlikely]]
-        return std::nullopt;
-
-    GRefPtr<GByteArray> array = adoptGRef(g_byte_array_sized_new(data->size()));
-    g_byte_array_append(array.get(), data->data(), data->size());
-
-    return array;
-}
 
 void ArgumentCoder<GRefPtr<GTlsCertificate>>::encode(Encoder& encoder, const GRefPtr<GTlsCertificate>& certificate)
 {

--- a/Source/WebKit/Shared/glib/CoreIPCGByteArray.cpp
+++ b/Source/WebKit/Shared/glib/CoreIPCGByteArray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,30 +23,37 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "CoreIPCGByteArray.h"
 
-#include "ArgumentCoders.h"
-#include <gio/gio.h>
-#include <wtf/glib/GRefPtr.h>
+#if USE(GLIB)
 
-typedef struct _GTlsCertificate GTlsCertificate;
-typedef struct _GUnixFDList GUnixFDList;
+#include <glib.h>
+#include <wtf/glib/GSpanExtras.h>
 
-namespace IPC {
+namespace WebKit {
 
-template<> struct ArgumentCoder<GRefPtr<GTlsCertificate>> {
-    static void encode(Encoder&, const GRefPtr<GTlsCertificate>&);
-    static std::optional<GRefPtr<GTlsCertificate>> decode(Decoder&);
-};
+CoreIPCGByteArray::CoreIPCGByteArray(const GRefPtr<GByteArray>& array)
+    : m_data(array)
+{
+}
 
-template<> struct ArgumentCoder<GTlsCertificateFlags> {
-    static void encode(Encoder&, GTlsCertificateFlags);
-    static std::optional<GTlsCertificateFlags> decode(Decoder&);
-};
+CoreIPCGByteArray::CoreIPCGByteArray(std::span<const uint8_t> data)
+    : m_data(adoptGRef(g_byte_array_sized_new(data.size())))
+{
+    g_byte_array_append(m_data.get(), data.data(), data.size());
+}
 
-template<> struct ArgumentCoder<GRefPtr<GUnixFDList>> {
-    static void encode(Encoder&, const GRefPtr<GUnixFDList>&);
-    static std::optional<GRefPtr<GUnixFDList>> decode(Decoder&);
-};
+std::span<const uint8_t> CoreIPCGByteArray::data() const
+{
+    return span(m_data);
+}
 
-} // namespace IPC
+CoreIPCGByteArray::operator GRefPtr<GByteArray>() const
+{
+    return m_data;
+}
+
+} // namespace WebKit
+
+#endif // USE(GLIB)

--- a/Source/WebKit/Shared/glib/CoreIPCGByteArray.h
+++ b/Source/WebKit/Shared/glib/CoreIPCGByteArray.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,28 +25,28 @@
 
 #pragma once
 
-#include "ArgumentCoders.h"
-#include <gio/gio.h>
+#if USE(GLIB)
+
+#include <span>
 #include <wtf/glib/GRefPtr.h>
 
-typedef struct _GTlsCertificate GTlsCertificate;
-typedef struct _GUnixFDList GUnixFDList;
+typedef struct _GByteArray GByteArray;
 
-namespace IPC {
+namespace WebKit {
 
-template<> struct ArgumentCoder<GRefPtr<GTlsCertificate>> {
-    static void encode(Encoder&, const GRefPtr<GTlsCertificate>&);
-    static std::optional<GRefPtr<GTlsCertificate>> decode(Decoder&);
+class CoreIPCGByteArray {
+public:
+    explicit CoreIPCGByteArray(const GRefPtr<GByteArray>&);
+    explicit CoreIPCGByteArray(std::span<const uint8_t>);
+
+    std::span<const uint8_t> data() const;
+
+    operator GRefPtr<GByteArray>() const;
+
+private:
+    GRefPtr<GByteArray> m_data;
 };
 
-template<> struct ArgumentCoder<GTlsCertificateFlags> {
-    static void encode(Encoder&, GTlsCertificateFlags);
-    static std::optional<GTlsCertificateFlags> decode(Decoder&);
-};
+} // namespace WebKit
 
-template<> struct ArgumentCoder<GRefPtr<GUnixFDList>> {
-    static void encode(Encoder&, const GRefPtr<GUnixFDList>&);
-    static std::optional<GRefPtr<GUnixFDList>> decode(Decoder&);
-};
-
-} // namespace IPC
+#endif // USE(GLIB)

--- a/Source/WebKit/Shared/glib/CoreIPCGByteArray.serialization.in
+++ b/Source/WebKit/Shared/glib/CoreIPCGByteArray.serialization.in
@@ -1,0 +1,35 @@
+# Copyright (C) 2026 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(GLIB)
+
+header: <glib.h>
+header: "CoreIPCGByteArray.h"
+
+additional_forward_declaration: typedef struct _GByteArray GByteArray
+
+[GRefPtrWrapped=GByteArray] class WebKit::CoreIPCGByteArray {
+    std::span<const uint8_t> data();
+}
+
+#endif

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -83,6 +83,7 @@ Shared/API/glib/WebKitUserMessage.cpp @no-unify
 Shared/Extensions/gtk/WebExtensionUtilitiesGtk.cpp
 
 Shared/glib/ArgumentCodersGLib.cpp
+Shared/glib/CoreIPCGByteArray.cpp
 Shared/glib/CoreIPCGVariant.cpp
 Shared/glib/InputMethodState.cpp
 Shared/glib/JavaScriptEvaluationResultGLib.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -81,6 +81,7 @@ Shared/API/glib/WebKitURIResponse.cpp @no-unify
 Shared/API/glib/WebKitUserMessage.cpp @no-unify
 
 Shared/glib/ArgumentCodersGLib.cpp
+Shared/glib/CoreIPCGByteArray.cpp
 Shared/glib/CoreIPCGVariant.cpp
 Shared/glib/InputMethodState.cpp
 Shared/glib/JavaScriptEvaluationResultGLib.cpp


### PR DESCRIPTION
#### a50c194e77c113a8d63da3b86444b5d8ec246d84
<pre>
[GLIB] Use GRefPtrWrapped for the GByteArray IPC serializer
<a href="https://bugs.webkit.org/show_bug.cgi?id=322162">https://bugs.webkit.org/show_bug.cgi?id=322162</a>

Reviewed by Carlos Garcia Campos.

Migrate ArgumentCoder&lt;GRefPtr&lt;GByteArray&gt;&gt; to a generated serializer
using GRefPtrWrapped, as 319460@main did for GVariant. The wire format is
unchanged. Its only user, the GTlsCertificate coder, now picks up the
generated coder from GeneratedSerializers.h.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GByteArray&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GByteArray&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/glib/ArgumentCodersGLib.h:
* Source/WebKit/Shared/glib/CoreIPCGByteArray.cpp: Copied from Source/WebKit/Shared/glib/ArgumentCodersGLib.h.
(WebKit::CoreIPCGByteArray::CoreIPCGByteArray):
(WebKit::CoreIPCGByteArray::data const):
(WebKit::CoreIPCGByteArray::operator GRefPtr&lt;GByteArray&gt; const):
* Source/WebKit/Shared/glib/CoreIPCGByteArray.h: Copied from Source/WebKit/Shared/glib/ArgumentCodersGLib.h.
* Source/WebKit/Shared/glib/CoreIPCGByteArray.serialization.in: Added.
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:

Canonical link: <a href="https://commits.webkit.org/319594@main">https://commits.webkit.org/319594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9dc384834a84053a9aa1a4ce139c7c4de8e4486

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191924 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146028 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141829 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122265 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/181023 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44205 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42473 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42106 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3085 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193850 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55316 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151240 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56005 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150944 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27637 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45526 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128288 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123987 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54518 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17102 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53900 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54139 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->