### PR TITLE
[Canvas] roundRect() and the Path2D constructor should use the spec's single union-typed argument instead of overloads

### DIFF
--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -242,12 +242,7 @@ void CanvasPath::rect(float x, float y, float width, float height)
     m_path.addRect(FloatRect(x, y, width, height));
 }
 
-ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float height, const RadiusVariant& radii)
-{
-    return roundRect(x, y, width, height, singleElementSpan(radii));
-}
-
-ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float height, std::span<const RadiusVariant> radii)
+ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float height, const RadiiVariant& radii)
 {
     // Based on Nov 5th 2021 version of https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-roundrect
     // 1. If any of x, y, w, or h are infinite or NaN, then return.
@@ -255,15 +250,26 @@ ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float hei
     if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(width) || !std::isfinite(height))
         return { };
 
+    // If radii is an unrestricted double or DOMPointInit, then set radii to « radii ».
+    RadiusVariant singleRadius;
+    auto radiiList = WTF::switchOn(radii,
+        [](const Vector<RadiusVariant>& radiiSequence) -> std::span<const RadiusVariant> {
+            return radiiSequence.span();
+        },
+        [&](const auto& radius) -> std::span<const RadiusVariant> {
+            singleRadius = radius;
+            return singleElementSpan(std::as_const(singleRadius));
+        });
+
     // 2. If radii is not a list of size one, two, three, or four, then throw a RangeError.
-    if (radii.size() > 4 || radii.empty())
-        return Exception { ExceptionCode::RangeError, makeString("radii must contain at least 1 element, up to 4. It contained "_s, radii.size(), " elements."_s) };
+    if (radiiList.size() > 4 || radiiList.empty())
+        return Exception { ExceptionCode::RangeError, makeString("radii must contain at least 1 element, up to 4. It contained "_s, radiiList.size(), " elements."_s) };
 
     // 3. Let normalizedRadii be an empty list.
     Vector<FloatPoint, 4> normalizedRadii;
 
     // 4. For each radius of radii:
-    for (auto& radius : radii) {
+    for (auto& radius : radiiList) {
         auto shouldReturnSilently = false;
         auto exception = WTF::switchOn(radius,
             // 4.1 If radius is a DOMPointInit:

--- a/Source/WebCore/html/canvas/CanvasPath.h
+++ b/Source/WebCore/html/canvas/CanvasPath.h
@@ -39,6 +39,7 @@ template<typename> class ExceptionOr;
 class CanvasPath {
 public:
     using RadiusVariant = Variant<double, DOMPointInit>;
+    using RadiiVariant = Variant<double, DOMPointInit, Vector<RadiusVariant>>;
     virtual ~CanvasPath() = default;
 
     void closePath();
@@ -50,8 +51,7 @@ public:
     ExceptionOr<void> arc(float x, float y, float r, float sa, float ea, bool anticlockwise);
     ExceptionOr<void> ellipse(float x, float y, float radiusX, float radiusY, float rotation, float startAngle, float endAngled, bool anticlockwise);
     void rect(float x, float y, float width, float height);
-    ExceptionOr<void> roundRect(float x, float y, float width, float height, const RadiusVariant& radii);
-    ExceptionOr<void> roundRect(float x, float y, float width, float height, std::span<const RadiusVariant> radii);
+    ExceptionOr<void> roundRect(float x, float y, float width, float height, const RadiiVariant&);
 
     float currentX() const;
     float currentY() const;

--- a/Source/WebCore/html/canvas/CanvasPath.idl
+++ b/Source/WebCore/html/canvas/CanvasPath.idl
@@ -35,8 +35,7 @@ interface mixin CanvasPath {
     undefined bezierCurveTo(unrestricted double cp1x, unrestricted double cp1y, unrestricted double cp2x, unrestricted double cp2y, unrestricted double x, unrestricted double y);
     undefined arcTo(unrestricted double x1, unrestricted double y1, unrestricted double x2, unrestricted double y2, unrestricted double radius);
     undefined rect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h);
-    undefined roundRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h, sequence<(unrestricted double or DOMPointInit)> radii);
-    undefined roundRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h, optional (unrestricted double or DOMPointInit) radii = 0.0);
+    undefined roundRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h, optional (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>) radii = 0.0);
     undefined arc(unrestricted double x, unrestricted double y, unrestricted double radius, unrestricted double startAngle, unrestricted double endAngle, optional boolean anticlockwise = false);
     undefined ellipse(unrestricted double x, unrestricted double y, unrestricted double radiusX, unrestricted double radiusY, unrestricted double rotation, unrestricted double startAngle, unrestricted double endAngle, optional boolean anticlockwise = false);
 };

--- a/Source/WebCore/html/canvas/Path2D.cpp
+++ b/Source/WebCore/html/canvas/Path2D.cpp
@@ -31,6 +31,7 @@
 #include "AffineTransform.h"
 #include "DOMMatrix2DInit.h"
 #include "DOMMatrixReadOnly.h"
+#include "SVGPathUtilities.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -38,6 +39,20 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Path2D);
 
 Path2D::~Path2D() = default;
+
+Ref<Path2D> Path2D::create(std::optional<PathInit>&& path)
+{
+    if (!path)
+        return adoptRef(*new Path2D);
+
+    return WTF::switchOn(WTF::move(*path),
+        [](Ref<Path2D>&& other) {
+            return create(other->path());
+        },
+        [](String&& pathData) {
+            return create(buildPathFromString(pathData));
+        });
+}
 
 ExceptionOr<void> Path2D::addPath(Path2D& path, DOMMatrix2DInit&& matrixInit)
 {

--- a/Source/WebCore/html/canvas/Path2D.h
+++ b/Source/WebCore/html/canvas/Path2D.h
@@ -28,9 +28,9 @@
 #pragma once
 
 #include "CanvasPath.h"
-#include "SVGPathUtilities.h"
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -39,26 +39,15 @@ struct DOMMatrix2DInit;
 class WEBCORE_EXPORT Path2D final : public RefCounted<Path2D>, public CanvasPath {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(Path2D, WEBCORE_EXPORT);
 public:
+    using PathInit = Variant<Ref<Path2D>, String>;
+
     virtual ~Path2D();
 
-    static Ref<Path2D> create()
-    {
-        return adoptRef(*new Path2D);
-    }
+    static Ref<Path2D> create(std::optional<PathInit>&&);
 
     static Ref<Path2D> create(const Path& path)
     {
         return adoptRef(*new Path2D(path));
-    }
-
-    static Ref<Path2D> create(const Path2D& path)
-    {
-        return create(path.path());
-    }
-
-    static Ref<Path2D> create(StringView pathData)
-    {
-        return create(buildPathFromString(pathData));
     }
 
     ExceptionOr<void> addPath(Path2D&, DOMMatrix2DInit&&);

--- a/Source/WebCore/html/canvas/Path2D.idl
+++ b/Source/WebCore/html/canvas/Path2D.idl
@@ -30,11 +30,9 @@
     Exposed=(Window,Worker),
     ExportMacro=WEBCORE_EXPORT
 ] interface Path2D {
-    constructor();
-    constructor(Path2D path);
+    constructor(optional (Path2D or DOMString) path);
     // FIXME: Implement missing constructor.
     // constructor(sequence<Path2D> paths, optional CanvasFillRule fillRule = "nonzero");
-    constructor(DOMString d);
 
     undefined addPath(Path2D path, optional DOMMatrix2DInit transform = {});
 };

--- a/Source/WebCore/inspector/InspectorCanvasArguments.cpp
+++ b/Source/WebCore/inspector/InspectorCanvasArguments.cpp
@@ -42,6 +42,7 @@
 #include "GPURenderPipelineDescriptor.h"
 #include "GPUShaderModuleDescriptor.h"
 #include "Path2D.h"
+#include "SVGPathUtilities.h"
 #include "WebGLBuffer.h"
 #include "WebGLFramebuffer.h"
 #include "WebGLProgram.h"


### PR DESCRIPTION
#### 0c4dcd74009d3566d369778f24cbb3c37997fb51
<pre>
[Canvas] roundRect() and the Path2D constructor should use the spec&apos;s single union-typed argument instead of overloads
<a href="https://bugs.webkit.org/show_bug.cgi?id=322170">https://bugs.webkit.org/show_bug.cgi?id=322170</a>
<a href="https://rdar.apple.com/185401231">rdar://185401231</a>

Reviewed by NOBODY (OOPS!).

Both operations were split into multiple IDL overloads even though the spec
declares each with a single optional union-typed argument. The split was not a
code generator limitation: sequences inside unions already work (css/DOMMatrix.idl)
and so do unions inside sequences inside unions (animation/ViewTimelineOptions.idl).

Collapse roundRect() to the spec&apos;s

- optional (unrestricted double or DOMPointInit or sequence&lt;(unrestricted double or DOMPointInit)&gt;) radii = 0.0

and the Path2D constructor to

- constructor(optional (Path2D or DOMString) path)

so each has one native implementation instead of two and three respectively.
CanvasPath::roundRect() now normalizes the argument up front, mapping the
sequence case to a span over the vector and the single-value case to a span over
a local, which keeps the sequence path allocation-free. The std::span overload is
removed and its body folded into the remaining function.

Path2D::create() moves out of line to Path2D.cpp; create(const Path&amp;) stays for
CanvasRenderingContext2DBase. Path2D.h no longer needs SVGPathUtilities.h, so
InspectorCanvasArguments.cpp includes it directly for buildStringFromPath().

The default is spelled 0.0 rather than the spec&apos;s 0 because the generated
Converter&lt;IDLUnion&lt;...&gt;&gt;::ReturnType { 0 } brace-initializes a Variant from an
int, and mpark::variant&apos;s converting constructor treats int -&gt; double as
narrowing, which removes the only viable alternative.

No change in behavior and covered by existing tests.

* Source/WebCore/html/canvas/CanvasPath.cpp:
(WebCore::CanvasPath::roundRect):
* Source/WebCore/html/canvas/CanvasPath.h:
* Source/WebCore/html/canvas/CanvasPath.idl:
* Source/WebCore/html/canvas/Path2D.cpp:
(WebCore::Path2D::create):
* Source/WebCore/html/canvas/Path2D.h:
* Source/WebCore/html/canvas/Path2D.idl:
* Source/WebCore/inspector/InspectorCanvasArguments.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c4dcd74009d3566d369778f24cbb3c37997fb51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147024 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64286d3f-d6a9-4e3e-91de-691c7bf3ccef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142614 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99024 "3 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25a2b59c-ea50-42aa-b00b-f00abde26ad2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123049 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0aeb148-80bc-4611-a579-30b9cb7a37e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45025 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43275 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42904 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4125 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194895 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56329 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152067 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57033 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151767 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46340 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129301 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125333 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55541 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17907 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54913 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55151 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54979 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->