### PR TITLE
[Text Extraction] Fix maxTouchPoints, touch-related bindings, and screen size when emulating desktop-class content

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8248,6 +8248,25 @@ ShouldPrintBackgrounds:
     WebCore:
       default: false
 
+ShouldReportViewportSizeAsScreenSize:
+  type: bool
+  status: embedder
+  humanReadableName: "Report Viewport Size As Screen Size"
+  humanReadableDescription: "Report the viewport size instead of the real screen size"
+  defaultValue:
+    WebCore:
+      default: false
+
+ShouldReportZeroMaxTouchPoints:
+  type: bool
+  status: embedder
+  humanReadableName: "Report Zero Max Touch Points"
+  humanReadableDescription: "Report navigator.maxTouchPoints as 0"
+  condition: ENABLE(IOS_TOUCH_EVENTS)
+  defaultValue:
+    WebCore:
+      default: false
+
 ShouldRespectImageOrientation:
   type: bool
   status: embedder

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1203,6 +1203,18 @@ FloatSize LocalFrame::screenSize() const
         return m_overrideScreenSize->size;
 
     auto defaultSize = screenRect(protect(view()).get()).size();
+
+    if (settings().shouldReportViewportSizeAsScreenSize()) {
+        if (RefPtr view = this->view()) {
+            auto unobscuredSize = view->unobscuredContentRectIncludingScrollbars().size();
+            return {
+                static_cast<float>(view->mapFromLayoutToCSSUnits(unobscuredSize.width())),
+                static_cast<float>(view->mapFromLayoutToCSSUnits(unobscuredSize.height()))
+            };
+        }
+        return defaultSize;
+    }
+
     RefPtr document = this->document();
     if (!document)
         return defaultSize;

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -457,11 +457,13 @@ int Navigator::maxTouchPoints() const
 {
 #if ENABLE(IOS_TOUCH_EVENTS) && !PLATFORM(MACCATALYST)
     RefPtr document = this->document();
-    if (!document || !document->quirks().needsZeroMaxTouchPointsQuirk())
-        return 5;
-#endif
+    if (document && (document->quirks().needsZeroMaxTouchPointsQuirk() || document->settings().shouldReportZeroMaxTouchPoints()))
+        return 0;
 
+    return 5;
+#else
     return 0;
+#endif
 }
 
 NavigatorUAData& Navigator::userAgentData() const

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -75,6 +75,11 @@ static bool shouldFlipScreenDimensions(const LocalFrame& frame)
     return document && document->quirks().shouldFlipScreenDimensions();
 }
 
+static bool shouldReportScreenSizeAsAvailableScreenSize(const LocalFrame& frame)
+{
+    return shouldApplyScreenFingerprintingProtections(frame) || frame.settings().shouldReportViewportSizeAsScreenSize();
+}
+
 int Screen::height() const
 {
     RefPtr frame = this->frame();
@@ -152,7 +157,7 @@ int Screen::availHeight() const
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::singleton().logScreenAPIAccessed(*protect(frame->document()), ScreenAPIsAccessed::AvailHeight);
 
-    if (shouldApplyScreenFingerprintingProtections(*frame))
+    if (shouldReportScreenSizeAsAvailableScreenSize(*frame))
         return static_cast<int>(frame->screenSize().height());
 
     return static_cast<int>(screenAvailableRect(protect(frame->view()).get()).height());
@@ -167,7 +172,7 @@ int Screen::availWidth() const
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::singleton().logScreenAPIAccessed(*protect(frame->document()), ScreenAPIsAccessed::AvailWidth);
 
-    if (shouldApplyScreenFingerprintingProtections(*frame))
+    if (shouldReportScreenSizeAsAvailableScreenSize(*frame))
         return static_cast<int>(frame->screenSize().width());
 
     return static_cast<int>(screenAvailableRect(protect(frame->view()).get()).width());

--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -110,6 +110,14 @@ void WebsitePoliciesData::applyToSettings(const WebsitePoliciesData& websitePoli
     if (auto overrideValue = websitePolicies.overrideTouchEventDOMAttributesEnabled)
         settings.setTouchEventDOMAttributesEnabled(*overrideValue);
 #endif
+
+#if ENABLE(IOS_TOUCH_EVENTS)
+    if (auto overrideValue = websitePolicies.overrideShouldReportZeroMaxTouchPoints)
+        settings.setShouldReportZeroMaxTouchPoints(*overrideValue);
+#endif
+
+    if (auto overrideValue = websitePolicies.overrideShouldReportViewportSizeAsScreenSize)
+        settings.setShouldReportViewportSizeAsScreenSize(*overrideValue);
 }
 
 void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePolicies, WebCore::DocumentLoader& documentLoader)
@@ -235,6 +243,14 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
     if (auto overrideValue = websitePolicies.overrideTouchEventDOMAttributesEnabled)
         frame->settings().setTouchEventDOMAttributesEnabled(*overrideValue);
 #endif
+
+#if ENABLE(IOS_TOUCH_EVENTS)
+    if (auto overrideValue = websitePolicies.overrideShouldReportZeroMaxTouchPoints)
+        frame->settings().setShouldReportZeroMaxTouchPoints(*overrideValue);
+#endif
+
+    if (auto overrideValue = websitePolicies.overrideShouldReportViewportSizeAsScreenSize)
+        frame->settings().setShouldReportViewportSizeAsScreenSize(*overrideValue);
 
     documentLoader.applyPoliciesToSettings();
 }

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -72,6 +72,10 @@ public:
 #if ENABLE(TOUCH_EVENTS)
     std::optional<bool> overrideTouchEventDOMAttributesEnabled;
 #endif
+#if ENABLE(IOS_TOUCH_EVENTS)
+    std::optional<bool> overrideShouldReportZeroMaxTouchPoints;
+#endif
+    std::optional<bool> overrideShouldReportViewportSizeAsScreenSize;
     std::optional<bool> globalPrivacyControlEnabled;
     WebsiteAutoplayPolicy autoplayPolicy { WebsiteAutoplayPolicy::Default };
     WebsitePopUpPolicy popUpPolicy { WebsitePopUpPolicy::Default };

--- a/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
+++ b/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
@@ -70,6 +70,10 @@ struct WebKit::WebsitePoliciesData {
 #if ENABLE(TOUCH_EVENTS)
     std::optional<bool> overrideTouchEventDOMAttributesEnabled;
 #endif
+#if ENABLE(IOS_TOUCH_EVENTS)
+    std::optional<bool> overrideShouldReportZeroMaxTouchPoints;
+#endif
+    std::optional<bool> overrideShouldReportViewportSizeAsScreenSize;
     std::optional<bool> globalPrivacyControlEnabled;
     WebKit::WebsiteAutoplayPolicy autoplayPolicy;
     WebKit::WebsitePopUpPolicy popUpPolicy;

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -156,6 +156,12 @@ public:
     void setOverrideTouchEventDOMAttributesEnabled(bool value) { m_data.overrideTouchEventDOMAttributesEnabled = value; }
 #endif
 
+#if ENABLE(IOS_TOUCH_EVENTS)
+    void setOverrideShouldReportZeroMaxTouchPoints(bool value) { m_data.overrideShouldReportZeroMaxTouchPoints = value; }
+#endif
+
+    void setOverrideShouldReportViewportSizeAsScreenSize(bool value) { m_data.overrideShouldReportViewportSizeAsScreenSize = value; }
+
     WebKit::WebsiteInlineMediaPlaybackPolicy inlineMediaPlaybackPolicy() const { return m_data.inlineMediaPlaybackPolicy; }
     void setInlineMediaPlaybackPolicy(WebKit::WebsiteInlineMediaPlaybackPolicy policy) { m_data.inlineMediaPlaybackPolicy = policy; }
 

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1573,12 +1573,26 @@ WebContentMode WebPageProxy::effectiveContentModeAfterAdjustingPolicies(API::Web
         policies.setCustomNavigatorPlatform("iPhone"_s);
     };
 
+    auto applyCapabilityPoliciesForContentMode = [&](WebContentMode contentMode) {
+        bool shouldEmulateDesktopClassHardware = contentMode == WebContentMode::Desktop && m_configuration->backgroundTextExtractionEnabled();
+#if ENABLE(TOUCH_EVENTS)
+        bool shouldOmitTouchEventDOMAttributes = shouldEmulateDesktopClassHardware
+            || (contentMode == WebContentMode::Desktop && needsSiteSpecificQuirks && Quirks::shouldOmitTouchEventDOMAttributesForDesktopWebsite(request.url()));
+        policies.setOverrideTouchEventDOMAttributesEnabled(!shouldOmitTouchEventDOMAttributes);
+#endif
+#if ENABLE(IOS_TOUCH_EVENTS)
+        policies.setOverrideShouldReportZeroMaxTouchPoints(shouldEmulateDesktopClassHardware);
+#endif
+        policies.setOverrideShouldReportViewportSizeAsScreenSize(shouldEmulateDesktopClassHardware && !desktopClassBrowsingSupported());
+    };
+
     if (needsSiteSpecificQuirks) {
         if (auto selectors = Quirks::defaultVisibilityAdjustmentSelectors(request.url()))
             policies.setVisibilityAdjustmentSelectors({ WTF::move(*selectors) });
 
         if (Quirks::needsIPhoneUserAgent(request.url())) {
             applyIPhoneUserAgent();
+            applyCapabilityPoliciesForContentMode(WebContentMode::Mobile);
             return WebContentMode::Mobile;
         }
     }
@@ -1589,6 +1603,7 @@ WebContentMode WebPageProxy::effectiveContentModeAfterAdjustingPolicies(API::Web
 
     if (!useDesktopBrowsingMode) {
         policies.setIdempotentModeAutosizingOnlyHonorsPercentages(true);
+        applyCapabilityPoliciesForContentMode(WebContentMode::Mobile);
         return WebContentMode::Mobile;
     }
 
@@ -1620,10 +1635,7 @@ WebContentMode WebPageProxy::effectiveContentModeAfterAdjustingPolicies(API::Web
         m_preferFasterClickOverDoubleTap = true;
     }
 
-#if ENABLE(TOUCH_EVENTS)
-    if (needsSiteSpecificQuirks && Quirks::shouldOmitTouchEventDOMAttributesForDesktopWebsite(request.url()))
-        policies.setOverrideTouchEventDOMAttributesEnabled(false);
-#endif
+    applyCapabilityPoliciesForContentMode(WebContentMode::Desktop);
 
     policies.setInlineMediaPlaybackPolicy(WebsiteInlineMediaPlaybackPolicy::DoesNotRequirePlaysInlineAttribute);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -3170,4 +3170,100 @@ TEST(TextExtractionTests, ExtractFromPDFLink)
 
 #endif // ENABLE(UNIFIED_PDF)
 
+#if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
+
+static RetainPtr<TestWKWebView> createWebViewForContentModeTesting(BOOL backgroundTextExtractionEnabled)
+{
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration _setBackgroundTextExtractionEnabled:backgroundTextExtractionEnabled];
+    return adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration]);
+}
+
+static void loadUsingContentMode(TestWKWebView *webView, WKContentMode contentMode)
+{
+    RetainPtr preferences = adoptNS([[WKWebpagePreferences alloc] init]);
+    [preferences setPreferredContentMode:contentMode];
+    [webView synchronouslyLoadHTMLString:@"<body>Hello world</body>" preferences:preferences];
+}
+
+static int intByEvaluatingJavaScript(TestWKWebView *webView, NSString *script)
+{
+    return [[webView objectByEvaluatingJavaScript:script] intValue];
+}
+
+#if ENABLE(TOUCH_EVENTS)
+
+static bool touchEventDOMAttributesAreExposed(TestWKWebView *webView)
+{
+    return [[webView objectByEvaluatingJavaScript:@"'ontouchstart' in window"] boolValue];
+}
+
+#endif
+
+static bool isSmallScreenDevice()
+{
+    return UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone;
+}
+
+static void expectDesktopClassHardwareEmulation(TestWKWebView *webView)
+{
+#if ENABLE(IOS_TOUCH_EVENTS)
+    EXPECT_EQ(0, intByEvaluatingJavaScript(webView, @"navigator.maxTouchPoints"));
+#endif
+#if ENABLE(TOUCH_EVENTS)
+    EXPECT_FALSE(touchEventDOMAttributesAreExposed(webView));
+#endif
+
+    if (!isSmallScreenDevice())
+        return;
+
+    int innerWidth = intByEvaluatingJavaScript(webView, @"innerWidth");
+    int innerHeight = intByEvaluatingJavaScript(webView, @"innerHeight");
+    EXPECT_EQ(innerWidth, intByEvaluatingJavaScript(webView, @"screen.width"));
+    EXPECT_EQ(innerHeight, intByEvaluatingJavaScript(webView, @"screen.height"));
+    EXPECT_EQ(innerWidth, intByEvaluatingJavaScript(webView, @"screen.availWidth"));
+    EXPECT_EQ(innerHeight, intByEvaluatingJavaScript(webView, @"screen.availHeight"));
+}
+
+static void expectNoDesktopClassHardwareEmulation(TestWKWebView *webView)
+{
+#if ENABLE(IOS_TOUCH_EVENTS)
+    EXPECT_EQ(5, intByEvaluatingJavaScript(webView, @"navigator.maxTouchPoints"));
+#endif
+#if ENABLE(TOUCH_EVENTS)
+    EXPECT_TRUE(touchEventDOMAttributesAreExposed(webView));
+#endif
+
+    if (!isSmallScreenDevice())
+        return;
+
+    int innerWidth = intByEvaluatingJavaScript(webView, @"innerWidth");
+    EXPECT_NE(innerWidth, intByEvaluatingJavaScript(webView, @"screen.width"));
+}
+
+TEST(TextExtractionTests, DesktopClassHardwareEmulationInDesktopContentMode)
+{
+    RetainPtr webView = createWebViewForContentModeTesting(YES);
+    {
+        loadUsingContentMode(webView, WKContentModeDesktop);
+        expectDesktopClassHardwareEmulation(webView);
+    }
+    {
+        loadUsingContentMode(webView, WKContentModeMobile);
+        expectNoDesktopClassHardwareEmulation(webView);
+    }
+    {
+        RetainPtr mobileWebView = createWebViewForContentModeTesting(YES);
+        loadUsingContentMode(mobileWebView, WKContentModeMobile);
+        expectNoDesktopClassHardwareEmulation(mobileWebView);
+    }
+    {
+        RetainPtr webViewWithoutTextExtraction = createWebViewForContentModeTesting(NO);
+        loadUsingContentMode(webViewWithoutTextExtraction, WKContentModeDesktop);
+        expectNoDesktopClassHardwareEmulation(webViewWithoutTextExtraction);
+    }
+}
+
+#endif // PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 94f879afe62d38e10d67527e7831a194d568438e
<pre>
[Text Extraction] Fix maxTouchPoints, touch-related bindings, and screen size when emulating desktop-class content
<a href="https://bugs.webkit.org/show_bug.cgi?id=322188">https://bugs.webkit.org/show_bug.cgi?id=322188</a>
<a href="https://rdar.apple.com/185245461">rdar://185245461</a>

Reviewed by Abrar Rahman Protyasha.

Make several adjustments to DOM-exposed APIs, in the case where both (1) background text extraction
is enabled, and (2) the requested content mode is `desktop`-class:

• Make `maxTouchPoints` report `0`.
• Hide TouchEvent-related bindings from JavaScript.
• Fix the screen dimensions (`screen.{width|height}`) to `window.inner{Width|Height}`.

...to ensure that websites loaded in this configuration on iPhone behave more similarly to Mac.

Test: TextExtractionTests.DesktopClassHardwareEmulationInDesktopContentMode

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::screenSize const):
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::maxTouchPoints const):
* Source/WebCore/page/Screen.cpp:
(WebCore::shouldReportScreenSizeAsAvailableScreenSize):
(WebCore::Screen::availHeight const):
(WebCore::Screen::availWidth const):
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::applyToSettings):
(WebKit::WebsitePoliciesData::applyToDocumentLoader):
* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/Shared/WebsitePoliciesData.serialization.in:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::effectiveContentModeAfterAdjustingPolicies):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::(TextExtractionTests, DesktopClassHardwareEmulationInDesktopContentMode)):

Canonical link: <a href="https://commits.webkit.org/319566@main">https://commits.webkit.org/319566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a538f3103808baeace34ef82263ceb84de4bb04c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146220 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1098b862-2a56-4027-a478-e70cc70dd78d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142001 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb23b77f-88f7-4ed4-ac3d-41e900f65871) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45685 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122437 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44370 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4404 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11208 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154767 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42266 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3282 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43170 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194043 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55508 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151412 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40538 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56197 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151118 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45688 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128480 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124242 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54710 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17262 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54092 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54331 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54157 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->