### PR TITLE
[Liquid Glass] Subject area in mail compose sometimes flashes when shrinking image down from original size

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4527,6 +4527,10 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
     if (wasEditable == editable)
         return;
 
+#if PLATFORM(MAC) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    _impl->updateScrollPocketVisibilityWhenScrolledToTopAndNonEditable();
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     [_contentView _didChangeWebViewEditability];
 #endif

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1877,7 +1877,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     _impl->updateTopScrollPocketStyle();
-    _impl->updateScrollPocketVisibilityWhenScrolledToTop();
+    _impl->updateScrollPocketVisibilityWhenScrolledToTopAndNonEditable();
     _impl->updateTopScrollPocketCaptureColor();
 #endif
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -889,7 +889,7 @@ public:
     NSScrollPocket *topScrollPocket() const LIFETIME_BOUND { return m_topScrollPocket.get(); }
     void registerViewAboveScrollPocket(NSView *);
     void unregisterViewAboveScrollPocket(NSView *);
-    void updateScrollPocketVisibilityWhenScrolledToTop();
+    void updateScrollPocketVisibilityWhenScrolledToTopAndNonEditable();
     void updateTopScrollPocketCaptureColor();
     void updateTopScrollPocketStyle();
     void updatePrefersSolidColorHardPocket();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2705,7 +2705,7 @@ void WebViewImpl::pageDidScroll(const IntPoint& scrollOffset)
 
     if (pageIsScrolledToTopDidChange) {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-        updateScrollPocketVisibilityWhenScrolledToTop();
+        updateScrollPocketVisibilityWhenScrolledToTopAndNonEditable();
         updatePrefersSolidColorHardPocket();
 #endif
         [protect(view()) didChangeValueForKey:@"hasScrolledContentsUnderTitlebar"];
@@ -2721,10 +2721,10 @@ void WebViewImpl::didEndSyntheticMomentumScrolling()
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
-void WebViewImpl::updateScrollPocketVisibilityWhenScrolledToTop()
+void WebViewImpl::updateScrollPocketVisibilityWhenScrolledToTopAndNonEditable()
 {
     RetainPtr view = m_view.get();
-    if ([view _usesAutomaticContentInsetBackgroundFill] && pageIsScrolledToTop())
+    if ([view _usesAutomaticContentInsetBackgroundFill] && pageIsScrolledToTop() && !m_page->isEditable())
         [view _addReasonToHideTopScrollPocket:HideScrollPocketReason::ScrolledToTop];
     else
         [view _removeReasonToHideTopScrollPocket:HideScrollPocketReason::ScrolledToTop];
@@ -8189,7 +8189,7 @@ void WebViewImpl::updateScrollPocket()
         [view addSubview:m_topScrollPocket.get()];
         for (NSView *pocketContainer in m_viewsAboveScrollPocket.get())
             [m_topScrollPocket addElementContainer:pocketContainer];
-        updateScrollPocketVisibilityWhenScrolledToTop();
+        updateScrollPocketVisibilityWhenScrolledToTopAndNonEditable();
         updatePrefersSolidColorHardPocket();
     } else
         captureView = [m_topScrollPocket captureView];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ObscuredContentInsets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ObscuredContentInsets.mm
@@ -544,6 +544,31 @@ TEST(ObscuredContentInsets, TopOverhangColorExtensionLayerRemovedQuicklyAfterNav
     EXPECT_NULL([webView firstLayerWithNameContaining:@"top overhang"]);
 }
 
+TEST(ObscuredContentInsets, ScrollPocketRemainsWhenScrolledToTopInEditableWebView)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 400)]);
+    [webView _setUsesAutomaticContentInsetBackgroundFill:YES];
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(100, 0, 0, 0)];
+    [webView waitForNextPresentationUpdate];
+    [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
+
+    EXPECT_NULL([webView _topScrollPocket]);
+
+    [webView _setEditable:YES];
+    EXPECT_NOT_NULL([webView _topScrollPocket]);
+
+    [webView objectByEvaluatingJavaScript:@"scrollTo(0, 500)"];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_NOT_NULL([webView _topScrollPocket]);
+
+    [webView objectByEvaluatingJavaScript:@"scrollTo(0, 0)"];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_NOT_NULL([webView _topScrollPocket]);
+
+    [webView _setEditable:NO];
+    EXPECT_NULL([webView _topScrollPocket]);
+}
+
 #endif // PLATFORM(MAC)
 
 #if ENABLE(HORIZONTAL_BANNER_VIEW_OVERLAYS)


### PR DESCRIPTION
#### 24356033c71e8e73c60bc99e751e0458937c04ac
<pre>
[Liquid Glass] Subject area in mail compose sometimes flashes when shrinking image down from original size
<a href="https://bugs.webkit.org/show_bug.cgi?id=322186">https://bugs.webkit.org/show_bug.cgi?id=322186</a>
<a href="https://rdar.apple.com/185383012">rdar://185383012</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

When resizing an image in Mail, it&apos;s possible for the top obscured inset area to flash for a frame
or two when resizing or changing an image, in such a way that the web view goes from being
scrollable to non-scrollable. This happens because of a general optimization to avoid adding the
scroll pocket when a web view is scrolled to the top — because various editing commands in Mail
compose (not just resizing an image, but deleting content, changing font size, etc.) can change the
scrollability of the page in a way that&apos;s not synchronized with painting, the scroll pocket can pop
in and out of the view hierarchy as the user edits.

This works around that issue in Mail by adding a carveout for this optimization in the case where
the web view is `_editable` (i.e. Mail compose, IMAP Notes). It would be ideal (for a future patch)
to try and synchronize scroll pocket updates due to changes in scrollability with the compositing
(rendering update) lifecycle.

Test: ObscuredContentInsets.ScrollPocketRemainsWhenScrolledToTopInEditableWebView

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setEditable:]):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setUsesAutomaticContentInsetBackgroundFill:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::pageDidScroll):
(WebKit::WebViewImpl::updateScrollPocketVisibilityWhenScrolledToTopAndNonEditable):
(WebKit::WebViewImpl::updateScrollPocket):
(WebKit::WebViewImpl::updateScrollPocketVisibilityWhenScrolledToTop): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, ScrollPocketRemainsWhenScrolledToTopInEditableWebView)):

Canonical link: <a href="https://commits.webkit.org/319537@main">https://commits.webkit.org/319537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8d300bba74857aa23916ae9e928b784de25e13a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146101 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a46f2131-1d40-468e-a04d-37cf541563c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141893 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5aea8b89-edae-462e-9835-4ef9ab03b91f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122328 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b187229-4c68-4214-9c63-e9a334af52d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44263 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42531 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42163 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3158 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48350 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193923 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55389 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151306 "Found 1 new test failure: compositing/geometry/abs-position-inside-opacity.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40518 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56078 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38786 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151010 "Found 1 new API test failure: TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45581 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128361 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124109 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54591 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17159 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53973 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54212 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54038 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->