### PR TITLE
[WPT] Import wasm-js-api.idl from upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/wasm-js-api.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/wasm-js-api.idl
@@ -15,11 +15,11 @@ dictionary WebAssemblyCompileOptions {
 
 [Exposed=*]
 namespace WebAssembly {
-    boolean validate(BufferSource bytes, optional WebAssemblyCompileOptions options = {});
-    Promise<Module> compile(BufferSource bytes, optional WebAssemblyCompileOptions options = {});
+    boolean validate([AllowResizable] AllowSharedBufferSource bytes, optional WebAssemblyCompileOptions options = {});
+    Promise<Module> compile([AllowResizable] AllowSharedBufferSource bytes, optional WebAssemblyCompileOptions options = {});
 
     Promise<WebAssemblyInstantiatedSource> instantiate(
-        BufferSource bytes, optional object importObject, optional WebAssemblyCompileOptions options = {});
+        [AllowResizable] AllowSharedBufferSource bytes, optional object importObject, optional WebAssemblyCompileOptions options = {});
 
     Promise<Instance> instantiate(
         Module moduleObject, optional object importObject);
@@ -56,7 +56,7 @@ dictionary ModuleImportDescriptor {
 
 [LegacyNamespace=WebAssembly, Exposed=*]
 interface Module {
-  constructor(BufferSource bytes, optional WebAssemblyCompileOptions options = {});
+  constructor([AllowResizable] AllowSharedBufferSource bytes, optional WebAssemblyCompileOptions options = {});
   static sequence<ModuleExportDescriptor> exports(Module moduleObject);
   static sequence<ModuleImportDescriptor> imports(Module moduleObject);
   static sequence<ArrayBuffer> customSections(Module moduleObject, DOMString sectionName);
@@ -144,7 +144,7 @@ dictionary ExceptionOptions {
 [LegacyNamespace=WebAssembly, Exposed=(Window,Worker,Worklet)]
 interface Exception {
   constructor(Tag exceptionTag, sequence<any> payload, optional ExceptionOptions options = {});
-  any getArg([EnforceRange] unsigned long index);
+  any getArg(Tag exceptionTag, [EnforceRange] unsigned long index);
   boolean is(Tag exceptionTag);
   readonly attribute (DOMString or undefined) stack;
 };

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any-expected.txt
@@ -8,9 +8,9 @@ PASS WebAssembly namespace: [[Prototype]] is Object.prototype
 PASS WebAssembly namespace: typeof is "object"
 PASS WebAssembly namespace: has no length property
 PASS WebAssembly namespace: has no name property
-PASS WebAssembly namespace: operation validate(BufferSource, optional WebAssemblyCompileOptions)
-PASS WebAssembly namespace: operation compile(BufferSource, optional WebAssemblyCompileOptions)
-PASS WebAssembly namespace: operation instantiate(BufferSource, optional object, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation validate(AllowSharedBufferSource, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation compile(AllowSharedBufferSource, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation instantiate(AllowSharedBufferSource, optional object, optional WebAssemblyCompileOptions)
 PASS WebAssembly namespace: operation instantiate(Module, optional object)
 PASS WebAssembly namespace: attribute JSTag
 PASS Module interface: existence and properties of interface object
@@ -87,7 +87,7 @@ PASS Exception interface object name
 PASS Exception interface: existence and properties of interface prototype object
 PASS Exception interface: existence and properties of interface prototype object's "constructor" property
 PASS Exception interface: existence and properties of interface prototype object's @@unscopables property
-FAIL Exception interface: operation getArg(unsigned long) assert_equals: property has wrong .length expected 1 but got 2
+PASS Exception interface: operation getArg(Tag, unsigned long)
 PASS Exception interface: operation is(Tag)
 PASS Exception interface: attribute stack
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.worker-expected.txt
@@ -8,9 +8,9 @@ PASS WebAssembly namespace: [[Prototype]] is Object.prototype
 PASS WebAssembly namespace: typeof is "object"
 PASS WebAssembly namespace: has no length property
 PASS WebAssembly namespace: has no name property
-PASS WebAssembly namespace: operation validate(BufferSource, optional WebAssemblyCompileOptions)
-PASS WebAssembly namespace: operation compile(BufferSource, optional WebAssemblyCompileOptions)
-PASS WebAssembly namespace: operation instantiate(BufferSource, optional object, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation validate(AllowSharedBufferSource, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation compile(AllowSharedBufferSource, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation instantiate(AllowSharedBufferSource, optional object, optional WebAssemblyCompileOptions)
 PASS WebAssembly namespace: operation instantiate(Module, optional object)
 PASS WebAssembly namespace: attribute JSTag
 PASS Module interface: existence and properties of interface object
@@ -87,7 +87,7 @@ PASS Exception interface object name
 PASS Exception interface: existence and properties of interface prototype object
 PASS Exception interface: existence and properties of interface prototype object's "constructor" property
 PASS Exception interface: existence and properties of interface prototype object's @@unscopables property
-FAIL Exception interface: operation getArg(unsigned long) assert_equals: property has wrong .length expected 1 but got 2
+PASS Exception interface: operation getArg(Tag, unsigned long)
 PASS Exception interface: operation is(Tag)
 PASS Exception interface: attribute stack
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/idlharness.any-expected.txt
@@ -4,9 +4,9 @@ PASS idl_test validation
 PASS Partial namespace WebAssembly: original namespace defined
 PASS Partial namespace WebAssembly: valid exposure set
 PASS Partial namespace WebAssembly: member names are unique
-PASS WebAssembly namespace: operation validate(BufferSource, optional WebAssemblyCompileOptions)
-PASS WebAssembly namespace: operation compile(BufferSource, optional WebAssemblyCompileOptions)
-PASS WebAssembly namespace: operation instantiate(BufferSource, optional object, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation validate(AllowSharedBufferSource, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation compile(AllowSharedBufferSource, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation instantiate(AllowSharedBufferSource, optional object, optional WebAssemblyCompileOptions)
 PASS WebAssembly namespace: operation instantiate(Module, optional object)
 PASS WebAssembly namespace: attribute JSTag
 PASS WebAssembly namespace: operation compileStreaming(Promise<Response>, optional WebAssemblyCompileOptions)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/idlharness.any.worker-expected.txt
@@ -4,9 +4,9 @@ PASS idl_test validation
 PASS Partial namespace WebAssembly: original namespace defined
 PASS Partial namespace WebAssembly: valid exposure set
 PASS Partial namespace WebAssembly: member names are unique
-PASS WebAssembly namespace: operation validate(BufferSource, optional WebAssemblyCompileOptions)
-PASS WebAssembly namespace: operation compile(BufferSource, optional WebAssemblyCompileOptions)
-PASS WebAssembly namespace: operation instantiate(BufferSource, optional object, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation validate(AllowSharedBufferSource, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation compile(AllowSharedBufferSource, optional WebAssemblyCompileOptions)
+PASS WebAssembly namespace: operation instantiate(AllowSharedBufferSource, optional object, optional WebAssemblyCompileOptions)
 PASS WebAssembly namespace: operation instantiate(Module, optional object)
 PASS WebAssembly namespace: attribute JSTag
 PASS WebAssembly namespace: operation compileStreaming(Promise<Response>, optional WebAssemblyCompileOptions)


### PR DESCRIPTION
#### c546092ed0e8df28c6bd9c8a18b8a247fa9b68be
<pre>
[WPT] Import wasm-js-api.idl from upstream

Reviewed by Yusuke Suzuki.

Upstream wasm-js-api.idl matches the JS API: Exception.getArg takes
(Tag, unsigned long). The imported snapshot still has getArg(unsigned
long), so idlharness expects length 1.

Also picks up AllowSharedBufferSource on compile, validate, and
instantiate.

Upstream: <a href="https://github.com/web-platform-tests/wpt/commit/db80bd24a77f1b5f8ba40a5b320dec3720a37c8d">https://github.com/web-platform-tests/wpt/commit/db80bd24a77f1b5f8ba40a5b320dec3720a37c8d</a>

* LayoutTests/imported/w3c/web-platform-tests/interfaces/wasm-js-api.idl:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/idlharness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/idlharness.any.worker-expected.txt:

Canonical link: <a href="https://commits.webkit.org/319572@main">https://commits.webkit.org/319572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/350c8b0130793f6e50e84ab4d6483b136469a992

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146122 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141911 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122346 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44278 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42551 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154675 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42188 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3179 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193944 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55410 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151324 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56099 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151027 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27626 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45600 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124137 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54612 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17184 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53994 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54233 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->