### PR TITLE
Cherry-pick 319510@main (fc8bf507185e). https://bugs.webkit.org/show_bug.cgi?id=322102

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -73,6 +73,9 @@ Ref<PlatformRawAudioData> PlatformRawAudioData::create(Ref<MediaSample>&& sample
 
 RefPtr<PlatformRawAudioData> PlatformRawAudioData::create(std::span<const uint8_t> sourceData, AudioSampleFormat format, float sampleRate, int64_t timestamp, size_t numberOfFrames, size_t numberOfChannels)
 {
+    if (!ensureGStreamerInitialized()) [[unlikely]]
+        return nullptr;
+
     ensureAudioDataDebugCategoryInitialized();
     auto [gstFormat, layout] = convertAudioSampleFormatToGStreamerFormat(format);
 

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -637,6 +637,26 @@ TransformationMatrix SkiaCompositingLayer::combinedTransform(const PaintContext&
     return transform;
 }
 
+static std::optional<SkMatrix> rotateContentsIfNeeded(OptionSet<TextureMapperFlags> flags, const FloatRect& contentsRect)
+{
+    auto rotate = [](float degrees, float x, float y) {
+        auto matrix = SkMatrix::Translate(x, y);
+        matrix.preRotate(degrees);
+        return matrix;
+    };
+
+    if (flags.contains(TextureMapperFlags::ShouldRotateTexture90))
+        return rotate(90, contentsRect.maxX(), contentsRect.y());
+
+    if (flags.contains(TextureMapperFlags::ShouldRotateTexture180))
+        return rotate(180, contentsRect.maxX(), contentsRect.maxY());
+
+    if (flags.contains(TextureMapperFlags::ShouldRotateTexture270))
+        return rotate(270, contentsRect.x(), contentsRect.maxY());
+
+    return std::nullopt;
+}
+
 void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context)
 {
     // Important: the walk does not clip the canvas to the damage, so every content draw below limits
@@ -646,7 +666,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
     // region is never empty, because paint() turns an empty one into a no-op.
     ASSERT(!context.compositingDamageRegion || !context.compositingDamageRegion->isEmpty());
 
-    const SkM44 transform(combinedTransform(context));
+    SkM44 transform(combinedTransform(context));
 
     const auto ctm = transform.asM33();
     bool enableAntialias = !ctm.preservesAxisAlignment() && !ctm.preservesRightAngles();
@@ -735,6 +755,8 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
         }
 
         sk_sp<SkImage> image;
+        std::optional<SkMatrix> rotationMatrix;
+        auto imageRect = m_contentsRect;
 
         if (m_contentsBuffer) {
 #if ENABLE(VIDEO)
@@ -749,6 +771,14 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
             } else
 #endif // ENABLE(VIDEO)
                 image = m_contentsBuffer->skiaImage();
+
+            auto flags = m_contentsBuffer->flags();
+            rotationMatrix = rotateContentsIfNeeded(flags, m_contentsRect);
+            if (rotationMatrix) {
+                imageRect.setLocation({ });
+                if (flags.containsAny({ TextureMapperFlags::ShouldRotateTexture90, TextureMapperFlags::ShouldRotateTexture270 }))
+                    imageRect.setSize(m_contentsRect.size().transposedSize());
+            }
         } else if (auto* buffer = m_imageBackingStore->buffer()) {
             image = buffer->skiaImage();
             if (!m_contentsTiling.size.isEmpty()) {
@@ -764,15 +794,20 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
 
         if (image) {
             if (shouldPaintNow) {
+                if (rotationMatrix)
+                    canvas.concat(*rotationMatrix);
                 SkPaint paint = setupPaint();
-                drawImageRectRestricted(canvas, context.damageRegionOrNull(), image.get(), SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(m_contentsRect),
+                drawImageRectRestricted(canvas, context.damageRegionOrNull(), image.get(), SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(imageRect),
                     SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint);
             } else {
+                if (rotationMatrix)
+                    transform.preConcat(*rotationMatrix);
+
                 // The contents image composites over the backing store, so it must use SrcOver always.
                 if (forcedSrcBlendMode && m_backingStore)
                     context.imageSetBatch.updatePaintProperties(canvas, context.colorFilter, context.blendMode);
 
-                context.imageSetBatch.addImage(canvas, image, m_contentsRect, transform, context.opacity, enableAntialias, context.damageRegionOrNull(), setupPaint());
+                context.imageSetBatch.addImage(canvas, image, imageRect, transform, context.opacity, enableAntialias, context.damageRegionOrNull(), setupPaint());
             }
         }
     }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
@@ -273,7 +273,8 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferYUV::skiaImage()
     }();
 
     SkYUVAInfo info(SkISize::Make(m_size.width(), m_size.height()), planeConfig, subsampling, yuvaColorSpace);
-    GrYUVABackendTextures yuvaBackendTextures(info, backendTextures.data(), kTopLeft_GrSurfaceOrigin);
+    auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
+    GrYUVABackendTextures yuvaBackendTextures(info, backendTextures.data(), origin);
     if (!yuvaBackendTextures.isValid())
         return nullptr;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -309,7 +309,12 @@ void GStreamerVideoCaptureSource::generatePresets()
         }
 
         IntSize size = { width, height };
-        double framerate;
+
+        if (!gst_structure_has_field(str, "framerate")) {
+            presets.append(VideoPreset { { size, { } } });
+            continue;
+        }
+
         Vector<FrameRateRange> frameRates;
         int32_t minFrameRateNumerator, minFrameRateDenominator, maxFrameRateNumerator, maxFrameRateDenominator, framerateNumerator, framerateDenominator;
         if (gst_structure_get(str, "framerate", GST_TYPE_FRACTION_RANGE, &minFrameRateNumerator, &minFrameRateDenominator, &maxFrameRateNumerator, &maxFrameRateDenominator, nullptr)) {
@@ -320,8 +325,10 @@ void GStreamerVideoCaptureSource::generatePresets()
 
             frameRates.append(range);
         } else if (gst_structure_get(str, "framerate", GST_TYPE_FRACTION, &framerateNumerator, &framerateDenominator, nullptr)) {
+            double framerate = 0;
             gst_util_fraction_to_double(framerateNumerator, framerateDenominator, &framerate);
-            frameRates.append({ framerate, framerate});
+            if (framerate)
+                frameRates.append({ framerate, framerate });
         } else {
             for (const auto& framerate : gstStructureGetList<double>(str, "framerate"_s))
                 frameRates.append({ framerate, framerate });


### PR DESCRIPTION
#### 1b1ffa4c8d10937620142e83f27687abd041ebbe
<pre>
Cherry-pick 319510@main (fc8bf507185e). <a href="https://bugs.webkit.org/show_bug.cgi?id=322102">https://bugs.webkit.org/show_bug.cgi?id=322102</a>

    [GTK][WPE] Skia compositor: handle video orientation
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322102">https://bugs.webkit.org/show_bug.cgi?id=322102</a>

    Reviewed by Adrian Perez de Castro.

    We need to check the texture mapper flags and rotate the current
    transformation when rotation flags are present.

    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
    (WebCore::rotateContentsIfNeeded):
    (WebCore::SkiaCompositingLayer::paintContents):
    * Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp:
    (WebCore::CoordinatedPlatformLayerBufferYUV::skiaImage):

    Canonical link: <a href="https://commits.webkit.org/319510@main">https://commits.webkit.org/319510@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.118@webkitglib/2.54">https://commits.webkit.org/317695.118@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 541d1e1e37788aa098d5d1be69f5107bf5bed24c
<pre>
Cherry-pick 319364@main (e9140a53f779). <a href="https://bugs.webkit.org/show_bug.cgi?id=321875">https://bugs.webkit.org/show_bug.cgi?id=321875</a>

    [GStreamer] Web process aborts in gstStructureGetList() when a capture device&apos;s caps have no framerate field
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321875">https://bugs.webkit.org/show_bug.cgi?id=321875</a>

    Reviewed by Nikolas Zimmermann.

    Check for the presence of framerate field in caps before attempting to fill video presets.

    * Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
    (WebCore::GStreamerVideoCaptureSource::generatePresets):

    Canonical link: <a href="https://commits.webkit.org/319364@main">https://commits.webkit.org/319364@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.117@webkitglib/2.54">https://commits.webkit.org/317695.117@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 6a525086ceb99f318f15d6af6392e8f9b5559033
<pre>
Cherry-pick 319360@main (0b7beb9ffda7). <a href="https://bugs.webkit.org/show_bug.cgi?id=321913">https://bugs.webkit.org/show_bug.cgi?id=321913</a>

    [GStreamer][WebCodecs] Ensure GStreamer is initialized when creating PlatformRawAudioData
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321913">https://bugs.webkit.org/show_bug.cgi?id=321913</a>

    Reviewed by Alicia Boya Garcia.

    Make sure GStreamer is initialized, or creating a WebCodecs AudioData from JS might trigger a
    WebProcess crash.

    * Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp:
    (WebCore::PlatformRawAudioData::create):

    Canonical link: <a href="https://commits.webkit.org/319360@main">https://commits.webkit.org/319360@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.116@webkitglib/2.54">https://commits.webkit.org/317695.116@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54c0bda0d6a864771f72ecb44616ab1a41156d47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181720 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/55667 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49470 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191945 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146049 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183582 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/56980 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55388 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141842 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146049 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184675 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/56980 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/49470 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122278 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/56980 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55388 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/49470 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/56980 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49470 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3106 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/48298 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/55388 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193871 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/55337 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/49470 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151261 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56026 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49470 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150965 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27603 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56026 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128309 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124024 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/54539 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/49470 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/53921 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54160 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/53986 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->