### PR TITLE
[ANGLE] Correctly rewrite unindexed interpolant array references

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/RewriteInterpolants.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/RewriteInterpolants.cpp
@@ -193,8 +193,8 @@ class WrapInterpolantsTraverser : public TIntermTraverser
             }
         }
 
-        const char *functionName   = nullptr;
-        TIntermSequence *arguments = new TIntermSequence{original};
+        const char *functionName = nullptr;
+        bool needsSampleID       = false;
         switch (type.getQualifier())
         {
             case EvqFragmentIn:
@@ -212,18 +212,55 @@ class WrapInterpolantsTraverser : public TIntermTraverser
                 break;
             case EvqSampleIn:
             case EvqNoPerspectiveSampleIn:
-                functionName = "interpolateAtSample";
-                arguments->push_back(new TIntermSymbol(BuiltInVariable::gl_SampleID()));
+                functionName           = "interpolateAtSample";
+                needsSampleID          = true;
                 mUsesSampleInterpolant = true;
                 break;
             default:
                 UNREACHABLE();
                 break;
         }
-        TIntermTyped *replacement = CreateBuiltInFunctionCallNode(
-            functionName, arguments, *mSymbolTable, kESSLInternalBackendBuiltIns);
 
-        queueReplacementWithParent(ancestor, original, replacement, OriginalNode::BECOMES_CHILD);
+        auto interpolate = [&](TIntermNode *interpolant) {
+            TIntermSequence *arguments = new TIntermSequence{interpolant};
+            if (needsSampleID)
+            {
+                arguments->push_back(new TIntermSymbol(BuiltInVariable::gl_SampleID()));
+            }
+            return CreateBuiltInFunctionCallNode(functionName, arguments, *mSymbolTable,
+                                                 kESSLInternalBackendBuiltIns);
+        };
+
+        TIntermTyped *originalTyped = original->getAsTyped();
+        const TType &originalType   = originalTyped->getType();
+        TIntermTyped *replacement   = nullptr;
+
+        if (originalType.isArray())
+        {
+            // An array reference has no matching overload. Since each element is an
+            // interpolant and not the array, interpolate the elements into a new one. The new
+            // array is just a temp, so it is not an interpolant itself.
+            TType resultType(originalType);
+            resultType.setInterpolant(false);
+
+            TIntermSequence elements;
+            const int size = static_cast<int>(originalType.getOutermostArraySize());
+            for (int i = 0; i < size; ++i)
+            {
+                TIntermBinary *element = new TIntermBinary(
+                    EOpIndexDirect, originalTyped->deepCopy(), CreateIndexNode(i));
+                elements.push_back(interpolate(element));
+            }
+            replacement = TIntermAggregate::CreateConstructor(resultType, &elements);
+        }
+        else
+        {
+            replacement = interpolate(original);
+        }
+
+        queueReplacementWithParent(
+            ancestor, original, replacement,
+            originalType.isArray() ? OriginalNode::IS_DROPPED : OriginalNode::BECOMES_CHILD);
     }
 
     bool usesSampleInterpolant() const { return mUsesSampleInterpolant; }

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/ShaderMultisampleInterpolation.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/ShaderMultisampleInterpolation.cpp
@@ -491,6 +491,94 @@ void main()
     EXPECT_PIXEL_COLOR_NEAR(0, 0, GLColor(0, 128, 0, 255), 1);
 }
 
+// Test that array references to interpolants compile and draw correctly.
+TEST_P(SampleMultisampleInterpolationTest, CompileArrayInterpolantReferences)
+{
+    ANGLE_SKIP_TEST_IF(!EnsureGLExtensionEnabled("GL_OES_shader_multisample_interpolation"));
+
+    constexpr char kVS[] = R"(#version 300 es
+#extension GL_OES_shader_multisample_interpolation : require
+
+in vec4 a_position;
+
+out vec3 interpolantArray[2];
+centroid out vec3 interpolantCentroidArray[2];
+sample out vec3 interpolantSampleArray[2];
+
+void main()
+{
+    gl_Position = a_position;
+
+    // Keep constant so that every read returns the same value.
+    interpolantArray[0] = vec3(10.0);
+    interpolantArray[1] = vec3(11.0);
+    interpolantCentroidArray[0] = vec3(20.0);
+    interpolantCentroidArray[1] = vec3(21.0);
+    interpolantSampleArray[0] = vec3(30.0);
+    interpolantSampleArray[1] = vec3(31.0);
+})";
+
+    constexpr char kFS[] = R"(#version 300 es
+#extension GL_OES_shader_multisample_interpolation : require
+
+precision highp float;
+
+in vec3 interpolantArray[2];
+centroid in vec3 interpolantCentroidArray[2];
+sample in vec3 interpolantSampleArray[2];
+
+out vec4 color;
+
+bool eq(vec3 a, vec3 b)
+{
+    return all(lessThan(abs(a - b), vec3(0.01)));
+}
+
+bool check(vec3 values[2], float base)
+{
+    return eq(values[0], vec3(base)) && eq(values[1], vec3(base + 1.0));
+}
+
+void main()
+{
+    // Marks each input as an interpolant, which is what made the uses below crash.
+    bool ok = eq(interpolateAtCentroid(interpolantArray[0]), vec3(10.0)) &&
+              eq(interpolateAtCentroid(interpolantCentroidArray[0]), vec3(20.0)) &&
+              eq(interpolateAtCentroid(interpolantSampleArray[0]), vec3(30.0));
+
+    // Test by assigning the array.
+    vec3 localArray[2];
+    vec3 localCentroidArray[2];
+    vec3 localSampleArray[2];
+    localArray         = interpolantArray;
+    localCentroidArray = interpolantCentroidArray;
+    localSampleArray   = interpolantSampleArray;
+    ok = ok && check(localArray, 10.0) && check(localCentroidArray, 20.0) &&
+         check(localSampleArray, 30.0);
+
+    // Test by passing the array to a function.
+    ok = ok && check(interpolantArray, 10.0) && check(interpolantCentroidArray, 20.0) &&
+         check(interpolantSampleArray, 30.0);
+
+    // Test by initializing from the array.
+    vec3 initArray[2]         = interpolantArray;
+    vec3 initCentroidArray[2] = interpolantCentroidArray;
+    vec3 initSampleArray[2]   = interpolantSampleArray;
+    ok = ok && check(initArray, 10.0) && check(initCentroidArray, 20.0) &&
+         check(initSampleArray, 30.0);
+
+    // Green indicates every check above passed.
+    color = ok ? vec4(0.0, 1.0, 0.0, 1.0) : vec4(1.0, 0.0, 0.0, 1.0);
+})";
+
+    ANGLE_GL_PROGRAM(program, kVS, kFS);
+
+    // Green only if every read matched what the vertex shader wrote.
+    drawQuad(program, "a_position", 0.0f);
+    ASSERT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
+}
+
 class SampleMultisampleInterpolationTest31 : public SampleMultisampleInterpolationTest
 {};
 


### PR DESCRIPTION
#### 37cb0315e58b50bdaacded723a686faa123cc176
<pre>
[ANGLE] Correctly rewrite unindexed interpolant array references
<a href="https://bugs.webkit.org/show_bug.cgi?id=322224">https://bugs.webkit.org/show_bug.cgi?id=322224</a>
<a href="https://rdar.apple.com/181806881">rdar://181806881</a>

Reviewed by Kimmo Kinnunen.

In a fragment shader, calling interpolateAt on a single element of an input array
marks the whole array as an interpolant. ANGLE&apos;s MSL translator then has to wrap
other references to it in an interpolation function. Since no overload takes an
entire array the internal symbol table returns nullptr. The caller then asserts
non-null in debug builds and dereferences the nullptr in release, crashing
either way.

Fix by interpolating each element and building a new array from the results. The
new array is just a temp, so it is not an interpolant itself. Each element gets
its own copy of the original reference, so the original is dropped rather than
reused.

* Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/RewriteInterpolants.cpp:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/ShaderMultisampleInterpolation.cpp:

Canonical link: <a href="https://commits.webkit.org/319977@main">https://commits.webkit.org/319977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/350392f8001652c43ee8d80a166fe9e2a46bf500

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193393 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147464 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1804426b-4800-4b04-ab03-8ffbb28405d7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142970 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b01ac10-d399-4dad-982b-58487f826a58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123397 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c9e6d820-82e9-49a0-9e82-896c7577879d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45395 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43643 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43263 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4567 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195334 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56767 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152457 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40900 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57472 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152153 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46703 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/125999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55980 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18274 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55351 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55589 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55418 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->