### PR TITLE
[interactive-widget] Viewport does not reflect dynamically changed value

### DIFF
--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/dynamic-meta-tag-mutation-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/dynamic-meta-tag-mutation-expected.txt
@@ -1,0 +1,23 @@
+CONSOLE MESSAGE: Viewport argument value "resize-content" for key "interactive-widget" is invalid, and has been ignored.
+interactive-widget=resizes-content:
+PASS internals.layoutViewportRect().height < window.initialLayoutViewport.height is true
+PASS internals.visualViewportRect().height == internals.layoutViewportRect().height is true
+PASS internals.layoutViewportRect().height == window.keyboardTopInView is true
+
+interactive-widget=overlays-content:
+PASS internals.layoutViewportRect().height became window.initialLayoutViewport.height
+PASS internals.visualViewportRect().height == internals.layoutViewportRect().height is true
+
+Invalid value falls back to resizes-visual:
+PASS internals.layoutViewportRect().height became window.initialLayoutViewport.height
+PASS internals.visualViewportRect().height < internals.layoutViewportRect().height is true
+PASS internals.visualViewportRect().height == window.keyboardTopInView is true
+
+interactive-widget=resizes-content:
+PASS internals.visualViewportRect().height became internals.layoutViewportRect().height
+PASS internals.layoutViewportRect().height < window.initialLayoutViewport.height is true
+PASS internals.layoutViewportRect().height == window.keyboardTopInView is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget/dynamic-meta-tag-mutation.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget/dynamic-meta-tag-mutation.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta id="viewport-meta" name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../../resources/js-test.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+
+        async function setInteractiveWidget(value) {
+            document.getElementById("viewport-meta").content = `width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=${value}`;
+            await UIHelper.ensureVisibleContentRectAndStablePresentationUpdate();
+        }
+
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            await setInteractiveWidget("resizes-content");
+
+            window.initialLayoutViewport = internals.layoutViewportRect();
+
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+            await UIHelper.ensureVisibleContentRectAndStablePresentationUpdate();
+
+            window.keyboardTopInView = (await UIHelper.inputViewBoundsInWebView()).top;
+
+            debug("interactive-widget=resizes-content:");
+            shouldBeTrue('internals.layoutViewportRect().height < window.initialLayoutViewport.height');
+            shouldBeTrue('internals.visualViewportRect().height == internals.layoutViewportRect().height');
+            shouldBeTrue('internals.layoutViewportRect().height == window.keyboardTopInView');
+
+            await setInteractiveWidget("overlays-content");
+
+            debug("\ninteractive-widget=overlays-content:");
+            await new Promise(resolve => shouldBecomeEqual('internals.layoutViewportRect().height', 'window.initialLayoutViewport.height', resolve));
+            shouldBeTrue('internals.visualViewportRect().height == internals.layoutViewportRect().height');
+
+            await setInteractiveWidget("resize-content");
+
+            debug("\nInvalid value falls back to resizes-visual:");
+            await new Promise(resolve => shouldBecomeEqual('internals.layoutViewportRect().height', 'window.initialLayoutViewport.height', resolve));
+            shouldBeTrue('internals.visualViewportRect().height < internals.layoutViewportRect().height');
+            shouldBeTrue('internals.visualViewportRect().height == window.keyboardTopInView');
+
+            await setInteractiveWidget("resizes-content");
+
+            debug("\ninteractive-widget=resizes-content:");
+            await new Promise(resolve => shouldBecomeEqual('internals.visualViewportRect().height', 'internals.layoutViewportRect().height', resolve));
+            shouldBeTrue('internals.layoutViewportRect().height < window.initialLayoutViewport.height');
+            shouldBeTrue('internals.layoutViewportRect().height == window.keyboardTopInView');
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1280,7 +1280,15 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
         [self _updateNeedsTopScrollPocketDueToVisibleContentInset];
 #endif
 
+        bool interactiveWidgetValueChanged = mainFrameCommitData.viewportMetaTagInteractiveWidget != _perProcessState.viewportMetaTagInteractiveWidget;
+
         _perProcessState.viewportMetaTagInteractiveWidget = mainFrameCommitData.viewportMetaTagInteractiveWidget;
+
+        if (interactiveWidgetValueChanged) {
+            [self _dispatchSetViewLayoutSize:[self activeViewLayoutSize:self.bounds]];
+            needUpdateVisibleContentRects = true;
+        }
+
         _perProcessState.viewportMetaTagWidth = mainFrameCommitData.viewportMetaTagWidth;
         _perProcessState.viewportMetaTagWidthWasExplicit = mainFrameCommitData.viewportMetaTagWidthWasExplicit;
         _perProcessState.viewportMetaTagCameFromImageDocument = mainFrameCommitData.viewportMetaTagCameFromImageDocument;


### PR DESCRIPTION
#### be13f86bc9486fe2d629ea46b67496da3e1057d2
<pre>
[interactive-widget] Viewport does not reflect dynamically changed value
<a href="https://bugs.webkit.org/show_bug.cgi?id=322197">https://bugs.webkit.org/show_bug.cgi?id=322197</a>
<a href="https://rdar.apple.com/185436571">rdar://185436571</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Currrently, when dynamically changing the interactive-widget
value after the keyboard is up, the value will change internally
but nothing acts upon the changed value. This is because only events
will trigger the update (e.g. bound changing, keyboard invoking).

So, if detected that the value has differed from the previous
interactive-widget value, re-dispatch the view layout size and
schedule a visible content rect update.

Add a layout test for this issue and verify it fails without the fix.
The test goes through these value changes:
1. Starts off initially with no value specified
2. Changes to resizes-content
3. Changes to overlays-content
4. Tries to change to resize-content but is invalid, thus falling back
to resizes-visual
5. Changes back to resizes-content

* LayoutTests/fast/visual-viewport/ios/interactive-widget/dynamic-meta-tag-mutation-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget/dynamic-meta-tag-mutation.html: Added.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:mainFrameData:pageData:transactionID:]):

Canonical link: <a href="https://commits.webkit.org/319577@main">https://commits.webkit.org/319577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42454c144a0ff6ef322328243e0bd7f541e8af6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146206 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f1ce6db-e23b-4983-9bc2-f9dfa6733b34) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141982 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa7d1c6b-3f31-4291-a9df-b26be3abe5a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122418 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b288cb2-daf0-483b-bbfa-cf2605ea2908) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44355 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42620 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42248 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3264 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194029 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151399 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56183 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38872 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151105 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27627 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45675 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128466 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124228 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54696 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17244 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54078 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54317 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54143 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->