### PR TITLE
[cleanup] Replace Document's two render tree booleans with an explicit RenderTreeState

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2090,7 +2090,7 @@ void AXObjectCache::notificationPostTimerFired()
     RefPtr document = m_document.get();
     m_notificationPostTimer.stop();
 
-    if (!document || !document->hasLivingRenderTree())
+    if (!document || document->renderTreeState() != Document::RenderTreeState::Built)
         return;
 
     // In tests, posting notifications has a tendency to immediately queue up other notifications, which can lead to unexpected behavior

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -223,7 +223,7 @@ static void appendAccessibilityObject(Ref<AXCoreObject> object, AccessibilityObj
         if (!frameView)
             return;
         RefPtr document = frameView->frame().document();
-        if (!document || !document->hasLivingRenderTree())
+        if (!document || document->renderTreeState() != Document::RenderTreeState::Built)
             return;
 
         CheckedPtr cache = axObject->axObjectCache();

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -447,7 +447,7 @@ void AccessibilityScrollView::addChildren()
 AccessibilityObject* AccessibilityScrollView::webAreaObject() const
 {
     RefPtr document = this->document();
-    if (!document || !document->hasLivingRenderTree() || m_remoteFrame)
+    if (!document || document->renderTreeState() != Document::RenderTreeState::Built || m_remoteFrame)
         return nullptr;
 
     if (CheckedPtr cache = axObjectCache())

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1050,7 +1050,7 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
         return;
     }
 
-    if (!axObject.document() || !axObject.document()->hasLivingRenderTree())
+    if (!axObject.document() || axObject.document()->renderTreeState() != Document::RenderTreeState::Built)
         return;
 
     // We're about to do a lot of work, so start the attribute cache.

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2499,7 +2499,7 @@ void KeyframeEffect::applyPendingAcceleratedActions()
         case AcceleratedAction::Stop:
             ASSERT(document());
             renderer->animationFinished(m_blendingKeyframes);
-            if (!document()->renderTreeBeingDestroyed())
+            if (document()->renderTreeState() != Document::RenderTreeState::BeingDestroyed)
                 protect(m_target)->invalidateStyleAndLayerComposition();
             m_runningAccelerated = canBeAccelerated() ? RunningAccelerated::NotStarted : RunningAccelerated::Prevented;
             break;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -927,7 +927,7 @@ void Document::removedLastRef()
 
     // FIXME: This condition is usually true, and can probably be unconditional.
     if (m_referencingNodeCount) {
-        RELEASE_ASSERT(!hasLivingRenderTree());
+        RELEASE_ASSERT(renderTreeState() != RenderTreeState::Built);
         // We must make sure not to be retaining any of our children through
         // these extra pointers or we will create a reference cycle.
         m_focusedElement = nullptr;
@@ -2285,7 +2285,7 @@ RefPtr<Range> Document::caretRangeFromPoint(int x, int y, HitTestSource source)
 
 std::optional<BoundaryPoint> Document::caretPositionFromPoint(const LayoutPoint& clientPoint, HitTestSource source)
 {
-    if (!hasLivingRenderTree())
+    if (renderTreeState() != RenderTreeState::Built)
         return std::nullopt;
 
     LayoutPoint localPoint;
@@ -2316,7 +2316,7 @@ std::optional<BoundaryPoint> Document::caretPositionFromPoint(const LayoutPoint&
 
 RefPtr<CaretPosition> Document::caretPositionFromPoint(double x, double y, CaretPositionFromPointOptions options)
 {
-    if (!hasLivingRenderTree())
+    if (renderTreeState() != RenderTreeState::Built)
         return nullptr;
 
     LayoutPoint localPoint;
@@ -2930,7 +2930,7 @@ void Document::resolveStyle(ResolveStyleType type)
 
 void Document::updateTextRenderer(Text& text, unsigned offsetOfReplacedText, unsigned lengthOfReplacedText)
 {
-    if (!hasLivingRenderTree())
+    if (renderTreeState() != RenderTreeState::Built)
         return;
 
     ensurePendingRenderTreeUpdate().addText(text, { offsetOfReplacedText, lengthOfReplacedText, std::nullopt });
@@ -2938,7 +2938,7 @@ void Document::updateTextRenderer(Text& text, unsigned offsetOfReplacedText, uns
 
 void Document::updateSVGRenderer(SVGElement& element, Style::SVGRendererUpdateType kind)
 {
-    if (!hasLivingRenderTree())
+    if (renderTreeState() != RenderTreeState::Built)
         return;
 
     // TransformAttributeOnly bypasses Style::Update so it does not flip needsStyleRecalc()
@@ -2963,7 +2963,7 @@ void Document::updateSVGRenderer(SVGElement& element, Style::SVGRendererUpdateTy
 
 Style::Update& Document::ensurePendingRenderTreeUpdate()
 {
-    ASSERT(hasLivingRenderTree());
+    ASSERT(renderTreeState() == RenderTreeState::Built);
 
     if (!m_pendingRenderTreeUpdate)
         m_pendingRenderTreeUpdate = makeUnique<Style::Update>(*this);
@@ -3193,7 +3193,7 @@ std::unique_ptr<Style::ComputedStyle> Document::styleForElementIgnoringPendingSt
 
     std::optional<Style::ComputedStyle> updatedDocumentStyle;
     CheckedPtr parentStyle = parentStyleArg;
-    if (!parentStyle && m_needsFullStyleRebuild && hasLivingRenderTree()) {
+    if (!parentStyle && m_needsFullStyleRebuild && renderTreeState() == RenderTreeState::Built) {
         updatedDocumentStyle.emplace(Style::resolveForDocument(*this));
         parentStyle = &*updatedDocumentStyle;
     }
@@ -3466,6 +3466,7 @@ void Document::createRenderTree()
 
     // FIXME: It would be better if we could pass the resolved document style directly here.
     m_renderView = createRenderer<RenderView>(*this, Style::ComputedStyle::create());
+    m_renderTreeState = RenderTreeState::Built;
     auto* renderView = m_renderView.get();
     Node::setRenderer(renderView);
 
@@ -3487,7 +3488,7 @@ void Document::didBecomeCurrentDocumentInFrame()
     if (!m_frame)
         return;
 
-    if (!hasLivingRenderTree())
+    if (renderTreeState() != RenderTreeState::Built)
         createRenderTree();
     if (!m_frame)
         return;
@@ -3570,7 +3571,7 @@ void Document::detachFromCachedFrame(CachedFrameBase& cachedFrame)
 
 void Document::destroyRenderTree()
 {
-    ASSERT(hasLivingRenderTree());
+    ASSERT(renderTreeState() == RenderTreeState::Built);
     ASSERT(frame());
     ASSERT(frame()->document() == this);
     ASSERT(page());
@@ -3578,7 +3579,7 @@ void Document::destroyRenderTree()
     // Prevent Widget tree changes from committing until the RenderView is dead and gone.
     WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
 
-    SetForScope change(m_renderTreeBeingDestroyed, true);
+    auto scope = SetForScope { m_renderTreeState, RenderTreeState::BeingDestroyed, RenderTreeState::NotBuilt };
 
     if (isTopDocument())
         clearAXObjectCache();
@@ -3665,7 +3666,7 @@ void Document::willBeRemovedFromFrame()
 
     styleScope().clearResolver();
 
-    if (hasLivingRenderTree())
+    if (renderTreeState() == RenderTreeState::Built)
         destroyRenderTree();
 
     if (auto* pluginDocument = dynamicDowncast<PluginDocument>(*this))
@@ -4406,7 +4407,7 @@ void Document::implicitClose()
     }
 
 #if PLATFORM(COCOA) || PLATFORM(WIN) || PLATFORM(GTK)
-    if (frame && hasLivingRenderTree() && AXObjectCache::accessibilityEnabled()) {
+    if (frame && renderTreeState() == RenderTreeState::Built && AXObjectCache::accessibilityEnabled()) {
         // The AX cache may have been cleared at this point, but we need to make sure it contains an
         // AX object to send the notification to. getOrCreate will make sure that an valid AX object
         // exists in the cache (we ignore the return value because we don't need it here). This is
@@ -5635,7 +5636,7 @@ void Document::processApplicationManifest(const ApplicationManifest& application
 
 MouseEventWithHitTestResults Document::prepareMouseEvent(const HitTestRequest& request, const DoublePoint& documentPoint, const PlatformMouseEvent& event)
 {
-    if (!hasLivingRenderTree())
+    if (renderTreeState() != RenderTreeState::Built)
         return MouseEventWithHitTestResults(event, HitTestResult(DoublePoint()));
 
     HitTestResult result(documentPoint);
@@ -8065,7 +8066,7 @@ Document* Document::mainFrameDocument() const
 
     // FIXME: This special-casing avoids incorrectly determined top documents during the process
     // of AXObjectCache teardown or notification posting for cached or being-destroyed documents.
-    if (backForwardCacheState() == NotInBackForwardCache && !m_renderTreeBeingDestroyed) {
+    if (backForwardCacheState() == NotInBackForwardCache && renderTreeState() != RenderTreeState::BeingDestroyed) {
         Document* localMainDocument = nullptr;
         if (RefPtr localMainFrame = this->localMainFrame())
             localMainDocument = localMainFrame->document();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -839,8 +839,13 @@ public:
     const Style::ComputedStyle& initialStyle() const LIFETIME_BOUND;
     void invalidateCachedInitialStyle();
 
-    bool renderTreeBeingDestroyed() const { return m_renderTreeBeingDestroyed; }
-    bool hasLivingRenderTree() const { return renderView() && !renderTreeBeingDestroyed(); }
+    enum class RenderTreeState : uint8_t {
+        NotBuilt,
+        Built,
+        BeingDestroyed,
+    };
+    RenderTreeState renderTreeState() const { return m_renderTreeState; }
+
     void updateRenderTree(std::unique_ptr<Style::Update> styleUpdate);
 
     bool updateLayoutIfDimensionsOutOfDate(Element&, OptionSet<DimensionsCheck> = { DimensionsCheck::Width, DimensionsCheck::Height }, OptionSet<LayoutOptions> = { });
@@ -2799,7 +2804,7 @@ private:
     bool m_sawElementsInKnownNamespaces { false };
     bool m_isSrcdocDocument { false };
 
-    bool m_renderTreeBeingDestroyed { false };
+    RenderTreeState m_renderTreeState { RenderTreeState::NotBuilt };
     bool m_hasPreparedForDestruction { false };
 
     bool m_hasStyleWithViewportUnits { false };

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1652,7 +1652,7 @@ int Element::clientWidth()
     Ref document = this->document();
     document->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Width, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
 
-    if (!document->hasLivingRenderTree())
+    if (document->renderTreeState() != Document::RenderTreeState::Built)
         return 0;
 
     CheckedRef renderView = *document->renderView();
@@ -1689,7 +1689,7 @@ int Element::clientHeight()
 {
     Ref document = this->document();
     document->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Height, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
-    if (!document->hasLivingRenderTree())
+    if (document->renderTreeState() != Document::RenderTreeState::Built)
         return 0;
 
     CheckedRef renderView = *document->renderView();

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -880,7 +880,7 @@ static Node::Editability NODELETE computeEditabilityFromComputedStyle(const Styl
 
 Node::Editability Node::computeEditabilityWithStyle(const Style::ComputedStyle* incomingStyle, UserSelectAllTreatment treatment, ShouldUpdateStyle shouldUpdateStyle) const
 {
-    if (!document().hasLivingRenderTree() || isPseudoElement())
+    if (document().renderTreeState() != Document::RenderTreeState::Built || isPseudoElement())
         return Editability::ReadOnly;
 
     Ref document = this->document();
@@ -3016,7 +3016,7 @@ void Node::setUsesEffectiveTextDirection(bool value)
 
 bool Node::inRenderedDocument() const
 {
-    return isConnected() && document().hasLivingRenderTree();
+    return isConnected() && document().renderTreeState() == Document::RenderTreeState::Built;
 }
 
 void Node::notifyInspectorOfRendererChange()

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -370,7 +370,7 @@ static std::optional<LayoutPoint> absolutePointIfNotClipped(Document& document, 
     const auto& settings = document.frame()->settings();
     if (settings.visualViewportEnabled() && settings.clientCoordinatesRelativeToLayoutViewport()) {
         document.updateLayout();
-        if (!document.view() || !document.hasLivingRenderTree())
+        if (!document.view() || document.renderTreeState() != Document::RenderTreeState::Built)
             return std::nullopt;
         RefPtr view = document.view();
         FloatPoint layoutViewportPoint = view->clientToLayoutViewportPoint(clientPoint);
@@ -415,7 +415,7 @@ RefPtr<Node> TreeScope::nodeFromPoint(const LayoutPoint& clientPoint, LayoutPoin
 
 RefPtr<Element> TreeScope::elementFromPoint(double clientX, double clientY, HitTestSource source)
 {
-    if (!documentScope().hasLivingRenderTree())
+    if (documentScope().renderTreeState() != Document::RenderTreeState::Built)
         return nullptr;
 
     auto node = nodeFromPoint(LayoutPoint { clientX, clientY }, nullptr, source);
@@ -438,7 +438,7 @@ Vector<Ref<Element>> TreeScope::elementsFromPoint(double clientX, double clientY
     Vector<Ref<Element>> elements;
 
     Ref document = documentScope();
-    if (!document->hasLivingRenderTree())
+    if (document->renderTreeState() != Document::RenderTreeState::Built)
         return elements;
 
     auto absolutePoint = absolutePointIfNotClipped(document, LayoutPoint(clientX, clientY));

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -526,7 +526,7 @@ void FrameSelection::setSelection(const VisibleSelection& selection, OptionSet<S
 void FrameSelection::updateSelectionAppearanceNow()
 {
     RefPtr document = m_document.get();
-    if (!document || !document->hasLivingRenderTree())
+    if (!document || document->renderTreeState() != Document::RenderTreeState::Built)
         return;
 
 #if ENABLE(TEXT_CARET)

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -219,7 +219,7 @@ static void getImage(Element& imageElement, RefPtr<Image>& image, CachedImage*& 
 
 void Editor::selectionWillChange()
 {
-    if (!hasComposition() || ignoreSelectionChanges() || document().selection().isNone() || !document().hasLivingRenderTree())
+    if (!hasComposition() || ignoreSelectionChanges() || document().selection().isNone() || document().renderTreeState() != Document::RenderTreeState::Built)
         return;
 
     cancelComposition();

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1221,7 +1221,7 @@ bool MediaElementSession::requiresPlaybackTargetRouteMonitoring() const
 static bool isElementMainContentForPurposesOfAutoplay(const HTMLMediaElement& element, bool shouldHitTestMainFrame)
 {
     Ref document = element.document();
-    if (!document->hasLivingRenderTree() || document->activeDOMObjectsAreStopped() || element.isSuspended() || !element.hasAudio() || !element.hasVideo())
+    if (document->renderTreeState() != Document::RenderTreeState::Built || document->activeDOMObjectsAreStopped() || element.isSuspended() || !element.hasAudio() || !element.hasVideo())
         return false;
 
     // Elements which have not yet been laid out, or which are not yet in the DOM, cannot be main content.

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -146,7 +146,7 @@ CheckedRef<Layout::ElementBox> BoxTreeUpdater::build()
 
 void BoxTreeUpdater::tearDown()
 {
-    if (m_document->renderTreeBeingDestroyed())
+    if (m_document->renderTreeState() == Document::RenderTreeState::BeingDestroyed)
         return rootLayoutBox().destroyChildren();
 
     Vector<CheckedRef<Layout::Box>> boxesToDetach;

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -214,7 +214,7 @@ LineLayout::~LineLayout()
     CheckedRef rootRenderer = flow();
     auto shouldPopulateBreakingPositionCache = [&] {
         auto mayHaveInvalidContent = isDamaged() || !m_inlineContent;
-        if (m_document->renderTreeBeingDestroyed() || mayHaveInvalidContent)
+        if (m_document->renderTreeState() == Document::RenderTreeState::BeingDestroyed || mayHaveInvalidContent)
             return false;
         return !m_inlineContentCache.inlineItems().isPopulatedFromCache();
     };

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -737,9 +737,9 @@ void FrameLoader::clear(RefPtr<Document>&& newDocument, bool clearWindowProperti
     if (neededClear && document->backForwardCacheState() != Document::InBackForwardCache) {
         document->cancelParsing();
         document->stopActiveDOMObjects();
-        bool hadLivingRenderTree = document->hasLivingRenderTree();
+        bool hadRenderTree = document->renderTreeState() == Document::RenderTreeState::Built;
         document->willBeRemovedFromFrame();
-        if (hadLivingRenderTree)
+        if (hadRenderTree)
             document->adjustFocusedNodeOnNodeRemoval(*document);
     }
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -235,7 +235,7 @@ void HistoryController::saveDocumentState()
 
     ASSERT(m_frame->document());
     Ref document = *m_frame->document();
-    if (item->isCurrentDocument(document) && document->hasLivingRenderTree()) {
+    if (item->isCurrentDocument(document) && document->renderTreeState() == Document::RenderTreeState::Built) {
         if (RefPtr documentLoader = document->loader())
             item->setShouldOpenExternalURLsPolicy(documentLoader->shouldOpenExternalURLsPolicyToPropagate());
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -212,7 +212,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     // down the raw HTML parsing case by loading images we don't intend to display.
     Ref element = this->element();
     Ref document = element->document();
-    if (!document->hasLivingRenderTree())
+    if (document->renderTreeState() != Document::RenderTreeState::Built)
         return;
 
     auto attr = element->imageSourceURL();
@@ -685,7 +685,7 @@ void ImageLoader::dispatchPendingBeforeLoadEvent()
         return;
     if (!m_image)
         return;
-    if (!element().document().hasLivingRenderTree())
+    if (element().document().renderTreeState() != Document::RenderTreeState::Built)
         return;
     m_hasPendingBeforeLoadEvent = false;
     if (!element().isConnected())
@@ -700,7 +700,7 @@ void ImageLoader::dispatchPendingLoadEvent()
     if (!m_image)
         return;
     m_hasPendingLoadEvent = false;
-    if (element().document().hasLivingRenderTree())
+    if (element().document().renderTreeState() == Document::RenderTreeState::Built)
         dispatchLoadEvent();
 
     // Only consider updating the protection ref-count of the Element immediately before returning
@@ -714,7 +714,7 @@ void ImageLoader::dispatchPendingErrorEvent()
         return;
     m_hasPendingErrorEvent = false;
     loadEventSender().cancelEvent(*this, eventNames().errorEvent);
-    if (element().document().hasLivingRenderTree())
+    if (element().document().renderTreeState() == Document::RenderTreeState::Built)
         protect(element())->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
     // Only consider updating the protection ref-count of the Element immediately before returning

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -317,7 +317,7 @@ void LocalFrame::setView(RefPtr<LocalFrameView>&& view)
     
     m_eventHandler->clear();
 
-    RELEASE_ASSERT(!m_doc || !m_doc->hasLivingRenderTree());
+    RELEASE_ASSERT(!m_doc || m_doc->renderTreeState() != Document::RenderTreeState::Built);
 
     m_view = WTF::move(view);
     

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -655,7 +655,7 @@ void Page::destroyRenderTrees()
         if (!localFrame->document())
             continue;
         Ref document = *localFrame->document();
-        if (document->hasLivingRenderTree())
+        if (document->renderTreeState() == Document::RenderTreeState::Built)
             document->destroyRenderTree();
     }
 }

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -2220,7 +2220,7 @@ static Expected<ResolvedMouseTarget, String> resolveMouseTarget(Node& targetNode
     if (!element || !element->isConnected())
         return makeUnexpected("Target element could not be found; uid may be stale"_s);
 
-    if (!element->document().hasLivingRenderTree())
+    if (element->document().renderTreeState() != Document::RenderTreeState::Built)
         return makeUnexpected("Target belongs to a detached document; uid may be stale"_s);
 
     {

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1039,7 +1039,7 @@ public:
     virtual bool shouldPaintSelectionGaps() const { return false; }
 
     // When performing a global document tear-down, or when going into the back/forward cache, the renderer of the document is cleared.
-    bool renderTreeBeingDestroyed() const; // Defined in RenderObjectInlines.h
+    bool renderTreeBeingDestroyed() const; // Defined in RenderObjectDocument.h
 
     void destroy();
 

--- a/Source/WebCore/rendering/RenderObjectDocument.h
+++ b/Source/WebCore/rendering/RenderObjectDocument.h
@@ -58,7 +58,7 @@ inline const Settings& RenderObject::settings() const
 
 inline bool RenderObject::renderTreeBeingDestroyed() const
 {
-    return document().renderTreeBeingDestroyed();
+    return document().renderTreeState() == Document::RenderTreeState::BeingDestroyed;
 }
 
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -153,7 +153,7 @@ void LegacyRenderSVGResourceContainer::markAllClientLayersForInvalidation()
         return;
 
     Ref document = (*m_clientLayers.begin())->renderer().document();
-    if (!document->view() || document->renderTreeBeingDestroyed())
+    if (!document->view() || document->renderTreeState() == Document::RenderTreeState::BeingDestroyed)
         return;
 
     auto inLayout = document->view()->layoutContext().isInLayout();

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -52,7 +52,7 @@ namespace Style {
 
 Style::ComputedStyle resolveForDocument(const Document& document)
 {
-    ASSERT(document.hasLivingRenderTree());
+    ASSERT(document.renderTreeState() == Document::RenderTreeState::Built);
 
     CheckedRef renderView = *document.renderView();
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -548,7 +548,7 @@ void Scope::updateActiveStyleSheets(UpdateType updateType)
     RELEASE_ASSERT(!m_isUpdatingStyleResolver);
     ASSERT(!m_pendingUpdate);
 
-    if (!m_document->hasLivingRenderTree())
+    if (m_document->renderTreeState() != Document::RenderTreeState::Built)
         return;
 
     if (m_document->inStyleRecalc() || m_document->inRenderTreeUpdate()) {
@@ -817,7 +817,7 @@ void Scope::pendingUpdateTimerFired()
 const Vector<Ref<StyleSheet>>& Scope::styleSheetsForStyleSheetList()
 {
     // FIXME: StyleSheetList content should be updated separately from style resolver updates.
-    if (m_document->hasLivingRenderTree())
+    if (m_document->renderTreeState() == Document::RenderTreeState::Built)
         flushPendingUpdate();
     else if (m_pendingUpdate) {
         // Documents without a living render tree (e.g. created by DOMParser) can't do full

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7779,7 +7779,7 @@ void WebPage::didChangeSelection(LocalFrame& frame)
         return;
 
     callOnMainRunLoop([protectedThis = Ref { *this }, frame = Ref { frame }] {
-        if (!frame->document() || !frame->document()->hasLivingRenderTree() || frame->selection().isNone()) [[unlikely]]
+        if (!frame->document() || frame->document()->renderTreeState() != Document::RenderTreeState::Built || frame->selection().isNone()) [[unlikely]]
             return;
 
         protectedThis->preemptivelySendAutocorrectionContext();
@@ -8106,7 +8106,7 @@ void WebPage::didEndUserTriggeredSelectionChanges()
 void WebPage::discardedComposition(const Document& document)
 {
     send(Messages::WebPageProxy::CompositionWasCanceled());
-    if (!document.hasLivingRenderTree())
+    if (document.renderTreeState() != Document::RenderTreeState::Built)
         return;
 
     sendEditorStateUpdate();
@@ -8601,7 +8601,7 @@ void WebPage::sendEditorStateUpdate()
     if (!frame)
         return;
 
-    if (frame->editor().ignoreSelectionChanges() || !frame->document() || !frame->document()->hasLivingRenderTree())
+    if (frame->editor().ignoreSelectionChanges() || !frame->document() || frame->document()->renderTreeState() != Document::RenderTreeState::Built)
         return;
 
     m_pendingEditorStateUpdateStatus = PendingEditorStateUpdateStatus::NotScheduled;

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -74,7 +74,7 @@ using namespace WebCore;
 static FloatRect inlineVideoFrame(HTMLVideoElement& element)
 {
     Ref document = element.document();
-    if (!document->hasLivingRenderTree() || document->activeDOMObjectsAreStopped())
+    if (document->renderTreeState() != Document::RenderTreeState::Built || document->activeDOMObjectsAreStopped())
         return { };
 
     document->updateLayout(LayoutOptions::IgnorePendingStylesheets);


### PR DESCRIPTION
#### fdbc1f896f5865455335e43a63137772389ed54c
<pre>
[cleanup] Replace Document&apos;s two render tree booleans with an explicit RenderTreeState
<a href="https://bugs.webkit.org/show_bug.cgi?id=322218">https://bugs.webkit.org/show_bug.cgi?id=322218</a>
&lt;<a href="https://rdar.apple.com/problem/185452641">rdar://problem/185452641</a>&gt;

Reviewed by Sam Weinig.

A document&apos;s render tree is in one of three states: not built, built, or being taken down. Taking one down is not
instantaneous - destroyRenderTree() walks the tree destroying renderers - so for that duration the tree is still
there but must not be walked or added to, which is a different situation from there being no tree at all.

Two booleans covered those three states between them, and neither named the third. hasLivingRenderTree() was
renderView() &amp;&amp; !renderTreeBeingDestroyed(), so a false answer meant either of the other two and callers could not
tell which; anyone who needed to went around it and read renderView() directly. &quot;Living&quot; invites the question of
whether a tree being destroyed counts, which is exactly the ambiguity.

(RenderObject::renderTreeBeingDestroyed() stays for now. It is a forwarder on a different class rather than a second way of
asking the same question of a Document, and it reads well at its 59 call sites, so only its body moves to the new state.)

No change in behavior.

* Source/WebCore/dom/Document.h:
(WebCore::Document::renderTreeState const):
(WebCore::Document::renderTreeBeingDestroyed const): Deleted.
(WebCore::Document::hasLivingRenderTree const): Deleted.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::createRenderTree):
(WebCore::Document::destroyRenderTree):
(WebCore::Document::topDocument const):
(WebCore::Document::removedLastRef):
(WebCore::Document::caretPositionFromPoint):
(WebCore::Document::updateTextRenderer):
(WebCore::Document::updateSVGRenderer):
(WebCore::Document::ensurePendingRenderTreeUpdate):
(WebCore::Document::styleForElementIgnoringPendingStylesheets):
(WebCore::Document::didBecomeCurrentDocumentInFrame):
(WebCore::Document::willBeRemovedFromFrame):
(WebCore::Document::implicitClose):
(WebCore::Document::prepareMouseEvent):
(WebCore::Document::mainFrameDocument const):
* Source/WebCore/rendering/RenderObjectDocument.h:
(WebCore::RenderObject::renderTreeBeingDestroyed const):
* Source/WebCore/rendering/RenderObject.h: Fix a stale comment naming the wrong header.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::notificationPostTimerFired):
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::appendAccessibilityObject):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::webAreaObject const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateChildren):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::applyPendingAcceleratedActions):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::clientWidth):
(WebCore::Element::clientHeight):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::computeEditabilityWithStyle const):
(WebCore::Node::inRenderedDocument const):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::absolutePointIfNotClipped):
(WebCore::TreeScope::elementFromPoint):
(WebCore::TreeScope::elementsFromPoint):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::updateSelectionAppearanceNow):
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::selectionWillChange):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::isElementMainContentForPurposesOfAutoplay):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::tearDown):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::~LineLayout):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::clear):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::saveDocumentState):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
(WebCore::ImageLoader::dispatchPendingBeforeLoadEvent):
(WebCore::ImageLoader::dispatchPendingLoadEvent):
(WebCore::ImageLoader::dispatchPendingErrorEvent):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::setView):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::destroyRenderTrees):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::resolveMouseTarget):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::markAllClientLayersForInvalidation):
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::updateActiveStyleSheets):
(WebCore::Style::Scope::styleSheetsForStyleSheetList):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didChangeSelection):
(WebKit::WebPage::discardedComposition):
(WebKit::WebPage::sendEditorStateUpdate):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::inlineVideoFrame):

Canonical link: <a href="https://commits.webkit.org/319598@main">https://commits.webkit.org/319598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42926c9f448586fd0086d510a7e45fcb59d49358

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192089 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146193 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0adebb14-2ec4-4b48-87ab-d1587ae687c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141979 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122415 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34c7800c-69fc-4a94-a6d2-2f2879fc24c7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44342 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42612 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42243 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3251 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194016 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55481 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151391 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40559 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56170 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151097 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45665 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128453 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124213 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54683 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17239 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54065 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54304 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54130 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->