### PR TITLE
[WPE][GTK] layout test gardening

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3113,9 +3113,6 @@ webkit.org/b/214029 imported/w3c/web-platform-tests/html/semantics/embedded-cont
 webkit.org/b/214125 imported/w3c/web-platform-tests/html/rendering/widgets/select-wrap-no-spill.optional.html [ Failure ]
 imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/propagate-text-decoration.html [ ImageOnlyFailure ]
 
-# GTK/WPE don't support the "none" value for selections of input and textarea elements.
-webkit.org/b/180931 imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/selection-after-content-change.html [ Failure ]
-
 # GTK/WPE fail newly added WPT `meter` element test cases.
 imported/w3c/web-platform-tests/html/semantics/forms/the-meter-element/meter-appearance-none-even-less-good-value-rendering.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-meter-element/meter-appearance-none-optimum-value-rendering.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/selection-after-content-change-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/selection-after-content-change-expected.txt
@@ -1,0 +1,21 @@
+
+
+PASS input out of document: selection must not change when setting the same value
+PASS input out of document: selection must change when setting a different value
+PASS input out of document: selection must not change when setting a value that becomes the same after the value sanitization algorithm
+PASS input in document: selection must not change when setting the same value
+PASS input in document: selection must change when setting a different value
+PASS input in document: selection must not change when setting a value that becomes the same after the value sanitization algorithm
+PASS input in document, with focus: selection must not change when setting the same value
+PASS input in document, with focus: selection must change when setting a different value
+PASS input in document, with focus: selection must not change when setting a value that becomes the same after the value sanitization algorithm
+PASS textarea out of document: selection must not change when setting the same value
+PASS textarea out of document: selection must change when setting a different value
+PASS textarea out of document: selection must not change when setting the same normalized value
+PASS textarea in document: selection must not change when setting the same value
+PASS textarea in document: selection must change when setting a different value
+PASS textarea in document: selection must not change when setting the same normalized value
+PASS textarea in document, with focus: selection must not change when setting the same value
+PASS textarea in document, with focus: selection must change when setting a different value
+PASS textarea in document, with focus: selection must not change when setting the same normalized value
+


### PR DESCRIPTION
#### fc43dbf0c3accd0ff0ba1c0113b87a963788645a
<pre>
[WPE][GTK] layout test gardening
<a href="https://bugs.webkit.org/show_bug.cgi?id=180931">https://bugs.webkit.org/show_bug.cgi?id=180931</a>

Unreviewed.

The only test guarded under this bug is W3C test:

html/semantics/forms/textfieldselection/selection-after-content-change.html

The result for GLIB ports is better than the general baseline,
therefore emit specific baseline for GLIB.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/selection-after-content-change-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/319515@main">https://commits.webkit.org/319515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1c3c7364cedd3d40cf5c95523ef4477308b8947

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55658 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49461 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55379 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/191936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45528 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44212 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/191936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154611 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3097 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193862 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55328 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151251 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56017 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150956 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27597 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45535 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124013 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54530 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53912 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54151 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->