### PR TITLE
[Canvas] CanvasRenderingContext2DBase::normalizeSpaces() widens Latin-1 text to UTF-16 and copies it twice

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.width.space.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.width.space.html
@@ -39,6 +39,11 @@ promise_test(async t => {
   _assertSame(ctx.measureText(' AB').width, 150, "ctx.measureText(' AB').width", "150");
   _assertSame(ctx.measureText('AB ').width, 150, "ctx.measureText('AB ').width", "150");
 
+  _assertSame(ctx.measureText('AB\x09').width, 150, "ctx.measureText('AB\\x09').width", "150");
+  _assertSame(ctx.measureText('AB\x0d').width, 150, "ctx.measureText('AB\\x0d').width", "150");
+  _assertSame(ctx.measureText('\x09').width, 50, "ctx.measureText('\\x09').width", "50");
+  _assertSame(ctx.measureText('あ\x09').width, ctx.measureText('あ ').width, "ctx.measureText('あ\\x09').width", "ctx.measureText('あ ').width");
+
 }, "Space characters are converted to U+0020 and NOT collapsed");
 </script>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.width.space.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.width.space.html
@@ -28,5 +28,10 @@ promise_test(async t => {
   _assertSame(ctx.measureText(' AB').width, 150, "ctx.measureText(' AB').width", "150");
   _assertSame(ctx.measureText('AB ').width, 150, "ctx.measureText('AB ').width", "150");
 
+  _assertSame(ctx.measureText('AB\x09').width, 150, "ctx.measureText('AB\\x09').width", "150");
+  _assertSame(ctx.measureText('AB\x0d').width, 150, "ctx.measureText('AB\\x0d').width", "150");
+  _assertSame(ctx.measureText('\x09').width, 50, "ctx.measureText('\\x09').width", "50");
+  _assertSame(ctx.measureText('あ\x09').width, ctx.measureText('あ ').width, "ctx.measureText('あ\\x09').width", "ctx.measureText('あ ').width");
+
 }, "Space characters are converted to U+0020 and NOT collapsed");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.width.space.worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.width.space.worker.js
@@ -23,6 +23,11 @@ promise_test(async t => {
 
   _assertSame(ctx.measureText(' AB').width, 150, "ctx.measureText(' AB').width", "150");
   _assertSame(ctx.measureText('AB ').width, 150, "ctx.measureText('AB ').width", "150");
+
+  _assertSame(ctx.measureText('AB\x09').width, 150, "ctx.measureText('AB\\x09').width", "150");
+  _assertSame(ctx.measureText('AB\x0d').width, 150, "ctx.measureText('AB\\x0d').width", "150");
+  _assertSame(ctx.measureText('\x09').width, 50, "ctx.measureText('\\x09').width", "50");
+  _assertSame(ctx.measureText('あ\x09').width, ctx.measureText('あ ').width, "ctx.measureText('あ\\x09').width", "ctx.measureText('あ ').width");
   t.done();
 }, "Space characters are converted to U+0020 and NOT collapsed");
 done();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/tools/yaml-new/text.yaml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/tools/yaml-new/text.yaml
@@ -440,6 +440,11 @@
 
     @assert ctx.measureText(' AB').width === 150;
     @assert ctx.measureText('AB ').width === 150;
+
+    @assert ctx.measureText('AB\x09').width === 150;
+    @assert ctx.measureText('AB\x0d').width === 150;
+    @assert ctx.measureText('\x09').width === 50;
+    @assert ctx.measureText('あ\x09').width === ctx.measureText('あ ').width;
   variants: *load-font-variant-definition
 
 - name: 2d.text.drawing.style.measure.rtl.text

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2874,26 +2874,34 @@ static inline bool NODELETE isSpaceThatNeedsReplacing(char16_t c)
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/common-microsyntaxes.html#space-character
     // This function returns true for 0x000B also, so that this is backward compatible.
     // Otherwise, the test LayoutTests/canvas/philip/tests/2d.text.draw.space.collapse.space.html will fail
-    return c == 0x0009 || c == 0x000A || c == 0x000B || c == 0x000C || c == 0x000D;
+    return c >= 0x0009 && c <= 0x000D;
+}
+
+template<typename CharacterType>
+static inline String createStringByNormalizingSpaces(std::span<const CharacterType> characters, size_t indexOfFirstSpace)
+{
+    ASSERT(indexOfFirstSpace < characters.size());
+
+    std::span<CharacterType> normalized;
+    auto result = String::createUninitialized(characters.size(), normalized);
+
+    memcpySpan(normalized, characters.first(indexOfFirstSpace));
+    for (size_t i = indexOfFirstSpace; i != characters.size(); ++i) {
+        auto character = characters[i];
+        normalized[i] = isSpaceThatNeedsReplacing(character) ? ' ' : character;
+    }
+    return result;
 }
 
 String CanvasRenderingContext2DBase::normalizeSpaces(const String& text)
 {
-    size_t i = text.find(isSpaceThatNeedsReplacing);
-    if (i == notFound)
+    size_t indexOfFirstSpace = text.find(isSpaceThatNeedsReplacing);
+    if (indexOfFirstSpace == notFound)
         return text;
 
-    unsigned textLength = text.length();
-    Vector<char16_t> charVector(textLength);
-    StringView(text).getCharacters(charVector.mutableSpan());
-
-    charVector[i++] = ' ';
-
-    for (; i < textLength; ++i) {
-        if (isSpaceThatNeedsReplacing(charVector[i]))
-            charVector[i] = ' ';
-    }
-    return String::adopt(WTF::move(charVector));
+    if (text.is8Bit())
+        return createStringByNormalizingSpaces(text.span8(), indexOfFirstSpace);
+    return createStringByNormalizingSpaces(text.span16(), indexOfFirstSpace);
 }
 
 static bool canUseCachedShapedText(const TextRun& textRun)


### PR DESCRIPTION
#### effd80c0d048afbb4cf0bb9a67eefa50f392d474
<pre>
[Canvas] CanvasRenderingContext2DBase::normalizeSpaces() widens Latin-1 text to UTF-16 and copies it twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=322174">https://bugs.webkit.org/show_bug.cgi?id=322174</a>
<a href="https://rdar.apple.com/185404560">rdar://185404560</a>

Reviewed by Gerald Squelart.

normalizeSpaces() replaces U+0009 through U+000D with U+0020 for every
fillText(), strokeText() and measureText() call. It unconditionally built a
Vector&lt;char16_t&gt;, so Latin-1 input came back 16-bit even though every replaced
character, and the replacement, is ASCII. That cost two fast paths on every draw
call: FontCascade::codePath() returns CodePath::Simple immediately for an 8-bit
run rather than scanning every character, and
TextUtil::containsStrongDirectionalityText(), which gates
canUseCachedShapedText(), skips its SIMD bidi scan for 8-bit text.

The Vector was copied twice as well: String::adopt(Vector&amp;&amp;) only adopts the
buffer when the vector&apos;s Malloc is StringImplMalloc, and Vector&apos;s default is
VectorBufferMalloc, so it fell through to create(vector.span()).

Dispatch on is8Bit() and build the result with String::createUninitialized(),
following StringImpl::createByReplacingInCharacters(): memcpy the prefix before
the first character needing replacement, then copy the remainder with the
replacement applied. 8-bit input stays 8-bit, in one allocation and one copy.

Also collapse isSpaceThatNeedsReplacing() to a range check, since U+0009 through
U+000D are contiguous. The same characters are matched; the range check is just
simpler to read, and clang already compiles both forms to the same code.

No change in behavior. Covered by existing tests, including
html/canvas/element/text/2d.text.draw.space.collapse.space.html, which is the
reason U+000B is matched despite not being a space character in the
specification.

Added cases to 2d.text.measure.width.space for strings whose only character
needing replacement is the last one, so the index returned by find() is the
final index and the prefix memcpy covers everything before it, down to a lone
U+0009 where the index is 0 and the prefix is empty. One case measures a
non-Latin-1 string both ways to cover the 16-bit path.
2d.text.measure.actualBoundingBox.whitespace.html already reaches that boundary
through measureText(&apos;A&apos; + whitespace), but nothing pinned the resulting width.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.width.space.html:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.width.space.html:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.width.space.worker.js:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/tools/yaml-new/text.yaml:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::isSpaceThatNeedsReplacing):
(WebCore::createStringByNormalizingSpaces):
(WebCore::CanvasRenderingContext2DBase::normalizeSpaces):

Canonical link: <a href="https://commits.webkit.org/319591@main">https://commits.webkit.org/319591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05d53f2a077a0999980fde1f187195259f74185c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146286 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/000380a2-0b8f-41ac-9b85-9490628a275b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142058 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc143b30-dfc0-4bb2-a7b0-fd970cf3b746) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162794 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122493 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4c69122-d32d-423d-a2ca-8f53de0ca666) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44423 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42319 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3347 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194110 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40555 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56266 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151177 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45745 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128548 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124327 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54777 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17314 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54158 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54397 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54225 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->