### PR TITLE
2D canvas beginLayer() resets shadowColor to opaque black and re-parses constant strings

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.layer-rendering-state-reset-in-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.layer-rendering-state-reset-in-layer-expected.txt
@@ -2,5 +2,5 @@
 Tests that rendering states are reset in layers and restored after.
 Actual output:
 
-FAIL Tests that rendering states are reset in layers and restored after. assert_equals: ctx.shadowColor === 'rgba(0, 0, 0, 0)' (got #000000[string], expected rgba(0, 0, 0, 0)[string]) expected "rgba(0, 0, 0, 0)" but got "#000000"
+PASS Tests that rendering states are reset in layers and restored after.
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -587,14 +587,22 @@ void CanvasRenderingContext2DBase::beginLayer()
 
     modifiableState().targetSwitcher = CanvasLayerContextSwitcher::create(*this, backingStoreBounds(), WTF::move(filter));
 
-    // Reset layer rendering state.
-    setGlobalAlpha(1.0);
-    setGlobalCompositeOperation("source-over"_s);
-    setShadowOffsetX(0);
-    setShadowOffsetY(0);
-    setShadowBlur(0);
-    setShadowColor("black"_s);
-    setFilterString("none"_s);
+    // Reset layer rendering state to its defaults.
+    auto& state = modifiableState();
+    state.globalAlpha = 1;
+    state.globalComposite = CompositeOperator::SourceOver;
+    state.globalBlend = BlendMode::Normal;
+    state.shadowOffset = { };
+    state.shadowBlur = 0;
+    state.shadowColor = Color::transparentBlack;
+    state.filterString = "none"_s;
+    state.filter = Style::Filter { CSS::Keyword::None { } };
+
+    if (auto* c = effectiveDrawingContext()) {
+        c->setAlpha(1);
+        c->setCompositeOperation(CompositeOperator::SourceOver, BlendMode::Normal);
+        c->setDropShadow({ { }, 0, Color::transparentBlack, ShadowRadiusMode::Legacy });
+    }
 }
 
 void CanvasRenderingContext2DBase::endLayer()


### PR DESCRIPTION
#### 5fb77d6068fb458d3b75048ea19c074eb8970cf2
<pre>
2D canvas beginLayer() resets shadowColor to opaque black and re-parses constant strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=322172">https://bugs.webkit.org/show_bug.cgi?id=322172</a>
<a href="https://rdar.apple.com/185404307">rdar://185404307</a>

Reviewed by Gerald Squelart.

beginLayer() reset the layer rendering state by calling the public setters with
constant strings. That was both wrong and expensive.

Wrong: setShadowColor(&quot;black&quot;) parses to opaque black, but the initial value of
shadowColor -- and the value beginLayer() is specified to reset to -- is
transparent black. Any shadowBlur or shadowOffset set inside the layer therefore
painted a shadow that should not exist, and ctx.shadowColor read back &quot;#000000&quot;
instead of &quot;rgba(0, 0, 0, 0)&quot;. Separately, setFilterString() gives up when the
canvas has no computed style, so a non-rendered canvas kept its filter inside the
layer and applied it twice.

Expensive: setGlobalCompositeOperation() and setShadowColor() parse before
checking whether the value changed, so every beginLayer() ran a composite
operator parse and a full CSS color parse. setFilterString() goes through
setFilterStringWithoutUpdatingStyle(), which calls Document::updateStyleIfNeeded()
-- a synchronous style recalc in the middle of beginLayer().

Set the state fields directly instead, and push only what the layer&apos;s
GraphicsContext needs: the transparency-layer switcher draws into the destination
context, so alpha, composite operator and shadow still have to be applied there.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.layer-rendering-state-reset-in-layer-expected.txt: Progression
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::beginLayer):

Canonical link: <a href="https://commits.webkit.org/319675@main">https://commits.webkit.org/319675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2496af32c17dd6098da53eaa9aed8f4cb286026d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146676 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9daa74f-d488-4eaf-9a70-76dd05e38256) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56017 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/142328 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56fc1a91-30ec-482f-9f94-86d01664fb9e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122761 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c50ec36-a662-477c-9546-5527f3f8b8a7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44724 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42993 "Passed tests") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/155124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42617 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3739 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194503 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55965 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151760 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/40640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56656 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151461 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46042 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128940 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124899 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55167 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17616 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54548 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54787 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54615 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->