### PR TITLE
[JSC] Fix BBQ i64.mul_wide register assignment in x64

### DIFF
--- a/JSTests/wasm/stress/bbq-mul-wide-register-pressure.js
+++ b/JSTests/wasm/stress/bbq-mul-wide-register-pressure.js
@@ -1,0 +1,77 @@
+//@ requireOptions("--useWasmWideArithmetic=1", "--useBBQJIT=1", "--useOMGJIT=0", "--thresholdForBBQOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeSoon=0")
+import * as assert from '../assert.js';
+
+// Test that i64.mul_wide_u and i64.mul_wide_s produce correct results in the
+// BBQ JIT under register pressure. On x86_64, the mul instruction produces
+// results in rdx:rax. If the register allocator assigns resultLo to rdx and
+// resultHi to rax, the move sequence must not destroy the low half.
+// This function sets 6 live locals before mul_wide to force the allocator
+// toward using eax/edx for the results.
+
+const bytes = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+
+    // type section: (i64, i64) -> (i64, i64)
+    0x01, 0x08, 0x01,
+    0x60, 0x02, 0x7e, 0x7e, 0x02, 0x7e, 0x7e,
+
+    // function section
+    0x03, 0x02, 0x01, 0x00,
+
+    // export section: "mul_wide_u_pressure" -> func 0
+    0x07, 0x17, 0x01,
+    0x13, 0x6d, 0x75, 0x6c, 0x5f, 0x77, 0x69, 0x64, 0x65, 0x5f, 0x75, 0x5f, 0x70, 0x72, 0x65, 0x73, 0x73, 0x75, 0x72, 0x65,
+    0x00, 0x00,
+
+    // code section
+    0x0a, 0x48, 0x01,
+    0x46,                     // body size = 70
+    0x01, 0x06, 0x7e,         // 1 local decl group: 6 i64 locals (indices 2-7)
+    0x20, 0x00, 0x42, 0x01, 0x7c, 0x21, 0x02,   // l2 = a + 1
+    0x20, 0x00, 0x42, 0x02, 0x7c, 0x21, 0x03,   // l3 = a + 2
+    0x20, 0x00, 0x42, 0x03, 0x7c, 0x21, 0x04,   // l4 = a + 3
+    0x20, 0x01, 0x42, 0x04, 0x7c, 0x21, 0x05,   // l5 = b + 4
+    0x20, 0x01, 0x42, 0x05, 0x7c, 0x21, 0x06,   // l6 = b + 5
+    0x20, 0x01, 0x42, 0x06, 0x7c, 0x21, 0x07,   // l7 = b + 6
+    0x20, 0x00,               // local.get a
+    0x20, 0x01,               // local.get b
+    0xfc, 0x16,               // i64.mul_wide_u
+    0x20, 0x02, 0x20, 0x03, 0x7c, 0x1a,        // drop(l2 + l3)
+    0x20, 0x04, 0x20, 0x05, 0x7c, 0x1a,        // drop(l4 + l5)
+    0x20, 0x06, 0x20, 0x07, 0x7c, 0x1a,        // drop(l6 + l7)
+    0x0b,
+]);
+
+const module = new WebAssembly.Module(bytes);
+const instance = new WebAssembly.Instance(module);
+const mul_wide_u_pressure = instance.exports["mul_wide_u_pressure"];
+
+// Cases where the low and high halves differ, so a swap would be detected.
+function computeExpected(a, b) {
+    const ua = BigInt.asUintN(64, a);
+    const ub = BigInt.asUintN(64, b);
+    const product = ua * ub;
+    return [product & 0xFFFFFFFFFFFFFFFFn, (product >> 64n) & 0xFFFFFFFFFFFFFFFFn];
+}
+
+const cases = [
+    [0xFFFFFFFFFFFFFFFFn, 0xFFFFFFFFFFFFFFFFn],
+    [0x8000000000000000n, 0x8000000000000000n],
+    [0x7FFFFFFFFFFFFFFFn, 0x7FFFFFFFFFFFFFFFn],
+    [1234567890123456789n, 9876543210987654321n],
+    [1n, 1n],
+    [0n, 0n],
+    [-1n, -1n],
+    [-1n, 1n],
+    [42n, 27n],
+    [0xDEADBEEFCAFEBABEn, 0x0123456789ABCDEFn],
+];
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    for (const [a, b] of cases) {
+        const r = mul_wide_u_pressure(a, b);
+        const [expectedLo, expectedHi] = computeExpected(a, b);
+        assert.eq(BigInt.asUintN(64, r[0]), expectedLo);
+        assert.eq(BigInt.asUintN(64, r[1]), expectedHi);
+    }
+}

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -2544,10 +2544,7 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
 
 [[nodiscard]] PartialResult BBQJIT::addI64MulWideU(Value lhs, Value rhs, Value& resultLo, Value& resultHi)
 {
-#if CPU(X86_64)
-    for (JSC::Reg reg : clobbersForDivX86())
-        clobber(reg);
-#endif
+    PREPARE_FOR_MOD_OR_DIV;
 
     std::optional<ScratchScope<1, 0>> lhsScratch, rhsScratch;
     Location lhsLocation = materializeToGPR(lhs, lhsScratch);
@@ -2568,13 +2565,8 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
         std::swap(lhsLocation, rhsLocation);
     m_jit.move(lhsLocation.asGPR(), X86Registers::eax);
     m_jit.x86UMulHigh64(rhsLocation.asGPR(), X86Registers::eax, X86Registers::edx);
-    if (resultLoLocation.asGPR() != X86Registers::edx) {
-        m_jit.move(X86Registers::eax, resultLoLocation.asGPR());
-        m_jit.move(X86Registers::edx, resultHiLocation.asGPR());
-    } else {
-        m_jit.move(X86Registers::edx, resultHiLocation.asGPR());
-        m_jit.move(X86Registers::eax, resultLoLocation.asGPR());
-    }
+    m_jit.move(X86Registers::eax, resultLoLocation.asGPR());
+    m_jit.move(X86Registers::edx, resultHiLocation.asGPR());
 #elif CPU(ARM64)
     if (resultHiLocation.asGPR() == lhsLocation.asGPR()) {
         m_jit.move(lhsLocation.asGPR(), wasmScratchGPR);
@@ -2595,10 +2587,7 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
 
 [[nodiscard]] PartialResult BBQJIT::addI64MulWideS(Value lhs, Value rhs, Value& resultLo, Value& resultHi)
 {
-#if CPU(X86_64)
-    for (JSC::Reg reg : clobbersForDivX86())
-        clobber(reg);
-#endif
+    PREPARE_FOR_MOD_OR_DIV;
 
     std::optional<ScratchScope<1, 0>> lhsScratch, rhsScratch;
     Location lhsLocation = materializeToGPR(lhs, lhsScratch);
@@ -2619,13 +2608,8 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
         std::swap(lhsLocation, rhsLocation);
     m_jit.move(lhsLocation.asGPR(), X86Registers::eax);
     m_jit.x86MulHigh64(rhsLocation.asGPR(), X86Registers::eax, X86Registers::edx);
-    if (resultLoLocation.asGPR() != X86Registers::edx) {
-        m_jit.move(X86Registers::eax, resultLoLocation.asGPR());
-        m_jit.move(X86Registers::edx, resultHiLocation.asGPR());
-    } else {
-        m_jit.move(X86Registers::edx, resultHiLocation.asGPR());
-        m_jit.move(X86Registers::eax, resultLoLocation.asGPR());
-    }
+    m_jit.move(X86Registers::eax, resultLoLocation.asGPR());
+    m_jit.move(X86Registers::edx, resultHiLocation.asGPR());
 #elif CPU(ARM64)
     if (resultHiLocation.asGPR() == lhsLocation.asGPR()) {
         m_jit.move(lhsLocation.asGPR(), wasmScratchGPR);


### PR DESCRIPTION
#### e88b92e29f0753e644abe33fdbc2b78c051ebf59
<pre>
[JSC] Fix BBQ i64.mul_wide register assignment in x64
<a href="https://bugs.webkit.org/show_bug.cgi?id=322211">https://bugs.webkit.org/show_bug.cgi?id=322211</a>
<a href="https://rdar.apple.com/185448059">rdar://185448059</a>

Reviewed by Mark Lam.

x64 needs to extract 128bit result from rdx:rax, but if register
allocator assigns resultLo = rdx and resultHi = rax, we clobber them.
This is the similar pattern to Mod/Div. So let&apos;s use PREPARE_FOR_MOD_OR_DIV
to clobber them and lock them so they are not selected for scratch registers.

Test: JSTests/wasm/stress/bbq-mul-wide-register-pressure.js

* JSTests/wasm/stress/bbq-mul-wide-register-pressure.js: Added.
(computeExpected):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64MulWideU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64MulWideS):

Canonical link: <a href="https://commits.webkit.org/319552@main">https://commits.webkit.org/319552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f627ec8a3bc8d067c6f8409e758f99d3c6c8886

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146169 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/309cbc7c-deea-4a39-b935-e5e2df21434a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141951 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17e87a32-13f6-4c6d-892d-5b20f4bfd8a1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122387 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1b57b5d-19b1-4816-a992-372cf226a44b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44317 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4354 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11159 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42217 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3227 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43119 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193992 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55457 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151364 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56146 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151069 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27617 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45645 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128429 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124188 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54659 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17213 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54041 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54280 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54106 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->