### PR TITLE
Cherry-pick 319424@main (f76f30efcb68). https://bugs.webkit.org/show_bug.cgi?id=322068

### DIFF
--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -166,7 +166,8 @@ void NetworkDataTaskSoup::createRequest(ResourceRequest&& request, WasBlockingCo
     messageFlags |= SOUP_MESSAGE_COLLECT_METRICS;
     if (m_shouldContentSniff == ContentSniffingPolicy::DoNotSniffContent)
         soup_message_disable_feature(m_soupMessage.get(), SOUP_TYPE_CONTENT_SNIFFER);
-    if (m_user.isEmpty() && m_password.isEmpty() && m_storedCredentialsPolicy == StoredCredentialsPolicy::DoNotUse) {
+    if ((m_user.isEmpty() && m_password.isEmpty() && m_storedCredentialsPolicy == StoredCredentialsPolicy::DoNotUse)
+        || m_currentRequest.hasHTTPHeaderField(HTTPHeaderName::Authorization)) {
         messageFlags |= SOUP_MESSAGE_DO_NOT_USE_AUTH_CACHE;
     }
     soup_message_set_flags(m_soupMessage.get(), static_cast<SoupMessageFlags>(soup_message_get_flags(m_soupMessage.get()) | messageFlags));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAuthentication.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAuthentication.cpp
@@ -29,6 +29,7 @@ static const char authTestPassword[] = "password";
 static const char authExpectedSuccessTitle[] = "WebKit2Gtk+ Authentication test";
 static const char authExpectedFailureTitle[] = "401 Authorization Required";
 static const char authExpectedAuthorization[] = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="; // Base64 encoding of "username:password".
+static const char authPageAuthorization[] = "Bearer page-token"; // Authorization header set by the page itself.
 static const char authSuccessHTMLString[] =
     "<html>"
     "<head><title>WebKit2Gtk+ Authentication test</title></head>"
@@ -326,6 +327,30 @@ static void testWebViewAuthenticationSuccess(AuthenticationTest* test, gconstpoi
     g_assert_true(test->m_authenticationSucceededReceived);
 }
 
+static void testWebViewAuthenticationPageProvidedAuthorizationHeader(AuthenticationTest* test, gconstpointer)
+{
+    // Authenticate once, so that the credentials end up in the auth cache for the whole domain.
+    test->loadURI(kServer->getURIForPath("/auth-test.html").data());
+    WebKitAuthenticationRequest* request = test->waitForAuthenticationRequest();
+    WebKitCredential* credential = webkit_credential_new(authTestUsername, authTestPassword, WEBKIT_CREDENTIAL_PERSISTENCE_FOR_SESSION);
+    webkit_authentication_request_authenticate(request, credential);
+    webkit_credential_free(credential);
+    test->waitUntilTitleChanged();
+    g_assert_cmpstr(webkit_web_view_get_title(test->webView()), ==, authExpectedSuccessTitle);
+    g_assert_true(test->m_authenticationSucceededReceived);
+
+    // A request that carries its own Authorization header must be sent as-is, even though the
+    // cached credentials would otherwise be used for this domain.
+    GUniqueOutPtr<GError> error;
+    auto* value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished(
+        "const response = await fetch('echo-authorization', { headers: { 'Authorization': 'Bearer page-token' } });"
+        "return await response.text();", nullptr, nullptr, &error.outPtr());
+    g_assert_no_error(error.get());
+    g_assert_nonnull(value);
+    GUniquePtr<char> authorization(WebViewTest::javascriptResultToCString(value));
+    g_assert_cmpstr(authorization.get(), ==, authPageAuthorization);
+}
+
 static void testWebViewAuthenticationEmptyRealm(AuthenticationTest* test, gconstpointer)
 {
     test->loadURI(kServer->getURIForPath("/empty-realm.html").data());
@@ -439,6 +464,10 @@ static void serverCallback(SoupServer* server, SoupServerMessage* message, const
             soup_server_message_set_status(message, isProxy ? SOUP_STATUS_PROXY_AUTHENTICATION_REQUIRED : SOUP_STATUS_UNAUTHORIZED, nullptr);
             soup_message_body_append(responseBody, SOUP_MEMORY_STATIC, authFailureHTMLString, strlen(authFailureHTMLString));
         }
+    } else if (g_str_has_suffix(path, "/echo-authorization")) {
+        const char* authorization = soup_message_headers_get_one(soup_server_message_get_request_headers(message), "Authorization");
+        soup_server_message_set_status(message, SOUP_STATUS_OK, nullptr);
+        soup_message_body_append(responseBody, SOUP_MEMORY_COPY, authorization ? authorization : "", authorization ? strlen(authorization) : 0);
     } else
         soup_server_message_set_status(message, SOUP_STATUS_NOT_FOUND, nullptr);
 
@@ -531,6 +560,7 @@ void beforeAll()
     EphemeralAuthenticationTest::add("Authentication", "authentication-ephemeral", testWebViewAuthenticationEphemeral);
     AuthenticationTest::add("Authentication", "authentication-storage", testWebViewAuthenticationStorage);
     AuthenticationTest::add("Authentication", "authentication-empty-realm", testWebViewAuthenticationEmptyRealm);
+    AuthenticationTest::add("Authentication", "authentication-page-provided-authorization-header", testWebViewAuthenticationPageProvidedAuthorizationHeader);
     ProxyAuthenticationTest::add("Authentication", "authentication-proxy", testWebViewAuthenticationProxy);
     ProxyAuthenticationTest::add("Authentication", "authentication-proxy-https", testWebViewAuthenticationProxyHTTPS);
 }


### PR DESCRIPTION
#### 6f79e4f3e9d4e3f3e476bdb140bf146500779b83
<pre>
Cherry-pick 319424@main (f76f30efcb68). <a href="https://bugs.webkit.org/show_bug.cgi?id=322068">https://bugs.webkit.org/show_bug.cgi?id=322068</a>

    [SOUP] An Authorization header set by the page is replaced by cached credentials
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322068">https://bugs.webkit.org/show_bug.cgi?id=322068</a>

    Reviewed by Michael Catanzaro.

    nce an authentication challenge has been answered for a host, libsoup&apos;s
    SoupAuthManager stamps the cached credentials onto every later request in that
    protection space, replacing an Authorization header the page had set itself.
    The Fetch standard uses the cached credential only &quot;If httpRequest&apos;s header
    list does not contain `Authorization`&quot;, and the Cocoa and curl ports already
    behave that way.

    Set SOUP_MESSAGE_DO_NOT_USE_AUTH_CACHE, libsoup&apos;s per-message opt-out, when the
    request already carries an Authorization header. A challenge still reaches the
    authentication handler and the retry authenticates as before.

    Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAuthentication.cpp

    * Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
    (WebKit::NetworkDataTaskSoup::createRequest):
    * Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAuthentication.cpp:
    (testWebViewAuthenticationPageProvidedAuthorizationHeader):
    (serverCallback):
    (beforeAll):

    Canonical link: <a href="https://commits.webkit.org/319424@main">https://commits.webkit.org/319424@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1105@webkitglib/2.52">https://commits.webkit.org/305877.1105@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f9d8120d24d74396bfbeab3b4c8282a8fc8d7d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181824 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/55771 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49574 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192049 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146153 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183686 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/57085 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55492 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141936 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146153 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184779 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/57085 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/49574 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122372 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/57085 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55492 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/49574 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/57085 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49574 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3211 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/48402 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/55492 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193975 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/55441 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/49574 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151353 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56130 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49574 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151058 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27613 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56130 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128413 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124171 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/54643 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/49574 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54025 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54264 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54090 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->