### PR TITLE
DisplayList::Recorder has a copy of remote GraphicsContext state per level

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -116,15 +116,24 @@ void GraphicsContextState::filterLastChangesForMatching(const GraphicsContextSta
     });
 }
 
-void GraphicsContextState::copyLastChangesFrom(const GraphicsContextState& state)
+void GraphicsContextState::copyPropertiesFrom(const GraphicsContextState& state, ChangeFlags changes)
 {
-    auto changes = state.m_changeFlags;
     if (!changes)
         return;
     forEachProperty([&](Change change, auto property) {
         if (changes.contains(change))
             this->*property = state.*property;
     });
+}
+
+bool GraphicsContextState::propertiesEqual(const GraphicsContextState& other) const
+{
+    bool equal = true;
+    forEachProperty([&](Change, auto property) {
+        if (!(this->*property == other.*property))
+            equal = false;
+    });
+    return equal;
 }
 
 static ASCIILiteral stateChangeName(GraphicsContextState::Change change)

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -140,8 +140,12 @@ public:
     // Removes change bit for each property that matches another state property.
     WEBCORE_EXPORT void filterLastChangesForMatching(const GraphicsContextState&);
 
-    // Copies properties that are marked changed in another state.
-    WEBCORE_EXPORT void copyLastChangesFrom(const GraphicsContextState&);
+    // Copies the given properties from another state, without marking them changed here. Used to
+    // track what the underlying context has been given.
+    WEBCORE_EXPORT void copyPropertiesFrom(const GraphicsContextState&, ChangeFlags);
+
+    // Whether every property holds the same value, ignoring changes() and purpose(). For assertions.
+    WEBCORE_EXPORT bool propertiesEqual(const GraphicsContextState&) const;
 
     Purpose purpose() const { return m_purpose; }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -47,6 +47,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(Recorder);
 
 Recorder::Recorder(IsDeferred isDeferred, const GraphicsContextState& state, const FloatRect& initialClip, const AffineTransform& initialCTM, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode)
     : GraphicsContext(isDeferred, state)
+    , m_committedState(state)
     , m_colorSpace(colorSpace)
     , m_initialClip(initialCTM.mapRect(initialClip))
     , m_drawGlyphsMode(drawGlyphsMode)
@@ -55,7 +56,7 @@ Recorder::Recorder(IsDeferred isDeferred, const GraphicsContextState& state, con
 #endif
 {
     ASSERT(!state.changes());
-    m_stateStack.append({ initialCTM, initialCTM.mapRect(initialClip) });
+    m_stateStack.append({ initialCTM, initialCTM.mapRect(initialClip), { } });
 }
 
 Recorder::~Recorder()
@@ -105,7 +106,7 @@ void Recorder::updateStateForSave(GraphicsContextState::Purpose purpose)
     ASSERT(purpose == GraphicsContextState::Purpose::SaveRestore);
     appendStateChangeItemIfNecessary();
     GraphicsContext::save(purpose);
-    m_stateStack.append(m_stateStack.last());
+    m_stateStack.append(ContextState { currentState().ctm, currentState().clipBounds, { } });
 }
 
 bool Recorder::updateStateForRestore(GraphicsContextState::Purpose purpose)
@@ -115,10 +116,25 @@ bool Recorder::updateStateForRestore(GraphicsContextState::Purpose purpose)
 
     ASSERT(purpose == GraphicsContextState::Purpose::SaveRestore);
     appendStateChangeItemIfNecessary();
+    auto committedChanges = currentState().committedChanges;
     GraphicsContext::restore(purpose);
-
     m_stateStack.removeLast();
+    m_committedState.copyPropertiesFrom(m_state, committedChanges);
+    ASSERT(m_state.propertiesEqual(m_committedState));
     return true;
+}
+
+GraphicsContextState::ChangeFlags Recorder::computeStateChanges()
+{
+    m_state.filterLastChangesForMatching(m_committedState);
+    return m_state.changes();
+}
+
+void Recorder::commitStateChanges(GraphicsContextState::ChangeFlags changes)
+{
+    m_committedState.copyPropertiesFrom(m_state, changes);
+    currentState().committedChanges.add(changes);
+    m_state.didApplyChanges();
 }
 
 bool Recorder::updateStateForTranslate(float x, float y)
@@ -169,7 +185,7 @@ void Recorder::updateStateForBeginTransparencyLayer(float opacity)
     GraphicsContext::beginTransparencyLayer(opacity);
     appendStateChangeItemIfNecessary();
     GraphicsContext::save(GraphicsContextState::Purpose::TransparencyLayer);
-    m_stateStack.append(m_stateStack.last().cloneForTransparencyLayer());
+    pushStateForTransparencyLayer();
 }
 
 void Recorder::updateStateForBeginTransparencyLayer(CompositeOperator compositeOperator, BlendMode blendMode)
@@ -177,7 +193,17 @@ void Recorder::updateStateForBeginTransparencyLayer(CompositeOperator compositeO
     GraphicsContext::beginTransparencyLayer(compositeOperator, blendMode);
     appendStateChangeItemIfNecessary();
     GraphicsContext::save(GraphicsContextState::Purpose::TransparencyLayer);
-    m_stateStack.append(m_stateStack.last().cloneForTransparencyLayer());
+    pushStateForTransparencyLayer();
+}
+
+void Recorder::pushStateForTransparencyLayer()
+{
+    // Beginning a transparency layer resets part of the state in the underlying context, the same
+    // properties GraphicsContextState::repurpose() has just reset in m_state, so resynchronise
+    // m_committedState with m_state wholesale rather than assuming the two resets agree. Mark the whole
+    // state as pushed by this level so that ending the layer rolls all of it back.
+    m_committedState.copyPropertiesFrom(m_state, GraphicsContextState::ChangeFlags::all());
+    m_stateStack.append(ContextState { currentState().ctm, currentState().clipBounds, GraphicsContextState::ChangeFlags::all() });
 }
 
 bool Recorder::updateStateForEndTransparencyLayer()
@@ -186,8 +212,11 @@ bool Recorder::updateStateForEndTransparencyLayer()
         return false;
     GraphicsContext::endTransparencyLayer();
     appendStateChangeItemIfNecessary();
+    auto committedChanges = currentState().committedChanges;
     m_stateStack.removeLast();
     GraphicsContext::restore(GraphicsContextState::Purpose::TransparencyLayer);
+    m_committedState.copyPropertiesFrom(m_state, committedChanges);
+    ASSERT(m_state.propertiesEqual(m_committedState));
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -80,15 +80,8 @@ protected:
     struct ContextState {
         AffineTransform ctm;
         FloatRect clipBounds;
-        std::optional<GraphicsContextState> lastDrawingState { std::nullopt };
-
-        ContextState cloneForTransparencyLayer() const
-        {
-            std::optional<GraphicsContextState> lastDrawingStateClone;
-            if (lastDrawingState)
-                lastDrawingStateClone = lastDrawingState->clone(GraphicsContextState::Purpose::TransparencyLayer);
-            return ContextState { ctm, clipBounds, WTF::move(lastDrawingStateClone) };
-        }
+        // GraphicsContextState properties to sync after restore().
+        GraphicsContextState::ChangeFlags committedChanges;
 
         void NODELETE translate(float x, float y);
         void rotate(float angleInRadians);
@@ -126,6 +119,11 @@ protected:
     WEBCORE_EXPORT FloatRect initialClip() const;
     DrawGlyphsMode drawGlyphsMode() const { return m_drawGlyphsMode; }
 
+    // The state difference between set GraphicsContext state and
+    // committed recording state.
+    WEBCORE_EXPORT GraphicsContextState::ChangeFlags computeStateChanges();
+    WEBCORE_EXPORT void commitStateChanges(GraphicsContextState::ChangeFlags);
+
     const DestinationColorSpace& colorSpace() const LIFETIME_BOUND final { return m_colorSpace; }
 
 private:
@@ -146,9 +144,13 @@ private:
 
     virtual void appendStateChangeItemIfNecessary() = 0;
 
+    void pushStateForTransparencyLayer();
+
     const AffineTransform& NODELETE ctm() const;
 
     Vector<ContextState, 4> m_stateStack;
+    // The state the committed to the recording.
+    GraphicsContextState m_committedState;
     DestinationColorSpace m_colorSpace;
     const FloatRect m_initialClip;
     const DrawGlyphsMode m_drawGlyphsMode { DrawGlyphsMode::Normal };

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -501,26 +501,13 @@ void RecorderImpl::setURLForRect(const URL& link, const FloatRect& destRect)
 void RecorderImpl::appendStateChangeItemIfNecessary()
 {
     auto& state = m_state;
-    auto& lastDrawingState = currentState().lastDrawingState;
-    if (lastDrawingState)
-        state.filterLastChangesForMatching(*lastDrawingState);
-    auto changes = state.changes();
+    auto changes = computeStateChanges();
     if (!changes)
         return;
 
-    auto didApplyChanges = [&] {
-        if (lastDrawingState)
-            lastDrawingState->copyLastChangesFrom(state);
-        else {
-            lastDrawingState = state;
-            lastDrawingState->didApplyChanges();
-        }
-        state.didApplyChanges();
-    };
-
     auto recordFullItem = [&] {
         m_items.append(SetState(state));
-        didApplyChanges();
+        commitStateChanges(changes);
     };
 
     if (!changes.containsOnly({ GraphicsContextState::Change::FillBrush, GraphicsContextState::Change::StrokeBrush, GraphicsContextState::Change::StrokeThickness })) {
@@ -552,7 +539,7 @@ void RecorderImpl::appendStateChangeItemIfNecessary()
     if (strokeColor || strokeThickness)
         m_items.append(SetInlineStroke(strokeColor, strokeThickness));
 
-    didApplyChanges();
+    commitStateChanges(changes);
 }
 
 void RecorderImpl::drawPlaceholder(Function<void(GraphicsContext&)>&& function)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -885,12 +885,10 @@ RefPtr<ImageBuffer> RemoteGraphicsContextProxy::createAlignedImageBuffer(const F
 void RemoteGraphicsContextProxy::appendStateChangeItemIfNecessary()
 {
     auto& state = m_state;
-    auto& lastDrawingState = currentState().lastDrawingState;
-    if (lastDrawingState)
-        state.filterLastChangesForMatching(*lastDrawingState);
-    auto changes = state.changes();
-    if (!changes)
+    auto pendingChanges = computeStateChanges();
+    if (!pendingChanges)
         return;
+    auto changes = pendingChanges;
     if (changes.contains(GraphicsContextState::Change::FillBrush)) {
         const auto& fillBrush = state.fillBrush();
         if (auto packedColor = fillBrush.packedColor())
@@ -966,22 +964,13 @@ void RemoteGraphicsContextProxy::appendStateChangeItemIfNecessary()
     if (changes.contains(GraphicsContextState::Change::DrawLuminanceMask))
         send(Messages::RemoteGraphicsContext::SetDrawLuminanceMask(state.drawLuminanceMask()));
 
-    if (lastDrawingState)
-        lastDrawingState->copyLastChangesFrom(state);
-    else {
-        lastDrawingState = state;
-        lastDrawingState->didApplyChanges();
-    }
-    state.didApplyChanges();
+    commitStateChanges(pendingChanges);
 }
 
 std::optional<RemoteGraphicsContextProxy::InlineStrokeData> RemoteGraphicsContextProxy::inlineStrokeStateIfBatchable()
 {
     auto& state = m_state;
-    auto& lastDrawingState = currentState().lastDrawingState;
-    if (lastDrawingState)
-        state.filterLastChangesForMatching(*lastDrawingState);
-    auto changes = state.changes();
+    auto changes = computeStateChanges();
     // Only fold the line into the batch if the sole pending state changes are
     // stroke color and/or thickness; anything else has to go through the normal
     // state-flush path.
@@ -993,21 +982,10 @@ std::optional<RemoteGraphicsContextProxy::InlineStrokeData> RemoteGraphicsContex
         return std::nullopt; // Gradient/pattern stroke: not representable inline.
 
     if (changes) {
-        // The stroke color/thickness travel inline with each buffered line, so
-        // mark them applied and keep lastDrawingState in sync for future diffs.
-        if (!lastDrawingState)
-            lastDrawingState = state;
-        else {
-            if (changes.contains(GraphicsContextState::Change::StrokeBrush)) {
-                // Set through strokeBrush() to avoid comparison. Only the color is copied: the GPU
-                // process applies the inline color on top of whatever brush it already has.
-                lastDrawingState->strokeBrush().setColor(state.strokeBrush().color());
-            }
-            if (changes.contains(GraphicsContextState::Change::StrokeThickness))
-                lastDrawingState->setStrokeThickness(state.strokeThickness());
-        }
-        state.didApplyChanges();
-        lastDrawingState->didApplyChanges();
+        // The stroke color and thickness travel inline with each buffered line. The GPU process
+        // applies them with setStrokeColor()/setStrokeThickness(), which replace the whole brush, so
+        // this is exactly the same state change the normal flush path would have made.
+        commitStateChanges(changes);
     }
     return InlineStrokeData { *packedColor, state.strokeThickness() };
 }


### PR DESCRIPTION
#### 65713772d8209dc7799659f689e84a216859c8dc
<pre>
DisplayList::Recorder has a copy of remote GraphicsContext state per level
<a href="https://bugs.webkit.org/show_bug.cgi?id=322168">https://bugs.webkit.org/show_bug.cgi?id=322168</a>
<a href="https://rdar.apple.com/185398807">rdar://185398807</a>

Reviewed by Matt Woodrow.

DisplayList::Recorder would maintain the full GraphicsContext state
in its save state stack. This used for two reasons:
1. When GraphicsContext state changes, the recorder does not immediately
   record the state change items. The record happens only when
   an item is recorded that does actual work (draw, save, restore).
2. Upon restore, the level was popped from the stack and the new
   top of the stack state entry would describe the state the remote was
   in.

Fullfill the 1. with maintaining one &quot;state currently committed to
recording&quot; flag. So any GraphicsContext state changes on top of that
needs to be sent when encountering item for actual work.

The 2. is unneeded, as after restore(), the recorded and local
GraphicsContext state must match.

Related to 2.:
Record only &quot;changes done in current state stack entry&quot;, in order to
speed up the state assign after restore(). Look at the changes
to know which properties were modified, so then copy those properties
back instead of the whole state object.

* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::copyPropertiesFrom):
(WebCore::GraphicsContextState::propertiesEqual const):
(WebCore::GraphicsContextState::copyLastChangesFrom): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextState.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::Recorder):
(WebCore::DisplayList::Recorder::updateStateForSave):
(WebCore::DisplayList::Recorder::updateStateForRestore):
(WebCore::DisplayList::Recorder::computeStateChanges):
(WebCore::DisplayList::Recorder::commitStateChanges):
(WebCore::DisplayList::Recorder::updateStateForBeginTransparencyLayer):
(WebCore::DisplayList::Recorder::pushStateForTransparencyLayer):
(WebCore::DisplayList::Recorder::updateStateForEndTransparencyLayer):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
(WebCore::DisplayList::Recorder::ContextState::cloneForTransparencyLayer const): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::appendStateChangeItemIfNecessary):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::appendStateChangeItemIfNecessary):
(WebKit::RemoteGraphicsContextProxy::inlineStrokeStateIfBatchable):

Canonical link: <a href="https://commits.webkit.org/319874@main">https://commits.webkit.org/319874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5d2144009546a5c10cba4112fcf2d146b8c51eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191942 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146046 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/263b2844-200d-41b5-a13f-b25f62b404a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141845 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98467 "3 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/916f9d74-70ab-464a-bc95-2e144bafec9b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122281 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b37a94d-dd37-420a-8937-0a61331f268c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44221 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42488 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154620 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42122 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3103 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193868 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55334 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151260 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40818 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56023 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150964 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45541 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128306 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124021 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54536 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17118 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53918 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54157 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53983 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->