### PR TITLE
REGRESSION(318650@main): process swap on navigation response can reuse a process that already hosts the navigating page

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6007,11 +6007,8 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             ASSERT(!destinationSuspendedPage || navigation->targetItem());
             RefPtr suspendedPage = destinationSuspendedPage ? RefPtr { protectedBackForwardCache->takeSuspendedPage(*protect(navigation->targetItem())) } : nullptr;
 
-            // It is difficult to get history right if we have several WebPage objects inside a single WebProcess for the same WebPageProxy. As a result, if we make sure to
-            // clear any SuspendedPageProxy for the current page that are backed by the destination process before we proceed with the navigation. This makes sure the WebPage
-            // we are about to create in the destination process will be the only one associated with this WebPageProxy.
             if (!destinationSuspendedPage && frame->isMainFrame())
-                protectedBackForwardCache->removeEntriesForPageAndProcess(*this, processNavigatingTo);
+                removeSuspendedPagesBeforeNavigation(processNavigatingTo);
 
             ASSERT(suspendedPage.get() == destinationSuspendedPage);
             if (suspendedPage && suspendedPage->pageIsClosedOrClosing())
@@ -10574,6 +10571,15 @@ void WebPageProxy::showBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&& safeBro
     m_uiClient->didShowSafeBrowsingWarning();
 }
 
+void WebPageProxy::removeSuspendedPagesBeforeNavigation(WebProcessProxy& process)
+{
+    // It is difficult to get history right if we have several WebPage objects inside a single WebProcess for the same
+    // WebPageProxy. As a result, we clear any SuspendedPageProxy for the current page that are backed by the
+    // destination process before we proceed with the navigation. This makes sure the WebPage we are about to create in
+    // the destination process will be the only one associated with this WebPageProxy.
+    protect(backForwardCache())->removeEntriesForPageAndProcess(*this, process);
+}
+
 void WebPageProxy::performProcessSwapForNavigationResponse(API::Navigation& navigation, Ref<BrowsingContextGroup>&& browsingContextGroupForSwap, Ref<WebProcessProxy>&& processForNavigation, WebCore::ProcessSwapDisposition processSwapDisposition, NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume, MonotonicTime originalNavigationStartTime, CompletionHandler<void(bool success)>&& completionHandler)
 {
     auto preventProcessShutdown = processForNavigation->shutdownPreventingScope();
@@ -10601,6 +10607,8 @@ void WebPageProxy::performProcessSwapForNavigationResponse(API::Navigation& navi
 
         if (!m_provisionalPage)
             send(Messages::WebPage::StopLoadingDueToProcessSwap());
+
+        removeSuspendedPagesBeforeNavigation(processForNavigation);
 
         continueNavigationInNewProcess(*navigation, *mainFrame, nullptr, browsingContextGroupForSwap, WTF::move(processForNavigation), ProcessSwapRequestedByClient::No, ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted, existingNetworkResourceLoadIdentifierToResume, LoadedWebArchive::No, NavigationUpgradeToHTTPSBehavior::BasedOnPolicy, processSwapDisposition, nullptr, originalNavigationStartTime);
         completionHandler(true);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3601,6 +3601,7 @@ private:
 
     void continueNavigationInNewProcess(API::Navigation&, WebFrameProxy&, RefPtr<SuspendedPageProxy>&&, BrowsingContextGroup&, Ref<WebProcessProxy>&&, ProcessSwapRequestedByClient, WebCore::ShouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume, LoadedWebArchive, WebCore::NavigationUpgradeToHTTPSBehavior, WebCore::ProcessSwapDisposition, WebsiteDataStore* replacedDataStoreForWebArchiveLoad, MonotonicTime originalNavigationStartTime);
     void performProcessSwapForNavigationResponse(API::Navigation&, Ref<BrowsingContextGroup>&&, Ref<WebProcessProxy>&&, WebCore::ProcessSwapDisposition, NetworkResourceLoadIdentifier, MonotonicTime originalNavigationStartTime, CompletionHandler<void(bool)>&&);
+    void removeSuspendedPagesBeforeNavigation(WebProcessProxy&);
 
     void setNeedsFontAttributes(bool);
     void updateFontAttributesAfterEditorStateChange();

--- a/TestExpectations/apitests
+++ b/TestExpectations/apitests
@@ -58,10 +58,6 @@ TestWebKitAPI.WebPageTransferableTests/exportToImage(type:) [ Skip ]
 [ iOS Debug ] TestWebKitAPI.ContentRuleList.RequestMethods [ Pass Timeout ]
 [ iOS Debug ] TestWebKitAPI.ContentRuleList.ResourceTypes [ Pass Timeout ]
 
-# webkit.org/b/321940 [ macOS DEBUG ] 2x TestWebKitAPI.EnhancedSecurityPolicies.MultiHopThenBackToSecure* (api-tests) are constant timeouts.
-[ mac Debug ] TestWebKitAPI.EnhancedSecurityPolicies.MultiHopThenBackToSecure [ Skip ]
-[ mac Debug ] TestWebKitAPI.EnhancedSecurityPolicies.MultiHopThenBackToSecureJavascript [ Skip ]
-
 # webkit.org/b/322125 [ iOS ]NEW TEST(319178@main): 3x TestWebKitAPI.HTTP2Server.* (api-tests) is a constant timeout. 
 [ iOS ] TestWebKitAPI.HTTP2Server.MultipleRequestsOverOneConnection [ Skip ]
 [ iOS ] TestWebKitAPI.HTTP2Server.NonDefaultStatusCodeAndResponseHeader [ Skip ]
@@ -226,7 +222,6 @@ rdar://163517689 [ ios ] TestWebKitAPI.ProcessSwap.CrashWithGestureController [ 
 rdar://137984168 [ ios ] TestWebKitAPI.ProcessSwap.NavigateBackAfterCrossOriginClientRedirect [ Skip ]
 rdar://163517689 [ ios ] TestWebKitAPI.ProcessSwap.SwapWithGestureController [ Skip ]
 webkit.org/b/242085 [ ios ] TestWebKitAPI.RequestTextInputContext.TextInteraction_FocusingAssistedElementShouldNotScrollToReveal [ Skip ]
-webkit.org/b/321947 [ debug ] TestWebKitAPI.ResourceLoadStatistics.BlockUnpartitionedThirdPartyCookies [ Skip ]
 rdar://136525714 [ mac ] TestWebKitAPI.ResourceLoadStatistics.ClientEvaluatedJavaScriptDoesNotLogUserInteraction [ Skip ]
 rdar://172325390 TestWebKitAPI.ResourceLoadStatistics.GrandfatherCallback [ Skip ]
 rdar://136535465 TestWebKitAPI.ResourceLoadStatistics.MigrateDataFromMissingTopFrameUniqueRedirectSameSiteStrictTableSchema [ Skip ]


### PR DESCRIPTION
#### c73014505affe2bd1a831719b86068cc07dcde4a
<pre>
REGRESSION(318650@main): process swap on navigation response can reuse a process that already hosts the navigating page
<a href="https://bugs.webkit.org/show_bug.cgi?id=321947">https://bugs.webkit.org/show_bug.cgi?id=321947</a>
<a href="https://rdar.apple.com/185124281">rdar://185124281</a>

Reviewed by Per Arne Vollan.

After 318650@main, we now mark the site for processes associated with a process swap on navigation
response correctly (e.g. swap due to COOP response header or forced EnhancedSecurity mode). This
means findReusableSuspendedPageProcess can now select those processes for reuse, while it could not
in the past.

This causes issues if one of those processes is subsequently selected for reuse in
performProcessSwapForNavigationResponse. That method does not clear suspended pages associated with
the current navigating page from the destination WebProcess. This can leave the destination
WebProcess in a state where it has both a suspended WebPage and a non-suspended WebPage associated
with the same identifier, which causes multiple asserts to trip in debug API tests.

Fix this by making performProcessSwapForNavigationResponse clear any suspended pages from the
process completing the navigation. This replicates logic that already exists in
decidePolicyForNavigationAction.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::removeSuspendedPagesBeforeNavigation):
(WebKit::WebPageProxy::performProcessSwapForNavigationResponse):
* Source/WebKit/UIProcess/WebPageProxy.h:
* TestExpectations/apitests:

Canonical link: <a href="https://commits.webkit.org/319571@main">https://commits.webkit.org/319571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2554a1fdd9a6e3618e36ec76a2742f7187092445

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181814 "60 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146143 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea13e8f7-29b1-4286-984f-12da9eb03f8c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f2e422e1-8ee1-400e-8ffa-c5fd74093d1e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122366 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44298 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42569 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42200 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3201 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193965 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55431 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151344 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40541 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56120 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151051 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45620 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128403 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124158 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54633 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17196 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54015 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54254 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->