### PR TITLE
[list-marker] A

### DIFF
--- a/LayoutTests/accessibility/list-marker-content-renderers-text-expected.txt
+++ b/LayoutTests/accessibility/list-marker-content-renderers-text-expected.txt
@@ -1,0 +1,16 @@
+This tests that a marker keeping its text in content renderers does not report that text to callers asking for text without list markers.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS nameOf('string-button') is "Reply Item A"
+PASS itemValue('string') is "AXValue: Item A"
+PASS nameOf('counter-button') is "Reply Item B"
+PASS itemValue('counter') is "AXValue: Item B"
+PASS nameOf('decimal-button') is "Reply Item C"
+PASS itemValue('decimal') is "AXValue: Item C"
+PASS nameOf('generated-button') is "Reply radish Item D"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/list-marker-content-renderers-text.html
+++ b/LayoutTests/accessibility/list-marker-content-renderers-text.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+<style>
+@counter-style rtl-cyclic { system: cyclic; symbols: "\627"; }
+.rtl-string li { list-style-type: "\627\644\641"; }
+.rtl-counter li { list-style-type: rtl-cyclic; }
+.rtl-list { direction: rtl; }
+.marker-content li::marker { content: "radish "; }
+</style>
+</head>
+<body>
+<div id="content">
+    <ul class="rtl-string"><li id="string">Item A</li></ul>
+    <a role="button" href="#" id="string-button" aria-labelledby="string-button string"><span>Reply</span></a>
+
+    <ul class="rtl-counter"><li id="counter">Item B</li></ul>
+    <a role="button" href="#" id="counter-button" aria-labelledby="counter-button counter"><span>Reply</span></a>
+
+    <ol class="rtl-list"><li id="decimal">Item C</li></ol>
+    <a role="button" href="#" id="decimal-button" aria-labelledby="decimal-button decimal"><span>Reply</span></a>
+
+    <ul class="marker-content"><li id="generated">Item D</li></ul>
+    <a role="button" href="#" id="generated-button" aria-labelledby="generated-button generated"><span>Reply</span></a>
+</div>
+<p id="description"></p>
+<div id="console"></div>
+<script>
+description("This tests that a marker keeping its text in content renderers does not report that text to callers asking for text without list markers.");
+
+function nameOf(buttonId) {
+    document.getElementById(buttonId).focus();
+    return platformValueForW3CName(accessibilityController.focusedElement);
+}
+
+function itemValue(itemId) {
+    return accessibilityController.accessibleElementById(itemId).stringValue;
+}
+
+if (window.accessibilityController) {
+    // Each list below gives its marker content renderers to hold the text with: the string and the
+    // counter style symbol are right-to-left, and a right-to-left list makes even decimal need bidi
+    // resolution. aria-labelledby asks for the name without list markers, so none of that text
+    // belongs in these names, nor in the list item's own value.
+    shouldBeEqualToString("nameOf('string-button')", "Reply Item A");
+    shouldBeEqualToString("itemValue('string')", "AXValue: Item A");
+
+    shouldBeEqualToString("nameOf('counter-button')", "Reply Item B");
+    shouldBeEqualToString("itemValue('counter')", "AXValue: Item B");
+
+    shouldBeEqualToString("nameOf('decimal-button')", "Reply Item C");
+    shouldBeEqualToString("itemValue('decimal')", "AXValue: Item C");
+
+    // A `content` marker is the exception: it computes no text of its own, so the renderers holding
+    // its content are the only source and they keep contributing. accname asks for that text in the
+    // name, see accname/name/comp_name_from_pseudo_content_marker.tentative.html.
+    shouldBeEqualToString("nameOf('generated-button')", "Reply radish Item D");
+
+    document.getElementById("content").style.visibility = "hidden";
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4310,7 +4310,7 @@ String AccessibilityNodeObject::stringValue() const
             } else if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(object->renderer())) {
                 // List markers have no DOM node. Flush any pending text run, then append marker text.
                 flushRun();
-                builder.append(renderListMarker->textWithSuffix());
+                builder.append(renderListMarker->textContent());
             }
         }
         flushRun();

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -113,6 +113,7 @@
 #include "RenderImage.h"
 #include "RenderListBox.h"
 #include "RenderListItem.h"
+#include "RenderListMarker.h"
 #include "RenderTableCell.h"
 #include "RenderView.h"
 #include "RuleFeature.h"
@@ -917,6 +918,10 @@ bool AccessibilityNodeObject::canHaveChildren() const
     // When <noscript> is not being used (its renderer() == 0), ignore its children
     if (node() && !renderer() && WebCore::elementName(node()) == ElementName::HTML_noscript)
         return false;
+
+    if (CheckedPtr listMarker = dynamicDowncast<RenderListMarker>(renderer()))
+        return listMarker->hasContentProperty();
+
     // If this is an AccessibilityRenderObject, then it's okay if this object
     // doesn't have a node - there are some renderers that don't have associated
     // nodes, like scroll areas and css-generated text.

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2167,7 +2167,7 @@ static StringView lineStartListMarkerText(const RenderListItem* listItem, const 
         return { };
 
     if (!markerText)
-        markerText = listItem->markerTextWithSuffix();
+        markerText = listItem->markerText();
     if (markerText->isEmpty())
         return { };
 
@@ -2184,7 +2184,7 @@ StringView AccessibilityObject::listMarkerTextForNodeAndPosition(Node* node, Pos
         return { };
     // Creating a VisiblePosition and determining its relationship to a line of text can be expensive.
     // Thus perform that determination only if we have some text to return.
-    auto markerText = listItem->markerTextWithSuffix();
+    auto markerText = listItem->markerText();
     if (markerText.isEmpty())
         return { };
     return lineStartListMarkerText(listItem.get(), startPosition, markerText);

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -434,7 +434,7 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
 
     if (mode.includeListMarkers == IncludeListMarkerText::Yes) {
         if (auto* listMarker = dynamicDowncast<RenderListMarker>(*m_renderer))
-            return listMarker->textWithSuffix();
+            return listMarker->textContent();
     }
 
     // Reflect when a content author has explicitly marked a line break.
@@ -583,9 +583,9 @@ String AccessibilityRenderObject::stringValue() const
 
     if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(m_renderer.get())) {
 #if USE(ATSPI)
-        return renderListMarker->textWithSuffix();
+        return renderListMarker->textContent();
 #else
-        return renderListMarker->textWithoutSuffix();
+        return renderListMarker->textContent(RenderListMarker::IncludeSuffix::No);
 #endif
     }
 
@@ -1737,7 +1737,7 @@ AXTextRunLineID AccessibilityRenderObject::listMarkerLineID() const
 String AccessibilityRenderObject::listMarkerText() const
 {
     CheckedPtr marker = dynamicDowncast<RenderListMarker>(renderer());
-    return marker ? marker->textWithSuffix() : String();
+    return marker ? marker->textContent() : String();
 }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -432,9 +432,13 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
     if (CheckedPtr fileUpload = dynamicDowncast<RenderFileUploadControl>(*m_renderer))
         return fileUpload->buttonValue();
 
-    if (mode.includeListMarkers == IncludeListMarkerText::Yes) {
-        if (auto* listMarker = dynamicDowncast<RenderListMarker>(*m_renderer))
-            return listMarker->textContent();
+    if (auto* listMarker = dynamicDowncast<RenderListMarker>(*m_renderer)) {
+        // A `content` marker has no text of its own; the child walk below reads the renderers holding it.
+        if (!listMarker->hasContentProperty()) {
+            if (mode.includeListMarkers == IncludeListMarkerText::Yes)
+                return listMarker->textContent();
+            return { };
+        }
     }
 
     // Reflect when a content author has explicitly marked a line break.

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -461,18 +461,11 @@ void RenderListItem::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintO
         excludedMarker->paintAsInlineBlock(paintInfo, flipForWritingModeForChild(*excludedMarker, paintOffset));
 }
 
-String RenderListItem::markerTextWithoutSuffix() const
+String RenderListItem::markerText(RenderListMarker::IncludeSuffix includeSuffix) const
 {
     if (!m_marker)
         return { };
-    return m_marker->textWithoutSuffix();
-}
-
-String RenderListItem::markerTextWithSuffix() const
-{
-    if (!m_marker)
-        return { };
-    return m_marker->textWithSuffix();
+    return m_marker->textContent(includeSuffix);
 }
 
 void RenderListItem::usedCounterDirectivesChanged()

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -39,8 +39,7 @@ public:
     int value() const;
     void updateValue();
 
-    WEBCORE_EXPORT String markerTextWithoutSuffix() const;
-    String NODELETE markerTextWithSuffix() const;
+    WEBCORE_EXPORT String markerText(RenderListMarker::IncludeSuffix = RenderListMarker::IncludeSuffix::Yes) const;
 
     void updateListMarkerNumbers();
 

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -388,7 +388,7 @@ void RenderListMarker::layout()
     } else {
         setLogicalWidth(minContentLogicalWidthContribution());
         setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
-        m_layoutBounds = layoutBoundForTextContent(textWithSuffix());
+        m_layoutBounds = layoutBoundForTextContent(m_textContent.textWithSuffix);
     }
 
     setMarginStart(0);
@@ -426,7 +426,7 @@ void RenderListMarker::layoutContentContainer(RenderBlockFlow& container)
 
     if (textNeedsBidiResolution()) {
         setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
-        m_layoutBounds = layoutBoundForTextContent(textWithSuffix());
+        m_layoutBounds = layoutBoundForTextContent(m_textContent.textWithSuffix);
     } else {
         setLogicalHeight(container.logicalHeight());
         m_layoutBounds = { contentBaseline, container.logicalHeight() - contentBaseline };

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -54,8 +54,11 @@ public:
     RenderListMarker(RenderListItem&, Style::ComputedStyle&&);
     virtual ~RenderListMarker();
 
-    String textWithoutSuffix() const { return m_textContent.textWithoutSuffix().toString(); };
-    String textWithSuffix() const { return m_textContent.textWithSuffix; };
+    enum class IncludeSuffix : bool { No, Yes };
+    String textContent(IncludeSuffix includeSuffix = IncludeSuffix::Yes) const
+    {
+        return includeSuffix == IncludeSuffix::Yes ? m_textContent.textWithSuffix : m_textContent.textWithoutSuffix().toString();
+    }
 
     bool NODELETE isInside() const;
     bool isDisclosureMarker() const;

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -365,7 +365,7 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
         ts << " [r="_s << cell->rowIndex() << " c="_s << cell->col() << " rs="_s << cell->rowSpan() << " cs="_s << cell->colSpan() << ']';
 
     if (auto* listMarker = dynamicDowncast<RenderListMarker>(o)) {
-        auto text = listMarker->textWithoutSuffix();
+        auto text = listMarker->textContent(RenderListMarker::IncludeSuffix::No);
         if (!text.isEmpty()) {
             if (text.length() != 1)
                 text = quoteAndEscapeNonPrintables(text);
@@ -918,7 +918,7 @@ String markerTextForListItem(Element* element)
     auto* renderer = dynamicDowncast<RenderListItem>(element->renderer());
     if (!renderer)
         return String();
-    return renderer->markerTextWithoutSuffix();
+    return renderer->markerText(RenderListMarker::IncludeSuffix::No);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 15244996a449170ee832afbc3ec6cc2682655395
<pre>
[list-marker] A list marker&apos;s text reaches names and values that asked for text without list markers
<a href="https://bugs.webkit.org/show_bug.cgi?id=322187">https://bugs.webkit.org/show_bug.cgi?id=322187</a>
&lt;<a href="https://rdar.apple.com/problem/185422271">rdar://problem/185422271</a>&gt;

Reviewed by NOBODY (OOPS!).

  &lt;style&gt;
  li { list-style-type: &quot;\627\644\641&quot; }
  &lt;/style&gt;
  &lt;ul&gt;&lt;li id=item&gt;Item Five
  &lt;a role=button aria-labelledby=&quot;button item&quot; id=button&gt;Reply

Whether a marker&apos;s text belongs in a name is the caller&apos;s to decide, and IncludeListMarkerText is how
it says so: aria-labelledby name computation passes No, and textUnderElement() answers for the marker
only when it is Yes.

A marker whose text needs bidi resolution does not draw that text itself, it keeps it in content
renderers, and those are reachable through AccessibilityRenderObject::firstChild(), which answers from
the render tree before it consults canHaveChildren(). The walk that builds a name reaches them that
way and takes their text, so the flag stops governing what the caller asked about. The name computed
for the button above comes out as &quot;Reply الفItem Five&quot;, and the list item&apos;s own value with it. Neither
the string above nor a right-to-left list of plain decimals is exotic, so this is what any
aria-labelledby pointing at such a list item reports today.

* LayoutTests/accessibility/list-marker-content-renderers-text-expected.txt: Added.
* LayoutTests/accessibility/list-marker-content-renderers-text.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::canHaveChildren const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textUnderElement const):
</pre>
----------------------------------------------------------------------
#### e5905cd68b10ee71493a1c31497758e2a8af6c86
<pre>
[list-marker] Ask the list marker for its text through one accessor
<a href="https://bugs.webkit.org/show_bug.cgi?id=322183">https://bugs.webkit.org/show_bug.cgi?id=322183</a>
&lt;<a href="https://rdar.apple.com/problem/185419069">rdar://problem/185419069</a>&gt;

Reviewed by NOBODY (OOPS!).

The marker builds its text from the counter style&apos;s prefix, its text and its suffix, and callers need
it either with that suffix or without. Two functions for that put the choice in the name a caller
picks, and leave every question about how the text is put together with two places to answer it. That
is about to matter: reporting the marker&apos;s text to accessibility and laying bullets out as marker text
both change what the text is made of and where it is kept.

So there is one way to ask, and the call site says what it needs rather than encoding it in the name
it calls. RenderListItem had the same pair forwarding to the marker&apos;s, so it collapses the same way.
The suffix is included by default, leaving the render tree dump, markerTextForListItem() and
stringValue() to say when they want the text without it. No behaviour change.

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::stringValue const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textUnderElement const):
(WebCore::AccessibilityRenderObject::stringValue const):
(WebCore::AccessibilityRenderObject::listMarkerText const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::lineStartListMarkerText):
(WebCore::AccessibilityObject::listMarkerTextForNodeAndPosition):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::markerText const):
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::layout):
(WebCore::RenderListMarker::layoutContentContainer):
* Source/WebCore/rendering/RenderListMarker.h:
(WebCore::RenderListMarker::textContent const):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::RenderTreeAsText::writeRenderObject):
(WebCore::markerTextForListItem):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15244996a449170ee832afbc3ec6cc2682655395

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146103 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d80dd69-7d53-4b89-821a-ed7003ccdcad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55442 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141896 "Found 1 new test failure: accessibility/list-marker-content-renderers-text.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122331 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5158891-ae0c-4f80-8b2f-1bb1159288d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44264 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42534 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42164 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3160 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193925 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162136 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151311 "Found 1 new test failure: accessibility/list-marker-content-renderers-text.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56080 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151014 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45591 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128363 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124111 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54593 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17160 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53975 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54040 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->