### PR TITLE
Add unit test showing frame access by name after another origin changes the name

### DIFF
--- a/LayoutTests/http/tests/frames/frame-name-changed-by-parent-expected.txt
+++ b/LayoutTests/http/tests/frames/frame-name-changed-by-parent-expected.txt
@@ -1,0 +1,4 @@
+ALERT: parent origin is http://127.0.0.1:8000
+ALERT: successfully accessed frame1
+ALERT: could not access frame2
+

--- a/LayoutTests/http/tests/frames/frame-name-changed-by-parent.html
+++ b/LayoutTests/http/tests/frames/frame-name-changed-by-parent.html
@@ -1,0 +1,10 @@
+<script>
+    if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+    onload = () => {
+        alert('parent origin is ' + window.origin);
+        let f = document.getElementById('frame1');
+        f.name = 'frame2';
+        f.contentWindow.postMessage('name changed', '*');
+    }
+</script>
+<iframe id="frame1" name="frame1" src="http://localhost:8000/frames/resources/child.html"></iframe>

--- a/LayoutTests/http/tests/frames/resources/child.html
+++ b/LayoutTests/http/tests/frames/resources/child.html
@@ -1,0 +1,19 @@
+<script>
+  window.addEventListener('message', (event) => {
+
+    // Chrome can't access either frame.
+    // Firefox can access frame2 but not frame1.
+    // Safari can access frame1 but not frame2.
+    try {
+      window.parent.frames['frame1'];
+      alert('successfully accessed frame1');
+    } catch (e) { alert('could not access frame1'); }
+
+    try {
+      window.parent.frames['frame2'];
+      alert('successfully accessed frame2');
+    } catch (e) { alert('could not access frame2'); }
+
+    if (window.testRunner) { testRunner.notifyDone() }
+  });
+</script>


### PR DESCRIPTION
#### be138da6d883626978e84bef80839e1ae5251dd3
<pre>
Add unit test showing frame access by name after another origin changes the name
<a href="https://bugs.webkit.org/show_bug.cgi?id=322213">https://bugs.webkit.org/show_bug.cgi?id=322213</a>
<a href="https://rdar.apple.com/185449874">rdar://185449874</a>

Reviewed by NOBODY (OOPS!).

This is a case where no two major browser engines agree on behavior.
This is being discussed in <a href="https://github.com/whatwg/html/issues/12663">https://github.com/whatwg/html/issues/12663</a>

* LayoutTests/http/tests/frames/frame-name-changed-by-parent-expected.txt: Added.
* LayoutTests/http/tests/frames/frame-name-changed-by-parent.html: Added.
* LayoutTests/http/tests/frames/resources/child.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be138da6d883626978e84bef80839e1ae5251dd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192075 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146179 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1361e8cc-b345-4ed4-a6b8-f2c2d70bbcef) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141962 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98552 "2 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af56c522-3083-4ee4-adb0-1b54ee96bae8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122398 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1ff1ab1e-ed0e-4aa2-97dc-4fdc7592ef2b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44327 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42598 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42224 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3237 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194002 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/162196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151374 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56156 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151079 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45653 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124198 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54669 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17220 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54051 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54290 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54116 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->