### PR TITLE
Cherry-pick 305413.996@safari-7624.5.1.10-branch (17b41f27a761). https://bugs.webkit.org/show_bug.cgi?id=317270

### DIFF
--- a/LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash-expected.txt
+++ b/LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes it it does not crash.

--- a/LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash.html
+++ b/LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<html>
+<body>
+<p>This test passes it it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+// Large logical File so the async blob load is still in flight when window.stop() runs.
+let chunk = new Blob([new ArrayBuffer(1 << 20)]);
+let big = chunk;
+for (let i = 0; i < 13; i++)
+    big = new Blob([big, big]);   // 8 GiB logical
+let hugeFile = new File([big], "huge.bin", {type: "application/octet-stream"});
+
+// Child iframe; retain only its Navigator.
+let f = document.createElement('iframe');
+document.body.appendChild(f);
+let childNav = f.contentWindow.navigator;
+
+// Cross-realm share(): receiver = child Navigator, [CallWith=CurrentDocument] binds the parent Document,
+// so the blob load is registered against the parent and survives child-frame removal.
+internals.withUserGesture(() => {
+    Navigator.prototype.share.call(childNav, { files: [hugeFile] });
+});
+
+// Drop the child realm; after GC, the only remaining Ref<Navigator> is the one captured
+// inside ShareDataReader::m_completionHandler.
+childNav = null;
+f.remove();
+f = null;
+for (let i = 0; i < 10; i++)  {
+    if (window.GCController)
+        GCController.collect();
+}
+
+// Yield, GC again, then cancel the in-flight blob load via window.stop().
+// FileReaderLoader::failed -> BlobLoader::didFail -> ShareDataReader::didFinishLoading (error branch)
+// invokes and destroys the local completionHandler, which releases the last Ref<Navigator>;
+// ~Navigator -> ~m_loader -> ~ShareDataReader frees `this`; the next statement cancel() is a UAF.
+setTimeout(() => {
+    for (let i = 0; i < 10; i++) {
+        if (window.GCController)
+            GCController.collect();
+    }
+    
+    window.stop();
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 100);
+</script>
+</body>
+</html>

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/dtls/dtls_transport.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/dtls/dtls_transport.cc
@@ -240,6 +240,9 @@ DtlsTransportInternalImpl::~DtlsTransportInternalImpl() {
 #if WEBRTC_WEBKIT_BUILD
     ice_transport_->UnsubscribeReceivingState(this);
     ice_transport_->UnsubscribeWritableState(this);
+    ice_transport()->UnsubscribeReadyToSend(this);
+    ice_transport()->UnsubscribeNetworkRouteChanged(this);
+    ice_transport()->UnsubscribeSentPacket(this);
 #endif
   }
 }

--- a/Source/WebCore/page/ShareDataReader.cpp
+++ b/Source/WebCore/page/ShareDataReader.cpp
@@ -51,8 +51,9 @@ void ShareDataReader::start(Document* document, ShareDataWithParsedURL&& shareDa
     int count = 0;
     m_pendingFileLoads.reserveInitialCapacity(m_shareData.shareData.files.size());
     for (auto& blob : m_shareData.shareData.files) {
-        Ref blobLoader = BlobLoader::create([this, count, fileName = blob->name()](BlobLoader&) {
-            this->didFinishLoading(count, fileName);
+        Ref blobLoader = BlobLoader::create([weakThis = WeakPtr { *this }, count, fileName = blob->name()](BlobLoader&) {
+            if (RefPtr protectedThis = weakThis)
+                protectedThis->didFinishLoading(count, fileName);
         });
         m_pendingFileLoads.append(blobLoader.copyRef());
         blobLoader->start(blob, document, FileReaderLoader::ReadAsArrayBuffer);

--- a/Source/WebCore/page/ShareDataReader.h
+++ b/Source/WebCore/page/ShareDataReader.h
@@ -27,6 +27,7 @@
 
 #include "ShareData.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ class Document;
 class ScriptExecutionContext;
 template<typename> class ExceptionOr;
 
-class ShareDataReader : public RefCounted<ShareDataReader> {
+class ShareDataReader : public RefCountedAndCanMakeWeakPtr<ShareDataReader> {
 public:
     static Ref<ShareDataReader> create(CompletionHandler<void(ExceptionOr<ShareDataWithParsedURL&>)>&& completionHandler) { return adoptRef(*new ShareDataReader(WTF::move(completionHandler))); }
     ~ShareDataReader();

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -39,6 +39,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
+#include <WebCore/Page.h>
 #include <wtf/DebugUtilities.h>
 #include <wtf/HexNumber.h>
 #include <wtf/text/StringBuilder.h>
@@ -642,8 +643,12 @@ void WebBackForwardList::backForwardAddItem(IPC::Connection& connection, Ref<Fra
         backForwardAddItemShared(connection, WTF::move(navigatedFrameState), webPageProxy->didLoadWebArchive() ? LoadedWebArchive::Yes : LoadedWebArchive::No);
 }
 
-static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProxy>& process)
+static constexpr unsigned maxFrameStateDepthForMessageCheck = WebCore::Page::maxFrameDepth;
+
+static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProxy>& process, unsigned depth = 0)
 {
+    MESSAGE_CHECK_WITH_RETURN_VALUE(process, depth < maxFrameStateDepthForMessageCheck, false);
+
     URL itemURL { frameState->urlString };
     URL itemOriginalURL { frameState->originalURLString };
 #if PLATFORM(COCOA)
@@ -658,6 +663,11 @@ static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProx
 #if PLATFORM(COCOA)
     }
 #endif
+
+    for (auto& child : frameState->children) {
+        if (!messageCheckItemURLs(child, process, depth + 1))
+            return false;
+    }
     return true;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -31,6 +31,7 @@
 #import "TestNavigationDelegate.h"
 #import "TestUIDelegate.h"
 #import "TestWKWebView.h"
+#import <WebCore/Page.h>
 #import <WebKit/WKBackForwardListItemPrivate.h>
 #import <WebKit/WKBackForwardListPrivate.h>
 #import <WebKit/WKNavigationDelegatePrivate.h>
@@ -1184,5 +1185,187 @@ TEST(WKBackForwardList, ForgedFileURLItemIsRejected)
 +
 +    EXPECT_WK_STREQ([webView _test_waitForAlert], "PASS: forged file:// back-forward item was rejected by MESSAGE_CHECK");
 +}
+
+static constexpr auto messageCheckSpoofHTML = R"TESTRESOURCE(
+<!DOCTYPE html>
+<script src="coreipc.js"></script>
+<script>
+
+const origParseMarkable = ArgumentParser.parseMarkable;
+ArgumentParser.parseMarkable = function (buffer, position, innerType) {
+    const [newPos, result] = origParseMarkable.call(this, buffer, position, innerType);
+    if (result && typeof result === 'object' && Object.keys(result).length > 0 && !Object.hasOwn(result, 'optionalValue'))
+        return [newPos, { optionalValue: result }];
+    return [newPos, result];
+};
+
+const wiretap = new IPCWireTap('UI', 'Outgoing');
+
+let frameItemIDCounter = 100000n;
+
+window.spoofBackForwardSetChildItem = function(topURL, nestedChildURLs) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('Timed out waiting for outgoing BackForwardAddItem')), 5000);
+
+        wiretap.tapNext(IPC.messages['WebBackForwardList_BackForwardAddItem'].name,
+            (process, connectionID, messageName, typedResult, result) => {
+                clearTimeout(timer);
+                try {
+                    if (!result) {
+                        reject(new Error('BackForwardAddItem result was undefined (parse likely failed; see WireTap console output)'));
+                        return;
+                    }
+
+                    const parentFrameItemID = result.navigatedFrameState && result.navigatedFrameState.frameItemID && result.navigatedFrameState.frameItemID.optionalValue;
+                    if (!parentFrameItemID || parentFrameItemID.object === undefined) {
+                        reject(new Error('navigatedFrameState.frameItemID was empty or missing fields; expected a present Markable from a real pushState'));
+                        return;
+                    }
+
+                    const fresh = () => ({
+                        object: ++frameItemIDCounter,
+                        processIdentifier: parentFrameItemID.processIdentifier
+                    });
+
+                    const makeFrameState = (urlString, children) => ({
+                        urlString: urlString,
+                        originalURLString: urlString,
+                        referrer: "",
+                        target: { string: "" },
+                        frameID: { },
+                        stateObjectData: { },
+                        documentSequenceNumber: 0n,
+                        itemSequenceNumber: 0n,
+                        navigationAPIKey: { },
+                        scrollPosition: { x: 0, y: 0 },
+                        shouldRestoreScrollPosition: false,
+                        pageScaleFactor: 0,
+                        httpBody: { },
+                        itemID: { },
+                        frameItemID: { optionalValue: fresh() },
+                        title: "",
+                        shouldOpenExternalURLsPolicy: 0,
+                        sessionStateObject: { },
+                        wasCreatedByJSWithoutUserInteraction: false,
+                        wasRestoredFromSession: false,
+                        policyContainer: { },
+                        children: children,
+                        documentState: []
+                    });
+
+                    // Build children[0] -> children[0] -> ... -> nestedChildURLs[N-1] chain.
+                    let chain = [];
+                    for (let i = nestedChildURLs.length - 1; i >= 0; --i)
+                        chain = [makeFrameState(nestedChildURLs[i], chain)];
+
+                    CoreIPC.UI.WebBackForwardList.BackForwardSetChildItem(IPC.pageID, {
+                        frameItemID: parentFrameItemID,
+                        frameState: makeFrameState(topURL, chain)
+                    });
+                    resolve();
+                } catch (e) {
+                    reject(new Error(`Tap callback failed: ${e && e.stack ? e.stack : e}`));
+                }
+            });
+
+        // Triggering a same-document pushState gets the WebContent process to send
+        // BackForwardAddItem out, which the wiretap above will intercept.
+        history.pushState(null, '', '#trigger-' + Math.random());
+    });
+};
+</script>
+)TESTRESOURCE"_s;
+
+static RetainPtr<NSString> runMessageCheckSpoof(NSString *topURL, NSArray<NSString *> *nestedChildURLs)
+{
+    RetainPtr coreIPCURL = [NSBundle.test_resourcesBundle URLForResource:@"coreipc" withExtension:@"js"];
+    RetainPtr coreIPCData = [NSData dataWithContentsOfURL:coreIPCURL.get()];
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { messageCheckSpoofHTML } },
+        { "/coreipc.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, coreIPCData.get() } },
+    });
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableIPCTestingAPI(configuration.get());
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadRequest:server.request("/"_s)];
+
+    __block bool spoofDone = false;
+    __block RetainPtr<NSError> spoofError;
+    NSDictionary *args = @{
+        @"topURL": topURL,
+        @"nested": nestedChildURLs,
+    };
+    [webView callAsyncJavaScript:@"return spoofBackForwardSetChildItem(topURL, nested);"
+        arguments:args
+        inFrame:nil
+        inContentWorld:WKContentWorld.pageWorld
+        completionHandler:^(id result, NSError *error) {
+            spoofError = error;
+            spoofDone = true;
+        }];
+    TestWebKitAPI::Util::run(&spoofDone);
+    if (spoofError)
+        NSLog(@"spoofBackForwardSetChildItem rejected: %@", spoofError.get());
+    EXPECT_NULL(spoofError.get());
+
+    // Let the spoofed BackForwardSetChildItem reach the UIProcess and get dispatched.
+    TestWebKitAPI::Util::spinRunLoop(30);
+    TestWebKitAPI::Util::runFor(0.05_s);
+
+    return [[webView backForwardList] _loggingStringForTesting];
+}
+
+TEST(WKBackForwardList, MessageCheckRejectsNestedFileURLChild)
+{
+    NSString *fileURL = @"file:///Users/victim/Library/Cookies/Cookies.binarycookies";
+    RetainPtr logging = runMessageCheckSpoof(@"https://attacker.example/innocuous", @[ fileURL ]);
+    EXPECT_FALSE([logging containsString:fileURL]);
+    EXPECT_FALSE([logging containsString:@"file://"]);
+}
+
+TEST(WKBackForwardList, MessageCheckRejectsDeeplyNestedFileURLChild)
+{
+    NSString *fileURL = @"file:///etc/passwd";
+    NSArray *nestedChain = @[
+        @"https://attacker.example/level1",
+        @"https://attacker.example/level2",
+        @"https://attacker.example/level3",
+        @"https://attacker.example/level4",
+        fileURL,
+    ];
+    RetainPtr logging = runMessageCheckSpoof(@"https://attacker.example/innocuous", nestedChain);
+    EXPECT_FALSE([logging containsString:fileURL]);
+    EXPECT_FALSE([logging containsString:@"file://"]);
+}
+
+TEST(WKBackForwardList, MessageCheckRejectsExcessiveChildDepth)
+{
+    // Send a chain guaranteed to be deeper than the max frame depth to catch the message check.
+    static constexpr unsigned chainDepth = static_cast<unsigned>(WebCore::Page::maxFrameDepth) + 1;
+
+    RetainPtr nestedChain = adoptNS([[NSMutableArray alloc] initWithCapacity:chainDepth]);
+    for (unsigned i = 0; i < chainDepth; ++i)
+        [nestedChain addObject:[NSString stringWithFormat:@"https://attacker.example/depth-%u", i]];
+
+    NSString *probeURL = [nestedChain lastObject];
+
+    RetainPtr logging = runMessageCheckSpoof(@"https://attacker.example/innocuous", nestedChain.get());
+    EXPECT_FALSE([logging containsString:probeURL]);
+}
+
+TEST(WKBackForwardList, MessageCheckAcceptsBenignNestedChildren)
+{
+    NSString *innerURL = @"https://example.com/inner";
+    NSArray *nestedChain = @[
+        @"https://example.com/middle",
+        innerURL,
+    ];
+    RetainPtr logging = runMessageCheckSpoof(@"https://example.com/outer", nestedChain);
+    EXPECT_TRUE([logging containsString:innerURL]);
+    EXPECT_TRUE([logging containsString:@"https://example.com/outer"]);
+    EXPECT_TRUE([logging containsString:@"https://example.com/middle"]);
+}
 
 #endif // ENABLE(IPC_TESTING_API)


### PR DESCRIPTION
#### 6733d583efbd3537b1d1d18b7b409bfb5ed22ed0
<pre>
Cherry-pick 305413.996@safari-7624.5.1.10-branch (17b41f27a761). <a href="https://bugs.webkit.org/show_bug.cgi?id=317270">https://bugs.webkit.org/show_bug.cgi?id=317270</a>

    missing UnsubscribeReadyToSend/NetworkRouteChanged in LibWebRTC ~DtlsTransportInternalImpl causes use-after-free
    <a href="https://rdar.apple.com/177131722">rdar://177131722</a>

    Reviewed by Eric Carlson.

    We unregister all callbacks that were registered when connecting to the ICE transport.
    Test validated with a specific STUN server.

    * Source/ThirdParty/libwebrtc/Source/webrtc/p2p/dtls/dtls_transport.cc:

    Identifier: 305413.996@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1109@webkitglib/2.52">https://commits.webkit.org/305877.1109@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 782ee5a34a0b5882d0b53288c390c45b3f8f02fc
<pre>
Cherry-pick 305413.994@safari-7624.5.1.10-branch (890fde552386). <a href="https://bugs.webkit.org/show_bug.cgi?id=317270">https://bugs.webkit.org/show_bug.cgi?id=317270</a>

    [WebCore] use-after-free in ShareDataReader::didFinishLoading: cancel() called on freed this after completionHandler destruction
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317270">https://bugs.webkit.org/show_bug.cgi?id=317270</a>
    <a href="https://rdar.apple.com/177909918">rdar://177909918</a>

    Reviewed by Per Arne Vollan and Ben Nham.

    Make sure we capture `weakThis` in the lambda instead of `this`, then
    convert to a RefPtr before calling `didfinishLoading()` so that `this`
    cannot be destroyed *while* running `didfinishLoading()`.

    Test: http/tests/webshare/shareddatareader-didfinishloading-crash.html

    * LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash-expected.txt: Added.
    * LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash.html: Added.
    * Source/WebCore/page/ShareDataReader.cpp:
    (WebCore::ShareDataReader::start):
    * Source/WebCore/page/ShareDataReader.h:

    Identifier: 305413.994@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1108@webkitglib/2.52">https://commits.webkit.org/305877.1108@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### a9bfb79a0956e18e86eefa0ce9f3314a93651440
<pre>
Cherry-pick 305413.993@safari-7624.5.1.10-branch (ce08c270d322). <a href="https://bugs.webkit.org/show_bug.cgi?id=317142">https://bugs.webkit.org/show_bug.cgi?id=317142</a>

    Incomplete fix of WebKit bug 315528 (Message check file urls in back/forward list messages)
    <a href="https://rdar.apple.com/177953315">rdar://177953315</a>

    Reviewed by Chris Dumez.

    Apply the message check to sub-items in the history item tree, and other validations of the tree.

    Test: Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm

    * Source/WebKit/UIProcess/WebBackForwardList.cpp:
    (WebKit::messageCheckItemURLs):
    * Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
    ((WKBackForwardList, MessageCheckRejectsNestedFileURLChild)):
    ((WKBackForwardList, MessageCheckRejectsDeeplyNestedFileURLChild)):
    ((WKBackForwardList, MessageCheckRejectsExcessiveChildDepth)):
    ((WKBackForwardList, MessageCheckAcceptsBenignNestedChildren)):

    Identifier: 305413.993@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1107@webkitglib/2.52">https://commits.webkit.org/305877.1107@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72e9ea0e5761fa1ae784686f1ac16687c1c42e05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181881 "10 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/55828 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49631 "The change is no longer eligible for processing.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192106 "Failed to checkout and rebase branch from PR 72051") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146210 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183743 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/57142 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55550 "The change is no longer eligible for processing.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192106 "Failed to checkout and rebase branch from PR 72051") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146210 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184836 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/57142 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/49631 "The change is no longer eligible for processing.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192106 "Failed to checkout and rebase branch from PR 72051") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/57142 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55550 "The change is no longer eligible for processing.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192106 "Failed to checkout and rebase branch from PR 72051") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/49631 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/57142 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49631 "The change is no longer eligible for processing.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/3268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/48459 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/55550 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194033 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/55498 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/49631 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56187 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49631 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/151108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27619 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56187 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128470 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124232 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/54700 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/49631 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54082 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54321 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54147 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->