### PR TITLE
Support per-child entity transforms for <model> inside a spatial portal

### DIFF
--- a/LayoutTests/spatial-css/resources/spatial-portal-utils.js
+++ b/LayoutTests/spatial-css/resources/spatial-portal-utils.js
@@ -75,3 +75,22 @@ async function waitForPortalTransform(portal, predicate, description, timeout = 
         await sleepForSeconds(0.1);
     }
 }
+
+async function waitForEntityTransform(model, predicate, description, timeout = 5000) {
+    const startTime = Date.now();
+
+    while (true) {
+        const transform = model.entityTransform;
+        if (predicate(transform))
+            return transform;
+
+        if (Date.now() - startTime > timeout)
+            throw new Error(`Timeout waiting for the child's entity transform: ${description}`);
+
+        await sleepForSeconds(0.1);
+    }
+}
+
+// The 3D matrix assertions reject a 2D argument outright, and DOMMatrix stays 2D until an operation touches z.
+const as3d = matrix => new DOMMatrixReadOnly(matrix.toFloat64Array());
+

--- a/LayoutTests/spatial-css/spatial-portal-model-entity-transform-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-model-entity-transform-expected.txt
@@ -1,0 +1,8 @@
+
+PASS an untransformed child reports an identity entityTransform
+PASS entityTransform on a child reads back what was set
+PASS entityTransform is refused while a CSS transform applies
+PASS entityTransform is accepted right after a CSS transform is cleared in the same task
+PASS a CSS transform overrides a transform previously set through entityTransform
+PASS entityTransform is accepted on a child whose stagemode is set
+

--- a/LayoutTests/spatial-css/spatial-portal-model-entity-transform.html
+++ b/LayoutTests/spatial-css/spatial-portal-model-entity-transform.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 400px; height: 300px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+const asset = "2x2x2-center.usdz";
+const translated = as3d(new DOMMatrixReadOnly().translate(200, 0, 0));
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    assert_3d_matrix_is_identity(model.entityTransform, true);
+}, `an untransformed child reports an identity entityTransform`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.entityTransform = translated;
+    assert_3d_matrix_approx_equals(model.entityTransform, translated);
+}, `entityTransform on a child reads back what was set`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.style.translate = "200px 0 0";
+    assert_throws_dom("InvalidStateError", () => {
+        model.entityTransform = translated;
+    });
+}, `entityTransform is refused while a CSS transform applies`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    // Deliberately one task: a stale computed style would make the setter refuse.
+    model.style.translate = "200px 0 0";
+    model.style.translate = "";
+    model.entityTransform = translated;
+
+    assert_3d_matrix_approx_equals(model.entityTransform, translated);
+}, `entityTransform is accepted right after a CSS transform is cleared in the same task`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.entityTransform = as3d(new DOMMatrixReadOnly().translate(-200, 0, 0));
+    model.style.translate = "200px 0 0";
+
+    const overridden = await waitForEntityTransform(model, transform => !transform.isIdentity
+        && Math.abs(transform.m41 - 200) < epsilon, "CSS overriding the scripted transform");
+    assert_3d_matrix_approx_equals(overridden, translated);
+}, `a CSS transform overrides a transform previously set through entityTransform`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset, "orbit");
+    await model.ready;
+
+    model.entityTransform = translated;
+    assert_3d_matrix_approx_equals(model.entityTransform, translated);
+}, `entityTransform is accepted on a child whose stagemode is set`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-model-transform-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-model-transform-expected.txt
@@ -1,0 +1,10 @@
+
+PASS CSS translate on a child becomes its entity transform
+PASS CSS rotate on a child becomes its entity transform
+PASS CSS scale on a child becomes its entity transform
+PASS the CSS transform property on a child becomes its entity transform
+PASS translate and rotate on a child compose in the order css-transforms-2 defines
+PASS a CSS transform on one child leaves its sibling alone
+PASS a transform set before the asset loads is applied once it does
+PASS clearing a CSS transform on a child returns it to identity
+

--- a/LayoutTests/spatial-css/spatial-portal-model-transform-transition-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-model-transform-transition-expected.txt
@@ -1,0 +1,4 @@
+
+PASS a CSS transition on a child's translate is interpolated rather than snapped
+PASS a CSS transition on a child settles on its end value
+

--- a/LayoutTests/spatial-css/spatial-portal-model-transform-transition.html
+++ b/LayoutTests/spatial-css/spatial-portal-model-transform-transition.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 400px; height: 300px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+const asset = "2x2x2-center.usdz";
+
+const sampleWhileAnimating = (model, seconds) => new Promise(resolve => {
+    const deltas = [];
+    const start = performance.now();
+    const tick = () => {
+        deltas.push(model.entityTransform.m41);
+        if (performance.now() - start < seconds * 1000) {
+            requestAnimationFrame(tick);
+            return;
+        }
+        resolve(deltas);
+    };
+    requestAnimationFrame(tick);
+});
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.style.transition = "translate 1s linear";
+    model.style.translate = "400px 0 0";
+
+    const deltas = await sampleWhileAnimating(model, 0.5);
+    const finalDelta = await new Promise(resolve => {
+        t.step_timeout(() => resolve(model.entityTransform.m41), 1000);
+    });
+
+    assert_greater_than(Math.abs(finalDelta), epsilon, "the transition reached a measurable end value");
+
+    const intermediate = deltas.filter(delta => Math.abs(delta) > epsilon
+        && Math.abs(delta) < Math.abs(finalDelta) - epsilon);
+    assert_greater_than(intermediate.length, 0, "the translation passed through intermediate values");
+}, `a CSS transition on a child's translate is interpolated rather than snapped`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.style.transition = "translate 1s linear";
+    model.style.translate = "400px 0 0";
+
+    await new Promise(resolve => t.step_timeout(resolve, 1500));
+    const settled = model.entityTransform.m41;
+
+    model.style.transition = "";
+    model.style.translate = "400px 0 0";
+    const immediate = model.entityTransform.m41;
+
+    assert_approx_equals(settled, immediate, epsilon, "the transition settles on the value it would reach directly");
+}, `a CSS transition on a child settles on its end value`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-model-transform-unsupported-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-model-transform-unsupported-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Ignoring a transform on a <model> inside a spatial portal: only uniform, shear-free transforms are supported.
+CONSOLE MESSAGE: Ignoring a transform on a <model> inside a spatial portal: only uniform, shear-free transforms are supported.
+
+PASS a non-uniform CSS scale on a child is refused and the last accepted transform is kept
+PASS a shearing CSS transform on a child is refused and the last accepted transform is kept
+

--- a/LayoutTests/spatial-css/spatial-portal-model-transform-unsupported.html
+++ b/LayoutTests/spatial-css/spatial-portal-model-transform-unsupported.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 400px; height: 300px; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+const asset = "2x2x2-center.usdz";
+
+// Kept in its own file: a refused transform is the likeliest path to a crash, which would take every test with it.
+const withAcceptedTranslate = async test => {
+    const portal = createPortal(test);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.style.translate = "200px 0 0";
+    const accepted = await waitForEntityTransform(model, transform => !transform.isIdentity, "accepted translate");
+    assert_3d_matrix_approx_equals(accepted, as3d(new DOMMatrixReadOnly().translate(200, 0, 0)));
+
+    return { portal, model, accepted };
+};
+
+// A sleep rather than a wait: there is no positive signal for a transform that was never applied.
+const assertUnchangedAfter = async (model, accepted) => {
+    await sleepForSeconds(0.3);
+    assert_3d_matrix_approx_equals(model.entityTransform, accepted);
+};
+
+promise_test(async t => {
+    const { model, accepted } = await withAcceptedTranslate(t);
+
+    model.style.scale = "1 2 1";
+    await assertUnchangedAfter(model, accepted);
+}, `a non-uniform CSS scale on a child is refused and the last accepted transform is kept`);
+
+promise_test(async t => {
+    const { model, accepted } = await withAcceptedTranslate(t);
+
+    model.style.transform = "matrix3d(1, 0, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)";
+    await assertUnchangedAfter(model, accepted);
+}, `a shearing CSS transform on a child is refused and the last accepted transform is kept`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-model-transform.html
+++ b/LayoutTests/spatial-css/spatial-portal-model-transform.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SpatialPortalEnabled=true ModelElementEnabled=true ModelProcessEnabled=true allowTestOnlyIPC=true ] -->
+<html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../model-element/resources/model-utils.js"></script>
+<script src="resources/spatial-portal-utils.js"></script>
+<style>
+    .portal { spatial: portal; width: 400px; height: 300px; }
+
+    /* In the stylesheet so it applies before the asset resolves. */
+    #preloaded { translate: 200px 0 0; }
+</style>
+<body>
+<script>
+'use strict';
+
+window.internals?.disableModelLoadDelaysForTesting();
+
+const asset = "2x2x2-center.usdz";
+
+const settledEntityTransform = (model, description) =>
+    waitForEntityTransform(model, transform => !transform.isIdentity, description);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.style.translate = "200px 0 0";
+    const transform = await settledEntityTransform(model, "translate");
+
+    assert_3d_matrix_approx_equals(transform, as3d(new DOMMatrixReadOnly().translate(200, 0, 0)));
+}, `CSS translate on a child becomes its entity transform`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.style.rotate = "45deg";
+    const transform = await settledEntityTransform(model, "rotate");
+
+    assert_3d_matrix_approx_equals(transform, as3d(new DOMMatrixReadOnly().rotate(0, 0, 45)));
+}, `CSS rotate on a child becomes its entity transform`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.style.scale = "2 2 2";
+    const transform = await settledEntityTransform(model, "scale");
+
+    assert_3d_matrix_approx_equals(transform, as3d(new DOMMatrixReadOnly().scale3d(2)));
+}, `CSS scale on a child becomes its entity transform`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.style.transform = "rotate3d(0, 1, 0, 45deg)";
+    const transform = await settledEntityTransform(model, "transform");
+
+    assert_3d_matrix_approx_equals(transform, as3d(new DOMMatrixReadOnly().rotate(0, 45, 0)));
+}, `the CSS transform property on a child becomes its entity transform`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.style.translate = "200px 0 0";
+    model.style.rotate = "45deg";
+    const composed = await settledEntityTransform(model, "composed");
+
+    assert_3d_matrix_approx_equals(composed, as3d(new DOMMatrixReadOnly().translate(200, 0, 0).rotate(0, 0, 45)));
+}, `translate and rotate on a child compose in the order css-transforms-2 defines`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const first = appendModel(portal, asset);
+    const second = appendModel(portal, asset);
+    await Promise.all([first.ready, second.ready]);
+
+    first.style.translate = "200px 0 0";
+    await settledEntityTransform(first, "first");
+
+    assert_3d_matrix_is_identity(second.entityTransform, true);
+}, `a CSS transform on one child leaves its sibling alone`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+
+    const preloaded = appendModel(portal, asset);
+    preloaded.id = "preloaded";
+    await preloaded.ready;
+
+    const applied = await settledEntityTransform(preloaded, "a transform authored before the asset resolved");
+    assert_3d_matrix_approx_equals(applied, as3d(new DOMMatrixReadOnly().translate(200, 0, 0)));
+}, `a transform set before the asset loads is applied once it does`);
+
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, asset);
+    await model.ready;
+
+    model.style.translate = "200px 0 0";
+    await settledEntityTransform(model, "translate");
+
+    model.style.translate = "";
+    const cleared = await waitForEntityTransform(model, transform => transform.isIdentity, "cleared");
+    assert_3d_matrix_is_identity(cleared, true);
+}, `clearing a CSS transform on a child returns it to identity`);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/spatial-css/spatial-portal-nested-model-stagemode-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-nested-model-stagemode-expected.txt
@@ -4,4 +4,5 @@ PASS portal-action on the portal takes effect regardless of a nested <model>'s s
 PASS stagemode on a standalone <model> is still honored
 PASS portal-action: orbit fits the content the same way stagemode: orbit fits a standalone <model>
 PASS stagemode becomes live again when a <model> is moved out of a spatial portal
+PASS a CSS transform on a child still applies when its stagemode is set
 

--- a/LayoutTests/spatial-css/spatial-portal-nested-model-stagemode.html
+++ b/LayoutTests/spatial-css/spatial-portal-nested-model-stagemode.html
@@ -105,6 +105,17 @@ promise_test(async t => {
     }, "entityTransform is read-only once the model is no longer nested");
 }, `stagemode becomes live again when a <model> is moved out of a spatial portal`);
 
+promise_test(async t => {
+    const portal = createPortal(t);
+    const subject = appendModel(portal, centeredCube, "orbit");
+    await subject.ready;
+
+    subject.style.translate = "200px 0 0";
+    const applied = await waitForEntityTransform(subject, transform => !transform.isIdentity, "under stage mode");
+
+    assert_3d_matrix_approx_equals(applied, as3d(new DOMMatrixReadOnly().translate(200, 0, 0)));
+}, `a CSS transform on a child still applies when its stagemode is set`);
+
 </script>
 </body>
 </html>

--- a/LayoutTests/spatial-css/spatial-portal-transform-auto-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-transform-auto-expected.txt
@@ -1,3 +1,4 @@
 
 PASS portal-transform: auto scales the portal's content to fit the portal box
+PASS portal-transform: auto ignores a transform on a child model
 

--- a/LayoutTests/spatial-css/spatial-portal-transform-auto.html
+++ b/LayoutTests/spatial-css/spatial-portal-transform-auto.html
@@ -31,6 +31,21 @@ promise_test(async t => {
     assert_3d_matrix_approx_equals(narrowTransform.scale3d(2), wideTransform);
 }, `portal-transform: auto scales the portal's content to fit the portal box`);
 
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, flatRectangle);
+    await model.ready;
+
+    const fit = await waitForPortalTransform(portal, portalTransformIsResolved, "portal");
+
+    model.style.translate = "200px 0 0";
+    model.style.scale = "2 2 2";
+    const applied = await waitForEntityTransform(model, transform => !transform.isIdentity, "child transform");
+
+    assert_3d_matrix_approx_equals(applied, as3d(new DOMMatrixReadOnly().translate(200, 0, 0).scale3d(2)));
+    assert_3d_matrix_approx_equals(resolvedPortalTransform(portal), fit);
+}, `portal-transform: auto ignores a transform on a child model`);
+
 </script>
 </body>
 </html>

--- a/LayoutTests/spatial-css/spatial-portal-transform-none-expected.txt
+++ b/LayoutTests/spatial-css/spatial-portal-transform-none-expected.txt
@@ -1,4 +1,6 @@
 
 PASS portal-transform: none is independent of the portal's size
 PASS portal-transform: none still centers the portal's content
+PASS portal-transform: none keeps centering its content when a child is transformed
+PASS a child's transform does not affect the fit when portal-transform flips to auto
 

--- a/LayoutTests/spatial-css/spatial-portal-transform-none.html
+++ b/LayoutTests/spatial-css/spatial-portal-transform-none.html
@@ -43,6 +43,43 @@ promise_test(async t => {
     assert_3d_matrix_approx_equals(transform, new DOMMatrixReadOnly().translate(-100, -50, -201));
 }, `portal-transform: none still centers the portal's content`);
 
+promise_test(async t => {
+    const portal = createPortal(t);
+    const model = appendModel(portal, offsetCube);
+    await model.ready;
+    await waitForPortalTransform(portal, portalTransformIsResolved, "portal");
+
+    model.style.translate = "200px 0 0";
+    model.style.scale = "2 2 2";
+    const applied = await waitForEntityTransform(model, transform => !transform.isIdentity, "child transform");
+
+    assert_3d_matrix_approx_equals(applied, as3d(new DOMMatrixReadOnly().translate(200, 0, 0).scale3d(2)));
+    assert_3d_matrix_approx_equals(resolvedPortalTransform(portal), new DOMMatrixReadOnly().translate(-100, -50, -201));
+}, `portal-transform: none keeps centering its content when a child is transformed`);
+
+promise_test(async t => {
+    const plainPortal = createPortal(t);
+    const plainModel = appendModel(plainPortal, centeredCube);
+    const transformedPortal = createPortal(t);
+    const transformedModel = appendModel(transformedPortal, centeredCube);
+    await Promise.all([plainModel.ready, transformedModel.ready]);
+
+    transformedModel.style.translate = "200px 0 0";
+    await waitForEntityTransform(transformedModel, transform => !transform.isIdentity, "child transform");
+
+    const plainBefore = await waitForPortalTransform(plainPortal, portalTransformIsResolved, "plain portal");
+    const transformedBefore = await waitForPortalTransform(transformedPortal, portalTransformIsResolved, "transformed portal");
+
+    plainPortal.style.portalTransform = "auto";
+    transformedPortal.style.portalTransform = "auto";
+
+    const refitted = before => transform => transform && !portalTransformsApproxEqual(transform, before);
+    const plainFit = await waitForPortalTransform(plainPortal, refitted(plainBefore), "plain fit");
+    const transformedFit = await waitForPortalTransform(transformedPortal, refitted(transformedBefore), "transformed fit");
+
+    assert_3d_matrix_approx_equals(transformedFit, plainFit);
+}, `a child's transform does not affect the fit when portal-transform flips to auto`);
+
 </script>
 </body>
 </html>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -110,6 +110,8 @@
 #if ENABLE(SPATIAL_PORTAL)
 #include "ElementAncestorIteratorInlines.h"
 #include "SpatialPortalController.h"
+#include "StyleTransformResolver.h"
+#include "TransformOperationData.h"
 #endif
 
 namespace WebCore {
@@ -422,6 +424,19 @@ bool HTMLModelElement::rendererIsNeeded(const Style::ComputedStyle& style)
     return HTMLElement::rendererIsNeeded(style);
 }
 
+ModelPlayer* HTMLModelElement::effectiveModelPlayer() const
+{
+    if (m_modelPlayer)
+        return m_modelPlayer.get();
+
+#if ENABLE(SPATIAL_PORTAL)
+    if (CheckedPtr controller = m_lastRegisteredPortalController.get())
+        return controller->playerForChild(nodeIdentifier());
+#endif
+
+    return nullptr;
+}
+
 #if ENABLE(SPATIAL_PORTAL)
 RefPtr<const Element> HTMLModelElement::findPortalAncestor() const
 {
@@ -452,6 +467,22 @@ SpatialPortalController* HTMLModelElement::lastRegisteredPortalController() cons
     return m_lastRegisteredPortalController.get();
 }
 
+void HTMLModelElement::updateEntityTransformFromCSS()
+{
+    CheckedPtr controller = findPortalController();
+    if (!controller)
+        return;
+
+    CheckedPtr style = computedStyle();
+    if (!style)
+        return;
+
+    using TransformOption = Style::TransformResolver::Option;
+    auto transform = Style::TransformResolver::computeTransform(*style, TransformOperationData(FloatRect { }), { TransformOption::Translate, TransformOption::Rotate, TransformOption::Scale });
+
+    controller->childTransformDidChange(*this, transform);
+}
+
 void HTMLModelElement::updateSpatialPortalController()
 {
     CheckedPtr controller = findPortalController();
@@ -480,6 +511,11 @@ void HTMLModelElement::didFailLoadingInsidePortal(const ResourceError&)
 
     m_dataMemoryCost.store(0, std::memory_order_relaxed);
     reportExtraMemoryCost();
+}
+
+void HTMLModelElement::didUpdateEntityTransformInsidePortal(const TransformationMatrix& transform)
+{
+    m_entityTransform = DOMMatrixReadOnly::create(transform, DOMMatrixReadOnly::Is2D::No);
 }
 
 void HTMLModelElement::spatialPortalContextDidChange()
@@ -1105,14 +1141,34 @@ const DOMMatrixReadOnly& HTMLModelElement::entityTransform() const
 
 ExceptionOr<void> HTMLModelElement::setEntityTransform(const DOMMatrixReadOnly& transform)
 {
+#if ENABLE(SPATIAL_PORTAL)
+    bool insidePortal = isInsidePortal();
+#else
+    constexpr bool insidePortal = false;
+#endif
+
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE)
-    if (canSetEntityTransform())
+    if (!insidePortal && canSetEntityTransform())
         return Exception { ExceptionCode::InvalidStateError, "Transform is read-only unless StageMode is set to 'none'"_s };
 #endif
 
-    auto player = m_modelPlayer;
+#if ENABLE(SPATIAL_PORTAL)
+    if (insidePortal) {
+        Ref document = this->document();
+        document->updateStyleIfNeeded();
+
+        CheckedPtr style = computedStyle();
+        if (style && Style::TransformResolver::hasTransformRelatedProperty(*style))
+            return Exception { ExceptionCode::InvalidStateError, "Transform is read-only while a CSS transform applies to a model inside a spatial portal"_s };
+    }
+#endif
+
+    RefPtr player = effectiveModelPlayer();
     if (!player) {
-        ASSERT_NOT_REACHED();
+#if ENABLE(SPATIAL_PORTAL)
+        if (!insidePortal)
+#endif
+            ASSERT_NOT_REACHED();
         return Exception { ExceptionCode::UnknownError };
     }
 
@@ -1487,19 +1543,6 @@ void HTMLModelElement::setCamera(HTMLModelElementCamera camera, DOMPromiseDeferr
 
 #if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
 
-ModelPlayer* HTMLModelElement::modelPlayerForAnimation() const
-{
-    if (m_modelPlayer)
-        return m_modelPlayer.get();
-
-#if ENABLE(SPATIAL_PORTAL)
-    if (CheckedPtr controller = m_lastRegisteredPortalController.get())
-        return controller->playerForChild(nodeIdentifier());
-#endif
-
-    return nullptr;
-}
-
 void HTMLModelElement::applyInitialAnimationState(ModelPlayer& modelPlayer)
 {
     auto nodeID = nodeIdentifier();
@@ -1515,19 +1558,19 @@ void HTMLModelElement::setPlaybackRate(double playbackRate)
 
     m_playbackRate = playbackRate;
 
-    if (RefPtr modelPlayer = modelPlayerForAnimation())
+    if (RefPtr modelPlayer = effectiveModelPlayer())
         modelPlayer->setPlaybackRate(nodeIdentifier(), playbackRate, [](double) { });
 }
 
 double HTMLModelElement::duration() const
 {
-    RefPtr modelPlayer = modelPlayerForAnimation();
+    RefPtr modelPlayer = effectiveModelPlayer();
     return modelPlayer ? modelPlayer->duration(nodeIdentifier()) : 0;
 }
 
 bool HTMLModelElement::paused() const
 {
-    RefPtr modelPlayer = modelPlayerForAnimation();
+    RefPtr modelPlayer = effectiveModelPlayer();
     return modelPlayer ? modelPlayer->paused(nodeIdentifier()) : true;
 }
 
@@ -1543,7 +1586,7 @@ void HTMLModelElement::pause(DOMPromiseDeferred<void>&& promise)
 
 void HTMLModelElement::setPaused(bool paused, DOMPromiseDeferred<void>&& promise)
 {
-    RefPtr modelPlayer = modelPlayerForAnimation();
+    RefPtr modelPlayer = effectiveModelPlayer();
     if (!modelPlayer) {
         promise.reject();
         return;
@@ -1564,7 +1607,7 @@ bool HTMLModelElement::autoplay() const
 
 void HTMLModelElement::updateAutoplay()
 {
-    if (RefPtr modelPlayer = modelPlayerForAnimation())
+    if (RefPtr modelPlayer = effectiveModelPlayer())
         modelPlayer->setAutoplay(nodeIdentifier(), autoplay());
 }
 
@@ -1575,19 +1618,19 @@ bool HTMLModelElement::loop() const
 
 void HTMLModelElement::updateLoop()
 {
-    if (RefPtr modelPlayer = modelPlayerForAnimation())
+    if (RefPtr modelPlayer = effectiveModelPlayer())
         modelPlayer->setLoop(nodeIdentifier(), loop());
 }
 
 double HTMLModelElement::currentTime() const
 {
-    RefPtr modelPlayer = modelPlayerForAnimation();
+    RefPtr modelPlayer = effectiveModelPlayer();
     return modelPlayer ? modelPlayer->currentTime(nodeIdentifier()).seconds() : 0;
 }
 
 void HTMLModelElement::setCurrentTime(double currentTime)
 {
-    if (RefPtr modelPlayer = modelPlayerForAnimation())
+    if (RefPtr modelPlayer = effectiveModelPlayer())
         modelPlayer->setCurrentTime(nodeIdentifier(), Seconds(currentTime), [] { });
 }
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -107,6 +107,7 @@ public:
 #if ENABLE(SPATIAL_PORTAL)
     void didFinishLoadingInsidePortal();
     void didFailLoadingInsidePortal(const ResourceError&);
+    void didUpdateEntityTransformInsidePortal(const TransformationMatrix&);
     void spatialPortalContextDidChange();
     SpatialPortalController* lastRegisteredPortalController() const;
 #endif
@@ -201,6 +202,11 @@ public:
 #endif
 
     void sizeMayHaveChanged();
+
+#if ENABLE(SPATIAL_PORTAL)
+    bool isInsidePortal() const;
+    void updateEntityTransformFromCSS();
+#endif
 
     void paintCurrentFrameInContext(GraphicsContext&, const FloatRect&);
 
@@ -311,8 +317,9 @@ private:
     RefPtr<const Element> findPortalAncestor() const;
     SpatialPortalController* findPortalController() const;
     void updateSpatialPortalController();
-    bool isInsidePortal() const;
 #endif
+
+    ModelPlayer* effectiveModelPlayer() const;
 
     void reportExtraMemoryCost();
 
@@ -321,8 +328,6 @@ private:
     void updateAutoplay();
     bool loop() const;
     void updateLoop();
-    // A <model> inside a spatial portal has no player of its own; the portal owns one.
-    ModelPlayer* modelPlayerForAnimation() const;
 #endif
 
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.cpp
@@ -326,6 +326,8 @@ void SpatialPortalController::loadChildModelIfReady(HTMLModelElement& model)
 
     it->value.loadedModel = modelData;
 
+    model.updateEntityTransformFromCSS();
+
     if (RefPtr<ModelPlayer> placeholder = std::exchange(it->value.placeholder, nullptr)) {
         auto animationState = placeholder->currentAnimationState(nodeID);
         auto transformState = placeholder->currentTransformState(nodeID);
@@ -707,6 +709,26 @@ void SpatialPortalController::modelDidFailLoading(ModelPlayer&, NodeIdentifier n
 
     if (RefPtr child = it->value.element.get())
         child->didFailLoadingInsidePortal(error);
+}
+
+void SpatialPortalController::childTransformDidChange(HTMLModelElement& model, const TransformationMatrix& transform)
+{
+    auto nodeID = model.nodeIdentifier();
+    if (hostedModelElement(nodeID) != &model)
+        return;
+
+    RefPtr player = m_modelPlayer;
+    if (!player)
+        return;
+
+    if (!player->supportsTransform(transform)) {
+        logWarning(*player, "Ignoring a transform on a <model> inside a spatial portal: only uniform, shear-free transforms are supported."_s);
+        return;
+    }
+
+    player->setEntityTransform(nodeID, transform);
+
+    model.didUpdateEntityTransformInsidePortal(transform);
 }
 
 void SpatialPortalController::modelDidUnload(ModelPlayer& player)

--- a/Source/WebCore/Modules/model-element/SpatialPortalController.h
+++ b/Source/WebCore/Modules/model-element/SpatialPortalController.h
@@ -75,6 +75,7 @@ public:
     void childModelDidChange(HTMLModelElement&);
     void childVisibilityStateChanged(HTMLModelElement&);
     void childWasSuspended(HTMLModelElement&);
+    void childTransformDidChange(HTMLModelElement&, const TransformationMatrix&);
 
     Element* portalElement() const { return m_portalElement.get(); }
     unsigned numberOfHostedModels() const { return m_hostedModels.size(); }

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2740,10 +2740,12 @@ bool KeyframeEffect::ticksContinuouslyWhileActive() const
     if (doesNotAffectStyles)
         return false;
 
-    auto targetHasDisplayContents = [&]() {
-        return m_target && !m_pseudoElementIdentifier && m_target->hasDisplayContents();
+    // A renderer-less target can still have a resolved style kept for it — display:contents, and a <model> inside
+    // a spatial:portal — in which case there is something to animate and this has to keep ticking.
+    auto targetHasStyleToAnimate = [&]() {
+        return m_target && !m_pseudoElementIdentifier && m_target->renderOrDisplayContentsStyle();
     };
-    if (!renderer() && !m_blendingKeyframes.properties().contains(CSSPropertyDisplay) && !targetHasDisplayContents())
+    if (!renderer() && !m_blendingKeyframes.properties().contains(CSSPropertyDisplay) && !targetHasStyleToAnimate())
         return false;
 
     if (isCompletelyAccelerated() && isRunningAccelerated()) {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2886,11 +2886,12 @@ bool Element::computedStyleIsDisplayNone()
 
 void Element::storeDisplayContentsOrNoneStyle(std::unique_ptr<Style::ComputedStyle> style)
 {
-    // This is used by RenderTreeUpdater to store the style for Elements with display:{contents|none}.
+    // This is used by RenderTreeUpdater to store the style for Elements with display:{contents|none}, and for
+    // renderer-less Elements that still need it (see renderOrDisplayContentsStyle()).
     // Normally style is held in renderers but display:contents doesn't generate one.
     // This is kept distinct from ElementRareData::computedStyle() which can update outside style resolution.
     // This way renderOrDisplayContentsStyle() always returns consistent styles matching the rendering state.
-    ASSERT(style && (style->display() == Style::DisplayType::Contents || style->display() == Style::DisplayType::None));
+    ASSERT(style);
     ASSERT(!renderer() || isPseudoElement());
     ensureElementRareData().setDisplayContentsOrNoneStyle(WTF::move(style));
 }
@@ -4811,6 +4812,12 @@ const Style::ComputedStyle* Element::renderOrDisplayContentsStyle(const std::opt
 
     if (hasDisplayContents())
         return elementRareData()->displayContentsOrNoneStyle();
+
+    if (!renderer() && hasRareData()) {
+        auto* style = elementRareData()->displayContentsOrNoneStyle();
+        if (style && style->display() != Style::DisplayType::None)
+            return style;
+    }
 
     return renderStyle();
 }

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -70,6 +70,10 @@
 #include "ContentChangeObserver.h"
 #endif
 
+#if ENABLE(SPATIAL_PORTAL)
+#include "HTMLModelElement.h"
+#endif
+
 namespace WebCore {
 
 RenderTreeUpdater::Parent::Parent(ContainerNode& root)
@@ -462,6 +466,20 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
         if (!elementUpdateStyle.logicalContainIntrinsicHeight().hasAuto())
             element.clearLastRememberedLogicalHeight();
     }
+
+#if ENABLE(SPATIAL_PORTAL)
+    // A <model> inside a spatial portal generates no renderer but drives a 3D entity from its resolved style, so a
+    // copy is kept for it. Cloned, not moved, because createRenderer() below still consumes the original, and only
+    // when the display:{contents|none} store above has not already taken it.
+    RefPtr modelInPortal = dynamicDowncast<HTMLModelElement>(element);
+    if (!hasDisplayContentsOrNone && modelInPortal && !element.renderer() && modelInPortal->isInsidePortal()) {
+        element.storeDisplayContentsOrNoneStyle(Style::ComputedStyle::clonePtr(elementUpdateStyle));
+
+        // Pushed from here rather than during style resolution, which clears the cached computed style before it runs.
+        if (!elementUpdate.changes.isEmpty())
+            modelInPortal->updateEntityTransformFromCSS();
+    }
+#endif
 
     auto scopeExit = makeScopeExit([&] {
         if (!hasDisplayContentsOrNone) {

--- a/Source/WebCore/style/StyleTransformResolver.cpp
+++ b/Source/WebCore/style/StyleTransformResolver.cpp
@@ -44,6 +44,11 @@ TransformResolver::TransformResolver(TransformationMatrix& transform, const Comp
 {
 }
 
+bool TransformResolver::hasTransformRelatedProperty(const ComputedStyle& style)
+{
+    return style.hasTransformRelatedProperty();
+}
+
 bool TransformResolver::affectedByTransformOrigin(const ComputedStyle& style)
 {
     return style.rotate().affectedByTransformOrigin()

--- a/Source/WebCore/style/StyleTransformResolver.h
+++ b/Source/WebCore/style/StyleTransformResolver.h
@@ -55,6 +55,8 @@ public:
 
     explicit TransformResolver(TransformationMatrix&, const ComputedStyle&);
 
+    static bool hasTransformRelatedProperty(const ComputedStyle&);
+
     static bool affectedByTransformOrigin(const ComputedStyle&);
     bool affectedByTransformOrigin() const;
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -206,6 +206,11 @@ private:
         bool loop { false };
         double playbackRate { 1.0 };
         std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore;
+#if ENABLE(SPATIAL_PORTAL)
+        // Set from CSS or the entityTransform attribute. Stored rather than applied directly because it can arrive
+        // before the entity exists, and has to be recomposed whenever the container's scale changes.
+        simd_float4x4 childTransform { matrix_identity_float4x4 };
+#endif
     };
     using TrackedModelMap = HashMap<WebCore::NodeIdentifier, UniqueRef<TrackedModel>>;
 
@@ -219,6 +224,9 @@ private:
     WebCore::StageModeOperation effectiveStageModeOperation() const;
     void updateTransformSRT();
     void notifyModelPlayerOfTransformChange();
+#if ENABLE(SPATIAL_PORTAL)
+    RESRT childEntityTransformSRT(const TrackedModel&) const;
+#endif
     void applyDefaultIBL();
     void updateForCurrentStageMode();
     void setUpLoadedEntity(WebCore::NodeIdentifier, WKRKEntity *);
@@ -270,6 +278,7 @@ private:
 #if ENABLE(SPATIAL_PORTAL)
     WebCore::PortalTransformKind m_portalTransform { WebCore::PortalTransformKind::Auto };
     WebCore::PortalActionKind m_portalAction { WebCore::PortalActionKind::None };
+    bool m_isSpatialPortal { false };
 #endif
 
     // For interactions

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -693,6 +693,27 @@ void ModelProcessModelPlayerProxy::notifyModelPlayerOfTransformChange()
     send(Messages::ModelProcessModelPlayer::DidUpdateEntityTransform(*m_nodeID, transform));
 }
 
+#if ENABLE(SPATIAL_PORTAL)
+
+RESRT ModelProcessModelPlayerProxy::childEntityTransformSRT(const TrackedModel& tracked) const
+{
+    RESRT srt {
+        .scale = tracked.originalEntityScale,
+        .rotation = simd_quaternion(0, simd_make_float3(1, 0, 0)),
+        .translation = simd_make_float3(0, 0, 0),
+    };
+
+    if (simd_equal(tracked.childTransform, matrix_identity_float4x4))
+        return srt;
+
+    RESRT childSRT = REMakeSRTFromMatrix(tracked.childTransform);
+    childSRT.translation /= effectivePointsPerMeter(m_layer.get());
+
+    return REMakeSRTFromMatrix(simd_mul(RESRTMatrix(childSRT), RESRTMatrix(srt)));
+}
+
+#endif // ENABLE(SPATIAL_PORTAL)
+
 void ModelProcessModelPlayerProxy::updateTransform()
 {
     if (!m_layer)
@@ -702,11 +723,17 @@ void ModelProcessModelPlayerProxy::updateTransform()
     if (!m_containerEntityWrapper)
         return;
 
-    // The container owns the global transforms (stagemode, portal-transform) and each model sits beneath with only its original scale applied.
+    // The container owns the global transforms (stagemode, portal-transform) and each model sits beneath with only its own scale and transform applied.
     [m_containerEntityWrapper setTransform:WKEntityTransform({ m_transformSRT.scale, m_transformSRT.rotation, m_transformSRT.translation })];
     for (UniqueRef<TrackedModel>& tracked : m_trackedModels.values()) {
-        if (tracked->entity)
-            [tracked->entity setTransform:WKEntityTransform({ tracked->originalEntityScale, simd_quaternion(0, simd_make_float3(1, 0, 0)), simd_make_float3(0, 0, 0) })];
+        if (!tracked->entity)
+            continue;
+#if ENABLE(SPATIAL_PORTAL)
+        RESRT childSRT = childEntityTransformSRT(tracked);
+#else
+        RESRT childSRT { .scale = tracked->originalEntityScale, .rotation = simd_quaternion(0, simd_make_float3(1, 0, 0)), .translation = simd_make_float3(0, 0, 0) };
+#endif
+        [tracked->entity setTransform:WKEntityTransform({ childSRT.scale, childSRT.rotation, childSRT.translation })];
     }
 #else
     RetainPtr reportingEntity = m_modelRKEntity;
@@ -825,10 +852,20 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
     [m_stageModeInteractionDriver setContainerTransformInPortal];
 #endif // HAVE(CORE_RE)
 
-    if (m_entityTransformToRestore) {
-        setEntityTransform(nodeID, *m_entityTransformToRestore);
+    auto entityTransformToRestore = std::exchange(m_entityTransformToRestore, std::nullopt);
+#if ENABLE(SPATIAL_PORTAL)
+    // FIXME: ModelProcessModelPlayer::m_entityTransform is a single value shared by every child,
+    // so the transform it saves for a reload is whichever child reported last, already composed with the container.
+    // Feeding that back per node would apply the container twice, so it is dropped here instead. A CSS transform
+    // survives regardless, because WebCore re-derives it from style at load; one set through the entityTransform
+    // attribute does not, and is lost across a suspend/resume. Fixed by keying that cache per node.
+    if (m_isSpatialPortal)
+        entityTransformToRestore = std::nullopt;
+#endif
+
+    if (entityTransformToRestore) {
+        setEntityTransform(nodeID, *entityTransformToRestore);
         notifyModelPlayerOfTransformChange();
-        m_entityTransformToRestore = std::nullopt;
     } else {
         computeTransform(true);
         updateTransform();
@@ -1137,8 +1174,25 @@ std::optional<WebCore::LayerHostingContextIdentifier> ModelProcessModelPlayerPro
     return WebCore::LayerHostingContextIdentifier(m_layerHostingContext->contextID());
 }
 
-void ModelProcessModelPlayerProxy::setEntityTransform(WebCore::NodeIdentifier, WebCore::TransformationMatrix transform)
+void ModelProcessModelPlayerProxy::setEntityTransform(WebCore::NodeIdentifier nodeID, WebCore::TransformationMatrix transform)
 {
+#if ENABLE(SPATIAL_PORTAL)
+    if (m_isSpatialPortal) {
+        auto& tracked = ensureTrackedModel(nodeID);
+        simd_float4x4 matrix = transform;
+        if (simd_equal(tracked.childTransform, matrix))
+            return;
+
+        tracked.childTransform = matrix;
+
+        if (RetainPtr entity = tracked.entity) {
+            RESRT childSRT = childEntityTransformSRT(tracked);
+            [entity setTransform:WKEntityTransform({ childSRT.scale, childSRT.rotation, childSRT.translation })];
+        }
+        return;
+    }
+#endif
+
     RESRT newSRT = REMakeSRTFromMatrix(transform);
     m_transformSRT = modelLocalizedTransformSRT(newSRT);
     m_entityTransformSetByScript = true;
@@ -1419,6 +1473,8 @@ void ModelProcessModelPlayerProxy::setHasPortal(bool hasPortal)
 
 void ModelProcessModelPlayerProxy::setPortalTransform(WebCore::PortalTransformKind kind)
 {
+    m_isSpatialPortal = true;
+
     if (m_portalTransform == kind)
         return;
 

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -509,9 +509,9 @@ void ModelProcessModelPlayer::setHasPortal(bool hasPortal)
 
 void ModelProcessModelPlayer::setPortalTransform(WebCore::PortalTransformKind kind)
 {
-    if (m_portalTransform == kind)
-        return;
-
+    // Deliberately unconditional. Skipping the send when the value matches the default
+    // would leave a portal whose portal-transform is the initial `auto` indistinguishable
+    // from a standalone <model>.
     m_portalTransform = kind;
     send(Messages::ModelProcessModelPlayerProxy::SetPortalTransform(m_portalTransform));
 }


### PR DESCRIPTION
#### 4490cd9a89cc244a137d6b0cea780e61b76dbe12
<pre>
Support per-child entity transforms for &lt;model&gt; inside a spatial portal
<a href="https://bugs.webkit.org/show_bug.cgi?id=322166">https://bugs.webkit.org/show_bug.cgi?id=322166</a>
<a href="https://rdar.apple.com/182292326">rdar://182292326</a>

Reviewed by Mike Wyrzykowski.

CSS transform/translate/rotate/scale on a &lt;model&gt; nested in a spatial: portal
now drive that child&apos;s entity, composed as (CSS) x (asset&apos;s original scale),
CSS outermost. The container still owns auto-fit, stage mode and
portal-transform, and a child&apos;s transform stays out of the auto containing
volume. Translations convert from CSS px to meters with pointsPerMeter,
and are deliberately not divided out of the container&apos;s scale: a child
sits inside the back spatial context, so portal-transform fits its position
along with its size.

CSS wins for a nested child: entityTransform throws InvalidStateError while a
CSS transform applies, and CSS overrides one set through the attribute.
stagemode no longer blocks entityTransform in a portal -- it drives the
container, this drives the child. Non-uniform and shearing transforms are
refused, keeping the last accepted one.

Such a child has no renderer, so RenderTreeUpdater keeps its resolved style,
Element::renderOrDisplayContentsStyle() returns it, and
KeyframeEffect::ticksContinuouslyWhileActive() keeps ticking without one;
otherwise transitions only snap.

Tests: spatial-css/spatial-portal-model-entity-transform.html
       spatial-css/spatial-portal-model-transform-transition.html
       spatial-css/spatial-portal-model-transform-unsupported.html
       spatial-css/spatial-portal-model-transform.html

* LayoutTests/spatial-css/resources/spatial-portal-utils.js:
* LayoutTests/spatial-css/spatial-portal-model-entity-transform-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-model-entity-transform.html: Added.
* LayoutTests/spatial-css/spatial-portal-model-transform-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-model-transform-transition-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-model-transform-transition.html: Added.
* LayoutTests/spatial-css/spatial-portal-model-transform-unsupported-expected.txt: Added.
* LayoutTests/spatial-css/spatial-portal-model-transform-unsupported.html: Added.
* LayoutTests/spatial-css/spatial-portal-model-transform.html: Added.
* LayoutTests/spatial-css/spatial-portal-nested-model-stagemode-expected.txt:
* LayoutTests/spatial-css/spatial-portal-nested-model-stagemode.html:
* LayoutTests/spatial-css/spatial-portal-transform-auto-expected.txt:
* LayoutTests/spatial-css/spatial-portal-transform-auto.html:
* LayoutTests/spatial-css/spatial-portal-transform-none-expected.txt:
* LayoutTests/spatial-css/spatial-portal-transform-none.html:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::effectiveModelPlayer const):
(WebCore::HTMLModelElement::updateEntityTransformFromCSS):
(WebCore::HTMLModelElement::didUpdateEntityTransformInsidePortal):
(WebCore::HTMLModelElement::setEntityTransform):
(WebCore::HTMLModelElement::setPlaybackRate):
(WebCore::HTMLModelElement::duration const):
(WebCore::HTMLModelElement::paused const):
(WebCore::HTMLModelElement::setPaused):
(WebCore::HTMLModelElement::updateAutoplay):
(WebCore::HTMLModelElement::updateLoop):
(WebCore::HTMLModelElement::currentTime const):
(WebCore::HTMLModelElement::setCurrentTime):
(WebCore::HTMLModelElement::modelPlayerForAnimation const): Deleted.
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/SpatialPortalController.cpp:
(WebCore::SpatialPortalController::loadChildModelIfReady):
(WebCore::SpatialPortalController::childTransformDidChange):
* Source/WebCore/Modules/model-element/SpatialPortalController.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::ticksContinuouslyWhileActive const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::storeDisplayContentsOrNoneStyle):
(WebCore::Element::renderOrDisplayContentsStyle const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateElementRenderer):
* Source/WebCore/style/StyleTransformResolver.cpp:
(WebCore::Style::TransformResolver::hasTransformRelatedProperty):
* Source/WebCore/style/StyleTransformResolver.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::childEntityTransformSRT const):
(WebKit::ModelProcessModelPlayerProxy::updateTransform):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::setEntityTransform):
(WebKit::ModelProcessModelPlayerProxy::setPortalTransform):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::setPortalTransform):

Canonical link: <a href="https://commits.webkit.org/319629@main">https://commits.webkit.org/319629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9265df283d9c69d57a265b74f9c6cc15aca94b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49810 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe0fb4b5-6208-47e7-949d-6eb468a7fffb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183919 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55727 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/192296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56047fba-8dfc-496b-90b2-c1ebdadff130) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45829 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/702e8b0c-e8b6-4307-8244-26594e8bf242) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/192296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42407 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3447 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194211 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151559 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40582 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56366 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/39032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151263 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45834 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124476 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54877 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17406 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54258 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54497 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54325 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->