### PR TITLE
REGRESSION(319506@main): HAVE(APPKIT_GESTURES_SUPPORT) build is broken ('AppKitGesturesTests.RefreshControl' does not conform to protocol 'AppKitGestureTestSuite')

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/RefreshControlGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/RefreshControlGesturesTests.swift
@@ -36,6 +36,8 @@ extension AppKitGesturesTests {
     @MainActor
     @Suite(.serialized, .timeLimit(.minutes(1)))
     final class RefreshControl: AppKitGestureTestSuite {
+        static let text = "Here's to the crazy ones."
+
         @MainActor
         private final class RefreshCounter {
             var count = 0


### PR DESCRIPTION
#### dd6bb17e781c65e0d85d219905c7c59f14ebea83
<pre>
REGRESSION(319506@main): HAVE(APPKIT_GESTURES_SUPPORT) build is broken (&apos;AppKitGesturesTests.RefreshControl&apos; does not conform to protocol &apos;AppKitGestureTestSuite&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=322169">https://bugs.webkit.org/show_bug.cgi?id=322169</a>
<a href="https://rdar.apple.com/185399358">rdar://185399358</a>

Unreviewed build fix.

This patch addresses the following build error:

```
/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/RefreshControlGesturesTests.swift:38:17: error: type &apos;AppKitGesturesTests.RefreshControl&apos; does not conform to protocol &apos;AppKitGestureTestSuite&apos;
    final class RefreshControl: AppKitGestureTestSuite {
/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/RefreshControlGesturesTests.swift:38:17: note: add stubs for conformance
    final class RefreshControl: AppKitGestureTestSuite {
/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift:78:16: note: protocol requires property &apos;text&apos; with type &apos;String&apos;
    static var text: String { get }
```

I regrettably dropped the `static var text` value from the RefreshControl
class, which meant it no longer conformed to the AppKitGestureTestSuite
protocol. We fix the issue in this patch.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/RefreshControlGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/319517@main">https://commits.webkit.org/319517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80fc910feeb43bf72f8bed03f5799fc937f2ea72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55665 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49468 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191943 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75118ae3-1792-43c6-a6d8-30d4ee089930) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55386 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe06ab75-02f2-4e1e-b960-8da2dc35cf5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184673 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/122283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55595860-8b1c-4291-a749-fad37fc1b80c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/154618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/42124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3104 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193869 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55335 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/162095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56024 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/150963 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27600 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/45542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124022 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54537 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/17120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53919 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54158 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53984 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->