### PR TITLE
[cleanup] Ask the list marker for its text through one accessor

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4310,7 +4310,7 @@ String AccessibilityNodeObject::stringValue() const
             } else if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(object->renderer())) {
                 // List markers have no DOM node. Flush any pending text run, then append marker text.
                 flushRun();
-                builder.append(renderListMarker->textWithSuffix());
+                builder.append(renderListMarker->textContent());
             }
         }
         flushRun();

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2167,7 +2167,7 @@ static StringView lineStartListMarkerText(const RenderListItem* listItem, const 
         return { };
 
     if (!markerText)
-        markerText = listItem->markerTextWithSuffix();
+        markerText = listItem->markerText();
     if (markerText->isEmpty())
         return { };
 
@@ -2184,7 +2184,7 @@ StringView AccessibilityObject::listMarkerTextForNodeAndPosition(Node* node, Pos
         return { };
     // Creating a VisiblePosition and determining its relationship to a line of text can be expensive.
     // Thus perform that determination only if we have some text to return.
-    auto markerText = listItem->markerTextWithSuffix();
+    auto markerText = listItem->markerText();
     if (markerText.isEmpty())
         return { };
     return lineStartListMarkerText(listItem.get(), startPosition, markerText);

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -434,7 +434,7 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
 
     if (mode.includeListMarkers == IncludeListMarkerText::Yes) {
         if (auto* listMarker = dynamicDowncast<RenderListMarker>(*m_renderer))
-            return listMarker->textWithSuffix();
+            return listMarker->textContent();
     }
 
     // Reflect when a content author has explicitly marked a line break.
@@ -583,9 +583,9 @@ String AccessibilityRenderObject::stringValue() const
 
     if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(m_renderer.get())) {
 #if USE(ATSPI)
-        return renderListMarker->textWithSuffix();
+        return renderListMarker->textContent();
 #else
-        return renderListMarker->textWithoutSuffix();
+        return renderListMarker->textContent(RenderListMarker::IncludeSuffix::No);
 #endif
     }
 
@@ -1737,7 +1737,7 @@ AXTextRunLineID AccessibilityRenderObject::listMarkerLineID() const
 String AccessibilityRenderObject::listMarkerText() const
 {
     CheckedPtr marker = dynamicDowncast<RenderListMarker>(renderer());
-    return marker ? marker->textWithSuffix() : String();
+    return marker ? marker->textContent() : String();
 }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -461,18 +461,11 @@ void RenderListItem::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintO
         excludedMarker->paintAsInlineBlock(paintInfo, flipForWritingModeForChild(*excludedMarker, paintOffset));
 }
 
-String RenderListItem::markerTextWithoutSuffix() const
+String RenderListItem::markerText(RenderListMarker::IncludeSuffix includeSuffix) const
 {
     if (!m_marker)
         return { };
-    return m_marker->textWithoutSuffix();
-}
-
-String RenderListItem::markerTextWithSuffix() const
-{
-    if (!m_marker)
-        return { };
-    return m_marker->textWithSuffix();
+    return m_marker->textContent(includeSuffix);
 }
 
 void RenderListItem::usedCounterDirectivesChanged()

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -39,8 +39,7 @@ public:
     int value() const;
     void updateValue();
 
-    WEBCORE_EXPORT String markerTextWithoutSuffix() const;
-    String NODELETE markerTextWithSuffix() const;
+    WEBCORE_EXPORT String markerText(RenderListMarker::IncludeSuffix = RenderListMarker::IncludeSuffix::Yes) const;
 
     void updateListMarkerNumbers();
 

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -388,7 +388,7 @@ void RenderListMarker::layout()
     } else {
         setLogicalWidth(minContentLogicalWidthContribution());
         setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
-        m_layoutBounds = layoutBoundForTextContent(textWithSuffix());
+        m_layoutBounds = layoutBoundForTextContent(m_textContent.textWithSuffix);
     }
 
     setMarginStart(0);
@@ -426,7 +426,7 @@ void RenderListMarker::layoutContentContainer(RenderBlockFlow& container)
 
     if (textNeedsBidiResolution()) {
         setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
-        m_layoutBounds = layoutBoundForTextContent(textWithSuffix());
+        m_layoutBounds = layoutBoundForTextContent(m_textContent.textWithSuffix);
     } else {
         setLogicalHeight(container.logicalHeight());
         m_layoutBounds = { contentBaseline, container.logicalHeight() - contentBaseline };

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -54,8 +54,11 @@ public:
     RenderListMarker(RenderListItem&, Style::ComputedStyle&&);
     virtual ~RenderListMarker();
 
-    String textWithoutSuffix() const { return m_textContent.textWithoutSuffix().toString(); };
-    String textWithSuffix() const { return m_textContent.textWithSuffix; };
+    enum class IncludeSuffix : bool { No, Yes };
+    String textContent(IncludeSuffix includeSuffix = IncludeSuffix::Yes) const
+    {
+        return includeSuffix == IncludeSuffix::Yes ? m_textContent.textWithSuffix : m_textContent.textWithoutSuffix().toString();
+    }
 
     bool NODELETE isInside() const;
     bool isDisclosureMarker() const;

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -365,7 +365,7 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
         ts << " [r="_s << cell->rowIndex() << " c="_s << cell->col() << " rs="_s << cell->rowSpan() << " cs="_s << cell->colSpan() << ']';
 
     if (auto* listMarker = dynamicDowncast<RenderListMarker>(o)) {
-        auto text = listMarker->textWithoutSuffix();
+        auto text = listMarker->textContent(RenderListMarker::IncludeSuffix::No);
         if (!text.isEmpty()) {
             if (text.length() != 1)
                 text = quoteAndEscapeNonPrintables(text);
@@ -918,7 +918,7 @@ String markerTextForListItem(Element* element)
     auto* renderer = dynamicDowncast<RenderListItem>(element->renderer());
     if (!renderer)
         return String();
-    return renderer->markerTextWithoutSuffix();
+    return renderer->markerText(RenderListMarker::IncludeSuffix::No);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 77327f67bb617aa82eda8beb0a0b3abc5b3cb728
<pre>
[cleanup] Ask the list marker for its text through one accessor
<a href="https://bugs.webkit.org/show_bug.cgi?id=322183">https://bugs.webkit.org/show_bug.cgi?id=322183</a>
&lt;<a href="https://rdar.apple.com/problem/185419069">rdar://problem/185419069</a>&gt;

Reviewed by Antti Koivisto.

No behavior change.

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::stringValue const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textUnderElement const):
(WebCore::AccessibilityRenderObject::stringValue const):
(WebCore::AccessibilityRenderObject::listMarkerText const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::lineStartListMarkerText):
(WebCore::AccessibilityObject::listMarkerTextForNodeAndPosition):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::markerText const):
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::layout):
(WebCore::RenderListMarker::layoutContentContainer):
* Source/WebCore/rendering/RenderListMarker.h:
(WebCore::RenderListMarker::textContent const):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::RenderTreeAsText::writeRenderObject):
(WebCore::markerTextForListItem):

Canonical link: <a href="https://commits.webkit.org/319600@main">https://commits.webkit.org/319600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98e7ef2644de38d07b65f19588e3924ecaab5ba3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191990 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146094 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72666b14-6420-4368-9f0c-55c42124fd7c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141886 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0095445-ac3f-4806-9661-577d680d5a4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122321 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44258 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42529 "Found 2 new API test failures: TestWebKitAPI.ProcessSwap.COEPProcessSwapOnSiteWhereLockdownModeIsDisabled, TestWebKitAPI.ProcessSwap.SessionStorage (failure)") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42160 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3151 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193916 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55382 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151297 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40560 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56071 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151001 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45577 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128354 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124102 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54584 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17156 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53966 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54205 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54031 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->