### PR TITLE
[JSC] Optimize wasm array.copy and array.fill

### DIFF
--- a/JSTests/wasm/gc/bulk-array-element-types.js
+++ b/JSTests/wasm/gc/bulk-array-element-types.js
@@ -1,0 +1,312 @@
+import * as assert from "../assert.js";
+import { instantiate } from "./wast-wrapper.js";
+
+// array.copy and array.fill are lowered per element type, and the length is only known to be
+// non-zero on one side of a branch, so exercise every element type against a constant length, a
+// runtime length and a zero length.
+
+// A packed element is written and read as an i32, so its operand type differs from its storage type.
+const cases = [
+    { type: "i8", valueType: "i32", get: "array.get_u", zero: 0, fill: 0x41 },
+    { type: "i16", valueType: "i32", get: "array.get_u", zero: 0, fill: 0x4142 },
+    { type: "i32", valueType: "i32", get: "array.get", zero: 0, fill: 0x41424344 },
+    { type: "i64", valueType: "i64", get: "array.get", zero: 0n, fill: 0x4142434445464748n },
+    { type: "f32", valueType: "f32", get: "array.get", zero: 0, fill: 1.5 },
+    { type: "f64", valueType: "f64", get: "array.get", zero: 0, fill: 1.5 },
+];
+
+function module({ type, valueType, get }, length) {
+    return instantiate(`
+        (module
+           (type $arr (array (mut ${type})))
+           (global $a (mut (ref null $arr)) (ref.null $arr))
+           (global $b (mut (ref null $arr)) (ref.null $arr))
+           (func (export "reset")
+             (global.set $a (array.new_default $arr (i32.const 16)))
+             (global.set $b (array.new_default $arr (i32.const 16))))
+           (func (export "fillConst") (param ${valueType})
+             (array.fill $arr (global.get $a) (i32.const 2) (local.get 0) (i32.const ${length})))
+           (func (export "fill") (param ${valueType}) (param i32)
+             (array.fill $arr (global.get $a) (i32.const 2) (local.get 0) (local.get 1)))
+           (func (export "copyConst")
+             (array.copy $arr $arr (global.get $b) (i32.const 3) (global.get $a) (i32.const 2) (i32.const ${length})))
+           (func (export "copy") (param i32)
+             (array.copy $arr $arr (global.get $b) (i32.const 3) (global.get $a) (i32.const 2) (local.get 0)))
+           (func (export "copyWithin") (param i32 i32 i32)
+             (array.copy $arr $arr (global.get $a) (local.get 0) (global.get $a) (local.get 1) (local.get 2)))
+           (func (export "getA") (param i32) (result ${valueType}) (${get} $arr (global.get $a) (local.get 0)))
+           (func (export "getB") (param i32) (result ${valueType}) (${get} $arr (global.get $b) (local.get 0)))
+           (func (export "setA") (param i32 ${valueType}) (array.set $arr (global.get $a) (local.get 0) (local.get 1))))
+    `).exports;
+}
+
+for (const c of cases) {
+    const length = 5;
+    // reset() installs fresh default-initialized arrays, so one module covers every scenario without
+    // depending on the instructions under test to clear them.
+    const m = module(c, length);
+
+    // A constant length lets the fill and the copy be emitted without a call at all.
+    m.reset();
+    m.fillConst(c.fill);
+    for (let i = 0; i < 16; ++i)
+        assert.eq(m.getA(i), i >= 2 && i < 2 + length ? c.fill : c.zero);
+
+    m.copyConst();
+    for (let i = 0; i < 16; ++i)
+        assert.eq(m.getB(i), i >= 3 && i < 3 + length ? c.fill : c.zero);
+
+    // The same work with the length only known at runtime.
+    m.reset();
+    m.fill(c.fill, length);
+    for (let i = 0; i < 16; ++i)
+        assert.eq(m.getA(i), i >= 2 && i < 2 + length ? c.fill : c.zero);
+
+    m.copy(length);
+    for (let i = 0; i < 16; ++i)
+        assert.eq(m.getB(i), i >= 3 && i < 3 + length ? c.fill : c.zero);
+
+    // A zero length is in bounds as long as neither offset is past the end, and must not write.
+    m.reset();
+    m.fill(c.fill, 0);
+    m.copy(0);
+    for (let i = 0; i < 16; ++i) {
+        assert.eq(m.getA(i), c.zero);
+        assert.eq(m.getB(i), c.zero);
+    }
+
+    // Overlapping ranges within one array move in both directions. A distinct value per element is
+    // what makes a copy that walks in the wrong direction observable.
+    for (const [dstOffset, srcOffset] of [[0, 4], [4, 0]]) {
+        m.reset();
+        const before = [];
+        for (let i = 0; i < 16; ++i) {
+            m.setA(i, c.valueType === "i64" ? BigInt(i + 1) : i + 1);
+            before.push(m.getA(i));
+        }
+
+        m.copyWithin(dstOffset, srcOffset, 8);
+        for (let i = 0; i < 16; ++i) {
+            const expected = i >= dstOffset && i < dstOffset + 8 ? before[srcOffset + (i - dstOffset)] : before[i];
+            assert.eq(m.getA(i), expected);
+        }
+    }
+}
+
+// Reference elements go through a copy that stores whole references, and need a write barrier.
+{
+    const m = instantiate(`
+        (module
+           (type $arr (array (mut anyref)))
+           (type $box (struct (field i32)))
+           (global $a (ref $arr) (array.new_default $arr (i32.const 8)))
+           (global $b (ref $arr) (array.new_default $arr (i32.const 8)))
+           (func (export "fill") (param i32) (param i32)
+             (array.fill $arr (global.get $a) (i32.const 1) (struct.new $box (local.get 0)) (local.get 1)))
+           (func (export "copy") (param i32)
+             (array.copy $arr $arr (global.get $b) (i32.const 2) (global.get $a) (i32.const 1) (local.get 0)))
+           (func (export "copyWithin") (param i32 i32 i32)
+             (array.copy $arr $arr (global.get $a) (local.get 0) (global.get $a) (local.get 1) (local.get 2)))
+           (func (export "setA") (param i32 i32)
+             (array.set $arr (global.get $a) (local.get 0) (struct.new $box (local.get 1))))
+           (func (export "getA") (param i32) (result i32)
+             (struct.get $box 0 (ref.cast (ref $box) (array.get $arr (global.get $a) (local.get 0)))))
+           (func (export "getB") (param i32) (result i32)
+             (struct.get $box 0 (ref.cast (ref $box) (array.get $arr (global.get $b) (local.get 0)))))
+           (func (export "isNullA") (param i32) (result i32)
+             (ref.is_null (array.get $arr (global.get $a) (local.get 0))))
+           (func (export "isNullB") (param i32) (result i32)
+             (ref.is_null (array.get $arr (global.get $b) (local.get 0)))))
+    `).exports;
+
+    m.fill(7, 4);
+    for (let i = 0; i < 8; ++i) {
+        if (i >= 1 && i < 5) {
+            assert.eq(m.isNullA(i), 0);
+            assert.eq(m.getA(i), 7);
+        } else
+            assert.eq(m.isNullA(i), 1);
+    }
+
+    m.copy(4);
+    for (let i = 0; i < 8; ++i) {
+        if (i >= 2 && i < 6) {
+            assert.eq(m.isNullB(i), 0);
+            assert.eq(m.getB(i), 7);
+        } else
+            assert.eq(m.isNullB(i), 1);
+    }
+
+    // A zero-length reference copy must not disturb the destination.
+    m.copy(0);
+    for (let i = 0; i < 8; ++i)
+        assert.eq(m.isNullB(i), i >= 2 && i < 6 ? 0 : 1);
+
+    // References move through a GC-safe memmove, so overlapping ranges have to walk in the direction
+    // that preserves the source.
+    for (const [dstOffset, srcOffset] of [[0, 3], [3, 0]]) {
+        const before = [];
+        for (let i = 0; i < 8; ++i) {
+            m.setA(i, i + 1);
+            before.push(i + 1);
+        }
+
+        m.copyWithin(dstOffset, srcOffset, 5);
+        for (let i = 0; i < 8; ++i) {
+            const expected = i >= dstOffset && i < dstOffset + 5 ? before[srcOffset + (i - dstOffset)] : before[i];
+            assert.eq(m.getA(i), expected);
+        }
+    }
+}
+
+// A v128 fill passes its two lanes separately, and a v128 payload is found by rounding the address
+// up at runtime rather than by a fixed offset.
+{
+    const m = instantiate(`
+        (module
+           (type $arr (array (mut v128)))
+           (global $a (ref $arr) (array.new_default $arr (i32.const 8)))
+           (global $b (ref $arr) (array.new_default $arr (i32.const 8)))
+           (func (export "fill") (param i32)
+             (array.fill $arr (global.get $a) (i32.const 1)
+               (v128.const i64x2 0x0102030405060708 0x1112131415161718)
+               (local.get 0)))
+           (func (export "copy") (param i32)
+             (array.copy $arr $arr (global.get $b) (i32.const 2) (global.get $a) (i32.const 1) (local.get 0)))
+           (func (export "getA0") (param i32) (result i64)
+             (i64x2.extract_lane 0 (array.get $arr (global.get $a) (local.get 0))))
+           (func (export "getA1") (param i32) (result i64)
+             (i64x2.extract_lane 1 (array.get $arr (global.get $a) (local.get 0))))
+           (func (export "getB0") (param i32) (result i64)
+             (i64x2.extract_lane 0 (array.get $arr (global.get $b) (local.get 0))))
+           (func (export "getB1") (param i32) (result i64)
+             (i64x2.extract_lane 1 (array.get $arr (global.get $b) (local.get 0)))))
+    `).exports;
+
+    const lane0 = 0x0102030405060708n;
+    const lane1 = 0x1112131415161718n;
+
+    m.fill(4);
+    for (let i = 0; i < 8; ++i) {
+        const filled = i >= 1 && i < 5;
+        assert.eq(m.getA0(i), filled ? lane0 : 0n);
+        assert.eq(m.getA1(i), filled ? lane1 : 0n);
+    }
+
+    m.copy(4);
+    for (let i = 0; i < 8; ++i) {
+        const copied = i >= 2 && i < 6;
+        assert.eq(m.getB0(i), copied ? lane0 : 0n);
+        assert.eq(m.getB1(i), copied ? lane1 : 0n);
+    }
+
+    // A zero length must leave both arrays alone.
+    m.fill(0);
+    m.copy(0);
+    for (let i = 0; i < 8; ++i) {
+        assert.eq(m.getA0(i), i >= 1 && i < 5 ? lane0 : 0n);
+        assert.eq(m.getB0(i), i >= 2 && i < 6 ? lane0 : 0n);
+    }
+}
+
+// offset + size is checked without wrapping, so a size that would overflow a 32-bit sum still traps
+// rather than being treated as in bounds.
+{
+    const m = instantiate(`
+        (module
+           (type $arr (array (mut i32)))
+           (global $a (ref $arr) (array.new_default $arr (i32.const 8)))
+           (func (export "fill") (param i32 i32)
+             (array.fill $arr (global.get $a) (local.get 0) (i32.const 1) (local.get 1)))
+           (func (export "copy") (param i32 i32 i32)
+             (array.copy $arr $arr (global.get $a) (local.get 0) (global.get $a) (local.get 1) (local.get 2))))
+    `).exports;
+
+    for (const [offset, size] of [[1, -1], [-1, 1], [-1, -1], [0, 9], [8, 1], [9, 0]]) {
+        assert.throws(() => m.fill(offset, size), WebAssembly.RuntimeError, "Out of bounds array.fill");
+        assert.throws(() => m.copy(offset, 0, size), WebAssembly.RuntimeError, "Out of bounds array.copy");
+        assert.throws(() => m.copy(0, offset, size), WebAssembly.RuntimeError, "Out of bounds array.copy");
+    }
+
+    // A zero-length range at the very end of the array is in bounds.
+    m.fill(8, 0);
+    m.copy(8, 8, 0);
+}
+
+// A constant offset and a constant size are extended to 64 bits by hand, so repeat the range check
+// with every operand constant.
+for (const [offset, size] of [[1, -1], [-1, 1], [-1, -1], [0, 9], [8, 1], [9, 0]]) {
+    const m = instantiate(`
+        (module
+           (type $arr (array (mut i32)))
+           (global $a (ref $arr) (array.new_default $arr (i32.const 8)))
+           (func (export "fill")
+             (array.fill $arr (global.get $a) (i32.const ${offset}) (i32.const 1) (i32.const ${size})))
+           (func (export "copy")
+             (array.copy $arr $arr (global.get $a) (i32.const ${offset}) (global.get $a) (i32.const 0) (i32.const ${size}))))
+    `).exports;
+
+    assert.throws(() => m.fill(), WebAssembly.RuntimeError, "Out of bounds array.fill");
+    assert.throws(() => m.copy(), WebAssembly.RuntimeError, "Out of bounds array.copy");
+}
+
+// A constant fill value whose bytes all repeat is lowered to a byte-wise fill, which needs the
+// element count scaled to a byte count. A float constant reaches the same path through its bits.
+{
+    const m = instantiate(`
+        (module
+           (type $i32arr (array (mut i32)))
+           (type $i64arr (array (mut i64)))
+           (type $f64arr (array (mut f64)))
+           (global $i32 (ref $i32arr) (array.new_default $i32arr (i32.const 8)))
+           (global $i64 (ref $i64arr) (array.new_default $i64arr (i32.const 8)))
+           (global $f64 (ref $f64arr) (array.new_default $f64arr (i32.const 8)))
+           (func (export "fillI32")
+             (array.fill $i32arr (global.get $i32) (i32.const 1) (i32.const 0x41414141) (i32.const 5)))
+           (func (export "fillI64")
+             (array.fill $i64arr (global.get $i64) (i32.const 1) (i64.const -1) (i32.const 5)))
+           (func (export "setF64") (param i32 f64)
+             (array.set $f64arr (global.get $f64) (local.get 0) (local.get 1)))
+           (func (export "fillF64")
+             (array.fill $f64arr (global.get $f64) (i32.const 1) (f64.const 0) (i32.const 5)))
+           (func (export "getI32") (param i32) (result i32) (array.get $i32arr (global.get $i32) (local.get 0)))
+           (func (export "getI64") (param i32) (result i64) (array.get $i64arr (global.get $i64) (local.get 0)))
+           (func (export "getF64") (param i32) (result f64) (array.get $f64arr (global.get $f64) (local.get 0))))
+    `).exports;
+
+    for (let i = 0; i < 8; ++i)
+        m.setF64(i, 1.5);
+
+    m.fillI32();
+    m.fillI64();
+    m.fillF64();
+
+    for (let i = 0; i < 8; ++i) {
+        const filled = i >= 1 && i < 6;
+        assert.eq(m.getI32(i), filled ? 0x41414141 : 0);
+        assert.eq(m.getI64(i), filled ? -1n : 0n);
+        assert.eq(m.getF64(i), filled ? 0 : 1.5);
+    }
+}
+
+// A null array traps on the length load that the bounds check needs, so it reports a plain null
+// access rather than a message naming the instruction.
+{
+    const m = instantiate(`
+        (module
+           (type $arr (array (mut i32)))
+           (global $null (ref null $arr) (ref.null $arr))
+           (func (export "fill") (param i32)
+             (array.fill $arr (global.get $null) (i32.const 0) (i32.const 1) (local.get 0)))
+           (func (export "copyDst") (param i32)
+             (array.copy $arr $arr (global.get $null) (i32.const 0) (array.new_default $arr (i32.const 4)) (i32.const 0) (local.get 0)))
+           (func (export "copySrc") (param i32)
+             (array.copy $arr $arr (array.new_default $arr (i32.const 4)) (i32.const 0) (global.get $null) (i32.const 0) (local.get 0))))
+    `).exports;
+
+    for (const size of [0, 1]) {
+        assert.throws(() => m.fill(size), WebAssembly.RuntimeError, "access to a null reference");
+        assert.throws(() => m.copyDst(size), WebAssembly.RuntimeError, "access to a null reference");
+        assert.throws(() => m.copySrc(size), WebAssembly.RuntimeError, "access to a null reference");
+    }
+}

--- a/JSTests/wasm/gc/bulk-array.js
+++ b/JSTests/wasm/gc/bulk-array.js
@@ -85,7 +85,7 @@ function testArrayFill() {
          (start 0))
     `),
     WebAssembly.RuntimeError,
-    "array.fill to a null reference"
+    "access to a null reference"
   );
 
   assert.throws(
@@ -98,7 +98,7 @@ function testArrayFill() {
          (start 0))
     `),
     WebAssembly.RuntimeError,
-    "array.fill to a null reference"
+    "access to a null reference"
   );
 
   assert.throws(
@@ -303,7 +303,7 @@ function testArrayCopy() {
          (start 0))
     `),
     WebAssembly.RuntimeError,
-    "array.copy to a null reference"
+    "access to a null reference"
   );
 
   assert.throws(
@@ -316,7 +316,7 @@ function testArrayCopy() {
          (start 0))
     `),
     WebAssembly.RuntimeError,
-    "array.copy to a null reference"
+    "access to a null reference"
   );
 
   assert.throws(
@@ -328,7 +328,7 @@ function testArrayCopy() {
          (start 0))
     `),
     WebAssembly.RuntimeError,
-    "array.copy to a null reference"
+    "access to a null reference"
   );
 
   assert.throws(
@@ -341,7 +341,7 @@ function testArrayCopy() {
          (start 0))
     `),
     WebAssembly.RuntimeError,
-    "array.copy to a null reference"
+    "access to a null reference"
   );
 
   assert.throws(

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -30,6 +30,7 @@
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 
 #include "B3Common.h"
+#include "B3Operations.h"
 #include "B3ValueRep.h"
 #include "BinarySwitch.h"
 #include "BytecodeStructs.h"
@@ -1689,32 +1690,84 @@ void BBQJIT::pushArrayNewFromSegment(ArraySegmentOperation operation, TypeSignat
         consume(src);
         consume(srcOffset);
         consume(size);
-        emitThrowException(ExceptionType::NullArrayCopy);
+        emitThrowException(ExceptionType::NullAccess);
         return { };
     }
 
-    if (typedDst.type().isNullable())
-        emitThrowOnNullReference(ExceptionType::NullArrayCopy, loadIfNecessary(dst));
-    if (typedSrc.type().isNullable())
-        emitThrowOnNullReference(ExceptionType::NullArrayCopy, loadIfNecessary(src));
+    StorageType elementType = getArrayElementType(dstTypeIndex);
+    size_t elementSize = elementType.elementSize();
+    ASSERT(hasOneBitSet(elementSize));
+    // Both element addresses and the byte count are scaled by the destination's stride, so a source
+    // whose stride differed would read outside its payload.
+    RELEASE_ASSERT(getArrayElementType(srcTypeIndex).elementSize() == elementSize);
 
-    Vector<Value, 8> arguments = {
-        instanceValue(),
-        dst,
-        dstOffset,
-        src,
-        srcOffset,
-        size
-    };
-    Value shouldThrow = topValue(TypeKind::I32);
-    emitCCall(&operationWasmArrayCopy, arguments, shouldThrow);
-    Location shouldThrowLocation = loadIfNecessary(shouldThrow);
+    {
+        // Both lengths are loaded first because a null array traps ahead of either range being out of
+        // bounds, and the load is what traps.
+        ScratchScope<2, 0> lengths(*this);
+        GPRReg dstLengthGPR = lengths.gpr(0);
+        GPRReg srcLengthGPR = lengths.gpr(1);
+
+        emitGetArraySizeWithNullCheck(typedDst, dstLengthGPR);
+        emitGetArraySizeWithNullCheck(typedSrc, srcLengthGPR);
+
+        emitArrayRangeCheck(dstLengthGPR, dstOffset, size, ExceptionType::OutOfBoundsArrayCopy);
+        emitArrayRangeCheck(srcLengthGPR, srcOffset, size, ExceptionType::OutOfBoundsArrayCopy);
+    }
 
     LOG_INSTRUCTION("ArrayCopy", dstTypeIndex, dst, dstOffset, srcTypeIndex, src, srcOffset, size);
 
-    recordJumpToThrowException(ExceptionType::OutOfBoundsArrayCopy, m_jit.branchTest32(ResultCondition::Zero, shouldThrowLocation.asGPR()));
+    bool isEmptyRange = size.isConst() && !size.asI32();
+    if (!isEmptyRange) {
+        // An empty range has nothing left to do once it is in bounds, and collection code copies empty
+        // ranges constantly, so branch around the call. Both edges of that branch have to agree on
+        // where every value lives, which is what the flush establishes.
+        flushRegisters();
 
-    consume(shouldThrow);
+        Vector<Value, 8> arguments;
+        JumpList isEmpty;
+        {
+            // emitCCall() cannot run with scratches held, so compute the arguments here and name the
+            // registers they landed in once the scope has released them.
+            ScratchScope<3, 0> scratches(*this);
+            GPRReg dstAddressGPR = scratches.gpr(0);
+            GPRReg srcAddressGPR = scratches.gpr(1);
+            GPRReg byteCountGPR = scratches.gpr(2);
+
+            emitZeroExtendI32(size, byteCountGPR);
+            if (!size.isConst())
+                isEmpty.append(m_jit.branchTest32(ResultCondition::Zero, byteCountGPR));
+
+            emitArrayElementAddress(elementType, dst, dstOffset, dstAddressGPR);
+            emitArrayElementAddress(elementType, src, srcOffset, srcAddressGPR);
+            m_jit.lshift64(byteCountGPR, TrustedImm32(getLSBSet(elementSize)), byteCountGPR);
+
+            arguments = {
+                Value::pinned(TypeKind::I64, Location::fromGPR(dstAddressGPR)),
+                Value::pinned(TypeKind::I64, Location::fromGPR(srcAddressGPR)),
+                Value::pinned(TypeKind::I64, Location::fromGPR(byteCountGPR)),
+            };
+        }
+
+        if (isRefType(elementType.unpacked())) {
+            // A reference has to move whole or the concurrent collector could read a torn JSValue, which
+            // a byte-wise copy does not promise.
+            emitCCall(&operationWasmArrayCopyRefs, arguments);
+
+            // emitWriteBarrier() allocates its own scratches, so stage the cell somewhere they cannot take.
+            emitMove(dst, Location::fromGPR(wasmScratchGPR));
+            emitWriteBarrier(wasmScratchGPR);
+        } else
+            emitCCall(&B3::operationMemoryCopy, arguments);
+
+        isEmpty.link(m_jit);
+    }
+
+    consume(dst);
+    consume(dstOffset);
+    consume(src);
+    consume(srcOffset);
+    consume(size);
 
     return { };
 }
@@ -5717,6 +5770,71 @@ void BBQJIT::emitArrayGetPayload(StorageType type, GPRReg arrayGPR, GPRReg paylo
     // For all other types, alignment shift is a compile-time constant
     // since JSCell always has >=8-byte alignment.
     m_jit.addPtr(MacroAssembler::TrustedImm32(JSWebAssemblyArray::alignedOffsetOfData(type.elementSize())), arrayGPR, payloadGPR);
+}
+
+void BBQJIT::emitZeroExtendI32(Value value, GPRReg resultGPR)
+{
+    ASSERT(value.type() == TypeKind::I32);
+    if (value.isConst()) {
+        m_jit.move(TrustedImm32(value.asI32()), resultGPR);
+        return;
+    }
+
+    // locationOf() binds a value that only lives in its canonical slot, which is how a constant
+    // materialized by emitStoreConst() is found.
+    Location location = locationOf(value);
+    if (location.isRegister())
+        m_jit.zeroExtend32ToWord(location.asGPR(), resultGPR);
+    else
+        m_jit.load32(location.asAddress(), resultGPR);
+}
+
+void BBQJIT::emitArrayRangeCheck(GPRReg lengthGPR, Value offset, Value size, ExceptionType exceptionType)
+{
+    // The scratches below are free to reallocate any unlocked register, including one holding the length.
+    ASSERT(m_gprAllocator.isLocked(lengthGPR));
+
+    ScratchScope<2, 0> scratches(*this);
+    GPRReg endGPR = scratches.gpr(0);
+    GPRReg sizeGPR = scratches.gpr(1);
+
+    emitZeroExtendI32(offset, endGPR);
+    if (size.isConst())
+        m_jit.add64(TrustedImm64(static_cast<uint64_t>(static_cast<uint32_t>(size.asI32()))), endGPR);
+    else {
+        emitZeroExtendI32(size, sizeGPR);
+        m_jit.add64(sizeGPR, endGPR);
+    }
+
+    recordJumpToThrowException(exceptionType, m_jit.branch64(RelationalCondition::Above, endGPR, lengthGPR));
+}
+
+void BBQJIT::emitGetArraySizeWithNullCheck(TypedExpression array, GPRReg lengthGPR)
+{
+    Location arrayLocation = loadIfNecessary(array.value());
+    if (array.type().isNullable())
+        emitThrowOnNullReferenceBeforeAccess(arrayLocation, JSWebAssemblyArray::offsetOfSize());
+    m_jit.load32(Address(arrayLocation.asGPR(), JSWebAssemblyArray::offsetOfSize()), lengthGPR);
+}
+
+void BBQJIT::emitArrayElementAddress(StorageType elementType, Value array, Value index, GPRReg resultGPR)
+{
+    ASSERT(resultGPR != wasmScratchGPR);
+    size_t elementSize = elementType.elementSize();
+    ASSERT(hasOneBitSet(elementSize));
+
+    emitMove(array, Location::fromGPR(wasmScratchGPR));
+    emitArrayGetPayload(elementType, wasmScratchGPR, resultGPR);
+
+    if (index.isConst()) {
+        if (uint32_t elementIndex = static_cast<uint32_t>(index.asI32()))
+            m_jit.add64(TrustedImm64(static_cast<uint64_t>(elementIndex) * elementSize), resultGPR);
+        return;
+    }
+
+    emitZeroExtendI32(index, wasmScratchGPR);
+    m_jit.lshift64(wasmScratchGPR, TrustedImm32(getLSBSet(elementSize)), wasmScratchGPR);
+    m_jit.add64(wasmScratchGPR, resultGPR);
 }
 
 } // namespace JSC::Wasm::BBQJITImpl

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1437,6 +1437,10 @@ public:
     [[nodiscard]] PartialResult addArrayNewFixed(TypeSignatureIndex typeIndex, ArgumentList& args, ExpressionType& result);
 
     void emitArrayGetPayload(StorageType, GPRReg arrayGPR, GPRReg payloadGPR);
+    void emitZeroExtendI32(Value, GPRReg resultGPR);
+    void emitGetArraySizeWithNullCheck(TypedExpression array, GPRReg lengthGPR);
+    void emitArrayRangeCheck(GPRReg lengthGPR, Value offset, Value size, ExceptionType);
+    void emitArrayElementAddress(StorageType elementType, Value array, Value index, GPRReg resultGPR);
 
     [[nodiscard]] PartialResult addArrayGet(ExtGCOpType arrayGetKind, TypeSignatureIndex typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -33,6 +33,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 
 #include "B3Common.h"
+#include "B3Operations.h"
 #include "B3ValueRep.h"
 #include "BinarySwitch.h"
 #include "BytecodeStructs.h"
@@ -1890,56 +1891,110 @@ void BBQJIT::emitArraySetUnchecked(TypeSignatureIndex typeIndex, Value arrayref,
         consume(offset);
         consume(value);
         consume(size);
-        emitThrowException(ExceptionType::NullArrayFill);
+        emitThrowException(ExceptionType::NullAccess);
         return { };
     }
 
-    if (typedArray.type().isNullable())
-        emitThrowOnNullReference(ExceptionType::NullArrayFill, loadIfNecessary(arrayref));
-
-    Value shouldThrow = topValue(TypeKind::I32);
-    if (value.type() != TypeKind::V128) {
-        value = marshallToI64(value);
-        Vector<Value, 8> arguments = {
-            instanceValue(),
-            arrayref,
-            offset,
-            value,
-            size
-        };
-        emitCCall(&operationWasmArrayFill, arguments, shouldThrow);
-    } else {
-        ASSERT(!value.isConst());
-        Location valueLocation = loadIfNecessary(value);
-        consume(value);
-
-        Value lane0, lane1;
-        {
-            ScratchScope<2, 0> scratches(*this);
-            lane0 = Value::pinned(TypeKind::I64, Location::fromGPR(scratches.gpr(0)));
-            lane1 = Value::pinned(TypeKind::I64, Location::fromGPR(scratches.gpr(1)));
-
-            m_jit.vectorExtractLaneInt64(TrustedImm32(0), valueLocation.asFPR(), scratches.gpr(0));
-            m_jit.vectorExtractLaneInt64(TrustedImm32(1), valueLocation.asFPR(), scratches.gpr(1));
-        }
-
-        Vector<Value, 8> arguments = {
-            instanceValue(),
-            arrayref,
-            offset,
-            lane0,
-            lane1,
-            size,
-        };
-        emitCCall(operationWasmArrayFillVector, arguments, shouldThrow);
+    StorageType elementType = getArrayElementType(typeIndex);
+    {
+        ScratchScope<1, 0> length(*this);
+        emitGetArraySizeWithNullCheck(typedArray, length.gpr(0));
+        emitArrayRangeCheck(length.gpr(0), offset, size, ExceptionType::OutOfBoundsArrayFill);
     }
-    Location shouldThrowLocation = loadIfNecessary(shouldThrow);
 
     LOG_INSTRUCTION("ArrayFill", typeIndex, arrayref, offset, value, size);
 
-    recordJumpToThrowException(ExceptionType::OutOfBoundsArrayFill, m_jit.branchTest32(ResultCondition::Zero, shouldThrowLocation.asGPR()));
+    bool isEmptyRange = size.isConst() && !size.asI32();
+    if (!isEmptyRange) {
+        bool fillsVector = value.type() == TypeKind::V128;
+        ASSERT_IMPLIES(fillsVector, !value.isConst());
+        // Reinterpreting a float fill value as its bits flushes it, which has to happen on both edges
+        // of the branch below, not just the one that calls.
+        Value fillBits = fillsVector ? value : marshallToI64(value);
 
-    consume(shouldThrow);
+        // An empty range has nothing left to do once it is in bounds, and collection code fills empty
+        // ranges constantly, so branch around the call. Both edges of that branch have to agree on
+        // where every value lives, which is what the flush establishes.
+        flushRegisters();
+
+        Vector<Value, 8> arguments;
+        JumpList isEmpty;
+        {
+            // emitCCall() cannot run with scratches held, so compute the arguments here and name the
+            // registers they landed in once the scope has released them.
+            ScratchScope<4, 0> scratches(*this);
+            GPRReg payloadGPR = scratches.gpr(0);
+            GPRReg countGPR = scratches.gpr(1);
+            GPRReg valueGPR = scratches.gpr(2);
+            GPRReg lane1GPR = scratches.gpr(3);
+
+            emitZeroExtendI32(size, countGPR);
+            if (!size.isConst())
+                isEmpty.append(m_jit.branchTest32(ResultCondition::Zero, countGPR));
+
+            emitArrayElementAddress(elementType, arrayref, offset, payloadGPR);
+
+            Value payload = Value::pinned(TypeKind::I64, Location::fromGPR(payloadGPR));
+            Value count = Value::pinned(TypeKind::I64, Location::fromGPR(countGPR));
+
+            if (fillsVector) {
+                // Read the lanes out of the slot the flush left them in; binding the vector to a
+                // register here is something the branch's other edge would not have done.
+                static_assert(tempSlotSize >= static_cast<int>(sizeof(v128_t)));
+                ASSERT(locationOf(fillBits).isMemory());
+                Address slot = locationOf(fillBits).asAddress();
+                m_jit.load64(slot, valueGPR);
+                m_jit.load64(slot.withOffset(sizeof(uint64_t)), lane1GPR);
+                arguments = {
+                    payload,
+                    Value::pinned(TypeKind::I64, Location::fromGPR(valueGPR)),
+                    Value::pinned(TypeKind::I64, Location::fromGPR(lane1GPR)),
+                    count,
+                };
+            } else {
+                emitMove(fillBits, Location::fromGPR(valueGPR));
+                // A one-byte element goes to the memory fill, which takes its pattern as an i32.
+                TypeKind valueType = elementType.elementSize() == 1 ? TypeKind::I32 : TypeKind::I64;
+                arguments = { payload, Value::pinned(valueType, Location::fromGPR(valueGPR)), count };
+            }
+        }
+
+        if (fillsVector)
+            emitCCall(&operationWasmArrayFill16B, arguments);
+        else if (isRefType(elementType.unpacked())) {
+            // A reference has to be stored whole or the concurrent collector could read a torn JSValue,
+            // which a wider store does not promise.
+            emitCCall(&operationWasmArrayFillRefs, arguments);
+
+            // emitWriteBarrier() allocates its own scratches, so stage the cell somewhere they cannot take.
+            emitMove(arrayref, Location::fromGPR(wasmScratchGPR));
+            emitWriteBarrier(wasmScratchGPR);
+        } else {
+            switch (elementType.elementSize()) {
+            case 1:
+                emitCCall(&B3::operationMemoryFill, arguments);
+                break;
+            case 2:
+                emitCCall(&operationWasmArrayFill2B, arguments);
+                break;
+            case 4:
+                emitCCall(&operationWasmArrayFill4B, arguments);
+                break;
+            case 8:
+                emitCCall(&operationWasmArrayFill8B, arguments);
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        }
+
+        isEmpty.link(m_jit);
+    }
+
+    consume(arrayref);
+    consume(offset);
+    consume(value);
+    consume(size);
 
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -61,8 +61,6 @@ namespace Wasm {
     macro(BadArrayNewInitElem, "Out of bounds or failed to allocate in array.new_elem"_s) \
     macro(BadArrayNewInitData, "Out of bounds or failed to allocate in array.new_data"_s) \
     macro(NullAccess, "access to a null reference"_s) \
-    macro(NullArrayFill, "array.fill to a null reference"_s) \
-    macro(NullArrayCopy, "array.copy to a null reference"_s) \
     macro(NullArrayInitElem, "array.init_elem to a null reference"_s) \
     macro(NullArrayInitData, "array.init_data to a null reference"_s) \
     macro(TypeErrorInvalidValueUse, "an exported wasm function cannot contain an invalid parameter or return value"_s) \
@@ -129,8 +127,6 @@ ALWAYS_INLINE bool isTypeErrorExceptionType(ExceptionType type)
     case ExceptionType::BadArrayNewInitElem:
     case ExceptionType::BadArrayNewInitData:
     case ExceptionType::NullAccess:
-    case ExceptionType::NullArrayFill:
-    case ExceptionType::NullArrayCopy:
     case ExceptionType::NullArrayInitElem:
     case ExceptionType::NullArrayInitData:
     case ExceptionType::NullRefAsNonNull:

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -938,7 +938,7 @@ WASM_IPINT_EXTERN_CPP_DECL(array_fill, IPIntStackEntry* sp)
     EncodedJSValue arrayref = sp[3].ref;
     JSValue arrayValue = JSValue::decode(arrayref);
     if (arrayValue.isNull()) [[unlikely]]
-        IPINT_THROW(Wasm::ExceptionType::NullArrayFill);
+        IPINT_THROW(Wasm::ExceptionType::NullAccess);
 
     ASSERT(arrayValue.isObject());
     JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(arrayValue.getObject());
@@ -974,7 +974,7 @@ WASM_IPINT_EXTERN_CPP_DECL(array_copy, IPIntStackEntry* sp)
     uint32_t size = sp[0].i32;
 
     if (JSValue::decode(dst).isNull() || JSValue::decode(src).isNull()) [[unlikely]]
-        IPINT_THROW(Wasm::ExceptionType::NullArrayCopy);
+        IPINT_THROW(Wasm::ExceptionType::NullAccess);
 
     if (!Wasm::arrayCopy(instance, dst, dstOffset, src, srcOffset, size)) [[unlikely]]
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsArrayCopy);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -954,7 +954,11 @@ private:
 
     void mutatorFence();
 
+    Value* emitGetArraySize(Value* array, bool canTrap);
     Value* emitGetArraySizeWithNullCheck(Type arrayType, Value*);
+    void emitArrayRangeCheck(Value* arraySize, Value* offset, Value* size, ExceptionType);
+    Value* emitArrayElementAddress(StorageType elementType, Value* array, Value* index);
+    void emitArrayFillRange(StorageType elementType, Value* array, Value* offset, Value* fillValue, Value* size);
     void emitNullCheck(Value*, ExceptionType);
     bool emitNullCheckBeforeAccess(Value*, ptrdiff_t offset);
     void emitArraySetUnchecked(TypeSignatureIndex, Value*, Value*, Value*);
@@ -3758,16 +3762,50 @@ auto OMGIRGenerator::addArrayNewFixed(TypeSignatureIndex typeIndex, ArgumentList
     return { };
 }
 
-Value* OMGIRGenerator::emitGetArraySizeWithNullCheck(Type arrayType, Value* array)
+Value* OMGIRGenerator::emitGetArraySize(Value* array, bool canTrap)
 {
-    int32_t offset = safeCast<int32_t>(JSWebAssemblyArray::offsetOfSize());
-    bool canTrap = false;
-    if (arrayType.isNullable())
-        canTrap = emitNullCheckBeforeAccess(array, offset);
     B3::Kind kind = canTrap ? trapping(WasmArrayLength) : B3::Kind(WasmArrayLength);
     auto* arrayLength = m_currentBlock->appendNew<WasmArrayLengthValue>(m_proc, kind, Int32, origin(), pointerOfWasmRef(array));
     m_heaps.decorateWasmArrayLength(&m_heaps.JSWebAssemblyArray_size, arrayLength);
     return arrayLength;
+}
+
+Value* OMGIRGenerator::emitGetArraySizeWithNullCheck(Type arrayType, Value* array)
+{
+    bool canTrap = false;
+    if (arrayType.isNullable())
+        canTrap = emitNullCheckBeforeAccess(array, safeCast<int32_t>(JSWebAssemblyArray::offsetOfSize()));
+    return emitGetArraySize(array, canTrap);
+}
+
+void OMGIRGenerator::emitArrayRangeCheck(Value* arraySize, Value* offset, Value* size, ExceptionType exceptionType)
+{
+    Value* end = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), pointerOfInt32(offset), pointerOfInt32(size));
+    CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), m_currentBlock->appendNew<Value>(m_proc, Above, origin(), end, pointerOfInt32(arraySize)));
+    check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+        this->emitExceptionCheck(jit, origin, exceptionType);
+    });
+}
+
+Value* OMGIRGenerator::emitArrayElementAddress(StorageType elementType, Value* array, Value* index)
+{
+    Value* arrayPtr = pointerOfWasmRef(array);
+    Value* payload;
+    if (JSWebAssemblyArray::needsV128AlignmentMask(elementType)) {
+        // A PreciseAllocation only guarantees 8-byte alignment, so v128 elements have to be found by
+        // rounding up at runtime rather than by a fixed offset.
+        payload = m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(),
+            m_currentBlock->appendNew<Value>(m_proc, Add, origin(), arrayPtr,
+                m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), JSWebAssemblyArray::offsetOfData() + 15)),
+            m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), static_cast<intptr_t>(-16)));
+    } else {
+        payload = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), arrayPtr,
+            m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), JSWebAssemblyArray::alignedOffsetOfData(elementType.elementSize())));
+    }
+
+    return m_currentBlock->appendNew<Value>(m_proc, Add, origin(), payload,
+        m_currentBlock->appendNew<Value>(m_proc, Mul, origin(), pointerOfInt32(index),
+            m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), elementType.elementSize())));
 }
 
 auto OMGIRGenerator::addArrayGet(ExtGCOpType arrayGetKind, TypeSignatureIndex typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result) -> PartialResult
@@ -3901,6 +3939,78 @@ auto OMGIRGenerator::addArrayLen(TypedExpression arrayref, ExpressionType& resul
     return { };
 }
 
+static std::optional<uint8_t> repeatedFillByte(Value* value, size_t elementSize)
+{
+    ASSERT(elementSize <= sizeof(uint64_t));
+    uint64_t bits;
+    if (value->hasInt())
+        bits = value->asInt();
+    else if (value->hasFloat())
+        bits = std::bit_cast<uint32_t>(value->asFloat());
+    else if (value->hasDouble())
+        bits = std::bit_cast<uint64_t>(value->asDouble());
+    else
+        return std::nullopt;
+
+    uint8_t byte = bits & 0xff;
+    for (size_t i = 1; i < elementSize; ++i) {
+        if (((bits >> (i * 8)) & 0xff) != byte)
+            return std::nullopt;
+    }
+    return byte;
+}
+
+void OMGIRGenerator::emitArrayFillRange(StorageType elementType, Value* array, Value* offsetValue, Value* valueValue, Value* sizeValue)
+{
+    size_t elementSize = elementType.elementSize();
+    Value* address = emitArrayElementAddress(elementType, array, offsetValue);
+    Value* count = pointerOfInt32(sizeValue);
+
+    if (isRefType(elementType.unpacked())) {
+        callWasmOperation(m_currentBlock, B3::Void, operationWasmArrayFillRefs, address, valueValue, count);
+        emitWriteBarrier(pointerOfWasmRef(array));
+        return;
+    }
+
+    if (elementType.unpacked().isV128()) {
+        Value* lane0 = m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), B3::VectorExtractLane, B3::Int64, SIMDLane::i64x2, SIMDSignMode::None, uint8_t { 0 }, valueValue);
+        Value* lane1 = m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), B3::VectorExtractLane, B3::Int64, SIMDLane::i64x2, SIMDSignMode::None, uint8_t { 1 }, valueValue);
+        callWasmOperation(m_currentBlock, B3::Void, operationWasmArrayFill16B, address, lane0, lane1, count);
+        return;
+    }
+
+    if (elementSize == 1) {
+        m_currentBlock->appendNew<BulkMemoryValue>(m_proc, MemoryFill, origin(), address, valueValue, count);
+        return;
+    }
+
+    if (auto fillByte = repeatedFillByte(valueValue, elementSize)) {
+        m_currentBlock->appendNew<BulkMemoryValue>(m_proc, MemoryFill, origin(), address, constant(Int32, *fillByte),
+            m_currentBlock->appendNew<Value>(m_proc, Mul, origin(), count,
+                m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), elementSize)));
+        return;
+    }
+
+    Value* bits = valueValue;
+    if (bits->type().isFloat())
+        bits = m_currentBlock->appendNew<Value>(m_proc, BitwiseCast, origin(), bits);
+    if (bits->type() == Int32)
+        bits = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), bits);
+
+    switch (elementSize) {
+    case 2:
+        callWasmOperation(m_currentBlock, B3::Void, operationWasmArrayFill2B, address, bits, count);
+        return;
+    case 4:
+        callWasmOperation(m_currentBlock, B3::Void, operationWasmArrayFill4B, address, bits, count);
+        return;
+    case 8:
+        callWasmOperation(m_currentBlock, B3::Void, operationWasmArrayFill8B, address, bits, count);
+        return;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 auto OMGIRGenerator::addArrayFill(TypeSignatureIndex typeIndex, TypedExpression arrayref, ExpressionType offset, ExpressionType value, ExpressionType size) -> PartialResult
 {
     StorageType elementType;
@@ -3911,62 +4021,75 @@ auto OMGIRGenerator::addArrayFill(TypeSignatureIndex typeIndex, TypedExpression 
     Value* valueValue = get(value);
     Value* sizeValue = get(size);
 
-    if (arrayref.type().isNullable())
-        emitNullCheck(arrayValue, ExceptionType::NullArrayFill);
+    Value* arraySize = emitGetArraySizeWithNullCheck(arrayref.type(), arrayValue);
+    emitArrayRangeCheck(arraySize, offsetValue, sizeValue, ExceptionType::OutOfBoundsArrayFill);
 
-    Value* resultValue;
-    if (!elementType.unpacked().isV128()) {
-        Value* valueGPR = valueValue;
-        if (valueValue->type().isFloat())
-            valueGPR = m_currentBlock->appendNew<Value>(m_proc, BitwiseCast, origin(), valueGPR);
-        resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmArrayFill,
-            instanceValue(), arrayValue, offsetValue, valueGPR, sizeValue);
-    } else {
-        Value* lane0 = m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), B3::VectorExtractLane, B3::Int64, SIMDLane::i64x2, SIMDSignMode::None, uint8_t { 0 }, valueValue);
-        Value* lane1 = m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), B3::VectorExtractLane, B3::Int64, SIMDLane::i64x2, SIMDSignMode::None, uint8_t { 1 }, valueValue);
-        resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmArrayFillVector,
-            instanceValue(), arrayValue, offsetValue, lane0, lane1, sizeValue);
-    }
+    auto* fillPath = m_proc.addBlock();
+    auto* continuation = m_proc.addBlock();
 
-    {
-        CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
-            m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), resultValue, constant(Int32, 0)));
+    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(), sizeValue,
+        FrequentedBlock(fillPath), FrequentedBlock(continuation));
+    fillPath->addPredecessor(m_currentBlock);
+    continuation->addPredecessor(m_currentBlock);
 
-        check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
-            this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsArrayFill);
-        });
-    }
+    m_currentBlock = fillPath;
+    emitArrayFillRange(elementType, arrayValue, offsetValue, valueValue, sizeValue);
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = continuation;
 
     return { };
 }
 
-auto OMGIRGenerator::addArrayCopy(TypeSignatureIndex, TypedExpression dst, ExpressionType dstOffset, TypeSignatureIndex, TypedExpression src, ExpressionType srcOffset, ExpressionType size) -> PartialResult
+auto OMGIRGenerator::addArrayCopy(TypeSignatureIndex dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, TypeSignatureIndex srcTypeIndex, TypedExpression src, ExpressionType srcOffset, ExpressionType size) -> PartialResult
 {
+    StorageType elementType;
+    getArrayElementType(dstTypeIndex, elementType);
+    size_t elementSize = elementType.elementSize();
+
+    // Both element addresses and the byte count are scaled by the destination's stride, so a source
+    // whose stride differed would read outside its payload.
+    StorageType srcElementType;
+    getArrayElementType(srcTypeIndex, srcElementType);
+    RELEASE_ASSERT(srcElementType.elementSize() == elementSize);
+
     auto dstValue = get(dst);
     auto dstOffsetValue = get(dstOffset);
     auto srcValue = get(src);
     auto srcOffsetValue = get(srcOffset);
     auto sizeValue = get(size);
 
-    if (dst.type().isNullable())
-        emitNullCheck(dstValue, ExceptionType::NullArrayCopy);
-    if (src.type().isNullable())
-        emitNullCheck(srcValue, ExceptionType::NullArrayCopy);
+    Value* dstSize = emitGetArraySizeWithNullCheck(dst.type(), dstValue);
+    Value* srcSize = emitGetArraySizeWithNullCheck(src.type(), srcValue);
+    emitArrayRangeCheck(dstSize, dstOffsetValue, sizeValue, ExceptionType::OutOfBoundsArrayCopy);
+    emitArrayRangeCheck(srcSize, srcOffsetValue, sizeValue, ExceptionType::OutOfBoundsArrayCopy);
 
-    Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmArrayCopy,
-        instanceValue(),
-        dstValue, dstOffsetValue,
-        srcValue, srcOffsetValue,
-        sizeValue);
+    auto* copyPath = m_proc.addBlock();
+    auto* continuation = m_proc.addBlock();
 
+    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(), sizeValue,
+        FrequentedBlock(copyPath), FrequentedBlock(continuation));
+    copyPath->addPredecessor(m_currentBlock);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = copyPath;
     {
-        CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
-            m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), resultValue, constant(Int32, 0)));
+        Value* dstAddress = emitArrayElementAddress(elementType, dstValue, dstOffsetValue);
+        Value* srcAddress = emitArrayElementAddress(elementType, srcValue, srcOffsetValue);
+        Value* byteCount = m_currentBlock->appendNew<Value>(m_proc, Mul, origin(), pointerOfInt32(sizeValue),
+            m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), elementSize));
 
-        check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
-            this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsArrayCopy);
-        });
+        if (isRefType(elementType.unpacked())) {
+            callWasmOperation(m_currentBlock, B3::Void, operationWasmArrayCopyRefs, dstAddress, srcAddress, byteCount);
+            emitWriteBarrier(pointerOfWasmRef(dstValue));
+        } else
+            m_currentBlock->appendNew<BulkMemoryValue>(m_proc, MemoryCopy, origin(), dstAddress, srcAddress, byteCount);
     }
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = continuation;
 
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -32,6 +32,7 @@
 
 #include "ButterflyInlines.h"
 #include "FrameTracers.h"
+#include "GCMemoryOperations.h"
 #include "IteratorOperations.h"
 #include "JITExceptions.h"
 #include "JSArrayBufferViewInlines.h"
@@ -55,7 +56,10 @@
 #include "WasmOSREntryPlan.h"
 #include "WasmOperationsInlines.h"
 #include "WasmWorklist.h"
+#include <algorithm>
 #include <bit>
+#include <span>
+#include <string.h>
 #include <wtf/DataLog.h>
 #include <wtf/Locker.h>
 #include <wtf/StdLibExtras.h>
@@ -1749,27 +1753,61 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayNewEmpty, EncodedJSValue, (J
     return JSValue::encode(array);
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill, UCPUStrictInt32, (JSWebAssemblyInstance* instance, EncodedJSValue arrayValue, uint32_t offset, uint64_t value, uint32_t size))
+template<typename Element>
+static ALWAYS_INLINE void fillArrayElements(void* payload, Element element, size_t elementCount)
 {
-    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
-    assertCalleeIsReferenced(callFrame, instance);
-    VM& vm = instance->vm();
-    WasmOperationPrologueCallFrameTracer tracer(vm, callFrame, OUR_RETURN_ADDRESS);
-    return toUCPUStrictInt32(arrayFill(vm, arrayValue, offset, value, size));
+#if OS(DARWIN)
+    // memset_pattern* truncates a trailing partial instance of the pattern, so widening a narrow
+    // element to a wider pattern never writes past the end.
+    // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/memset_pattern4.3.html
+    size_t byteCount = elementCount * sizeof(Element);
+    if constexpr (sizeof(Element) == sizeof(uint16_t)) {
+        uint32_t pattern = (static_cast<uint32_t>(element) << 16) | element;
+        memset_pattern4(payload, &pattern, byteCount);
+    } else if constexpr (sizeof(Element) == sizeof(uint32_t))
+        memset_pattern4(payload, &element, byteCount);
+    else if constexpr (sizeof(Element) == sizeof(uint64_t))
+        memset_pattern8(payload, &element, byteCount);
+    else {
+        static_assert(sizeof(Element) == 16);
+        memset_pattern16(payload, &element, byteCount);
+    }
+#else
+    std::ranges::fill(std::span { static_cast<Element*>(payload), elementCount }, element);
+#endif
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFillVector, UCPUStrictInt32, (JSWebAssemblyInstance* instance, EncodedJSValue arrayValue, uint32_t offset, uint64_t lane0, uint64_t lane1, uint32_t size))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill2B, void, (void* payload, uint64_t value, size_t elementCount))
 {
-    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
-    assertCalleeIsReferenced(callFrame, instance);
-    VM& vm = instance->vm();
-    WasmOperationPrologueCallFrameTracer tracer(vm, callFrame, OUR_RETURN_ADDRESS);
-    return toUCPUStrictInt32(arrayFill(vm, arrayValue, offset, v128_t { lane0, lane1 }, size));
+    fillArrayElements(payload, static_cast<uint16_t>(value), elementCount);
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayCopy, UCPUStrictInt32, (JSWebAssemblyInstance* instance, EncodedJSValue dst, uint32_t dstOffset, EncodedJSValue src, uint32_t srcOffset, uint32_t size))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill4B, void, (void* payload, uint64_t value, size_t elementCount))
 {
-    return toUCPUStrictInt32(arrayCopy(instance, dst, dstOffset, src, srcOffset, size));
+    fillArrayElements(payload, static_cast<uint32_t>(value), elementCount);
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill8B, void, (void* payload, uint64_t value, size_t elementCount))
+{
+    fillArrayElements(payload, value, elementCount);
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill16B, void, (void* payload, uint64_t lane0, uint64_t lane1, size_t elementCount))
+{
+    fillArrayElements(payload, v128_t { lane0, lane1 }, elementCount);
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFillRefs, void, (uint64_t* payload, uint64_t value, size_t elementCount))
+{
+    // A reference is stored whole so the concurrent collector cannot observe a torn JSValue.
+    volatile uint64_t* cursor = payload;
+    for (size_t i = 0; i < elementCount; ++i)
+        cursor[i] = value;
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayCopyRefs, void, (uint64_t* dst, const uint64_t* src, size_t byteCount))
+{
+    gcSafeMemmove(dst, src, byteCount);
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayInitElem, UCPUStrictInt32, (JSWebAssemblyInstance* instance, EncodedJSValue dst, uint32_t dstOffset, uint32_t srcElementIndex, uint32_t srcOffset, uint32_t size))

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -132,9 +132,13 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayNewVector, EncodedJSValue, 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayNewData, EncodedJSValue, (JSWebAssemblyInstance* instance, uint32_t typeIndex, uint32_t dataSegmentIndex, uint32_t arraySize, uint32_t offset));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayNewElem, EncodedJSValue, (JSWebAssemblyInstance* instance, uint32_t typeIndex, uint32_t elemSegmentIndex, uint32_t arraySize, uint32_t offset));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayNewEmpty, EncodedJSValue, (JSWebAssemblyInstance* instance, uint32_t typeIndex, uint32_t size));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill, UCPUStrictInt32, (JSWebAssemblyInstance*, EncodedJSValue, uint32_t, uint64_t, uint32_t));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFillVector, UCPUStrictInt32, (JSWebAssemblyInstance*, EncodedJSValue, uint32_t, uint64_t, uint64_t, uint32_t));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayCopy, UCPUStrictInt32, (JSWebAssemblyInstance*, EncodedJSValue, uint32_t, EncodedJSValue, uint32_t, uint32_t));
+// The Fill operations take an element count; the Copy operation takes a byte count.
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill2B, void, (void* payload, uint64_t value, size_t elementCount));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill4B, void, (void* payload, uint64_t value, size_t elementCount));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill8B, void, (void* payload, uint64_t value, size_t elementCount));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill16B, void, (void* payload, uint64_t lane0, uint64_t lane1, size_t elementCount));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFillRefs, void, (uint64_t* payload, uint64_t value, size_t elementCount));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayCopyRefs, void, (uint64_t* dst, const uint64_t* src, size_t byteCount));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayInitElem, UCPUStrictInt32, (JSWebAssemblyInstance*, EncodedJSValue, uint32_t, uint32_t, uint32_t, uint32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmArrayInitData, UCPUStrictInt32, (JSWebAssemblyInstance*, EncodedJSValue, uint32_t, uint32_t, uint32_t, uint32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmAnyConvertExtern, EncodedJSValue, (EncodedJSValue));


### PR DESCRIPTION
#### 3c0f403d81c9ce38a7f5256f0209f941610de414
<pre>
[JSC] Optimize wasm array.copy and array.fill
<a href="https://bugs.webkit.org/show_bug.cgi?id=322222">https://bugs.webkit.org/show_bug.cgi?id=322222</a>
<a href="https://rdar.apple.com/185455041">rdar://185455041</a>

Reviewed by Yijia Huang.

This patch optimizes WasmGC array.copy and array.fill.

1. We noticed that they are called frequently with count = 0. So we do
   bound check etc. in the JIT code and skip calling a function when
   count = 0. This optimization is done in BBQ and OMG both.
2. For non-ref types, array.copy can use B3 MemoryCopy operation, which
   is introduced for `memory.copy` too. For ref-types, we need to call
   GC-safe memory move operations, so we cannot use it.
3. For non-ref types, array.fill uses very fast memset operations, using
   memset_pattern16 / memset_pattern8 / memset_pattern4. For ref-types,
   we have naive loop as it needs to be GC-safe.

Test: JSTests/wasm/gc/bulk-array-element-types.js

* JSTests/wasm/gc/bulk-array-element-types.js: Added.
(module):
(get return):
(get string_appeared_here):
(const.cases.get string_appeared_here):
* JSTests/wasm/gc/bulk-array.js:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitZeroExtendI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitArrayRangeCheck):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitGetArraySizeWithNullCheck):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitArrayElementAddress):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayFill):
* Source/JavaScriptCore/wasm/WasmExceptionType.h:
(JSC::Wasm::isTypeErrorExceptionType):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitGetArraySize):
(JSC::Wasm::OMGIRGenerator::emitGetArraySizeWithNullCheck):
(JSC::Wasm::OMGIRGenerator::emitArrayRangeCheck):
(JSC::Wasm::OMGIRGenerator::emitArrayElementAddress):
(JSC::Wasm::repeatedFillByte):
(JSC::Wasm::OMGIRGenerator::emitArrayFillRange):
(JSC::Wasm::OMGIRGenerator::addArrayFill):
(JSC::Wasm::OMGIRGenerator::addArrayCopy):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:

Canonical link: <a href="https://commits.webkit.org/319567@main">https://commits.webkit.org/319567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcd47bb9ee57962d46721860e90f55b78334371a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192128 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146232 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88f83967-db82-4610-978e-e112badbb8d5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142009 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74560b7e-cec2-4190-bd1b-5ef52fa5d4ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45688 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122445 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a03ddac-82ce-4146-939d-97f584e4d6e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44373 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/4412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11214 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42271 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3292 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43182 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48481 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194055 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55520 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151421 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56209 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151127 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27624 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45694 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128492 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124254 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54723 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17267 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54104 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54343 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54169 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->