### PR TITLE
Align HTMLCanvasElement interface with HTML spec for toDataURL() and toBlob()

### DIFF
--- a/Source/WebCore/html/HTMLCanvasElement.idl
+++ b/Source/WebCore/html/HTMLCanvasElement.idl
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement
+
 typedef (
 #if defined(ENABLE_WEBGL) && ENABLE_WEBGL
     WebGLRenderingContext or
@@ -53,8 +55,8 @@ typedef (Element or CanvasElementImage) CanvasElementImageSource;
 
     [CallWith=CurrentGlobalObject] RenderingContext? getContext(DOMString contextId, any... arguments);
 
-    DOMString toDataURL(optional DOMString type, optional any quality);
-    undefined toBlob(BlobCallback callback, optional DOMString type, optional any quality);
+    USVString toDataURL(optional DOMString type = "image/png", optional any quality);
+    undefined toBlob(BlobCallback callback, optional DOMString type = "image/png", optional any quality);
     [Conditional=OFFSCREEN_CANVAS, EnabledBySetting=OffscreenCanvasEnabled, NewObject] OffscreenCanvas transferControlToOffscreen();
 
     [Conditional=MEDIA_STREAM, NewObject] MediaStream captureStream(optional double frameRequestRate);


### PR DESCRIPTION
#### 80df4def20e353fcac0db435bb69dcec20f8c4b3
<pre>
Align HTMLCanvasElement interface with HTML spec for toDataURL() and toBlob()
<a href="https://bugs.webkit.org/show_bug.cgi?id=322163">https://bugs.webkit.org/show_bug.cgi?id=322163</a>
<a href="https://rdar.apple.com/185391614">rdar://185391614</a>

Reviewed by Ryosuke Niwa.

Bring the IDL for HTMLCanvasElement.toDataURL() and toBlob() in line with
<a href="https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement">https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement</a>:

    USVString toDataURL(optional DOMString type = &quot;image/png&quot;, optional any quality);
    undefined toBlob(BlobCallback callback, optional DOMString type = &quot;image/png&quot;, optional any quality);

Both changes are no-ops at the JS boundary, so there is nothing new to test:

1. toDataURL()&apos;s return type becomes USVString. The implementation returns an
 UncachedString, and JSConverter&lt;IDLUSVString&gt;::convert(const UncachedString&amp;)
 is identical to the IDLDOMString overload -- both are jsString(vm, value.string)
 -- so the generated binding is unchanged. USVString on a return type is a
 declarative claim that the value contains no unpaired surrogates, which is
 trivially true of a base64 data URL. The distinction only has teeth in the
 JS-to-native direction, where valueToUSVString() substitutes U+FFFD.

2. Defaulting `type` to &quot;image/png&quot; changes convertOptionalWithDefault&lt;IDLDOMString&gt;
 to hand the implementation &quot;image/png&quot; instead of a null String when the
 argument is omitted or undefined. The parameter&apos;s only consumer in either
 function is toEncodingMimeType(), which already maps both inputs to the same
 result: a null String is rejected by MIMETypeRegistry::isSupportedImageMIMETypeForEncoding()
 on its isEmpty() check and falls back to &quot;image/png&quot;, while &quot;image/png&quot; is
 supported and returns its own ASCII-lowercased self. This also makes
 HTMLCanvasElement consistent with ImageEncodeOptions.type in OffscreenCanvas.idl,
 which already carries the same default.

Also add the spec URL to the top of the file, matching the convention used by the
other IDL files in this directory.

* Source/WebCore/html/HTMLCanvasElement.idl:

Canonical link: <a href="https://commits.webkit.org/319529@main">https://commits.webkit.org/319529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06fe6666575dfe797d5d4eb820d3a4a1dc3e2835

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146031 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f7ada8d-069e-44fc-94c6-e483f39b9a71) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141830 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/129c4dc0-3304-4a57-96de-ed4d1744f9a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122266 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44da16b3-baa6-437f-af4f-977dcdd49d05) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44208 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42475 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42108 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3088 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193853 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55319 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151243 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40510 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56008 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150948 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45528 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128291 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123993 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54521 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17104 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53903 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53968 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->