### PR TITLE
corner-shape: offset-path does not respect corner-shape

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-001-expected.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test reference: &lt;coord-box&gt; &lt;border-box&gt; follows 'corner-shape: bevel'</title>
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  border-radius: 105px;
+  corner-shape: bevel;
+  border: 10px solid black;
+  width: 400px;
+  height: 400px;
+}
+#box {
+  background-color: green;
+  border-radius: 50%;
+  top: 100px;
+  left: 100px;
+  position: relative;
+  transform: translate(200px, -115px);
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-001-ref.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test reference: &lt;coord-box&gt; &lt;border-box&gt; follows 'corner-shape: bevel'</title>
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  border-radius: 105px;
+  corner-shape: bevel;
+  border: 10px solid black;
+  width: 400px;
+  height: 400px;
+}
+#box {
+  background-color: green;
+  border-radius: 50%;
+  top: 100px;
+  left: 100px;
+  position: relative;
+  transform: translate(200px, -115px);
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-001.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test: &lt;coord-box&gt; &lt;border-box&gt; follows 'corner-shape: bevel'</title>
+<link rel="match" href="corner-shape-offset-path-coord-box-001-ref.html">
+<link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-coord-box">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
+<meta name="assert" content="A <coord-box> offset-path follows the corner-shape contour, so a distance that lands inside a corner puts the box on the bevel's chord rather than on an arc.">
+<meta name="fuzzy" content="maxDifference=0-8; totalPixels=0-16">
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  border-radius: 105px;
+  corner-shape: bevel;
+  border: 10px solid black;
+  width: 400px;
+  height: 400px;
+}
+#box {
+  background-color: green;
+  border-radius: 50%;
+  top: 100px;
+  left: 100px;
+  position: relative;
+  offset-path: border-box;
+  offset-distance: 273.63961px;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-002-expected.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test reference: &lt;coord-box&gt; &lt;border-box&gt; follows 'corner-shape: notch'</title>
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  border-radius: 105px;
+  corner-shape: notch;
+  border: 10px solid black;
+  width: 400px;
+  height: 400px;
+}
+#box {
+  background-color: green;
+  border-radius: 50%;
+  top: 100px;
+  left: 100px;
+  position: relative;
+  transform: translate(207px, -55px);
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-002-ref.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test reference: &lt;coord-box&gt; &lt;border-box&gt; follows 'corner-shape: notch'</title>
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  border-radius: 105px;
+  corner-shape: notch;
+  border: 10px solid black;
+  width: 400px;
+  height: 400px;
+}
+#box {
+  background-color: green;
+  border-radius: 50%;
+  top: 100px;
+  left: 100px;
+  position: relative;
+  transform: translate(207px, -55px);
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-002.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test: &lt;coord-box&gt; &lt;border-box&gt; follows 'corner-shape: notch'</title>
+<link rel="match" href="corner-shape-offset-path-coord-box-002-ref.html">
+<link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-coord-box">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
+<meta name="assert" content="A notch corner contributes both of its straight legs to the <coord-box> offset path, so a distance past the first leg puts the box on the leg running back out to the edge.">
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  border-radius: 105px;
+  corner-shape: notch;
+  border: 10px solid black;
+  width: 400px;
+  height: 400px;
+}
+#box {
+  background-color: green;
+  border-radius: 50%;
+  top: 100px;
+  left: 100px;
+  position: relative;
+  offset-path: border-box;
+  offset-distance: 367px;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/Source/WebCore/platform/animation/values/paths/AcceleratedEffectBoxPath.cpp
+++ b/Source/WebCore/platform/animation/values/paths/AcceleratedEffectBoxPath.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(THREADED_ANIMATIONS)
 
 #include "AnimationUtilities.h"
+#include "BorderShape.h"
 #include "Path.h"
 #include "TransformOperationData.h"
 
@@ -39,6 +40,9 @@ namespace WebCore {
 std::optional<WebCore::Path> tryPath(const AcceleratedEffectBoxPath&, const TransformOperationData& data)
 {
     if (auto motionPathData = data.motionPathData) {
+        if (auto shaped = BorderShape::pathForShapedRect(motionPathData->offsetRect(), motionPathData->cornerCurvatures))
+            return shaped;
+
         WebCore::Path result;
         result.addRoundedRect(motionPathData->offsetRect(), PathRoundedRect::Strategy::PreferBezier);
         return result;

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -605,12 +605,18 @@ static void addMorphedOutsetCorner(Path& path, const CornerInput& input, float d
 } // namespace
 
 // https://drafts.csswg.org/css-borders-4/#contour-path
-void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, const FloatRect* targetRect, OutsetMiter outsetMiter, float deviceScaleFactor)
+void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, const FloatRect* targetRect, OutsetMiter outsetMiter, float deviceScaleFactor, ContourStart contourStart)
 {
     RectCorners<Corner> corners;
     buildCorners(corners, cornerRects);
 
     bool started = false;
+
+    if (contourStart == ContourStart::TopEdge) {
+        path.moveTo(corners[BoxCorner::TopLeft].end);
+        started = true;
+    }
+
     for (auto key : { BoxCorner::TopRight, BoxCorner::BottomRight, BoxCorner::BottomLeft, BoxCorner::TopLeft }) {
         const auto& corner = corners[key];
         double startInset = cornerRects[key].startInset;

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.h
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.h
@@ -43,9 +43,10 @@ struct CornerInput {
 };
 
 enum class OutsetMiter : bool { No, Yes };
+enum class ContourStart : bool { FirstCorner, TopEdge };
 
 // https://drafts.csswg.org/css-borders-4/#contour-path
-void borderContourPath(Path&, const RectCorners<CornerInput>&, const FloatRect* targetRect = nullptr, OutsetMiter = OutsetMiter::No, float deviceScaleFactor = 1.0f);
+void borderContourPath(Path&, const RectCorners<CornerInput>&, const FloatRect* targetRect = nullptr, OutsetMiter = OutsetMiter::No, float deviceScaleFactor = 1.0f, ContourStart = ContourStart::FirstCorner);
 
 // https://drafts.csswg.org/css-borders-4/#corner-shape-constrain-radii
 double oppositeCornerScaleFactor(const RectCorners<CornerInput>&);

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -442,6 +442,26 @@ static void addOuterCornerShapeToPath(Path& path, const FloatRoundedRect& outerS
     borderContourPath(path, cornerRects);
 }
 
+std::optional<Path> BorderShape::pathForShapedRect(const FloatRoundedRect& roundedRect, const RectCorners<float>& cornerCurvatures)
+{
+    auto& radii = roundedRect.radii();
+    auto isRound = [](float curvature, const FloatSize& radius) {
+        return curvature == 1.0f || radius.isEmpty();
+    };
+    if (isRound(cornerCurvatures.topLeft(), radii.topLeft())
+        && isRound(cornerCurvatures.topRight(), radii.topRight())
+        && isRound(cornerCurvatures.bottomLeft(), radii.bottomLeft())
+        && isRound(cornerCurvatures.bottomRight(), radii.bottomRight()))
+        return std::nullopt;
+
+    RectCorners<CornerInput> cornerRects;
+    buildCornerInputs(roundedRect, cornerCurvatures, 0, 0, 0, 0, cornerRects);
+
+    Path path;
+    borderContourPath(path, cornerRects, nullptr, OutsetMiter::No, 1.0f, ContourStart::TopEdge);
+    return path;
+}
+
 Path BorderShape::pathForOuterCornerShape(const FloatRoundedRect& outerSnapped, const std::optional<FloatRoundedRect>& snappedOffsetReference) const
 {
     Path path;

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -87,6 +87,8 @@ public:
 
     bool shapeIntersectsHitTestLocation(const HitTestLocation&, float deviceScaleFactor) const;
 
+    static std::optional<Path> pathForShapedRect(const FloatRoundedRect&, const RectCorners<float>& cornerCurvatures);
+
     // Returns true if no corner regions of the outer border intersect the given rect,
     // meaning border painting can use simpler rectangular paths.
     bool allCornersClippedOut(const LayoutRect&) const;

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -113,6 +113,7 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
 
     MotionPathData data;
     data.containingBlockBoundingRect = containingBlockRectForRenderer(renderer, *container, offsetPath);
+    data.cornerCurvatures = BorderShape::shapeForBorderRect(container->style(), container->borderBoxRect()).cornerCurvatures();
     data.offsetFromContainingBlock = offsetFromContainer(renderer, *container, data.containingBlockBoundingRect.rect());
 
     auto zoom = renderer.style().usedZoomForLength();

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/FloatRoundedRect.h>
+#include <WebCore/RectCorners.h>
 #include <WebCore/RenderLayerModelObject.h>
 
 namespace WebCore {
@@ -46,6 +47,7 @@ struct MotionPathData {
     FloatRoundedRect containingBlockBoundingRect;
     FloatPoint offsetFromContainingBlock;
     FloatPoint usedStartingPosition;
+    RectCorners<float> cornerCurvatures { 1.0f, 1.0f, 1.0f, 1.0f };
 
     FloatPoint NODELETE currentOffset() const;
     FloatRoundedRect NODELETE offsetRect() const;

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -27,6 +27,7 @@
 #include "PathOperation.h"
 
 #include "AnimationUtilities.h"
+#include "BorderShape.h"
 #include "CSSRayValue.h"
 #include "SVGElement.h"
 #include "SVGElementTypeHelpers.h"
@@ -138,6 +139,9 @@ Ref<PathOperation> BoxPathOperation::clone() const
 std::optional<Path> BoxPathOperation::getPath(const TransformOperationData& data, Style::ZoomFactor) const
 {
     if (auto motionPathData = data.motionPathData) {
+        if (auto shaped = BorderShape::pathForShapedRect(motionPathData->offsetRect(), motionPathData->cornerCurvatures))
+            return shaped;
+
         Path path;
         path.addRoundedRect(motionPathData->offsetRect(), PathRoundedRect::Strategy::PreferBezier);
         return path;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1053,6 +1053,14 @@ header: <WebCore/RectEdges.h>
     bool left();
 }
 
+header: <WebCore/RectCorners.h>
+[CustomHeader] class WebCore::RectCorners<float> {
+    float topLeft();
+    float topRight();
+    float bottomLeft();
+    float bottomRight();
+}
+
 [CustomHeader] class WebCore::RectEdges<WebCore::Color> {
     WebCore::Color top();
     WebCore::Color right();
@@ -2079,6 +2087,7 @@ header: <WebCore/MotionPath.h>
     WebCore::FloatRoundedRect containingBlockBoundingRect;
     WebCore::FloatPoint offsetFromContainingBlock;
     WebCore::FloatPoint usedStartingPosition;
+    WebCore::RectCorners<float> cornerCurvatures;
 };
 
 header: <WebCore/TransformOperationData.h>


### PR DESCRIPTION
#### 5278e92549a1635a7387a4cd9566b2d2af211e11
<pre>
corner-shape: offset-path does not respect corner-shape
<a href="https://bugs.webkit.org/show_bug.cgi?id=322210">https://bugs.webkit.org/show_bug.cgi?id=322210</a>
<a href="https://rdar.apple.com/185447602">rdar://185447602</a>

Reviewed by Simon Fraser.

Thread the reference box&apos;s corner curvatures through MotionPathData so the
&lt;coord-box&gt; path can be built from the corner-shape contour, falling back
to the rounded rect when every corner is round.

* Source/WebCore/platform/animation/values/paths/AcceleratedEffectBoxPath.cpp:
(WebCore::tryPath):
* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:
(WebCore::borderContourPath):
* Source/WebCore/platform/graphics/CornerShapeUtilities.h:
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::pathForShapedRect):
* Source/WebCore/rendering/BorderShape.h:
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::MotionPath::motionPathDataForRenderer):
* Source/WebCore/rendering/MotionPath.h:
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::BoxPathOperation::getPath const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-offset-path-coord-box-002.html: Added.

Canonical link: <a href="https://commits.webkit.org/319655@main">https://commits.webkit.org/319655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d7bfce5ad3f25d5374d279bc773dd213c8a27df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49752 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192226 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146330 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55671 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/192226 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162837 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/192226 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42731 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/192226 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154867 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42362 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3391 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194154 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55619 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151514 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56310 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151218 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27675 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45789 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128592 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124411 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54821 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17357 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54441 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->