### PR TITLE
[JSC][Wasm] Implement WebAssembly.Function behind useWasmJSTypes

### DIFF
--- a/JSTests/wasm/js-api/function-constructor-call-indirect.js
+++ b/JSTests/wasm/js-api/function-constructor-call-indirect.js
@@ -1,0 +1,58 @@
+//@ requireOptions("--useWasmJSTypes=true")
+import * as assert from "../assert.js";
+import { instantiate } from "../wabt-wrapper.js";
+import { instantiate as instantiateWast } from "../gc/wast-wrapper.js";
+
+{
+    const table = new WebAssembly.Table({ element: "anyfunc", initial: 1 });
+    const fun = new WebAssembly.Function({ parameters: [], results: ["i32"] }, () => 42);
+    table.set(0, fun);
+    const instance = await instantiate(`
+        (module
+          (import "m" "table" (table 1 funcref))
+          (type $t (func (result i32)))
+          (func (export "main") (result i32)
+            (call_indirect (type $t) (i32.const 0))))
+    `, { m: { table } });
+    for (let i = 0; i < 10; ++i)
+        assert.eq(instance.exports.main(), 42);
+}
+
+{
+    const fun = new WebAssembly.Function({ parameters: [], results: ["i32"] }, () => 42);
+    const instance = instantiateWast(`
+        (module
+          (type $t (func (result i32)))
+          (func (export "main") (param $f funcref) (result i32)
+            (call_ref $t (ref.cast (ref $t) (local.get $f)))))
+    `);
+    for (let i = 0; i < 10; ++i)
+        assert.eq(instance.exports.main(fun), 42);
+}
+
+{
+    const table = new WebAssembly.Table({ element: "anyfunc", initial: 1 });
+    const fun = new WebAssembly.Function({ parameters: [], results: ["i32"] }, () => 42);
+    table.set(0, fun);
+    const instance = instantiateWast(`
+        (module
+          (import "m" "table" (table 1 funcref))
+          (type $t (func (result i32)))
+          (func (export "main") (result i32)
+            (return_call_indirect (type $t) (i32.const 0))))
+    `, { m: { table } });
+    for (let i = 0; i < 10; ++i)
+        assert.eq(instance.exports.main(), 42);
+}
+
+{
+    const fun = new WebAssembly.Function({ parameters: [], results: ["i32"] }, () => 42);
+    const instance = instantiateWast(`
+        (module
+          (type $t (func (result i32)))
+          (func (export "main") (param $f funcref) (result i32)
+            (return_call_ref $t (ref.cast (ref $t) (local.get $f)))))
+    `);
+    for (let i = 0; i < 10; ++i)
+        assert.eq(instance.exports.main(fun), 42);
+}

--- a/JSTests/wasm/js-api/function-constructor-wasm.js
+++ b/JSTests/wasm/js-api/function-constructor-wasm.js
@@ -1,0 +1,26 @@
+//@ requireOptions("--useWasmJSTypes=true")
+import * as assert from "../assert.js";
+import { instantiate } from "../wabt-wrapper.js";
+
+{
+    const fun = new WebAssembly.Function({ parameters: [], results: ["i32"] }, () => 7);
+    const instance = await instantiate(`
+        (module
+          (import "m" "fun" (func $fun (result i32)))
+          (func (export "main") (result i32)
+            (call $fun))
+          (export "fun1" (func $fun)))
+    `, { m: { fun } });
+    assert.eq(instance.exports.main(), 7);
+    assert.eq(instance.exports.fun1, fun);
+}
+
+{
+    const instance = await instantiate(`
+        (module
+          (func (export "f") (result i32)
+            (i32.const 1)))
+    `);
+    assert.eq(new WebAssembly.Function({ parameters: [], results: ["i32"] }, instance.exports.f), instance.exports.f);
+    assert.throws(() => new WebAssembly.Function({ parameters: ["i32"], results: [] }, instance.exports.f), TypeError, "");
+}

--- a/JSTests/wasm/js-api/function-constructor.js
+++ b/JSTests/wasm/js-api/function-constructor.js
@@ -1,0 +1,88 @@
+//@ requireOptions("--useWasmJSTypes=true")
+import * as assert from "../assert.js";
+
+function addxy(x, y) {
+    return x + y;
+}
+
+function doNothing() {}
+
+{
+    assert.eq(typeof WebAssembly.Function, "function");
+    assert.eq(WebAssembly.Function.name, "Function");
+    assert.eq(WebAssembly.Function.length, 2);
+}
+
+{
+    const fun = new WebAssembly.Function({ parameters: ["i32", "i32"], results: ["i32"] }, addxy);
+    assert.eq(fun instanceof WebAssembly.Function, true);
+    assert.eq(fun(1, 2), 3);
+    assert.throws(() => new fun(1, 2), TypeError, "");
+    const type = fun.type();
+    assert.eq(type.parameters.length, 2);
+    assert.eq(type.parameters[0], "i32");
+    assert.eq(type.parameters[1], "i32");
+    assert.eq(type.results.length, 1);
+    assert.eq(type.results[0], "i32");
+}
+
+{
+    const fun = new WebAssembly.Function({ parameters: [], results: [] }, doNothing);
+    assert.eq(fun(), undefined);
+    const type = fun.type();
+    assert.eq(type.parameters.length, 0);
+    assert.eq(type.results.length, 0);
+}
+
+{
+    const fun = new WebAssembly.Function({ parameters: ["i64"], results: ["i64"] }, x => x + 1n);
+    assert.eq(fun(1n), 2n);
+}
+
+{
+    const table = new WebAssembly.Table({ element: "anyfunc", initial: 1 });
+    const fun = new WebAssembly.Function({ parameters: ["i32"], results: [] }, doNothing);
+    table.set(0, fun);
+    assert.eq(table.get(0), fun);
+}
+
+assert.throws(() => WebAssembly.Function({ parameters: [], results: [] }, doNothing), TypeError, "");
+assert.throws(() => new WebAssembly.Function(), TypeError, "");
+assert.throws(() => new WebAssembly.Function({ parameters: [] }, doNothing), TypeError, "");
+assert.throws(() => new WebAssembly.Function({ results: [] }, doNothing), TypeError, "");
+assert.throws(() => new WebAssembly.Function({ parameters: ["nope"], results: [] }, doNothing), TypeError, "");
+assert.throws(() => new WebAssembly.Function({ parameters: [], results: [] }, {}), TypeError, "");
+assert.throws(() => new WebAssembly.Function({ parameters: [], results: [] }, 72), TypeError, "");
+
+{
+    const multi = new WebAssembly.Function({ parameters: [], results: ["i32", "i32"] }, () => [1, 2]);
+    const values = multi();
+    assert.eq(values[0], 1);
+    assert.eq(values[1], 2);
+    const tooFew = new WebAssembly.Function({ parameters: [], results: ["i32", "i32"] }, () => [1]);
+    assert.throws(() => tooFew(), TypeError, "");
+}
+
+{
+    class F extends WebAssembly.Function {}
+    const fun = new F({ parameters: [], results: [] }, doNothing);
+    assert.eq(fun instanceof F, true);
+}
+
+{
+    const wrapped = new WebAssembly.Function({ parameters: [], results: [] }, doNothing);
+    assert.eq(new WebAssembly.Function({ parameters: [], results: [] }, wrapped), wrapped);
+    assert.throws(() => new WebAssembly.Function({ parameters: ["i32"], results: [] }, wrapped), TypeError, "");
+}
+
+{
+    const fun = new WebAssembly.Function({ parameters: ["i32"], results: ["i32"] }, x => x + 1);
+    {
+        const unused = new WebAssembly.Module(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]));
+        unused;
+    }
+    fullGC();
+    assert.eq(fun.type().parameters[0], "i32");
+    assert.eq(fun.type().results[0], "i32");
+    assert.eq(fun(1), 2);
+}

--- a/JSTests/wasm/js-api/web-assembly-function.js
+++ b/JSTests/wasm/js-api/web-assembly-function.js
@@ -17,6 +17,7 @@ const bin = builder.WebAssembly().get();
 const module = new WebAssembly.Module(bin);
 const instance = new WebAssembly.Instance(module);
 
+assert.eq(typeof WebAssembly.Function, "undefined");
 assert.eq(Object.getPrototypeOf(instance.exports.foo), Function.prototype);
 {
     assert.truthy(typeof instance.exports.foo === "function", "is_function bytecode should handle wasm function.");

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/call.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/call.tentative.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL test calling function undefined is not a constructor (evaluating 'new WebAssembly.Function({parameters: ["i32", "i32"], results: ["i32"]}, addxy)')
-FAIL test constructing function undefined is not a constructor (evaluating 'new WebAssembly.Function({parameters: ["i32", "i32"], results: ["i32"]}, addxy)')
+PASS test calling function
+PASS test constructing function
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/call.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/call.tentative.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL test calling function undefined is not a constructor (evaluating 'new WebAssembly.Function({parameters: ["i32", "i32"], results: ["i32"]}, addxy)')
-FAIL test constructing function undefined is not a constructor (evaluating 'new WebAssembly.Function({parameters: ["i32", "i32"], results: ["i32"]}, addxy)')
+PASS test calling function
+PASS test constructing function
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/constructor.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/constructor.tentative.any-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL name assert_implements: WebAssembly.Function is not implemented undefined
-FAIL length assert_implements: WebAssembly.Function is not implemented undefined
-FAIL Too few arguments assert_implements: WebAssembly.Function is not implemented undefined
-FAIL Calling assert_implements: WebAssembly.Function is not implemented undefined
-FAIL construct with JS function assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail with missing results assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail with missing parameters assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail with non-string parameters & results assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail with non-existent parameter and result type assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail with non-function object assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail to construct with non-callable object assert_implements: WebAssembly.Function is not implemented undefined
+PASS name
+PASS length
+PASS Too few arguments
+PASS Calling
+PASS construct with JS function
+PASS fail with missing results
+PASS fail with missing parameters
+PASS fail with non-string parameters & results
+PASS fail with non-existent parameter and result type
+PASS fail with non-function object
+PASS fail to construct with non-callable object
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/constructor.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/constructor.tentative.any.worker-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL name assert_implements: WebAssembly.Function is not implemented undefined
-FAIL length assert_implements: WebAssembly.Function is not implemented undefined
-FAIL Too few arguments assert_implements: WebAssembly.Function is not implemented undefined
-FAIL Calling assert_implements: WebAssembly.Function is not implemented undefined
-FAIL construct with JS function assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail with missing results assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail with missing parameters assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail with non-string parameters & results assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail with non-existent parameter and result type assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail with non-function object assert_implements: WebAssembly.Function is not implemented undefined
-FAIL fail to construct with non-callable object assert_implements: WebAssembly.Function is not implemented undefined
+PASS name
+PASS length
+PASS Too few arguments
+PASS Calling
+PASS construct with JS function
+PASS fail with missing results
+PASS fail with missing parameters
+PASS fail with non-string parameters & results
+PASS fail with non-existent parameter and result type
+PASS fail with non-function object
+PASS fail to construct with non-callable object
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/table.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/table.tentative.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test insertion into table undefined is not a constructor (evaluating 'new WebAssembly.Function({parameters: ["i32"], results: []}, testfunc)')
+PASS Test insertion into table
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/table.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/table.tentative.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test insertion into table undefined is not a constructor (evaluating 'new WebAssembly.Function({parameters: ["i32"], results: []}, testfunc)')
+PASS Test insertion into table
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/type.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/type.tentative.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Check empty results and parameters undefined is not a constructor (evaluating 'new WebAssembly.Function(functype, func)')
-FAIL Check all types undefined is not a constructor (evaluating 'new WebAssembly.Function(functype, func)')
+PASS Check empty results and parameters
+PASS Check all types
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/type.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/type.tentative.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Check empty results and parameters undefined is not a constructor (evaluating 'new WebAssembly.Function(functype, func)')
-FAIL Check all types undefined is not a constructor (evaluating 'new WebAssembly.Function(functype, func)')
+PASS Check empty results and parameters
+PASS Check all types
 

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -146,6 +146,8 @@ set(JavaScriptCore_OBJECT_LUT_SOURCES
     wasm/js/WebAssemblyGlobalPrototype.cpp
     wasm/js/WebAssemblyInstanceConstructor.cpp
     wasm/js/WebAssemblyInstancePrototype.cpp
+    wasm/js/WebAssemblyJSFunctionConstructor.cpp
+    wasm/js/WebAssemblyJSFunctionPrototype.cpp
     wasm/js/WebAssemblyLinkErrorConstructor.cpp
     wasm/js/WebAssemblyLinkErrorPrototype.cpp
     wasm/js/WebAssemblyMemoryConstructor.cpp

--- a/Source/JavaScriptCore/DerivedSources-input.xcfilelist
+++ b/Source/JavaScriptCore/DerivedSources-input.xcfilelist
@@ -254,6 +254,8 @@ $(PROJECT_DIR)/wasm/js/WebAssemblyStructConstructor.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblyStructPrototype.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblySuspendErrorConstructor.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblySuspendErrorPrototype.cpp
+$(PROJECT_DIR)/wasm/js/WebAssemblyJSFunctionConstructor.cpp
+$(PROJECT_DIR)/wasm/js/WebAssemblyJSFunctionPrototype.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblyTableConstructor.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblyTablePrototype.cpp
 $(PROJECT_DIR)/wasm/js/WebAssemblyTagConstructor.cpp

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -4097,6 +4097,10 @@
 		234E91C42EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendErrorPrototype.cpp; path = js/WebAssemblySuspendErrorPrototype.cpp; sourceTree = "<group>"; };
 		237C93D92E95A85F00F62455 /* WebAssemblySuspendingConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendingConstructor.h; path = js/WebAssemblySuspendingConstructor.h; sourceTree = "<group>"; };
 		237C93DA2E95A85F00F62455 /* WebAssemblySuspendingConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendingConstructor.cpp; path = js/WebAssemblySuspendingConstructor.cpp; sourceTree = "<group>"; };
+		A10F00012F4E00010000F001 /* WebAssemblyJSFunctionConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyJSFunctionConstructor.cpp; path = js/WebAssemblyJSFunctionConstructor.cpp; sourceTree = "<group>"; };
+		A10F00022F4E00010000F002 /* WebAssemblyJSFunctionConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblyJSFunctionConstructor.h; path = js/WebAssemblyJSFunctionConstructor.h; sourceTree = "<group>"; };
+		A10F00032F4E00010000F003 /* WebAssemblyJSFunctionPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyJSFunctionPrototype.cpp; path = js/WebAssemblyJSFunctionPrototype.cpp; sourceTree = "<group>"; };
+		A10F00042F4E00010000F004 /* WebAssemblyJSFunctionPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblyJSFunctionPrototype.h; path = js/WebAssemblyJSFunctionPrototype.h; sourceTree = "<group>"; };
 		237C93DB2E95A85F00F62455 /* WebAssemblySuspendingPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendingPrototype.h; path = js/WebAssemblySuspendingPrototype.h; sourceTree = "<group>"; };
 		237C93DC2E95A85F00F62455 /* WebAssemblySuspendingPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendingPrototype.cpp; path = js/WebAssemblySuspendingPrototype.cpp; sourceTree = "<group>"; };
 		23863EE92E5EC91500E57879 /* WebAssemblyBuiltinTrampoline.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyBuiltinTrampoline.cpp; path = js/WebAssemblyBuiltinTrampoline.cpp; sourceTree = "<group>"; };
@@ -10752,6 +10756,10 @@
 				AD2FCBB51DB58DA400B3E736 /* WebAssemblyInstanceConstructor.h */,
 				AD2FCBB61DB58DA400B3E736 /* WebAssemblyInstancePrototype.cpp */,
 				AD2FCBB71DB58DA400B3E736 /* WebAssemblyInstancePrototype.h */,
+				A10F00012F4E00010000F001 /* WebAssemblyJSFunctionConstructor.cpp */,
+				A10F00022F4E00010000F002 /* WebAssemblyJSFunctionConstructor.h */,
+				A10F00032F4E00010000F003 /* WebAssemblyJSFunctionPrototype.cpp */,
+				A10F00042F4E00010000F004 /* WebAssemblyJSFunctionPrototype.h */,
 				ADE8029D1E08F2260058DE78 /* WebAssemblyLinkErrorConstructor.cpp */,
 				ADE802951E08F1C90058DE78 /* WebAssemblyLinkErrorConstructor.h */,
 				ADE802961E08F1C90058DE78 /* WebAssemblyLinkErrorPrototype.cpp */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1262,6 +1262,8 @@ wasm/js/WebAssemblyGlobalConstructor.cpp
 wasm/js/WebAssemblyGlobalPrototype.cpp
 wasm/js/WebAssemblyInstanceConstructor.cpp
 wasm/js/WebAssemblyInstancePrototype.cpp
+wasm/js/WebAssemblyJSFunctionConstructor.cpp
+wasm/js/WebAssemblyJSFunctionPrototype.cpp
 wasm/js/WebAssemblyLinkErrorConstructor.cpp
 wasm/js/WebAssemblyLinkErrorPrototype.cpp
 wasm/js/WebAssemblyMemoryConstructor.cpp

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -189,6 +189,7 @@ namespace JSC::B3 {
     macro(VM_exception, VM::exceptionOffset(), Mutability::Mutable) \
     macro(WatchpointSet_state, WatchpointSet::offsetOfState(), Mutability::Mutable) \
     macro(WasmFuncRefTable_functions, Wasm::FuncRefTable::offsetOfFunctions(), Mutability::Mutable) \
+    macro(WasmFuncRefTable_wrappers, Wasm::FuncRefTable::offsetOfWrappers(), Mutability::Mutable) \
     macro(WasmFuncRefTableFunction_boxedCallee, Wasm::FuncRefTable::Function::offsetOfBoxedCallee(), Mutability::Mutable) \
     macro(WasmFuncRefTableFunction_entrypointLoadLocation, Wasm::FuncRefTable::Function::offsetOfEntrypointLoadLocation(), Mutability::Mutable) \
     macro(WasmFuncRefTableFunction_rtt, Wasm::FuncRefTable::Function::offsetOfRTT(), Mutability::Mutable) \

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -100,6 +100,7 @@
 #include "VM.h"
 #include "VerifierSlotVisitorInlines.h"
 #include "WasmCallee.h"
+#include "WebAssemblyWrapperFunction.h"
 #include "WeakMapImplInlines.h"
 #include "WeakSetInlines.h"
 #include <algorithm>
@@ -416,6 +417,7 @@ Heap::Heap(VM& vm, HeapType heapType)
 #if ENABLE(WEBASSEMBLY)
     , webAssemblyExceptionHeapCellType(IsoHeapCellType::Args<JSWebAssemblyException>())
     , webAssemblyFunctionHeapCellType(IsoHeapCellType::Args<WebAssemblyFunction>())
+    , webAssemblyWrapperFunctionHeapCellType(IsoHeapCellType::Args<WebAssemblyWrapperFunction>())
     , webAssemblyGlobalHeapCellType(IsoHeapCellType::Args<JSWebAssemblyGlobal>())
     , webAssemblyInstanceHeapCellType(IsoHeapCellType::Args<JSWebAssemblyInstance>())
     , webAssemblyMemoryHeapCellType(IsoHeapCellType::Args<JSWebAssemblyMemory>())
@@ -1161,6 +1163,12 @@ void Heap::deleteAllCodeBlocks(DeleteAllCodeEffort effort)
             m_webAssemblyInstanceSpace->forEachLiveCell([&] (HeapCell* cell, HeapCell::Kind kind) {
                 ASSERT_UNUSED(kind, kind == HeapCell::JSCell);
                 static_cast<JSWebAssemblyInstance*>(cell)->clearJSCallICs(vm);
+            });
+        }
+        if (m_webAssemblyWrapperFunctionSpace) {
+            m_webAssemblyWrapperFunctionSpace->forEachLiveCell([&] (HeapCell* cell, HeapCell::Kind kind) {
+                ASSERT_UNUSED(kind, kind == HeapCell::JSCell);
+                static_cast<WebAssemblyWrapperFunction*>(cell)->clearJSCallICs(vm);
             });
         }
     }

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -195,7 +195,7 @@ class Heap;
     v(webAssemblyTableSpace, webAssemblyTableHeapCellType, JSWebAssemblyTable) \
     v(webAssemblyTagSpace, webAssemblyTagHeapCellType, JSWebAssemblyTag) \
     v(webAssemblyStreamingContextSpace, destructibleCellHeapCellType, JSWebAssemblyStreamingContext) \
-    v(webAssemblyWrapperFunctionSpace, cellHeapCellType, WebAssemblyWrapperFunction)
+    v(webAssemblyWrapperFunctionSpace, webAssemblyWrapperFunctionHeapCellType, WebAssemblyWrapperFunction)
 
 // FIXME: This is a bit confusingly named since the objects in here are exclusive to the subspace but they can vary in size thus can't be in an IsoSubspace.
 #define FOR_EACH_JSC_WEBASSEMBLY_DYNAMIC_NON_ISO_SUBSPACE(v) \
@@ -1104,6 +1104,7 @@ public:
 #if ENABLE(WEBASSEMBLY)
     IsoHeapCellType webAssemblyExceptionHeapCellType;
     IsoHeapCellType webAssemblyFunctionHeapCellType;
+    IsoHeapCellType webAssemblyWrapperFunctionHeapCellType;
     IsoHeapCellType webAssemblyGlobalHeapCellType;
     // We can use IsoHeapCellType for instances because it's allocated out of a PreciseSubspace reserved for just instances.
     IsoHeapCellType webAssemblyInstanceHeapCellType;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -314,6 +314,8 @@
 #include "WebAssemblyGlobalPrototype.h"
 #include "WebAssemblyInstanceConstructor.h"
 #include "WebAssemblyInstancePrototype.h"
+#include "WebAssemblyJSFunctionConstructor.h"
+#include "WebAssemblyJSFunctionPrototype.h"
 #include "WebAssemblyLinkErrorConstructor.h"
 #include "WebAssemblyLinkErrorPrototype.h"
 #include "WebAssemblyMemoryConstructor.h"
@@ -333,6 +335,7 @@
 #include "WebAssemblyTablePrototype.h"
 #include "WebAssemblyTagConstructor.h"
 #include "WebAssemblyTagPrototype.h"
+#include "WebAssemblyWrapperFunction.h"
 #include "WrapForValidIteratorPrototypeInlines.h"
 #include "runtime/VM.h"
 #include <wtf/CryptographicallyRandomNumber.h>
@@ -2176,11 +2179,17 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
             });
         m_webAssemblyFunctionStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                init.set(WebAssemblyFunction::createStructure(init.vm, init.owner, init.owner->m_functionPrototype.get()));
+                JSValue prototype = Options::useWasmJSTypes()
+                    ? init.owner->webAssemblyJSFunctionStructure()->storedPrototype()
+                    : init.owner->m_functionPrototype.get();
+                init.set(WebAssemblyFunction::createStructure(init.vm, init.owner, prototype));
             });
         m_webAssemblyWrapperFunctionStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                init.set(WebAssemblyWrapperFunction::createStructure(init.vm, init.owner, init.owner->m_functionPrototype.get()));
+                JSValue prototype = Options::useWasmJSTypes()
+                    ? init.owner->webAssemblyJSFunctionStructure()->storedPrototype()
+                    : init.owner->m_functionPrototype.get();
+                init.set(WebAssemblyWrapperFunction::createStructure(init.vm, init.owner, prototype));
             });
         m_webAssemblyJSTag.initLater(
             [] (const Initializer<JSWebAssemblyTag>& init) {
@@ -2208,6 +2217,8 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
             webAssembly->putDirectWithoutTransition(vm, Identifier::fromString(vm, "Suspending"_s), webAssemblySuspendingConstructor(), static_cast<unsigned>(PropertyAttribute::DontEnum));
             webAssembly->putDirectWithoutTransition(vm, Identifier::fromString(vm, "SuspendError"_s), webAssemblySuspendErrorConstructor(), static_cast<unsigned>(PropertyAttribute::DontEnum));
         }
+        if (Options::useWasmJSTypes())
+            webAssembly->putDirectWithoutTransition(vm, Identifier::fromString(vm, "Function"_s), webAssemblyJSFunctionConstructor(), static_cast<unsigned>(PropertyAttribute::DontEnum));
     }
 #endif // ENABLE(WEBASSEMBLY)
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -198,18 +198,19 @@ constexpr bool typeExposedByDefault = true;
 
 #if ENABLE(WEBASSEMBLY)
 #define FOR_EACH_WEBASSEMBLY_CONSTRUCTOR_TYPE(macro) \
-    macro(WebAssemblyCompileError, webAssemblyCompileError, webAssemblyCompileError, ErrorInstance,             CompileError, error,  typeExposedByDefault) \
-    macro(WebAssemblyException,    webAssemblyException,    webAssemblyException,    JSWebAssemblyException,    Exception,    object, typeExposedByDefault) \
-    macro(WebAssemblyGlobal,       webAssemblyGlobal,       webAssemblyGlobal,       JSWebAssemblyGlobal,       Global,       object, typeExposedByDefault) \
-    macro(WebAssemblyInstance,     webAssemblyInstance,     webAssemblyInstance,     JSWebAssemblyInstance,     Instance,     object, typeExposedByDefault) \
-    macro(WebAssemblyLinkError,    webAssemblyLinkError,    webAssemblyLinkError,    ErrorInstance,             LinkError,    error,  typeExposedByDefault) \
-    macro(WebAssemblyMemory,       webAssemblyMemory,       webAssemblyMemory,       JSWebAssemblyMemory,       Memory,       object, typeExposedByDefault) \
-    macro(WebAssemblyModule,       webAssemblyModule,       webAssemblyModule,       JSWebAssemblyModule,       Module,       object, typeExposedByDefault) \
-    macro(WebAssemblyRuntimeError, webAssemblyRuntimeError, webAssemblyRuntimeError, ErrorInstance,             RuntimeError, error,  typeExposedByDefault) \
-    macro(WebAssemblySuspendError, webAssemblySuspendError, webAssemblySuspendError, ErrorInstance,             SuspendError, error,  typeExposedByDefault) \
-    macro(WebAssemblySuspending,   webAssemblySuspending,   webAssemblySuspending,   JSFunctionWithFields,   Suspending, object, typeExposedByDefault) \
-    macro(WebAssemblyTable,        webAssemblyTable,        webAssemblyTable,        JSWebAssemblyTable,        Table,        object, typeExposedByDefault) \
-    macro(WebAssemblyTag,          webAssemblyTag,          webAssemblyTag,          JSWebAssemblyTag,          Tag,          object, typeExposedByDefault) 
+    macro(WebAssemblyCompileError, webAssemblyCompileError, webAssemblyCompileError, ErrorInstance,                CompileError, error,    typeExposedByDefault) \
+    macro(WebAssemblyException,    webAssemblyException,    webAssemblyException,    JSWebAssemblyException,       Exception,    object,   typeExposedByDefault) \
+    macro(WebAssemblyGlobal,       webAssemblyGlobal,       webAssemblyGlobal,       JSWebAssemblyGlobal,          Global,       object,   typeExposedByDefault) \
+    macro(WebAssemblyInstance,     webAssemblyInstance,     webAssemblyInstance,     JSWebAssemblyInstance,        Instance,     object,   typeExposedByDefault) \
+    macro(WebAssemblyJSFunction,   webAssemblyJSFunction,   webAssemblyJSFunction,   WebAssemblyWrapperFunction,   Function,     function, typeExposedByDefault) \
+    macro(WebAssemblyLinkError,    webAssemblyLinkError,    webAssemblyLinkError,    ErrorInstance,                LinkError,    error,    typeExposedByDefault) \
+    macro(WebAssemblyMemory,       webAssemblyMemory,       webAssemblyMemory,       JSWebAssemblyMemory,          Memory,       object,   typeExposedByDefault) \
+    macro(WebAssemblyModule,       webAssemblyModule,       webAssemblyModule,       JSWebAssemblyModule,          Module,       object,   typeExposedByDefault) \
+    macro(WebAssemblyRuntimeError, webAssemblyRuntimeError, webAssemblyRuntimeError, ErrorInstance,                RuntimeError, error,    typeExposedByDefault) \
+    macro(WebAssemblySuspendError, webAssemblySuspendError, webAssemblySuspendError, ErrorInstance,                SuspendError, error,    typeExposedByDefault) \
+    macro(WebAssemblySuspending,   webAssemblySuspending,   webAssemblySuspending,   JSFunctionWithFields,         Suspending,   object,   typeExposedByDefault) \
+    macro(WebAssemblyTable,        webAssemblyTable,        webAssemblyTable,        JSWebAssemblyTable,           Table,        object,   typeExposedByDefault) \
+    macro(WebAssemblyTag,          webAssemblyTag,          webAssemblyTag,          JSWebAssemblyTag,             Tag,          object,   typeExposedByDefault)
 #else
 #define FOR_EACH_WEBASSEMBLY_CONSTRUCTOR_TYPE(macro)
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -61,6 +61,7 @@
 #include "WasmOps.h"
 #include "WasmThunks.h"
 #include "WasmTypeDefinition.h"
+#include "WebAssemblyFunctionBase.h"
 #include <bit>
 #include <cmath>
 #include <wtf/Assertions.h>
@@ -4591,6 +4592,12 @@ void BBQJIT::emitIndirectCall(const char* opcode, unsigned callProfileIndex, con
     JumpList afterCall;
     m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfBoxedCallee()), wasmScratchGPR);
     m_jit.storeWasmCalleeToCalleeCallFrame(wasmScratchGPR);
+    m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfTargetInstance()), m_jit.scratchRegister());
+    Jump hasTargetInstance = m_jit.branchTestPtr(ResultCondition::NonZero, m_jit.scratchRegister());
+    m_jit.loadPtr(CCallHelpers::Address(importableFunction, WebAssemblyFunctionBase::offsetOfCallLinkInfoFromImportableFunction()), m_jit.scratchRegister());
+    m_jit.storePtr(m_jit.scratchRegister(), CCallHelpers::calleeFrameCodeBlockBeforeCall());
+    Jump afterContextSwitch = m_jit.jump();
+    hasTargetInstance.link(&m_jit);
     if (m_profile->isMegamorphic(callProfileIndex)) {
         m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfTargetInstance()), wasmScratchGPR);
         // Do a context switch if needed.
@@ -4624,6 +4631,7 @@ void BBQJIT::emitIndirectCall(const char* opcode, unsigned callProfileIndex, con
         m_jit.storePtr(wasmScratchGPR, CCallHelpers::Address(GPRInfo::jitDataRegister, safeCast<int32_t>(BaselineData::offsetOfData() + sizeof(CallProfile) * callProfileIndex + CallProfile::offsetOfBoxedCallee())));
         profilingDone.link(m_jit);
     }
+    afterContextSwitch.link(&m_jit);
 
     m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfEntrypointLoadLocation()), wasmScratchGPR);
     m_jit.call(CCallHelpers::Address(wasmScratchGPR), WasmEntryPtrTag);
@@ -4675,11 +4683,13 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
         Checked<int32_t> topSourceOffsetFromFP = static_cast<int32_t>(roundUpToMultipleOf<stackAlignmentBytes()>(topSource));
 
         m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfTargetInstance()), wasmScratchGPR);
+        Jump isConstructedJSFunction = m_jit.branchTestPtr(ResultCondition::Zero, wasmScratchGPR);
         Jump isSameInstance = m_jit.branchPtr(RelationalCondition::Equal, wasmScratchGPR, GPRInfo::wasmContextInstancePointer);
         emitRestoreInstanceFrameIfNeeded(m_jit, GPRInfo::wasmContextInstancePointer, callerStackSize, m_frameSize, topSourceOffsetFromFP, wasmScratchGPR, wasmBaseMemoryPointer);
         m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfTargetInstance()), GPRInfo::wasmContextInstancePointer);
         loadWebAssemblyGlobalState(wasmBaseMemoryPointer, wasmBoundsCheckingSizeRegister);
         isSameInstance.link(m_jit);
+        isConstructedJSFunction.link(&m_jit);
     }
 
     m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfBoxedCallee()), wasmScratchGPR);
@@ -4766,6 +4776,12 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
 #else
     UNREACHABLE_FOR_PLATFORM();
 #endif
+
+    m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfTargetInstance()), wasmScratchGPR);
+    Jump hasTargetInstance = m_jit.branchTestPtr(ResultCondition::NonZero, wasmScratchGPR);
+    m_jit.loadPtr(CCallHelpers::Address(importableFunction, WebAssemblyFunctionBase::offsetOfCallLinkInfoFromImportableFunction()), wasmScratchGPR);
+    m_jit.storePtr(wasmScratchGPR, CCallHelpers::calleeFrameCodeBlockBeforeTailCall());
+    hasTargetInstance.link(&m_jit);
 
     m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfEntrypointLoadLocation()), importableFunction);
     m_jit.farJump(CCallHelpers::Address(importableFunction), WasmEntryPtrTag);
@@ -4876,6 +4892,19 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
 
                 indexEqual.link(&m_jit);
             }
+
+            m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfTargetInstance()), wasmScratchGPR);
+            Jump hasTargetInstance = m_jit.branchTestPtr(ResultCondition::NonZero, wasmScratchGPR);
+            m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfTable(m_info, tableIndex)), wasmScratchGPR);
+            m_jit.loadPtr(Address(wasmScratchGPR, FuncRefTable::offsetOfWrappers()), wasmScratchGPR);
+            GPRReg wrapperIndex = scratches.gpr(1);
+            m_jit.move(importableFunction, wrapperIndex);
+            m_jit.subPtr(callableFunctionBuffer, wrapperIndex);
+            static_assert(hasOneBitSet(sizeof(FuncRefTable::Function)));
+            m_jit.urshiftPtr(TrustedImm32(getLSBSet(sizeof(FuncRefTable::Function))), wrapperIndex);
+            m_jit.loadPtr(BaseIndex(wasmScratchGPR, wrapperIndex, CCallHelpers::ScalePtr), wasmScratchGPR);
+            m_jit.addPtr(TrustedImm32(WebAssemblyFunctionBase::offsetOfImportableFunction()), wasmScratchGPR, importableFunction);
+            hasTargetInstance.link(&m_jit);
         }
     }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -1224,10 +1224,13 @@ static ALWAYS_INLINE UGPRPair prepareCallIndirectImpl(JSWebAssemblyInstance* ins
             callProfile.observeCallIndirect(boxedCallee);
     }
 
-    IPINT_HANDLE_STEP_INTO_CALL(instance->vm(), function->boxedCallee, function->targetInstance.get());
+    JSWebAssemblyInstance* targetInstance = function->targetInstance.get();
+    if (!targetInstance)
+        targetInstance = instance;
+    IPINT_HANDLE_STEP_INTO_CALL(instance->vm(), function->boxedCallee, targetInstance);
 
     auto callTarget = *function->entrypointLoadLocation;
-    WASM_CALL_RETURN(function->targetInstance.get(), callTarget);
+    WASM_CALL_RETURN(targetInstance, callTarget);
 }
 
 static ALWAYS_INLINE UGPRPair prepareCallRefImpl(JSWebAssemblyInstance* instance, CallFrame* callFrame, uint32_t callProfileIndex, IPIntStackEntry* sp)
@@ -1248,6 +1251,8 @@ static ALWAYS_INLINE UGPRPair prepareCallRefImpl(JSWebAssemblyInstance* instance
     auto* wasmFunction = uncheckedDowncast<WebAssemblyFunctionBase>(referenceAsObject);
     auto& function = wasmFunction->importableFunction();
     JSWebAssemblyInstance* calleeInstance = wasmFunction->instance();
+    if (!calleeInstance)
+        calleeInstance = instance;
     auto boxedCallee = function.boxedCallee.encodedBits();
     sp->ref = boxedCallee;
     Register& functionInfoSlot = std::bit_cast<Register*>(sp)[1];

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -871,7 +871,7 @@ public:
     using ValueResults = Vector<Value*, 16>;
     void fillCallResults(Value* callResult, const RTT& signature, ValueResults&);
     [[nodiscard]] PartialResult emitDirectCall(unsigned, FunctionSpaceIndex functionIndexSpace, const RTT&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
-    [[nodiscard]] PartialResult emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const RTT&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
+    [[nodiscard]] PartialResult emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, Value* wrapper, const RTT&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
 
     Vector<ConstrainedValue> createCallConstrainedArgs(BasicBlock*, const CallInformation& wasmCalleeInfo, const ArgumentList&);
     auto createCallPatchpoint(BasicBlock*, const RTT&, const CallInformation&, const ArgumentList& tmpArgs) -> CallPatchpointData;
@@ -1950,7 +1950,7 @@ static void emitWasmCallStackResultsAndSPRestore(CCallHelpers& jit,
     jit.addPtr(CCallHelpers::TrustedImm32(-frameSize), GPRInfo::callFrameRegister, MacroAssembler::stackPointerRegister);
 }
 
-auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const RTT& signature, const ArgumentList& args, ValueResults& results, CallType callType) -> PartialResult
+auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, Value* wrapper, const RTT& signature, const ArgumentList& args, ValueResults& results, CallType callType) -> PartialResult
 {
     const bool isTailCallRootCaller = callType == CallType::TailCall && !m_inlineParent;
 
@@ -1978,6 +1978,7 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
         unsigned patchArgsIndex = patchpoint->reps().size();
         patchpoint->append(calleeCode, ValueRep(GPRInfo::nonPreservedNonArgumentGPR0));
         patchpoint->append(calleeInstance, ValueRep::SomeRegister);
+        patchpoint->append(wrapper, ValueRep(GPRInfo::nonPreservedNonArgumentGPR1));
         // Cross-instance setup below reloads pinned registers before the tail-call shuffle consumes late inputs.
         patchpoint->clobberLate(RegisterSet::wasmPinnedRegisters());
         // emitRestoreInstanceFrameIfNeeded needs two scratches. wasmBaseMemoryPointer is
@@ -1991,6 +1992,7 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
         patchpoint->setGenerator([prepareForCall = prepareForCall, patchArgsIndex, callerStackSize = static_cast<int32_t>(callerStackSize), mode = m_mode](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
             GPRReg calleeInstanceGPR = params[patchArgsIndex + 1].gpr();
             GPRReg scratch2 = mode == MemoryMode::Signaling ? params.gpScratch(0) : GPRInfo::wasmBoundsCheckingSizeRegister;
+            auto constructedJSFunction = jit.branchTestPtr(CCallHelpers::Zero, calleeInstanceGPR);
             auto sameInstance = jit.branchPtr(CCallHelpers::Equal, calleeInstanceGPR, GPRInfo::wasmContextInstancePointer);
             {
                 AllowMacroScratchRegisterUsage allowScratch(jit);
@@ -2008,7 +2010,16 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
                 jit.cageConditionally(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, calleeInstanceGPR);
             }
             sameInstance.link(&jit);
+            GPRReg wrapperGPR = params[patchArgsIndex + 2].gpr();
+            jit.move(CCallHelpers::TrustedImmPtr(nullptr), wrapperGPR);
+            auto afterContextSwitch = jit.jump();
+            constructedJSFunction.link(&jit);
+            afterContextSwitch.link(&jit);
             prepareForCall->run(jit, params);
+            auto noWrapper = jit.branchTestPtr(CCallHelpers::Zero, wrapperGPR);
+            jit.loadPtr(CCallHelpers::Address(wrapperGPR, WebAssemblyFunctionBase::offsetOfCallLinkInfo()), wrapperGPR);
+            jit.storePtr(wrapperGPR, CCallHelpers::calleeFrameCodeBlockBeforeTailCall());
+            noWrapper.link(&jit);
             AllowMacroScratchRegisterUsage allowScratch(jit);
             jit.farJump(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
         });
@@ -2020,10 +2031,13 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
         BasicBlock* continuation = m_proc.addBlock();
         BasicBlock* doContextSwitch = m_proc.addBlock();
 
+        Value* isNullInstance = m_currentBlock->appendNew<Value>(m_proc, Equal, origin(),
+            calleeInstance, constant(pointerType(), 0));
         Value* isSameContextInstance = m_currentBlock->appendNew<Value>(m_proc, Equal, origin(),
             calleeInstance, instanceValue());
+        Value* skipContextSwitch = m_currentBlock->appendNew<Value>(m_proc, BitOr, origin(), isNullInstance, isSameContextInstance);
         m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(),
-            isSameContextInstance, FrequentedBlock(continuation), FrequentedBlock(doContextSwitch));
+            skipContextSwitch, FrequentedBlock(continuation), FrequentedBlock(doContextSwitch));
 
         PatchpointValue* patchpoint = doContextSwitch->appendNew<PatchpointValue>(m_proc, B3::Void, origin());
         patchpoint->effects.writesPinned = true;
@@ -2063,6 +2077,8 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
     unsigned patchArgsIndex = patchpoint->reps().size();
     patchpoint->append(calleeCode, ValueRep::SomeRegister);
     patchpoint->append(boxedCalleeCallee, ValueRep::SomeRegister);
+    patchpoint->append(wrapper, ValueRep::SomeRegister);
+    patchpoint->append(calleeInstance, ValueRep::SomeRegister);
     patchArgsIndex += m_proc.resultCount(patchpoint->type());
     patchpoint->setGenerator([this, handle = handle, prepareForCall = prepareForCall, patchArgsIndex, signature = Ref<const RTT>(signature), wasmCalleeInfo = WTF::move(wasmCalleeInfo)](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
         AllowMacroScratchRegisterUsage allowScratch(jit);
@@ -2072,6 +2088,12 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
             handle->collectStackMap(this, params);
 
         jit.storeWasmCalleeToCalleeCallFrame(params[patchArgsIndex + 1].gpr());
+        GPRReg wrapperGPR = params[patchArgsIndex + 2].gpr();
+        GPRReg calleeInstanceGPR = params[patchArgsIndex + 3].gpr();
+        auto hasTargetInstance = jit.branchTestPtr(CCallHelpers::NonZero, calleeInstanceGPR);
+        jit.loadPtr(CCallHelpers::Address(wrapperGPR, WebAssemblyFunctionBase::offsetOfCallLinkInfo()), wrapperGPR);
+        jit.storePtr(wrapperGPR, CCallHelpers::calleeFrameCodeBlockBeforeCall());
+        hasTargetInstance.link(&jit);
         jit.call(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
         emitWasmCallStackResultsAndSPRestore(jit, params, signature, wasmCalleeInfo);
     });
@@ -6551,6 +6573,18 @@ auto OMGIRGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIn
     Value* calleeInstance = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), callableFunction, safeCast<int32_t>(FuncRefTable::Function::offsetOfTargetInstance()));
     m_heaps.decorateMemory(&m_heaps.WasmFuncRefTableFunction_targetInstance, calleeInstance);
 
+    auto* table = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfTable(m_info, tableIndex)));
+    m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_tables[tableIndex], table);
+    table->setReadsMutability(B3::Mutability::Immutable);
+    table->setControlDependent(false);
+
+    Value* wrappers = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), table, safeCast<int32_t>(FuncRefTable::offsetOfWrappers()));
+    m_heaps.decorateMemory(&m_heaps.WasmFuncRefTable_wrappers, wrappers);
+
+    Value* wrapper = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(),
+        m_currentBlock->appendNew<Value>(m_proc, Add, origin(), wrappers,
+            m_currentBlock->appendNew<Value>(m_proc, Mul, origin(), calleeIndex, constant(pointerType(), sizeof(void*)))));
+
     auto inliningResult = tryInliningPolymorphicCalls(callProfileIndex, calleeInstance, calleeCallee, signature, args, callType, isTailCallRootCaller, continuation);
     if (!inliningResult.has_value()) [[unlikely]]
         return makeUnexpected(WTF::move(inliningResult.error()));
@@ -6613,7 +6647,7 @@ auto OMGIRGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIn
     m_heaps.decorateMemory(&m_heaps.WasmWasmCallableFunctionLocation_value, calleeCode);
 
     ValueResults slowValues;
-    auto result = emitIndirectCall(calleeInstance, calleeCode, calleeCallee, signature, args, slowValues, callType);
+    auto result = emitIndirectCall(calleeInstance, calleeCode, calleeCallee, wrapper, signature, args, slowValues, callType);
     if (!result.has_value()) [[unlikely]]
         return result;
 
@@ -6677,6 +6711,8 @@ auto OMGIRGenerator::addCallRef(unsigned callProfileIndex, const RTT& signature,
     Value* calleeInstance = m_currentBlock->appendNew<MemoryValue>(m_proc, wrapTrapping(Load), pointerType(), origin(), pointerOfWasmRef(callee), offset);
     m_heaps.decorateMemory(&m_heaps.WebAssemblyFunctionBase_targetInstance, calleeInstance);
 
+    Value* wrapper = pointerOfWasmRef(callee);
+
     Value* calleeCallee = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), pointerOfWasmRef(callee), safeCast<int32_t>(WebAssemblyFunctionBase::offsetOfBoxedCallee()));
     m_heaps.decorateMemory(&m_heaps.WebAssemblyFunctionBase_boxedCallee, calleeCallee);
 
@@ -6695,7 +6731,7 @@ auto OMGIRGenerator::addCallRef(unsigned callProfileIndex, const RTT& signature,
     m_heaps.decorateMemory(&m_heaps.WasmWasmCallableFunctionLocation_value, calleeCode);
 
     ValueResults slowValues;
-    auto result = emitIndirectCall(calleeInstance, calleeCode, calleeCallee, signature, args, slowValues, callType);
+    auto result = emitIndirectCall(calleeInstance, calleeCode, calleeCallee, wrapper, signature, args, slowValues, callType);
     if (!result.has_value()) [[unlikely]]
         return result;
 

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -335,7 +335,7 @@ void FuncRefTable::setFunction(uint32_t index, WebAssemblyFunctionBase* function
 {
     ASSERT(index < length());
     ASSERT_WITH_SECURITY_IMPLICATION(isSubtype(function->type(), wasmType()));
-    VM& vm = function->instance()->vm();
+    VM& vm = m_owner->vm();
     auto& slot = m_importableFunctions.get()[index];
     slot = function->importableFunction();
     m_wrappers.get()[index].set(vm, m_owner, function);

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -149,6 +149,7 @@ public:
     void copyFunction(FuncRefTable* srcTable, uint32_t dstIndex, uint32_t srcIndex);
 
     static constexpr ptrdiff_t offsetOfFunctions() { return OBJECT_OFFSETOF(FuncRefTable, m_importableFunctions); }
+    static constexpr ptrdiff_t offsetOfWrappers() { return OBJECT_OFFSETOF(FuncRefTable, m_wrappers); }
     static constexpr ptrdiff_t offsetOfTail() { return WTF::roundUpToMultipleOf<alignof(Function)>(sizeof(FuncRefTable)); }
     static constexpr ptrdiff_t offsetOfFunctionsForFixedSizedTable() { return offsetOfTail(); }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
@@ -66,6 +66,8 @@ public:
     static constexpr ptrdiff_t offsetOfBoxedCallee() { return OBJECT_OFFSETOF(WebAssemblyFunctionBase, m_importableFunction) + WasmToWasmImportableFunction::offsetOfBoxedCallee(); }
     static constexpr ptrdiff_t offsetOfTargetInstance() { return OBJECT_OFFSETOF(WebAssemblyFunctionBase, m_importableFunction) + WasmToWasmImportableFunction::offsetOfTargetInstance(); }
     static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyFunctionBase, m_importableFunction) + WasmToWasmImportableFunction::offsetOfRTT(); }
+    static constexpr ptrdiff_t offsetOfCallLinkInfo() { return OBJECT_OFFSETOF(WebAssemblyFunctionBase, m_callLinkInfo); }
+    static constexpr ptrdiff_t offsetOfCallLinkInfoFromImportableFunction() { return offsetOfCallLinkInfo() - offsetOfImportableFunction(); }
 
 protected:
     DECLARE_DEFAULT_FINISH_CREATION;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionConstructor.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2026 Sergey Rubanov <chi187@gmail.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebAssemblyJSFunctionConstructor.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "CallData.h"
+#include "Error.h"
+#include "Identifier.h"
+#include "IteratorOperations.h"
+#include "JSCInlines.h"
+#include "JSGlobalObject.h"
+#include "JSObjectInlines.h"
+#include "JSWebAssemblyHelpers.h"
+#include "WasmTypeDefinition.h"
+#include "WasmTypeDefinitionInlines.h"
+#include "WebAssemblyFunction.h"
+#include "WebAssemblyFunctionBase.h"
+#include "WebAssemblyJSFunctionPrototype.h"
+#include "WebAssemblyWrapperFunction.h"
+
+namespace JSC {
+
+const ClassInfo WebAssemblyJSFunctionConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyJSFunctionConstructor) };
+
+static JSC_DECLARE_HOST_FUNCTION(constructWebAssemblyJSFunction);
+static JSC_DECLARE_HOST_FUNCTION(callWebAssemblyJSFunctionConstructor);
+
+static bool parseValueType(JSGlobalObject* globalObject, JSValue value, Wasm::Type& type)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    String valueString = value.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+    if (valueString == "i32"_s)
+        type = Wasm::Types::I32;
+    else if (valueString == "i64"_s)
+        type = Wasm::Types::I64;
+    else if (valueString == "f32"_s)
+        type = Wasm::Types::F32;
+    else if (valueString == "f64"_s)
+        type = Wasm::Types::F64;
+    else if (valueString == "v128"_s)
+        type = Wasm::Types::V128;
+    else if (valueString == "funcref"_s || valueString == "anyfunc"_s)
+        type = Wasm::funcrefType();
+    else if (valueString == "externref"_s)
+        type = Wasm::externrefType();
+    else {
+        throwTypeError(globalObject, scope, "WebAssembly.Function expects a valid value type"_s);
+        return false;
+    }
+    return true;
+}
+
+static void parseTypeList(JSGlobalObject* globalObject, JSValue list, Vector<Wasm::Type, 16>& types)
+{
+    forEachInIterable(globalObject, list, [&](VM&, JSGlobalObject* globalObject, JSValue nextType) {
+        Wasm::Type type;
+        if (!parseValueType(globalObject, nextType, type))
+            return;
+        types.append(type);
+    });
+}
+
+JSC_DEFINE_HOST_FUNCTION(constructWebAssemblyJSFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (callFrame->argumentCount() < 2)
+        return throwVMTypeError(globalObject, scope, "WebAssembly.Function constructor expects 2 arguments"_s);
+
+    JSValue typeValue = callFrame->uncheckedArgument(0);
+    if (!typeValue.isObject())
+        return throwVMTypeError(globalObject, scope, "WebAssembly.Function constructor expects a function type object"_s);
+
+    JSObject* typeObject = asObject(typeValue);
+    JSValue parametersValue = typeObject->get(globalObject, Identifier::fromString(vm, "parameters"_s));
+    RETURN_IF_EXCEPTION(scope, { });
+    if (parametersValue.isUndefined())
+        return throwVMTypeError(globalObject, scope, "WebAssembly.Function constructor expects a 'parameters' property"_s);
+
+    JSValue resultsValue = typeObject->get(globalObject, Identifier::fromString(vm, "results"_s));
+    RETURN_IF_EXCEPTION(scope, { });
+    if (resultsValue.isUndefined())
+        return throwVMTypeError(globalObject, scope, "WebAssembly.Function constructor expects a 'results' property"_s);
+
+    Vector<Wasm::Type, 16> parameters;
+    parseTypeList(globalObject, parametersValue, parameters);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    Vector<Wasm::Type, 16> results;
+    parseTypeList(globalObject, resultsValue, results);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSValue functionValue = callFrame->uncheckedArgument(1);
+    auto callData = JSC::getCallData(functionValue);
+    if (callData.type == CallData::Type::None)
+        return throwVMTypeError(globalObject, scope, "WebAssembly.Function constructor expects a function"_s);
+
+    Ref<const Wasm::RTT> rtt = Wasm::TypeInformation::rttForFunction(results, parameters);
+    WebAssemblyFunction* wasmFunction = nullptr;
+    WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
+    if (isWebAssemblyHostFunction(functionValue, wasmFunction, wasmWrapperFunction)) {
+        WebAssemblyFunctionBase* existing = wasmFunction ? static_cast<WebAssemblyFunctionBase*>(wasmFunction) : wasmWrapperFunction;
+        if (!existing->rtt() || !existing->rtt()->isSubRTT(rtt.get()))
+            return throwVMTypeError(globalObject, scope, "WebAssembly.Function signature does not match the provided WebAssembly function"_s);
+        return JSValue::encode(existing);
+    }
+
+    Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, webAssemblyJSFunctionStructure, asObject(callFrame->newTarget()), callFrame->jsCallee());
+    RETURN_IF_EXCEPTION(scope, { });
+    return JSValue::encode(WebAssemblyWrapperFunction::createFromJSFunction(vm, globalObject, structure, asObject(functionValue), WTF::move(rtt)));
+}
+
+JSC_DEFINE_HOST_FUNCTION(callWebAssemblyJSFunctionConstructor, (JSGlobalObject* globalObject, CallFrame*))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Function"_s));
+}
+
+WebAssemblyJSFunctionConstructor* WebAssemblyJSFunctionConstructor::create(VM& vm, Structure* structure, WebAssemblyJSFunctionPrototype* thisPrototype)
+{
+    auto* constructor = new (NotNull, allocateCell<WebAssemblyJSFunctionConstructor>(vm)) WebAssemblyJSFunctionConstructor(vm, structure);
+    constructor->finishCreation(vm, thisPrototype);
+    return constructor;
+}
+
+Structure* WebAssemblyJSFunctionConstructor::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(InternalFunctionType, StructureFlags), info());
+}
+
+void WebAssemblyJSFunctionConstructor::finishCreation(VM& vm, WebAssemblyJSFunctionPrototype* prototype)
+{
+    constexpr unsigned length = 2;
+    Base::finishCreation(vm, length, "Function"_s, PropertyAdditionMode::WithoutStructureTransition);
+    putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::DontDelete);
+}
+
+WebAssemblyJSFunctionConstructor::WebAssemblyJSFunctionConstructor(VM& vm, Structure* structure)
+    : Base(vm, structure, callWebAssemblyJSFunctionConstructor, constructWebAssemblyJSFunction)
+{
+}
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionConstructor.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Sergey Rubanov <chi187@gmail.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "InternalFunction.h"
+
+namespace JSC {
+
+class WebAssemblyJSFunctionPrototype;
+
+class WebAssemblyJSFunctionConstructor final : public InternalFunction {
+public:
+    using Base = InternalFunction;
+
+    static WebAssemblyJSFunctionConstructor* create(VM&, Structure*, WebAssemblyJSFunctionPrototype*);
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    DECLARE_INFO;
+
+private:
+    WebAssemblyJSFunctionConstructor(VM&, Structure*);
+    void finishCreation(VM&, WebAssemblyJSFunctionPrototype*);
+};
+STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(WebAssemblyJSFunctionConstructor, InternalFunction);
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionPrototype.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 Sergey Rubanov <chi187@gmail.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebAssemblyJSFunctionPrototype.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "JSCInlines.h"
+#include "ObjectConstructor.h"
+#include "WasmFormat.h"
+#include "WasmTypeDefinitionInlines.h"
+#include "WebAssemblyFunctionBase.h"
+
+namespace JSC {
+
+static JSC_DECLARE_HOST_FUNCTION(webAssemblyJSFunctionProtoFuncType);
+
+const ClassInfo WebAssemblyJSFunctionPrototype::s_info = { "WebAssembly.Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyJSFunctionPrototype) };
+
+WebAssemblyJSFunctionPrototype* WebAssemblyJSFunctionPrototype::create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
+{
+    auto* object = new (NotNull, allocateCell<WebAssemblyJSFunctionPrototype>(vm)) WebAssemblyJSFunctionPrototype(vm, structure);
+    object->finishCreation(vm, globalObject);
+    return object;
+}
+
+Structure* WebAssemblyJSFunctionPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
+}
+
+void WebAssemblyJSFunctionPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
+{
+    Base::finishCreation(vm);
+    ASSERT(inherits(info()));
+    JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("type"_s, webAssemblyJSFunctionProtoFuncType, static_cast<unsigned>(PropertyAttribute::None), 0, ImplementationVisibility::Public);
+}
+
+WebAssemblyJSFunctionPrototype::WebAssemblyJSFunctionPrototype(VM& vm, Structure* structure)
+    : Base(vm, structure)
+{
+}
+
+JSC_DEFINE_HOST_FUNCTION(webAssemblyJSFunctionProtoFuncType, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* wasmFunction = dynamicDowncast<WebAssemblyFunctionBase>(callFrame->thisValue());
+    if (!wasmFunction)
+        return throwVMTypeError(globalObject, scope, "WebAssembly.Function.prototype.type called on non-WebAssembly function"_s);
+
+    RefPtr<const Wasm::RTT> signature = wasmFunction->rtt();
+    if (!signature)
+        return throwVMTypeError(globalObject, scope, "WebAssembly.Function.prototype.type unable to produce type descriptor"_s);
+
+    MarkedArgumentBuffer parameterList;
+    parameterList.ensureCapacity(signature->argumentCount());
+    for (unsigned i = 0; i < signature->argumentCount(); ++i) {
+        JSString* typeString = Wasm::typeToJSAPIString(vm, signature->argumentType(i));
+        if (!typeString)
+            return throwVMTypeError(globalObject, scope, "WebAssembly.Function.prototype.type unable to produce type descriptor"_s);
+        parameterList.append(typeString);
+    }
+
+    MarkedArgumentBuffer resultList;
+    resultList.ensureCapacity(signature->returnCount());
+    for (unsigned i = 0; i < signature->returnCount(); ++i) {
+        JSString* typeString = Wasm::typeToJSAPIString(vm, signature->returnType(i));
+        if (!typeString)
+            return throwVMTypeError(globalObject, scope, "WebAssembly.Function.prototype.type unable to produce type descriptor"_s);
+        resultList.append(typeString);
+    }
+
+    if (parameterList.hasOverflowed() || resultList.hasOverflowed()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return { };
+    }
+
+    JSArray* parameters = constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), parameterList);
+    RETURN_IF_EXCEPTION(scope, { });
+    JSArray* results = constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), resultList);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSObject* type = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
+    type->putDirect(vm, Identifier::fromString(vm, "parameters"_s), parameters);
+    type->putDirect(vm, Identifier::fromString(vm, "results"_s), results);
+    return JSValue::encode(type);
+}
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionPrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionPrototype.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Sergey Rubanov <chi187@gmail.com>. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -13,7 +13,7 @@
  * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR
  * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
  * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
  * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
@@ -25,46 +25,32 @@
 
 #pragma once
 
-#include <wtf/Platform.h>
-
 #if ENABLE(WEBASSEMBLY)
 
-#include <JavaScriptCore/WebAssemblyFunctionBase.h>
+#include "JSObject.h"
 
 namespace JSC {
 
-class WebAssemblyWrapperFunction final : public WebAssemblyFunctionBase {
+class WebAssemblyJSFunctionPrototype final : public JSNonFinalObject {
 public:
-    using Base = WebAssemblyFunctionBase;
-
+    using Base = JSNonFinalObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags;
 
-    static constexpr DestructionMode needsDestruction = NeedsDestruction;
-    static void destroy(JSCell*);
-
-    template<typename CellType, SubspaceAccess mode>
+    template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {
-        return vm.webAssemblyWrapperFunctionSpace<mode>();
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(WebAssemblyJSFunctionPrototype, Base);
+        return &vm.plainObjectSpace();
     }
+
+    static WebAssemblyJSFunctionPrototype* create(VM&, JSGlobalObject*, Structure*);
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;
 
-    DECLARE_VISIT_CHILDREN;
-
-    static WebAssemblyWrapperFunction* create(VM&, JSGlobalObject*, Structure*, JSObject*, unsigned importIndex, JSWebAssemblyInstance*, Ref<const Wasm::RTT>&&);
-    static WebAssemblyWrapperFunction* createFromJSFunction(VM&, JSGlobalObject*, Structure*, JSObject*, Ref<const Wasm::RTT>&&);
-    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
-
-    JSObject* function() LIFETIME_BOUND { return m_function.get(); }
-    void clearJSCallICs(VM&);
-
 private:
-    WebAssemblyWrapperFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSObject* function, Wasm::WasmOrJSImportableFunction&&, Wasm::WasmOrJSImportableFunctionCallLinkInfo*);
-
-    WriteBarrier<JSObject> m_function;
-    std::unique_ptr<Wasm::WasmOrJSImportableFunctionCallLinkInfo> m_ownedCallLinkInfo;
-    RefPtr<const Wasm::RTT> m_ownedRTT;
+    WebAssemblyJSFunctionPrototype(VM&, Structure*);
+    void finishCreation(VM&, JSGlobalObject*);
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -287,6 +287,8 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                 const Wasm::RTT& expectedRTT = moduleInformation.rtt(moduleInformation.importFunctionTypeSignatureIndices[import.kindIndex]);
                 if (!importedRTT || !importedRTT->isSubRTT(expectedRTT))
                     return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported function"_s, "signature doesn't match the provided WebAssembly function's signature"_s)));
+                if (wasmWrapperFunction)
+                    m_instance->setFunctionWrapper(import.kindIndex, wasmWrapperFunction);
             }
             // iii. Otherwise:
             // a. Let closure be a new host function of the given signature which calls v by coercing WebAssembly arguments to JavaScript arguments via ToJSValue and returns the result, if any, by coercing via ToWebAssemblyValue.

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
@@ -28,8 +28,14 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "CallLinkInfo.h"
+#include "IteratorOperations.h"
+#include "JSArray.h"
 #include "JSObjectInlines.h"
+#include "JSWebAssemblyHelpers.h"
 #include "JSWebAssemblyInstance.h"
+#include "LLIntData.h"
+#include "ObjectConstructor.h"
 #include "WasmTypeDefinitionInlines.h"
 
 namespace JSC {
@@ -38,6 +44,7 @@ const ClassInfo WebAssemblyWrapperFunction::s_info = { "WebAssemblyWrapperFuncti
 
 static JSC_DECLARE_HOST_FUNCTION(callWebAssemblyWrapperFunction);
 static JSC_DECLARE_HOST_FUNCTION(callWebAssemblyWrapperFunctionIncludingInvalidValues);
+static JSC_DECLARE_HOST_FUNCTION(callWebAssemblyJSFunction);
 
 WebAssemblyWrapperFunction::WebAssemblyWrapperFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSObject* function, Wasm::WasmOrJSImportableFunction&& importableFunction, WasmOrJSImportableFunctionCallLinkInfo* callLinkInfo)
     : Base(vm, executable, globalObject, structure, WTF::move(importableFunction), callLinkInfo)
@@ -76,6 +83,39 @@ WebAssemblyWrapperFunction* WebAssemblyWrapperFunction::create(VM& vm, JSGlobalO
     return result;
 }
 
+WebAssemblyWrapperFunction* WebAssemblyWrapperFunction::createFromJSFunction(VM& vm, JSGlobalObject* globalObject, Structure* structure, JSObject* function, Ref<const Wasm::RTT>&& signature)
+{
+    ASSERT_WITH_MESSAGE(!function->inherits<WebAssemblyWrapperFunction>(), "We should never double wrap a wrapper function.");
+
+    String name = emptyString();
+    NativeExecutable* executable = nullptr;
+    unsigned length = signature->argumentCount();
+    if (signature->argumentsOrResultsIncludeV128() || signature->argumentsOrResultsIncludeExnref()) [[unlikely]]
+        executable = vm.getHostFunction(callWebAssemblyWrapperFunctionIncludingInvalidValues, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, length, name);
+    else
+        executable = vm.getHostFunction(callWebAssemblyJSFunction, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, length, name);
+
+    RELEASE_ASSERT(JSValue(function).isCallable());
+    auto ownedCallLinkInfo = makeUnique<Wasm::WasmOrJSImportableFunctionCallLinkInfo>();
+    ownedCallLinkInfo->boxedCallee = CalleeBits::encodeNativeCallee(&Wasm::WasmToJSCallee::singleton());
+    ownedCallLinkInfo->entrypointLoadLocation = &ownedCallLinkInfo->importFunctionStub;
+    ownedCallLinkInfo->rtt = signature.ptr();
+    ownedCallLinkInfo->importFunctionStub = LLInt::getCodeRef<WasmEntryPtrTag>(wasm_to_js_wrapper_entry).code();
+    ownedCallLinkInfo->importFunction.set(vm, globalObject, function);
+    auto callLinkInfo = makeUnique<DataOnlyCallLinkInfo>();
+    callLinkInfo->initialize(vm, nullptr, CallLinkInfo::CallType::Call, CodeOrigin { });
+    WTF::storeStoreFence();
+    ownedCallLinkInfo->callLinkInfo = WTF::move(callLinkInfo);
+
+    Wasm::WasmOrJSImportableFunction importable = *ownedCallLinkInfo;
+    WebAssemblyWrapperFunction* result = new (NotNull, allocateCell<WebAssemblyWrapperFunction>(vm)) WebAssemblyWrapperFunction(vm, executable, globalObject, structure, function, WTF::move(importable), ownedCallLinkInfo.get());
+    result->m_ownedRTT = WTF::move(signature);
+    result->m_ownedCallLinkInfo = WTF::move(ownedCallLinkInfo);
+    result->finishCreation(vm);
+    vm.writeBarrier(result);
+    return result;
+}
+
 Structure* WebAssemblyWrapperFunction::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {
     ASSERT(globalObject);
@@ -94,6 +134,21 @@ void WebAssemblyWrapperFunction::visitChildrenImpl(JSCell* cell, Visitor& visito
 
 DEFINE_VISIT_CHILDREN(WebAssemblyWrapperFunction);
 
+void WebAssemblyWrapperFunction::destroy(JSCell* cell)
+{
+    SUPPRESS_MEMORY_UNSAFE_CAST auto* wrapper = static_cast<WebAssemblyWrapperFunction*>(cell);
+    wrapper->clearJSCallICs(wrapper->vm());
+    wrapper->WebAssemblyWrapperFunction::~WebAssemblyWrapperFunction();
+}
+
+void WebAssemblyWrapperFunction::clearJSCallICs(VM& vm)
+{
+    if (auto* owned = m_ownedCallLinkInfo.get()) {
+        if (auto* callLinkInfo = owned->callLinkInfo.get())
+            callLinkInfo->unlinkOrUpgrade(vm, nullptr, nullptr);
+    }
+}
+
 JSC_DEFINE_HOST_FUNCTION(callWebAssemblyWrapperFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -110,6 +165,73 @@ JSC_DEFINE_HOST_FUNCTION(callWebAssemblyWrapperFunctionIncludingInvalidValues, (
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     return throwVMTypeError(globalObject, scope, Wasm::errorMessageForExceptionType(Wasm::ExceptionType::TypeErrorInvalidValueUse));
+}
+
+JSC_DEFINE_HOST_FUNCTION(callWebAssemblyJSFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* wasmFunction = uncheckedDowncast<WebAssemblyWrapperFunction>(callFrame->jsCallee());
+    JSObject* function = wasmFunction->function();
+    RefPtr<const Wasm::RTT> signature = wasmFunction->rtt();
+    RELEASE_ASSERT(signature);
+
+    MarkedArgumentBuffer args;
+    args.ensureCapacity(signature->argumentCount());
+    for (unsigned i = 0; i < signature->argumentCount(); ++i) {
+        uint64_t bits = toWebAssemblyValue(globalObject, signature->argumentType(i), callFrame->argument(i));
+        RETURN_IF_EXCEPTION(scope, { });
+        args.append(toJSValue(globalObject, signature->argumentType(i), bits));
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+    if (args.hasOverflowed()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return { };
+    }
+
+    auto callData = JSC::getCallDataInline(function);
+    RELEASE_ASSERT(callData.type != CallData::Type::None);
+    JSValue result = call(globalObject, function, callData, jsUndefined(), args);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (!signature->returnCount())
+        return JSValue::encode(jsUndefined());
+
+    if (signature->returnCount() == 1) {
+        uint64_t bits = toWebAssemblyValue(globalObject, signature->returnType(0), result);
+        RETURN_IF_EXCEPTION(scope, { });
+        RELEASE_AND_RETURN(scope, JSValue::encode(toJSValue(globalObject, signature->returnType(0), bits)));
+    }
+
+    unsigned iterationCount = 0;
+    MarkedArgumentBuffer jsValues;
+    jsValues.ensureCapacity(signature->returnCount());
+    forEachInIterable(globalObject, result, [&](VM&, JSGlobalObject*, JSValue value) {
+        if (jsValues.size() < signature->returnCount())
+            jsValues.append(value);
+        ++iterationCount;
+    });
+    RETURN_IF_EXCEPTION(scope, { });
+    if (jsValues.hasOverflowed()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return { };
+    }
+    if (iterationCount != signature->returnCount())
+        return throwVMTypeError(globalObject, scope, "Incorrect number of values returned to Wasm from JS"_s);
+
+    MarkedArgumentBuffer converted;
+    converted.ensureCapacity(signature->returnCount());
+    for (unsigned i = 0; i < signature->returnCount(); ++i) {
+        uint64_t bits = toWebAssemblyValue(globalObject, signature->returnType(i), jsValues.at(i));
+        RETURN_IF_EXCEPTION(scope, { });
+        converted.append(toJSValue(globalObject, signature->returnType(i), bits));
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+    if (converted.hasOverflowed()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return { };
+    }
+    RELEASE_AND_RETURN(scope, JSValue::encode(constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), converted)));
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### d7eb2228568ec1aa7624db4d5f75fd3649f78bd5
<pre>
[JSC][Wasm] Implement WebAssembly.Function behind useWasmJSTypes
<a href="https://bugs.webkit.org/show_bug.cgi?id=322206">https://bugs.webkit.org/show_bug.cgi?id=322206</a>

Reviewed by NOBODY (OOPS!).

Add the JS types constructor so a JS function can be wrapped as an
exported Wasm function with an explicit signature. type() reflects
that signature. Instances are WebAssembly.Function and can go in
funcref tables. BBQ and OMG keep the caller instance when
targetInstance is null and pass the wrapper CallLinkInfo as the
callee CodeBlock, matching IPInt. Off by default; WebKitTestRunner
enables the testable pref.

* Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionConstructor.cpp: Added.
* Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionConstructor.h: Added.
* Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionPrototype.cpp: Added.
* Source/JavaScriptCore/wasm/js/WebAssemblyJSFunctionPrototype.h: Added.
* Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmTable.cpp:
* Source/JavaScriptCore/wasm/WasmTable.h:
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/heap/Heap.cpp:
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/DerivedSources-input.xcfilelist:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* JSTests/wasm/js-api/function-constructor.js: Added.
* JSTests/wasm/js-api/function-constructor-wasm.js: Added.
* JSTests/wasm/js-api/function-constructor-call-indirect.js: Added.
* JSTests/wasm/js-api/web-assembly-function.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/constructor.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/constructor.tentative.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/call.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/call.tentative.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/type.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/type.tentative.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/table.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/table.tentative.any.worker-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7eb2228568ec1aa7624db4d5f75fd3649f78bd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192212 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146316 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142095 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98657 "2 flakes 16 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44453 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42720 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4496 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11292 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42349 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3377 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43270 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194140 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55605 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151503 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56296 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151207 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45774 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128578 "Failed to build and analyze WebKit") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124384 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54807 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17344 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54188 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54427 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->