### PR TITLE
corner-shape: replace BorderShape's deprecated rounded-rect accessors so every call site acknowledges the corner shape

### DIFF
--- a/LayoutTests/apple-visual-effects/corner-shape-hosted-material-shape-mask-expected.txt
+++ b/LayoutTests/apple-visual-effects/corner-shape-hosted-material-shape-mask-expected.txt
@@ -1,0 +1,4 @@
+round: mask layer absent, expected absent - PASS
+square: mask layer absent, expected absent - PASS
+bevel: mask layer present, expected present - PASS
+notch: mask layer present, expected present - PASS

--- a/LayoutTests/apple-visual-effects/corner-shape-hosted-material-shape-mask.html
+++ b/LayoutTests/apple-visual-effects/corner-shape-hosted-material-shape-mask.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>corner-shape: a hosted material needs a shape mask layer even without a clipping layer of its own</title>
+    <style>
+        body {
+            margin: 0;
+            background: linear-gradient(red, blue) fixed;
+        }
+
+        .material {
+            height: 150px;
+            border-radius: 40px;
+            -apple-visual-effect: -apple-system-glass-material;
+        }
+
+        #round { width: 200px; corner-shape: round; }
+        #square { width: 201px; corner-shape: square; }
+        #bevel { width: 202px; corner-shape: bevel; }
+        #notch { width: 203px; corner-shape: notch; }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        const EXPECT_MASK = {
+            200: ['round', false],
+            201: ['square', false],
+            202: ['bevel', true],
+            203: ['notch', true],
+        };
+
+        function runTest()
+        {
+            if (!window.internals) {
+        document.getElementById('results').textContent = 'This test requires window.internals.';
+        return;
+            }
+
+            const tree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CLIPPING);
+            const masked = new Set();
+            const lines = tree.split('\n');
+            let currentWidth = null;
+            for (let index = 0; index < lines.length; index++) {
+        const bounds = lines[index].match(/\(bounds (\d+)\.\d+ 150\.\d+\)/);
+        if (bounds)
+                    currentWidth = bounds[1];
+        if (lines[index].includes('(mask layer') && currentWidth)
+                    masked.add(currentWidth);
+            }
+
+            const results = Object.keys(EXPECT_MASK).map(width => {
+        const [shape, expected] = EXPECT_MASK[width];
+        const hasMask = masked.has(width);
+        return `${shape}: mask layer ${hasMask ? 'present' : 'absent'}, expected `
+                    + `${expected ? 'present' : 'absent'} - ${hasMask === expected ? 'PASS' : 'FAIL'}`;
+            });
+            document.getElementById('results').textContent = results.join('\n');
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <div class="material" id="round"></div>
+    <div class="material" id="square"></div>
+    <div class="material" id="bevel"></div>
+    <div class="material" id="notch"></div>
+    <pre id="results"></pre>
+</body>
+</html>

--- a/LayoutTests/compositing/corner-shape-backdrop-filter-clip-expected.html
+++ b/LayoutTests/compositing/corner-shape-backdrop-filter-clip-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>corner-shape: a composited backdrop-filter is clipped to the contour — reference</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: green;
+        }
+
+        .target {
+            width: 200px;
+            height: 200px;
+            margin: 20px;
+            background-color: black;
+            clip-path: polygon(
+        60px 0px, 140px 0px, 200px 60px, 200px 140px,
+        140px 200px, 60px 200px, 0px 140px, 0px 60px);
+        }
+    </style>
+</head>
+<body>
+    <div class="target"></div>
+</body>
+</html>

--- a/LayoutTests/compositing/corner-shape-backdrop-filter-clip.html
+++ b/LayoutTests/compositing/corner-shape-backdrop-filter-clip.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>corner-shape: a composited backdrop-filter is clipped to the contour</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: green;
+        }
+
+        .target {
+            width: 200px;
+            height: 200px;
+            margin: 20px;
+            border-radius: 60px;
+            corner-shape: bevel;
+            backdrop-filter: brightness(0);
+            will-change: transform;
+        }
+    </style>
+</head>
+<body>
+    <div class="target"></div>
+</body>
+</html>

--- a/LayoutTests/fast/borders/corner-shape-inner-border-expected.html
+++ b/LayoutTests/fast/borders/corner-shape-inner-border-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Borders and Box Decorations 4: a thick border's inner edge follows 'corner-shape' — reference</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .target {
+            position: relative;
+            box-sizing: border-box;
+            width: 200px;
+            height: 200px;
+            margin: 20px;
+            background-color: red;
+            clip-path: polygon(
+        60px 0px, 140px 0px, 200px 60px, 200px 140px,
+        140px 200px, 60px 200px, 0px 140px, 0px 60px);
+        }
+
+        .target::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background-color: green;
+            clip-path: polygon(
+        68.284px 20px, 131.716px 20px, 180px 68.284px, 180px 131.716px,
+        131.716px 180px, 68.284px 180px, 20px 131.716px, 20px 68.284px);
+        }
+    </style>
+</head>
+<body>
+    <div class="target"></div>
+</body>
+</html>

--- a/LayoutTests/fast/borders/corner-shape-inner-border.html
+++ b/LayoutTests/fast/borders/corner-shape-inner-border.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Borders and Box Decorations 4: a thick border's inner edge follows 'corner-shape'</title>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-120">
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .target {
+            box-sizing: border-box;
+            width: 200px;
+            height: 200px;
+            margin: 20px;
+            border: 20px solid red;
+            border-radius: 60px;
+            corner-shape: bevel;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <div class="target"></div>
+</body>
+</html>

--- a/LayoutTests/fast/masking/corner-shape-clip-path-coord-box-expected.html
+++ b/LayoutTests/fast/masking/corner-shape-clip-path-coord-box-expected.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Borders and Box Decorations 4: a &lt;coord-box&gt; 'clip-path' follows 'corner-shape' — reference</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .box {
+            position: relative;
+            float: left;
+            box-sizing: border-box;
+            width: 200px;
+            height: 200px;
+            margin: 20px;
+            border: 20px solid transparent;
+        }
+
+        .overflowing {
+            position: absolute;
+            inset: -40px;
+            background-color: blue;
+        }
+
+        #border-box {
+            clip-path: polygon(
+        60px 0px, 140px 0px, 200px 60px, 200px 140px,
+        140px 200px, 60px 200px, 0px 140px, 0px 60px);
+        }
+
+        #padding-box {
+            clip-path: polygon(
+        68.284px 20px, 131.716px 20px, 180px 68.284px, 180px 131.716px,
+        131.716px 180px, 68.284px 180px, 20px 131.716px, 20px 68.284px);
+        }
+    </style>
+</head>
+<body>
+    <div class="box" id="border-box"><div class="overflowing"></div></div>
+    <div class="box" id="padding-box"><div class="overflowing"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/masking/corner-shape-clip-path-coord-box.html
+++ b/LayoutTests/fast/masking/corner-shape-clip-path-coord-box.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Borders and Box Decorations 4: a &lt;coord-box&gt; 'clip-path' follows 'corner-shape'</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        .box {
+            position: relative;
+            float: left;
+            box-sizing: border-box;
+            width: 200px;
+            height: 200px;
+            margin: 20px;
+            border: 20px solid transparent;
+            border-radius: 60px;
+            corner-shape: bevel;
+        }
+
+        .overflowing {
+            position: absolute;
+            inset: -40px;
+            background-color: blue;
+        }
+
+        #border-box { clip-path: border-box; }
+        #padding-box { clip-path: padding-box; }
+    </style>
+</head>
+<body>
+    <div class="box" id="border-box"><div class="overflowing"></div></div>
+    <div class="box" id="padding-box"><div class="overflowing"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/motion-path/corner-shape-offset-path-coord-box-expected-mismatch.html
+++ b/LayoutTests/fast/motion-path/corner-shape-offset-path-coord-box-expected-mismatch.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Motion Path: a &lt;coord-box&gt; 'offset-path' follows 'corner-shape' — mismatch reference</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        #container {
+            position: relative;
+            width: 300px;
+            height: 300px;
+            margin: 50px;
+            border-radius: 50%;
+        }
+
+        #dot {
+            position: absolute;
+            width: 20px;
+            height: 20px;
+            background-color: blue;
+            offset-path: border-box;
+            offset-distance: 12.5%;
+        }
+    </style>
+</head>
+<body>
+    <div id="container"><div id="dot"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/motion-path/corner-shape-offset-path-coord-box.html
+++ b/LayoutTests/fast/motion-path/corner-shape-offset-path-coord-box.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Motion Path: a &lt;coord-box&gt; 'offset-path' follows 'corner-shape'</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: white;
+        }
+
+        #container {
+            position: relative;
+            width: 300px;
+            height: 300px;
+            margin: 50px;
+            border-radius: 50%;
+            corner-shape: bevel;
+        }
+
+        #dot {
+            position: absolute;
+            width: 20px;
+            height: 20px;
+            background-color: blue;
+            offset-path: border-box;
+            offset-distance: 12.5%;
+        }
+    </style>
+</head>
+<body>
+    <div id="container"><div id="dot"></div></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/corner-shape-overflow-scroll-shape-mask-expected.txt
+++ b/LayoutTests/fast/scrolling/corner-shape-overflow-scroll-shape-mask-expected.txt
@@ -1,0 +1,6 @@
+round: mask layer absent, expected absent - PASS
+square: mask layer absent, expected absent - PASS
+scoop: mask layer present, expected present - PASS
+bevel: mask layer present, expected present - PASS
+notch: mask layer present, expected present - PASS
+superellipse(-2): mask layer present, expected present - PASS

--- a/LayoutTests/fast/scrolling/corner-shape-overflow-scroll-shape-mask.html
+++ b/LayoutTests/fast/scrolling/corner-shape-overflow-scroll-shape-mask.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>corner-shape: a composited overflow scroller needs a shape mask layer only when its clip is not a rounded rect</title>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        ::-webkit-scrollbar {
+            display: none;
+        }
+
+        .scroller {
+            height: 150px;
+            border-radius: 40px;
+            overflow: scroll;
+        }
+
+        .scroller > div {
+            height: 400px;
+            background-color: green;
+            transform: translateZ(0);
+        }
+
+        #round { width: 200px; corner-shape: round; }
+        #square { width: 201px; corner-shape: square; }
+        #scoop { width: 202px; corner-shape: scoop; }
+        #bevel { width: 203px; corner-shape: bevel; }
+        #notch { width: 204px; corner-shape: notch; }
+        #superellipse { width: 205px; corner-shape: superellipse(-2); }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        const EXPECT_MASK = {
+            200: ['round', false],
+            201: ['square', false],
+            202: ['scoop', true],
+            203: ['bevel', true],
+            204: ['notch', true],
+            205: ['superellipse(-2)', true],
+        };
+
+        function runTest()
+        {
+            if (!window.internals) {
+        document.getElementById('results').textContent = 'This test requires window.internals.';
+        return;
+            }
+
+            const tree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CLIPPING);
+            const masked = new Set();
+            const lines = tree.split('\n');
+            let currentWidth = null;
+            for (let index = 0; index < lines.length; index++) {
+        const bounds = lines[index].match(/\(bounds (\d+)\.\d+ 150\.\d+\)/);
+        if (bounds)
+                    currentWidth = bounds[1];
+        if (lines[index].includes('(mask layer') && currentWidth)
+                    masked.add(currentWidth);
+            }
+
+            const results = Object.keys(EXPECT_MASK).map(width => {
+        const [shape, expected] = EXPECT_MASK[width];
+        const hasMask = masked.has(width);
+        return `${shape}: mask layer ${hasMask ? 'present' : 'absent'}, expected `
+                    + `${expected ? 'present' : 'absent'} - ${hasMask === expected ? 'PASS' : 'FAIL'}`;
+            });
+            document.getElementById('results').textContent = results.join('\n');
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <div class="scroller" id="round"><div></div></div>
+    <div class="scroller" id="square"><div></div></div>
+    <div class="scroller" id="scoop"><div></div></div>
+    <div class="scroller" id="bevel"><div></div></div>
+    <div class="scroller" id="notch"><div></div></div>
+    <div class="scroller" id="superellipse"><div></div></div>
+    <pre id="results"></pre>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/corner-shape-event-region-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/corner-shape-event-region-expected.txt
@@ -1,0 +1,13 @@
+square: event region found - PASS
+round: event region found - PASS
+bevel: event region found - PASS
+scoop: event region found - PASS
+notch: event region found - PASS
+square covers its whole box - PASS
+round leaves its corners uncovered - PASS
+bevel leaves its corners uncovered - PASS
+scoop leaves its corners uncovered - PASS
+notch leaves its corners uncovered - PASS
+bevel differs from round - PASS
+scoop differs from round - PASS
+notch differs from round - PASS

--- a/LayoutTests/fast/scrolling/mac/corner-shape-event-region.html
+++ b/LayoutTests/fast/scrolling/mac/corner-shape-event-region.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Borders and Box Decorations 4: a layer's event region follows 'corner-shape', not the rounded rect</title>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        .scroller {
+            overflow: scroll;
+            height: 50px;
+            width: 50px;
+        }
+
+        .scrollcontent {
+            height: 100px;
+            width: 50px;
+        }
+
+        .testdiv {
+            box-sizing: border-box;
+            height: 200px;
+            border-radius: 50px;
+            background-color: blue;
+            will-change: transform;
+        }
+
+        #square { width: 200px; corner-shape: square; }
+        #round { width: 201px; corner-shape: round; }
+        #bevel { width: 202px; corner-shape: bevel; }
+        #scoop { width: 203px; corner-shape: scoop; }
+        #notch { width: 204px; corner-shape: notch; }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        const BOX_HEIGHT = 200;
+
+        const SHAPES = [
+            { name: 'square', width: 200 },
+            { name: 'round', width: 201 },
+            { name: 'bevel', width: 202 },
+            { name: 'scoop', width: 203 },
+            { name: 'notch', width: 204 },
+        ];
+
+        function eventRegionAreaByLayerWidth(tree)
+        {
+            const areaByWidth = new Map();
+            let currentWidth = null;
+            let inEventRegion = false;
+
+            for (const line of tree.split('\n')) {
+                const bounds = line.match(/\(bounds (\d+)\.\d+ 200\.\d+\)/);
+                if (bounds) {
+                    currentWidth = bounds[1];
+                    inEventRegion = false;
+                    continue;
+                }
+
+                if (line.includes('(event region')) {
+                    inEventRegion = true;
+                    continue;
+                }
+
+                if (!inEventRegion)
+                    continue;
+
+                const rect = line.match(/\(rect \(-?\d+,-?\d+\) width=(\d+) height=(\d+)\)/);
+                if (!rect) {
+                    inEventRegion = false;
+                    continue;
+                }
+
+                const area = parseInt(rect[1], 10) * parseInt(rect[2], 10);
+                areaByWidth.set(currentWidth, (areaByWidth.get(currentWidth) || 0) + area);
+            }
+
+            return areaByWidth;
+        }
+
+        function runTest()
+        {
+            if (!window.internals) {
+                document.getElementById('results').textContent = 'This test requires window.internals.';
+                return;
+            }
+
+            const tree = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION);
+            const areaByWidth = eventRegionAreaByLayerWidth(tree);
+
+            const areaFor = shape => areaByWidth.get(String(shape.width));
+            const results = [];
+
+            for (const shape of SHAPES) {
+                const found = areaFor(shape) !== undefined;
+                results.push(`${shape.name}: event region found - ${found ? 'PASS' : 'FAIL'}`);
+            }
+
+            const [square, round] = SHAPES;
+
+            results.push(`square covers its whole box - ${areaFor(square) === square.width * BOX_HEIGHT ? 'PASS' : 'FAIL'}`);
+
+            for (const shape of SHAPES.slice(1)) {
+                const area = areaFor(shape);
+                const covered = area !== undefined && area < shape.width * BOX_HEIGHT;
+                results.push(`${shape.name} leaves its corners uncovered - ${covered ? 'PASS' : 'FAIL'}`);
+            }
+
+            for (const shape of SHAPES.slice(2)) {
+                const differs = areaFor(shape) !== undefined && areaFor(round) !== undefined
+                    && areaFor(shape) !== areaFor(round);
+                results.push(`${shape.name} differs from round - ${differs ? 'PASS' : 'FAIL'}`);
+            }
+
+            document.getElementById('results').textContent = results.join('\n');
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <div class="scroller"><div class="scrollcontent"></div></div>
+    <div class="testdiv" id="square"></div>
+    <div class="testdiv" id="round"></div>
+    <div class="testdiv" id="bevel"></div>
+    <div class="testdiv" id="scoop"></div>
+    <div class="testdiv" id="notch"></div>
+    <pre id="results"></pre>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-left-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-left-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL corner-shape: notch with shape-outside assert_array_approx_equals: property 0, expected 82 +/- 2, expected 82 but got 129.1875
-FAIL corner-shape: bevel with shape-outside assert_array_approx_equals: property 0, expected 106 +/- 2, expected 106 but got 129.1875
-FAIL corner-shape: notch bevel with shape-outside assert_array_approx_equals: property 0, expected 106 +/- 2, expected 106 but got 129.1875
+PASS corner-shape: notch with shape-outside
+PASS corner-shape: bevel with shape-outside
+PASS corner-shape: notch bevel with shape-outside
 PASS corner-shape: round with shape-outside
-FAIL corner-shape: square with shape-outside assert_array_approx_equals: property 0, expected 140 +/- 2, expected 140 but got 129.1875
-FAIL corner-shape: scoop with shape-outside assert_array_approx_equals: property 0, expected 88 +/- 2, expected 88 but got 129.1875
-FAIL corner-shape: superellipse(1.5) with shape-outside assert_array_approx_equals: property 0, expected 135 +/- 2, expected 135 but got 129.1875
-FAIL corner-shape: superellipse(-.8) with shape-outside assert_array_approx_equals: property 0, expected 88 +/- 2, expected 88 but got 129.1875
+PASS corner-shape: square with shape-outside
+PASS corner-shape: scoop with shape-outside
+PASS corner-shape: superellipse(1.5) with shape-outside
+PASS corner-shape: superellipse(-.8) with shape-outside
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-right-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-right-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL corner-shape: notch with shape-outside assert_array_approx_equals: property 0, expected 120 +/- 2, expected 120 but got 72
-FAIL corner-shape: bevel with shape-outside assert_array_approx_equals: property 0, expected 96 +/- 2, expected 96 but got 72
-FAIL corner-shape: notch bevel with shape-outside assert_array_approx_equals: property 0, expected 120 +/- 2, expected 120 but got 72
+PASS corner-shape: notch with shape-outside
+PASS corner-shape: bevel with shape-outside
+PASS corner-shape: notch bevel with shape-outside
 PASS corner-shape: round with shape-outside
-FAIL corner-shape: square with shape-outside assert_array_approx_equals: property 0, expected 60 +/- 2, expected 60 but got 72
-FAIL corner-shape: scoop with shape-outside assert_array_approx_equals: property 0, expected 114 +/- 2, expected 114 but got 72
-FAIL corner-shape: superellipse(1.5) with shape-outside assert_array_approx_equals: property 0, expected 65 +/- 2, expected 65 but got 72
-FAIL corner-shape: superellipse(-.8) with shape-outside assert_array_approx_equals: property 0, expected 112 +/- 2, expected 112 but got 72
+PASS corner-shape: square with shape-outside
+PASS corner-shape: scoop with shape-outside
+PASS corner-shape: superellipse(1.5) with shape-outside
+PASS corner-shape: superellipse(-.8) with shape-outside
 

--- a/Source/WebCore/platform/animation/values/paths/AcceleratedEffectBoxPath.cpp
+++ b/Source/WebCore/platform/animation/values/paths/AcceleratedEffectBoxPath.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(THREADED_ANIMATIONS)
 
 #include "AnimationUtilities.h"
+#include "BorderShape.h"
 #include "Path.h"
 #include "TransformOperationData.h"
 
@@ -39,6 +40,9 @@ namespace WebCore {
 std::optional<WebCore::Path> tryPath(const AcceleratedEffectBoxPath&, const TransformOperationData& data)
 {
     if (auto motionPathData = data.motionPathData) {
+        if (auto shaped = BorderShape::pathForShapedRect(motionPathData->offsetRect(), motionPathData->cornerCurvatures))
+            return shaped;
+
         WebCore::Path result;
         result.addRoundedRect(motionPathData->offsetRect(), PathRoundedRect::Strategy::PreferBezier);
         return result;

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -661,6 +661,14 @@ void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, 
     path.closeSubpath();
 }
 
+Vector<FloatPoint> sampleCornerShape(const CornerInput& input, unsigned stepsPerHalf)
+{
+    auto corner = resolveCornerAdjustment(makeCorner(input), input.startInset, input.endInset).corner;
+    Vector<FloatPoint> points;
+    sampleDrawnCorner(corner, stepsPerHalf, points);
+    return points;
+}
+
 static Vector<FloatPoint> normalizedInnerCornerHull(double curvature)
 {
     if (curvature >= 0.0)

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.h
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.h
@@ -24,7 +24,9 @@
 
 #pragma once
 
+#include <WebCore/FloatPoint.h>
 #include <WebCore/RectCorners.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -46,6 +48,9 @@ enum class OutsetMiter : bool { No, Yes };
 
 // https://drafts.csswg.org/css-borders-4/#contour-path
 void borderContourPath(Path&, const RectCorners<CornerInput>&, const FloatRect* targetRect = nullptr, OutsetMiter = OutsetMiter::No, float deviceScaleFactor = 1.0f);
+
+// Points along one corner's drawn curve.
+Vector<FloatPoint> sampleCornerShape(const CornerInput&, unsigned stepsPerHalf);
 
 // https://drafts.csswg.org/css-borders-4/#corner-shape-constrain-radii
 double oppositeCornerScaleFactor(const RectCorners<CornerInput>&);

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -315,6 +315,8 @@ public:
     virtual void setBackdropFiltersRect(const FloatRoundedRect& backdropFiltersRect) { m_backdropFiltersRect = backdropFiltersRect; }
     const FloatRoundedRect& backdropFiltersRect() const LIFETIME_BOUND { return m_backdropFiltersRect; }
 
+    void setBackdropFiltersShapePath(const Path& path) { m_backdropFiltersShapePath = path; }
+
     BlendMode blendMode() const { return m_blendMode; }
     virtual void setBlendMode(BlendMode blendMode) { m_blendMode = blendMode; }
 
@@ -695,6 +697,7 @@ protected:
     ScalingFilter m_contentsMinificationFilter = ScalingFilter::Linear;
     ScalingFilter m_contentsMagnificationFilter = ScalingFilter::Linear;
     FloatRoundedRect m_backdropFiltersRect;
+    Path m_backdropFiltersShapePath;
     std::optional<FloatRect> m_animationExtent;
 
     EventRegion m_eventRegion;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2804,7 +2804,7 @@ void GraphicsLayerCA::updateBackdropFiltersRect()
 
     auto backdropRectRelativeToBackdropLayer = m_backdropFiltersRect;
     backdropRectRelativeToBackdropLayer.setLocation({ });
-    updateClippingStrategy(*backdropLayer, m_backdropClippingLayer, backdropRectRelativeToBackdropLayer);
+    updateClippingStrategy(*backdropLayer, m_backdropClippingLayer, backdropRectRelativeToBackdropLayer, &m_backdropFiltersShapePath);
 
     if (m_layerClones) {
         for (auto& clone : m_layerClones->backdropLayerClones) {
@@ -2816,7 +2816,7 @@ void GraphicsLayerCA::updateBackdropFiltersRect()
             RefPtr<PlatformCALayer> backdropClippingLayerClone = m_layerClones->backdropClippingLayerClones.get(cloneID);
 
             bool hadBackdropClippingLayer = backdropClippingLayerClone;
-            updateClippingStrategy(backdropCloneLayer, backdropClippingLayerClone, backdropRectRelativeToBackdropLayer);
+            updateClippingStrategy(backdropCloneLayer, backdropClippingLayerClone, backdropRectRelativeToBackdropLayer, &m_backdropFiltersShapePath);
 
             if (!backdropClippingLayerClone)
                 m_layerClones->backdropClippingLayerClones.remove(cloneID);
@@ -3257,9 +3257,10 @@ void GraphicsLayerCA::updateContentsColorLayer()
 
 // The clipping strategy depends on whether the rounded rect has equal corner radii.
 // roundedRect is in the coordinate space of clippingLayer.
-void GraphicsLayerCA::updateClippingStrategy(PlatformCALayer& clippingLayer, RefPtr<PlatformCALayer>& shapeMaskLayer, const FloatRoundedRect& roundedRect)
+void GraphicsLayerCA::updateClippingStrategy(PlatformCALayer& clippingLayer, RefPtr<PlatformCALayer>& shapeMaskLayer, const FloatRoundedRect& roundedRect, const Path* shapePath)
 {
-    bool hasShapePath = !contentsClipShapePath().isEmpty();
+    // A corner-shape contour can only be expressed as a shape mask, so skip the corner-radius fast paths.
+    bool hasShapePath = shapePath && !shapePath->isEmpty();
 
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     if (!hasShapePath && m_isSeparated && roundedRect.radii().hasEvenCorners() && clippingLayer.bounds() == roundedRect.rect()) {
@@ -3296,7 +3297,7 @@ void GraphicsLayerCA::updateClippingStrategy(PlatformCALayer& clippingLayer, Ref
     shapeMaskLayer->setBounds(shapeBounds);
     
     if (hasShapePath) {
-        auto localPath = contentsClipShapePath();
+        auto localPath = *shapePath;
         localPath.translate(-toFloatSize(rectLocation));
         shapeMaskLayer->setShapePath(localPath);
     } else {
@@ -3336,7 +3337,7 @@ void GraphicsLayerCA::updateContentsRects()
         contentsClippingLayer->setPosition(m_contentsClippingRect.rect().location());
         contentsClippingLayer->setBounds(m_contentsClippingRect.rect());
         
-        updateClippingStrategy(contentsClippingLayer, m_contentsShapeMaskLayer, m_contentsClippingRect);
+        updateClippingStrategy(contentsClippingLayer, m_contentsShapeMaskLayer, m_contentsClippingRect, &contentsClipShapePath());
 
         if (RefPtr contentsLayer = m_contentsLayer; contentsLayer && gainedOrLostClippingLayer) {
             contentsLayer->removeFromSuperlayer();
@@ -3379,7 +3380,7 @@ void GraphicsLayerCA::updateContentsRects()
             RefPtr<PlatformCALayer> shapeMaskLayerClone = m_layerClones->contentsShapeMaskLayerClones.get(cloneID);
 
             bool hadShapeMask = shapeMaskLayerClone;
-            updateClippingStrategy(Ref { clone.value }, shapeMaskLayerClone, m_contentsClippingRect);
+            updateClippingStrategy(Ref { clone.value }, shapeMaskLayerClone, m_contentsClippingRect, &contentsClipShapePath());
 
             if (!shapeMaskLayerClone)
                 m_layerClones->contentsShapeMaskLayerClones.remove(cloneID);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -388,7 +388,7 @@ private:
     void setupContentsLayer(PlatformCALayer*, CompositingCoordinatesOrientation = defaultContentsOrientation);
     PlatformCALayer* contentsLayer() const { return m_contentsLayer.get(); }
 
-    void updateClippingStrategy(PlatformCALayer&, RefPtr<PlatformCALayer>& shapeMaskLayer, const FloatRoundedRect&);
+    void updateClippingStrategy(PlatformCALayer&, RefPtr<PlatformCALayer>& shapeMaskLayer, const FloatRoundedRect&, const Path* shapePath = nullptr);
 
     WEBCORE_EXPORT void setReplicatedByLayer(RefPtr<GraphicsLayer>&&) override;
 

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -865,7 +865,7 @@ void BorderPainter::clipBorderSidePolygon(const BorderShape& borderShape, BoxSid
     auto outerRect = borderShape.snappedOuterRect(deviceScaleFactor);
 
     auto innerRect = borderShape.snappedInnerRect(deviceScaleFactor);
-    auto innerBorder = borderShape.deprecatedInnerRoundedRect();
+    auto innerBorder = borderShape.shapedRectForInnerShape();
 
     // For each side, create a quad that encompasses all parts of that side that may draw,
     // including areas inside the innerBorder.

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -41,6 +41,7 @@
 #include "LayoutRoundedRect.h"
 #include "Path.h"
 #include "StyleComputedStyle+GettersInlines.h"
+#include <algorithm>
 #include <cmath>
 
 namespace WebCore {
@@ -129,6 +130,18 @@ BorderShape BorderShape::shapeForBorderRect(const Style::ComputedStyle& style, c
     return BorderShape { borderRect, usedBorderWidths };
 }
 
+BorderShape BorderShape::shapeForOffsetRect(const LayoutRect& borderRect, const LayoutRoundedRectRadii& borderRadii, const RectCorners<float>& cornerCurvatures, const LayoutRect& offsetRect)
+{
+    auto radii = borderRadii;
+    radii.expand(borderRect.y() - offsetRect.y(), offsetRect.maxY() - borderRect.maxY(), borderRect.x() - offsetRect.x(), offsetRect.maxX() - borderRect.maxX());
+    if (!radii.areRenderableInRect(offsetRect))
+        radii.makeRenderableInRect(offsetRect);
+
+    auto shape = BorderShape { offsetRect, { }, radii, cornerCurvatures };
+    shape.m_offsetReferenceRect = LayoutRoundedRect { borderRect, borderRadii };
+    return shape;
+}
+
 BorderShape BorderShape::shapeForOffsetRect(const Style::ComputedStyle& style, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges)
 {
     auto usedEdgeWidths = applyClosedEdges(edgeWidths, closedEdges);
@@ -198,22 +211,22 @@ BorderShape BorderShape::shapeWithBorderWidths(const RectEdges<LayoutUnit>& bord
     return shape;
 }
 
-LayoutRoundedRect BorderShape::deprecatedRoundedRect() const
+LayoutRoundedRect BorderShape::shapedRectForOuterShape() const
 {
     return m_borderRect;
 }
 
-LayoutRoundedRect BorderShape::deprecatedInnerRoundedRect() const
+LayoutRoundedRect BorderShape::shapedRectForInnerShape() const
 {
     return m_innerEdgeRect;
 }
 
-FloatRoundedRect BorderShape::deprecatedPixelSnappedRoundedRect(float deviceScaleFactor) const
+FloatRoundedRect BorderShape::snappedShapedRectForOuterShape(float deviceScaleFactor) const
 {
     return m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
 }
 
-FloatRoundedRect BorderShape::deprecatedPixelSnappedInnerRoundedRect(float deviceScaleFactor) const
+FloatRoundedRect BorderShape::snappedShapedRectForInnerShape(float deviceScaleFactor) const
 {
     return m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
 }
@@ -434,12 +447,118 @@ static void addAlignedToCurveOffsetContour(Path& path, const FloatRoundedRect& r
     borderContourPath(path, referenceCorners, &targetRect, outsetMiter);
 }
 
+static void buildOuterCornerInputs(const FloatRoundedRect& outerSnapped, const RectCorners<float>& cornerCurvatures, const std::optional<FloatRoundedRect>& offsetReference, RectCorners<CornerInput>& cornerRects)
+{
+    buildCornerInputs(outerSnapped, cornerCurvatures, 0, 0, 0, 0, cornerRects);
+    rebuildOffsetCornersFromReference(cornerRects, offsetReference, cornerCurvatures, outerSnapped.rect());
+}
+
 static void addOuterCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const RectCorners<float>& cornerCurvatures, const std::optional<FloatRoundedRect>& offsetReferenceRect)
 {
     RectCorners<CornerInput> cornerRects;
-    buildCornerInputs(outerSnapped, cornerCurvatures, 0, 0, 0, 0, cornerRects);
-    rebuildOffsetCornersFromReference(cornerRects, offsetReferenceRect, cornerCurvatures, outerSnapped.rect());
+    buildOuterCornerInputs(outerSnapped, cornerCurvatures, offsetReferenceRect, cornerRects);
     borderContourPath(path, cornerRects);
+}
+
+static FloatPoint outerVertexForCorner(const FloatRect& rect, BoxCorner corner)
+{
+    switch (corner) {
+    case BoxCorner::TopLeft:     return rect.minXMinYCorner();
+    case BoxCorner::TopRight:    return rect.maxXMinYCorner();
+    case BoxCorner::BottomLeft:  return rect.minXMaxYCorner();
+    case BoxCorner::BottomRight: return rect.maxXMaxYCorner();
+    }
+    return { };
+}
+
+static Vector<FloatPoint> densifyContour(const Vector<FloatPoint>& points, float maximumSpacing)
+{
+    Vector<FloatPoint> dense;
+    for (size_t index = 0; index + 1 < points.size(); ++index) {
+        auto start = points[index];
+        auto span = points[index + 1] - start;
+        dense.append(start);
+
+        auto interiorCount = static_cast<unsigned>(std::floor(span.diagonalLength() / maximumSpacing));
+        for (unsigned step = 1; step <= interiorCount; ++step)
+            dense.append(start + span.scaled(float(step) / (interiorCount + 1)));
+    }
+    if (!points.isEmpty())
+        dense.append(points.last());
+    return dense;
+}
+
+Vector<FloatPoint> BorderShape::outerShapeAsPolygon(float deviceScaleFactor, unsigned stepsPerHalf) const
+{
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    RectCorners<CornerInput> cornerRects;
+    buildOuterCornerInputs(outerSnapped, m_cornerCurvatures, snappedOffsetReferenceRect(deviceScaleFactor), cornerRects);
+
+    Vector<FloatPoint> contour;
+    for (auto key : { BoxCorner::TopRight, BoxCorner::BottomRight, BoxCorner::BottomLeft, BoxCorner::TopLeft })
+        contour.appendVector(sampleCornerShape(cornerRects[key], stepsPerHalf));
+
+    if (!contour.isEmpty())
+        contour.append(contour.first());
+    return contour;
+}
+
+std::optional<Path> BorderShape::pathForShapedRect(const FloatRoundedRect& roundedRect, const RectCorners<float>& cornerCurvatures)
+{
+    auto& radii = roundedRect.radii();
+    auto isRound = [](float curvature, const FloatSize& radius) {
+        return curvature == 1.0f || radius.isEmpty();
+    };
+    if (isRound(cornerCurvatures.topLeft(), radii.topLeft())
+        && isRound(cornerCurvatures.topRight(), radii.topRight())
+        && isRound(cornerCurvatures.bottomLeft(), radii.bottomLeft())
+        && isRound(cornerCurvatures.bottomRight(), radii.bottomRight()))
+        return std::nullopt;
+
+    RectCorners<CornerInput> cornerRects;
+    buildCornerInputs(roundedRect, cornerCurvatures, 0, 0, 0, 0, cornerRects);
+
+    Path path;
+    borderContourPath(path, cornerRects);
+    return path;
+}
+
+Region BorderShape::approximateAsRegion(float deviceScaleFactor, unsigned stepLength) const
+{
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (!hasNonRoundCornerShape())
+        return WebCore::approximateAsRegion(outerSnapped, stepLength);
+
+    RectCorners<CornerInput> cornerRects;
+    buildOuterCornerInputs(outerSnapped, m_cornerCurvatures, snappedOffsetReferenceRect(deviceScaleFactor), cornerRects);
+
+    auto rect = outerSnapped.rect();
+    Region region;
+    region.unite(enclosingIntRect(rect));
+
+    for (auto key : { BoxCorner::TopLeft, BoxCorner::TopRight, BoxCorner::BottomLeft, BoxCorner::BottomRight }) {
+        const auto& input = cornerRects[key];
+
+        auto extent = std::max(0.0, std::min(input.width, input.height));
+        auto step = std::max(1u, stepLength);
+        auto count = std::clamp(static_cast<unsigned>((extent + step / 2.0) / step), 2u, 20u);
+
+        bool straightSided = !input.curvature || std::isinf(input.curvature);
+        auto samples = sampleCornerShape(input, straightSided ? 1 : count);
+        if (samples.size() < 2)
+            continue;
+        if (straightSided)
+            samples = densifyContour(samples, std::max(1.0, extent / count));
+
+        auto vertex = outerVertexForCorner(rect, key);
+        for (auto& point : samples) {
+            FloatRect cornerRect { vertex, FloatSize { } };
+            cornerRect.extend(point);
+            region.subtract(roundedIntRect(cornerRect));
+        }
+    }
+
+    return region;
 }
 
 Path BorderShape::pathForOuterCornerShape(const FloatRoundedRect& outerSnapped, const std::optional<FloatRoundedRect>& snappedOffsetReference) const

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -33,6 +33,7 @@
 #include "LayoutRoundedRect.h"
 #include "RectCorners.h"
 #include "RectEdges.h"
+#include "Region.h"
 #include "RenderStyleConstants.h"
 #include <optional>
 
@@ -49,8 +50,6 @@ class ComputedStyle;
 }
 
 // BorderShape is used to fill and clip to the shape formed by the border and padding boxes with border-radius.
-// In future, this may be a more complex shape than a rounded rect, so accessors that return rounded rects
-// are deprecated.
 class BorderShape {
 public:
     static BorderShape shapeForBorderRect(const Style::ComputedStyle&, const LayoutRect& borderRect, RectEdges<bool> closedEdges = { true });
@@ -61,6 +60,7 @@ public:
     // allow for scaling the corner radii; radii expand outward or shrink inward based on the offset
     // between borderRect and offsetRect.
     static BorderShape shapeForOffsetRect(const Style::ComputedStyle&, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges = { true });
+    static BorderShape shapeForOffsetRect(const LayoutRect& borderRect, const LayoutRoundedRectRadii&, const RectCorners<float>& cornerCurvatures, const LayoutRect& offsetRect);
 
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths);
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const LayoutRoundedRectRadii&);
@@ -76,16 +76,22 @@ public:
     // Takes `closedEdges` into account.
     const RectEdges<LayoutUnit>& borderWidths() const LIFETIME_BOUND { return m_borderWidths; }
 
-    LayoutRoundedRect NODELETE deprecatedRoundedRect() const;
-    LayoutRoundedRect NODELETE deprecatedInnerRoundedRect() const;
-    FloatRoundedRect deprecatedPixelSnappedRoundedRect(float deviceScaleFactor) const;
-    FloatRoundedRect deprecatedPixelSnappedInnerRoundedRect(float deviceScaleFactor) const;
+    LayoutRoundedRect NODELETE shapedRectForOuterShape() const;
+    LayoutRoundedRect NODELETE shapedRectForInnerShape() const;
+    FloatRoundedRect snappedShapedRectForOuterShape(float deviceScaleFactor) const;
+    FloatRoundedRect snappedShapedRectForInnerShape(float deviceScaleFactor) const;
 
     // Returns true if the given rect is entirely inside the inner/outer shape.
     bool innerShapeContains(const LayoutRect&) const;
     bool outerShapeContains(const LayoutRect&) const;
 
     bool shapeIntersectsHitTestLocation(const HitTestLocation&, float deviceScaleFactor) const;
+
+    Region approximateAsRegion(float deviceScaleFactor, unsigned stepLength = 20) const;
+
+    Vector<FloatPoint> outerShapeAsPolygon(float deviceScaleFactor, unsigned stepsPerHalf = 8) const;
+
+    static std::optional<Path> pathForShapedRect(const FloatRoundedRect&, const RectCorners<float>& cornerCurvatures);
 
     // Returns true if no corner regions of the outer border intersect the given rect,
     // meaning border painting can use simpler rectangular paths.

--- a/Source/WebCore/rendering/ClipPathPaintScope.cpp
+++ b/Source/WebCore/rendering/ClipPathPaintScope.cpp
@@ -81,7 +81,12 @@ std::pair<Path, WindRule> ClipPathPaintScope::computeClipPath(const RenderLayerM
         [&](const Style::BoxPath& clipPath) -> std::pair<Path, WindRule> {
             CheckedPtr box = dynamicDowncast<RenderBox>(renderer);
             if (box) {
-                auto shapeRect = computeRoundedRectForBoxShape(clipPath.referenceBox(), *box).pixelSnappedRoundedRectForPainting(renderer.document().deviceScaleFactor());
+                auto deviceScaleFactor = renderer.document().deviceScaleFactor();
+                if (auto path = computePathForBoxShape(clipPath.referenceBox(), *box, deviceScaleFactor)) {
+                    path->translate(FloatSize { offsetFromRoot });
+                    return { WTF::move(*path), WindRule::NonZero };
+                }
+                auto shapeRect = computeRoundedRectForBoxShape(clipPath.referenceBox(), *box).pixelSnappedRoundedRectForPainting(deviceScaleFactor);
                 shapeRect.move(offsetFromRoot);
                 return { shapeRect.path(), WindRule::NonZero };
             }

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "EventRegion.h"
 
+#include "BorderShape.h"
 #include "EventTrackingRegions.h"
 #include "HTMLFormControlElement.h"
 #include "Logging.h"
@@ -52,7 +53,21 @@ EventRegionContext::EventRegionContext(EventRegion& eventRegion)
 
 EventRegionContext::~EventRegionContext() = default;
 
+void EventRegionContext::unite(const BorderShape& borderShape, float deviceScaleFactor, const RenderObject& renderer, const Style::ComputedStyle& style, bool overrideUserModifyIsEditable, ContributeToInteractionRegions contributeToInteractionRegions)
+{
+    if (!borderShape.hasNonRoundCornerShape()) {
+        unite(borderShape.snappedShapedRectForOuterShape(deviceScaleFactor), renderer, style, overrideUserModifyIsEditable, contributeToInteractionRegions);
+        return;
+    }
+    uniteRegion(borderShape.approximateAsRegion(deviceScaleFactor), borderShape.snappedOuterRect(deviceScaleFactor), renderer, style, overrideUserModifyIsEditable, contributeToInteractionRegions);
+}
+
 void EventRegionContext::unite(const FloatRoundedRect& roundedRect, const RenderObject& renderer, const Style::ComputedStyle& style, bool overrideUserModifyIsEditable, ContributeToInteractionRegions contributeToInteractionRegions)
+{
+    uniteRegion(approximateAsRegion(roundedRect), roundedRect.rect(), renderer, style, overrideUserModifyIsEditable, contributeToInteractionRegions);
+}
+
+void EventRegionContext::uniteRegion(Region&& shapeRegion, const FloatRect& bounds, const RenderObject& renderer, const Style::ComputedStyle& style, bool overrideUserModifyIsEditable, ContributeToInteractionRegions contributeToInteractionRegions)
 {
     auto transformAndClipIfNeeded = [&](auto input, auto transform) {
         if (m_transformStack.isEmpty() && m_clipStack.isEmpty())
@@ -65,7 +80,7 @@ void EventRegionContext::unite(const FloatRoundedRect& roundedRect, const Render
         return transformedAndClippedInput;
     };
 
-    auto region = transformAndClipIfNeeded(approximateAsRegion(roundedRect), [](auto affineTransform, auto region) {
+    auto region = transformAndClipIfNeeded(WTF::move(shapeRegion), [](auto affineTransform, auto region) {
         return affineTransform.mapRegion(region);
     });
     m_eventRegion.unite(region, renderer, style, overrideUserModifyIsEditable);
@@ -74,7 +89,7 @@ void EventRegionContext::unite(const FloatRoundedRect& roundedRect, const Render
     if (contributeToInteractionRegions == ContributeToInteractionRegions::No)
         return;
 
-    auto rect = roundedRect.rect();
+    auto rect = bounds;
     if (auto* modelObject = dynamicDowncast<RenderLayerModelObject>(renderer))
         rect = snapRectToDevicePixelsIfNeeded(rect, *modelObject);
     auto layerBounds = transformAndClipIfNeeded(rect, [](auto affineTransform, auto rect) {
@@ -95,6 +110,7 @@ void EventRegionContext::unite(const FloatRoundedRect& roundedRect, const Render
 
     uniteInteractionRegions(renderer, layerBounds, clipOffset, transform);
 #else
+    UNUSED_PARAM(bounds);
     UNUSED_PARAM(renderer);
     UNUSED_PARAM(contributeToInteractionRegions);
 #endif

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -44,6 +44,7 @@
 
 namespace WebCore {
 
+class BorderShape;
 class EventRegion;
 class Path;
 class RenderObject;
@@ -64,6 +65,7 @@ public:
 
     enum class ContributeToInteractionRegions : bool { No, Yes };
     WEBCORE_EXPORT void unite(const FloatRoundedRect&, const RenderObject&, const Style::ComputedStyle&, bool overrideUserModifyIsEditable = false, ContributeToInteractionRegions = ContributeToInteractionRegions::Yes);
+    WEBCORE_EXPORT void unite(const BorderShape&, float deviceScaleFactor, const RenderObject&, const Style::ComputedStyle&, bool overrideUserModifyIsEditable = false, ContributeToInteractionRegions = ContributeToInteractionRegions::Yes);
     bool contains(const IntRect&) const;
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
@@ -77,6 +79,8 @@ public:
 #endif
 
 private:
+    void uniteRegion(Region&&, const FloatRect& bounds, const RenderObject&, const Style::ComputedStyle&, bool overrideUserModifyIsEditable, ContributeToInteractionRegions);
+
     EventRegion& m_eventRegion;
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -51,7 +51,7 @@ static FloatRoundedRect containingBlockRectForRenderer(const RenderObject& rende
             auto referenceBox = offsetPath.referenceBox();
             auto referenceRect = container.referenceBoxRect(referenceBox);
             auto borderShape = BorderShape::shapeForBorderRect(container.style(), LayoutRect(referenceRect));
-            return borderShape.deprecatedPixelSnappedRoundedRect(protect(container.document())->deviceScaleFactor());
+            return borderShape.snappedShapedRectForOuterShape(protect(container.document())->deviceScaleFactor());
         },
         [&](const auto& offsetPath) -> FloatRoundedRect {
             auto referenceBox = offsetPath.referenceBox();
@@ -113,6 +113,8 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
 
     MotionPathData data;
     data.containingBlockBoundingRect = containingBlockRectForRenderer(renderer, *container, offsetPath);
+    // Carried so offset-path: <box> can follow the corner-shape contour rather than the rounded rect.
+    data.cornerCurvatures = BorderShape::shapeForBorderRect(container->style(), container->borderBoxRect()).cornerCurvatures();
     data.offsetFromContainingBlock = offsetFromContainer(renderer, *container, data.containingBlockBoundingRect.rect());
 
     auto zoom = renderer.style().usedZoomForLength();

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/FloatRoundedRect.h>
+#include <WebCore/RectCorners.h>
 #include <WebCore/RenderLayerModelObject.h>
 
 namespace WebCore {
@@ -46,6 +47,7 @@ struct MotionPathData {
     FloatRoundedRect containingBlockBoundingRect;
     FloatPoint offsetFromContainingBlock;
     FloatPoint usedStartingPosition;
+    RectCorners<float> cornerCurvatures { 1.0f, 1.0f, 1.0f, 1.0f };
 
     FloatPoint NODELETE currentOffset() const;
     FloatRoundedRect NODELETE offsetRect() const;

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -27,6 +27,7 @@
 #include "PathOperation.h"
 
 #include "AnimationUtilities.h"
+#include "BorderShape.h"
 #include "CSSRayValue.h"
 #include "SVGElement.h"
 #include "SVGElementTypeHelpers.h"
@@ -138,6 +139,9 @@ Ref<PathOperation> BoxPathOperation::clone() const
 std::optional<Path> BoxPathOperation::getPath(const TransformOperationData& data, Style::ZoomFactor) const
 {
     if (auto motionPathData = data.motionPathData) {
+        if (auto shaped = BorderShape::pathForShapedRect(motionPathData->offsetRect(), motionPathData->cornerCurvatures))
+            return shaped;
+
         Path path;
         path.addRoundedRect(motionPathData->offsetRect(), PathRoundedRect::Strategy::PreferBezier);
         return path;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1252,9 +1252,9 @@ void RenderBlock::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
         Ref document = this->document();
         if (paintInfo.paintBehavior.contains(PaintBehavior::EventRegionIncludeBackground) && visibleToHitTesting()) {
             auto borderShape = BorderShape::shapeForBorderRect(style(), borderRect);
-            LOG_WITH_STREAM(EventRegions, stream << "RenderBlock " << *this << " uniting region " << borderShape.deprecatedRoundedRect() << " event listener types " << style().eventListenerRegionTypes());
+            LOG_WITH_STREAM(EventRegions, stream << "RenderBlock " << *this << " uniting region " << borderShape.shapedRectForOuterShape() << " event listener types " << style().eventListenerRegionTypes());
             bool overrideUserModifyIsEditable = isRenderTextControl() && protect(downcast<RenderTextControl>(*this).textFormControlElement())->isInnerTextElementEditable();
-            paintInfo.eventRegionContext()->unite(borderShape.deprecatedPixelSnappedRoundedRect(document->deviceScaleFactor()), *this, style(), overrideUserModifyIsEditable);
+            paintInfo.eventRegionContext()->unite(borderShape, document->deviceScaleFactor(), *this, style(), overrideUserModifyIsEditable);
         }
 
         if (!paintInfo.paintBehavior.contains(PaintBehavior::EventRegionIncludeForeground))

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -995,7 +995,7 @@ LayoutUnit RenderBox::constrainContentBoxLogicalHeightByMinMax(LayoutUnit logica
 LayoutRoundedRect::Radii RenderBox::borderRadii() const
 {
     auto borderShape = BorderShape::shapeForBorderRect(style(), paddingBoxRectIncludingScrollbar());
-    return borderShape.deprecatedRoundedRect().radii();
+    return borderShape.radii();
 }
 
 IntRect absoluteInteractionBounds(const RenderObject& renderer)

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -900,15 +900,24 @@ void RenderLayerBacking::updateBackdropFiltersGeometry()
     FloatRoundedRect backdropFiltersRect;
     if (renderBox->style().border().hasBorderRadius() && !renderBox->hasClip()) {
         auto borderShape = BorderShape::shapeForBorderRect(renderBox->style(), renderBox->borderBoxRect());
-        auto roundedBoxRect = borderShape.deprecatedRoundedRect();
+        auto roundedBoxRect = borderShape.shapedRectForOuterShape();
         roundedBoxRect.move(contentOffsetInCompositingLayer());
         backdropFiltersRect = roundedBoxRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor());
+
+        if (renderBox->style().border().hasNonRoundCornerShape()) {
+            auto shapePath = borderShape.pathForOuterShape(deviceScaleFactor());
+            shapePath.translate(FloatSize { contentOffsetInCompositingLayer() });
+            m_graphicsLayer->setBackdropFiltersShapePath(shapePath);
+            backdropFiltersRect = FloatRoundedRect { backdropFiltersRect.rect() };
+        } else
+            m_graphicsLayer->setBackdropFiltersShapePath({ });
     } else {
         auto boxRect = renderBox->borderBoxRect();
         if (renderBox->hasClip())
             boxRect.intersect(renderBox->clipRect({ }));
         boxRect.move(contentOffsetInCompositingLayer());
         backdropFiltersRect = FloatRoundedRect(snapRectToDevicePixels(boxRect, deviceScaleFactor()));
+        m_graphicsLayer->setBackdropFiltersShapePath({ });
     }
 
     m_graphicsLayer->setBackdropFiltersRect(backdropFiltersRect);
@@ -1010,9 +1019,14 @@ void RenderLayerBacking::updateAppleVisualEffect(const Style::ComputedStyle& sty
         if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer())) {
             if (renderBox->style().border().hasBorderRadius()) {
                 auto borderShape = BorderShape::shapeForBorderRect(renderBox->style(), renderBox->borderBoxRect());
-                auto roundedBoxRect = borderShape.deprecatedRoundedRect();
+                auto roundedBoxRect = borderShape.shapedRectForOuterShape();
                 roundedBoxRect.move(contentOffsetInCompositingLayer());
-                visualEffectData.borderRect = roundedBoxRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor());
+                auto snappedBoxRect = roundedBoxRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor());
+
+                if (renderBox->style().border().hasNonRoundCornerShape())
+                    snappedBoxRect = FloatRoundedRect { snappedBoxRect.rect() };
+
+                visualEffectData.borderRect = snappedBoxRect;
             }
         }
     }
@@ -1257,7 +1271,7 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
         // If it's scrollable, it has to be a box.
         auto& renderBox = downcast<RenderBox>(renderer());
         auto borderShape = BorderShape::shapeForBorderRect(renderBox.style(), renderBox.borderBoxRect());
-        FloatRoundedRect contentsClippingRect = borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor());
+        FloatRoundedRect contentsClippingRect = borderShape.snappedShapedRectForInnerShape(deviceScaleFactor());
         needsDescendantsClippingLayer = contentsClippingRect.hasNonZeroRadii();
     } else
         needsDescendantsClippingLayer = RenderLayerCompositor::clipsCompositingDescendants(m_owningLayer);
@@ -1738,7 +1752,7 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
         auto computeMasksToBoundsRect = [&] {
             if ((renderer().hasClipPath() || renderer().style().border().hasBorderRadius())) {
                 auto borderShape = BorderShape::shapeForBorderRect(renderer().style(), m_owningLayer.rendererBorderBoxRect());
-                auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor), renderer().style());
+                auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.snappedShapedRectForInnerShape(deviceScaleFactor), renderer().style());
                 contentsClippingRect.move(LayoutSize(-clipLayer->offsetFromRenderer()));
                 return contentsClippingRect;
             }
@@ -2155,7 +2169,7 @@ void RenderLayerBacking::updateContentsRects()
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         if (RenderLayerCompositor::isSeparated(renderer())) {
             auto borderShape = BorderShape::shapeForBorderRect(renderVideo->style(), renderVideo->borderBoxRect());
-            auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor()), renderVideo->style());
+            auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.snappedShapedRectForInnerShape(deviceScaleFactor()), renderVideo->style());
             contentsClippingRect.move(contentOffsetInCompositingLayer());
             m_graphicsLayer->setContentsClippingRect(contentsClippingRect);
             setContentsClipShapePath(*m_graphicsLayer, renderVideo->style(), borderShape, deviceScaleFactor(), contentOffsetInCompositingLayer());
@@ -2172,7 +2186,7 @@ void RenderLayerBacking::updateContentsRects()
             contentsClippingRect = FloatRoundedRect(m_graphicsLayer->contentsRect());
         } else {
             auto borderShape = renderVideo->borderShapeForContentClipping(renderVideo->borderBoxRect());
-            contentsClippingRect = contentsClippingRectForCornerShape(borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor()), renderVideo->style());
+            contentsClippingRect = contentsClippingRectForCornerShape(borderShape.snappedShapedRectForInnerShape(deviceScaleFactor()), renderVideo->style());
             // Intersect with the (small) destination rect so the oversized contents layer is clipped to what's actually visible.
             contentsClippingRect = FloatRoundedRect(intersection(contentsClippingRect.rect(), FloatRect(renderVideo->videoBox())), contentsClippingRect.radii());
             contentsClippingRect.move(contentOffsetInCompositingLayer());
@@ -2199,7 +2213,7 @@ void RenderLayerBacking::updateContentsRects()
     if (needsContentsClippingRectUpdate) {
         if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer())) {
             auto borderShape = BorderShape::shapeForBorderRect(renderBox->style(), renderBox->borderBoxRect());
-            auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor()), renderBox->style());
+            auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.snappedShapedRectForInnerShape(deviceScaleFactor()), renderBox->style());
             contentsClippingRect.move(contentOffsetInCompositingLayer());
             m_graphicsLayer->setContentsClippingRect(contentsClippingRect);
             setContentsClipShapePath(*m_graphicsLayer, renderBox->style(), borderShape, deviceScaleFactor(), contentOffsetInCompositingLayer());
@@ -2214,7 +2228,7 @@ void RenderLayerBacking::updateContentsRects()
         else {
             // FIXME: Support visible overflow for replaced content.
             auto borderShape = renderReplaced->borderShapeForContentClipping(renderReplaced->borderBoxRect());
-            auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor()), renderReplaced->style());
+            auto contentsClippingRect = contentsClippingRectForCornerShape(borderShape.snappedShapedRectForInnerShape(deviceScaleFactor()), renderReplaced->style());
             contentsClippingRect.move(contentOffsetInCompositingLayer());
             m_graphicsLayer->setContentsClippingRect(contentsClippingRect);
             setContentsClipShapePath(*m_graphicsLayer, renderReplaced->style(), borderShape, deviceScaleFactor(), contentOffsetInCompositingLayer());
@@ -3183,7 +3197,15 @@ bool RenderLayerBacking::needsCornerShapeMask() const
     if (!renderer().style().border().hasCornerShapeOutsideRoundedRect())
         return false;
 
-    return m_graphicsLayer->contentsRectClipsDescendants() || m_childContainmentLayer || m_scrollContainerLayer;
+    if (m_graphicsLayer->contentsRectClipsDescendants() || m_childContainmentLayer || m_scrollContainerLayer)
+        return true;
+
+#if HAVE(MATERIAL_HOSTING)
+    if (appleVisualEffectIsHostedMaterial(renderer().style().appleVisualEffect()))
+        return true;
+#endif
+
+    return false;
 }
 
 // Masking layer is used for masks, clip-path, or corner-shape

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3752,7 +3752,7 @@ Vector<CompositedClipData> RenderLayerCompositor::computeAncestorClippingStack(c
                 }
 
                 auto borderShape = BorderShape::shapeForBorderRect(box->style(), box->borderBoxRect());
-                auto clipRoundedRect = borderShape.deprecatedInnerRoundedRect();
+                auto clipRoundedRect = borderShape.shapedRectForInnerShape();
 
                 auto offset = layer.convertToLayerCoords(&ancestorLayer, { }, RenderLayer::AdjustForColumns);
                 auto rect = clipRoundedRect.rect();
@@ -5860,7 +5860,7 @@ LayoutRoundedRect RenderLayerCompositor::parentRelativeScrollableRect(const Rend
         scrollableRect = LayoutRoundedRect { box->paddingBoxRect() };
         if (box->style().border().hasBorderRadius()) {
             auto borderShape = BorderShape::shapeForBorderRect(box->style(), box->borderBoxRect());
-            scrollableRect = borderShape.deprecatedInnerRoundedRect();
+            scrollableRect = borderShape.shapedRectForInnerShape();
         }
     }
 

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -294,7 +294,7 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
             auto contributeToInteractionRegions = (svgRootHasChildrenOrFilters && !isSkippedContentRoot(*this))
                 ? EventRegionContext::ContributeToInteractionRegions::No
                 : EventRegionContext::ContributeToInteractionRegions::Yes;
-            paintInfo.eventRegionContext()->unite(borderShape.deprecatedPixelSnappedRoundedRect(protect(document())->deviceScaleFactor()), *this, style(), false, contributeToInteractionRegions);
+            paintInfo.eventRegionContext()->unite(borderShape, protect(document())->deviceScaleFactor(), *this, style(), false, contributeToInteractionRegions);
         }
 
         if (svgRootHasChildrenOrFilters && !isSkippedContentRoot(*this))

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -866,7 +866,10 @@ bool RenderTheme::paint(const RenderBox& box, ControlPart& part, const PaintInfo
     auto controlStyle = extractControlStyleForRenderer(box);
     auto& context = paintInfo.context();
 
-    context.drawControlPart(part, borderShape.deprecatedPixelSnappedRoundedRect(deviceScaleFactor), deviceScaleFactor, controlStyle);
+    auto partRect = borderShape.hasNonRoundCornerShape()
+        ? FloatRoundedRect { borderShape.snappedOuterRect(deviceScaleFactor) }
+        : borderShape.snappedShapedRectForOuterShape(deviceScaleFactor);
+    context.drawControlPart(part, partRect, deviceScaleFactor, controlStyle);
     return false;
 }
 
@@ -890,6 +893,15 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
 
     float deviceScaleFactor = protect(box.document())->deviceScaleFactor();
     FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, deviceScaleFactor);
+
+    // Control art knows only a corner radius, so the part is clipped to the contour. Done here rather than per
+    // part, because each draws its own way and some never reach drawControlPart().
+    bool needsCornerShapeClip = box.style().border().hasNonRoundCornerShape();
+    GraphicsContextStateSaver cornerShapeStateSaver(paintInfo.context(), needsCornerShapeClip);
+    if (needsCornerShapeClip) {
+        auto borderShape = BorderShape::shapeForBorderRect(box.style(), LayoutRect(devicePixelSnappedRect));
+        paintInfo.context().clipPath(borderShape.pathForOuterShape(deviceScaleFactor));
+    }
 
     switch (appearance) {
     case StyleAppearance::Checkbox:

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -36,6 +36,7 @@ OBJC_CLASS UIImage;
 
 namespace WebCore {
 
+class BorderShape;
 class GraphicsContext;
 struct AttachmentLayout;
 
@@ -172,7 +173,7 @@ private:
     RenderThemeIOS();
     virtual ~RenderThemeIOS();
 
-    void paintTextFieldInnerShadow(const PaintInfo&, const FloatRoundedRect&);
+    void paintTextFieldInnerShadow(const PaintInfo&, const BorderShape&, float deviceScaleFactor);
 
     Color checkboxRadioBorderColor(OptionSet<ControlStyle::State>, OptionSet<StyleColorOptions>);
     Color checkboxRadioBackgroundColor(const Style::ComputedStyle&, OptionSet<ControlStyle::State>, OptionSet<StyleColorOptions>);

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -304,7 +304,7 @@ void RenderThemeIOS::adjustTextFieldStyle(Style::ComputedStyle& style, const Ele
     adjustBackgroundColor();
 }
 
-void RenderThemeIOS::paintTextFieldInnerShadow(const PaintInfo& paintInfo, const FloatRoundedRect& roundedRect)
+void RenderThemeIOS::paintTextFieldInnerShadow(const PaintInfo& paintInfo, const BorderShape& borderShape, float deviceScaleFactor)
 {
     auto& context = paintInfo.context();
 
@@ -315,14 +315,14 @@ void RenderThemeIOS::paintTextFieldInnerShadow(const PaintInfo& paintInfo, const
     context.setFillColor(Color::black);
 
     Path innerShadowPath;
-    FloatRect innerShadowRect = roundedRect.rect();
+    FloatRect innerShadowRect = borderShape.snappedOuterRect(deviceScaleFactor);
     innerShadowRect.inflate(std::max<float>(innerShadowOffset.width(), innerShadowOffset.height()) + innerShadowBlur);
     innerShadowPath.addRect(innerShadowRect);
 
-    FloatRoundedRect innerShadowHoleRect = roundedRect;
     // FIXME: This is not from the spec; but without it we get antialiasing fringe from the fill; we need a better solution.
-    innerShadowHoleRect.inflate(0.5);
-    innerShadowPath.addRoundedRect(innerShadowHoleRect);
+    auto inflatedShape = borderShape;
+    inflatedShape.inflate(LayoutUnit(0.5));
+    inflatedShape.addOuterShapeToPath(innerShadowPath, deviceScaleFactor);
 
     context.setFillRule(WindRule::EvenOdd);
     context.fillPath(innerShadowPath);
@@ -342,12 +342,13 @@ void RenderThemeIOS::paintTextFieldDecorations(const RenderBox& box, const Paint
         shouldPaintFillAndInnerShadow = true;
 
     if (PAL::currentUserInterfaceIdiomIsVision() && shouldPaintFillAndInnerShadow) {
+        auto deviceScaleFactor = protect(box.document())->deviceScaleFactor();
         auto borderShape = BorderShape::shapeForBorderRect(box.style(), LayoutRect(rect));
-        auto path = borderShape.pathForOuterShape(protect(box.document())->deviceScaleFactor());
+        auto path = borderShape.pathForOuterShape(deviceScaleFactor);
         context.setFillColor(Color::black.colorWithAlphaByte(10));
         context.drawPath(path);
         context.clipPath(path);
-        paintTextFieldInnerShadow(paintInfo,  borderShape.deprecatedPixelSnappedRoundedRect(protect(box.document())->deviceScaleFactor()));
+        paintTextFieldInnerShadow(paintInfo, borderShape, deviceScaleFactor);
     }
 }
 

--- a/Source/WebCore/rendering/shapes/BoxLayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/BoxLayoutShape.cpp
@@ -31,7 +31,9 @@
 #include "BoxLayoutShape.h"
 
 #include "BorderShape.h"
+#include "Path.h"
 #include "RenderBoxInlines.h"
+#include <limits>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {
@@ -63,6 +65,17 @@ static inline LayoutRoundedRect::Radii computeMarginBoxShapeRadii(const LayoutRo
         computeMarginBoxShapeRadius(radii.bottomRight(), LayoutSize(renderer.marginRight(), renderer.marginBottom())));
 }
 
+static BorderShape marginBoxBorderShape(const Style::ComputedStyle& style, const RenderBox& renderer)
+{
+    auto marginBox = renderer.marginBoxRect();
+    auto borderShape = BorderShape::shapeForBorderRect(style, renderer.borderBoxRect());
+    auto radii = computeMarginBoxShapeRadii(borderShape.radii(), renderer);
+    radii.scale(calcBorderRadiiConstraintScaleFor(marginBox, radii));
+    if (!radii.areRenderableInRect(marginBox))
+        radii.makeRenderableInRect(marginBox);
+    return BorderShape { marginBox, { }, radii, borderShape.cornerCurvatures() };
+}
+
 LayoutRoundedRect computeRoundedRectForBoxShape(CSSBoxType box, const RenderBox& renderer)
 {
     CheckedRef style = renderer.style();
@@ -70,31 +83,57 @@ LayoutRoundedRect computeRoundedRectForBoxShape(CSSBoxType box, const RenderBox&
     case CSSBoxType::MarginBox: {
         if (!style->border().hasBorderRadius())
             return LayoutRoundedRect(renderer.marginBoxRect(), LayoutRoundedRect::Radii());
-
-        auto marginBox = renderer.marginBoxRect();
-        auto borderShape = BorderShape::shapeForBorderRect(style, renderer.borderBoxRect());
-        LayoutRoundedRect::Radii radii = computeMarginBoxShapeRadii(borderShape.radii(), renderer);
-        radii.scale(calcBorderRadiiConstraintScaleFor(marginBox, radii));
-        return LayoutRoundedRect(marginBox, radii);
+        return marginBoxBorderShape(style, renderer).shapedRectForOuterShape();
     }
     case CSSBoxType::PaddingBox:
-        return BorderShape::shapeForBorderRect(style, renderer.borderBoxRect()).deprecatedInnerRoundedRect();
+        return BorderShape::shapeForBorderRect(style, renderer.borderBoxRect()).shapedRectForInnerShape();
     // fill-box compute to content-box for HTML elements.
     case CSSBoxType::FillBox:
     case CSSBoxType::ContentBox: {
         auto borderShape = renderer.borderShapeForContentClipping(renderer.borderBoxRect());
-        return borderShape.deprecatedInnerRoundedRect();
+        return borderShape.shapedRectForInnerShape();
     }
     // stroke-box, view-box compute to border-box for HTML elements.
     case CSSBoxType::BorderBox:
     case CSSBoxType::StrokeBox:
     case CSSBoxType::ViewBox:
     case CSSBoxType::BoxMissing:
-        return BorderShape::shapeForBorderRect(style, renderer.borderBoxRect()).deprecatedRoundedRect();
+        return BorderShape::shapeForBorderRect(style, renderer.borderBoxRect()).shapedRectForOuterShape();
     }
 
     ASSERT_NOT_REACHED();
-    return BorderShape::shapeForBorderRect(style, renderer.borderBoxRect()).deprecatedRoundedRect();
+    return BorderShape::shapeForBorderRect(style, renderer.borderBoxRect()).shapedRectForOuterShape();
+}
+
+std::optional<Path> computePathForBoxShape(CSSBoxType box, const RenderBox& renderer, float deviceScaleFactor)
+{
+    CheckedRef style = renderer.style();
+    if (!style->border().hasBorderRadius())
+        return std::nullopt;
+
+    auto pathIfNotRounded = [&](const BorderShape& borderShape, bool inner) -> std::optional<Path> {
+        if (!borderShape.hasNonRoundCornerShape())
+            return std::nullopt;
+        return inner ? borderShape.pathForInnerShape(deviceScaleFactor) : borderShape.pathForOuterShape(deviceScaleFactor);
+    };
+
+    switch (box) {
+    case CSSBoxType::PaddingBox:
+        return pathIfNotRounded(BorderShape::shapeForBorderRect(style, renderer.borderBoxRect()), true);
+    case CSSBoxType::FillBox:
+    case CSSBoxType::ContentBox:
+        return pathIfNotRounded(renderer.borderShapeForContentClipping(renderer.borderBoxRect()), true);
+    case CSSBoxType::BorderBox:
+    case CSSBoxType::StrokeBox:
+    case CSSBoxType::ViewBox:
+    case CSSBoxType::BoxMissing:
+        return pathIfNotRounded(BorderShape::shapeForBorderRect(style, renderer.borderBoxRect()), false);
+    case CSSBoxType::MarginBox:
+        return pathIfNotRounded(marginBoxBorderShape(style, renderer), false);
+    }
+
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
 }
 
 LayoutRect BoxLayoutShape::shapeMarginLogicalBoundingBox() const
@@ -119,6 +158,38 @@ FloatRoundedRect BoxLayoutShape::shapeMarginBounds() const
     return marginBounds;
 }
 
+static std::optional<LineSegment> contourExtentBetween(const Vector<FloatPoint>& contour, float bandTop, float bandBottom)
+{
+    float minimumX = std::numeric_limits<float>::max();
+    float maximumX = std::numeric_limits<float>::lowest();
+    auto include = [&](float candidateX) {
+        minimumX = std::min(minimumX, candidateX);
+        maximumX = std::max(maximumX, candidateX);
+    };
+
+    for (size_t index = 0; index + 1 < contour.size(); ++index) {
+        auto start = contour[index];
+        auto end = contour[index + 1];
+
+        if (start.y() >= bandTop && start.y() <= bandBottom)
+            include(start.x());
+
+        if (start.y() == end.y())
+            continue;
+
+        for (float bandEdge : { bandTop, bandBottom }) {
+            if (bandEdge < std::min(start.y(), end.y()) || bandEdge > std::max(start.y(), end.y()))
+                continue;
+            auto fraction = (bandEdge - start.y()) / (end.y() - start.y());
+            include(start.x() + fraction * (end.x() - start.x()));
+        }
+    }
+
+    if (minimumX > maximumX)
+        return std::nullopt;
+    return LineSegment(minimumX, maximumX);
+}
+
 LineSegment BoxLayoutShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUnit logicalHeight) const
 {
     const FloatRoundedRect& marginBounds = shapeMarginBounds();
@@ -128,6 +199,12 @@ LineSegment BoxLayoutShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUni
     float y1 = logicalTop;
     float y2 = logicalTop + logicalHeight;
     const FloatRect& rect = marginBounds.rect();
+
+    if (!m_contour.isEmpty()) {
+        if (auto extent = contourExtentBetween(m_contour, y1, y2))
+            return *extent;
+        return LineSegment();
+    }
 
     if (!marginBounds.hasNonZeroRadii())
         return LineSegment(rect.x(), rect.maxX());

--- a/Source/WebCore/rendering/shapes/BoxLayoutShape.h
+++ b/Source/WebCore/rendering/shapes/BoxLayoutShape.h
@@ -32,17 +32,22 @@
 #include "FloatRoundedRect.h"
 #include "LayoutShape.h"
 #include "RenderStyleConstants.h"
+#include <optional>
 
 namespace WebCore {
 
+class Path;
 class RenderBox;
 
 LayoutRoundedRect computeRoundedRectForBoxShape(CSSBoxType, const RenderBox&);
 
+std::optional<Path> computePathForBoxShape(CSSBoxType, const RenderBox&, float deviceScaleFactor);
+
 class BoxLayoutShape final : public LayoutShape {
 public:
-    BoxLayoutShape(const FloatRoundedRect& bounds)
+    BoxLayoutShape(const FloatRoundedRect& bounds, Vector<FloatPoint>&& contour = { })
         : m_bounds(bounds)
+        , m_contour(WTF::move(contour))
     {
     }
 
@@ -56,6 +61,7 @@ private:
     FloatRoundedRect shapeMarginBounds() const;
 
     FloatRoundedRect m_bounds;
+    Vector<FloatPoint> m_contour;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "LayoutShape.h"
 
+#include "BorderShape.h"
 #include "BoxLayoutShape.h"
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
@@ -235,12 +236,26 @@ Ref<const LayoutShape> LayoutShape::createRasterShape(Image* image, float thresh
     return createShape();
 }
 
-Ref<const LayoutShape> LayoutShape::createBoxShape(const LayoutRoundedRect& roundedRect, WritingMode writingMode, float logicalMargin)
+Ref<const LayoutShape> LayoutShape::createBoxShape(const LayoutRoundedRect& roundedRect, const RectCorners<float>& cornerCurvatures, float deviceScaleFactor, WritingMode writingMode, float logicalMargin)
 {
     ASSERT(roundedRect.rect().width() >= 0 && roundedRect.rect().height() >= 0);
 
     FloatRoundedRect bounds { roundedRect };
-    auto shape = adoptRef(*new BoxLayoutShape(bounds));
+
+    auto shapeForContour = [&] {
+        if (logicalMargin > 0) {
+            auto marginRect = roundedRect.rect();
+            marginRect.inflate(LayoutUnit(logicalMargin));
+            return BorderShape::shapeForOffsetRect(roundedRect.rect(), roundedRect.radii(), cornerCurvatures, marginRect);
+        }
+        return BorderShape { roundedRect.rect(), { }, roundedRect.radii(), cornerCurvatures };
+    }();
+
+    Vector<FloatPoint> contour;
+    if (shapeForContour.hasNonRoundCornerShape())
+        contour = shapeForContour.outerShapeAsPolygon(deviceScaleFactor, 16);
+
+    Ref shape = adoptRef(*new BoxLayoutShape(bounds, WTF::move(contour)));
     shape->m_writingMode = writingMode;
     shape->m_margin = logicalMargin;
 

--- a/Source/WebCore/rendering/shapes/LayoutShape.h
+++ b/Source/WebCore/rendering/shapes/LayoutShape.h
@@ -31,6 +31,7 @@
 
 #include <WebCore/LayoutRect.h>
 #include <WebCore/Path.h>
+#include <WebCore/RectCorners.h>
 #include <WebCore/StyleShapeForward.h>
 #include <WebCore/WritingMode.h>
 #include <wtf/RefCounted.h>
@@ -73,7 +74,7 @@ public:
 
     static Ref<const LayoutShape> createShape(const Style::BasicShape&, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, LayoutUnit borderBoxLogicalWidth, WritingMode, float logicalMargin, Style::ZoomFactor);
     static Ref<const LayoutShape> createRasterShape(Image*, float threshold, const LayoutRect& logicalImageRect, const LayoutRect& logicalMarginRect, WritingMode, float logicalMargin);
-    static Ref<const LayoutShape> createBoxShape(const LayoutRoundedRect&, WritingMode, float logicalMargin);
+    static Ref<const LayoutShape> createBoxShape(const LayoutRoundedRect&, const RectCorners<float>& cornerCurvatures, float deviceScaleFactor, WritingMode, float logicalMargin);
 
     virtual ~LayoutShape() = default;
 

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "ShapeOutsideInfo.h"
 
+#include "BorderShape.h"
 #include "BoxLayoutShape.h"
 #include "FloatingObjects.h"
 #include "NullGraphicsContext.h"
@@ -282,29 +283,40 @@ Ref<const LayoutShape> makeShapeForShapeOutside(const RenderBox& renderer)
         },
         [&](const Style::ShapeOutside::ShapeBox&) {
             auto shapeRect = computeRoundedRectForBoxShape(shapeOutside.effectiveCSSBox(), renderer);
+            auto curvatures = BorderShape::shapeForBorderRect(style, renderer.borderBoxRect()).cornerCurvatures();
             auto flipForWritingAndInlineDirection = [&] {
                 // FIXME: We should consider this moving to LayoutRoundedRect::transposedRect.
                 if (!isHorizontalWritingMode) {
                     shapeRect = shapeRect.transposedRect();
                     auto radiiForBlockDirection = shapeRect.radii();
-                    if (writingMode.isLineOverLeft()) // sideways-lr
+                    auto blockDirection = curvatures;
+                    if (writingMode.isLineOverLeft()) {
+                        // sideways-lr
                         shapeRect.setRadii({ radiiForBlockDirection.bottomLeft(), radiiForBlockDirection.topLeft(), radiiForBlockDirection.bottomRight(), radiiForBlockDirection.topRight() });
-                    else if (writingMode.isBlockLeftToRight()) // vertical-lr
+                        curvatures = { blockDirection.bottomLeft(), blockDirection.topLeft(), blockDirection.bottomRight(), blockDirection.topRight() };
+                    } else if (writingMode.isBlockLeftToRight()) {
+                        // vertical-lr
                         shapeRect.setRadii({ radiiForBlockDirection.topLeft(), radiiForBlockDirection.bottomLeft(), radiiForBlockDirection.topRight(), radiiForBlockDirection.bottomRight() });
-                    else // vertical-rl, sideways-rl
+                        curvatures = { blockDirection.topLeft(), blockDirection.bottomLeft(), blockDirection.topRight(), blockDirection.bottomRight() };
+                    } else {
+                        // vertical-rl, sideways-rl
                         shapeRect.setRadii({ radiiForBlockDirection.topRight(), radiiForBlockDirection.bottomRight(), radiiForBlockDirection.topLeft(), radiiForBlockDirection.bottomLeft() });
+                        curvatures = { blockDirection.topRight(), blockDirection.bottomRight(), blockDirection.topLeft(), blockDirection.bottomLeft() };
+                    }
                 }
                 if (writingMode.isBidiRTL()) {
                     auto radii = shapeRect.radii();
+                    auto beforeFlip = curvatures;
                     shapeRect.setRadii({ radii.topRight(), radii.topLeft(), radii.bottomRight(), radii.bottomLeft() });
+                    curvatures = { beforeFlip.topRight(), beforeFlip.topLeft(), beforeFlip.bottomRight(), beforeFlip.bottomLeft() };
                 }
             };
             flipForWritingAndInlineDirection();
-            return LayoutShape::createBoxShape(shapeRect, writingMode, logicalMargin);
+            return LayoutShape::createBoxShape(shapeRect, curvatures, renderer.document().deviceScaleFactor(), writingMode, logicalMargin);
         },
         [&](const CSS::Keyword::None&) {
             ASSERT_NOT_REACHED();
-            return LayoutShape::createBoxShape(LayoutRoundedRect { { } }, writingMode, 0);
+            return LayoutShape::createBoxShape(LayoutRoundedRect { { } }, { 1.0f, 1.0f, 1.0f, 1.0f }, 1, writingMode, 0);
         }
     );
 }

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -393,7 +393,7 @@ void RenderSVGRoot::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOf
         // children should contribute to interaction regions.
         auto borderRect = LayoutRect(adjustedPaintOffset, borderBoxSize());
         auto borderShape = BorderShape::shapeForBorderRect(style(), borderRect);
-        paintInfo.eventRegionContext()->unite(borderShape.deprecatedPixelSnappedRoundedRect(document().deviceScaleFactor()), *this, style(), false, EventRegionContext::ContributeToInteractionRegions::No);
+        paintInfo.eventRegionContext()->unite(borderShape, document().deviceScaleFactor(), *this, style(), false, EventRegionContext::ContributeToInteractionRegions::No);
     }
 
     if (paintInfo.paintRootBackgroundOnly())

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1053,6 +1053,14 @@ header: <WebCore/RectEdges.h>
     bool left();
 }
 
+header: <WebCore/RectCorners.h>
+[CustomHeader] class WebCore::RectCorners<float> {
+    float topLeft();
+    float topRight();
+    float bottomLeft();
+    float bottomRight();
+}
+
 [CustomHeader] class WebCore::RectEdges<WebCore::Color> {
     WebCore::Color top();
     WebCore::Color right();
@@ -2074,6 +2082,7 @@ header: <WebCore/MotionPath.h>
     WebCore::FloatRoundedRect containingBlockBoundingRect;
     WebCore::FloatPoint offsetFromContainingBlock;
     WebCore::FloatPoint usedStartingPosition;
+    WebCore::RectCorners<float> cornerCurvatures;
 };
 
 header: <WebCore/TransformOperationData.h>


### PR DESCRIPTION
#### f3931dca60e078589ffcdeec9210dfcb7dfb6466
<pre>
corner-shape: replace BorderShape&apos;s deprecated rounded-rect accessors so every call site acknowledges the corner shape
<a href="https://bugs.webkit.org/show_bug.cgi?id=322193">https://bugs.webkit.org/show_bug.cgi?id=322193</a>
<a href="https://rdar.apple.com/185429288">rdar://185429288</a>

Reviewed by NOBODY (OOPS!).

Every remaining caller silently substituted the round-cornered rect for the real
contour, so bevel/notch/square/superellipse corners were ignored by event and
interaction regions, shape-outside, clip-path and offset-path &lt;box&gt; values,
backdrop-filter clipping, and hosted-material effects. This replaces all four
deprecated functions

* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-left-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-right-expected.txt:
* Source/WebCore/platform/animation/values/paths/AcceleratedEffectBoxPath.cpp:
(WebCore::tryPath):
* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:
(WebCore::sampleCornerShape):
* Source/WebCore/platform/graphics/CornerShapeUtilities.h:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::setBackdropFiltersShapePath):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateBackdropFiltersRect):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::clipBorderSidePolygon const):
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::shapeForOffsetRect):
(WebCore::BorderShape::shapedRectForOuterShape const):
(WebCore::BorderShape::shapedRectForInnerShape const):
(WebCore::BorderShape::snappedShapedRectForOuterShape const):
(WebCore::BorderShape::snappedShapedRectForInnerShape const):
(WebCore::buildOuterCornerInputs):
(WebCore::addOuterCornerShapeToPath):
(WebCore::outerVertexForCorner):
(WebCore::densifyContour):
(WebCore::BorderShape::outerShapeAsPolygon const):
(WebCore::BorderShape::pathForShapedRect):
(WebCore::BorderShape::approximateAsRegion const):
(WebCore::BorderShape::deprecatedRoundedRect const): Deleted.
(WebCore::BorderShape::deprecatedInnerRoundedRect const): Deleted.
(WebCore::BorderShape::deprecatedPixelSnappedRoundedRect const): Deleted.
(WebCore::BorderShape::deprecatedPixelSnappedInnerRoundedRect const): Deleted.
* Source/WebCore/rendering/BorderShape.h:
* Source/WebCore/rendering/ClipPathPaintScope.cpp:
(WebCore::ClipPathPaintScope::computeClipPath):
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::unite):
(WebCore::EventRegionContext::uniteRegion):
* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::containingBlockRectForRenderer):
(WebCore::MotionPath::motionPathDataForRenderer):
* Source/WebCore/rendering/MotionPath.h:
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::BoxPathOperation::getPath const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paintObject):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::borderRadii const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateBackdropFiltersGeometry):
(WebCore::RenderLayerBacking::updateAppleVisualEffect):
(WebCore::RenderLayerBacking::updateConfiguration):
(WebCore::RenderLayerBacking::updateGeometry):
(WebCore::RenderLayerBacking::updateContentsRects):
(WebCore::RenderLayerBacking::needsCornerShapeMask const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeAncestorClippingStack const):
(WebCore::RenderLayerCompositor::parentRelativeScrollableRect const):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paint):
* Source/WebCore/rendering/ios/RenderThemeIOS.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintTextFieldInnerShadow):
(WebCore::RenderThemeIOS::paintTextFieldDecorations):
* Source/WebCore/rendering/shapes/BoxLayoutShape.cpp:
(WebCore::marginBoxBorderShape):
(WebCore::computeRoundedRectForBoxShape):
(WebCore::computePathForBoxShape):
(WebCore::contourExtentBetween):
(WebCore::BoxLayoutShape::getExcludedInterval const):
* Source/WebCore/rendering/shapes/BoxLayoutShape.h:
* Source/WebCore/rendering/shapes/LayoutShape.cpp:
(WebCore::LayoutShape::createBoxShape):
* Source/WebCore/rendering/shapes/LayoutShape.h:
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::makeShapeForShapeOutside):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::paintObject):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* LayoutTests/apple-visual-effects/corner-shape-hosted-material-shape-mask-expected.txt: Added.
* LayoutTests/apple-visual-effects/corner-shape-hosted-material-shape-mask.html: Added.
* LayoutTests/compositing/corner-shape-backdrop-filter-clip-expected.html: Added.
* LayoutTests/compositing/corner-shape-backdrop-filter-clip.html: Added.
* LayoutTests/fast/borders/corner-shape-inner-border-expected.html: Added.
* LayoutTests/fast/borders/corner-shape-inner-border.html: Added.
* LayoutTests/fast/masking/corner-shape-clip-path-coord-box-expected.html: Added.
* LayoutTests/fast/masking/corner-shape-clip-path-coord-box.html: Added.
* LayoutTests/fast/motion-path/corner-shape-offset-path-coord-box-expected-mismatch.html: Added.
* LayoutTests/fast/motion-path/corner-shape-offset-path-coord-box.html: Added.
* LayoutTests/fast/scrolling/corner-shape-overflow-scroll-shape-mask-expected.txt: Added.
* LayoutTests/fast/scrolling/corner-shape-overflow-scroll-shape-mask.html: Added.
* LayoutTests/fast/scrolling/mac/corner-shape-event-region-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/corner-shape-event-region.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3931dca60e078589ffcdeec9210dfcb7dfb6466

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192019 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55462 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141917 "Found 3 new test failures: compositing/corner-shape-backdrop-filter-clip.html fast/borders/corner-shape-inner-border.html fast/masking/corner-shape-clip-path-coord-box.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98518 "3 flakes 16 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122352 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44285 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42553 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154682 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42187 "Found 1 new test failure: apple-visual-effects/corner-shape-hosted-material-shape-mask.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3180 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48372 "Found 1 new failure in rendering/RenderTheme.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193945 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55411 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162159 "Exiting early after 10 failures. 121 tests run. 1 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151327 "Found 2 new test failures: compositing/corner-shape-backdrop-filter-clip.html fast/borders/corner-shape-inner-border.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56100 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38810 "Found 2 new test failures: apple-visual-effects/corner-shape-hosted-material-shape-mask.html imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151030 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45606 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128383 "Found 1 new failure in rendering/RenderTheme.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124138 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54613 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17183 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53995 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54060 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->