### PR TITLE
Cherry-pick 305413.1001@safari-7624.5-branch (4c69ed8ad988). https://bugs.webkit.org/show_bug.cgi?id=317270

### DIFF
--- a/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race-expected.txt
+++ b/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Concurrent cache.put of opaque responses from main thread and Workers must not crash WebContent
+

--- a/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race.html
+++ b/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+</head>
+<body>
+<script>
+const NUM_WORKERS = 4;
+const PUTS_PER_THREAD = 30;
+const REMOTE = get_host_info().HTTP_REMOTE_ORIGIN + "/";
+
+const workerSrc = `
+const REMOTE = ${JSON.stringify(REMOTE)};
+const PUTS = ${PUTS_PER_THREAD};
+self.onmessage = async (e) => {
+    if (e.data !== "go")
+        return;
+    try {
+        const cache = await caches.open("opaque-response-race");
+        const responses = await Promise.all(
+            Array.from({length: PUTS}, (_, i) =>
+                fetch(REMOTE + "?w=" + i + "-" + Math.random(), { mode: "no-cors", cache: "no-store" })));
+        await Promise.all(responses.map((r, i) =>
+            cache.put("https://example.com/w-" + i + "-" + Math.random(), r).catch(() => {})));
+        postMessage("done");
+    } catch (err) {
+        postMessage("error:" + err);
+    }
+};
+`;
+
+promise_test(async t => {
+    await caches.delete("opaque-response-race");
+    const cache = await caches.open("opaque-response-race");
+
+    const url = URL.createObjectURL(new Blob([workerSrc], { type: "application/javascript" }));
+    t.add_cleanup(() => URL.revokeObjectURL(url));
+    const workers = [];
+    const workerDone = [];
+    for (let i = 0; i < NUM_WORKERS; i++) {
+        const w = new Worker(url);
+        workers.push(w);
+        workerDone.push(new Promise((resolve, reject) => {
+            w.onmessage = (e) => e.data === "done" ? resolve() : reject(new Error(e.data));
+            w.onerror = (e) => reject(new Error(e.message));
+        }));
+    }
+
+    for (const worker of workers)
+        worker.postMessage("go");
+
+    const mainResponses = await Promise.all(
+        Array.from({length: PUTS_PER_THREAD}, (_, i) =>
+            fetch(REMOTE + "?m=" + i + "-" + Math.random(), { mode: "no-cors", cache: "no-store" })));
+    const mainPuts = mainResponses.map((r, i) =>
+        cache.put("https://example.com/m-" + i + "-" + Math.random(), r).catch(() => {}));
+
+    await Promise.all([...mainPuts, ...workerDone]);
+
+    for (const worker of workers)
+        worker.terminate();
+    await caches.delete("opaque-response-race");
+}, "Concurrent cache.put of opaque responses from main thread and Workers must not crash WebContent");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
@@ -64,15 +64,22 @@ uint64_t CacheStorageConnection::computeRecordBodySize(const FetchResponse& resp
         return computeRealBodySize(body);
     }
 
-    return m_opaqueResponseToSizeWithPaddingMap.ensure(response.opaqueLoadIdentifier(), [&] () {
-        uint64_t realSize = computeRealBodySize(body);
+    {
+        Locker lock { m_opaqueResponseToSizeWithPaddingMapLock };
+        auto iterator = m_opaqueResponseToSizeWithPaddingMap.find(response.opaqueLoadIdentifier());
+        if (iterator != m_opaqueResponseToSizeWithPaddingMap.end())
+            return iterator->value;
+    }
 
-        // Padding the size as per https://github.com/whatwg/storage/issues/31.
-        uint64_t sizeWithPadding = realSize + static_cast<uint64_t>(cryptographicallyRandomUnitInterval() * 128000);
-        sizeWithPadding = ((sizeWithPadding / 32000) + 1) * 32000;
+    // We compute the size outside of the lock as form data size computation may hop to main thread.
+    uint64_t realSize = computeRealBodySize(body);
 
-        return sizeWithPadding;
-    }).iterator->value;
+    // Padding the size as per https://github.com/whatwg/storage/issues/31.
+    uint64_t sizeWithPadding = realSize + static_cast<uint64_t>(cryptographicallyRandomUnitInterval() * 128000);
+    sizeWithPadding = ((sizeWithPadding / 32000) + 1) * 32000;
+
+    Locker lock { m_opaqueResponseToSizeWithPaddingMapLock };
+    return m_opaqueResponseToSizeWithPaddingMap.add(response.opaqueLoadIdentifier(), sizeWithPadding).iterator->value;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.h
@@ -30,6 +30,7 @@
 #include <WebCore/RetrieveRecordsOptions.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/Lock.h>
 #include <wtf/NativePromise.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -70,10 +71,11 @@ public:
     virtual void updateQuotaBasedOnSpaceUsage(const ClientOrigin&) { }
 
 private:
-    uint64_t computeRealBodySize(const DOMCacheEngine::ResponseBody&);
+    uint64_t computeRealBodySize(const DOMCacheEngine::ResponseBody&) WTF_EXCLUDES_LOCK(m_opaqueResponseToSizeWithPaddingMapLock);
 
 protected:
-    HashMap<uint64_t, uint64_t> m_opaqueResponseToSizeWithPaddingMap;
+    Lock m_opaqueResponseToSizeWithPaddingMapLock;
+    HashMap<uint64_t, uint64_t> m_opaqueResponseToSizeWithPaddingMap WTF_GUARDED_BY_LOCK(m_opaqueResponseToSizeWithPaddingMapLock);
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 46c2bf82724f1f430d6558b43069a5f63ec340a7
<pre>
Cherry-pick 305413.1001@safari-7624.5-branch (4c69ed8ad988). <a href="https://bugs.webkit.org/show_bug.cgi?id=317270">https://bugs.webkit.org/show_bug.cgi?id=317270</a>

    Unsynchronized cross-thread access to m_opaqueResponseToSizeWithPaddingMap in CacheStorageConnection::computeRecordBodySize
    <a href="https://rdar.apple.com/177953125">rdar://177953125</a>

    Reviewed by Chris Dumez.

    We add a lock and the related lock assertions to prevent unlocked access to the map.
    Given the potential locking that may happen for form data size computation, we make sure to compute the response real size outside of the lock.

    Test: http/wpt/cache-storage/cache-put-opaque-response-race.html

    * LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race-expected.txt: Added.
    * LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race.html: Added.
    * Source/WebCore/Modules/cache/CacheStorageConnection.cpp:
    (WebCore::CacheStorageConnection::computeRecordBodySize):
    * Source/WebCore/Modules/cache/CacheStorageConnection.h:

    Identifier: 305413.1001@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1106@webkitglib/2.52">https://commits.webkit.org/305877.1106@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bed8e912ed87efba462bdad923f68fd9ee549f1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181831 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/55778 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/49581 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192056 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146160 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183693 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/57092 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55499 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141949 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146160 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184786 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/57092 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/49581 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122385 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/57092 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/55499 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/49581 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/57092 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49581 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3218 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/48409 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/55499 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193983 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/55448 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/49581 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151362 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/56137 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/49581 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151067 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27615 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/56137 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/128420 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/124179 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/54650 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/49581 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/54032 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/54271 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/54097 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->