### PR TITLE
Cherry-pick 319424@main (f76f30efcb68). https://bugs.webkit.org/show_bug.cgi?id=322068

### DIFF
--- a/LayoutTests/accessibility/gtk/text-at-offset-user-select-none-expected.txt
+++ b/LayoutTests/accessibility/gtk/text-at-offset-user-select-none-expected.txt
@@ -1,0 +1,19 @@
+text inside the link
+second line
+Text outside the block
+This tests the ability to get element text inside a link when user-select:none is set.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS link.characterAtOffset(0) is 't, 0, 1'
+PASS link.characterAtOffset(6) is 'n, 6, 7'
+PASS link.wordAtOffset(0) is 'text , 0, 5'
+PASS link.wordAtOffset(6) is 'inside , 5, 12'
+PASS link.lineAtOffset(0) is 'text inside the link\n, 0, 21'
+PASS link.lineAtOffset(23) is 'second line, 21, 32'
+PASS secondLineRuns.includes("Range attributes for 'second line'") is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/gtk/text-at-offset-user-select-none.html
+++ b/LayoutTests/accessibility/gtk/text-at-offset-user-select-none.html
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body id="body">
+<div style='-webkit-user-select:none'>
+<a href='https://www.webkitgtk.org' id='link'>text inside the link<br/>second line</a>
+</div>
+<span>Text outside the block</span>
+<div id="console"></div>
+<script>
+description("This tests the ability to get element text inside a link when user-select:none is set.");
+if (window.accessibilityController) {
+    var link = accessibilityController.accessibleElementById("link");
+
+    shouldBe("link.characterAtOffset(0)", "'t, 0, 1'");
+    shouldBe("link.characterAtOffset(6)", "'n, 6, 7'");
+    shouldBe("link.wordAtOffset(0)", "'text , 0, 5'");
+    shouldBe("link.wordAtOffset(6)", "'inside , 5, 12'");
+    shouldBe("link.lineAtOffset(0)", "'text inside the link\\n, 0, 21'");
+    shouldBe("link.lineAtOffset(23)", "'second line, 21, 32'");
+
+    var secondLineRuns = link.attributedStringForRange(21, 11);
+    shouldBeTrue("secondLineRuns.includes(\"Range attributes for 'second line'\")");
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2022,7 +2022,7 @@ VisiblePosition AccessibilityNodeObject::visiblePositionForIndex(int index) cons
         return { };
 #if USE(ATSPI)
     // We need to consider replaced elements for GTK, as they will be presented with the 'object replacement character' (0xFFFC).
-    return WebCore::visiblePositionForIndex(index, node.get(), TextIteratorBehavior::EmitsObjectReplacementCharacters);
+    return WebCore::visiblePositionForIndex(index, node.get(), TextIteratorBehavior::EmitsObjectReplacementCharacters, AllowUserSelectNone::Yes);
 #else
     return visiblePositionForIndexUsingCharacterIterator(*node, index);
 #endif

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -909,8 +909,8 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         endPosition = lastPositionInOrAfterNode(endRenderer->node());
     }
 
-    auto startOffset = adjustOutputOffset(m_coreObject->indexForVisiblePosition(startPosition), m_hasListMarkerAtStart);
-    auto endOffset = adjustOutputOffset(m_coreObject->indexForVisiblePosition(endPosition), m_hasListMarkerAtStart);
+    auto startOffset = adjustOutputOffset(m_coreObject->indexForVisiblePosition(VisiblePosition(startPosition, VisiblePosition::defaultAffinity, AllowUserSelectNone::Yes)), m_hasListMarkerAtStart);
+    auto endOffset = adjustOutputOffset(m_coreObject->indexForVisiblePosition(VisiblePosition(endPosition, VisiblePosition::defaultAffinity, AllowUserSelectNone::Yes)), m_hasListMarkerAtStart);
     if (!includeDefault)
         return { WTF::move(attributes), startOffset, endOffset };
 

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -1001,7 +1001,7 @@ RefPtr<Node> Position::rootUserSelectAllForNode(Node* node)
 }
 
 // This function should be kept in sync with PositionIterator::isCandidate().
-bool Position::isCandidate() const
+bool Position::isCandidate(AllowUserSelectNone allowUserSelectNone) const
 {
     if (isNull())
         return false;
@@ -1021,13 +1021,13 @@ bool Position::isCandidate() const
 
     if (is<RenderText>(*renderer)) {
         auto [resolvedText, resolvedOffset] = resolvedTextRendererAndOffset();
-        return !nodeIsUserSelectNone(node.get()) && resolvedText && resolvedText->containsCaretOffset(resolvedOffset);
+        return (allowUserSelectNone == AllowUserSelectNone::Yes || !nodeIsUserSelectNone(node.get())) && resolvedText && resolvedText->containsCaretOffset(resolvedOffset);
     }
 
     if (positionBeforeOrAfterNodeIsCandidate(*node)) {
         return ((atFirstEditingPositionForNode() && m_anchorType == PositionIsBeforeAnchor)
             || (atLastEditingPositionForNode() && m_anchorType == PositionIsAfterAnchor))
-            && !nodeIsUserSelectNone(node->parentNode());
+            && (allowUserSelectNone == AllowUserSelectNone::Yes || !nodeIsUserSelectNone(node->parentNode()));
     }
 
     if (is<HTMLHtmlElement>(*m_anchorNode))
@@ -1037,14 +1037,14 @@ bool Position::isCandidate() const
         if (isAnyOf<RenderBlockFlow, RenderGrid, RenderFlexibleBox>(*block)) {
             if (block->logicalHeight() || is<HTMLBodyElement>(*m_anchorNode) || protect(m_anchorNode)->isRootEditableElement()) {
                 if (!Position::hasRenderedNonAnonymousDescendantsWithHeight(*block))
-                    return atFirstEditingPositionForNode() && !Position::nodeIsUserSelectNone(node.get());
-                return protect(m_anchorNode)->hasEditableStyle() && !Position::nodeIsUserSelectNone(node.get()) && atEditingBoundary();
+                    return atFirstEditingPositionForNode() && (allowUserSelectNone == AllowUserSelectNone::Yes  || !Position::nodeIsUserSelectNone(node.get()));
+                return protect(m_anchorNode)->hasEditableStyle() && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(node.get())) && atEditingBoundary();
             }
             return false;
         }
     }
 
-    return protect(m_anchorNode)->hasEditableStyle() && !Position::nodeIsUserSelectNone(node.get()) && atEditingBoundary();
+    return protect(m_anchorNode)->hasEditableStyle() && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(node.get())) && atEditingBoundary();
 }
 
 bool Position::isRenderedCharacter() const

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -51,6 +51,8 @@ enum PositionMoveType {
     BackwardDeletion // Subject to platform conventions.
 };
 
+enum class AllowUserSelectNone : bool { No, Yes };
+
 struct InlineBoxAndOffset;
 
 class Position {
@@ -174,7 +176,7 @@ public:
     WEBCORE_EXPORT Position upstream(EditingBoundaryCrossingRule = CannotCrossEditingBoundary) const;
     WEBCORE_EXPORT Position downstream(EditingBoundaryCrossingRule = CannotCrossEditingBoundary) const;
     
-    bool isCandidate() const;
+    bool isCandidate(AllowUserSelectNone = AllowUserSelectNone::No) const;
     bool isRenderedCharacter() const;
     bool rendersInDifferentPosition(const Position&) const;
 

--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -159,7 +159,7 @@ bool PositionIterator::atEndOfNode() const
 }
 
 // This function should be kept in sync with Position::isCandidate().
-bool PositionIterator::isCandidate() const
+bool PositionIterator::isCandidate(AllowUserSelectNone allowUserSelectNone) const
 {
     RefPtr anchorNode = node();
     if (!anchorNode)
@@ -176,14 +176,14 @@ bool PositionIterator::isCandidate() const
         return Position(*this).isCandidate();
 
     if (is<RenderText>(*renderer)) {
-        if (Position::nodeIsUserSelectNone(anchorNode.get()))
+        if (Position::nodeIsUserSelectNone(anchorNode.get()) && allowUserSelectNone == AllowUserSelectNone::No)
             return false;
         auto [resolvedText, resolvedOffset] = Position(*this).resolvedTextRendererAndOffset();
         return resolvedText && resolvedText->containsCaretOffset(resolvedOffset);
     }
 
     if (positionBeforeOrAfterNodeIsCandidate(*anchorNode))
-        return (atStartOfNode() || atEndOfNode()) && !Position::nodeIsUserSelectNone(anchorNode->parentNode());
+        return (atStartOfNode() || atEndOfNode()) && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(anchorNode->parentNode()));
 
     if (is<HTMLHtmlElement>(*anchorNode))
         return false;
@@ -192,14 +192,14 @@ bool PositionIterator::isCandidate() const
         if (isAnyOf<RenderBlockFlow, RenderGrid, RenderFlexibleBox>(*block)) {
             if (block->logicalHeight() || is<HTMLBodyElement>(*anchorNode) || anchorNode->isRootEditableElement()) {
                 if (!Position::hasRenderedNonAnonymousDescendantsWithHeight(*block))
-                    return atStartOfNode() && !Position::nodeIsUserSelectNone(anchorNode.get());
-                return anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(anchorNode.get()) && Position(*this).atEditingBoundary();
+                    return atStartOfNode() && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(anchorNode.get()));
+                return anchorNode->hasEditableStyle() && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(anchorNode.get())) && Position(*this).atEditingBoundary();
             }
             return false;
         }
     }
 
-    return anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(anchorNode.get()) && Position(*this).atEditingBoundary();
+    return anchorNode->hasEditableStyle() && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(anchorNode.get())) && Position(*this).atEditingBoundary();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PositionIterator.h
+++ b/Source/WebCore/dom/PositionIterator.h
@@ -48,7 +48,7 @@ public:
     bool atEnd() const;
     bool NODELETE atStartOfNode() const;
     bool atEndOfNode() const;
-    bool isCandidate() const;
+    bool isCandidate(AllowUserSelectNone = AllowUserSelectNone::No) const;
 
 private:
     RefPtr<Node> m_anchorNode;

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -209,11 +209,11 @@ RefPtr<Element> unsplittableElementForPosition(const Position& position)
     return editableRootForPosition(position);
 }
 
-Position nextCandidate(const Position& position)
+Position nextCandidate(const Position& position, AllowUserSelectNone allowUserSelectNone)
 {
     for (PositionIterator nextPosition = position; !nextPosition.atEnd(); ) {
         nextPosition.increment();
-        if (nextPosition.isCandidate())
+        if (nextPosition.isCandidate(allowUserSelectNone))
             return nextPosition;
     }
     return { };
@@ -241,12 +241,12 @@ Position nextVisuallyDistinctCandidate(const Position& position, SkipDisplayCont
     return { };
 }
 
-Position previousCandidate(const Position& position)
+Position previousCandidate(const Position& position, AllowUserSelectNone allowUserSelectNone)
 {
     PositionIterator previousPosition = position;
     while (!previousPosition.atStart()) {
         previousPosition.decrement();
-        if (previousPosition.isCandidate())
+        if (previousPosition.isCandidate(allowUserSelectNone))
             return previousPosition;
     }
     return { };
@@ -1026,11 +1026,11 @@ VisiblePosition visiblePositionForPositionWithOffset(const VisiblePosition& posi
     return visiblePositionForIndex(startIndex + offset, root.get());
 }
 
-VisiblePosition visiblePositionForIndex(int index, Node* scope, TextIteratorBehaviors behaviors)
+VisiblePosition visiblePositionForIndex(int index, Node* scope, TextIteratorBehaviors behaviors, AllowUserSelectNone allowUserSelectNone)
 {
     if (!scope)
         return { };
-    return { makeDeprecatedLegacyPosition(resolveCharacterLocation(makeRangeSelectingNodeContents(*scope), index, behaviors)) };
+    return { makeDeprecatedLegacyPosition(resolveCharacterLocation(makeRangeSelectingNodeContents(*scope), index, behaviors)), VisiblePosition::defaultAffinity, allowUserSelectNone };
 }
 
 VisiblePosition visiblePositionForIndexUsingCharacterIterator(Node& node, int index)

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -135,8 +135,8 @@ WEBCORE_EXPORT EnclosingLayerInfomation computeEnclosingLayer(const SimpleRange&
 // Position
 // -------------------------------------------------------------------------
 
-Position nextCandidate(const Position&);
-Position previousCandidate(const Position&);
+Position nextCandidate(const Position&, AllowUserSelectNone = AllowUserSelectNone::No);
+Position previousCandidate(const Position&, AllowUserSelectNone = AllowUserSelectNone::No);
 
 enum class SkipDisplayContents : bool { No, Yes };
 Position nextVisuallyDistinctCandidate(const Position&, SkipDisplayContents = SkipDisplayContents::Yes);
@@ -171,7 +171,7 @@ bool lineBreakExistsAtVisiblePosition(const VisiblePosition&);
 WEBCORE_EXPORT int indexForVisiblePosition(const VisiblePosition&, RefPtr<ContainerNode>& scope);
 int indexForVisiblePosition(Node&, const VisiblePosition&, TextIteratorBehaviors);
 WEBCORE_EXPORT VisiblePosition visiblePositionForPositionWithOffset(const VisiblePosition&, int offset);
-WEBCORE_EXPORT VisiblePosition visiblePositionForIndex(int index, Node* scope, TextIteratorBehaviors = TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions);
+WEBCORE_EXPORT VisiblePosition visiblePositionForIndex(int index, Node* scope, TextIteratorBehaviors = TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions, AllowUserSelectNone = AllowUserSelectNone::No);
 VisiblePosition visiblePositionForIndexUsingCharacterIterator(Node&, int index); // FIXME: Why do we need this version?
 
 WEBCORE_EXPORT VisiblePosition closestEditablePositionInElementForAbsolutePoint(const Element&, const IntPoint&);

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -70,8 +70,9 @@ static RenderTextFragment* remainingTextFragmentForFirstLetter(const RenderObjec
     return { };
 }
 
-VisiblePosition::VisiblePosition(const Position& position, Affinity affinity)
-    : m_deepPosition { canonicalPosition(position) }
+VisiblePosition::VisiblePosition(const Position& position, Affinity affinity, AllowUserSelectNone allowUserSelectNone)
+    : m_deepPosition(canonicalPosition(position, allowUserSelectNone))
+    , m_allowUserSelectNone(allowUserSelectNone)
 {
     if (affinity == Affinity::Upstream && !isNull()) {
         auto upstreamCopy = *this;
@@ -502,7 +503,7 @@ VisiblePosition VisiblePosition::honorEditingBoundaryAtOrBefore(const VisiblePos
     }
 
     // Return the last position before pos that is in the same editable region as this position
-    return lastEditablePositionBeforePositionInRoot(position.deepEquivalent(), highestRoot.get());
+    return VisiblePosition(lastEditablePositionBeforePositionInRoot(position.deepEquivalent(), highestRoot.get()), VisiblePosition::defaultAffinity, position.allowUserSelectNone());
 }
 
 VisiblePosition VisiblePosition::honorEditingBoundaryAtOrAfter(const VisiblePosition& otherPosition, bool* reachedBoundary) const
@@ -539,21 +540,21 @@ VisiblePosition VisiblePosition::honorEditingBoundaryAtOrAfter(const VisiblePosi
     }
 
     // Return the next position after pos that is in the same editable region as this position
-    return firstEditablePositionAfterPositionInRoot(otherPosition.deepEquivalent(), highestRoot.get());
+    return VisiblePosition(firstEditablePositionAfterPositionInRoot(otherPosition.deepEquivalent(), highestRoot.get()), VisiblePosition::defaultAffinity, otherPosition.allowUserSelectNone());
 }
 
-static Position canonicalizeCandidate(const Position& candidate)
+static Position canonicalizeCandidate(const Position& candidate, AllowUserSelectNone allowUserSelectNone)
 {
     if (candidate.isNull())
         return Position();
-    ASSERT(candidate.isCandidate());
+    ASSERT(candidate.isCandidate(allowUserSelectNone));
     Position upstream = candidate.upstream();
-    if (upstream.isCandidate())
+    if (upstream.isCandidate(allowUserSelectNone))
         return upstream;
     return candidate;
 }
 
-Position VisiblePosition::canonicalPosition(const Position& passedPosition)
+Position VisiblePosition::canonicalPosition(const Position& passedPosition, AllowUserSelectNone allowUserSelectNone)
 {
     // The updateLayout call below can do so much that even the position passed
     // in to us might get changed as a side effect. Specifically, there are code
@@ -574,16 +575,16 @@ Position VisiblePosition::canonicalPosition(const Position& passedPosition)
     RefPtr node = position.containerNode();
 
     Position candidate = position.upstream();
-    if (candidate.isCandidate())
+    if (candidate.isCandidate(allowUserSelectNone))
         return candidate;
     candidate = position.downstream();
-    if (candidate.isCandidate())
+    if (candidate.isCandidate(allowUserSelectNone))
         return candidate;
 
     // When neither upstream or downstream gets us to a candidate (upstream/downstream won't leave 
     // blocks or enter new ones), we search forward and backward until we find one.
-    Position next = canonicalizeCandidate(nextCandidate(position));
-    Position prev = canonicalizeCandidate(previousCandidate(position));
+    Position next = canonicalizeCandidate(nextCandidate(position, allowUserSelectNone), allowUserSelectNone);
+    Position prev = canonicalizeCandidate(previousCandidate(position, allowUserSelectNone), allowUserSelectNone);
     RefPtr nextNode = next.deprecatedNode();
     RefPtr prevNode = prev.deprecatedNode();
 

--- a/Source/WebCore/editing/VisiblePosition.h
+++ b/Source/WebCore/editing/VisiblePosition.h
@@ -40,7 +40,7 @@ public:
     VisiblePosition() = default;
 
     // This constructor will ignore the passed-in affinity if the position is not at the end of a line.
-    WEBCORE_EXPORT VisiblePosition(const Position&, Affinity = defaultAffinity);
+    WEBCORE_EXPORT VisiblePosition(const Position&, Affinity = defaultAffinity, AllowUserSelectNone = AllowUserSelectNone::No);
 
     bool isNull() const { return m_deepPosition.isNull(); }
     bool isNotNull() const { return m_deepPosition.isNotNull(); }
@@ -48,6 +48,7 @@ public:
 
     Position deepEquivalent() const { return m_deepPosition; }
     Affinity affinity() const { return m_affinity; }
+    AllowUserSelectNone allowUserSelectNone() const { return m_allowUserSelectNone; }
 
     void setAffinity(Affinity affinity) { m_affinity = affinity; }
 
@@ -98,13 +99,14 @@ public:
 #endif
 
 private:
-    static Position canonicalPosition(const Position&);
+    static Position canonicalPosition(const Position&, AllowUserSelectNone = AllowUserSelectNone::No);
 
     Position leftVisuallyDistinctCandidate() const;
     Position rightVisuallyDistinctCandidate() const;
 
     Position m_deepPosition;
     Affinity m_affinity { defaultAffinity };
+    AllowUserSelectNone m_allowUserSelectNone;
 };
 
 bool operator==(const VisiblePosition&, const VisiblePosition&);

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -100,7 +100,7 @@ static Position previousLineCandidatePosition(Node* node, const VisiblePosition&
         Position pos = previousNode->hasTagName(HTMLNames::brTag) ? positionBeforeNode(*previousNode) :
             makeDeprecatedLegacyPosition(previousNode.get(), caretMaxOffset(*previousNode));
         
-        if (pos.isCandidate())
+        if (pos.isCandidate(visiblePosition.allowUserSelectNone()))
             return pos;
 
         previousNode = previousLeafWithSameEditability(previousNode.get(), editableType);
@@ -122,7 +122,7 @@ static Position nextLineCandidatePosition(Node* node, const VisiblePosition& vis
         Position pos;
         pos = makeDeprecatedLegacyPosition(nextNode.get(), caretMinOffset(*nextNode));
         
-        if (pos.isCandidate())
+        if (pos.isCandidate(visiblePosition.allowUserSelectNone()))
             return pos;
 
         nextNode = nextLeafWithSameEditability(nextNode.get(), editableType);
@@ -572,13 +572,13 @@ static VisiblePosition previousBoundary(const VisiblePosition& position, Boundar
     unsigned next = backwardSearchForBoundaryWithTextIterator(it, string, suffixLength, searchFunction);
 
     if (!next)
-        return it.atEnd() ? makeDeprecatedLegacyPosition(searchRange->start) : position;
+        return it.atEnd() ? VisiblePosition(makeDeprecatedLegacyPosition(searchRange->start), VisiblePosition::defaultAffinity, position.allowUserSelectNone()) : position;
 
     Ref node = (it.atEnd() ? *searchRange : it.range()).start.container;
     RefPtr textNode = dynamicDowncast<Text>(node);
     if (textNode && !suffixLength && next <= textNode->length()) {
         // The next variable contains a usable index into a text node.
-        return makeDeprecatedLegacyPosition(node.ptr(), next);
+        return VisiblePosition(makeDeprecatedLegacyPosition(node.ptr(), next), VisiblePosition::defaultAffinity, position.allowUserSelectNone());
     }
 
     // Use the character iterator to translate the next value into a DOM position.
@@ -586,7 +586,7 @@ static VisiblePosition previousBoundary(const VisiblePosition& position, Boundar
     if (next < string.size() - suffixLength)
         charIt.advance(string.size() - suffixLength - next);
     // FIXME: charIt can get out of shadow host.
-    return makeDeprecatedLegacyPosition(charIt.range().end);
+    return VisiblePosition(makeDeprecatedLegacyPosition(charIt.range().end), VisiblePosition::defaultAffinity, position.allowUserSelectNone());
 }
 
 static VisiblePosition nextBoundary(const VisiblePosition& c, BoundarySearchFunction searchFunction)
@@ -636,7 +636,7 @@ static VisiblePosition nextBoundary(const VisiblePosition& c, BoundarySearchFunc
         }
     }
 
-    return VisiblePosition(pos, Affinity::Upstream);
+    return VisiblePosition(pos, Affinity::Upstream, c.allowUserSelectNone());
 }
 
 // ---------
@@ -776,7 +776,7 @@ static VisiblePosition startPositionForLine(const VisiblePosition& c, LineEndpoi
     }
 
     if (RefPtr startTextNode = dynamicDowncast<Text>(*startNode))
-        return Position(startTextNode.releaseNonNull(), downcast<InlineIterator::TextBox>(*startBox).start());
+        return VisiblePosition(Position(startTextNode.releaseNonNull(), downcast<InlineIterator::TextBox>(*startBox).start()), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
     return positionBeforeNode(*startNode);
 }
 
@@ -860,7 +860,7 @@ static VisiblePosition endPositionForLine(const VisiblePosition& c, LineEndpoint
     } else
         pos = positionAfterNode(*endNode);
 
-    return VisiblePosition(pos, Affinity::Upstream);
+    return VisiblePosition(pos, Affinity::Upstream, c.allowUserSelectNone());
 }
 
 static bool inSameLogicalLine(const VisiblePosition& a, const VisiblePosition& b)
@@ -1052,7 +1052,7 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
             RenderedPosition renderedPosition(position);
             lineBox = renderedPosition.lineBox();
             if (!lineBox)
-                return position;
+                return VisiblePosition(position, VisiblePosition::defaultAffinity, visiblePosition.allowUserSelectNone());
         }
     }
     
@@ -1065,12 +1065,12 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
         CheckedRef renderer = box->renderer();
         RefPtr node = renderer->node();
         if (node && editingIgnoresContent(*node))
-            return positionInParentBeforeNode(*node);
+            return VisiblePosition(positionInParentBeforeNode(*node), VisiblePosition::defaultAffinity, visiblePosition.allowUserSelectNone());
         // FIXME: The HitTestSource state should be propagated down from calls into JavaScript bindings.
         // For the time being, just err on the side of passing in `Bindings`.
         CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer.get());
         auto localOffset = renderBox ? renderBox->locationOffset() : LayoutSize { };
-        return const_cast<RenderObject&>(renderer.get()).visiblePositionForPoint(pointInLine - localOffset, HitTestSource::Script);
+        return const_cast<RenderObject&>(renderer.get()).visiblePositionForPoint(pointInLine - localOffset, HitTestSource::Script, visiblePosition.allowUserSelectNone());
     }
 
     // Could not find a next line. This means we must already be on the last line.
@@ -1079,7 +1079,7 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
     RefPtr rootElement = rootEditableOrDocumentElement(*node, editableType);
     if (!rootElement)
         return VisiblePosition();
-    return lastPositionInNode(*rootElement);
+    return VisiblePosition(lastPositionInNode(*rootElement), VisiblePosition::defaultAffinity, visiblePosition.allowUserSelectNone());
 }
 
 // ---------
@@ -1266,14 +1266,14 @@ VisiblePosition startOfParagraph(const VisiblePosition& c, EditingBoundaryCrossi
     RefPtr node = findStartOfParagraph(startNode.get(), highestRoot.get(), startBlock.get(), offset, type, boundaryCrossingRule);
 
     if (RefPtr textNode = dynamicDowncast<Text>(node))
-        return Position(WTF::move(textNode), offset);
+        return VisiblePosition(Position(WTF::move(textNode), offset), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
 
     if (type == Position::PositionIsOffsetInAnchor) {
         ASSERT(type == Position::PositionIsOffsetInAnchor || !offset);
-        return Position(WTF::move(node), offset, type);
+        return VisiblePosition(Position(WTF::move(node), offset, type), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
     }
 
-    return Position(WTF::move(node), type);
+    return VisiblePosition(Position(WTF::move(node), type), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
 }
 
 VisiblePosition endOfParagraph(const VisiblePosition& c, EditingBoundaryCrossingRule boundaryCrossingRule)
@@ -1296,12 +1296,12 @@ VisiblePosition endOfParagraph(const VisiblePosition& c, EditingBoundaryCrossing
     RefPtr node = findEndOfParagraph(startNode.get(), highestRoot.get(), stayInsideBlock.get(), offset, type, boundaryCrossingRule);
 
     if (RefPtr textNode = dynamicDowncast<Text>(node))
-        return Position(WTF::move(textNode), offset);
+        return VisiblePosition(Position(WTF::move(textNode), offset), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
 
     if (type == Position::PositionIsOffsetInAnchor)
-        return Position(WTF::move(node), offset, type);
+        return VisiblePosition(Position(WTF::move(node), offset, type), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
 
-    return Position(WTF::move(node), type);
+    return VisiblePosition(Position(WTF::move(node), type), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
 }
 
 // FIXME: isStartOfParagraph(startOfNextParagraph(pos)) is not always true
@@ -1368,7 +1368,7 @@ VisiblePosition startOfBlock(const VisiblePosition& visiblePosition, EditingBoun
     RefPtr<Node> startBlock;
     if (!position.containerNode() || !(startBlock = enclosingBlock(protect(position.containerNode()), rule)))
         return VisiblePosition();
-    return firstPositionInNode(*startBlock);
+    return VisiblePosition(firstPositionInNode(*startBlock), VisiblePosition::defaultAffinity, visiblePosition.allowUserSelectNone());
 }
 
 VisiblePosition endOfBlock(const VisiblePosition& visiblePosition, EditingBoundaryCrossingRule rule)
@@ -1377,7 +1377,7 @@ VisiblePosition endOfBlock(const VisiblePosition& visiblePosition, EditingBounda
     RefPtr<Node> endBlock;
     if (!position.containerNode() || !(endBlock = enclosingBlock(protect(position.containerNode()), rule)))
         return VisiblePosition();
-    return lastPositionInNode(*endBlock);
+    return VisiblePosition(lastPositionInNode(*endBlock), VisiblePosition::defaultAffinity, visiblePosition.allowUserSelectNone());
 }
 
 bool inSameBlock(const VisiblePosition& a, const VisiblePosition& b)

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
@@ -173,9 +173,9 @@ struct LookupTable : TableBase {
                 if (!isValidEnd(buffer, &coverage2->ranges[countRange]))
                     return false;
                 for (uint16_t i = 0, indexTo = 0; i < countRange; ++i) {
-                    uint16_t from = coverage2->ranges[i].start;
-                    uint16_t fromEnd = coverage2->ranges[i].end + 1; // OpenType "end" is inclusive
-                    if (indexTo + (fromEnd - from) > countTo)
+                    unsigned from = coverage2->ranges[i].start;
+                    unsigned fromEnd = coverage2->ranges[i].end + 1; // OpenType "end" is inclusive
+                    if (fromEnd <= from || indexTo + (fromEnd - from) > countTo)
                         return false;
                     for (; from != fromEnd; ++from, ++indexTo)
                         map->set(from, singleSubstitution2->substitute[indexTo]);

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1847,10 +1847,10 @@ PositionWithAffinity RenderObject::positionForPoint(const LayoutPoint&, HitTestS
     return createPositionWithAffinity(caretMinOffset(), Affinity::Downstream);
 }
 
-VisiblePosition RenderObject::visiblePositionForPoint(const LayoutPoint& point, HitTestSource source)
+VisiblePosition RenderObject::visiblePositionForPoint(const LayoutPoint& point, HitTestSource source, AllowUserSelectNone allowUserSelectNone)
 {
     auto positionWithAffinity = positionForPoint(point, source, nullptr);
-    return VisiblePosition(positionWithAffinity.position(), positionWithAffinity.affinity());
+    return VisiblePosition(positionWithAffinity.position(), positionWithAffinity.affinity(), allowUserSelectNone);
 }
 
 bool RenderObject::isComposited() const

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -28,6 +28,7 @@
 #include <WebCore/CachedImageClient.h>
 #include <WebCore/LayoutRect.h>
 #include <WebCore/PlatformLayerIdentifier.h>
+#include <WebCore/Position.h>
 #include <WebCore/RenderObjectEnums.h>
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/RepaintRectCalculation.h>
@@ -803,7 +804,7 @@ public:
     PositionWithAffinity createPositionWithAffinity(int offset, Affinity) const;
     PositionWithAffinity createPositionWithAffinity(const Position&) const;
 
-    WEBCORE_EXPORT VisiblePosition visiblePositionForPoint(const LayoutPoint&, HitTestSource);
+    WEBCORE_EXPORT VisiblePosition visiblePositionForPoint(const LayoutPoint&, HitTestSource, AllowUserSelectNone = AllowUserSelectNone::No);
 
     // Returns the containing block level element for this element.
     WEBCORE_EXPORT RenderBlock* containingBlock() const;

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -167,7 +167,8 @@ void NetworkDataTaskSoup::createRequest(ResourceRequest&& request, WasBlockingCo
     messageFlags |= SOUP_MESSAGE_COLLECT_METRICS;
     if (m_shouldContentSniff == ContentSniffingPolicy::DoNotSniffContent)
         soup_message_disable_feature(m_soupMessage.get(), SOUP_TYPE_CONTENT_SNIFFER);
-    if (m_user.isEmpty() && m_password.isEmpty() && m_storedCredentialsPolicy == StoredCredentialsPolicy::DoNotUse) {
+    if ((m_user.isEmpty() && m_password.isEmpty() && m_storedCredentialsPolicy == StoredCredentialsPolicy::DoNotUse)
+        || m_currentRequest.hasHTTPHeaderField(HTTPHeaderName::Authorization)) {
         messageFlags |= SOUP_MESSAGE_DO_NOT_USE_AUTH_CACHE;
     }
     soup_message_set_flags(m_soupMessage.get(), static_cast<SoupMessageFlags>(soup_message_get_flags(m_soupMessage.get()) | messageFlags));

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtension.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtension.cpp
@@ -554,7 +554,7 @@ const char* webkit_web_extension_get_path(WebKitWebExtension* extension)
  * Get the parsed manifest version, or `0` if there is no
  * version specified in the manifest.
  *
- * A [error@WebKit.WebExtensionError.UNSUPPORTED_MANIFEST_VERSION] error will be
+ * A [error@WebExtensionError.UNSUPPORTED_MANIFEST_VERSION] error will be
  * reported if the manifest version isn't specified.
  * 
  * Returns: the parsed manifest version.

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -77,9 +77,9 @@ void webkitWebViewRestoreWindow(WebKitWebView*, CompletionHandler<void()>&& comp
  * The new view will use the default [class@WebContext] and will not
  * have an associated [class@UserContentManager].
  *
- * See also [id@webkit_web_view_new_with_context],
- * [id@webkit_web_view_new_with_user_content_manager]), and
- * [id@webkit_web_view_new_with_settings].
+ * Set the [property@WebView:web-context],
+ * [property@WebView:user-content-manager] or [property@WebView:settings]
+ * properties at construction to use a different configuration.
  *
  * Returns: The newly created web view.
  */
@@ -109,8 +109,8 @@ WebKitWebView* webkit_web_view_new(WebKitWebViewBackend* backend)
  * The new web view will use the given [class@WebContext] and will not have
  * an associated [class@UserContentManager].
  *
- * See also [id@webkit_web_view_new_with_user_content_manager] and
- * [id@webkit_web_view_new_with_settings].
+ * See also [ctor@WebView.new_with_user_content_manager] and
+ * [ctor@WebView.new_with_settings].
  *
  * Returns: The newly created web view.
  */
@@ -169,8 +169,8 @@ WebKitWebView* webkit_web_view_new_with_related_view(WebKitWebViewBackend* backe
  *
  * Creates a new web view with the given settings.
  *
- * See also [id@webkit_web_view_new_with_context], and
- * [id@webkit_web_view_new_with_user_content_manager].
+ * See also [ctor@WebView.new_with_context] and
+ * [ctor@WebView.new_with_user_content_manager].
  *
  * Returns: (transfer full): The newly created web view.
  *

--- a/Source/WebKit/WPEPlatform/docs/overview.md
+++ b/Source/WebKit/WPEPlatform/docs/overview.md
@@ -109,7 +109,7 @@ lifecycles you can rely on.
 
 The minimum viable usage looks like this:
 
-1. Create a [class@WebKit.WebView] without specifying a display or a
+1. Create a `WebKitWebView` without specifying a display or a
    backend. WebKit then uses the default display automatically — it is
    obtained by iterating the registered platform modules in priority
    order and connecting to the first one that succeeds.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAuthentication.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAuthentication.cpp
@@ -29,6 +29,7 @@ static const char authTestPassword[] = "password";
 static const char authExpectedSuccessTitle[] = "WebKit2Gtk+ Authentication test";
 static const char authExpectedFailureTitle[] = "401 Authorization Required";
 static const char authExpectedAuthorization[] = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="; // Base64 encoding of "username:password".
+static const char authPageAuthorization[] = "Bearer page-token"; // Authorization header set by the page itself.
 static const char authSuccessHTMLString[] =
     "<html>"
     "<head><title>WebKit2Gtk+ Authentication test</title></head>"
@@ -326,6 +327,30 @@ static void testWebViewAuthenticationSuccess(AuthenticationTest* test, gconstpoi
     g_assert_true(test->m_authenticationSucceededReceived);
 }
 
+static void testWebViewAuthenticationPageProvidedAuthorizationHeader(AuthenticationTest* test, gconstpointer)
+{
+    // Authenticate once, so that the credentials end up in the auth cache for the whole domain.
+    test->loadURI(kServer->getURIForPath("/auth-test.html").data());
+    WebKitAuthenticationRequest* request = test->waitForAuthenticationRequest();
+    WebKitCredential* credential = webkit_credential_new(authTestUsername, authTestPassword, WEBKIT_CREDENTIAL_PERSISTENCE_FOR_SESSION);
+    webkit_authentication_request_authenticate(request, credential);
+    webkit_credential_free(credential);
+    test->waitUntilTitleChanged();
+    g_assert_cmpstr(webkit_web_view_get_title(test->webView()), ==, authExpectedSuccessTitle);
+    g_assert_true(test->m_authenticationSucceededReceived);
+
+    // A request that carries its own Authorization header must be sent as-is, even though the
+    // cached credentials would otherwise be used for this domain.
+    GUniqueOutPtr<GError> error;
+    auto* value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished(
+        "const response = await fetch('echo-authorization', { headers: { 'Authorization': 'Bearer page-token' } });"
+        "return await response.text();", nullptr, nullptr, &error.outPtr());
+    g_assert_no_error(error.get());
+    g_assert_nonnull(value);
+    GUniquePtr<char> authorization(WebViewTest::javascriptResultToCString(value));
+    g_assert_cmpstr(authorization.get(), ==, authPageAuthorization);
+}
+
 static void testWebViewAuthenticationEmptyRealm(AuthenticationTest* test, gconstpointer)
 {
     test->loadURI(kServer->getURIForPath("/empty-realm.html").data());
@@ -439,6 +464,10 @@ static void serverCallback(SoupServer* server, SoupServerMessage* message, const
             soup_server_message_set_status(message, isProxy ? SOUP_STATUS_PROXY_AUTHENTICATION_REQUIRED : SOUP_STATUS_UNAUTHORIZED, nullptr);
             soup_message_body_append(responseBody, SOUP_MEMORY_STATIC, authFailureHTMLString, strlen(authFailureHTMLString));
         }
+    } else if (g_str_has_suffix(path, "/echo-authorization")) {
+        const char* authorization = soup_message_headers_get_one(soup_server_message_get_request_headers(message), "Authorization");
+        soup_server_message_set_status(message, SOUP_STATUS_OK, nullptr);
+        soup_message_body_append(responseBody, SOUP_MEMORY_COPY, authorization ? authorization : "", authorization ? strlen(authorization) : 0);
     } else
         soup_server_message_set_status(message, SOUP_STATUS_NOT_FOUND, nullptr);
 
@@ -531,6 +560,7 @@ void beforeAll()
     EphemeralAuthenticationTest::add("Authentication", "authentication-ephemeral", testWebViewAuthenticationEphemeral);
     AuthenticationTest::add("Authentication", "authentication-storage", testWebViewAuthenticationStorage);
     AuthenticationTest::add("Authentication", "authentication-empty-realm", testWebViewAuthenticationEmptyRealm);
+    AuthenticationTest::add("Authentication", "authentication-page-provided-authorization-header", testWebViewAuthenticationPageProvidedAuthorizationHeader);
     ProxyAuthenticationTest::add("Authentication", "authentication-proxy", testWebViewAuthenticationProxy);
     ProxyAuthenticationTest::add("Authentication", "authentication-proxy-https", testWebViewAuthenticationProxyHTTPS);
 }


### PR DESCRIPTION
#### 189f1c29ba3a6be1caea28238835520b738f69a9
<pre>
Cherry-pick 319424@main (f76f30efcb68). <a href="https://bugs.webkit.org/show_bug.cgi?id=322068">https://bugs.webkit.org/show_bug.cgi?id=322068</a>

    [SOUP] An Authorization header set by the page is replaced by cached credentials
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322068">https://bugs.webkit.org/show_bug.cgi?id=322068</a>

    Reviewed by Michael Catanzaro.

    nce an authentication challenge has been answered for a host, libsoup&apos;s
    SoupAuthManager stamps the cached credentials onto every later request in that
    protection space, replacing an Authorization header the page had set itself.
    The Fetch standard uses the cached credential only &quot;If httpRequest&apos;s header
    list does not contain `Authorization`&quot;, and the Cocoa and curl ports already
    behave that way.

    Set SOUP_MESSAGE_DO_NOT_USE_AUTH_CACHE, libsoup&apos;s per-message opt-out, when the
    request already carries an Authorization header. A challenge still reaches the
    authentication handler and the retry authenticates as before.

    Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAuthentication.cpp

    * Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
    (WebKit::NetworkDataTaskSoup::createRequest):
    * Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAuthentication.cpp:
    (testWebViewAuthenticationPageProvidedAuthorizationHeader):
    (serverCallback):
    (beforeAll):

    Canonical link: <a href="https://commits.webkit.org/319424@main">https://commits.webkit.org/319424@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.115@webkitglib/2.54">https://commits.webkit.org/317695.115@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 7902ef28ba5376e186e22936f4f814046830b417
<pre>
Cherry-pick 318359@main (291c3ca40cf8). <a href="https://bugs.webkit.org/show_bug.cgi?id=318228">https://bugs.webkit.org/show_bug.cgi?id=318228</a>

    AX: AT-SPI implementation computes offsets incorrectly when user-select:none is set
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318228">https://bugs.webkit.org/show_bug.cgi?id=318228</a>

    Reviewed by Tyler Wilcock.

    When GetStringAtOffset is called, the code currently uses VisiblePositions
    to calculate text boundaries. The VisiblePosition code skips over text
    when user-select:none is set, causing the resulting positions to be
    canonicalized to point outside of the node, resulting in offsets that
    are out of synch with the text that is being exposed for accessibility
    purposes. This later causes a crash when the code tries to convert
    the offsets to UTF-8, but the offsets can be larger than the length of
    the text.

    VisiblePositions now optionally consider positions inside user-select:none
    to be valid, and the setting is propagated when new VisiblePositions
    are constructed based on existing ones.

    * LayoutTests/accessibility/gtk/text-at-offset-user-select-none-expected.txt: Added.
    * LayoutTests/accessibility/gtk/text-at-offset-user-select-none.html: Added.
    * Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
    (WebCore::AccessibilityNodeObject::visiblePositionForIndex const):
    * Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
    (WebCore::AccessibilityObjectAtspi::textAttributes const):
    * Source/WebCore/dom/Position.cpp:
    (WebCore::Position::isCandidate const):
    * Source/WebCore/dom/Position.h:
    * Source/WebCore/dom/PositionIterator.cpp:
    (WebCore::PositionIterator::isCandidate const):
    * Source/WebCore/dom/PositionIterator.h:
    * Source/WebCore/editing/Editing.cpp:
    (WebCore::nextCandidate):
    (WebCore::previousCandidate):
    (WebCore::visiblePositionForIndex):
    * Source/WebCore/editing/Editing.h:
    * Source/WebCore/editing/VisiblePosition.cpp:
    (WebCore::VisiblePosition::VisiblePosition):
    (WebCore::VisiblePosition::honorEditingBoundaryAtOrBefore const):
    (WebCore::VisiblePosition::honorEditingBoundaryAtOrAfter const):
    (WebCore::canonicalizeCandidate):
    (WebCore::VisiblePosition::canonicalPosition):
    * Source/WebCore/editing/VisiblePosition.h:
    (WebCore::VisiblePosition::allowUserSelectNone const):
    * Source/WebCore/editing/VisibleUnits.cpp:
    (WebCore::previousLineCandidatePosition):
    (WebCore::nextLineCandidatePosition):
    (WebCore::previousBoundary):
    (WebCore::nextBoundary):
    (WebCore::startPositionForLine):
    (WebCore::endPositionForLine):
    (WebCore::nextLinePosition):
    (WebCore::startOfParagraph):
    (WebCore::endOfParagraph):
    (WebCore::startOfBlock):
    (WebCore::endOfBlock):
    * Source/WebCore/rendering/RenderObject.cpp:
    (WebCore::RenderObject::visiblePositionForPoint):
    * Source/WebCore/rendering/RenderObject.h:

    Canonical link: <a href="https://commits.webkit.org/318359@main">https://commits.webkit.org/318359@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.114@webkitglib/2.54">https://commits.webkit.org/317695.114@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 05ce0ecaa57fbcaf58a79dcb241d64bca584d387
<pre>
Cherry-pick 318988@main (bf034981129c). <a href="https://bugs.webkit.org/show_bug.cgi?id=321516">https://bugs.webkit.org/show_bug.cgi?id=321516</a>

    [GLib] Fix documentation warnings
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321516">https://bugs.webkit.org/show_bug.cgi?id=321516</a>

    Reviewed by Adrian Perez de Castro.

    This fixes some simple warnings.

    * Source/WebKit/UIProcess/API/glib/WebKitWebExtension.cpp:

    This required an upstream fix: <a href="https://gitlab.gnome.org/GNOME/gi-docgen/-/merge_requests/272">https://gitlab.gnome.org/GNOME/gi-docgen/-/merge_requests/272</a>

    * Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp:
    * Source/WebKit/WPEPlatform/docs/overview.md:

    WPEPlatform can&apos;t link to WebKit easily, since the dependency is
    the reverse of that.

    Canonical link: <a href="https://commits.webkit.org/318988@main">https://commits.webkit.org/318988@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.113@webkitglib/2.54">https://commits.webkit.org/317695.113@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 68fa8947a81b6a6bcd823ca4fca0282bd1660049
<pre>
Cherry-pick 319036@main (2196077a54c4). &lt;bug&gt;

    Out-of-bounds read in OpenType vertical GSUB coverage range fill
    <a href="https://bugs.webkit.org/show_bug.cgi?id=">https://bugs.webkit.org/show_bug.cgi?id=</a>

    Reviewed by Michael Catanzaro.

    OpenTypeVerticalData loads vertical glyph substitutions from a
    downloaded font&apos;s GSUB table, which is attacker controlled.
    LookupTable::getSubstitutions() fills the substitution map one Coverage
    Format 2 range at a time. from and fromEnd were uint16_t with fromEnd
    set to end + 1, so a range whose end is 0xffff wraps fromEnd to 0. The
    guard indexTo + (fromEnd - from) &gt; countTo then underflows on the
    truncated value and passes, and the inner loop walks from start through
    0xffff before from wraps back to 0, reading
    singleSubstitution2-&gt;substitute[indexTo] far past its validated
    glyphCount entries. substitute is a raw pointer into the GSUB buffer, so
    this is an unchecked heap read past the table. A reversed range with
    start greater than end underflows the same guard.

    Widen from and fromEnd to unsigned so end + 1 stays exact, and reject
    fromEnd &lt;= from to drop reversed and empty ranges before the copy. Valid
    ranges map the same glyphs as before.

    * Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp:
    (WebCore::OpenType::LookupTable::getSubstitutions):

    Canonical link: <a href="https://commits.webkit.org/319036@main">https://commits.webkit.org/319036@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.112@webkitglib/2.54">https://commits.webkit.org/317695.112@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bf9ad975f63fda6373b28366f794546dbb79b27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181710 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/55657 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49460 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191935 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146039 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183572 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/56969 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55378 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141841 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146039 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184665 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/56969 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/49460 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122277 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/56969 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55378 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/49460 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/56969 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49460 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3096 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/48288 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/55378 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193861 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/55327 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/49460 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151253 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56016 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49460 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150958 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27599 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56016 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128299 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124012 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/54529 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/49460 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/53911 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54150 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53976 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->