### PR TITLE
[EME][OpenCDM] Querying robustness level from CDM instead of hardcoding the levels

### DIFF
--- a/Source/WebCore/platform/GStreamer.cmake
+++ b/Source/WebCore/platform/GStreamer.cmake
@@ -152,6 +152,13 @@ if (ENABLE_ENCRYPTED_MEDIA AND ENABLE_THUNDER)
     # Globally add thunder libraries, required for the check_cxx_symbol_exists call.
     set(CMAKE_REQUIRED_LIBRARIES ${THUNDER_LIBRARIES})
 
+    check_cxx_symbol_exists(opencdm_system_supported_robustness ${THUNDER_INCLUDE_DIR}/open_cdm.h HAS_OCDM_SUPPORTED_ROBUSTNESS)
+    if (HAS_OCDM_SUPPORTED_ROBUSTNESS)
+      list(APPEND WebCore_PRIVATE_DEFINITIONS THUNDER_HAS_OCDM_SUPPORTED_ROBUSTNESS=1)
+    else ()
+      list(APPEND WebCore_PRIVATE_DEFINITIONS THUNDER_HAS_OCDM_SUPPORTED_ROBUSTNESS=0)
+    endif ()
+
     check_cxx_symbol_exists(opencdm_gstreamer_session_decrypt_buffer ${THUNDER_INCLUDE_DIR}/open_cdm_adapter.h HAS_OCDM_DECRYPT_BUFFER)
     if (HAS_OCDM_DECRYPT_BUFFER)
       list(APPEND WebCore_PRIVATE_DEFINITIONS THUNDER_HAS_OCDM_DECRYPT_BUFFER=1)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -177,7 +177,45 @@ bool CDMPrivateThunder::supportsConfiguration(const CDMKeySystemConfiguration& c
 
 Vector<String> CDMPrivateThunder::supportedRobustnesses() const
 {
-    return { emptyString(), "SW_SECURE_DECODE"_s, "SW_SECURE_CRYPTO"_s };
+    static const Vector<String> defaultRobustnesses { emptyAtom(), "SW_SECURE_DECODE"_s, "SW_SECURE_CRYPTO"_s };
+
+#if THUNDER_HAS_OCDM_SUPPORTED_ROBUSTNESS
+    if (!m_thunderSystem) {
+        GST_WARNING("CDMPrivateThunder: No active OpenCDM system. Falling back to default WebKit robustness levels.");
+        return defaultRobustnesses;
+    }
+
+    Vector<String> robustnesses { emptyAtom() };
+    char** buffers = nullptr;
+    uint16_t count = 0;
+
+    auto error = opencdm_system_supported_robustness(m_thunderSystem.get(), &buffers, &count);
+
+    if (buffers) {
+        if (count) {
+            robustnesses.reserveCapacity(robustnesses.size() + count);
+            // There's basically no good way to avoid unsafe-buffer-usage-in-container when interacting with a legacy
+            // char** buffer that doesn't depend on us. A modern opencdm API should use a std::vector or std::array,
+            // but it's not in our hands. Using an unsafe span is the less bad way. It's unsafe because the compiler
+            // can't ensure that buffers actually have a length of count, but we do know it's true.
+            for (char* buffer : unsafeMakeSpan(buffers, count)) {
+                if (buffer) {
+                    if (error == ERROR_NONE)
+                        robustnesses.append(String::fromLatin1(buffer));
+                    free(buffer);
+                }
+            }
+        }
+        free(buffers);
+    }
+
+    if (error == ERROR_NONE && robustnesses.size() > 1)
+        return robustnesses;
+
+    GST_WARNING("Failed to get robustness levels from OCDM. Falling back to default WebKit robustness levels.");
+#endif
+
+    return defaultRobustnesses;
 }
 
 CDMRequirement CDMPrivateThunder::distinctiveIdentifiersRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const


### PR DESCRIPTION
#### 616b4d83e35eb3e6bad52c0db85f6b9f28bf0144
<pre>
[EME][OpenCDM] Querying robustness level from CDM instead of hardcoding the levels
<a href="https://bugs.webkit.org/show_bug.cgi?id=322180">https://bugs.webkit.org/show_bug.cgi?id=322180</a>

Reviewed by Nikolas Zimmermann.

A new OpenCDM API (optional at build time) is now available to query
supported robustness levels directly from the CDM, instead of having
them hardcoded. CDMPrivateThunder::supportedRobustnesses() should be
update to use that new API when it&apos;s available, but ensuring backwards
compatibility when not.

This patch checks uses the new API (when available) to get a dynamically
allocated array of strings with the different robustness levels
supported. That array must be freed by the callee. Unfortunately, the
way in which the opencdm_system_supported_robustness() API call is
defined, it forces us to use unsafe pointer arithmetic, because the
compiler can&apos;t ensure that buffers actually have a length of count.
We do know the assumption about buffers&apos; length is true, so we use an
unsafe span as the less bad way to keep the unsafeness contained.

For a detailed explanation of how the safety restrictions work, see:
<a href="https://clang.llvm.org/docs/SafeBuffers.html">https://clang.llvm.org/docs/SafeBuffers.html</a>

Original author: Krishna Priya Kanagaraj &lt;krishnapriya_kanagaraj@comcast.com&gt;

* Source/WebCore/platform/GStreamer.cmake: Detect if opencdm_system_supported_robustness() exists and set the THUNDER_HAS_OCDM_SUPPORTED_ROBUSTNESS preprocessor define to 1 or 0 accordingly.
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::CDMPrivateThunder::supportedRobustnesses const): Query the OpenCDM robustness API when available, get the answer into a Vector and return it, freeing the underlying data structure returned by the API.

Canonical link: <a href="https://commits.webkit.org/319531@main">https://commits.webkit.org/319531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f65b0224db169c81109ffe5c77185325dcd5cef2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192005 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55448 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/141902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45582 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122337 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44268 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42538 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42171 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3166 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193931 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55397 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40506 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56086 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151019 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45589 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128369 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124121 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54599 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17167 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53981 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54220 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->