### PR TITLE
Use sparse GraphicsContext state stack

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -68,8 +68,7 @@ GraphicsContext::~GraphicsContext()
 void GraphicsContext::save(GraphicsContextState::Purpose purpose)
 {
     ASSERT(purpose == GraphicsContextState::Purpose::SaveRestore || purpose == GraphicsContextState::Purpose::TransparencyLayer);
-    m_stack.append(m_state);
-    m_state.repurpose(purpose);
+    m_stack.save(m_state, purpose);
 }
 
 void GraphicsContext::restore(GraphicsContextState::Purpose purpose)
@@ -82,13 +81,7 @@ void GraphicsContext::restore(GraphicsContextState::Purpose purpose)
     ASSERT_UNUSED(purpose, purpose == m_state.purpose());
     ASSERT_UNUSED(purpose, purpose == GraphicsContextState::Purpose::SaveRestore || purpose == GraphicsContextState::Purpose::TransparencyLayer);
 
-    m_state = m_stack.last();
-    m_stack.removeLast();
-
-    // Make sure we deallocate the state stack buffer when it goes empty.
-    // Canvas elements will immediately save() again, but that goes into inline capacity.
-    if (m_stack.isEmpty())
-        m_stack.clear();
+    m_stack.restore(m_state);
 }
 
 void GraphicsContext::unwindStateStack(unsigned count)

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -400,7 +400,7 @@ protected:
 
     GraphicsContextState m_state;
 private:
-    Vector<GraphicsContextState, 1> m_stack;
+    GraphicsContextStateStack m_stack;
 
     unsigned m_transparencyLayerCount { 0 };
     const IsDeferred m_isDeferred : 1; // NOLINT

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -39,8 +39,13 @@ GraphicsContextState::GraphicsContextState(const ChangeFlags& changeFlags, Inter
 
 void GraphicsContextState::repurpose(Purpose purpose)
 {
-    if (purpose == Purpose::Initial)
+    m_purpose = purpose;
+
+    if (purpose == Purpose::Initial) {
         m_changeFlags = { };
+        m_changesSinceSave = ChangeFlags::all();
+        return;
+    }
 
 #if USE(CG)
     // CGContextBeginTransparencyLayer() sets the CG global alpha to 1. Keep the clone's alpha in sync.
@@ -49,10 +54,16 @@ void GraphicsContextState::repurpose(Purpose purpose)
         m_style = std::nullopt;
         m_dropShadow = std::nullopt;
         m_compositeMode = { CompositeOperator::SourceOver, BlendMode::Normal };
+        // The platform context is the one that resets these, so they are not changes to apply to it.
+        m_changeFlags = { };
+
+        // The local state stack still has to restore these on restore().
+        m_changesSinceSave.add({ Change::Alpha, Change::Style, Change::DropShadow, Change::CompositeMode });
+        return;
     }
 #endif
-
-    m_purpose = purpose;
+    m_changeFlags = { };
+    m_changesSinceSave = { };
 }
 
 GraphicsContextState GraphicsContextState::clone(Purpose purpose) const
@@ -92,7 +103,7 @@ void GraphicsContextState::mergeLastChanges(const GraphicsContextState& state)
         if (!changes.contains(change) || this->*property == state.*property)
             return;
         this->*property = state.*property;
-        m_changeFlags.add(change);
+        addChange(change);
     });
 }
 
@@ -102,7 +113,7 @@ void GraphicsContextState::mergeAllChanges(const GraphicsContextState& state)
         if (this->*property == state.*property)
             return;
         this->*property = state.*property;
-        m_changeFlags.add(change);
+        addChange(change);
     });
 }
 
@@ -125,6 +136,137 @@ void GraphicsContextState::copyLastChangesFrom(const GraphicsContextState& state
         if (changes.contains(change))
             this->*property = state.*property;
     });
+}
+
+GraphicsContextStateStack::SmallProperties GraphicsContextStateStack::smallProperties(const GraphicsContextState& state)
+{
+    return {
+        std::to_underlying(state.imageInterpolationQuality()),
+        state.textDrawingMode().toRaw(),
+        state.shouldAntialias(),
+        state.shouldSmoothFonts(),
+        state.shouldSubpixelQuantizeFonts(),
+        state.shadowsIgnoreTransforms(),
+        state.drawLuminanceMask()
+    };
+}
+
+void GraphicsContextStateStack::applySmallProperties(GraphicsContextState& state, SmallProperties values)
+{
+    state.m_imageInterpolationQuality = static_cast<InterpolationQuality>(values.imageInterpolationQuality);
+    state.m_textDrawingMode = TextDrawingModeFlags::fromRaw(values.textDrawingMode);
+    state.m_shouldAntialias = values.shouldAntialias;
+    state.m_shouldSmoothFonts = values.shouldSmoothFonts;
+    state.m_shouldSubpixelQuantizeFonts = values.shouldSubpixelQuantizeFonts;
+    state.m_shadowsIgnoreTransforms = values.shadowsIgnoreTransforms;
+    state.m_drawLuminanceMask = values.drawLuminanceMask;
+}
+
+void GraphicsContextStateStack::save(GraphicsContextState& current, Purpose purpose)
+{
+    // We do not record unset changes, so platform context is synchronized before.
+    ASSERT(!current.changes());
+    // Going from Initial to first save(), we record all properties,
+    // because we do not know which properties the level 1 modifies.
+    ASSERT(current.purpose() != Purpose::Initial || current.changesSinceSave() == ChangeFlags::all());
+
+    auto changes = current.changesSinceSave();
+
+    if (changes.contains(Change::FillBrush))
+        m_fillBrush.append(current.fillBrush());
+    if (changes.contains(Change::StrokeBrush))
+        m_strokeBrush.append(current.strokeBrush());
+    if (changes.contains(Change::StrokeThickness))
+        m_strokeThickness.append(current.strokeThickness());
+    if (changes.contains(Change::FillRule))
+        m_fillRule.append(current.fillRule());
+    if (changes.contains(Change::StrokeStyle))
+        m_strokeStyle.append(current.strokeStyle());
+    if (changes.contains(Change::CompositeMode))
+        m_compositeMode.append(current.compositeMode());
+    if (changes.contains(Change::DropShadow))
+        m_dropShadow.append(current.dropShadow());
+    if (changes.contains(Change::Style))
+        m_style.append(current.style());
+    if (changes.contains(Change::Alpha))
+        m_alpha.append(current.alpha());
+    if (changes.containsAny(smallChanges))
+        m_smallProperties.append(smallProperties(current));
+
+    m_levels.append({ changes, current.purpose() });
+
+    current.m_changesSinceSave = { };
+    // repurpose() adds the properties it resets to the new level's changes since save, so that
+    // restore() puts them back.
+    current.repurpose(purpose);
+}
+
+template<typename T, typename VectorT>
+static void restoreValue(GraphicsContextState::ChangeFlags changesSinceSave, GraphicsContextState::ChangeFlags pushedValues, GraphicsContextState::Change change, VectorT& values, T& current)
+{
+    if (changesSinceSave.contains(change)) {
+        current = pushedValues.contains(change) ? values.takeLast() : values.last();
+        return;
+    }
+    if (pushedValues.contains(change))
+        values.removeLast();
+}
+
+void GraphicsContextStateStack::restore(GraphicsContextState& current)
+{
+    ASSERT(!m_levels.isEmpty());
+    ASSERT(!current.changes());
+
+    auto level = m_levels.takeLast();
+    auto changesSinceSave = current.changesSinceSave();
+
+    restoreValue(changesSinceSave, level.pushedValues, Change::FillBrush, m_fillBrush, current.m_fillBrush);
+    restoreValue(changesSinceSave, level.pushedValues, Change::StrokeBrush, m_strokeBrush, current.m_strokeBrush);
+    restoreValue(changesSinceSave, level.pushedValues, Change::StrokeThickness, m_strokeThickness, current.m_strokeThickness);
+    restoreValue(changesSinceSave, level.pushedValues, Change::FillRule, m_fillRule, current.m_fillRule);
+    restoreValue(changesSinceSave, level.pushedValues, Change::StrokeStyle, m_strokeStyle, current.m_strokeStyle);
+    restoreValue(changesSinceSave, level.pushedValues, Change::CompositeMode, m_compositeMode, current.m_compositeMode);
+    restoreValue(changesSinceSave, level.pushedValues, Change::DropShadow, m_dropShadow, current.m_dropShadow);
+    restoreValue(changesSinceSave, level.pushedValues, Change::Style, m_style, current.m_style);
+    restoreValue(changesSinceSave, level.pushedValues, Change::Alpha, m_alpha, current.m_alpha);
+    if (changesSinceSave.containsAny(smallChanges)) {
+        bool pushed = level.pushedValues.containsAny(smallChanges);
+        applySmallProperties(current, pushed ? m_smallProperties.takeLast() : m_smallProperties.last());
+    } else if (level.pushedValues.containsAny(smallChanges))
+        m_smallProperties.removeLast();
+
+    // The properties the level below had changed are the ones it pushed, and it will push them again
+    // if it saves again.
+    current.m_changesSinceSave = level.pushedValues;
+    current.m_purpose = level.purpose;
+
+    if (m_levels.isEmpty()) {
+        // The outermost level pushed every property and popped them all, so nothing is left. Make
+        // sure we deallocate the state stack buffers. Canvas elements will immediately save() again,
+        // but that goes into inline capacity.
+        ASSERT(m_fillBrush.isEmpty());
+        ASSERT(m_strokeBrush.isEmpty());
+        ASSERT(m_strokeThickness.isEmpty());
+        ASSERT(m_fillRule.isEmpty());
+        ASSERT(m_strokeStyle.isEmpty());
+        ASSERT(m_compositeMode.isEmpty());
+        ASSERT(m_dropShadow.isEmpty());
+        ASSERT(m_style.isEmpty());
+        ASSERT(m_alpha.isEmpty());
+        ASSERT(m_smallProperties.isEmpty());
+
+        m_levels.clear();
+        m_fillBrush.clear();
+        m_strokeBrush.clear();
+        m_strokeThickness.clear();
+        m_fillRule.clear();
+        m_strokeStyle.clear();
+        m_compositeMode.clear();
+        m_dropShadow.clear();
+        m_style.clear();
+        m_alpha.clear();
+        m_smallProperties.clear();
+    }
 }
 
 static ASCIILiteral stateChangeName(GraphicsContextState::Change change)

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -31,8 +31,11 @@
 #include <WebCore/WindRule.h>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/OptionSet.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
+
+class GraphicsContextStateStack;
 
 class GraphicsContextState {
     friend class GraphicsContextCairo;
@@ -75,15 +78,19 @@ public:
     void repurpose(Purpose);
     GraphicsContextState clone(Purpose) const;
 
+    // The changes that have not been applied to the platform context yet.
     ChangeFlags changes() const { return m_changeFlags; }
     void didApplyChanges() { m_changeFlags = { }; }
+
+    // The changes made since the save() that started this state stack level.
+    ChangeFlags changesSinceSave() const { return m_changesSinceSave; }
 
     SourceBrush& fillBrush() LIFETIME_BOUND { return m_fillBrush; }
     const SourceBrush& fillBrush() const LIFETIME_BOUND { return m_fillBrush; }
     void setFillBrush(const SourceBrush& brush) { setProperty(Change::FillBrush, &GraphicsContextState::m_fillBrush, brush); }
     void setFillColor(const Color& color) { setProperty(Change::FillBrush, &GraphicsContextState::m_fillBrush, { color }); }
-    void setFillGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform) { m_fillBrush.setGradient(WTF::move(gradient), spaceTransform); m_changeFlags.add(Change::FillBrush); }
-    void setFillPattern(Ref<Pattern>&& pattern) { m_fillBrush.setPattern(WTF::move(pattern)); m_changeFlags.add(Change::FillBrush); }
+    void setFillGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform) { m_fillBrush.setGradient(WTF::move(gradient), spaceTransform); addChange(Change::FillBrush); }
+    void setFillPattern(Ref<Pattern>&& pattern) { m_fillBrush.setPattern(WTF::move(pattern)); addChange(Change::FillBrush); }
 
     WindRule fillRule() const { return m_fillRule; }
     void setFillRule(WindRule fillRule) { setProperty(Change::FillRule, &GraphicsContextState::m_fillRule, fillRule); }
@@ -92,8 +99,8 @@ public:
     const SourceBrush& strokeBrush() const LIFETIME_BOUND { return m_strokeBrush; }
     void setStrokeBrush(const SourceBrush& brush) { setProperty(Change::StrokeBrush, &GraphicsContextState::m_strokeBrush, brush); }
     void setStrokeColor(const Color& color) { setProperty(Change::StrokeBrush, &GraphicsContextState::m_strokeBrush, { color }); }
-    void setStrokeGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform) { m_strokeBrush.setGradient(WTF::move(gradient), spaceTransform); m_changeFlags.add(Change::StrokeBrush); }
-    void setStrokePattern(Ref<Pattern>&& pattern) { m_strokeBrush.setPattern(WTF::move(pattern)); m_changeFlags.add(Change::StrokeBrush); }
+    void setStrokeGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform) { m_strokeBrush.setGradient(WTF::move(gradient), spaceTransform); addChange(Change::StrokeBrush); }
+    void setStrokePattern(Ref<Pattern>&& pattern) { m_strokeBrush.setPattern(WTF::move(pattern)); addChange(Change::StrokeBrush); }
 
     float strokeThickness() const { return m_strokeThickness; }
     void setStrokeThickness(float strokeThickness) { setProperty(Change::StrokeThickness, &GraphicsContextState::m_strokeThickness, strokeThickness); }
@@ -149,8 +156,15 @@ public:
 
 private:
     friend struct IPC::ArgumentCoder<GraphicsContextState>;
+    friend class GraphicsContextStateStack;
 
     template<typename Functor> static constexpr void forEachProperty(NOESCAPE const Functor&);
+
+    void addChange(Change change)
+    {
+        m_changeFlags.add(change);
+        m_changesSinceSave.add(change);
+    }
 
     template<typename T>
     void setProperty(Change change, T GraphicsContextState::*property, const T& value)
@@ -160,7 +174,7 @@ private:
             return;
 #endif
         this->*property = value;
-        m_changeFlags.add(change);
+        addChange(change);
     }
 
     template<typename T>
@@ -171,12 +185,13 @@ private:
             return;
 #endif
         this->*property = std::forward<T>(value);
-        m_changeFlags.add(change);
+        addChange(change);
     }
 
     SourceBrush m_fillBrush { Color::black };
     SourceBrush m_strokeBrush { Color::black };
     ChangeFlags m_changeFlags;
+    ChangeFlags m_changesSinceSave { ChangeFlags::all() }; // Initial -> save pushes all properties.
     float m_strokeThickness { 0 };
     WindRule m_fillRule { WindRule::NonZero };
     StrokeStyle m_strokeStyle { StrokeStyle::SolidStroke };
@@ -196,6 +211,63 @@ private:
     bool m_drawLuminanceMask { false };
 
     Purpose m_purpose { Purpose::Initial };
+};
+
+class GraphicsContextStateStack {
+public:
+    using Change = GraphicsContextState::Change;
+    using ChangeFlags = GraphicsContextState::ChangeFlags;
+    using Purpose = GraphicsContextState::Purpose;
+
+    bool isEmpty() const { return m_levels.isEmpty(); }
+    unsigned size() const { return m_levels.size(); }
+
+    void save(GraphicsContextState& current, Purpose);
+    void restore(GraphicsContextState& current);
+
+private:
+    friend class GraphicsContextState;
+
+    struct SmallProperties {
+        unsigned imageInterpolationQuality : 3; // InterpolationQuality
+        unsigned textDrawingMode : 2; // TextDrawingModeFlags
+        unsigned shouldAntialias : 1;
+        unsigned shouldSmoothFonts : 1;
+        unsigned shouldSubpixelQuantizeFonts : 1;
+        unsigned shadowsIgnoreTransforms : 1;
+        unsigned drawLuminanceMask : 1;
+    };
+    static_assert(sizeof(SmallProperties) <= 4, "SmallProperties should pack into a word");
+    static_assert(static_cast<unsigned>(InterpolationQuality::High) < 8, "imageInterpolationQuality needs more bits");
+    static_assert(2 * static_cast<unsigned>(TextDrawingMode::Stroke) - 1 < 4, "textDrawingMode needs more bits");
+
+    static constexpr ChangeFlags smallChanges {
+        Change::ImageInterpolationQuality, Change::TextDrawingMode, Change::ShouldAntialias,
+        Change::ShouldSmoothFonts, Change::ShouldSubpixelQuantizeFonts,
+        Change::ShadowsIgnoreTransforms, Change::DrawLuminanceMask
+    };
+
+    static SmallProperties smallProperties(const GraphicsContextState&);
+    static void applySmallProperties(GraphicsContextState&, SmallProperties);
+
+    struct Level {
+        ChangeFlags pushedValues; // The properties whose value this level pushed, which its restore() pops.
+        Purpose purpose;
+    };
+
+    Vector<Level, 1> m_levels;
+
+    // Each of these holds the value the property had before save().
+    Vector<SourceBrush, 1> m_fillBrush;
+    Vector<SourceBrush, 1> m_strokeBrush;
+    Vector<float, 1> m_strokeThickness;
+    Vector<float, 1> m_alpha;
+    Vector<std::optional<GraphicsDropShadow>> m_dropShadow;
+    Vector<std::optional<GraphicsStyle>> m_style;
+    Vector<WindRule, 1> m_fillRule;
+    Vector<StrokeStyle, 1> m_strokeStyle;
+    Vector<CompositeMode, 1> m_compositeMode;
+    Vector<SmallProperties, 1> m_smallProperties;
 };
 
 TextStream& operator<<(TextStream&, GraphicsContextState::Change);

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -60,7 +60,8 @@ private:
     bool invalidatingImagesWithAsyncDecodes() const final { return m_paintInvalidationReasons == PaintInvalidationReasons::InvalidatingImagesWithAsyncDecodes; }
     bool detectingContentfulPaint() const final { return m_paintInvalidationReasons == PaintInvalidationReasons::DetectingContentfulPaint; }
 
-    void didUpdateState(GraphicsContextState&) final { }
+    // Move this to save() override once didUpdateState is removed.
+    void didUpdateState(GraphicsContextState& state) final { state.didApplyChanges(); }
 
     void drawNativeImage(const NativeImage&, const FloatRect&, const FloatRect&, ImagePaintingOptions) final { }
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -864,8 +864,10 @@ void GraphicsContextSkia::translate(float x, float y)
     m_canvas.translate(SkFloatToScalar(x), SkFloatToScalar(y));
 }
 
-void GraphicsContextSkia::didUpdateState(GraphicsContextState&)
+void GraphicsContextSkia::didUpdateState(GraphicsContextState& state)
 {
+    // Move this to save() override once didUpdateState is removed.
+    state.didApplyChanges();
 }
 
 void GraphicsContextSkia::concatCTM(const AffineTransform& ctm)

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -239,6 +239,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/FloatSegmentTest.cpp
         Tests/WebCore/FloatSizeTests.cpp
         Tests/WebCore/FlowModeTests.cpp
+        Tests/WebCore/GraphicsContextStateStackTests.cpp
         Tests/WebCore/GridPosition.cpp
         Tests/WebCore/HTMLParserIdioms.cpp
         Tests/WebCore/HTTPParsers.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -759,6 +759,7 @@
 				WebCore/FlowModeTests.cpp,
 				WebCore/FontCascade.cpp,
 				WebCore/FontShadowTests.cpp,
+				WebCore/GraphicsContextStateStackTests.cpp,
 				WebCore/GridPosition.cpp,
 				WebCore/HTMLParserIdioms.cpp,
 				WebCore/HTTPHeaderField.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/GraphicsContextStateStackTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/GraphicsContextStateStackTests.cpp
@@ -1,0 +1,393 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Helpers/Test.h"
+#include <WebCore/GraphicsContext.h>
+#include <WebCore/GraphicsContextState.h>
+
+namespace TestWebKitAPI {
+using namespace WebCore;
+
+using Purpose = GraphicsContextState::Purpose;
+
+// GraphicsContext::save() stores the values its restore() has to put back in a
+// GraphicsContextStateStack. This context does not do anything else, so the state it exposes is the
+// state the stack maintains. NullGraphicsContext cannot be used, since it makes save() and restore()
+// no-ops.
+class TestGraphicsContext final : public GraphicsContext {
+public:
+    TestGraphicsContext() = default;
+    explicit TestGraphicsContext(const GraphicsContextState& state)
+        : GraphicsContext(IsDeferred::No, state)
+    {
+    }
+
+private:
+    // The state stack requires that a state change has reached the platform context before the next
+    // save(), and there is no platform context here.
+    void didUpdateState(GraphicsContextState& state) final { state.didApplyChanges(); }
+
+    void drawNativeImage(const NativeImage&, const FloatRect&, const FloatRect&, ImagePaintingOptions) final { }
+    void drawPattern(const NativeImage&, const FloatRect&, const FloatRect&, const AffineTransform&, const FloatPoint&, const FloatSize&, ImagePaintingOptions) final { }
+    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final { }
+
+#if USE(CG)
+    void applyStrokePattern() final { }
+    void applyFillPattern() final { }
+    bool isCALayerContext() const final { return false; }
+#endif
+
+    void drawRect(const FloatRect&, float = 1) final { }
+    void drawLine(const FloatPoint&, const FloatPoint&) final { }
+    void drawEllipse(const FloatRect&) final { }
+    void fillPath(const Path&) final { }
+    void strokePath(const Path&) final { }
+    void fillRect(const FloatRect&, RequiresClipToRect) final { }
+    void fillRect(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect) final { }
+    void fillRect(const FloatRect&, const Color&) final { }
+    void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) final { }
+    void strokeRect(const FloatRect&, float) final { }
+    void clipPath(const Path&, WindRule = WindRule::EvenOdd) final { }
+    void drawLinesForText(const FloatPoint&, float, std::span<const FloatSegment>, bool, bool, StrokeStyle) final { }
+    void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final { }
+    void drawFocusRing(const Path&, float, const Color&, float) final { }
+    void drawFocusRing(const Vector<FloatRect>&, float, const Color&, float) final { }
+    void setLineCap(LineCap) final { }
+    void setLineDash(const DashArray&, float) final { }
+    void setLineJoin(LineJoin) final { }
+    void setMiterLimit(float) final { }
+    void clearRect(const FloatRect&) final { }
+    void resetClip() final { }
+    void clip(const FloatRect&) final { }
+    void clipOut(const FloatRect&) final { }
+    void clipOut(const Path&) final { }
+    void scale(const FloatSize&) final { }
+    void rotate(float) final { }
+    void translate(float, float) final { }
+    void concatCTM(const AffineTransform&) final { }
+    void setCTM(const AffineTransform&) final { }
+    AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const final { return { }; }
+};
+
+TEST(GraphicsContextStateStackTests, RestorePutsBackAPropertyTheLevelChanged)
+{
+    TestGraphicsContext context;
+    context.setStrokeThickness(3);
+    context.setFillColor(Color::red);
+
+    context.save();
+    EXPECT_EQ(1u, context.stackSize());
+    context.setFillColor(Color::green);
+    context.setStrokeThickness(7);
+    context.restore();
+
+    EXPECT_EQ(0u, context.stackSize());
+    EXPECT_EQ(Color::red, context.fillColor());
+    EXPECT_EQ(3.f, context.strokeThickness());
+}
+
+TEST(GraphicsContextStateStackTests, RestorePutsBackAPropertyNoLevelBelowChanged)
+{
+    TestGraphicsContext context;
+    auto initialQuality = context.imageInterpolationQuality();
+    EXPECT_NE(InterpolationQuality::Low, initialQuality);
+
+    context.save();
+    context.setImageInterpolationQuality(InterpolationQuality::Low);
+    context.restore();
+
+    EXPECT_EQ(initialQuality, context.imageInterpolationQuality());
+}
+
+TEST(GraphicsContextStateStackTests, RestoreLeavesAPropertyTheLevelDidNotChange)
+{
+    TestGraphicsContext context;
+    context.setAlpha(0.25f);
+
+    context.save();
+    context.setStrokeThickness(5);
+    context.restore();
+
+    EXPECT_EQ(0.25f, context.alpha());
+}
+
+TEST(GraphicsContextStateStackTests, ChangingAPropertyToTheValueItHasIsRestored)
+{
+    TestGraphicsContext context;
+    context.setAlpha(0.5f);
+
+    context.save();
+    context.setAlpha(0.5f);
+    context.setAlpha(0.75f);
+    context.restore();
+
+    EXPECT_EQ(0.5f, context.alpha());
+}
+
+TEST(GraphicsContextStateStackTests, NestedLevelsAreRestoredInOrder)
+{
+    TestGraphicsContext context;
+    context.setAlpha(0.1f);
+
+    context.save();
+    context.setAlpha(0.2f);
+    context.save();
+    context.setAlpha(0.3f);
+    context.save();
+    // This level changes nothing.
+    EXPECT_EQ(3u, context.stackSize());
+
+    context.restore();
+    EXPECT_EQ(0.3f, context.alpha());
+    context.restore();
+    EXPECT_EQ(0.2f, context.alpha());
+    context.restore();
+    EXPECT_EQ(0.1f, context.alpha());
+    EXPECT_EQ(0u, context.stackSize());
+}
+
+TEST(GraphicsContextStateStackTests, LevelsBelowAreRestoredAfterAnInnerLevelChangedTheSameProperty)
+{
+    TestGraphicsContext context;
+    context.setAlpha(0.1f);
+
+    context.save();
+    // The level below changed the alpha, this one does not.
+    context.save();
+    context.setAlpha(0.9f);
+    context.restore();
+    EXPECT_EQ(0.1f, context.alpha());
+    context.setAlpha(0.5f);
+    context.restore();
+
+    EXPECT_EQ(0.1f, context.alpha());
+}
+
+TEST(GraphicsContextStateStackTests, SuccessiveLevelsAreRestored)
+{
+    TestGraphicsContext context;
+
+    for (unsigned i = 1; i <= 4; ++i) {
+        context.setAlpha(1.f / i);
+        context.save();
+        context.setAlpha(0.f);
+        context.restore();
+        EXPECT_EQ(1.f / i, context.alpha());
+    }
+}
+
+TEST(GraphicsContextStateStackTests, DeeplyNestedLevelsAreRestored)
+{
+    constexpr unsigned levels = 40;
+    TestGraphicsContext context;
+
+    for (unsigned i = 0; i < levels; ++i) {
+        context.save();
+        context.setStrokeThickness(i);
+        context.setFillColor(i % 2 ? Color::red : Color::green);
+    }
+    EXPECT_EQ(levels, context.stackSize());
+    for (unsigned i = levels; i--;) {
+        EXPECT_EQ(static_cast<float>(i), context.strokeThickness());
+        context.restore();
+    }
+    EXPECT_EQ(0u, context.stackSize());
+    EXPECT_EQ(0.f, context.strokeThickness());
+    EXPECT_EQ(Color::black, context.fillColor());
+}
+
+TEST(GraphicsContextStateStackTests, RestoreInAContextStartedFromAnExistingState)
+{
+    // A recording context is started from the state of the context it records for, which is that
+    // state repurposed to Purpose::Initial: it has no changes left to apply.
+    GraphicsContextState state;
+    state.setAlpha(0.5f);
+    state.didApplyChanges();
+
+    TestGraphicsContext context { state };
+    EXPECT_EQ(0.5f, context.alpha());
+
+    context.save();
+    context.setAlpha(0.25f);
+    context.restore();
+
+    EXPECT_EQ(0.5f, context.alpha());
+}
+
+TEST(GraphicsContextStateStackTests, RestorePutsBackThePurposeOfTheLevelBelow)
+{
+    TestGraphicsContext context;
+    EXPECT_EQ(Purpose::Initial, context.state().purpose());
+
+    context.save();
+    EXPECT_EQ(Purpose::SaveRestore, context.state().purpose());
+    context.save(Purpose::TransparencyLayer);
+    EXPECT_EQ(Purpose::TransparencyLayer, context.state().purpose());
+
+    context.restore(Purpose::TransparencyLayer);
+    EXPECT_EQ(Purpose::SaveRestore, context.state().purpose());
+    context.restore();
+    EXPECT_EQ(Purpose::Initial, context.state().purpose());
+}
+
+TEST(GraphicsContextStateStackTests, RestoreOfATransparencyLayerLevelPutsBackTheResetProperties)
+{
+    TestGraphicsContext context;
+    context.setAlpha(0.5f);
+    context.setCompositeOperation(CompositeOperator::SourceIn);
+    context.setDropShadow({ { 1, 2 }, 3, Color::red });
+
+    context.save(Purpose::TransparencyLayer);
+#if USE(CG)
+    // CGContextBeginTransparencyLayer() resets these in the platform context.
+    EXPECT_EQ(1.f, context.alpha());
+    EXPECT_EQ(CompositeOperator::SourceOver, context.compositeOperation());
+    EXPECT_FALSE(context.dropShadow().has_value());
+#endif
+    context.restore(Purpose::TransparencyLayer);
+
+    EXPECT_EQ(0.5f, context.alpha());
+    EXPECT_EQ(CompositeOperator::SourceIn, context.compositeOperation());
+    ASSERT_TRUE(context.dropShadow().has_value());
+    EXPECT_EQ(Color::red, context.dropShadow()->color);
+}
+
+// Three values per property, all different from each other and from the initial value, so that a
+// property that is stored or restored as another one of the same type is caught.
+struct EveryProperty {
+    SourceBrush fillBrush;
+    WindRule fillRule;
+    SourceBrush strokeBrush;
+    float strokeThickness;
+    StrokeStyle strokeStyle;
+    CompositeMode compositeMode;
+    GraphicsDropShadow dropShadow;
+    GraphicsDropShadow style;
+    float alpha;
+    InterpolationQuality imageInterpolationQuality;
+    TextDrawingModeFlags textDrawingMode;
+    bool shouldAntialias;
+    bool shouldSmoothFonts;
+    bool shouldSubpixelQuantizeFonts;
+    bool shadowsIgnoreTransforms;
+    bool drawLuminanceMask;
+};
+
+static EveryProperty firstValues()
+{
+    return {
+        SourceBrush { Color::red }, WindRule::EvenOdd, SourceBrush { Color::green }, 2,
+        StrokeStyle::DottedStroke, { CompositeOperator::SourceIn, BlendMode::Multiply },
+        { { 1, 2 }, 3, Color::blue }, { { 4, 5 }, 6, Color::cyan }, 0.25f,
+        InterpolationQuality::Low, TextDrawingMode::Stroke, false, false, false, true, true
+    };
+}
+
+static EveryProperty secondValues()
+{
+    return {
+        SourceBrush { Color::magenta }, WindRule::NonZero, SourceBrush { Color::yellow }, 8,
+        StrokeStyle::DashedStroke, { CompositeOperator::DestinationOver, BlendMode::Screen },
+        { { 7, 8 }, 9, Color::white }, { { 10, 11 }, 12, Color::gray }, 0.75f,
+        InterpolationQuality::High, TextDrawingMode::Fill, true, true, true, false, false
+    };
+}
+
+static EveryProperty thirdValues()
+{
+    return {
+        SourceBrush { Color::gold }, WindRule::EvenOdd, SourceBrush { Color::purple }, 16,
+        StrokeStyle::DoubleStroke, { CompositeOperator::DestinationIn, BlendMode::Darken },
+        { { 13, 14 }, 15, Color::orange }, { { 16, 17 }, 18, Color::lightGray }, 0.5f,
+        InterpolationQuality::Medium, TextDrawingMode::Stroke, false, false, false, true, true
+    };
+}
+
+static void setEveryProperty(GraphicsContext& context, const EveryProperty& values)
+{
+    context.setFillBrush(values.fillBrush);
+    context.setFillRule(values.fillRule);
+    context.setStrokeBrush(values.strokeBrush);
+    context.setStrokeThickness(values.strokeThickness);
+    context.setStrokeStyle(values.strokeStyle);
+    context.setCompositeMode(values.compositeMode);
+    context.setDropShadow(values.dropShadow);
+    context.setStyle(GraphicsStyle { values.style });
+    context.setAlpha(values.alpha);
+    context.setImageInterpolationQuality(values.imageInterpolationQuality);
+    context.setTextDrawingMode(values.textDrawingMode);
+    context.setShouldAntialias(values.shouldAntialias);
+    context.setShouldSmoothFonts(values.shouldSmoothFonts);
+    context.setShouldSubpixelQuantizeFonts(values.shouldSubpixelQuantizeFonts);
+    context.setShadowsIgnoreTransforms(values.shadowsIgnoreTransforms);
+    context.setDrawLuminanceMask(values.drawLuminanceMask);
+}
+
+static void expectEveryProperty(const GraphicsContext& context, const EveryProperty& values)
+{
+    EXPECT_EQ(values.fillBrush.color(), context.fillColor());
+    EXPECT_EQ(values.fillRule, context.fillRule());
+    EXPECT_EQ(values.strokeBrush.color(), context.strokeColor());
+    EXPECT_EQ(values.strokeThickness, context.strokeThickness());
+    EXPECT_EQ(values.strokeStyle, context.strokeStyle());
+    EXPECT_EQ(values.compositeMode.operation, context.compositeOperation());
+    EXPECT_EQ(values.compositeMode.blendMode, context.blendMode());
+    ASSERT_TRUE(context.dropShadow().has_value());
+    EXPECT_EQ(values.dropShadow, *context.dropShadow());
+    ASSERT_TRUE(context.style().has_value());
+    ASSERT_TRUE(std::holds_alternative<GraphicsDropShadow>(*context.style()));
+    EXPECT_EQ(values.style, std::get<GraphicsDropShadow>(*context.style()));
+    EXPECT_EQ(values.alpha, context.alpha());
+    EXPECT_EQ(values.imageInterpolationQuality, context.imageInterpolationQuality());
+    EXPECT_EQ(values.textDrawingMode, context.textDrawingMode());
+    EXPECT_EQ(values.shouldAntialias, context.shouldAntialias());
+    EXPECT_EQ(values.shouldSmoothFonts, context.shouldSmoothFonts());
+    EXPECT_EQ(values.shouldSubpixelQuantizeFonts, context.shouldSubpixelQuantizeFonts());
+    EXPECT_EQ(values.shadowsIgnoreTransforms, context.shadowsIgnoreTransforms());
+    EXPECT_EQ(values.drawLuminanceMask, context.drawLuminanceMask());
+}
+
+TEST(GraphicsContextStateStackTests, RestorePutsBackEveryProperty)
+{
+    TestGraphicsContext context;
+
+    // The first level restores from the values the first save() stored for every property, the
+    // second one from the values its own save() pushed.
+    setEveryProperty(context, firstValues());
+    context.save();
+    setEveryProperty(context, secondValues());
+    context.save();
+    setEveryProperty(context, thirdValues());
+
+    expectEveryProperty(context, thirdValues());
+    context.restore();
+    expectEveryProperty(context, secondValues());
+    context.restore();
+    expectEveryProperty(context, firstValues());
+}
+
+}


### PR DESCRIPTION
#### 4eb58db47ec94f704670a1e5f7ef36441bf70778
<pre>
Use sparse GraphicsContext state stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=322184">https://bugs.webkit.org/show_bug.cgi?id=322184</a>
<a href="https://rdar.apple.com/185419558">rdar://185419558</a>

Reviewed by NOBODY (OOPS!).

Implement GraphicsContext::save() with one Vector per saved property.
This intends to make save() cost proportional to the changed properties.
This in turn is needed to expand state to contain currently
unrepresented state data, such as transform and line style properties.

Implement by tracking changes to current state since last save().
Upon save(), push these properties to the state Vectors and record
the change accounting bitfield to the state level stack.
Upon corresponding restore(), restore all currently changed properties
from the last element of the vectors. If the last element was pushed
as part of the now restored element, pop the element from the vector.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::save):
(WebCore::GraphicsContext::restore):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::repurpose):
(WebCore::GraphicsContextState::mergeLastChanges):
(WebCore::GraphicsContextState::mergeAllChanges):
(WebCore::GraphicsContextStateStack::smallProperties):
(WebCore::GraphicsContextStateStack::applySmallProperties):
(WebCore::GraphicsContextStateStack::save):
(WebCore::restoreValue):
(WebCore::GraphicsContextStateStack::restore):
* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::changesSinceSave const):
(WebCore::GraphicsContextState::setFillGradient):
(WebCore::GraphicsContextState::setFillPattern):
(WebCore::GraphicsContextState::setStrokeGradient):
(WebCore::GraphicsContextState::setStrokePattern):
(WebCore::GraphicsContextState::addChange):
(WebCore::GraphicsContextState::setProperty):
(WebCore::GraphicsContextStateStack::isEmpty const):
(WebCore::GraphicsContextStateStack::size const):
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::didUpdateState):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4eb58db47ec94f704670a1e5f7ef36441bf70778

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146091 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ead31ede-a87f-4c4c-a812-4ea92606d33a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141894 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98498 "3 flakes 14 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9cdd8f4f-0887-4fdf-9b4e-f5e6d61d5a42) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122329 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c4adea0-8e1b-4ee6-9e81-0f20873535e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44260 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42526 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42161 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3148 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193913 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55379 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151299 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56068 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151003 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45579 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128351 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124097 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54581 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17157 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53963 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54202 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54028 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->