### PR TITLE
CG: Recompute context drop shadow, style if shadowsIgnoreTransforms changes

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1200,12 +1200,20 @@ void GraphicsContextCG::setCGStyle(const std::optional<GraphicsStyle>& style, bo
 
 void GraphicsContextCG::didUpdateState(GraphicsContextState& state)
 {
-    if (!state.changes())
+    auto changes = state.changes();
+    if (!changes)
         return;
+
+    if (changes.contains(GraphicsContextState::Change::ShadowsIgnoreTransforms)) {
+        if (state.dropShadow())
+            changes.add(GraphicsContextState::Change::DropShadow);
+        if (state.style())
+            changes.add(GraphicsContextState::Change::Style);
+    }
 
     auto context = platformContext();
 
-    for (auto change : state.changes()) {
+    for (auto change : changes) {
         switch (change) {
         case GraphicsContextState::Change::FillBrush:
             if (!state.fillBrush().hasPatternOrGradient())


### PR DESCRIPTION
#### 00ae68f09d41443303068e64f5f654a6c2979feb
<pre>
CG: Recompute context drop shadow, style if shadowsIgnoreTransforms changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322175">https://bugs.webkit.org/show_bug.cgi?id=322175</a>
<a href="https://rdar.apple.com/185405205">rdar://185405205</a>

Reviewed by Mike Wyrzykowski.

CG drop shadow and style depend on shadowsIgnoreTransforms.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::didUpdateState):

Canonical link: <a href="https://commits.webkit.org/319534@main">https://commits.webkit.org/319534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/956b66528867f389ceeb8637096ba631c3ab6f02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191991 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146095 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/440b6262-888a-4b58-9a5b-2c71bf759511) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141887 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5d93176-0aa3-4ac9-812f-d8c1e82ca925) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122322 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/543db716-97e3-427d-a2e1-430a1e21da06) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44257 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42528 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42157 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3152 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193917 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55383 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151307 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40514 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56072 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38780 "Too many flaky failures: http/tests/media/text-served-as-text.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/post-frames.html, http/tests/privateClickMeasurement/store-private-click-measurement.html, http/tests/resourceLoadStatistics/grandfathering.html, http/tests/security/canvas-remote-read-remote-image-allowed-with-credentials.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-frame-src2.html, http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image-UpgradeMixedContent.https.html, http/tests/site-isolation/focus-click-navigation-activeElement.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151002 "Found 1 new API test failure: TestWebKitSettings:/webkit/WebKitSettings/user-agent (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45578 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128355 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124103 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54585 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17153 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53967 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54206 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54032 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->