### PR TITLE
CG: Synchronize platform context properties lazily

### DIFF
--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -55,6 +55,7 @@ bool BifurcatedGraphicsContext::hasPlatformContext() const
 
 PlatformGraphicsContext* BifurcatedGraphicsContext::platformContext() const
 {
+    const_cast<BifurcatedGraphicsContext&>(*this).updatePlatformContextStateIfNeeded();
     return m_primaryContext.platformContext();
 }
 
@@ -67,6 +68,7 @@ void BifurcatedGraphicsContext::save(GraphicsContextState::Purpose purpose)
 {
     // FIXME: Consider not using the BifurcatedGraphicsContext's state stack at all,
     // and making all of the state getters and setters virtual.
+    updatePlatformContextStateIfNeeded();
     GraphicsContext::save(purpose);
     m_primaryContext.save(purpose);
     m_secondaryContext.save(purpose);
@@ -85,6 +87,7 @@ void BifurcatedGraphicsContext::restore(GraphicsContextState::Purpose purpose)
 
 void BifurcatedGraphicsContext::drawRect(const FloatRect& rect, float borderThickness)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawRect(rect, borderThickness);
     m_secondaryContext.drawRect(rect, borderThickness);
 
@@ -93,6 +96,7 @@ void BifurcatedGraphicsContext::drawRect(const FloatRect& rect, float borderThic
 
 void BifurcatedGraphicsContext::drawLine(const FloatPoint& from, const FloatPoint& to)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawLine(from, to);
     m_secondaryContext.drawLine(from, to);
 
@@ -101,6 +105,7 @@ void BifurcatedGraphicsContext::drawLine(const FloatPoint& from, const FloatPoin
 
 void BifurcatedGraphicsContext::drawEllipse(const FloatRect& rect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawEllipse(rect);
     m_secondaryContext.drawEllipse(rect);
 
@@ -110,6 +115,7 @@ void BifurcatedGraphicsContext::drawEllipse(const FloatRect& rect)
 #if USE(CG)
 void BifurcatedGraphicsContext::applyStrokePattern()
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.applyStrokePattern();
     m_secondaryContext.applyStrokePattern();
 
@@ -118,6 +124,7 @@ void BifurcatedGraphicsContext::applyStrokePattern()
 
 void BifurcatedGraphicsContext::applyFillPattern()
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.applyFillPattern();
     m_secondaryContext.applyFillPattern();
 
@@ -127,6 +134,7 @@ void BifurcatedGraphicsContext::applyFillPattern()
 
 void BifurcatedGraphicsContext::drawPath(const Path& path)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawPath(path);
     m_secondaryContext.drawPath(path);
 
@@ -135,6 +143,7 @@ void BifurcatedGraphicsContext::drawPath(const Path& path)
 
 void BifurcatedGraphicsContext::fillPath(const Path& path)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.fillPath(path);
     m_secondaryContext.fillPath(path);
 
@@ -143,6 +152,7 @@ void BifurcatedGraphicsContext::fillPath(const Path& path)
 
 void BifurcatedGraphicsContext::strokePath(const Path& path)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.strokePath(path);
     m_secondaryContext.strokePath(path);
 
@@ -151,6 +161,7 @@ void BifurcatedGraphicsContext::strokePath(const Path& path)
 
 void BifurcatedGraphicsContext::beginTransparencyLayer(float opacity)
 {
+    updatePlatformContextStateIfNeeded();
     GraphicsContext::beginTransparencyLayer(opacity);
     m_primaryContext.beginTransparencyLayer(opacity);
     m_secondaryContext.beginTransparencyLayer(opacity);
@@ -162,6 +173,7 @@ void BifurcatedGraphicsContext::beginTransparencyLayer(float opacity)
 
 void BifurcatedGraphicsContext::beginTransparencyLayer(CompositeOperator compositeOperator, BlendMode blendMode)
 {
+    updatePlatformContextStateIfNeeded();
     GraphicsContext::beginTransparencyLayer(compositeOperator, blendMode);
     m_primaryContext.beginTransparencyLayer(compositeOperator, blendMode);
     m_secondaryContext.beginTransparencyLayer(compositeOperator, blendMode);
@@ -173,6 +185,7 @@ void BifurcatedGraphicsContext::beginTransparencyLayer(CompositeOperator composi
 
 void BifurcatedGraphicsContext::endTransparencyLayer()
 {
+    updatePlatformContextStateIfNeeded();
     GraphicsContext::endTransparencyLayer();
     m_primaryContext.endTransparencyLayer();
     m_secondaryContext.endTransparencyLayer();
@@ -184,6 +197,7 @@ void BifurcatedGraphicsContext::endTransparencyLayer()
 
 void BifurcatedGraphicsContext::applyDeviceScaleFactor(float factor)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.applyDeviceScaleFactor(factor);
     m_secondaryContext.applyDeviceScaleFactor(factor);
 
@@ -192,6 +206,7 @@ void BifurcatedGraphicsContext::applyDeviceScaleFactor(float factor)
 
 void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, RequiresClipToRect requiresClipToRect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.fillRect(rect, requiresClipToRect);
     m_secondaryContext.fillRect(rect, requiresClipToRect);
 
@@ -200,6 +215,7 @@ void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, RequiresClipToRe
 
 void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, const Color& color)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.fillRect(rect, color);
     m_secondaryContext.fillRect(rect, color);
 
@@ -208,6 +224,7 @@ void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, const Color& col
 
 void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, Gradient& gradient)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.fillRect(rect, gradient);
     m_secondaryContext.fillRect(rect, gradient);
 
@@ -216,6 +233,7 @@ void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, Gradient& gradie
 
 void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, Gradient& gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect requiresClipToRect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.fillRect(rect, gradient, gradientSpaceTransform, requiresClipToRect);
     m_secondaryContext.fillRect(rect, gradient, gradientSpaceTransform, requiresClipToRect);
 
@@ -224,6 +242,7 @@ void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, Gradient& gradie
 
 void BifurcatedGraphicsContext::fillRoundedRectImpl(const FloatRoundedRect& rect, const Color& color)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.fillRoundedRectImpl(rect, color);
     m_secondaryContext.fillRoundedRectImpl(rect, color);
 
@@ -232,6 +251,7 @@ void BifurcatedGraphicsContext::fillRoundedRectImpl(const FloatRoundedRect& rect
 
 void BifurcatedGraphicsContext::fillRectWithRoundedHole(const FloatRect& rect, const FloatRoundedRect& roundedHoleRect, const Color& color)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.fillRectWithRoundedHole(rect, roundedHoleRect, color);
     m_secondaryContext.fillRectWithRoundedHole(rect, roundedHoleRect, color);
 
@@ -240,6 +260,7 @@ void BifurcatedGraphicsContext::fillRectWithRoundedHole(const FloatRect& rect, c
 
 void BifurcatedGraphicsContext::clearRect(const FloatRect& rect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.clearRect(rect);
     m_secondaryContext.clearRect(rect);
 
@@ -248,6 +269,7 @@ void BifurcatedGraphicsContext::clearRect(const FloatRect& rect)
 
 void BifurcatedGraphicsContext::strokeRect(const FloatRect& rect, float lineWidth)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.strokeRect(rect, lineWidth);
     m_secondaryContext.strokeRect(rect, lineWidth);
 
@@ -256,6 +278,7 @@ void BifurcatedGraphicsContext::strokeRect(const FloatRect& rect, float lineWidt
 
 void BifurcatedGraphicsContext::fillEllipse(const FloatRect& ellipse)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.fillEllipse(ellipse);
     m_secondaryContext.fillEllipse(ellipse);
 
@@ -264,6 +287,7 @@ void BifurcatedGraphicsContext::fillEllipse(const FloatRect& ellipse)
 
 void BifurcatedGraphicsContext::strokeEllipse(const FloatRect& ellipse)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.strokeEllipse(ellipse);
     m_secondaryContext.strokeEllipse(ellipse);
 
@@ -286,6 +310,7 @@ RenderingMode BifurcatedGraphicsContext::renderingMode() const
 
 void BifurcatedGraphicsContext::clip(const FloatRect& rect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.clip(rect);
     m_secondaryContext.clip(rect);
 
@@ -294,6 +319,7 @@ void BifurcatedGraphicsContext::clip(const FloatRect& rect)
 
 void BifurcatedGraphicsContext::clipRoundedRect(const FloatRoundedRect& rect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.clipRoundedRect(rect);
     m_secondaryContext.clipRoundedRect(rect);
 
@@ -302,6 +328,7 @@ void BifurcatedGraphicsContext::clipRoundedRect(const FloatRoundedRect& rect)
 
 void BifurcatedGraphicsContext::clipOut(const FloatRect& rect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.clipOut(rect);
     m_secondaryContext.clipOut(rect);
 
@@ -310,6 +337,7 @@ void BifurcatedGraphicsContext::clipOut(const FloatRect& rect)
 
 void BifurcatedGraphicsContext::clipOutRoundedRect(const FloatRoundedRect& rect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.clipOutRoundedRect(rect);
     m_secondaryContext.clipOutRoundedRect(rect);
 
@@ -318,6 +346,7 @@ void BifurcatedGraphicsContext::clipOutRoundedRect(const FloatRoundedRect& rect)
 
 void BifurcatedGraphicsContext::clipOut(const Path& path)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.clipOut(path);
     m_secondaryContext.clipOut(path);
 
@@ -326,6 +355,7 @@ void BifurcatedGraphicsContext::clipOut(const Path& path)
 
 void BifurcatedGraphicsContext::clipPath(const Path& path, WindRule windRule)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.clipPath(path, windRule);
     m_secondaryContext.clipPath(path, windRule);
 
@@ -334,6 +364,7 @@ void BifurcatedGraphicsContext::clipPath(const Path& path, WindRule windRule)
 
 void BifurcatedGraphicsContext::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.clipToImageBuffer(imageBuffer, destRect);
     m_secondaryContext.clipToImageBuffer(imageBuffer, destRect);
 
@@ -347,6 +378,7 @@ IntRect BifurcatedGraphicsContext::clipBounds() const
 
 void BifurcatedGraphicsContext::resetClip()
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.resetClip();
     m_secondaryContext.resetClip();
 
@@ -355,6 +387,7 @@ void BifurcatedGraphicsContext::resetClip()
 
 void BifurcatedGraphicsContext::setLineCap(LineCap lineCap)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.setLineCap(lineCap);
     m_secondaryContext.setLineCap(lineCap);
 
@@ -363,6 +396,7 @@ void BifurcatedGraphicsContext::setLineCap(LineCap lineCap)
 
 void BifurcatedGraphicsContext::setLineDash(const DashArray& dashArray, float dashOffset)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.setLineDash(dashArray, dashOffset);
     m_secondaryContext.setLineDash(dashArray, dashOffset);
 
@@ -371,6 +405,7 @@ void BifurcatedGraphicsContext::setLineDash(const DashArray& dashArray, float da
 
 void BifurcatedGraphicsContext::setLineJoin(LineJoin lineJoin)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.setLineJoin(lineJoin);
     m_secondaryContext.setLineJoin(lineJoin);
 
@@ -379,6 +414,7 @@ void BifurcatedGraphicsContext::setLineJoin(LineJoin lineJoin)
 
 void BifurcatedGraphicsContext::setMiterLimit(float miterLimit)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.setMiterLimit(miterLimit);
     m_secondaryContext.setMiterLimit(miterLimit);
 
@@ -387,6 +423,7 @@ void BifurcatedGraphicsContext::setMiterLimit(float miterLimit)
 
 void BifurcatedGraphicsContext::drawNativeImage(const NativeImage& nativeImage, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawNativeImage(nativeImage, destRect, srcRect, options);
     m_secondaryContext.drawNativeImage(nativeImage, destRect, srcRect, options);
 
@@ -395,6 +432,7 @@ void BifurcatedGraphicsContext::drawNativeImage(const NativeImage& nativeImage, 
 
 void BifurcatedGraphicsContext::drawSystemImage(SystemImage& systemImage, const FloatRect& destinationRect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawSystemImage(systemImage, destinationRect);
     m_secondaryContext.drawSystemImage(systemImage, destinationRect);
 
@@ -403,6 +441,7 @@ void BifurcatedGraphicsContext::drawSystemImage(SystemImage& systemImage, const 
 
 void BifurcatedGraphicsContext::drawControlPart(ControlPart& part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawControlPart(part, borderRect, deviceScaleFactor, style);
     m_secondaryContext.drawControlPart(part, borderRect, deviceScaleFactor, style);
 
@@ -411,6 +450,7 @@ void BifurcatedGraphicsContext::drawControlPart(ControlPart& part, const FloatRo
 
 void BifurcatedGraphicsContext::drawPattern(const NativeImage& nativeImage, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawPattern(nativeImage, destRect, tileRect, patternTransform, phase, spacing, options);
     m_secondaryContext.drawPattern(nativeImage, destRect, tileRect, patternTransform, phase, spacing, options);
 
@@ -419,6 +459,7 @@ void BifurcatedGraphicsContext::drawPattern(const NativeImage& nativeImage, cons
 
 ImageDrawResult BifurcatedGraphicsContext::drawImage(Image& image, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions options)
 {
+    updatePlatformContextStateIfNeeded();
     auto result = m_primaryContext.drawImage(image, destination, source, options);
     m_secondaryContext.drawImage(image, destination, source, options);
 
@@ -429,6 +470,7 @@ ImageDrawResult BifurcatedGraphicsContext::drawImage(Image& image, const FloatRe
 
 ImageDrawResult BifurcatedGraphicsContext::drawTiledImage(Image& image, const FloatRect& destination, const FloatPoint& source, const FloatSize& tileSize, const FloatSize& spacing, ImagePaintingOptions options)
 {
+    updatePlatformContextStateIfNeeded();
     auto result = m_primaryContext.drawTiledImage(image, destination, source, tileSize, spacing, options);
     m_secondaryContext.drawTiledImage(image, destination, source, tileSize, spacing, options);
 
@@ -439,6 +481,7 @@ ImageDrawResult BifurcatedGraphicsContext::drawTiledImage(Image& image, const Fl
 
 ImageDrawResult BifurcatedGraphicsContext::drawTiledImage(Image& image, const FloatRect& destination, const FloatRect& source, const FloatSize& tileScaleFactor, Image::TileRule hRule, Image::TileRule vRule, ImagePaintingOptions options)
 {
+    updatePlatformContextStateIfNeeded();
     auto result = m_primaryContext.drawTiledImage(image, destination, source, tileScaleFactor, hRule, vRule, options);
     m_secondaryContext.drawTiledImage(image, destination, source, tileScaleFactor, hRule, vRule, options);
     
@@ -450,6 +493,7 @@ ImageDrawResult BifurcatedGraphicsContext::drawTiledImage(Image& image, const Fl
 #if ENABLE(VIDEO)
 void BifurcatedGraphicsContext::drawVideoFrame(const VideoFrame& videoFrame, const FloatRect& destination, WebCore::ImageOrientation orientation, bool shouldDiscardAlpha)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawVideoFrame(videoFrame, destination, orientation, shouldDiscardAlpha);
     m_secondaryContext.drawVideoFrame(videoFrame, destination, orientation, shouldDiscardAlpha);
 
@@ -459,6 +503,7 @@ void BifurcatedGraphicsContext::drawVideoFrame(const VideoFrame& videoFrame, con
 
 void BifurcatedGraphicsContext::scale(const FloatSize& scale)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.scale(scale);
     m_secondaryContext.scale(scale);
 
@@ -467,6 +512,7 @@ void BifurcatedGraphicsContext::scale(const FloatSize& scale)
 
 void BifurcatedGraphicsContext::rotate(float angleInRadians)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.rotate(angleInRadians);
     m_secondaryContext.rotate(angleInRadians);
 
@@ -475,6 +521,7 @@ void BifurcatedGraphicsContext::rotate(float angleInRadians)
 
 void BifurcatedGraphicsContext::translate(float x, float y)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.translate(x, y);
     m_secondaryContext.translate(x, y);
 
@@ -483,6 +530,7 @@ void BifurcatedGraphicsContext::translate(float x, float y)
 
 void BifurcatedGraphicsContext::concatCTM(const AffineTransform& transform)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.concatCTM(transform);
     m_secondaryContext.concatCTM(transform);
 
@@ -491,6 +539,7 @@ void BifurcatedGraphicsContext::concatCTM(const AffineTransform& transform)
 
 void BifurcatedGraphicsContext::setCTM(const AffineTransform& transform)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.setCTM(transform);
     m_secondaryContext.setCTM(transform);
 
@@ -504,6 +553,7 @@ AffineTransform BifurcatedGraphicsContext::getCTM(IncludeDeviceScale includeDevi
 
 void BifurcatedGraphicsContext::drawFocusRing(const Path& path, float outlineWidth, const Color& color, float zoomFactor)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawFocusRing(path, outlineWidth, color, zoomFactor);
     m_secondaryContext.drawFocusRing(path, outlineWidth, color, zoomFactor);
 
@@ -512,6 +562,7 @@ void BifurcatedGraphicsContext::drawFocusRing(const Path& path, float outlineWid
 
 void BifurcatedGraphicsContext::drawFocusRing(const Vector<FloatRect>& rects, float outlineWidth, const Color& color, float zoomFactor)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawFocusRing(rects, outlineWidth, color, zoomFactor);
     m_secondaryContext.drawFocusRing(rects, outlineWidth, color, zoomFactor);
 
@@ -520,6 +571,7 @@ void BifurcatedGraphicsContext::drawFocusRing(const Vector<FloatRect>& rects, fl
 
 FloatSize BifurcatedGraphicsContext::drawText(const FontCascade& cascade, const TextRun& run, const FloatPoint& point, unsigned from, std::optional<unsigned> to)
 {
+    updatePlatformContextStateIfNeeded();
     auto size = m_primaryContext.drawText(cascade, run, point, from, to);
     m_secondaryContext.drawText(cascade, run, point, from, to);
     
@@ -530,6 +582,7 @@ FloatSize BifurcatedGraphicsContext::drawText(const FontCascade& cascade, const 
 
 void BifurcatedGraphicsContext::drawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& point, FontSmoothingMode fontSmoothingMode)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawGlyphs(font, glyphs, advances, point, fontSmoothingMode);
     m_secondaryContext.drawGlyphs(font, glyphs, advances, point, fontSmoothingMode);
 
@@ -538,6 +591,7 @@ void BifurcatedGraphicsContext::drawGlyphs(const Font& font, std::span<const Gly
 
 void BifurcatedGraphicsContext::drawEmphasisMarks(const FontCascade& cascade, const TextRun& run, const AtomString& mark, const FloatPoint& point, unsigned from, std::optional<unsigned> to)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawEmphasisMarks(cascade, run, mark, point, from, to);
     m_secondaryContext.drawEmphasisMarks(cascade, run, mark, point, from, to);
 
@@ -546,6 +600,7 @@ void BifurcatedGraphicsContext::drawEmphasisMarks(const FontCascade& cascade, co
 
 void BifurcatedGraphicsContext::drawBidiText(const FontCascade& cascade, const TextRun& run, const FloatPoint& point, FontCascade::CustomFontNotReadyAction customFontNotReadyAction)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawBidiText(cascade, run, point, customFontNotReadyAction);
     m_secondaryContext.drawBidiText(cascade, run, point, customFontNotReadyAction);
 
@@ -554,6 +609,7 @@ void BifurcatedGraphicsContext::drawBidiText(const FontCascade& cascade, const T
 
 void BifurcatedGraphicsContext::drawLinesForText(const FloatPoint& point, float thickness, std::span<const FloatSegment> lineSegments, bool printing, bool doubleLines, StrokeStyle strokeStyle)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawLinesForText(point, thickness, lineSegments, printing, doubleLines, strokeStyle);
     m_secondaryContext.drawLinesForText(point, thickness, lineSegments, printing, doubleLines, strokeStyle);
 
@@ -562,6 +618,7 @@ void BifurcatedGraphicsContext::drawLinesForText(const FloatPoint& point, float 
 
 void BifurcatedGraphicsContext::drawDotsForDocumentMarker(const FloatRect& rect, DocumentMarkerLineStyle markerStyle)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.drawDotsForDocumentMarker(rect, markerStyle);
     m_secondaryContext.drawDotsForDocumentMarker(rect, markerStyle);
 
@@ -570,6 +627,7 @@ void BifurcatedGraphicsContext::drawDotsForDocumentMarker(const FloatRect& rect,
 
 void BifurcatedGraphicsContext::beginPage(const FloatRect& pageRect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.beginPage(pageRect);
     m_secondaryContext.beginPage(pageRect);
 
@@ -578,6 +636,7 @@ void BifurcatedGraphicsContext::beginPage(const FloatRect& pageRect)
 
 void BifurcatedGraphicsContext::endPage()
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.endPage();
     m_secondaryContext.endPage();
 
@@ -586,6 +645,7 @@ void BifurcatedGraphicsContext::endPage()
 
 void BifurcatedGraphicsContext::setURLForRect(const URL& url, const FloatRect& rect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.setURLForRect(url, rect);
     m_secondaryContext.setURLForRect(url, rect);
 
@@ -594,6 +654,7 @@ void BifurcatedGraphicsContext::setURLForRect(const URL& url, const FloatRect& r
 
 void BifurcatedGraphicsContext::setDestinationForRect(const String& name, const FloatRect& rect)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.setDestinationForRect(name, rect);
     m_secondaryContext.setDestinationForRect(name, rect);
 
@@ -602,6 +663,7 @@ void BifurcatedGraphicsContext::setDestinationForRect(const String& name, const 
 
 void BifurcatedGraphicsContext::addDestinationAtPoint(const String& name, const FloatPoint& point)
 {
+    updatePlatformContextStateIfNeeded();
     m_primaryContext.addDestinationAtPoint(name, point);
     m_secondaryContext.addDestinationAtPoint(name, point);
 
@@ -613,14 +675,18 @@ bool BifurcatedGraphicsContext::supportsInternalLinks() const
     return m_primaryContext.supportsInternalLinks();
 }
 
-void BifurcatedGraphicsContext::didUpdateState(GraphicsContextState& state)
+void BifurcatedGraphicsContext::updatePlatformContextStateIfNeeded()
 {
-    // This calls mergeLastChanges() instead of didUpdateState() so that changes
-    // are also applied to each context's GraphicsContextState, so that code
-    // internal to the child contexts that reads from the state gets the right values.
-    m_primaryContext.mergeLastChanges(state);
-    m_secondaryContext.mergeLastChanges(state);
-    state.didApplyChanges();
+    if (!m_state.changes())
+        return;
+
+    // This calls mergeLastChanges() so that the changes are also applied to each context's
+    // GraphicsContextState, so that code internal to the child contexts that reads from the
+    // state gets the right values. The child contexts apply them to their platform contexts
+    // when they need to.
+    m_primaryContext.mergeLastChanges(m_state);
+    m_secondaryContext.mergeLastChanges(m_state);
+    m_state.didApplyChanges();
 
     VERIFY_STATE_SYNCHRONIZATION();
 }

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -150,9 +150,11 @@ public:
 
     bool supportsInternalLinks() const final;
 
-    void didUpdateState(GraphicsContextState&) final;
-
 private:
+    // The child contexts are kept in sync lazily, before any operation that needs them to
+    // observe the current state. They apply the state to their platform contexts in turn.
+    void updatePlatformContextStateIfNeeded();
+
     void verifyStateSynchronization();
 
     bool m_hasLoggedAboutDesynchronizedState { false };

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -166,9 +166,14 @@ public:
     void mergeLastChanges(const GraphicsContextState&);
     void mergeAllChanges(const GraphicsContextState&);
 
+#if USE(CG) || USE(SKIA)
+    // Compatibility function: when all platforms implement lazy state sync, remove this.
+    void didUpdateState(GraphicsContextState&) { }
+#else
     // Called *after* any change to GraphicsContextState; generally used to propagate changes
     // to the platform context's state.
     virtual void didUpdateState(GraphicsContextState&) = 0;
+#endif
 
     WEBCORE_EXPORT virtual void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
     WEBCORE_EXPORT virtual void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -60,7 +60,9 @@ private:
     bool invalidatingImagesWithAsyncDecodes() const final { return m_paintInvalidationReasons == PaintInvalidationReasons::InvalidatingImagesWithAsyncDecodes; }
     bool detectingContentfulPaint() const final { return m_paintInvalidationReasons == PaintInvalidationReasons::DetectingContentfulPaint; }
 
+#if !USE(CG) && !USE(SKIA)
     void didUpdateState(GraphicsContextState&) final { }
+#endif
 
     void drawNativeImage(const NativeImage&, const FloatRect&, const FloatRect&, ImagePaintingOptions) final { }
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -223,10 +223,6 @@ GraphicsContextCG::GraphicsContextCG(CGContextRef cgContext, CGContextSource sou
     , m_renderingMode(knownRenderingMode.value_or(renderingModeForCGContext(cgContext, source)))
     , m_isLayerCGContext(source == GraphicsContextCG::CGContextFromCALayer)
 {
-    if (!cgContext)
-        return;
-    // Make sure the context starts in sync with our state.
-    didUpdateState(m_state);
 }
 
 GraphicsContextCG::~GraphicsContextCG() = default;
@@ -266,6 +262,12 @@ const DestinationColorSpace& GraphicsContextCG::colorSpace() const
 
 void GraphicsContextCG::save(GraphicsContextState::Purpose purpose)
 {
+    // Apply the state before saving, so that the state pushed on the stack describes the gstate
+    // saved below. This has to happen before GraphicsContext::save(), because
+    // Purpose::TransparencyLayer resets the properties CG resets for a layer without marking them
+    // as changed, and a pending change to them would otherwise reach the context as the reset
+    // value instead of the value the layer has to be composited with.
+    updatePlatformContextStateIfNeeded();
     GraphicsContext::save(purpose);
     CGContextSaveGState(contextForState());
 }
@@ -1078,6 +1080,12 @@ void GraphicsContextCG::beginTransparencyLayer(float opacity)
 {
     GraphicsContext::beginTransparencyLayer(opacity);
 
+    // CG composites the layer using the alpha, style and blend mode that are in effect when the
+    // layer begins, and resets them for the layer contents. Purpose::TransparencyLayer resets
+    // them in our state to match, without marking them as changed, so any pending change to them
+    // has to reach the context before that happens.
+    updatePlatformContextStateIfNeeded();
+
     save(GraphicsContextState::Purpose::TransparencyLayer);
 
     CGContextRef context = platformContext();
@@ -1198,67 +1206,67 @@ void GraphicsContextCG::setCGStyle(const std::optional<GraphicsStyle>& style, bo
     );
 }
 
-void GraphicsContextCG::didUpdateState(GraphicsContextState& state)
+void GraphicsContextCG::updatePlatformContextState()
 {
-    if (!state.changes())
-        return;
+    // Consume the changes up front: applying them below must not recurse back here, either
+    // via platformContext() or by re-entering through one of the appliers.
+    auto changes = m_state.changes();
+    m_state.didApplyChanges();
 
     auto context = platformContext();
 
-    for (auto change : state.changes()) {
+    for (auto change : changes) {
         switch (change) {
         case GraphicsContextState::Change::FillBrush:
-            if (!state.fillBrush().hasPatternOrGradient())
-                setCGFillColor(context, state.fillBrush().color(), colorSpace());
+            if (!m_state.fillBrush().hasPatternOrGradient())
+                setCGFillColor(context, m_state.fillBrush().color(), colorSpace());
             break;
 
         case GraphicsContextState::Change::StrokeThickness:
-            CGContextSetLineWidth(context, std::max(state.strokeThickness(), 0.f));
+            CGContextSetLineWidth(context, std::max(m_state.strokeThickness(), 0.f));
             break;
 
         case GraphicsContextState::Change::StrokeBrush:
-            if (!state.strokeBrush().hasPatternOrGradient())
-                CGContextSetStrokeColorWithColor(context, cachedCGColorInDestinationStandardRange(state.strokeBrush().color(), colorSpace()).get());
+            if (!m_state.strokeBrush().hasPatternOrGradient())
+                CGContextSetStrokeColorWithColor(context, cachedCGColorInDestinationStandardRange(m_state.strokeBrush().color(), colorSpace()).get());
             break;
 
         case GraphicsContextState::Change::CompositeMode:
-            setCGBlendMode(context, state.compositeMode().operation, state.compositeMode().blendMode);
+            setCGBlendMode(context, m_state.compositeMode().operation, m_state.compositeMode().blendMode);
             break;
 
         case GraphicsContextState::Change::DropShadow:
-            setCGDropShadow(state.dropShadow(), state.shadowsIgnoreTransforms());
+            setCGDropShadow(m_state.dropShadow(), m_state.shadowsIgnoreTransforms());
             break;
 
         case GraphicsContextState::Change::Style:
-            setCGStyle(state.style(), state.shadowsIgnoreTransforms());
+            setCGStyle(m_state.style(), m_state.shadowsIgnoreTransforms());
             break;
 
         case GraphicsContextState::Change::Alpha:
-            CGContextSetAlpha(context, state.alpha());
+            CGContextSetAlpha(context, m_state.alpha());
             break;
 
         case GraphicsContextState::Change::ImageInterpolationQuality:
-            CGContextSetInterpolationQuality(context, toCGInterpolationQuality(state.imageInterpolationQuality()));
+            CGContextSetInterpolationQuality(context, toCGInterpolationQuality(m_state.imageInterpolationQuality()));
             break;
 
         case GraphicsContextState::Change::TextDrawingMode:
-            CGContextSetTextDrawingMode(context, cgTextDrawingMode(state.textDrawingMode()));
+            CGContextSetTextDrawingMode(context, cgTextDrawingMode(m_state.textDrawingMode()));
             break;
 
         case GraphicsContextState::Change::ShouldAntialias:
-            CGContextSetShouldAntialias(context, state.shouldAntialias());
+            CGContextSetShouldAntialias(context, m_state.shouldAntialias());
             break;
 
         case GraphicsContextState::Change::ShouldSmoothFonts:
-            CGContextSetShouldSmoothFonts(context, state.shouldSmoothFonts());
+            CGContextSetShouldSmoothFonts(context, m_state.shouldSmoothFonts());
             break;
 
         default:
             break;
         }
     }
-
-    state.didApplyChanges();
 }
 
 void GraphicsContextCG::setMiterLimit(float limit)
@@ -1408,6 +1416,11 @@ void GraphicsContextCG::setLineJoin(LineJoin join)
         break;
     }
 }
+
+// The transform functions below apply the pending state to the platform context even though they
+// do not draw. Shadows and styles are converted to device space using the user to base transform,
+// so a pending shadow or style has to reach the context while the transform it was set under is
+// still current. The same applies to the base transform change in applyDeviceScaleFactor().
 
 void GraphicsContextCG::scale(const FloatSize& size)
 {

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -136,17 +136,17 @@ public:
 
     bool supportsInternalLinks() const final;
 
-    void didUpdateState(GraphicsContextState&) final;
-
     virtual bool canUseShadowBlur() const;
 
     FloatRect roundToDevicePixels(const FloatRect&) const;
 
-    // Returns the platform context for draws.
+    // Returns the platform context for draws. Any pending GraphicsContextState changes are
+    // applied first, since a draw must observe the current state.
     CGContextRef contextForDraw()
     {
         ASSERT(m_cgContext);
         m_hasDrawn = true;
+        updatePlatformContextStateIfNeeded();
         return m_cgContext.get();
     }
 
@@ -159,6 +159,13 @@ public:
 #endif
 
 private:
+    void updatePlatformContextStateIfNeeded()
+    {
+        if (m_state.changes())
+            updatePlatformContextState();
+    }
+    void updatePlatformContextState();
+
     void setCGDropShadow(const std::optional<GraphicsDropShadow>&, bool shadowsIgnoreTransforms);
     void clearCGDropShadow();
 #if HAVE(CGSTYLE_COLORMATRIX_BLUR)
@@ -167,7 +174,9 @@ private:
 #endif
     void setCGStyle(const std::optional<GraphicsStyle>&, bool shadowsIgnoreTransforms);
 
-    // Returns the platform context for purposes of context state change, not draws.
+    // Returns the platform context for purposes of context state change, not draws. Pending
+    // GraphicsContextState changes are not applied, so this must not be used by anything that
+    // observes the state.
     CGContextRef NODELETE contextForState() const;
 
     const RetainPtr<CGContextRef> m_cgContext;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -68,9 +68,11 @@ void Recorder::appendDisplayList(const DisplayList& displayList)
     GraphicsContext::drawDisplayList(displayList, Ref { ControlFactory::singleton() });
 }
 
+#if !USE(CG) && !USE(SKIA)
 void Recorder::didUpdateState(GraphicsContextState&)
 {
 }
+#endif
 
 bool Recorder::decomposeDrawGlyphsIfNeeded(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)
 {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -138,7 +138,10 @@ private:
 
     void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) final { ASSERT_NOT_REACHED(); }
 
+#if !USE(CG) && !USE(SKIA)
+    // The recorder applies the state lazily, in appendStateChangeItemIfNecessary().
     WEBCORE_EXPORT void didUpdateState(GraphicsContextState&) final;
+#endif
 
     WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
     WEBCORE_EXPORT AffineTransform getCTM(GraphicsContext::IncludeDeviceScale = PossiblyIncludeDeviceScale) const final;

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -864,10 +864,6 @@ void GraphicsContextSkia::translate(float x, float y)
     m_canvas.translate(SkFloatToScalar(x), SkFloatToScalar(y));
 }
 
-void GraphicsContextSkia::didUpdateState(GraphicsContextState&)
-{
-}
-
 void GraphicsContextSkia::concatCTM(const AffineTransform& ctm)
 {
     m_canvas.concat(ctm);

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -64,8 +64,6 @@ public:
 
     void replayStateOnCanvas(SkCanvas&) const;
 
-    void didUpdateState(GraphicsContextState&) final;
-
     void setLineCap(LineCap) final;
     void setLineDash(const DashArray&, float) final;
     void setLineJoin(LineJoin) final;


### PR DESCRIPTION
#### eb147e124cdb346561d6c1560014ee0db05fdcb0
<pre>
CG: Synchronize platform context properties lazily
<a href="https://bugs.webkit.org/show_bug.cgi?id=322173">https://bugs.webkit.org/show_bug.cgi?id=322173</a>
<a href="https://rdar.apple.com/185404315">rdar://185404315</a>

Reviewed by NOBODY (OOPS!).

GraphicsContext::setStrokeStyle and similar setters would update
the underlying platform context immediately after setting the property.
This work is redundant if the draw is not happening.
Also multiple property sets would cause unneeded overhead.

Remove the virtual function notifying the implementation of the changes.
Instead, sync all the changes in each draw call. The sync happens
through GraphicsContextCG::platformContext() call when the draw call
obtains the context.

This is work towards further reducing the setting overhead, when
when draw calls set state and then restore the prestine state even
though future calls might overwrite the restored state immediately.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::platformContext const):
(WebCore::BifurcatedGraphicsContext::save):
(WebCore::BifurcatedGraphicsContext::drawRect):
(WebCore::BifurcatedGraphicsContext::drawLine):
(WebCore::BifurcatedGraphicsContext::drawEllipse):
(WebCore::BifurcatedGraphicsContext::applyStrokePattern):
(WebCore::BifurcatedGraphicsContext::applyFillPattern):
(WebCore::BifurcatedGraphicsContext::drawPath):
(WebCore::BifurcatedGraphicsContext::fillPath):
(WebCore::BifurcatedGraphicsContext::strokePath):
(WebCore::BifurcatedGraphicsContext::beginTransparencyLayer):
(WebCore::BifurcatedGraphicsContext::endTransparencyLayer):
(WebCore::BifurcatedGraphicsContext::applyDeviceScaleFactor):
(WebCore::BifurcatedGraphicsContext::fillRect):
(WebCore::BifurcatedGraphicsContext::fillRoundedRectImpl):
(WebCore::BifurcatedGraphicsContext::fillRectWithRoundedHole):
(WebCore::BifurcatedGraphicsContext::clearRect):
(WebCore::BifurcatedGraphicsContext::strokeRect):
(WebCore::BifurcatedGraphicsContext::fillEllipse):
(WebCore::BifurcatedGraphicsContext::strokeEllipse):
(WebCore::BifurcatedGraphicsContext::clip):
(WebCore::BifurcatedGraphicsContext::clipRoundedRect):
(WebCore::BifurcatedGraphicsContext::clipOut):
(WebCore::BifurcatedGraphicsContext::clipOutRoundedRect):
(WebCore::BifurcatedGraphicsContext::clipPath):
(WebCore::BifurcatedGraphicsContext::clipToImageBuffer):
(WebCore::BifurcatedGraphicsContext::resetClip):
(WebCore::BifurcatedGraphicsContext::setLineCap):
(WebCore::BifurcatedGraphicsContext::setLineDash):
(WebCore::BifurcatedGraphicsContext::setLineJoin):
(WebCore::BifurcatedGraphicsContext::setMiterLimit):
(WebCore::BifurcatedGraphicsContext::drawNativeImage):
(WebCore::BifurcatedGraphicsContext::drawSystemImage):
(WebCore::BifurcatedGraphicsContext::drawControlPart):
(WebCore::BifurcatedGraphicsContext::drawPattern):
(WebCore::BifurcatedGraphicsContext::drawImage):
(WebCore::BifurcatedGraphicsContext::drawTiledImage):
(WebCore::BifurcatedGraphicsContext::drawVideoFrame):
(WebCore::BifurcatedGraphicsContext::scale):
(WebCore::BifurcatedGraphicsContext::rotate):
(WebCore::BifurcatedGraphicsContext::translate):
(WebCore::BifurcatedGraphicsContext::concatCTM):
(WebCore::BifurcatedGraphicsContext::setCTM):
(WebCore::BifurcatedGraphicsContext::drawFocusRing):
(WebCore::BifurcatedGraphicsContext::drawText):
(WebCore::BifurcatedGraphicsContext::drawGlyphs):
(WebCore::BifurcatedGraphicsContext::drawEmphasisMarks):
(WebCore::BifurcatedGraphicsContext::drawBidiText):
(WebCore::BifurcatedGraphicsContext::drawLinesForText):
(WebCore::BifurcatedGraphicsContext::drawDotsForDocumentMarker):
(WebCore::BifurcatedGraphicsContext::beginPage):
(WebCore::BifurcatedGraphicsContext::endPage):
(WebCore::BifurcatedGraphicsContext::setURLForRect):
(WebCore::BifurcatedGraphicsContext::setDestinationForRect):
(WebCore::BifurcatedGraphicsContext::addDestinationAtPoint):
(WebCore::BifurcatedGraphicsContext::updatePlatformContextStateIfNeeded):
(WebCore::BifurcatedGraphicsContext::didUpdateState): Deleted.
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::didUpdateState):
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::GraphicsContextCG):
(WebCore::GraphicsContextCG::save):
(WebCore::GraphicsContextCG::beginTransparencyLayer):
(WebCore::GraphicsContextCG::updatePlatformContextState):
(WebCore::GraphicsContextCG::didUpdateState): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::didUpdateState): Deleted.
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb147e124cdb346561d6c1560014ee0db05fdcb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181731 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191956 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146060 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc8d7d0c-8621-4f1b-b79b-14607d01419f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141859 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98473 "2 flakes 14 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/062f1390-0fc8-4cf4-954e-4d12989fbb4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184686 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45545 "Found 2 new test failures: fast/text/empty-shadow.html fast/text/multiple-text-shadow-overflow-layout-rect.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122294 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e7b7ffb-0b60-44d2-b67a-56884f59e1a4) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44230 "Found 12 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-painting-text-shadow-001.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-negcoord.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity-near-zero.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity-zero.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/color-inherit.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/multiple-noblur.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/text-shadow-emoji-transparent.html imported/w3c/web-platform-tests/css/css-view-transitions/block-with-overflowing-text.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42498 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154628 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42129 "Found 14 new test failures: fast/css/paint-order-shadow.html fast/text/empty-shadow.html fast/text/multiple-text-shadow-overflow-layout-rect.html imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-painting-text-shadow-001.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-negcoord.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity-near-zero.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity-zero.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/color-inherit.html ... (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3117 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48309 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46753 "Found 14 new test failures: fast/css/paint-order-shadow.html fast/text/empty-shadow.html fast/text/multiple-text-shadow-overflow-layout-rect.html imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-painting-text-shadow-001.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-negcoord.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity-near-zero.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity-zero.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/color-inherit.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193882 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55348 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151271 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56037 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38752 "Found 14 new test failures: fast/css/paint-order-shadow.html fast/text/empty-shadow.html fast/text/multiple-text-shadow-overflow-layout-rect.html imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-currentcolor-painting-text-shadow-001.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-negcoord.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity-near-zero.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity-zero.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/color-inherit.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150975 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45549 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128320 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124043 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54550 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17125 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53932 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54171 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53997 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->