### PR TITLE
Remove non-standard Blend node from Style::Calculation tree

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcOperator.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperator.cpp
@@ -66,7 +66,6 @@ TextStream& operator<<(TextStream& ts, Operator op)
     case Operator::ProgressNoClamp: ts << "progress(no-clamp)"_s; break;
     case Operator::Random: ts << "random"_s; break;
     case Operator::CalcMix: ts << "calc-mix"_s; break;
-    case Operator::Blend: ts << "blend"_s; break;
     }
     return ts;
 }

--- a/Source/WebCore/css/calc/CSSCalcOperator.h
+++ b/Source/WebCore/css/calc/CSSCalcOperator.h
@@ -64,7 +64,6 @@ enum class Operator : uint8_t {
     ProgressNoClamp,
     Random,
     CalcMix,
-    Blend,
 };
 
 TextStream& operator<<(TextStream&, Operator);

--- a/Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp
@@ -66,7 +66,6 @@ static auto toCSS(const Child&, const ToCSSConversionOptions&) -> CSSCalc::Child
 static auto toCSS(const Number&, const ToCSSConversionOptions&) -> CSSCalc::Child;
 static auto toCSS(const Percentage&, const ToCSSConversionOptions&) -> CSSCalc::Child;
 static auto toCSS(const Dimension&, const ToCSSConversionOptions&) -> CSSCalc::Child;
-static auto toCSS(const IndirectNode<Blend>&, const ToCSSConversionOptions&) -> CSSCalc::Child;
 template<typename CalculationOp> auto toCSS(const IndirectNode<CalculationOp>&, const ToCSSConversionOptions&) -> CSSCalc::Child;
 
 static auto toStyle(const CSSCalc::Random::Sharing&, const ToStyleConversionOptions&) -> Random::Fixed;
@@ -171,35 +170,6 @@ CSSCalc::Child toCSS(const Percentage& percentage, const ToCSSConversionOptions&
 CSSCalc::Child toCSS(const Dimension& root, const ToCSSConversionOptions& options)
 {
     return CSSCalc::makeChild(CSSCalc::CanonicalDimension { .value = root.value, .dimension = options.canonicalDimension });
-}
-
-CSSCalc::Child toCSS(const IndirectNode<Blend>& root, const ToCSSConversionOptions& options)
-{
-    // FIXME: (http://webkit.org/b/122036) Create a CSSCalc::Tree equivalent of Blend.
-
-    auto createBlendHalf = [](const auto& child, const auto& options, auto progress) -> CSSCalc::Child {
-        auto product = multiply(
-            toCSS(child, options),
-            CSSCalc::makeChild(CSSCalc::Number { .value = progress })
-        );
-
-        if (auto replacement = CSSCalc::simplify(product, options.simplification))
-            return WTF::move(*replacement);
-
-        auto type = toType(product);
-        return CSSCalc::makeChild(WTF::move(product), *type);
-    };
-
-    auto sum = add(
-        createBlendHalf(root->from, options, 1 - root->progress),
-        createBlendHalf(root->to, options, root->progress)
-    );
-
-    if (auto replacement = simplify(sum, options.simplification))
-        return WTF::move(*replacement);
-
-    auto type = CSSCalc::toType(sum);
-    return CSSCalc::makeChild(WTF::move(sum), *type);
 }
 
 template<typename CalculationOp> CSSCalc::Child toCSS(const IndirectNode<CalculationOp>& root, const ToCSSConversionOptions& options)

--- a/Source/WebCore/style/calc/StyleCalculationTree+Copy.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree+Copy.cpp
@@ -32,7 +32,6 @@ namespace WebCore {
 namespace Style {
 namespace Calculation {
 
-static auto copy(double) -> double;
 static auto copy(const std::optional<Child>& root) -> std::optional<Child>;
 static auto copy(const Random::Fixed&) -> Random::Fixed;
 static auto copy(const CSS::Keyword::None&) -> CSS::Keyword::None;
@@ -51,11 +50,6 @@ static auto copy(const IndirectNode<Op>&) -> Child;
 Tree copy(const Tree& tree)
 {
     return Tree { .root = copy(tree.root) };
-}
-
-double copy(double value)
-{
-    return value;
 }
 
 std::optional<Child> copy(const std::optional<Child>& root)

--- a/Source/WebCore/style/calc/StyleCalculationTree+Evaluation.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree+Evaluation.cpp
@@ -48,7 +48,6 @@ static auto evaluate(const IndirectNode<Max>&, double percentResolutionLength, c
 static auto evaluate(const IndirectNode<Hypot>&, double percentResolutionLength, const ZoomFactor&) -> double;
 static auto evaluate(const IndirectNode<Random>&, double percentResolutionLength, const ZoomFactor&) -> double;
 static auto evaluate(const IndirectNode<CalcMix>&, double percentResolutionLength, const ZoomFactor&) -> double;
-static auto evaluate(const IndirectNode<Blend>&, double percentResolutionLength, const ZoomFactor&) -> double;
 template<typename Op>
 static auto evaluate(const IndirectNode<Op>&, double percentResolutionLength, const ZoomFactor&) -> double;
 
@@ -149,11 +148,6 @@ double evaluate(const IndirectNode<CalcMix>& root, double percentResolutionLengt
     return executeMathOperation<CalcMix>(root->children, [&](const auto& item) -> std::pair<double, double> {
         return { evaluate(item.value, percentResolutionLength, usedZoom), item.weight };
     });
-}
-
-double evaluate(const IndirectNode<Blend>& root, double percentResolutionLength, const ZoomFactor& usedZoom)
-{
-    return (1.0 - root->progress) * evaluate(root->from, percentResolutionLength, usedZoom) + root->progress * evaluate(root->to, percentResolutionLength, usedZoom);
 }
 
 template<typename Op> double evaluate(const IndirectNode<Op>& root, double percentResolutionLength, const ZoomFactor& usedZoom)

--- a/Source/WebCore/style/calc/StyleCalculationTree.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree.cpp
@@ -39,7 +39,6 @@ WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Acos);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Asin);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Atan);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Atan2);
-WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Blend);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(CalcMix);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Clamp);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Cos);
@@ -203,7 +202,10 @@ Child subtract(Child&& a, Child&& b)
 
 Child blend(Child&& from, Child&& to, double progress)
 {
-    return makeChild(Blend { .progress = progress, .from = WTF::move(from), .to = WTF::move(to) });
+    return add(
+        multiply(WTF::move(from), number(1 - progress)),
+        multiply(WTF::move(to), number(progress))
+    );
 }
 
 static size_t computeDepth(const Child& root)

--- a/Source/WebCore/style/calc/StyleCalculationTree.h
+++ b/Source/WebCore/style/calc/StyleCalculationTree.h
@@ -76,9 +76,6 @@ struct ProgressNoClamp;
 struct Random;
 struct CalcMix;
 
-// Non-standard
-struct Blend;
-
 template<typename Op>
 concept Leaf = requires(Op) {
     Op::isLeaf == true;
@@ -165,8 +162,7 @@ using Node = Variant<
     IndirectNode<Progress>,
     IndirectNode<ProgressNoClamp>,
     IndirectNode<Random>,
-    IndirectNode<CalcMix>,
-    IndirectNode<Blend>
+    IndirectNode<CalcMix>
 >;
 
 struct Child {
@@ -560,18 +556,6 @@ struct CalcMix {
     bool operator==(const CalcMix&) const = default;
 };
 
-// Non-standard
-struct Blend {
-    WTF_MAKE_STRUCT_TZONE_ALLOCATED(Blend);
-    static constexpr auto op = CSSCalc::Operator::Blend;
-
-    double progress;
-    Child from;
-    Child to;
-
-    bool operator==(const Blend&) const = default;
-};
-
 // MARK: Construction
 
 // Default implementation of ChildConstruction used for all indirect nodes.
@@ -829,16 +813,6 @@ template<size_t I> const auto& get(const CalcMix& root)
     return root.children;
 }
 
-template<size_t I> const auto& get(const Blend& root)
-{
-    if constexpr (!I)
-        return root.progress;
-    else if constexpr (I == 1)
-        return root.from;
-    else if constexpr (I == 2)
-        return root.to;
-}
-
 // MARK: Child Definition
 
 template<typename T>
@@ -893,7 +867,6 @@ OP_TUPLE_LIKE_CONFORMANCE(Progress, 3);
 OP_TUPLE_LIKE_CONFORMANCE(ProgressNoClamp, 3);
 OP_TUPLE_LIKE_CONFORMANCE(Random, 4);
 OP_TUPLE_LIKE_CONFORMANCE(CalcMix, 1);
-OP_TUPLE_LIKE_CONFORMANCE(Blend, 3);
 
 #undef OP_TUPLE_LIKE_CONFORMANCE
 


### PR DESCRIPTION
#### 0d599a87fc423ce58ec92d1b77326b6ce96007c6
<pre>
Remove non-standard Blend node from Style::Calculation tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=322209">https://bugs.webkit.org/show_bug.cgi?id=322209</a>

Reviewed by Alan Baradlay.

Remove non-standard Blend node from Style::Calculation tree. The standard
nodes can be used just as well.

* Source/WebCore/css/calc/CSSCalcOperator.cpp:
* Source/WebCore/css/calc/CSSCalcOperator.h:
* Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp:
* Source/WebCore/style/calc/StyleCalculationTree+Copy.cpp:
* Source/WebCore/style/calc/StyleCalculationTree+Evaluation.cpp:
* Source/WebCore/style/calc/StyleCalculationTree.cpp:
* Source/WebCore/style/calc/StyleCalculationTree.h:

Canonical link: <a href="https://commits.webkit.org/319604@main">https://commits.webkit.org/319604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88efc0b9d0b0ae65d8d0742dab8428820acbfc3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192139 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146243 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142019 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162752 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44383 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42651 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42278 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3303 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194066 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55531 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151433 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40564 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56220 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151139 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45704 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128503 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124265 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54734 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17274 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54115 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->