### PR TITLE
[Site Isolation] REGRESSION (317940@main): Context menu is positioned incorrectly in scrolled isolated iframes

### DIFF
--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -147,10 +147,10 @@ public:
     virtual void notifyWidget(WidgetNotification) { }
 
     IntPoint convertToRootView(IntPoint) const;
-    FloatPoint convertToRootView(FloatPoint) const;
+    WEBCORE_EXPORT FloatPoint convertToRootView(FloatPoint) const;
     DoublePoint convertToRootView(DoublePoint) const;
     WEBCORE_EXPORT IntRect convertToRootView(const IntRect&) const;
-    FloatRect convertToRootView(const FloatRect&) const;
+    WEBCORE_EXPORT FloatRect convertToRootView(const FloatRect&) const;
 
     WEBCORE_EXPORT IntPoint convertFromRootView(IntPoint) const;
     FloatPoint convertFromRootView(FloatPoint) const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10692,6 +10692,14 @@ template<typename T> T WebPage::contentsToRootView(WebCore::FrameIdentifier fram
         return geometry;
     }
 
+    // For a remote frame, the geometry received here already has that frame's own scroll position
+    // removed, via contentsToRootView() in the process actually hosting it. The RemoteFrameView's
+    // scroll position mirrors that same scroll (for other purposes, e.g. IntersectionObserver), so
+    // calling contentsToRootView() here would subtract it a second time. Use convertToRootView()
+    // instead, which only walks up the containing view chain without touching this frame's own scroll.
+    if (is<RemoteFrame>(*coreFrame))
+        return view->convertToRootView(geometry);
+
     return view->contentsToRootView(geometry);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -6891,6 +6891,58 @@ TEST(SiteIsolation, CoordinateTransformation)
     Util::run(&done);
 }
 
+// Regression test for rdar://184770853, a case of the bug fixed by rdar://183236270 that
+// resurfaced in a different code path. The point given to _convertPoint:fromFrame:toMainFrameCoordinates:
+// is in the child frame's own root-view coordinates, i.e. already independent of the child's
+// scroll position (this is exactly how a context menu's location is computed and threaded up
+// through ancestor processes, via WebPage::contentsToRootView() on the RemoteFrameView standing
+// in for the child in the parent's process). Scrolling the child should not change the result.
+TEST(SiteIsolation, CoordinateTransformationWithScrolledFrame)
+{
+    HTTPServer server({
+        { "/example"_s, { "<br><iframe id='wk' src='https://webkit.org/iframe'></iframe>"_s } },
+        { "/iframe"_s, { "<body style='margin: 0; width: 3000px; height: 3000px'>hi</body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    auto convertPoint = [] (TestWKWebView *webView, CGPoint point) {
+        __block CGPoint result;
+        __block bool done { false };
+        [webView _convertPoint:point fromFrame:[webView firstChildFrame] toMainFrameCoordinates:^(CGPoint transformedPoint, NSError *error) {
+            EXPECT_NULL(error);
+            result = transformedPoint;
+            done = true;
+        }];
+        Util::run(&done);
+        return result;
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    auto unscrolledResult = convertPoint(webView.get(), { 11, 10 });
+
+    [webView evaluateJavaScript:@"window.scrollTo(100, 200)" inFrame:[webView firstChildFrame] completionHandler:nil];
+    while (true) {
+        __block bool scrolled { false };
+        __block bool done { false };
+        [webView evaluateJavaScript:@"window.scrollY === 200" inFrame:[webView firstChildFrame] completionHandler:^(id result, NSError *) {
+            scrolled = [result boolValue];
+            done = true;
+        }];
+        Util::run(&done);
+        if (scrolled)
+            break;
+        Util::spinRunLoop();
+    }
+    [webView waitForNextPresentationUpdate];
+
+    auto scrolledResult = convertPoint(webView.get(), { 11, 10 });
+    EXPECT_EQ(scrolledResult.x, unscrolledResult.x);
+    EXPECT_EQ(scrolledResult.y, unscrolledResult.y);
+}
+
 RetainPtr<_WKTextManipulationToken> createToken(NSString *identifier, NSString *content)
 {
     RetainPtr<_WKTextManipulationToken> token = adoptNS([[_WKTextManipulationToken alloc] init]);


### PR DESCRIPTION
#### 7058bd359bbac2340505217ea14406aabccacec8
<pre>
[Site Isolation] REGRESSION (<a href="https://commits.webkit.org/317940@main">317940@main</a>): Context menu is positioned incorrectly in scrolled isolated iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322195">https://bugs.webkit.org/show_bug.cgi?id=322195</a>
<a href="https://rdar.apple.com/184770853">rdar://184770853</a>

Reviewed by NOBODY (OOPS!).

For a remote frame, the geometry received here already has that frame&apos;s own scroll position
removed, via contentsToRootView() in the process actually hosting it. The RemoteFrameView&apos;s
scroll position mirrors that same scroll (for other purposes, e.g. IntersectionObserver), so
calling contentsToRootView() here would subtract it a second time. Use convertToRootView()
instead, which only walks up the containing view chain without touching this frame&apos;s own scroll.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebCore/platform/Widget.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::contentsToRootView):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, CoordinateTransformationWithScrolledFrame)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7058bd359bbac2340505217ea14406aabccacec8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146121 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6a83a52-c5b4-4003-95bf-c1031999cd4c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141915 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98517 "3 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e9c16e8-bcb6-455c-887e-45ce0338a53b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122350 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77b11513-e149-456e-9e1d-5061cdfd8ad6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44283 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42550 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42182 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3178 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193943 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55409 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151325 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56098 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151028 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45603 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128381 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124136 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54611 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17178 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53993 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54232 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54058 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->