### PR TITLE
[JSC] Clear MicrotaskCallCache in VM when CodeBlock gets detached

### DIFF
--- a/JSTests/stress/microtask-call-cache-delete-all-code.js
+++ b/JSTests/stress/microtask-call-cache-delete-all-code.js
@@ -1,0 +1,31 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+const count = 3000;
+
+async function* generator()
+{
+    for (let index = 0; index < count; ++index)
+        yield index;
+}
+
+async function sum()
+{
+    let result = 0;
+    for await (const value of generator())
+        result += value;
+    return result;
+}
+
+asyncTestStart(1);
+sum().then((result) => {
+    shouldBe(result, count * (count - 1) / 2);
+    asyncTestPassed();
+});
+
+// Deleting all code detaches every CodeBlock from its executable, and it runs once this script returns,
+// so the resumptions above happen afterwards and must not reuse the entry points cached for them here.
+$vm.deleteAllCodeWhenIdle();

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1148,6 +1148,10 @@ void Heap::deleteAllCodeBlocks(DeleteAllCodeEffort effort)
                 });
         });
 
+    // MicrotaskCallCache lives outside any CodeBlock and keys its cached entry points on the callee's
+    // executable, so after the code is detached above its callee check would still hit and call into it.
+    vm.clearMicrotaskCallCaches();
+
 #if ENABLE(WEBASSEMBLY)
     {
         // We must ensure that we clear the JS call ICs from Wasm. Otherwise, Wasm will

--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.cpp
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.cpp
@@ -73,16 +73,20 @@ void MicrotaskCall::unlinkOrUpgradeImpl(VM&, CodeBlock* oldCodeBlock, CodeBlock*
     m_addressForCall = nullptr;
 }
 
+void MicrotaskCall::clear()
+{
+    if (isOnList())
+        remove();
+    m_addressForCall = nullptr;
+    m_codeBlock = nullptr;
+    m_functionExecutable = nullptr;
+    m_numParameters = 0;
+}
+
 void MicrotaskCall::reconcileWeakReferencesAtGCEnd(VM& vm)
 {
-    if ((m_functionExecutable && !vm.heap.isMarked(m_functionExecutable)) || (m_codeBlock && !vm.heap.isMarked(m_codeBlock))) {
-        if (isOnList())
-            remove();
-        m_addressForCall = nullptr;
-        m_codeBlock = nullptr;
-        m_functionExecutable = nullptr;
-        m_numParameters = 0;
-    }
+    if ((m_functionExecutable && !vm.heap.isMarked(m_functionExecutable)) || (m_codeBlock && !vm.heap.isMarked(m_codeBlock)))
+        clear();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.h
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.h
@@ -68,6 +68,7 @@ public:
     void unlinkOrUpgradeImpl(VM&, CodeBlock* oldCodeBlock, CodeBlock* newCodeBlock);
     void relink(VM&, JSFunction*);
 
+    void clear();
     void reconcileWeakReferencesAtGCEnd(VM&);
 
 private:
@@ -107,6 +108,12 @@ public:
         auto* result = &m_entries[m_nextEntryIndex];
         m_nextEntryIndex = (m_nextEntryIndex + 1) & (cacheSize - 1);
         return result;
+    }
+
+    void clear()
+    {
+        for (auto& entry : m_entries)
+            entry.clear();
     }
 
     void reconcileWeakReferencesAtGCEnd(VM& vm)

--- a/Source/JavaScriptCore/runtime/CodeCache.h
+++ b/Source/JavaScriptCore/runtime/CodeCache.h
@@ -230,7 +230,11 @@ public:
 
     void updateCache(const UnlinkedFunctionExecutable*, const SourceCode&, CodeSpecializationKind, const UnlinkedFunctionCodeBlock*);
 
-    void clear() { m_sourceCode.clear(); }
+    void clear()
+    {
+        write();
+        m_sourceCode.clear();
+    }
     JS_EXPORT_PRIVATE void write();
 
 private:

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -170,6 +170,9 @@ DEFINE_VISIT_AGGREGATE(MarkedMicrotaskDeque);
 template<bool useCallOnEachMicrotask>
 ALWAYS_INLINE std::pair<JSGlobalObject*, bool> MicrotaskQueue::drainImpl(JSGlobalObject* currentGlobalObject, VM& vm, TopExceptionScope& catchScope)
 {
+    // Entries hold the callee's CodeBlock and entry point untraced, which is only sound on the stack:
+    // conservative scanning keeps them alive, and code is detached only outside a VM entry scope. A cache
+    // that outlives a drain needs clear() and reconcileWeakReferencesAtGCEnd, as VM's own cache does.
     MicrotaskCallCache microtaskCallCache;
 
     while (!m_queue.isEmpty()) {

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1899,6 +1899,11 @@ void VM::reconcileWeakReferencesAtGCEnd()
     m_syncResumeCallCache->reconcileWeakReferencesAtGCEnd(*this);
 }
 
+void VM::clearMicrotaskCallCaches()
+{
+    m_syncResumeCallCache->clear();
+}
+
 template<typename Visitor>
 void VM::visitAggregateImpl(Visitor& visitor)
 {

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -936,6 +936,7 @@ public:
 
     const UniqueRef<MicrotaskCallCache> m_syncResumeCallCache;
     MicrotaskCallCache& syncResumeCallCache() { return m_syncResumeCallCache.get(); }
+    void clearMicrotaskCallCaches();
 
     enum class StructureChainIntegrityEvent : uint8_t {
         Add,


### PR DESCRIPTION
#### 75a9d414a4a8b98d26840162d103eb16227eaeb6
<pre>
[JSC] Clear MicrotaskCallCache in VM when CodeBlock gets detached
<a href="https://bugs.webkit.org/show_bug.cgi?id=322226">https://bugs.webkit.org/show_bug.cgi?id=322226</a>
<a href="https://rdar.apple.com/184993354">rdar://184993354</a>

Reviewed by Yijia Huang.

When Heap::deleteAllCodeBlocks is called, CodeBlock is forcefully
detached from the ScriptExecutable. As a result, many of CallLinkInfo
cache&apos;s Executable -&gt; CodeBlock pair gets broken. When using CachedCall
/ MicrotaskCall on the stack, this is fine since we use them only after
entering VMEntryScope, and Heap::deleteAllCodeBlocks cannot be called
with VMEntryScope. But MicrotaskCallCache in VM is not scoped with
VMEntryScope, thus its pairing is important and needs to be cleared when
Heap::deleteAllCodeBlocks is called.

We are doing the same thing for Wasm&apos;s DataIC below, and we need to do
the same for VM&apos;s MicrotaskCallCache. This patch clears that cache in
Heap::deleteAllCodeBlocks.

Test: JSTests/stress/microtask-call-cache-delete-all-code.js

* JSTests/stress/microtask-call-cache-delete-all-code.js: Added.
(shouldBe):
(async generator):
(async sum):
(sum.then):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::deleteAllCodeBlocks):
* Source/JavaScriptCore/interpreter/MicrotaskCall.cpp:
(JSC::MicrotaskCall::clear):
(JSC::MicrotaskCall::reconcileWeakReferencesAtGCEnd):
* Source/JavaScriptCore/interpreter/MicrotaskCall.h:
* Source/JavaScriptCore/runtime/CodeCache.h:
(JSC::CodeCache::clear):
* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::MicrotaskQueue::drainImpl):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::clearMicrotaskCallCaches):
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/319570@main">https://commits.webkit.org/319570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc0f2987f0131dd8b851f775759fe58419bdc6e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192144 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/146248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02ee99d3-ecb1-430e-8cdf-29b663eea48a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142025 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/146248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/20f7b1ef-fcd7-4e49-bc5f-95bc3b597380) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184874 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/45703 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/162759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122461 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a55151e1-b10d-49da-a553-bfc3e936e4cf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/44388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/42656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/4428 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/11228 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154785 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42285 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3308 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/43198 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48497 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/46911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194072 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55536 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/151439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56225 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151144 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27625 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45709 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128508 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124274 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54739 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17281 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54120 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54359 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54185 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->